### PR TITLE
Enhance npm tarball propagation handling in CI/CD workflow and Docker…

### DIFF
--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -108,16 +108,23 @@ jobs:
         working-directory: apps/mesh
       - name: Wait for npm propagation
         run: |
-          echo "Waiting for npm registry propagation..."
-          for i in $(seq 1 12); do
-            if npm view decocms@${{ needs.prepare.outputs.version }} version >/dev/null 2>&1; then
-              echo "Version available on npm after $((i * 10))s"
+          VERSION=${{ needs.prepare.outputs.version }}
+          # Poll the tarball, not the manifest. `npm view ... version` hits the
+          # version manifest, which propagates almost immediately, but `bun add`
+          # downloads the .tgz from the CDN, which propagates later. Gating on the
+          # manifest lets build-docker start before the tarball is fetchable, so
+          # `bun add decocms@$VERSION` 404s. Gate on the actual tarball instead.
+          TARBALL="https://registry.npmjs.org/decocms/-/decocms-${VERSION}.tgz"
+          echo "Waiting for npm tarball propagation: $TARBALL"
+          for i in $(seq 1 30); do
+            if curl -fsI "$TARBALL" >/dev/null 2>&1; then
+              echo "Tarball available on npm CDN after $((i * 10))s"
               exit 0
             fi
-            echo "Attempt $i/12 - not yet available, waiting 10s..."
+            echo "Attempt $i/30 - tarball not yet propagated, waiting 10s..."
             sleep 10
           done
-          echo "Version not available on npm after 120s"
+          echo "Tarball not available on npm CDN after 300s"
           exit 1
 
   build-docker:

--- a/apps/mesh/Dockerfile
+++ b/apps/mesh/Dockerfile
@@ -24,8 +24,15 @@ RUN groupadd -g 1001 bunapp && \
 USER bunuser
 WORKDIR /app/apps/mesh
 
-# Install the package locally during build (cached in image layer)
-RUN bun add decocms@${MESH_VERSION}
+# Install the package locally during build (cached in image layer).
+# Retry to absorb npm CDN tarball-propagation lag: a freshly published version
+# can be in the manifest while its .tgz is still 404ing on the CDN.
+RUN for i in $(seq 1 10); do \
+      bun add decocms@${MESH_VERSION} && exit 0; \
+      echo "bun add attempt $i/10 failed, waiting 15s for npm propagation..."; \
+      sleep 15; \
+    done; \
+    echo "bun add decocms@${MESH_VERSION} failed after 10 attempts" && exit 1
 
 # Drop the build toolchain now that native modules have been compiled.
 USER root


### PR DESCRIPTION
…file. Update the release workflow to wait for the npm tarball instead of the version manifest, ensuring successful package installation. Modify Dockerfile to retry package installation with exponential backoff to accommodate CDN propagation delays.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make npm publish propagation reliable in CI and Docker builds. The release workflow now waits for the `decocms` tarball on the npm CDN, and the Dockerfile retries installation to avoid 404s right after publish.

- **Bug Fixes**
  - Release: poll the `decocms` tarball URL (not the version manifest) before building the Docker image.
  - Docker: retry `bun add decocms@$MESH_VERSION` with simple backoff (10 attempts, 15s delay) to absorb CDN lag.

<sup>Written for commit 326267d0fc706585000acdbfe090c876f1a88a38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3560?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

