### PR TITLE
Feat/watch running summary

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1954,6 +1954,95 @@ export async function createApp(options: CreateAppOptions = {}) {
     });
   });
 
+  // Per-user (cross-org) running-threads feed for the home "all my work" view.
+  // The channel is the USER, not an org, so it's mounted here (before the
+  // /api/:org aggregator, which would otherwise capture "me" as an org slug).
+  // SSE channels are opaque strings, so we reuse the hub + NATS broadcast via a
+  // `user:<id>` channel — no hub changes. The reactor emits each transition to
+  // that channel for the thread's creator.
+  app.get("/api/me/watch", async (c) => {
+    const meshContext = c.var.meshContext;
+    const userId = meshContext.auth.user?.id ?? meshContext.auth.apiKey?.userId;
+    if (!userId) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const typesParam = c.req.query("types");
+    const typePatterns = typesParam
+      ? typesParam
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean)
+      : null;
+
+    const channel = `user:${userId}`;
+    const listenerId = crypto.randomUUID();
+
+    return streamSSE(c, async (stream) => {
+      await stream.writeSSE({
+        event: "connected",
+        data: JSON.stringify({
+          listenerId,
+          channel,
+          typePatterns,
+          connectedAt: new Date().toISOString(),
+        }),
+      });
+
+      // Cross-org snapshot from the DB (membership-gated), authoritative.
+      try {
+        const running = await threadStorage.summarizeRunningForUser(userId);
+        const summaryEvent = createDecopilotRunningSummaryEvent(running);
+        await stream.writeSSE({
+          id: summaryEvent.id,
+          event: summaryEvent.type,
+          data: JSON.stringify(summaryEvent),
+        });
+      } catch (err) {
+        console.error("[me/watch] running summary snapshot failed", err);
+      }
+
+      const registered = sseHub.add({
+        id: listenerId,
+        organizationId: channel,
+        typePatterns: typePatterns?.length ? typePatterns : null,
+        push: (event: SSEEvent) => {
+          stream
+            .writeSSE({
+              id: event.id,
+              event: event.type,
+              data: JSON.stringify(event),
+            })
+            .catch(() => {
+              sseHub.remove(channel, listenerId);
+            });
+        },
+      });
+
+      if (!registered) {
+        await stream.writeSSE({
+          event: "error",
+          data: JSON.stringify({ error: "Too many connections" }),
+        });
+        return;
+      }
+
+      const keepaliveInterval = setInterval(() => {
+        stream.writeSSE({ event: "keepalive", data: "" }).catch(() => {
+          clearInterval(keepaliveInterval);
+        });
+      }, 30_000);
+
+      await new Promise<void>((resolve) => {
+        stream.onAbort(() => {
+          clearInterval(keepaliveInterval);
+          sseHub.remove(channel, listenerId);
+          resolve();
+        });
+      });
+    });
+  });
+
   // User-scoped link daemon long-poll routes. The link is the USER, not an org:
   // each handler reads ctx.auth.user.id (populated by the global
   // ContextFactory.create middleware, which resolves the MCP OAuth bearer via

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -19,6 +19,8 @@ import { usesLocalObjectStorage } from "../tools/connection/dev-assets";
 import { DECO_STORE_URL, isDecoHostedMcp } from "@/core/deco-constants";
 import {
   createDecopilotRunningSummaryEvent,
+  DECOPILOT_RUNNING_SUMMARY_EVENT,
+  DECOPILOT_USER_RUNNING_SUMMARY_EVENT,
   WellKnownOrgMCPId,
 } from "@decocms/mesh-sdk";
 import { PrometheusSerializer } from "@opentelemetry/exporter-prometheus";
@@ -754,6 +756,18 @@ export const watchHandler: MiddlewareHandler<Env> = async (c) => {
     : null;
 
   const listenerId = crypto.randomUUID();
+  // A connection can opt into either running-summary scope via ?types. The home
+  // badge requests both over THIS one connection; the chat pool requests neither
+  // (so it doesn't pay the snapshot query or hold a user-channel listener).
+  const wantsOrgSummary =
+    !typePatterns || typePatterns.includes(DECOPILOT_RUNNING_SUMMARY_EVENT);
+  const wantsUserSummary =
+    !typePatterns ||
+    typePatterns.includes(DECOPILOT_USER_RUNNING_SUMMARY_EVENT);
+  // Second listener for the cross-org user channel, so a single connection can
+  // carry both org and user summaries (no separate /api/me/watch connection).
+  const userListenerId = crypto.randomUUID();
+  const userChannel = `user:${userId}`;
 
   return streamSSE(c, async (stream) => {
     // Send initial connection event
@@ -767,41 +781,68 @@ export const watchHandler: MiddlewareHandler<Env> = async (c) => {
       }),
     });
 
-    // Snapshot of currently-running threads grouped by agent. Authoritative
-    // and cross-pod (DB-backed), unlike the per-pod run registry. Best-effort:
+    // Connect-time snapshots (authoritative, cross-pod, DB-backed). Best-effort:
     // a failed snapshot must not tear down the live stream.
-    try {
-      const running = await meshContext.storage.threads.summarizeRunning();
-      const summaryEvent = createDecopilotRunningSummaryEvent(running);
-      await stream.writeSSE({
-        id: summaryEvent.id,
-        event: summaryEvent.type,
-        data: JSON.stringify(summaryEvent),
-      });
-    } catch (err) {
-      console.error("[watch] running summary snapshot failed", err);
+    if (wantsOrgSummary) {
+      try {
+        const running = await meshContext.storage.threads.summarizeRunning();
+        const ev = createDecopilotRunningSummaryEvent(running, "org");
+        await stream.writeSSE({
+          id: ev.id,
+          event: ev.type,
+          data: JSON.stringify(ev),
+        });
+      } catch (err) {
+        console.error("[watch] org running summary snapshot failed", err);
+      }
+    }
+    if (wantsUserSummary) {
+      try {
+        const running =
+          await meshContext.storage.threads.summarizeRunningForUser(userId);
+        const ev = createDecopilotRunningSummaryEvent(running, "user");
+        await stream.writeSSE({
+          id: ev.id,
+          event: ev.type,
+          data: JSON.stringify(ev),
+        });
+      } catch (err) {
+        console.error("[watch] user running summary snapshot failed", err);
+      }
     }
 
-    // Register listener with the SSE hub
+    const push = (event: SSEEvent) => {
+      // Write to the SSE stream — fire-and-forget
+      stream
+        .writeSSE({
+          id: event.id,
+          event: event.type,
+          data: JSON.stringify(event),
+        })
+        .catch(() => {
+          // Stream broken — remove immediately so no further events are
+          // attempted. onAbort handles interval cleanup.
+          sseHub.remove(orgId, listenerId);
+          if (wantsUserSummary) sseHub.remove(userChannel, userListenerId);
+        });
+    };
+
+    // Org-channel listener (org events + org summary).
     const registered = sseHub.add({
       id: listenerId,
       organizationId: orgId,
       typePatterns: typePatterns?.length ? typePatterns : null,
-      push: (event: SSEEvent) => {
-        // Write to the SSE stream — fire-and-forget
-        stream
-          .writeSSE({
-            id: event.id,
-            event: event.type,
-            data: JSON.stringify(event),
-          })
-          .catch(() => {
-            // Stream broken — remove immediately so no further events are
-            // attempted. onAbort handles interval cleanup.
-            sseHub.remove(orgId, listenerId);
-          });
-      },
+      push,
     });
+    // User-channel listener (cross-org user summary), same stream.
+    if (wantsUserSummary) {
+      sseHub.add({
+        id: userListenerId,
+        organizationId: userChannel,
+        typePatterns: typePatterns?.length ? typePatterns : null,
+        push,
+      });
+    }
 
     if (!registered) {
       await stream.writeSSE({
@@ -826,6 +867,7 @@ export const watchHandler: MiddlewareHandler<Env> = async (c) => {
       stream.onAbort(() => {
         clearInterval(keepaliveInterval);
         sseHub.remove(orgId, listenerId);
+        if (wantsUserSummary) sseHub.remove(userChannel, userListenerId);
         resolve();
       });
     });
@@ -1951,95 +1993,6 @@ export async function createApp(options: CreateAppOptions = {}) {
       cliVersion: claim.cliVersion,
       previewPort: claim.previewPort,
       connectedAt: claim.connectedAt,
-    });
-  });
-
-  // Per-user (cross-org) running-threads feed for the home "all my work" view.
-  // The channel is the USER, not an org, so it's mounted here (before the
-  // /api/:org aggregator, which would otherwise capture "me" as an org slug).
-  // SSE channels are opaque strings, so we reuse the hub + NATS broadcast via a
-  // `user:<id>` channel — no hub changes. The reactor emits each transition to
-  // that channel for the thread's creator.
-  app.get("/api/me/watch", async (c) => {
-    const meshContext = c.var.meshContext;
-    const userId = meshContext.auth.user?.id ?? meshContext.auth.apiKey?.userId;
-    if (!userId) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
-
-    const typesParam = c.req.query("types");
-    const typePatterns = typesParam
-      ? typesParam
-          .split(",")
-          .map((t) => t.trim())
-          .filter(Boolean)
-      : null;
-
-    const channel = `user:${userId}`;
-    const listenerId = crypto.randomUUID();
-
-    return streamSSE(c, async (stream) => {
-      await stream.writeSSE({
-        event: "connected",
-        data: JSON.stringify({
-          listenerId,
-          channel,
-          typePatterns,
-          connectedAt: new Date().toISOString(),
-        }),
-      });
-
-      // Cross-org snapshot from the DB (membership-gated), authoritative.
-      try {
-        const running = await threadStorage.summarizeRunningForUser(userId);
-        const summaryEvent = createDecopilotRunningSummaryEvent(running);
-        await stream.writeSSE({
-          id: summaryEvent.id,
-          event: summaryEvent.type,
-          data: JSON.stringify(summaryEvent),
-        });
-      } catch (err) {
-        console.error("[me/watch] running summary snapshot failed", err);
-      }
-
-      const registered = sseHub.add({
-        id: listenerId,
-        organizationId: channel,
-        typePatterns: typePatterns?.length ? typePatterns : null,
-        push: (event: SSEEvent) => {
-          stream
-            .writeSSE({
-              id: event.id,
-              event: event.type,
-              data: JSON.stringify(event),
-            })
-            .catch(() => {
-              sseHub.remove(channel, listenerId);
-            });
-        },
-      });
-
-      if (!registered) {
-        await stream.writeSSE({
-          event: "error",
-          data: JSON.stringify({ error: "Too many connections" }),
-        });
-        return;
-      }
-
-      const keepaliveInterval = setInterval(() => {
-        stream.writeSSE({ event: "keepalive", data: "" }).catch(() => {
-          clearInterval(keepaliveInterval);
-        });
-      }, 30_000);
-
-      await new Promise<void>((resolve) => {
-        stream.onAbort(() => {
-          clearInterval(keepaliveInterval);
-          sseHub.remove(channel, listenerId);
-          resolve();
-        });
-      });
     });
   });
 

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -17,7 +17,10 @@ import {
 import { getPublicUrl } from "@/core/server-constants";
 import { usesLocalObjectStorage } from "../tools/connection/dev-assets";
 import { DECO_STORE_URL, isDecoHostedMcp } from "@/core/deco-constants";
-import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
+import {
+  createDecopilotRunningSummaryEvent,
+  WellKnownOrgMCPId,
+} from "@decocms/mesh-sdk";
 import { PrometheusSerializer } from "@opentelemetry/exporter-prometheus";
 import { Hono } from "hono";
 import { getCookie } from "hono/cookie";
@@ -124,6 +127,11 @@ import {
   NoopConnectionCircuitStore,
   setConnectionCircuitStore,
 } from "../mcp-clients/connection-circuit-store";
+import {
+  DbRunningThreadsStore,
+  JetStreamKVRunningThreadsStore,
+  type RunningThreadsStore,
+} from "./routes/decopilot/running-threads-store";
 import {
   InMemoryModelListCache,
   type ModelListCache,
@@ -714,9 +722,13 @@ const eventsHandler: MiddlewareHandler<Env> = async (c) => {
  *
  * On connect, emits in order:
  *   1. `event: connected` — listener metadata
- *   2. Live events from the SSE hub.
+ *   2. `event: decopilot.running.summary` — snapshot of in_progress threads
+ *      grouped by agent ("X agents working on N tasks"), re-sent on reconnect.
+ *   3. Live events from the SSE hub.
  *
- * Clients use `COLLECTION_THREADS_LIST` for their initial state.
+ * Clients use `COLLECTION_THREADS_LIST` for their initial thread state and keep
+ * the running summary live from the reactor's `decopilot.running.summary`
+ * broadcasts.
  */
 export const watchHandler: MiddlewareHandler<Env> = async (c) => {
   const meshContext = c.var.meshContext;
@@ -754,6 +766,21 @@ export const watchHandler: MiddlewareHandler<Env> = async (c) => {
         connectedAt: new Date().toISOString(),
       }),
     });
+
+    // Snapshot of currently-running threads grouped by agent. Authoritative
+    // and cross-pod (DB-backed), unlike the per-pod run registry. Best-effort:
+    // a failed snapshot must not tear down the live stream.
+    try {
+      const running = await meshContext.storage.threads.summarizeRunning();
+      const summaryEvent = createDecopilotRunningSummaryEvent(running);
+      await stream.writeSSE({
+        id: summaryEvent.id,
+        event: summaryEvent.type,
+        data: JSON.stringify(summaryEvent),
+      });
+    } catch (err) {
+      console.error("[watch] running summary snapshot failed", err);
+    }
 
     // Register listener with the SSE hub
     const registered = sseHub.add({
@@ -884,6 +911,10 @@ export async function createApp(options: CreateAppOptions = {}) {
   let linkClaimRegistry: LinkClaimRegistry;
   let linkWorkQueue: LinkWorkQueue | null = null;
   let natsProvider: NatsConnectionProvider | null = null;
+  // KV-backed in the NATS branch; falls back to a DB-backed store once
+  // threadStorage exists (assigned below). Powers the reactor's running-summary
+  // broadcast.
+  let runningThreadsStore: RunningThreadsStore | null = null;
 
   if (options.eventBus) {
     // Test mode: use provided event bus and no-op stubs (no NATS required)
@@ -955,6 +986,12 @@ export async function createApp(options: CreateAppOptions = {}) {
     });
     ccs.init().catch(() => {});
     connectionCircuitStore = ccs;
+
+    const rts = new JetStreamKVRunningThreadsStore({
+      getJetStream: () => natsProvider!.getJetStream(),
+    });
+    rts.init().catch(() => {});
+    runningThreadsStore = rts;
 
     providerKeyCache = createProviderKeyCache({
       getConnection: () => natsProvider!.getConnection(),
@@ -1127,10 +1164,17 @@ export async function createApp(options: CreateAppOptions = {}) {
     });
   }
 
+  // No NATS (test / dev single-pod) → read the running set straight from the DB,
+  // which the reactor has already updated by the time it asks for the summary.
+  if (!runningThreadsStore) {
+    runningThreadsStore = new DbRunningThreadsStore(threadStorage);
+  }
+
   const cancelReactorDeps: RunReactorDeps = {
     storage: threadStorage,
     streamBuffer,
     sseHub,
+    runningStore: runningThreadsStore,
   };
 
   const runRegistry = new RunRegistry(cancelReactorDeps);
@@ -1183,6 +1227,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     providerKeyCache.teardown();
     teardownMcpCacheInvalidation();
     connectionCircuitStore.teardown();
+    runningThreadsStore?.teardown();
     setMcpListCache(null);
     setConnectionCircuitStore(null);
   };

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -21,6 +21,8 @@ import {
   createDecopilotRunningSummaryEvent,
   DECOPILOT_RUNNING_SUMMARY_EVENT,
   DECOPILOT_USER_RUNNING_SUMMARY_EVENT,
+  type RunningSummaryScope,
+  type RunningThread,
   WellKnownOrgMCPId,
 } from "@decocms/mesh-sdk";
 import { PrometheusSerializer } from "@opentelemetry/exporter-prometheus";
@@ -722,15 +724,8 @@ const eventsHandler: MiddlewareHandler<Env> = async (c) => {
  * Resolves the org from `ctx.organization.id` (set by `resolveOrgFromPath`
  * on the `/api/:org/watch` mount). Auth is required.
  *
- * On connect, emits in order:
- *   1. `event: connected` — listener metadata
- *   2. `event: decopilot.running.summary` — snapshot of in_progress threads
- *      grouped by agent ("X agents working on N tasks"), re-sent on reconnect.
- *   3. Live events from the SSE hub.
- *
- * Clients use `COLLECTION_THREADS_LIST` for their initial thread state and keep
- * the running summary live from the reactor's `decopilot.running.summary`
- * broadcasts.
+ * On connect, emits a `connected` event, then running-summary snapshots (org
+ * and/or per-user scope, per `?types`), then live events from the SSE hub.
  */
 export const watchHandler: MiddlewareHandler<Env> = async (c) => {
   const meshContext = c.var.meshContext;
@@ -756,16 +751,13 @@ export const watchHandler: MiddlewareHandler<Env> = async (c) => {
     : null;
 
   const listenerId = crypto.randomUUID();
-  // A connection can opt into either running-summary scope via ?types. The home
-  // badge requests both over THIS one connection; the chat pool requests neither
-  // (so it doesn't pay the snapshot query or hold a user-channel listener).
+  // Either running-summary scope is opt-in via ?types; the home badge requests
+  // both over this one connection, the chat pool requests neither.
   const wantsOrgSummary =
     !typePatterns || typePatterns.includes(DECOPILOT_RUNNING_SUMMARY_EVENT);
   const wantsUserSummary =
     !typePatterns ||
     typePatterns.includes(DECOPILOT_USER_RUNNING_SUMMARY_EVENT);
-  // Second listener for the cross-org user channel, so a single connection can
-  // carry both org and user summaries (no separate /api/me/watch connection).
   const userListenerId = crypto.randomUUID();
   const userChannel = `user:${userId}`;
 
@@ -781,38 +773,34 @@ export const watchHandler: MiddlewareHandler<Env> = async (c) => {
       }),
     });
 
-    // Connect-time snapshots (authoritative, cross-pod, DB-backed). Best-effort:
-    // a failed snapshot must not tear down the live stream.
-    if (wantsOrgSummary) {
+    // Connect-time snapshots, best-effort: a failure must not tear down the stream.
+    const writeSnapshot = async (
+      scope: RunningSummaryScope,
+      load: () => Promise<RunningThread[]>,
+    ) => {
       try {
-        const running = await meshContext.storage.threads.summarizeRunning();
-        const ev = createDecopilotRunningSummaryEvent(running, "org");
+        const ev = createDecopilotRunningSummaryEvent(await load(), scope);
         await stream.writeSSE({
           id: ev.id,
           event: ev.type,
           data: JSON.stringify(ev),
         });
       } catch (err) {
-        console.error("[watch] org running summary snapshot failed", err);
+        console.error(`[watch] ${scope} running summary snapshot failed`, err);
       }
+    };
+    if (wantsOrgSummary) {
+      await writeSnapshot("org", () =>
+        meshContext.storage.threads.summarizeRunning(),
+      );
     }
     if (wantsUserSummary) {
-      try {
-        const running =
-          await meshContext.storage.threads.summarizeRunningForUser(userId);
-        const ev = createDecopilotRunningSummaryEvent(running, "user");
-        await stream.writeSSE({
-          id: ev.id,
-          event: ev.type,
-          data: JSON.stringify(ev),
-        });
-      } catch (err) {
-        console.error("[watch] user running summary snapshot failed", err);
-      }
+      await writeSnapshot("user", () =>
+        meshContext.storage.threads.summarizeRunningForUser(userId),
+      );
     }
 
     const push = (event: SSEEvent) => {
-      // Write to the SSE stream — fire-and-forget
       stream
         .writeSSE({
           id: event.id,
@@ -820,21 +808,18 @@ export const watchHandler: MiddlewareHandler<Env> = async (c) => {
           data: JSON.stringify(event),
         })
         .catch(() => {
-          // Stream broken — remove immediately so no further events are
-          // attempted. onAbort handles interval cleanup.
+          // Stream broken — remove now; onAbort handles interval cleanup.
           sseHub.remove(orgId, listenerId);
           if (wantsUserSummary) sseHub.remove(userChannel, userListenerId);
         });
     };
 
-    // Org-channel listener (org events + org summary).
     const registered = sseHub.add({
       id: listenerId,
       organizationId: orgId,
       typePatterns: typePatterns?.length ? typePatterns : null,
       push,
     });
-    // User-channel listener (cross-org user summary), same stream.
     if (wantsUserSummary) {
       sseHub.add({
         id: userListenerId,
@@ -953,9 +938,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   let linkClaimRegistry: LinkClaimRegistry;
   let linkWorkQueue: LinkWorkQueue | null = null;
   let natsProvider: NatsConnectionProvider | null = null;
-  // KV-backed in the NATS branch; falls back to a DB-backed store once
-  // threadStorage exists (assigned below). Powers the reactor's running-summary
-  // broadcast.
+  // KV-backed under NATS; DB-backed fallback assigned below when absent.
   let runningThreadsStore: RunningThreadsStore | null = null;
 
   if (options.eventBus) {
@@ -1206,8 +1189,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     });
   }
 
-  // No NATS (test / dev single-pod) → read the running set straight from the DB,
-  // which the reactor has already updated by the time it asks for the summary.
+  // No NATS (test / dev single-pod) → read the running set straight from the DB.
   if (!runningThreadsStore) {
     runningThreadsStore = new DbRunningThreadsStore(threadStorage);
   }

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
@@ -80,8 +80,7 @@ function makeReactor(): {
     storage,
     sseHub: {
       emit(orgId, event) {
-        // running.summary is an orthogonal cross-cutting broadcast; these
-        // tests assert the run-lifecycle event sequence, so filter it out.
+        // These tests assert the run-lifecycle sequence; drop the summary broadcast.
         if (event.type === DECOPILOT_RUNNING_SUMMARY_EVENT) return;
         sseEvents.push({ orgId, event });
       },

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
@@ -36,6 +36,8 @@ import type { SSEEvent } from "@/event-bus";
 import { SqlThreadStorage } from "@/storage/threads";
 import type { Thread } from "@/storage/types";
 import { reactAll, type RunReactorDeps } from "./run-reactor";
+import { NoopRunningThreadsStore } from "./running-threads-store";
+import { DECOPILOT_RUNNING_SUMMARY_EVENT } from "@decocms/mesh-sdk";
 import type { RunEvent } from "./run-state";
 import type { StreamBuffer } from "./stream-buffer";
 
@@ -78,6 +80,9 @@ function makeReactor(): {
     storage,
     sseHub: {
       emit(orgId, event) {
+        // running.summary is an orthogonal cross-cutting broadcast; these
+        // tests assert the run-lifecycle event sequence, so filter it out.
+        if (event.type === DECOPILOT_RUNNING_SUMMARY_EVENT) return;
         sseEvents.push({ orgId, event });
       },
     },
@@ -87,6 +92,7 @@ function makeReactor(): {
         purged.push(taskId);
       },
     } as unknown as StreamBuffer,
+    runningStore: new NoopRunningThreadsStore(),
   };
   return { deps, sseEvents, purged };
 }

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
@@ -37,7 +37,10 @@ import { SqlThreadStorage } from "@/storage/threads";
 import type { Thread } from "@/storage/types";
 import { reactAll, type RunReactorDeps } from "./run-reactor";
 import { NoopRunningThreadsStore } from "./running-threads-store";
-import { DECOPILOT_RUNNING_SUMMARY_EVENT } from "@decocms/mesh-sdk";
+import {
+  DECOPILOT_RUNNING_SUMMARY_EVENT,
+  DECOPILOT_USER_RUNNING_SUMMARY_EVENT,
+} from "@decocms/mesh-sdk";
 import type { RunEvent } from "./run-state";
 import type { StreamBuffer } from "./stream-buffer";
 
@@ -80,8 +83,13 @@ function makeReactor(): {
     storage,
     sseHub: {
       emit(orgId, event) {
-        // These tests assert the run-lifecycle sequence; drop the summary broadcast.
-        if (event.type === DECOPILOT_RUNNING_SUMMARY_EVENT) return;
+        // These tests assert the run-lifecycle sequence; drop the summary broadcasts.
+        if (
+          event.type === DECOPILOT_RUNNING_SUMMARY_EVENT ||
+          event.type === DECOPILOT_USER_RUNNING_SUMMARY_EVENT
+        ) {
+          return;
+        }
         sseEvents.push({ orgId, event });
       },
     },

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -35,15 +35,10 @@ export interface RunReactorDeps {
   storage: ThreadStoragePort;
   streamBuffer: StreamBuffer;
   sseHub: { emit(orgId: string, event: SSEEvent): void };
-  /** Cross-pod running-thread set powering the home "agents working" badge. */
   runningStore: RunningThreadsStore;
 }
 
-/**
- * Apply a running-set mutation and broadcast the resulting summary through the
- * SSE hub. Best-effort: the badge must never block or fail a run transition, so
- * store/emit errors are swallowed.
- */
+// Best-effort throughout: the badge must never block or fail a run transition.
 async function syncRunningSummary(
   deps: RunReactorDeps,
   orgId: string,
@@ -57,11 +52,7 @@ async function syncRunningSummary(
   }
 }
 
-/**
- * Fire-and-forget per-user (cross-org) summary on the `user:<id>` channel.
- * Computed from the DB — lower-traffic than the org channel and where the
- * agent-title join lives — and never awaited, so it can't slow a transition.
- */
+// Fire-and-forget per-user (cross-org) summary on the `user:<id>` channel.
 function emitUserRunningSummary(
   deps: RunReactorDeps,
   userId: string | null | undefined,
@@ -78,6 +69,31 @@ function emitUserRunningSummary(
     .catch((err) =>
       console.error("[run-reactor] user running summary failed", err),
     );
+}
+
+// Mark a thread running in the cross-pod store and refresh both summary feeds.
+async function markThreadRunning(
+  deps: RunReactorDeps,
+  orgId: string,
+  taskId: string,
+  thread:
+    | {
+        virtual_mcp_id?: string | null;
+        title?: string | null;
+        created_by?: string | null;
+      }
+    | null
+    | undefined,
+): Promise<void> {
+  await syncRunningSummary(deps, orgId, (store) =>
+    store.markRunning(orgId, {
+      id: taskId,
+      virtual_mcp_id: thread?.virtual_mcp_id ?? "",
+      title: thread?.title ?? null,
+      organization_id: orgId,
+    }),
+  );
+  emitUserRunningSummary(deps, thread?.created_by);
 }
 
 // ============================================================================
@@ -148,15 +164,7 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
           updatedAt: startedThread?.updated_at,
         }),
       );
-      await syncRunningSummary(deps, event.orgId, (store) =>
-        store.markRunning(event.orgId, {
-          id: event.taskId,
-          virtual_mcp_id: startedThread?.virtual_mcp_id ?? "",
-          title: startedThread?.title ?? null,
-          organization_id: event.orgId,
-        }),
-      );
-      emitUserRunningSummary(deps, startedThread?.created_by);
+      await markThreadRunning(deps, event.orgId, event.taskId, startedThread);
       return;
     }
 
@@ -177,15 +185,7 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
           updatedAt: resumedThread?.updated_at,
         }),
       );
-      await syncRunningSummary(deps, event.orgId, (store) =>
-        store.markRunning(event.orgId, {
-          id: event.taskId,
-          virtual_mcp_id: resumedThread?.virtual_mcp_id ?? "",
-          title: resumedThread?.title ?? null,
-          organization_id: event.orgId,
-        }),
-      );
-      emitUserRunningSummary(deps, resumedThread?.created_by);
+      await markThreadRunning(deps, event.orgId, event.taskId, resumedThread);
       return;
     }
 
@@ -194,8 +194,7 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
         event.orgId,
         createDecopilotStepEvent(event.taskId, event.stepCount),
       );
-      // Refresh liveness so a long, actively-streaming run isn't pruned from
-      // the running count. Best-effort, no summary emit (count is unchanged).
+      // Refresh liveness so a long streaming run isn't pruned from the count.
       deps.runningStore.touch(event.orgId, event.taskId).catch(() => {});
       return;
 

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -72,7 +72,7 @@ function emitUserRunningSummary(
     .then((threads) =>
       deps.sseHub.emit(
         `user:${userId}`,
-        createDecopilotRunningSummaryEvent(threads),
+        createDecopilotRunningSummaryEvent(threads, "user"),
       ),
     )
     .catch((err) =>

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -52,23 +52,24 @@ async function syncRunningSummary(
   }
 }
 
-// Fire-and-forget per-user (cross-org) summary on the `user:<id>` channel.
-function emitUserRunningSummary(
+// Per-user (cross-org) summary on the `user:<id>` channel. Awaited (not
+// fire-and-forget) so the cross-org query completes within the reactor's flow
+// instead of racing per-request teardown — otherwise the count-0 on completion
+// is lost and "All my work" stays stale. Errors are swallowed, never thrown.
+async function emitUserRunningSummary(
   deps: RunReactorDeps,
   userId: string | null | undefined,
-): void {
+): Promise<void> {
   if (!userId) return;
-  deps.storage
-    .summarizeRunningForUser(userId)
-    .then((threads) =>
-      deps.sseHub.emit(
-        `user:${userId}`,
-        createDecopilotRunningSummaryEvent(threads, "user"),
-      ),
-    )
-    .catch((err) =>
-      console.error("[run-reactor] user running summary failed", err),
+  try {
+    const threads = await deps.storage.summarizeRunningForUser(userId);
+    deps.sseHub.emit(
+      `user:${userId}`,
+      createDecopilotRunningSummaryEvent(threads, "user"),
     );
+  } catch (err) {
+    console.error("[run-reactor] user running summary failed", err);
+  }
 }
 
 // Mark a thread running in the cross-pod store and refresh both summary feeds.
@@ -93,7 +94,7 @@ async function markThreadRunning(
       organization_id: orgId,
     }),
   );
-  emitUserRunningSummary(deps, thread?.created_by);
+  await emitUserRunningSummary(deps, thread?.created_by);
 }
 
 // ============================================================================
@@ -131,7 +132,7 @@ async function handleTerminalStatus(
   await syncRunningSummary(deps, orgId, (store) =>
     store.markStopped(orgId, taskId),
   );
-  emitUserRunningSummary(deps, thread?.created_by);
+  await emitUserRunningSummary(deps, thread?.created_by);
 }
 
 // ============================================================================
@@ -252,7 +253,7 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
       await syncRunningSummary(deps, event.orgId, (store) =>
         store.markStopped(event.orgId, event.taskId),
       );
-      emitUserRunningSummary(deps, failedThread?.created_by);
+      await emitUserRunningSummary(deps, failedThread?.created_by);
       return;
     }
 

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -57,6 +57,29 @@ async function syncRunningSummary(
   }
 }
 
+/**
+ * Fire-and-forget per-user (cross-org) summary on the `user:<id>` channel.
+ * Computed from the DB — lower-traffic than the org channel and where the
+ * agent-title join lives — and never awaited, so it can't slow a transition.
+ */
+function emitUserRunningSummary(
+  deps: RunReactorDeps,
+  userId: string | null | undefined,
+): void {
+  if (!userId) return;
+  deps.storage
+    .summarizeRunningForUser(userId)
+    .then((threads) =>
+      deps.sseHub.emit(
+        `user:${userId}`,
+        createDecopilotRunningSummaryEvent(threads),
+      ),
+    )
+    .catch((err) =>
+      console.error("[run-reactor] user running summary failed", err),
+    );
+}
+
 // ============================================================================
 // handleTerminalStatus — shared helper for RUN_COMPLETED / RUN_REQUIRES_ACTION
 // ============================================================================
@@ -92,6 +115,7 @@ async function handleTerminalStatus(
   await syncRunningSummary(deps, orgId, (store) =>
     store.markStopped(orgId, taskId),
   );
+  emitUserRunningSummary(deps, thread?.created_by);
 }
 
 // ============================================================================
@@ -129,8 +153,10 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
           id: event.taskId,
           virtual_mcp_id: startedThread?.virtual_mcp_id ?? "",
           title: startedThread?.title ?? null,
+          organization_id: event.orgId,
         }),
       );
+      emitUserRunningSummary(deps, startedThread?.created_by);
       return;
     }
 
@@ -156,8 +182,10 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
           id: event.taskId,
           virtual_mcp_id: resumedThread?.virtual_mcp_id ?? "",
           title: resumedThread?.title ?? null,
+          organization_id: event.orgId,
         }),
       );
+      emitUserRunningSummary(deps, resumedThread?.created_by);
       return;
     }
 
@@ -225,6 +253,7 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
       await syncRunningSummary(deps, event.orgId, (store) =>
         store.markStopped(event.orgId, event.taskId),
       );
+      emitUserRunningSummary(deps, failedThread?.created_by);
       return;
     }
 

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -14,10 +14,13 @@ import type { SSEEvent } from "@/event-bus";
 import type { ThreadStoragePort } from "@/storage/ports";
 import {
   createDecopilotFinishEvent,
+  createDecopilotRunningSummaryEvent,
   createDecopilotStepEvent,
   createDecopilotThreadStatusEvent,
+  type RunningThread,
 } from "@decocms/mesh-sdk";
 import type { StreamBuffer } from "./stream-buffer";
+import type { RunningThreadsStore } from "./running-threads-store";
 import type { RunEvent, RunTransition } from "./run-state";
 
 // ============================================================================
@@ -32,6 +35,26 @@ export interface RunReactorDeps {
   storage: ThreadStoragePort;
   streamBuffer: StreamBuffer;
   sseHub: { emit(orgId: string, event: SSEEvent): void };
+  /** Cross-pod running-thread set powering the home "agents working" badge. */
+  runningStore: RunningThreadsStore;
+}
+
+/**
+ * Apply a running-set mutation and broadcast the resulting summary through the
+ * SSE hub. Best-effort: the badge must never block or fail a run transition, so
+ * store/emit errors are swallowed.
+ */
+async function syncRunningSummary(
+  deps: RunReactorDeps,
+  orgId: string,
+  action: (store: RunningThreadsStore) => Promise<RunningThread[]>,
+): Promise<void> {
+  try {
+    const threads = await action(deps.runningStore);
+    deps.sseHub.emit(orgId, createDecopilotRunningSummaryEvent(threads));
+  } catch (err) {
+    console.error("[run-reactor] running summary sync failed", err);
+  }
 }
 
 // ============================================================================
@@ -66,6 +89,9 @@ async function handleTerminalStatus(
     }),
   );
   sseHub.emit(orgId, createDecopilotFinishEvent(taskId, status));
+  await syncRunningSummary(deps, orgId, (store) =>
+    store.markStopped(orgId, taskId),
+  );
 }
 
 // ============================================================================
@@ -98,6 +124,13 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
           updatedAt: startedThread?.updated_at,
         }),
       );
+      await syncRunningSummary(deps, event.orgId, (store) =>
+        store.markRunning(event.orgId, {
+          id: event.taskId,
+          virtual_mcp_id: startedThread?.virtual_mcp_id ?? "",
+          title: startedThread?.title ?? null,
+        }),
+      );
       return;
     }
 
@@ -118,6 +151,13 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
           updatedAt: resumedThread?.updated_at,
         }),
       );
+      await syncRunningSummary(deps, event.orgId, (store) =>
+        store.markRunning(event.orgId, {
+          id: event.taskId,
+          virtual_mcp_id: resumedThread?.virtual_mcp_id ?? "",
+          title: resumedThread?.title ?? null,
+        }),
+      );
       return;
     }
 
@@ -126,6 +166,9 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
         event.orgId,
         createDecopilotStepEvent(event.taskId, event.stepCount),
       );
+      // Refresh liveness so a long, actively-streaming run isn't pruned from
+      // the running count. Best-effort, no summary emit (count is unchanged).
+      deps.runningStore.touch(event.orgId, event.taskId).catch(() => {});
       return;
 
     case "RUN_COMPLETED":
@@ -178,6 +221,9 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
       sseHub.emit(
         event.orgId,
         createDecopilotFinishEvent(event.taskId, "failed"),
+      );
+      await syncRunningSummary(deps, event.orgId, (store) =>
+        store.markStopped(event.orgId, event.taskId),
       );
       return;
     }

--- a/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
@@ -38,7 +38,10 @@ import { RunRegistry } from "./run-registry";
 import type { RunReactorDeps } from "./run-reactor";
 import type { StreamBuffer } from "./stream-buffer";
 import { NoopRunningThreadsStore } from "./running-threads-store";
-import { DECOPILOT_RUNNING_SUMMARY_EVENT } from "@decocms/mesh-sdk";
+import {
+  DECOPILOT_RUNNING_SUMMARY_EVENT,
+  DECOPILOT_USER_RUNNING_SUMMARY_EVENT,
+} from "@decocms/mesh-sdk";
 
 const ORG = "org_1";
 const USER = "user_1";
@@ -79,8 +82,13 @@ function makeRegistry(opts: { clock?: () => Date } = {}) {
     storage,
     sseHub: {
       emit(orgId, event) {
-        // These tests assert the run-lifecycle sequence; drop the summary broadcast.
-        if (event.type === DECOPILOT_RUNNING_SUMMARY_EVENT) return;
+        // These tests assert the run-lifecycle sequence; drop the summary broadcasts.
+        if (
+          event.type === DECOPILOT_RUNNING_SUMMARY_EVENT ||
+          event.type === DECOPILOT_USER_RUNNING_SUMMARY_EVENT
+        ) {
+          return;
+        }
         sseEvents.push({ orgId, event });
       },
     },

--- a/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
@@ -79,8 +79,7 @@ function makeRegistry(opts: { clock?: () => Date } = {}) {
     storage,
     sseHub: {
       emit(orgId, event) {
-        // running.summary is an orthogonal cross-cutting broadcast; these
-        // tests assert the run-lifecycle event sequence, so filter it out.
+        // These tests assert the run-lifecycle sequence; drop the summary broadcast.
         if (event.type === DECOPILOT_RUNNING_SUMMARY_EVENT) return;
         sseEvents.push({ orgId, event });
       },

--- a/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
@@ -37,6 +37,8 @@ import type { Thread } from "@/storage/types";
 import { RunRegistry } from "./run-registry";
 import type { RunReactorDeps } from "./run-reactor";
 import type { StreamBuffer } from "./stream-buffer";
+import { NoopRunningThreadsStore } from "./running-threads-store";
+import { DECOPILOT_RUNNING_SUMMARY_EVENT } from "@decocms/mesh-sdk";
 
 const ORG = "org_1";
 const USER = "user_1";
@@ -77,6 +79,9 @@ function makeRegistry(opts: { clock?: () => Date } = {}) {
     storage,
     sseHub: {
       emit(orgId, event) {
+        // running.summary is an orthogonal cross-cutting broadcast; these
+        // tests assert the run-lifecycle event sequence, so filter it out.
+        if (event.type === DECOPILOT_RUNNING_SUMMARY_EVENT) return;
         sseEvents.push({ orgId, event });
       },
     },
@@ -85,6 +90,7 @@ function makeRegistry(opts: { clock?: () => Date } = {}) {
         purged.push(taskId);
       },
     } as unknown as StreamBuffer,
+    runningStore: new NoopRunningThreadsStore(),
   };
   const registry = opts.clock
     ? new RunRegistry(deps, opts.clock)

--- a/apps/mesh/src/api/routes/decopilot/run-registry.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { RunRegistry } from "./run-registry";
 import type { StreamBuffer } from "./stream-buffer";
 import type { RunReactorDeps } from "./run-reactor";
+import { NoopRunningThreadsStore } from "./running-threads-store";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,6 +42,7 @@ function inertDeps(): RunReactorDeps {
     } as unknown as RunReactorDeps["storage"],
     streamBuffer: { purge() {} } as unknown as StreamBuffer,
     sseHub: { emit() {} },
+    runningStore: new NoopRunningThreadsStore(),
   };
 }
 

--- a/apps/mesh/src/api/routes/decopilot/running-threads-store.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/running-threads-store.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { RUNNING_THREAD_IDLE_MS } from "@/core/constants";
+import { __test } from "./running-threads-store";
+
+const { prune, toRunningThreads } = __test;
+
+describe("running-threads-store prune", () => {
+  const now = 1_000_000_000;
+
+  it("keeps entries within the idle window", () => {
+    const org = { t1: { v: "a", t: "Alpha", p: now - 1000 } };
+    expect(prune(org, now)).toEqual(org);
+  });
+
+  it("drops entries idle past the timeout (orphaned runs self-heal)", () => {
+    const org = {
+      fresh: { v: "a", t: "Alpha", p: now - 1000 },
+      stale: { v: "b", t: "Beta", p: now - RUNNING_THREAD_IDLE_MS - 1 },
+    };
+    expect(prune(org, now)).toEqual({
+      fresh: { v: "a", t: "Alpha", p: now - 1000 },
+    });
+  });
+
+  it("keeps an entry exactly at the cutoff", () => {
+    const org = { edge: { v: "a", t: null, p: now - RUNNING_THREAD_IDLE_MS } };
+    expect(prune(org, now)).toEqual(org);
+  });
+});
+
+describe("running-threads-store toRunningThreads", () => {
+  it("maps stored entries to RunningThread shape", () => {
+    expect(
+      toRunningThreads({
+        t1: { v: "a", t: "Alpha", p: 1 },
+        t2: { v: "", t: null, p: 2 },
+      }),
+    ).toEqual([
+      { id: "t1", virtual_mcp_id: "a", title: "Alpha" },
+      { id: "t2", virtual_mcp_id: "", title: null },
+    ]);
+  });
+});

--- a/apps/mesh/src/api/routes/decopilot/running-threads-store.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/running-threads-store.test.ts
@@ -8,22 +8,29 @@ describe("running-threads-store prune", () => {
   const now = 1_000_000_000;
 
   it("keeps entries within the idle window", () => {
-    const org = { t1: { v: "a", t: "Alpha", p: now - 1000 } };
+    const org = { t1: { v: "a", t: "Alpha", o: "o1", p: now - 1000 } };
     expect(prune(org, now)).toEqual(org);
   });
 
   it("drops entries idle past the timeout (orphaned runs self-heal)", () => {
     const org = {
-      fresh: { v: "a", t: "Alpha", p: now - 1000 },
-      stale: { v: "b", t: "Beta", p: now - RUNNING_THREAD_IDLE_MS - 1 },
+      fresh: { v: "a", t: "Alpha", o: "o1", p: now - 1000 },
+      stale: {
+        v: "b",
+        t: "Beta",
+        o: "o1",
+        p: now - RUNNING_THREAD_IDLE_MS - 1,
+      },
     };
     expect(prune(org, now)).toEqual({
-      fresh: { v: "a", t: "Alpha", p: now - 1000 },
+      fresh: { v: "a", t: "Alpha", o: "o1", p: now - 1000 },
     });
   });
 
   it("keeps an entry exactly at the cutoff", () => {
-    const org = { edge: { v: "a", t: null, p: now - RUNNING_THREAD_IDLE_MS } };
+    const org = {
+      edge: { v: "a", t: null, o: "o1", p: now - RUNNING_THREAD_IDLE_MS },
+    };
     expect(prune(org, now)).toEqual(org);
   });
 });
@@ -32,12 +39,12 @@ describe("running-threads-store toRunningThreads", () => {
   it("maps stored entries to RunningThread shape", () => {
     expect(
       toRunningThreads({
-        t1: { v: "a", t: "Alpha", p: 1 },
-        t2: { v: "", t: null, p: 2 },
+        t1: { v: "a", t: "Alpha", o: "o1", p: 1 },
+        t2: { v: "", t: null, o: "o2", p: 2 },
       }),
     ).toEqual([
-      { id: "t1", virtual_mcp_id: "a", title: "Alpha" },
-      { id: "t2", virtual_mcp_id: "", title: null },
+      { id: "t1", virtual_mcp_id: "a", title: "Alpha", organization_id: "o1" },
+      { id: "t2", virtual_mcp_id: "", title: null, organization_id: "o2" },
     ]);
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/running-threads-store.ts
+++ b/apps/mesh/src/api/routes/decopilot/running-threads-store.ts
@@ -56,8 +56,10 @@ export interface RunningThreadsStore {
 interface StoredEntry {
   /** virtual_mcp_id; "" when agentless. */
   v: string;
-  /** agent title; null when unknown. */
+  /** thread title; null when untitled. */
   t: string | null;
+  /** organization id (the channel's org — kept so toRunningThreads is complete). */
+  o: string;
   /** lastProgressAt, epoch ms. */
   p: number;
 }
@@ -82,6 +84,7 @@ function toRunningThreads(org: StoredOrg): RunningThread[] {
     id,
     virtual_mcp_id: e.v,
     title: e.t,
+    organization_id: e.o,
   }));
 }
 
@@ -148,7 +151,12 @@ export class JetStreamKVRunningThreadsStore implements RunningThreadsStore {
   markRunning(orgId: string, thread: RunningThread): Promise<RunningThread[]> {
     return this.mutate(orgId, (org, now) => ({
       ...org,
-      [thread.id]: { v: thread.virtual_mcp_id, t: thread.title, p: now },
+      [thread.id]: {
+        v: thread.virtual_mcp_id,
+        t: thread.title,
+        o: thread.organization_id,
+        p: now,
+      },
     }));
   }
 

--- a/apps/mesh/src/api/routes/decopilot/running-threads-store.ts
+++ b/apps/mesh/src/api/routes/decopilot/running-threads-store.ts
@@ -1,24 +1,5 @@
 /**
  * Cross-pod running-thread set for the home "X agents working on N tasks" badge.
- *
- * The authoritative count is spread across pods (each pod's run registry only
- * knows its own in-flight runs), so this store materializes it in a shared
- * place. Two backends sit behind one interface:
- *
- *   - JetStreamKVRunningThreadsStore (prod): a NATS JetStream KV key per org
- *     holding the org's running threads. Cheap reads, cross-pod, and a per-entry
- *     `lastProgressAt` lets a crashed/orphaned run be pruned on the same idle
- *     timeline the reaper uses — without depending on the reaper (which only
- *     sweeps the owning pod's memory).
- *   - DbRunningThreadsStore (dev / no-NATS): reads the threads table directly via
- *     `summarizeRunning`. The reactor updates the row BEFORE calling the store,
- *     so a fresh read reflects the transition. Single-pod, so a per-transition
- *     query is fine.
- *
- * The run reactor calls markRunning/markStopped on each transition and emits the
- * returned list as a `decopilot.running.summary` event through the SSE hub. The
- * `/watch` connect snapshot is served separately from the DB (authoritative and
- * infrequent, so it sidesteps KV cold-start undercounts after a deploy).
  * Best-effort throughout: a counter for a homepage badge must never block or
  * fail a run.
  */
@@ -29,6 +10,7 @@ import {
   StorageType,
   type JetStreamClient,
   type KV,
+  type KvEntry,
 } from "nats";
 import type { RunningThread } from "@decocms/mesh-sdk";
 import {
@@ -38,13 +20,9 @@ import {
 import type { ThreadStoragePort } from "@/storage/ports";
 
 export interface RunningThreadsStore {
-  /** Record a thread as running; returns the org's current running set. */
   markRunning(orgId: string, thread: RunningThread): Promise<RunningThread[]>;
-  /** Record a thread as no longer running; returns the org's running set. */
   markStopped(orgId: string, threadId: string): Promise<RunningThread[]>;
-  /** Refresh a running thread's liveness (no emit). No-op if absent. */
   touch(orgId: string, threadId: string): Promise<void>;
-  /** Current running set for an org (stale entries excluded). */
   summarize(orgId: string): Promise<RunningThread[]>;
   teardown(): void;
 }
@@ -53,14 +31,11 @@ export interface RunningThreadsStore {
 // JetStream KV backend
 // ============================================================================
 
+// Compact stored shape; p = lastProgressAt (epoch ms), drives idle pruning.
 interface StoredEntry {
-  /** virtual_mcp_id; "" when agentless. */
   v: string;
-  /** thread title; null when untitled. */
   t: string | null;
-  /** organization id (the channel's org — kept so toRunningThreads is complete). */
   o: string;
-  /** lastProgressAt, epoch ms. */
   p: number;
 }
 
@@ -69,7 +44,6 @@ type StoredOrg = Record<string, StoredEntry>;
 const KV_BUCKET = "DECOCMS_RUNNING_THREADS";
 const MAX_CAS_ATTEMPTS = 5;
 
-/** Drop entries idle past the timeout (orphaned/crashed runs self-heal here). */
 function prune(org: StoredOrg, now: number): StoredOrg {
   const cutoff = now - RUNNING_THREAD_IDLE_MS;
   const out: StoredOrg = {};
@@ -98,19 +72,29 @@ export class JetStreamKVRunningThreadsStore implements RunningThreadsStore {
 
   async init(): Promise<void> {
     const js = this.options.getJetStream();
-    if (!js) return; // NATS not ready — paused until re-init
+    if (!js) return;
     this.kv = await js.views.kv(KV_BUCKET, {
       storage: StorageType.Memory,
       ttl: nanos(RUNNING_THREADS_KV_TTL_MS),
     });
   }
 
-  /**
-   * Optimistic read-modify-write across replicas, mirroring the connection
-   * circuit store: create() rejects if the key exists, update() rejects on a
-   * stale revision — both mean another replica raced us, so we retry. After a
-   * few attempts we give up; a lost update only briefly skews a cosmetic count.
-   */
+  private async read(
+    orgId: string,
+  ): Promise<{ live: KvEntry | null; org: StoredOrg }> {
+    const entry = await this.kv!.get(orgId);
+    const live =
+      entry &&
+      entry.operation !== "DEL" &&
+      entry.operation !== "PURGE" &&
+      entry.value?.length
+        ? entry
+        : null;
+    return { live, org: live ? this.codec.decode(live.value) : {} };
+  }
+
+  // Optimistic read-modify-write: create()/update() reject on a concurrent
+  // replica write, so we retry. A lost update only briefly skews the count.
   private async mutate(
     orgId: string,
     fn: (org: StoredOrg, now: number) => StoredOrg,
@@ -119,30 +103,19 @@ export class JetStreamKVRunningThreadsStore implements RunningThreadsStore {
     for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
       try {
         const now = Date.now();
-        const entry = await this.kv.get(orgId);
-        const live =
-          entry &&
-          entry.operation !== "DEL" &&
-          entry.operation !== "PURGE" &&
-          entry.value?.length;
-
-        const prev: StoredOrg = live ? this.codec.decode(entry.value) : {};
+        const { live, org: prev } = await this.read(orgId);
         const next = fn(prune(prev, now), now);
 
         if (Object.keys(next).length === 0) {
-          // Nothing running — drop the key so an idle org leaves no footprint.
           if (live) await this.kv.delete(orgId);
           return [];
         }
         const encoded = this.codec.encode(next);
-        if (live) {
-          await this.kv.update(orgId, encoded, entry.revision);
-        } else {
-          await this.kv.create(orgId, encoded);
-        }
+        if (live) await this.kv.update(orgId, encoded, live.revision);
+        else await this.kv.create(orgId, encoded);
         return toRunningThreads(next);
       } catch {
-        // create race / revision conflict — retry the read-modify-write
+        // create race / revision conflict — retry
       }
     }
     return [];
@@ -179,18 +152,8 @@ export class JetStreamKVRunningThreadsStore implements RunningThreadsStore {
   async summarize(orgId: string): Promise<RunningThread[]> {
     if (!this.kv) return [];
     try {
-      const entry = await this.kv.get(orgId);
-      if (
-        !entry ||
-        entry.operation === "DEL" ||
-        entry.operation === "PURGE" ||
-        !entry.value?.length
-      ) {
-        return [];
-      }
-      return toRunningThreads(
-        prune(this.codec.decode(entry.value), Date.now()),
-      );
+      const { org } = await this.read(orgId);
+      return toRunningThreads(prune(org, Date.now()));
     } catch {
       return [];
     }
@@ -202,14 +165,10 @@ export class JetStreamKVRunningThreadsStore implements RunningThreadsStore {
 }
 
 // ============================================================================
-// DB backend (dev / no-NATS)
+// DB backend (dev / no-NATS) — reactor updates the row before asking, so a
+// fresh read reflects the transition.
 // ============================================================================
 
-/**
- * Reads the threads table. The reactor updates the row's status BEFORE calling
- * markRunning/markStopped, so re-reading reflects the transition. Single-pod,
- * so a query per transition is acceptable.
- */
 export class DbRunningThreadsStore implements RunningThreadsStore {
   constructor(private readonly storage: ThreadStoragePort) {}
 
@@ -244,5 +203,4 @@ export class NoopRunningThreadsStore implements RunningThreadsStore {
   teardown(): void {}
 }
 
-// Exposed for unit tests.
 export const __test = { prune, toRunningThreads };

--- a/apps/mesh/src/api/routes/decopilot/running-threads-store.ts
+++ b/apps/mesh/src/api/routes/decopilot/running-threads-store.ts
@@ -1,0 +1,240 @@
+/**
+ * Cross-pod running-thread set for the home "X agents working on N tasks" badge.
+ *
+ * The authoritative count is spread across pods (each pod's run registry only
+ * knows its own in-flight runs), so this store materializes it in a shared
+ * place. Two backends sit behind one interface:
+ *
+ *   - JetStreamKVRunningThreadsStore (prod): a NATS JetStream KV key per org
+ *     holding the org's running threads. Cheap reads, cross-pod, and a per-entry
+ *     `lastProgressAt` lets a crashed/orphaned run be pruned on the same idle
+ *     timeline the reaper uses — without depending on the reaper (which only
+ *     sweeps the owning pod's memory).
+ *   - DbRunningThreadsStore (dev / no-NATS): reads the threads table directly via
+ *     `summarizeRunning`. The reactor updates the row BEFORE calling the store,
+ *     so a fresh read reflects the transition. Single-pod, so a per-transition
+ *     query is fine.
+ *
+ * The run reactor calls markRunning/markStopped on each transition and emits the
+ * returned list as a `decopilot.running.summary` event through the SSE hub. The
+ * `/watch` connect snapshot is served separately from the DB (authoritative and
+ * infrequent, so it sidesteps KV cold-start undercounts after a deploy).
+ * Best-effort throughout: a counter for a homepage badge must never block or
+ * fail a run.
+ */
+
+import {
+  JSONCodec,
+  nanos,
+  StorageType,
+  type JetStreamClient,
+  type KV,
+} from "nats";
+import type { RunningThread } from "@decocms/mesh-sdk";
+import {
+  RUNNING_THREAD_IDLE_MS,
+  RUNNING_THREADS_KV_TTL_MS,
+} from "@/core/constants";
+import type { ThreadStoragePort } from "@/storage/ports";
+
+export interface RunningThreadsStore {
+  /** Record a thread as running; returns the org's current running set. */
+  markRunning(orgId: string, thread: RunningThread): Promise<RunningThread[]>;
+  /** Record a thread as no longer running; returns the org's running set. */
+  markStopped(orgId: string, threadId: string): Promise<RunningThread[]>;
+  /** Refresh a running thread's liveness (no emit). No-op if absent. */
+  touch(orgId: string, threadId: string): Promise<void>;
+  /** Current running set for an org (stale entries excluded). */
+  summarize(orgId: string): Promise<RunningThread[]>;
+  teardown(): void;
+}
+
+// ============================================================================
+// JetStream KV backend
+// ============================================================================
+
+interface StoredEntry {
+  /** virtual_mcp_id; "" when agentless. */
+  v: string;
+  /** agent title; null when unknown. */
+  t: string | null;
+  /** lastProgressAt, epoch ms. */
+  p: number;
+}
+
+type StoredOrg = Record<string, StoredEntry>;
+
+const KV_BUCKET = "DECOCMS_RUNNING_THREADS";
+const MAX_CAS_ATTEMPTS = 5;
+
+/** Drop entries idle past the timeout (orphaned/crashed runs self-heal here). */
+function prune(org: StoredOrg, now: number): StoredOrg {
+  const cutoff = now - RUNNING_THREAD_IDLE_MS;
+  const out: StoredOrg = {};
+  for (const [id, e] of Object.entries(org)) {
+    if (e.p >= cutoff) out[id] = e;
+  }
+  return out;
+}
+
+function toRunningThreads(org: StoredOrg): RunningThread[] {
+  return Object.entries(org).map(([id, e]) => ({
+    id,
+    virtual_mcp_id: e.v,
+    title: e.t,
+  }));
+}
+
+export class JetStreamKVRunningThreadsStore implements RunningThreadsStore {
+  private kv: KV | null = null;
+  private readonly codec = JSONCodec<StoredOrg>();
+
+  constructor(
+    private readonly options: { getJetStream: () => JetStreamClient | null },
+  ) {}
+
+  async init(): Promise<void> {
+    const js = this.options.getJetStream();
+    if (!js) return; // NATS not ready — paused until re-init
+    this.kv = await js.views.kv(KV_BUCKET, {
+      storage: StorageType.Memory,
+      ttl: nanos(RUNNING_THREADS_KV_TTL_MS),
+    });
+  }
+
+  /**
+   * Optimistic read-modify-write across replicas, mirroring the connection
+   * circuit store: create() rejects if the key exists, update() rejects on a
+   * stale revision — both mean another replica raced us, so we retry. After a
+   * few attempts we give up; a lost update only briefly skews a cosmetic count.
+   */
+  private async mutate(
+    orgId: string,
+    fn: (org: StoredOrg, now: number) => StoredOrg,
+  ): Promise<RunningThread[]> {
+    if (!this.kv) return [];
+    for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+      try {
+        const now = Date.now();
+        const entry = await this.kv.get(orgId);
+        const live =
+          entry &&
+          entry.operation !== "DEL" &&
+          entry.operation !== "PURGE" &&
+          entry.value?.length;
+
+        const prev: StoredOrg = live ? this.codec.decode(entry.value) : {};
+        const next = fn(prune(prev, now), now);
+
+        if (Object.keys(next).length === 0) {
+          // Nothing running — drop the key so an idle org leaves no footprint.
+          if (live) await this.kv.delete(orgId);
+          return [];
+        }
+        const encoded = this.codec.encode(next);
+        if (live) {
+          await this.kv.update(orgId, encoded, entry.revision);
+        } else {
+          await this.kv.create(orgId, encoded);
+        }
+        return toRunningThreads(next);
+      } catch {
+        // create race / revision conflict — retry the read-modify-write
+      }
+    }
+    return [];
+  }
+
+  markRunning(orgId: string, thread: RunningThread): Promise<RunningThread[]> {
+    return this.mutate(orgId, (org, now) => ({
+      ...org,
+      [thread.id]: { v: thread.virtual_mcp_id, t: thread.title, p: now },
+    }));
+  }
+
+  markStopped(orgId: string, threadId: string): Promise<RunningThread[]> {
+    return this.mutate(orgId, (org) => {
+      if (!(threadId in org)) return org;
+      const { [threadId]: _removed, ...rest } = org;
+      return rest;
+    });
+  }
+
+  async touch(orgId: string, threadId: string): Promise<void> {
+    await this.mutate(orgId, (org, now) => {
+      const e = org[threadId];
+      if (!e) return org;
+      return { ...org, [threadId]: { ...e, p: now } };
+    });
+  }
+
+  async summarize(orgId: string): Promise<RunningThread[]> {
+    if (!this.kv) return [];
+    try {
+      const entry = await this.kv.get(orgId);
+      if (
+        !entry ||
+        entry.operation === "DEL" ||
+        entry.operation === "PURGE" ||
+        !entry.value?.length
+      ) {
+        return [];
+      }
+      return toRunningThreads(
+        prune(this.codec.decode(entry.value), Date.now()),
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  teardown(): void {
+    this.kv = null;
+  }
+}
+
+// ============================================================================
+// DB backend (dev / no-NATS)
+// ============================================================================
+
+/**
+ * Reads the threads table. The reactor updates the row's status BEFORE calling
+ * markRunning/markStopped, so re-reading reflects the transition. Single-pod,
+ * so a query per transition is acceptable.
+ */
+export class DbRunningThreadsStore implements RunningThreadsStore {
+  constructor(private readonly storage: ThreadStoragePort) {}
+
+  markRunning(orgId: string): Promise<RunningThread[]> {
+    return this.storage.summarizeRunning(orgId);
+  }
+  markStopped(orgId: string): Promise<RunningThread[]> {
+    return this.storage.summarizeRunning(orgId);
+  }
+  async touch(): Promise<void> {}
+  summarize(orgId: string): Promise<RunningThread[]> {
+    return this.storage.summarizeRunning(orgId);
+  }
+  teardown(): void {}
+}
+
+// ============================================================================
+// Noop (tests)
+// ============================================================================
+
+export class NoopRunningThreadsStore implements RunningThreadsStore {
+  async markRunning(): Promise<RunningThread[]> {
+    return [];
+  }
+  async markStopped(): Promise<RunningThread[]> {
+    return [];
+  }
+  async touch(): Promise<void> {}
+  async summarize(): Promise<RunningThread[]> {
+    return [];
+  }
+  teardown(): void {}
+}
+
+// Exposed for unit tests.
+export const __test = { prune, toRunningThreads };

--- a/apps/mesh/src/core/constants.ts
+++ b/apps/mesh/src/core/constants.ts
@@ -62,6 +62,22 @@ export const CONNECTION_DISABLE_MIN_WINDOW_MS = 60_000; // 60 seconds
 export const CONNECTION_CIRCUIT_TTL_MS = 5 * 60_000; // 5 minutes
 
 /**
+ * A running-thread entry is pruned from the home "X agents working on N tasks"
+ * count if its last progress is older than this. Matches the decopilot reaper's
+ * `RUN_IDLE_TIMEOUT_MS` so the badge drops a crashed/orphaned run on the same
+ * timeline the reaper force-fails it — without depending on the reaper, which
+ * only sweeps runs in the owning pod's memory.
+ */
+export const RUNNING_THREAD_IDLE_MS = 10 * 60_000; // 10 minutes
+
+/**
+ * Bucket TTL for the running-threads KV key. Refreshed on every write, so an
+ * org with active runs keeps its key alive; an org that goes fully quiet lets
+ * the whole key expire. Set comfortably above RUNNING_THREAD_IDLE_MS.
+ */
+export const RUNNING_THREADS_KV_TTL_MS = 30 * 60_000; // 30 minutes
+
+/**
  * Cooldown before an auto-disabled (status="error") connection is re-probed.
  * After this window a single request triggers a half-open handshake; success
  * re-activates the connection, failure restarts the window. Manual "inactive"

--- a/apps/mesh/src/core/constants.ts
+++ b/apps/mesh/src/core/constants.ts
@@ -61,20 +61,10 @@ export const CONNECTION_DISABLE_MIN_WINDOW_MS = 60_000; // 60 seconds
 /** TTL for shared failure-counter entries — a connection that stops failing self-resets. */
 export const CONNECTION_CIRCUIT_TTL_MS = 5 * 60_000; // 5 minutes
 
-/**
- * A running-thread entry is pruned from the home "X agents working on N tasks"
- * count if its last progress is older than this. Matches the decopilot reaper's
- * `RUN_IDLE_TIMEOUT_MS` so the badge drops a crashed/orphaned run on the same
- * timeline the reaper force-fails it — without depending on the reaper, which
- * only sweeps runs in the owning pod's memory.
- */
+/** Prune a running-thread entry whose last progress is older than this — matches the reaper's idle timeout. */
 export const RUNNING_THREAD_IDLE_MS = 10 * 60_000; // 10 minutes
 
-/**
- * Bucket TTL for the running-threads KV key. Refreshed on every write, so an
- * org with active runs keeps its key alive; an org that goes fully quiet lets
- * the whole key expire. Set comfortably above RUNNING_THREAD_IDLE_MS.
- */
+/** TTL for the running-threads KV key, refreshed on every write. Keep above RUNNING_THREAD_IDLE_MS. */
 export const RUNNING_THREADS_KV_TTL_MS = 30 * 60_000; // 30 minutes
 
 /**

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -9,6 +9,7 @@ import type {
   OrderByExpression,
   WhereExpression,
 } from "@decocms/bindings/collections";
+import type { RunningThread } from "@decocms/mesh-sdk";
 import type { ConnectionEntity } from "../tools/connection/schema";
 import type {
   VirtualMCPEntity,
@@ -105,6 +106,14 @@ export interface ThreadStoragePort {
     organizationId: string,
     virtualMcpIds: string[],
   ): Promise<Map<string, { last_used_at: string; last_used_by: string }>>;
+
+  /**
+   * Threads currently `in_progress` for an org, each tagged with its agent
+   * (virtual MCP) title. Backs the home "X agents working on N tasks" snapshot
+   * emitted on `/watch` connect. Org-wide and authoritative (cross-pod), unlike
+   * the per-pod in-memory run registry.
+   */
+  summarizeRunning(organizationId: string): Promise<RunningThread[]>;
 
   // Message operations - upserts by id (updates existing rows)
   saveMessages(data: ThreadMessage[], organizationId: string): Promise<void>;

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -107,20 +107,10 @@ export interface ThreadStoragePort {
     virtualMcpIds: string[],
   ): Promise<Map<string, { last_used_at: string; last_used_by: string }>>;
 
-  /**
-   * Threads currently `in_progress` for an org, each tagged with its agent
-   * (virtual MCP) title. Backs the home "X agents working on N tasks" snapshot
-   * emitted on `/watch` connect. Org-wide and authoritative (cross-pod), unlike
-   * the per-pod in-memory run registry.
-   */
+  /** An org's `in_progress` threads — backs the home running-summary snapshot. */
   summarizeRunning(organizationId: string): Promise<RunningThread[]>;
 
-  /**
-   * A user's in_progress threads across EVERY org they're a member of — backs
-   * the per-user "all my work" feed. Membership-gated and not org-scoped.
-   * `agent_title` is resolved here since cross-org agents can't be resolved on
-   * the client.
-   */
+  /** A user's `in_progress` threads across every org they're a member of (membership-gated, agent_title resolved server-side). */
   summarizeRunningForUser(userId: string): Promise<RunningThread[]>;
 
   // Message operations - upserts by id (updates existing rows)

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -115,6 +115,14 @@ export interface ThreadStoragePort {
    */
   summarizeRunning(organizationId: string): Promise<RunningThread[]>;
 
+  /**
+   * A user's in_progress threads across EVERY org they're a member of — backs
+   * the per-user "all my work" feed. Membership-gated and not org-scoped.
+   * `agent_title` is resolved here since cross-org agents can't be resolved on
+   * the client.
+   */
+  summarizeRunningForUser(userId: string): Promise<RunningThread[]>;
+
   // Message operations - upserts by id (updates existing rows)
   saveMessages(data: ThreadMessage[], organizationId: string): Promise<void>;
   listMessages(

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -23,6 +23,24 @@ function toIsoString(v: Date | string): string {
   return typeof v === "string" ? v : v.toISOString();
 }
 
+function toRunningThread(row: {
+  id: string;
+  virtual_mcp_id: string | null;
+  title: string | null;
+  organization_id: string;
+  agent_title?: string | null;
+}): RunningThread {
+  const thread: RunningThread = {
+    id: row.id,
+    virtual_mcp_id: row.virtual_mcp_id ?? "",
+    title: row.title ?? null,
+    organization_id: row.organization_id,
+  };
+  if (row.agent_title !== undefined)
+    thread.agent_title = row.agent_title ?? null;
+  return thread;
+}
+
 // ============================================================================
 // Org-Scoped Thread Storage (repository pattern)
 // ============================================================================
@@ -590,9 +608,8 @@ export class SqlThreadStorage implements ThreadStoragePort {
   }
 
   async summarizeRunning(organizationId: string): Promise<RunningThread[]> {
-    // Org feed: thread id + agent id + thread title. The agent display
-    // name/icon is resolved client-side from virtual_mcp_id (same org), so no
-    // connections join here.
+    // No connections join: the agent name/icon is resolved client-side from
+    // virtual_mcp_id (same org).
     const rows = await this.db
       .selectFrom("threads")
       .select(["id", "virtual_mcp_id", "title", "organization_id"])
@@ -601,19 +618,12 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .where("hidden", "=", false)
       .execute();
 
-    return rows.map((row) => ({
-      id: row.id,
-      virtual_mcp_id: row.virtual_mcp_id ?? "",
-      title: row.title ?? null,
-      organization_id: row.organization_id,
-    }));
+    return rows.map(toRunningThread);
   }
 
   async summarizeRunningForUser(userId: string): Promise<RunningThread[]> {
-    // Per-user (cross-org) feed: the user's own in_progress threads in every
-    // org they're STILL a member of (the member join is the access gate). The
-    // connections join resolves the agent title, since the client can't resolve
-    // a cross-org agent from the current org's cache.
+    // The member join is the access gate; the connections join resolves the
+    // agent title, which the client can't do for a cross-org agent.
     const rows = await this.db
       .selectFrom("threads as t")
       .innerJoin("member as m", (join) =>
@@ -634,13 +644,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .where("t.hidden", "=", false)
       .execute();
 
-    return rows.map((row) => ({
-      id: row.id,
-      virtual_mcp_id: row.virtual_mcp_id ?? "",
-      title: row.title ?? null,
-      organization_id: row.organization_id,
-      agent_title: row.agent_title ?? null,
-    }));
+    return rows.map(toRunningThread);
   }
 
   async findLastUsedByVirtualMcpIds(

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -125,6 +125,11 @@ export class OrgScopedThreadStorage {
     return this.inner.summarizeRunning(this.requireOrg());
   }
 
+  /** Cross-org by design (the per-user feed) — intentionally not org-bound. */
+  summarizeRunningForUser(userId: string): Promise<RunningThread[]> {
+    return this.inner.summarizeRunningForUser(userId);
+  }
+
   findLastUsedByVirtualMcpIds(
     virtualMcpIds: string[],
   ): Promise<Map<string, { last_used_at: string; last_used_by: string }>> {

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -585,17 +585,14 @@ export class SqlThreadStorage implements ThreadStoragePort {
   }
 
   async summarizeRunning(organizationId: string): Promise<RunningThread[]> {
-    // Left-join so a running thread with a missing/empty virtual_mcp_id still
-    // appears (counts toward "N tasks", not toward "X agents"). `connections`
-    // holds the agent (VIRTUAL connection) the thread runs under; its `title`
-    // is the agent display name.
+    // Thread id + its agent (virtual_mcp_id) + the thread's own title. The agent
+    // display name/icon is resolved client-side from virtual_mcp_id, so no join.
     const rows = await this.db
-      .selectFrom("threads as t")
-      .leftJoin("connections as c", "c.id", "t.virtual_mcp_id")
-      .select(["t.id as id", "t.virtual_mcp_id as virtual_mcp_id", "c.title"])
-      .where("t.organization_id", "=", organizationId)
-      .where("t.status", "=", "in_progress")
-      .where("t.hidden", "=", false)
+      .selectFrom("threads")
+      .select(["id", "virtual_mcp_id", "title"])
+      .where("organization_id", "=", organizationId)
+      .where("status", "=", "in_progress")
+      .where("hidden", "=", false)
       .execute();
 
     return rows.map((row) => ({

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -585,11 +585,12 @@ export class SqlThreadStorage implements ThreadStoragePort {
   }
 
   async summarizeRunning(organizationId: string): Promise<RunningThread[]> {
-    // Thread id + its agent (virtual_mcp_id) + the thread's own title. The agent
-    // display name/icon is resolved client-side from virtual_mcp_id, so no join.
+    // Org feed: thread id + agent id + thread title. The agent display
+    // name/icon is resolved client-side from virtual_mcp_id (same org), so no
+    // connections join here.
     const rows = await this.db
       .selectFrom("threads")
-      .select(["id", "virtual_mcp_id", "title"])
+      .select(["id", "virtual_mcp_id", "title", "organization_id"])
       .where("organization_id", "=", organizationId)
       .where("status", "=", "in_progress")
       .where("hidden", "=", false)
@@ -599,6 +600,41 @@ export class SqlThreadStorage implements ThreadStoragePort {
       id: row.id,
       virtual_mcp_id: row.virtual_mcp_id ?? "",
       title: row.title ?? null,
+      organization_id: row.organization_id,
+    }));
+  }
+
+  async summarizeRunningForUser(userId: string): Promise<RunningThread[]> {
+    // Per-user (cross-org) feed: the user's own in_progress threads in every
+    // org they're STILL a member of (the member join is the access gate). The
+    // connections join resolves the agent title, since the client can't resolve
+    // a cross-org agent from the current org's cache.
+    const rows = await this.db
+      .selectFrom("threads as t")
+      .innerJoin("member as m", (join) =>
+        join
+          .onRef("m.organizationId", "=", "t.organization_id")
+          .on("m.userId", "=", userId),
+      )
+      .leftJoin("connections as c", "c.id", "t.virtual_mcp_id")
+      .select([
+        "t.id as id",
+        "t.virtual_mcp_id as virtual_mcp_id",
+        "t.title as title",
+        "t.organization_id as organization_id",
+        "c.title as agent_title",
+      ])
+      .where("t.created_by", "=", userId)
+      .where("t.status", "=", "in_progress")
+      .where("t.hidden", "=", false)
+      .execute();
+
+    return rows.map((row) => ({
+      id: row.id,
+      virtual_mcp_id: row.virtual_mcp_id ?? "",
+      title: row.title ?? null,
+      organization_id: row.organization_id,
+      agent_title: row.agent_title ?? null,
     }));
   }
 

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -6,6 +6,7 @@
  */
 
 import { sql, type Kysely } from "kysely";
+import type { RunningThread } from "@decocms/mesh-sdk";
 import { generatePrefixedId } from "@/shared/utils/generate-id";
 import { DEFAULT_THREAD_TITLE } from "@/api/routes/decopilot/constants";
 import type { ThreadStoragePort } from "./ports";
@@ -118,6 +119,10 @@ export class OrgScopedThreadStorage {
     options?: { limit?: number; offset?: number },
   ): Promise<{ threads: Thread[]; total: number }> {
     return this.inner.listByTriggerIds(this.requireOrg(), triggerIds, options);
+  }
+
+  summarizeRunning(): Promise<RunningThread[]> {
+    return this.inner.summarizeRunning(this.requireOrg());
   }
 
   findLastUsedByVirtualMcpIds(
@@ -577,6 +582,27 @@ export class SqlThreadStorage implements ThreadStoragePort {
       threads: rows.map((row) => this.threadFromDbRow(row)),
       total: Number(countResult?.count || 0),
     };
+  }
+
+  async summarizeRunning(organizationId: string): Promise<RunningThread[]> {
+    // Left-join so a running thread with a missing/empty virtual_mcp_id still
+    // appears (counts toward "N tasks", not toward "X agents"). `connections`
+    // holds the agent (VIRTUAL connection) the thread runs under; its `title`
+    // is the agent display name.
+    const rows = await this.db
+      .selectFrom("threads as t")
+      .leftJoin("connections as c", "c.id", "t.virtual_mcp_id")
+      .select(["t.id as id", "t.virtual_mcp_id as virtual_mcp_id", "c.title"])
+      .where("t.organization_id", "=", organizationId)
+      .where("t.status", "=", "in_progress")
+      .where("t.hidden", "=", false)
+      .execute();
+
+    return rows.map((row) => ({
+      id: row.id,
+      virtual_mcp_id: row.virtual_mcp_id ?? "",
+      title: row.title ?? null,
+    }));
   }
 
   async findLastUsedByVirtualMcpIds(

--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -63,7 +63,7 @@ function getOrgColorStyle(name: string): {
   };
 }
 
-function OrgIcon({
+export function OrgIcon({
   org,
   size = "sm",
 }: {

--- a/apps/mesh/src/web/components/details/workflow/hooks/use-workflow-sse.ts
+++ b/apps/mesh/src/web/components/details/workflow/hooks/use-workflow-sse.ts
@@ -15,24 +15,10 @@
 import { useSyncExternalStore } from "react";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { useProjectContext } from "@decocms/mesh-sdk";
-import { createSSESubscription } from "../../../../hooks/create-sse-subscription";
+import { workflowWatchView } from "../../../../hooks/watch-sse-pool";
 
-// ============================================================================
-// Shared connection pool
-// ============================================================================
-
-const WORKFLOW_EVENT_TYPES = [
-  "workflow.execution.created",
-  "workflow.execution.resumed",
-  "workflow.step.execute",
-  "workflow.step.completed",
-];
-
-const workflowSSE = createSSESubscription({
-  buildUrl: (orgSlug) =>
-    `/api/${encodeURIComponent(orgSlug)}/watch?types=workflow.*`,
-  eventTypes: WORKFLOW_EVENT_TYPES,
-});
+// Workflow view of the unified `/watch` pool (watch-sse-pool.ts).
+const workflowSSE = workflowWatchView;
 
 /** Tool names whose query caches should be invalidated on workflow events */
 const INVALIDATION_TARGETS = [

--- a/apps/mesh/src/web/hooks/create-sse-subscription.ts
+++ b/apps/mesh/src/web/hooks/create-sse-subscription.ts
@@ -1,62 +1,67 @@
 /**
- * Shared SSE subscription factory
- *
- * Manages ref-counted EventSource connections so multiple React components
- * can subscribe to the same SSE endpoint without opening duplicate connections.
- *
- * Each call to `createSSESubscription` creates an independent connection pool
- * keyed by a caller-provided key (typically an orgId).
- *
- * Reconnection: When EventSource enters CLOSED state (server restart, network
- * change), the connection is automatically re-established with exponential
- * backoff (1s → 2s → 4s, capped at 30s). Existing event listeners are
- * re-attached to the new EventSource transparently, and any subscriber that
- * registered an `onReconnect` callback is invoked once the re-established
- * connection opens (initial connect does NOT fire `onReconnect`).
+ * Shared SSE subscription factory. Within a tab, subscribers for the same key
+ * share one ref-counted EventSource. With `crossTab`, exactly one tab per key
+ * holds the real EventSource (leader, elected via a Web Lock) and rebroadcasts
+ * events over a BroadcastChannel — so the whole browser stays under the ~6
+ * connections-per-origin HTTP/1.1 cap. Same-origin tabs share cookies (same
+ * user), so keying by org slug is safe.
  */
 
 import { exponentialBackoffWithJitter } from "@decocms/std";
 
-/** Max reconnect delay in ms */
 const MAX_RECONNECT_DELAY_MS = 30_000;
-/** Base reconnect delay in ms */
 const BASE_RECONNECT_DELAY_MS = 1_000;
 
+type Handler = (e: MessageEvent) => void;
+
+type ChannelMessage =
+  | { kind: "event"; type: string; data: string }
+  | { kind: "reconnect" }
+  | { kind: "hello" };
+
 interface SharedConnection {
-  es: EventSource;
+  key: string;
   refCount: number;
-  /** Active handlers to re-attach after reconnect */
-  handlers: Set<(e: MessageEvent) => void>;
+  handlers: Set<Handler>;
   /** Per-subscriber callbacks fired after a re-establishment (not initial open). */
   reconnectHandlers: Set<() => void>;
-  /** Current reconnect attempt (reset on successful open) */
+  /** Latest event per sticky type, replayed to new subscribers / late tabs. */
+  sticky: Map<string, MessageEvent>;
+  /** First open is initial connect; a later open is a re-establishment. */
+  bootDone: boolean;
+
+  es: EventSource | null;
+  isLeader: boolean;
   reconnectAttempt: number;
-  /** Pending reconnect timer */
   reconnectTimer: ReturnType<typeof setTimeout> | null;
+
+  channel: BroadcastChannel | null;
+  /** Aborts a pending Web Lock request on teardown. */
+  lockAbort: AbortController | null;
+  /** Resolving this frees the held Web Lock (relinquishes leadership). */
+  releaseLeadership: (() => void) | null;
 }
 
 export interface SSESubscriptionOptions {
-  /** URL builder given a connection key */
   buildUrl: (key: string) => string;
-  /** SSE event types to listen for */
   eventTypes: string[];
+  /** Web Lock + BroadcastChannel namespace; required when `crossTab` is on. */
+  name?: string;
+  /** Event types cached and replayed to new subscribers / late tabs (snapshot semantics). */
+  stickyTypes?: string[];
+  /** Share one EventSource across same-origin tabs; falls back to per-tab when unsupported. */
+  crossTab?: boolean;
 }
 
 export interface SSESubscription {
   /**
-   * Subscribe to SSE events for the given key.
-   * Returns an unsubscribe function.
-   *
-   * Multiple subscribers share one EventSource per key; the connection
-   * is closed when the last subscriber unsubscribes.
-   *
-   * @param onReconnect Optional. Fired once each time the underlying
-   * EventSource is re-established after a drop. NOT fired on the first
-   * successful connect — subscribers do their own initial load.
+   * Subscribe to SSE events for the given key; returns an unsubscribe function.
+   * `onReconnect` fires after each re-establishment (drop or leadership
+   * hand-off), never on the first connect — subscribers do their own initial load.
    */
   subscribe: (
     key: string,
-    handler: (e: MessageEvent) => void,
+    handler: Handler,
     onReconnect?: () => void,
   ) => () => void;
 }
@@ -64,51 +69,80 @@ export interface SSESubscription {
 export function createSSESubscription(
   options: SSESubscriptionOptions,
 ): SSESubscription {
-  const { buildUrl, eventTypes } = options;
+  const { buildUrl, eventTypes, name, stickyTypes, crossTab = false } = options;
+  const stickySet = new Set(stickyTypes ?? []);
   const connections = new Map<string, SharedConnection>();
 
-  function attachListeners(
-    es: EventSource,
-    handlers: Set<(e: MessageEvent) => void>,
-  ): void {
-    for (const type of eventTypes) {
-      for (const handler of handlers) {
-        es.addEventListener(type, handler);
+  const supportsCrossTab =
+    crossTab &&
+    typeof BroadcastChannel !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    typeof navigator.locks !== "undefined";
+
+  if (supportsCrossTab && !name) {
+    throw new Error("createSSESubscription: `name` is required when crossTab");
+  }
+
+  /** Deliver an event to every local handler + update sticky cache. */
+  function deliver(conn: SharedConnection, ev: MessageEvent): void {
+    if (stickySet.has(ev.type)) conn.sticky.set(ev.type, ev);
+    conn.bootDone = true;
+    for (const handler of conn.handlers) {
+      try {
+        handler(ev);
+      } catch {
+        // a misbehaving subscriber must not break fan-out
       }
     }
   }
 
-  function createEventSource(
-    key: string,
-    conn: SharedConnection,
-    fireReconnect: boolean,
-  ): void {
-    const es = new EventSource(buildUrl(key));
+  /** Fire local onReconnect callbacks (after a drop / leadership hand-off). */
+  function fireReconnect(conn: SharedConnection): void {
+    for (const cb of conn.reconnectHandlers) {
+      try {
+        cb();
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  function createEventSource(conn: SharedConnection): void {
+    const es = new EventSource(buildUrl(conn.key));
+    conn.es = es;
 
     es.onopen = () => {
       conn.reconnectAttempt = 0;
-      if (fireReconnect) {
-        for (const cb of conn.reconnectHandlers) cb();
+      // Re-establishment (network blip / leadership promotion); skip initial connect.
+      if (conn.bootDone) {
+        fireReconnect(conn);
+        conn.channel?.postMessage({
+          kind: "reconnect",
+        } satisfies ChannelMessage);
       }
+      conn.bootDone = true;
     };
 
     es.onerror = () => {
-      if (es.readyState === EventSource.CLOSED) {
-        scheduleReconnect(key, conn);
+      if (conn.es === es && es.readyState === EventSource.CLOSED) {
+        scheduleReconnect(conn);
       }
     };
 
-    conn.es = es;
-    attachListeners(es, conn.handlers);
+    const relay: Handler = (e) => {
+      conn.channel?.postMessage({
+        kind: "event",
+        type: e.type,
+        data: e.data,
+      } satisfies ChannelMessage);
+      deliver(conn, e);
+    };
+
+    for (const type of eventTypes) es.addEventListener(type, relay);
   }
 
-  function scheduleReconnect(key: string, conn: SharedConnection): void {
-    if (conn.refCount <= 0) {
-      connections.delete(key);
-      return;
-    }
-
-    if (conn.reconnectTimer) return;
+  function scheduleReconnect(conn: SharedConnection): void {
+    if (conn.refCount <= 0 || conn.reconnectTimer) return;
 
     const delay = exponentialBackoffWithJitter(
       MAX_RECONNECT_DELAY_MS,
@@ -121,32 +155,123 @@ export function createSSESubscription(
 
     conn.reconnectTimer = setTimeout(() => {
       conn.reconnectTimer = null;
-
-      if (conn.refCount <= 0) {
-        connections.delete(key);
-        return;
-      }
-
-      conn.es.close();
-      createEventSource(key, conn, /* fireReconnect */ true);
+      if (conn.refCount <= 0 || !conn.isLeader) return;
+      conn.es?.close();
+      createEventSource(conn);
     }, delay);
   }
 
-  function getOrCreate(key: string): SharedConnection {
-    let conn = connections.get(key);
-    if (!conn) {
-      conn = {
-        es: null!,
-        refCount: 0,
-        handlers: new Set(),
-        reconnectHandlers: new Set(),
-        reconnectAttempt: 0,
-        reconnectTimer: null,
-      };
-      createEventSource(key, conn, /* fireReconnect */ false);
-      connections.set(key, conn);
+  function becomeLeader(conn: SharedConnection): void {
+    if (conn.refCount <= 0) {
+      conn.releaseLeadership?.();
+      conn.releaseLeadership = null;
+      return;
     }
+    conn.isLeader = true;
+    createEventSource(conn);
+  }
+
+  function requestLeadership(conn: SharedConnection): void {
+    if (!supportsCrossTab) {
+      becomeLeader(conn);
+      return;
+    }
+    conn.lockAbort = new AbortController();
+    navigator.locks
+      .request(
+        `sse-leader:${name}:${conn.key}`,
+        { signal: conn.lockAbort.signal },
+        () =>
+          new Promise<void>((resolve) => {
+            conn.releaseLeadership = resolve;
+            becomeLeader(conn);
+          }),
+      )
+      .catch(() => {
+        // AbortError on teardown, or transient lock errors — nothing to do.
+      });
+  }
+
+  function handleChannelMessage(
+    conn: SharedConnection,
+    msg: ChannelMessage,
+  ): void {
+    if (msg.kind === "event") {
+      deliver(conn, new MessageEvent(msg.type, { data: msg.data }));
+    } else if (msg.kind === "reconnect") {
+      fireReconnect(conn);
+    } else if (msg.kind === "hello") {
+      // New tab joined — replay sticky snapshots so it paints current state.
+      if (conn.isLeader) {
+        for (const ev of conn.sticky.values()) {
+          conn.channel?.postMessage({
+            kind: "event",
+            type: ev.type,
+            data: ev.data,
+          } satisfies ChannelMessage);
+        }
+      }
+    }
+  }
+
+  function getOrCreate(key: string): SharedConnection {
+    const existing = connections.get(key);
+    if (existing) return existing;
+
+    const conn: SharedConnection = {
+      key,
+      refCount: 0,
+      handlers: new Set(),
+      reconnectHandlers: new Set(),
+      sticky: new Map(),
+      bootDone: false,
+      es: null,
+      isLeader: false,
+      reconnectAttempt: 0,
+      reconnectTimer: null,
+      channel: null,
+      lockAbort: null,
+      releaseLeadership: null,
+    };
+    connections.set(key, conn);
+
+    if (supportsCrossTab) {
+      const channel = new BroadcastChannel(`sse:${name}:${key}`);
+      channel.onmessage = (e) =>
+        handleChannelMessage(conn, e.data as ChannelMessage);
+      conn.channel = channel;
+      // Ask any existing leader to replay its sticky snapshots to us.
+      channel.postMessage({ kind: "hello" } satisfies ChannelMessage);
+    }
+
+    requestLeadership(conn);
     return conn;
+  }
+
+  function teardown(conn: SharedConnection): void {
+    if (conn.reconnectTimer) {
+      clearTimeout(conn.reconnectTimer);
+      conn.reconnectTimer = null;
+    }
+    conn.es?.close();
+    conn.es = null;
+    conn.releaseLeadership?.(); // free the lock if we hold leadership
+    conn.releaseLeadership = null;
+    conn.lockAbort?.abort(); // cancel a pending lock request if following
+    conn.lockAbort = null;
+    conn.channel?.close();
+    conn.channel = null;
+    connections.delete(conn.key);
+  }
+
+  // HMR: release locks / channels so a dev reload doesn't orphan the Web Lock.
+  const hot = (
+    import.meta as unknown as { hot?: { dispose: (cb: () => void) => void } }
+  ).hot;
+  if (hot) {
+    hot.dispose(() => {
+      for (const conn of [...connections.values()]) teardown(conn);
+    });
   }
 
   return {
@@ -156,8 +281,13 @@ export function createSSESubscription(
       conn.handlers.add(handler);
       if (onReconnect) conn.reconnectHandlers.add(onReconnect);
 
-      for (const type of eventTypes) {
-        conn.es.addEventListener(type, handler);
+      // Replay any cached sticky snapshots to the new subscriber.
+      for (const ev of conn.sticky.values()) {
+        try {
+          handler(ev);
+        } catch {
+          // ignore
+        }
       }
 
       let unsubscribed = false;
@@ -165,20 +295,27 @@ export function createSSESubscription(
         if (unsubscribed) return;
         unsubscribed = true;
 
-        for (const type of eventTypes) {
-          conn.es.removeEventListener(type, handler);
-        }
         conn.handlers.delete(handler);
         if (onReconnect) conn.reconnectHandlers.delete(onReconnect);
         conn.refCount--;
-        if (conn.refCount <= 0) {
-          if (conn.reconnectTimer) {
-            clearTimeout(conn.reconnectTimer);
-          }
-          conn.es.close();
-          connections.delete(key);
-        }
+        if (conn.refCount <= 0) teardown(conn);
       };
+    },
+  };
+}
+
+/** View over a shared subscription that delivers only the given event types. */
+export function filterEventTypes(
+  base: SSESubscription,
+  types: string[],
+): SSESubscription {
+  const allow = new Set(types);
+  return {
+    subscribe(key, handler, onReconnect) {
+      const wrapped: Handler = (e) => {
+        if (allow.has(e.type)) handler(e);
+      };
+      return base.subscribe(key, wrapped, onReconnect);
     },
   };
 }

--- a/apps/mesh/src/web/hooks/decopilot-sse-pool.ts
+++ b/apps/mesh/src/web/hooks/decopilot-sse-pool.ts
@@ -1,22 +1,5 @@
-/**
- * Shared decopilot SSE pool.
- *
- * One ref-counted EventSource per `orgSlug` for `/api/:org/watch` filtered
- * to ALL_DECOPILOT_EVENT_TYPES. Both `useDecopilotEvents` and
- * `ThreadManagerStore` subscribe here so an org only ever holds a single
- * `/watch` connection.
- */
+// `decopilot.*` view of the unified `/watch` pool (watch-sse-pool.ts).
+import type { SSESubscription } from "./create-sse-subscription";
+import { decopilotWatchView } from "./watch-sse-pool";
 
-import { ALL_DECOPILOT_EVENT_TYPES } from "@decocms/mesh-sdk";
-import {
-  createSSESubscription,
-  type SSESubscription,
-} from "./create-sse-subscription";
-
-export const decopilotSSE: SSESubscription = createSSESubscription({
-  buildUrl: (orgSlug) => {
-    const typesParam = ALL_DECOPILOT_EVENT_TYPES.join(",");
-    return `/api/${encodeURIComponent(orgSlug)}/watch?types=${typesParam}`;
-  },
-  eventTypes: [...ALL_DECOPILOT_EVENT_TYPES],
-});
+export const decopilotSSE: SSESubscription = decopilotWatchView;

--- a/apps/mesh/src/web/hooks/decopilot-sse-pool.ts
+++ b/apps/mesh/src/web/hooks/decopilot-sse-pool.ts
@@ -7,27 +7,16 @@
  * `/watch` connection.
  */
 
-import {
-  ALL_DECOPILOT_EVENT_TYPES,
-  DECOPILOT_RUNNING_SUMMARY_EVENT,
-} from "@decocms/mesh-sdk";
+import { ALL_DECOPILOT_EVENT_TYPES } from "@decocms/mesh-sdk";
 import {
   createSSESubscription,
   type SSESubscription,
 } from "./create-sse-subscription";
 
-// The running-summary event is written directly to the stream on connect and
-// broadcast on transitions; the client needs a listener registered for its
-// type to receive it. Kept separate from the broadcast `ALL_DECOPILOT_EVENT_TYPES`.
-const POOL_EVENT_TYPES = [
-  ...ALL_DECOPILOT_EVENT_TYPES,
-  DECOPILOT_RUNNING_SUMMARY_EVENT,
-];
-
 export const decopilotSSE: SSESubscription = createSSESubscription({
   buildUrl: (orgSlug) => {
-    const typesParam = POOL_EVENT_TYPES.join(",");
+    const typesParam = ALL_DECOPILOT_EVENT_TYPES.join(",");
     return `/api/${encodeURIComponent(orgSlug)}/watch?types=${typesParam}`;
   },
-  eventTypes: POOL_EVENT_TYPES,
+  eventTypes: [...ALL_DECOPILOT_EVENT_TYPES],
 });

--- a/apps/mesh/src/web/hooks/decopilot-sse-pool.ts
+++ b/apps/mesh/src/web/hooks/decopilot-sse-pool.ts
@@ -7,16 +7,27 @@
  * `/watch` connection.
  */
 
-import { ALL_DECOPILOT_EVENT_TYPES } from "@decocms/mesh-sdk";
+import {
+  ALL_DECOPILOT_EVENT_TYPES,
+  DECOPILOT_RUNNING_SUMMARY_EVENT,
+} from "@decocms/mesh-sdk";
 import {
   createSSESubscription,
   type SSESubscription,
 } from "./create-sse-subscription";
 
+// The running-summary event is written directly to the stream on connect and
+// broadcast on transitions; the client needs a listener registered for its
+// type to receive it. Kept separate from the broadcast `ALL_DECOPILOT_EVENT_TYPES`.
+const POOL_EVENT_TYPES = [
+  ...ALL_DECOPILOT_EVENT_TYPES,
+  DECOPILOT_RUNNING_SUMMARY_EVENT,
+];
+
 export const decopilotSSE: SSESubscription = createSSESubscription({
   buildUrl: (orgSlug) => {
-    const typesParam = ALL_DECOPILOT_EVENT_TYPES.join(",");
+    const typesParam = POOL_EVENT_TYPES.join(",");
     return `/api/${encodeURIComponent(orgSlug)}/watch?types=${typesParam}`;
   },
-  eventTypes: [...ALL_DECOPILOT_EVENT_TYPES],
+  eventTypes: POOL_EVENT_TYPES,
 });

--- a/apps/mesh/src/web/hooks/use-running-summary.ts
+++ b/apps/mesh/src/web/hooks/use-running-summary.ts
@@ -1,19 +1,21 @@
 /**
- * useRunningSummary — live "X agents working on N tasks" for an org.
+ * useRunningSummary — live running-thread state for an org, powering the home
+ * "X agents working on N tasks" badge and its hover list.
  *
  * The server is authoritative: `/watch` emits a `decopilot.running.summary`
  * snapshot on connect (and re-emits on reconnect), and the run reactor
- * broadcasts a fresh summary through the SSE hub on every thread transition. So
- * the client just stores the latest summary it receives — no delta bookkeeping.
+ * broadcasts a fresh one through the SSE hub on every thread transition. So the
+ * client just stores the latest payload it receives — no delta bookkeeping.
  *
  * State lives in a module-level, ref-counted store keyed by orgSlug so every
- * call-site shares one value and the single pooled `/watch` connection.
+ * call-site shares one value and one dedicated `/watch` connection.
  */
 
 import {
   DECOPILOT_RUNNING_SUMMARY_EVENT,
   type DecopilotRunningSummaryEvent,
   type RunningSummary,
+  type RunningThread,
 } from "@decocms/mesh-sdk";
 import { useSyncExternalStore } from "react";
 import { Store } from "@/web/components/chat/store/store-primitive";
@@ -33,24 +35,28 @@ const runningSummarySSE = createSSESubscription({
   eventTypes: [DECOPILOT_RUNNING_SUMMARY_EVENT],
 });
 
-const EMPTY: RunningSummary = Object.freeze({
-  totalRunning: 0,
-  agentCount: 0,
-  agents: [],
+export interface RunningState {
+  summary: RunningSummary;
+  threads: RunningThread[];
+}
+
+const EMPTY: RunningState = Object.freeze({
+  summary: { totalRunning: 0, agentCount: 0 },
+  threads: [],
 });
 
 interface SummaryEntry {
-  store: Store<RunningSummary>;
+  store: Store<RunningState>;
   sseRefCount: number;
   sseUnsub: (() => void) | null;
   subscribe: (onChange: () => void) => () => void;
-  getSnapshot: () => RunningSummary;
+  getSnapshot: () => RunningState;
 }
 
 const entries = new Map<string, SummaryEntry>();
 
 function createEntry(orgSlug: string): SummaryEntry {
-  const store = new Store<RunningSummary>(EMPTY);
+  const store = new Store<RunningState>(EMPTY);
 
   const handleMessage = (e: MessageEvent): void => {
     let event: DecopilotRunningSummaryEvent;
@@ -60,7 +66,7 @@ function createEntry(orgSlug: string): SummaryEntry {
       return;
     }
     if (event.type !== DECOPILOT_RUNNING_SUMMARY_EVENT) return;
-    store.set(event.data.summary);
+    store.set({ summary: event.data.summary, threads: event.data.threads });
   };
 
   const entry: SummaryEntry = {
@@ -100,10 +106,10 @@ function getEntry(orgSlug: string): SummaryEntry {
 }
 
 /**
- * Live running-thread summary for an org. Returns zeros until the connect
- * snapshot lands.
+ * Live running-thread state for an org: the summary counts plus the per-thread
+ * list (for the hover popover). Returns empties until the connect snapshot lands.
  */
-export function useRunningSummary(orgSlug: string): RunningSummary {
+export function useRunningSummary(orgSlug: string): RunningState {
   const entry = getEntry(orgSlug);
   return useSyncExternalStore(
     entry.subscribe,

--- a/apps/mesh/src/web/hooks/use-running-summary.ts
+++ b/apps/mesh/src/web/hooks/use-running-summary.ts
@@ -1,0 +1,99 @@
+/**
+ * useRunningSummary — live "X agents working on N tasks" for an org.
+ *
+ * The server is authoritative: `/watch` emits a `decopilot.running.summary`
+ * snapshot on connect (and re-emits on reconnect), and the run reactor
+ * broadcasts a fresh summary through the SSE hub on every thread transition. So
+ * the client just stores the latest summary it receives — no delta bookkeeping.
+ *
+ * State lives in a module-level, ref-counted store keyed by orgSlug so every
+ * call-site shares one value and the single pooled `/watch` connection.
+ */
+
+import {
+  DECOPILOT_RUNNING_SUMMARY_EVENT,
+  type DecopilotRunningSummaryEvent,
+  type RunningSummary,
+} from "@decocms/mesh-sdk";
+import { useSyncExternalStore } from "react";
+import { Store } from "@/web/components/chat/store/store-primitive";
+import { decopilotSSE } from "./decopilot-sse-pool";
+
+const EMPTY: RunningSummary = Object.freeze({
+  totalRunning: 0,
+  agentCount: 0,
+  agents: [],
+});
+
+interface SummaryEntry {
+  store: Store<RunningSummary>;
+  sseRefCount: number;
+  sseUnsub: (() => void) | null;
+  subscribe: (onChange: () => void) => () => void;
+  getSnapshot: () => RunningSummary;
+}
+
+const entries = new Map<string, SummaryEntry>();
+
+function createEntry(orgSlug: string): SummaryEntry {
+  const store = new Store<RunningSummary>(EMPTY);
+
+  const handleMessage = (e: MessageEvent): void => {
+    let event: DecopilotRunningSummaryEvent;
+    try {
+      event = JSON.parse(e.data);
+    } catch {
+      return;
+    }
+    if (event.type !== DECOPILOT_RUNNING_SUMMARY_EVENT) return;
+    store.set(event.data.summary);
+  };
+
+  const entry: SummaryEntry = {
+    store,
+    sseRefCount: 0,
+    sseUnsub: null,
+    getSnapshot: store.get,
+    subscribe: (onChange) => {
+      const storeUnsub = store.subscribe(onChange);
+      entry.sseRefCount++;
+      if (entry.sseRefCount === 1) {
+        entry.sseUnsub = decopilotSSE.subscribe(orgSlug, handleMessage);
+      }
+      return () => {
+        storeUnsub();
+        entry.sseRefCount--;
+        if (entry.sseRefCount === 0) {
+          entry.sseUnsub?.();
+          entry.sseUnsub = null;
+          // Reset so a later remount re-seeds from the next connect snapshot.
+          store.set(EMPTY);
+        }
+      };
+    },
+  };
+
+  return entry;
+}
+
+function getEntry(orgSlug: string): SummaryEntry {
+  let entry = entries.get(orgSlug);
+  if (!entry) {
+    entry = createEntry(orgSlug);
+    entries.set(orgSlug, entry);
+  }
+  return entry;
+}
+
+/**
+ * Live running-thread summary for an org. Returns zeros until the connect
+ * snapshot lands.
+ */
+export function useRunningSummary(orgSlug: string): RunningSummary {
+  const entry = getEntry(orgSlug);
+  return useSyncExternalStore(
+    entry.subscribe,
+    entry.getSnapshot,
+    entry.getSnapshot,
+  );
+}

--- a/apps/mesh/src/web/hooks/use-running-summary.ts
+++ b/apps/mesh/src/web/hooks/use-running-summary.ts
@@ -1,20 +1,8 @@
 /**
- * useRunningSummary — live running-thread state for the home badge + hover list.
- *
- * ONE dedicated, ref-counted `/watch` connection per tab carries BOTH scopes:
- *   - "org"  → this org's running threads (DECOPILOT_RUNNING_SUMMARY_EVENT)
- *   - "user" → your running threads across every org you belong to
- *     (DECOPILOT_USER_RUNNING_SUMMARY_EVENT, delivered over the same connection
- *      because the server also listens on the `user:<id>` channel)
- *
- * Keeping it to a single thin connection matters: browsers cap ~6 concurrent
- * connections per domain over HTTP/1.1, so multiple tabs each holding several
- * SSE streams would exhaust the pool and hang the app.
- *
- * The server is authoritative: each scope's snapshot arrives on connect (and on
- * reconnect), and the reactor broadcasts fresh ones on every transition. The
- * cached value is NOT cleared when the last subscriber leaves, so a remount
- * paints the last known counts immediately instead of flashing empty.
+ * Live running-thread state for the home badge + hover list. The "org" and
+ * "user" (cross-org) scopes both arrive over the unified `/watch` connection
+ * (watch-sse-pool.ts). Store values persist across mount/unmount so a remount
+ * paints the last known counts instead of flashing empty.
  */
 
 import {
@@ -26,18 +14,11 @@ import {
 } from "@decocms/mesh-sdk";
 import { useSyncExternalStore } from "react";
 import { Store } from "@/web/components/chat/store/store-primitive";
-import { createSSESubscription } from "./create-sse-subscription";
+import { runningSummaryWatchView } from "./watch-sse-pool";
 
 export type RunningScope = "org" | "user";
 
-const runningSummarySSE = createSSESubscription({
-  buildUrl: (orgSlug) =>
-    `/api/${encodeURIComponent(orgSlug)}/watch?types=${DECOPILOT_RUNNING_SUMMARY_EVENT},${DECOPILOT_USER_RUNNING_SUMMARY_EVENT}`,
-  eventTypes: [
-    DECOPILOT_RUNNING_SUMMARY_EVENT,
-    DECOPILOT_USER_RUNNING_SUMMARY_EVENT,
-  ],
-});
+const runningSummarySSE = runningSummaryWatchView;
 
 export interface RunningState {
   summary: RunningSummary;
@@ -49,8 +30,7 @@ const EMPTY: RunningState = Object.freeze({
   threads: [],
 });
 
-// Per-org store for the org scope; a single global store for the user scope
-// (it's cross-org). Values persist across mount/unmount to avoid empty flashes.
+// Per-org store for the org scope; one global store for the (cross-org) user scope.
 const orgStores = new Map<string, Store<RunningState>>();
 const userStore = new Store<RunningState>(EMPTY);
 
@@ -63,7 +43,6 @@ function orgStore(orgSlug: string): Store<RunningState> {
   return s;
 }
 
-// One ref-counted SSE connection per org slug, feeding both stores.
 interface Conn {
   refCount: number;
   unsub: (() => void) | null;
@@ -101,13 +80,11 @@ function acquireConnection(orgSlug: string): () => void {
     if (conn.refCount <= 0) {
       conn.unsub?.();
       conns.delete(orgSlug);
-      // Intentionally keep the store values (no reset) so a later remount shows
-      // the last known counts immediately rather than flashing empty.
+      // Keep store values (no reset) so a later remount shows last known counts.
     }
   };
 }
 
-// Stable subscribe/getSnapshot per (scope, orgSlug) for useSyncExternalStore.
 interface HookEntry {
   subscribe: (onChange: () => void) => () => void;
   getSnapshot: () => RunningState;
@@ -135,10 +112,6 @@ function getHookEntry(orgSlug: string, scope: RunningScope): HookEntry {
   return entry;
 }
 
-/**
- * Live running-thread state for the given scope. Both scopes share the org's
- * single `/watch` connection. Returns empties until the first snapshot lands.
- */
 export function useRunningSummary(
   orgSlug: string,
   scope: RunningScope,

--- a/apps/mesh/src/web/hooks/use-running-summary.ts
+++ b/apps/mesh/src/web/hooks/use-running-summary.ts
@@ -1,14 +1,17 @@
 /**
- * useRunningSummary — live running-thread state for an org, powering the home
- * "X agents working on N tasks" badge and its hover list.
+ * useRunningSummary — live running-thread state for the home badge + hover list.
  *
- * The server is authoritative: `/watch` emits a `decopilot.running.summary`
- * snapshot on connect (and re-emits on reconnect), and the run reactor
- * broadcasts a fresh one through the SSE hub on every thread transition. So the
- * client just stores the latest payload it receives — no delta bookkeeping.
+ * Two scopes:
+ *   - "org"  → the current org's running threads (`/api/:org/watch`), team view.
+ *   - "user" → your own running threads across every org (`/api/me/watch`).
  *
- * State lives in a module-level, ref-counted store keyed by orgSlug so every
- * call-site shares one value and one dedicated `/watch` connection.
+ * The server is authoritative: each feed emits a `decopilot.running.summary`
+ * snapshot on connect (and on reconnect), and the run reactor broadcasts a fresh
+ * one on every thread transition (to the org channel and the creator's user
+ * channel). The client just stores the latest payload — no delta bookkeeping.
+ *
+ * State lives in module-level, ref-counted stores keyed by `scope:key`, so every
+ * call-site shares one value and one dedicated `/watch` connection per feed.
  */
 
 import {
@@ -21,17 +24,18 @@ import { useSyncExternalStore } from "react";
 import { Store } from "@/web/components/chat/store/store-primitive";
 import { createSSESubscription } from "./create-sse-subscription";
 
-/**
- * Dedicated `/watch` connection for the running summary — NOT the shared
- * decopilot pool. The summary's authoritative value arrives as the connect
- * snapshot (and on reconnect); a late subscriber joining the already-open
- * shared pool would miss that one-shot snapshot and sit at 0 until the next
- * transition. A dedicated, ref-counted connection guarantees every mount gets a
- * fresh snapshot. Filtered to just the summary type so it's a thin stream.
- */
-const runningSummarySSE = createSSESubscription({
+export type RunningScope = "org" | "user";
+
+// Dedicated, ref-counted `/watch` connections (one per feed). NOT the shared
+// decopilot pool: a late subscriber joining an already-open shared connection
+// would miss the one-shot connect snapshot. Filtered to just the summary type.
+const orgRunningSummarySSE = createSSESubscription({
   buildUrl: (orgSlug) =>
     `/api/${encodeURIComponent(orgSlug)}/watch?types=${DECOPILOT_RUNNING_SUMMARY_EVENT}`,
+  eventTypes: [DECOPILOT_RUNNING_SUMMARY_EVENT],
+});
+const userRunningSummarySSE = createSSESubscription({
+  buildUrl: () => `/api/me/watch?types=${DECOPILOT_RUNNING_SUMMARY_EVENT}`,
   eventTypes: [DECOPILOT_RUNNING_SUMMARY_EVENT],
 });
 
@@ -55,8 +59,9 @@ interface SummaryEntry {
 
 const entries = new Map<string, SummaryEntry>();
 
-function createEntry(orgSlug: string): SummaryEntry {
+function createEntry(scope: RunningScope, connKey: string): SummaryEntry {
   const store = new Store<RunningState>(EMPTY);
+  const sse = scope === "user" ? userRunningSummarySSE : orgRunningSummarySSE;
 
   const handleMessage = (e: MessageEvent): void => {
     let event: DecopilotRunningSummaryEvent;
@@ -78,7 +83,7 @@ function createEntry(orgSlug: string): SummaryEntry {
       const storeUnsub = store.subscribe(onChange);
       entry.sseRefCount++;
       if (entry.sseRefCount === 1) {
-        entry.sseUnsub = runningSummarySSE.subscribe(orgSlug, handleMessage);
+        entry.sseUnsub = sse.subscribe(connKey, handleMessage);
       }
       return () => {
         storeUnsub();
@@ -96,21 +101,26 @@ function createEntry(orgSlug: string): SummaryEntry {
   return entry;
 }
 
-function getEntry(orgSlug: string): SummaryEntry {
-  let entry = entries.get(orgSlug);
+function getEntry(scope: RunningScope, connKey: string): SummaryEntry {
+  const mapKey = `${scope}:${connKey}`;
+  let entry = entries.get(mapKey);
   if (!entry) {
-    entry = createEntry(orgSlug);
-    entries.set(orgSlug, entry);
+    entry = createEntry(scope, connKey);
+    entries.set(mapKey, entry);
   }
   return entry;
 }
 
 /**
- * Live running-thread state for an org: the summary counts plus the per-thread
- * list (for the hover popover). Returns empties until the connect snapshot lands.
+ * Live running-thread state for the given scope. The org feed is keyed by
+ * orgSlug; the user feed is a single per-session connection. Returns empties
+ * until the connect snapshot lands.
  */
-export function useRunningSummary(orgSlug: string): RunningState {
-  const entry = getEntry(orgSlug);
+export function useRunningSummary(
+  orgSlug: string,
+  scope: RunningScope,
+): RunningState {
+  const entry = getEntry(scope, scope === "user" ? "me" : orgSlug);
   return useSyncExternalStore(
     entry.subscribe,
     entry.getSnapshot,

--- a/apps/mesh/src/web/hooks/use-running-summary.ts
+++ b/apps/mesh/src/web/hooks/use-running-summary.ts
@@ -17,7 +17,21 @@ import {
 } from "@decocms/mesh-sdk";
 import { useSyncExternalStore } from "react";
 import { Store } from "@/web/components/chat/store/store-primitive";
-import { decopilotSSE } from "./decopilot-sse-pool";
+import { createSSESubscription } from "./create-sse-subscription";
+
+/**
+ * Dedicated `/watch` connection for the running summary — NOT the shared
+ * decopilot pool. The summary's authoritative value arrives as the connect
+ * snapshot (and on reconnect); a late subscriber joining the already-open
+ * shared pool would miss that one-shot snapshot and sit at 0 until the next
+ * transition. A dedicated, ref-counted connection guarantees every mount gets a
+ * fresh snapshot. Filtered to just the summary type so it's a thin stream.
+ */
+const runningSummarySSE = createSSESubscription({
+  buildUrl: (orgSlug) =>
+    `/api/${encodeURIComponent(orgSlug)}/watch?types=${DECOPILOT_RUNNING_SUMMARY_EVENT}`,
+  eventTypes: [DECOPILOT_RUNNING_SUMMARY_EVENT],
+});
 
 const EMPTY: RunningSummary = Object.freeze({
   totalRunning: 0,
@@ -58,7 +72,7 @@ function createEntry(orgSlug: string): SummaryEntry {
       const storeUnsub = store.subscribe(onChange);
       entry.sseRefCount++;
       if (entry.sseRefCount === 1) {
-        entry.sseUnsub = decopilotSSE.subscribe(orgSlug, handleMessage);
+        entry.sseUnsub = runningSummarySSE.subscribe(orgSlug, handleMessage);
       }
       return () => {
         storeUnsub();

--- a/apps/mesh/src/web/hooks/use-running-summary.ts
+++ b/apps/mesh/src/web/hooks/use-running-summary.ts
@@ -1,21 +1,25 @@
 /**
  * useRunningSummary — live running-thread state for the home badge + hover list.
  *
- * Two scopes:
- *   - "org"  → the current org's running threads (`/api/:org/watch`), team view.
- *   - "user" → your own running threads across every org (`/api/me/watch`).
+ * ONE dedicated, ref-counted `/watch` connection per tab carries BOTH scopes:
+ *   - "org"  → this org's running threads (DECOPILOT_RUNNING_SUMMARY_EVENT)
+ *   - "user" → your running threads across every org you belong to
+ *     (DECOPILOT_USER_RUNNING_SUMMARY_EVENT, delivered over the same connection
+ *      because the server also listens on the `user:<id>` channel)
  *
- * The server is authoritative: each feed emits a `decopilot.running.summary`
- * snapshot on connect (and on reconnect), and the run reactor broadcasts a fresh
- * one on every thread transition (to the org channel and the creator's user
- * channel). The client just stores the latest payload — no delta bookkeeping.
+ * Keeping it to a single thin connection matters: browsers cap ~6 concurrent
+ * connections per domain over HTTP/1.1, so multiple tabs each holding several
+ * SSE streams would exhaust the pool and hang the app.
  *
- * State lives in module-level, ref-counted stores keyed by `scope:key`, so every
- * call-site shares one value and one dedicated `/watch` connection per feed.
+ * The server is authoritative: each scope's snapshot arrives on connect (and on
+ * reconnect), and the reactor broadcasts fresh ones on every transition. The
+ * cached value is NOT cleared when the last subscriber leaves, so a remount
+ * paints the last known counts immediately instead of flashing empty.
  */
 
 import {
   DECOPILOT_RUNNING_SUMMARY_EVENT,
+  DECOPILOT_USER_RUNNING_SUMMARY_EVENT,
   type DecopilotRunningSummaryEvent,
   type RunningSummary,
   type RunningThread,
@@ -26,17 +30,13 @@ import { createSSESubscription } from "./create-sse-subscription";
 
 export type RunningScope = "org" | "user";
 
-// Dedicated, ref-counted `/watch` connections (one per feed). NOT the shared
-// decopilot pool: a late subscriber joining an already-open shared connection
-// would miss the one-shot connect snapshot. Filtered to just the summary type.
-const orgRunningSummarySSE = createSSESubscription({
+const runningSummarySSE = createSSESubscription({
   buildUrl: (orgSlug) =>
-    `/api/${encodeURIComponent(orgSlug)}/watch?types=${DECOPILOT_RUNNING_SUMMARY_EVENT}`,
-  eventTypes: [DECOPILOT_RUNNING_SUMMARY_EVENT],
-});
-const userRunningSummarySSE = createSSESubscription({
-  buildUrl: () => `/api/me/watch?types=${DECOPILOT_RUNNING_SUMMARY_EVENT}`,
-  eventTypes: [DECOPILOT_RUNNING_SUMMARY_EVENT],
+    `/api/${encodeURIComponent(orgSlug)}/watch?types=${DECOPILOT_RUNNING_SUMMARY_EVENT},${DECOPILOT_USER_RUNNING_SUMMARY_EVENT}`,
+  eventTypes: [
+    DECOPILOT_RUNNING_SUMMARY_EVENT,
+    DECOPILOT_USER_RUNNING_SUMMARY_EVENT,
+  ],
 });
 
 export interface RunningState {
@@ -49,78 +49,101 @@ const EMPTY: RunningState = Object.freeze({
   threads: [],
 });
 
-interface SummaryEntry {
-  store: Store<RunningState>;
-  sseRefCount: number;
-  sseUnsub: (() => void) | null;
+// Per-org store for the org scope; a single global store for the user scope
+// (it's cross-org). Values persist across mount/unmount to avoid empty flashes.
+const orgStores = new Map<string, Store<RunningState>>();
+const userStore = new Store<RunningState>(EMPTY);
+
+function orgStore(orgSlug: string): Store<RunningState> {
+  let s = orgStores.get(orgSlug);
+  if (!s) {
+    s = new Store<RunningState>(EMPTY);
+    orgStores.set(orgSlug, s);
+  }
+  return s;
+}
+
+// One ref-counted SSE connection per org slug, feeding both stores.
+interface Conn {
+  refCount: number;
+  unsub: (() => void) | null;
+}
+const conns = new Map<string, Conn>();
+
+function acquireConnection(orgSlug: string): () => void {
+  let conn = conns.get(orgSlug);
+  if (!conn) {
+    const store = orgStore(orgSlug);
+    const handler = (e: MessageEvent): void => {
+      let event: DecopilotRunningSummaryEvent;
+      try {
+        event = JSON.parse(e.data);
+      } catch {
+        return;
+      }
+      const next: RunningState = {
+        summary: event.data.summary,
+        threads: event.data.threads,
+      };
+      if (event.type === DECOPILOT_RUNNING_SUMMARY_EVENT) {
+        store.set(next);
+      } else if (event.type === DECOPILOT_USER_RUNNING_SUMMARY_EVENT) {
+        userStore.set(next);
+      }
+    };
+    conn = { refCount: 0, unsub: null };
+    conns.set(orgSlug, conn);
+    conn.unsub = runningSummarySSE.subscribe(orgSlug, handler);
+  }
+  conn.refCount++;
+  return () => {
+    conn.refCount--;
+    if (conn.refCount <= 0) {
+      conn.unsub?.();
+      conns.delete(orgSlug);
+      // Intentionally keep the store values (no reset) so a later remount shows
+      // the last known counts immediately rather than flashing empty.
+    }
+  };
+}
+
+// Stable subscribe/getSnapshot per (scope, orgSlug) for useSyncExternalStore.
+interface HookEntry {
   subscribe: (onChange: () => void) => () => void;
   getSnapshot: () => RunningState;
 }
+const hookEntries = new Map<string, HookEntry>();
 
-const entries = new Map<string, SummaryEntry>();
-
-function createEntry(scope: RunningScope, connKey: string): SummaryEntry {
-  const store = new Store<RunningState>(EMPTY);
-  const sse = scope === "user" ? userRunningSummarySSE : orgRunningSummarySSE;
-
-  const handleMessage = (e: MessageEvent): void => {
-    let event: DecopilotRunningSummaryEvent;
-    try {
-      event = JSON.parse(e.data);
-    } catch {
-      return;
-    }
-    if (event.type !== DECOPILOT_RUNNING_SUMMARY_EVENT) return;
-    store.set({ summary: event.data.summary, threads: event.data.threads });
-  };
-
-  const entry: SummaryEntry = {
-    store,
-    sseRefCount: 0,
-    sseUnsub: null,
-    getSnapshot: store.get,
-    subscribe: (onChange) => {
-      const storeUnsub = store.subscribe(onChange);
-      entry.sseRefCount++;
-      if (entry.sseRefCount === 1) {
-        entry.sseUnsub = sse.subscribe(connKey, handleMessage);
-      }
-      return () => {
-        storeUnsub();
-        entry.sseRefCount--;
-        if (entry.sseRefCount === 0) {
-          entry.sseUnsub?.();
-          entry.sseUnsub = null;
-          // Reset so a later remount re-seeds from the next connect snapshot.
-          store.set(EMPTY);
-        }
-      };
-    },
-  };
-
-  return entry;
-}
-
-function getEntry(scope: RunningScope, connKey: string): SummaryEntry {
-  const mapKey = `${scope}:${connKey}`;
-  let entry = entries.get(mapKey);
+function getHookEntry(orgSlug: string, scope: RunningScope): HookEntry {
+  const key = `${scope}:${orgSlug}`;
+  let entry = hookEntries.get(key);
   if (!entry) {
-    entry = createEntry(scope, connKey);
-    entries.set(mapKey, entry);
+    const store = scope === "user" ? userStore : orgStore(orgSlug);
+    entry = {
+      getSnapshot: store.get,
+      subscribe: (onChange) => {
+        const release = acquireConnection(orgSlug);
+        const off = store.subscribe(onChange);
+        return () => {
+          off();
+          release();
+        };
+      },
+    };
+    hookEntries.set(key, entry);
   }
   return entry;
 }
 
 /**
- * Live running-thread state for the given scope. The org feed is keyed by
- * orgSlug; the user feed is a single per-session connection. Returns empties
- * until the connect snapshot lands.
+ * Live running-thread state for the given scope. Both scopes share the org's
+ * single `/watch` connection. Returns empties until the first snapshot lands.
  */
 export function useRunningSummary(
   orgSlug: string,
   scope: RunningScope,
 ): RunningState {
-  const entry = getEntry(scope, scope === "user" ? "me" : orgSlug);
+  const entry = getHookEntry(orgSlug, scope);
   return useSyncExternalStore(
     entry.subscribe,
     entry.getSnapshot,

--- a/apps/mesh/src/web/hooks/watch-sse-pool.ts
+++ b/apps/mesh/src/web/hooks/watch-sse-pool.ts
@@ -16,7 +16,7 @@ import {
 } from "./create-sse-subscription";
 
 /** Concrete workflow event names emitted on `/watch`. */
-export const WORKFLOW_EVENT_TYPES = [
+const WORKFLOW_EVENT_TYPES = [
   "workflow.execution.created",
   "workflow.execution.resumed",
   "workflow.step.execute",
@@ -45,7 +45,7 @@ const WATCH_EVENT_TYPES = [
 ];
 
 /** The single shared, cross-tab `/watch` connection (streams the full union). */
-export const watchSSE: SSESubscription = createSSESubscription({
+const watchSSE: SSESubscription = createSSESubscription({
   name: "watch",
   buildUrl: (orgSlug) =>
     `/api/${encodeURIComponent(orgSlug)}/watch?types=${WATCH_URL_TYPES.join(",")}`,

--- a/apps/mesh/src/web/hooks/watch-sse-pool.ts
+++ b/apps/mesh/src/web/hooks/watch-sse-pool.ts
@@ -1,0 +1,72 @@
+/**
+ * Unified `/api/:org/watch` SSE pool. Every consumer (decopilot, workflow,
+ * running-summary) shares ONE cross-tab connection per org that streams the
+ * union of their event types; each takes a `filterEventTypes` view of its own.
+ */
+
+import {
+  ALL_DECOPILOT_EVENT_TYPES,
+  DECOPILOT_RUNNING_SUMMARY_EVENT,
+  DECOPILOT_USER_RUNNING_SUMMARY_EVENT,
+} from "@decocms/mesh-sdk";
+import {
+  createSSESubscription,
+  filterEventTypes,
+  type SSESubscription,
+} from "./create-sse-subscription";
+
+/** Concrete workflow event names emitted on `/watch`. */
+export const WORKFLOW_EVENT_TYPES = [
+  "workflow.execution.created",
+  "workflow.execution.resumed",
+  "workflow.step.execute",
+  "workflow.step.completed",
+];
+
+/** Running-summary event names (snapshot-like: cached + replayed to new tabs). */
+const RUNNING_SUMMARY_EVENT_TYPES = [
+  DECOPILOT_RUNNING_SUMMARY_EVENT,
+  DECOPILOT_USER_RUNNING_SUMMARY_EVENT,
+];
+
+// Server matches running-summary types by EXACT string (gates a snapshot query),
+// so list them verbatim; `workflow.*` is a wildcard the server expands.
+const WATCH_URL_TYPES = [
+  ...ALL_DECOPILOT_EVENT_TYPES,
+  "workflow.*",
+  ...RUNNING_SUMMARY_EVENT_TYPES,
+];
+
+/** Concrete event names the client attaches listeners for. */
+const WATCH_EVENT_TYPES = [
+  ...ALL_DECOPILOT_EVENT_TYPES,
+  ...WORKFLOW_EVENT_TYPES,
+  ...RUNNING_SUMMARY_EVENT_TYPES,
+];
+
+/** The single shared, cross-tab `/watch` connection (streams the full union). */
+export const watchSSE: SSESubscription = createSSESubscription({
+  name: "watch",
+  buildUrl: (orgSlug) =>
+    `/api/${encodeURIComponent(orgSlug)}/watch?types=${WATCH_URL_TYPES.join(",")}`,
+  eventTypes: WATCH_EVENT_TYPES,
+  stickyTypes: RUNNING_SUMMARY_EVENT_TYPES,
+  crossTab: true,
+});
+
+/** Decopilot thread events (step / finish / thread.status). */
+export const decopilotWatchView: SSESubscription = filterEventTypes(watchSSE, [
+  ...ALL_DECOPILOT_EVENT_TYPES,
+]);
+
+/** Workflow execution events. */
+export const workflowWatchView: SSESubscription = filterEventTypes(
+  watchSSE,
+  WORKFLOW_EVENT_TYPES,
+);
+
+/** Running-summary events (org + per-user scope). */
+export const runningSummaryWatchView: SSESubscription = filterEventTypes(
+  watchSSE,
+  RUNNING_SUMMARY_EVENT_TYPES,
+);

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -288,10 +288,11 @@ function CustomizeToolbar({
 const SCOPE_STORAGE_KEY = "running-summary-scope";
 
 function readScope(): RunningScope {
+  // Default to "user" (All my work); only "org" when explicitly chosen.
   try {
-    return localStorage.getItem(SCOPE_STORAGE_KEY) === "user" ? "user" : "org";
+    return localStorage.getItem(SCOPE_STORAGE_KEY) === "org" ? "org" : "user";
   } catch {
-    return "org";
+    return "user";
   }
 }
 

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -18,8 +18,8 @@ import {
 } from "@deco/ui/components/hover-card.tsx";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import { extractTextFromOutput } from "@/web/components/chat/message/parts/utils.ts";
-import { usePanelActions } from "@/web/layouts/shell-layout";
 import { KEYS } from "@/web/lib/query-keys";
+import { useNavigate } from "@tanstack/react-router";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Chat } from "@/web/components/chat";
@@ -38,13 +38,16 @@ import {
 import { useCurrentLink } from "@/web/hooks/use-current-link";
 import { useDecoCredits } from "@/web/hooks/use-deco-credits";
 import { homeNextActionsQueryOptions } from "@/web/hooks/use-home-next-actions";
-import { useRunningSummary } from "@/web/hooks/use-running-summary";
+import {
+  type RunningScope,
+  useRunningSummary,
+} from "@/web/hooks/use-running-summary";
 import { organizationSettingsQueryOptions } from "@/web/hooks/use-organization-settings";
 import {
   agentHasClonableSource,
   hasLocalCliHarness,
 } from "@/web/lib/agent-capabilities";
-import { authClient } from "@/web/lib/auth-client";
+import { authClient, useActiveOrganizations } from "@/web/lib/auth-client";
 import { Toolbar } from "@/web/layouts/agent-shell-layout/toolbar";
 import { HomeBackground } from "./background";
 
@@ -282,23 +285,52 @@ function CustomizeToolbar({
  * reveals the running threads, each with its agent and latest assistant snippet;
  * clicking a row opens that thread.
  */
+const SCOPE_STORAGE_KEY = "running-summary-scope";
+
+function readScope(): RunningScope {
+  try {
+    return localStorage.getItem(SCOPE_STORAGE_KEY) === "user" ? "user" : "org";
+  } catch {
+    return "org";
+  }
+}
+
 function RunningSummaryLine() {
   const { org } = useProjectContext();
-  const { summary, threads } = useRunningSummary(org.slug);
+  const [scope, setScopeState] = useState<RunningScope>(readScope);
+  const setScope = (next: RunningScope) => {
+    setScopeState(next);
+    try {
+      localStorage.setItem(SCOPE_STORAGE_KEY, next);
+    } catch {
+      // ignore (private mode / disabled storage)
+    }
+  };
 
-  if (summary.totalRunning === 0) {
+  // Subscribe to both feeds so the badge is visible (and the scope toggle
+  // reachable) whenever EITHER scope has work — switching never unmounts it.
+  const orgState = useRunningSummary(org.slug, "org");
+  const userState = useRunningSummary(org.slug, "user");
+
+  if (
+    orgState.summary.totalRunning === 0 &&
+    userState.summary.totalRunning === 0
+  ) {
     return null;
   }
 
-  const tasks = `${summary.totalRunning} task${
-    summary.totalRunning === 1 ? "" : "s"
-  }`;
+  const state = scope === "user" ? userState : orgState;
+  const { totalRunning, agentCount } = state.summary;
+  const emptyLabel =
+    scope === "user"
+      ? "Nothing running across your orgs"
+      : "Nothing running in this org";
   const label =
-    summary.agentCount > 0
-      ? `${summary.agentCount} agent${
-          summary.agentCount === 1 ? "" : "s"
-        } working on ${tasks}`
-      : `${tasks} running`;
+    totalRunning === 0
+      ? emptyLabel
+      : agentCount > 0
+        ? `${agentCount} agent${agentCount === 1 ? "" : "s"} working on ${totalRunning} task${totalRunning === 1 ? "" : "s"}`
+        : `${totalRunning} task${totalRunning === 1 ? "" : "s"} running`;
 
   return (
     <HoverCard openDelay={120} closeDelay={120}>
@@ -307,33 +339,86 @@ function RunningSummaryLine() {
           type="button"
           className="mt-3 flex items-center justify-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
         >
-          <span className="relative flex h-2 w-2">
-            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
-            <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
-          </span>
+          {totalRunning > 0 ? (
+            <span className="relative flex h-2 w-2">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
+            </span>
+          ) : null}
           {label}
         </button>
       </HoverCardTrigger>
       <HoverCardContent align="center" className="w-80 p-1">
-        <RunningThreadsList threads={threads} />
+        <div className="flex items-center gap-1 px-1 pb-1">
+          <ScopeTab
+            active={scope === "org"}
+            count={orgState.summary.totalRunning}
+            onClick={() => setScope("org")}
+          >
+            This org
+          </ScopeTab>
+          <ScopeTab
+            active={scope === "user"}
+            count={userState.summary.totalRunning}
+            onClick={() => setScope("user")}
+          >
+            All my work
+          </ScopeTab>
+        </div>
+        <RunningThreadsList threads={state.threads} scope={scope} />
       </HoverCardContent>
     </HoverCard>
   );
 }
 
-function RunningThreadsList({ threads }: { threads: RunningThread[] }) {
-  const { org } = useProjectContext();
-  const { setTaskId } = usePanelActions();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+function ScopeTab({
+  active,
+  count,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  count: number;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
+        active
+          ? "bg-muted text-foreground"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+      {count > 0 ? ` (${count})` : ""}
+    </button>
+  );
+}
+
+function RunningThreadsList({
+  threads,
+  scope,
+}: {
+  threads: RunningThread[];
+  scope: RunningScope;
+}) {
+  const { data: orgs } = useActiveOrganizations();
+  const slugByOrgId = new Map<string, string>(
+    (orgs ?? []).map(
+      (o: { id: string; slug: string }): [string, string] => [o.id, o.slug],
+    ),
+  );
 
   if (threads.length === 0) {
     return (
       <div className="px-2 py-3 text-center text-xs text-muted-foreground">
-        Nothing running right now.
+        {scope === "user"
+          ? "Nothing running across your orgs."
+          : "Nothing running in this org."}
       </div>
     );
   }
@@ -342,13 +427,9 @@ function RunningThreadsList({ threads }: { threads: RunningThread[] }) {
     <div className="flex max-h-80 flex-col gap-0.5 overflow-y-auto">
       {threads.map((thread) => (
         <RunningThreadRow
-          key={thread.id}
+          key={`${thread.organization_id}:${thread.id}`}
           thread={thread}
-          orgSlug={org.slug}
-          client={client}
-          onOpen={() =>
-            setTaskId(thread.id, thread.virtual_mcp_id || undefined)
-          }
+          orgSlug={slugByOrgId.get(thread.organization_id)}
         />
       ))}
     </div>
@@ -358,19 +439,27 @@ function RunningThreadsList({ threads }: { threads: RunningThread[] }) {
 function RunningThreadRow({
   thread,
   orgSlug,
-  client,
-  onOpen,
 }: {
   thread: RunningThread;
-  orgSlug: string;
-  client: ReturnType<typeof useMCPClient>;
-  onOpen: () => void;
+  orgSlug: string | undefined;
 }) {
+  const navigate = useNavigate();
   const agent = useVirtualMCP(thread.virtual_mcp_id);
-  // Latest message; fetched lazily when the popover (and thus this row) mounts.
-  // A running thread's newest message is normally the streaming assistant turn.
+  // Resolve agent from the current org's cache; for cross-org rows that misses,
+  // so fall back to the server-supplied agent_title.
+  const agentName = agent?.title ?? thread.agent_title ?? "Agent";
+
+  // Latest message, fetched lazily when the popover mounts, against the THREAD's
+  // own org (cross-org threads need their own client). A running thread's newest
+  // message is normally the streaming assistant turn.
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: thread.organization_id,
+    orgSlug: orgSlug ?? "",
+  });
   const { data: snippet } = useQuery({
-    queryKey: KEYS.runningThreadLatest(orgSlug, thread.id),
+    queryKey: KEYS.runningThreadLatest(thread.organization_id, thread.id),
+    enabled: !!orgSlug && !!client,
     queryFn: async () => {
       if (!client) return null;
       const result = (await client.callTool({
@@ -389,23 +478,29 @@ function RunningThreadRow({
     staleTime: 5_000,
   });
 
+  const open = () => {
+    if (!orgSlug) return;
+    navigate({
+      to: "/$org/$taskId",
+      params: { org: orgSlug, taskId: thread.id },
+      search: { chat: 1, virtualmcpid: thread.virtual_mcp_id || undefined },
+    });
+  };
+
   return (
     <button
       type="button"
-      onClick={onOpen}
-      className="flex w-full items-start gap-2 rounded-md p-2 text-left transition-colors hover:bg-muted"
+      onClick={open}
+      disabled={!orgSlug}
+      className="flex w-full items-start gap-2 rounded-md p-2 text-left transition-colors hover:bg-muted disabled:opacity-60"
     >
-      <AgentAvatar
-        icon={agent?.icon ?? null}
-        name={agent?.title ?? "Agent"}
-        size="sm"
-      />
+      <AgentAvatar icon={agent?.icon ?? null} name={agentName} size="sm" />
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-medium text-foreground">
           {thread.title || "Untitled task"}
         </div>
         <div className="truncate text-xs text-muted-foreground">
-          {agent?.title ?? "Agent"}
+          {agentName}
         </div>
         {snippet ? (
           <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -28,6 +28,7 @@ import {
 import { useCurrentLink } from "@/web/hooks/use-current-link";
 import { useDecoCredits } from "@/web/hooks/use-deco-credits";
 import { homeNextActionsQueryOptions } from "@/web/hooks/use-home-next-actions";
+import { useRunningSummary } from "@/web/hooks/use-running-summary";
 import { organizationSettingsQueryOptions } from "@/web/hooks/use-organization-settings";
 import {
   agentHasClonableSource,
@@ -134,6 +135,7 @@ function MobileHome({
         <p className="text-3xl font-medium text-foreground text-center max-w-[280px]">
           What's on your mind, {userName}?
         </p>
+        <RunningSummaryLine />
       </div>
       <div className="relative w-full flex flex-col gap-4 pb-8 px-4">
         <Chat.Input showConnectionsBanner />
@@ -185,6 +187,7 @@ function DesktopHome({
                 <p className="text-3xl font-medium text-foreground">
                   What's on your mind, {userName}?
                 </p>
+                <RunningSummaryLine />
               </div>
               <div className="relative w-full">
                 <Capybara />
@@ -259,6 +262,40 @@ function CustomizeToolbar({
       <LayoutAlt04 size={14} />
       Customize
     </button>
+  );
+}
+
+/**
+ * "X agents working on N tasks" — live count of in_progress threads in the org,
+ * seeded by the /watch connect snapshot and kept fresh by the reactor's
+ * running-summary broadcasts. Renders nothing when nothing is running.
+ */
+function RunningSummaryLine() {
+  const { org } = useProjectContext();
+  const summary = useRunningSummary(org.slug);
+
+  if (summary.totalRunning === 0) {
+    return null;
+  }
+
+  const tasks = `${summary.totalRunning} task${
+    summary.totalRunning === 1 ? "" : "s"
+  }`;
+  const label =
+    summary.agentCount > 0
+      ? `${summary.agentCount} agent${
+          summary.agentCount === 1 ? "" : "s"
+        } working on ${tasks}`
+      : `${tasks} running`;
+
+  return (
+    <div className="mt-3 flex items-center justify-center gap-2 text-sm text-muted-foreground">
+      <span className="relative flex h-2 w-2">
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
+        <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
+      </span>
+      {label}
+    </div>
   );
 }
 

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -1,5 +1,6 @@
 import {
   getWellKnownDecopilotVirtualMCP,
+  isDecopilot,
   type RunningThread,
   SELF_MCP_ALIAS_ID,
   useMCPClient,
@@ -409,9 +410,10 @@ function RunningThreadsList({
 }) {
   const { data: orgs } = useActiveOrganizations();
   const slugByOrgId = new Map<string, string>(
-    (orgs ?? []).map(
-      (o: { id: string; slug: string }): [string, string] => [o.id, o.slug],
-    ),
+    (orgs ?? []).map((o: { id: string; slug: string }): [string, string] => [
+      o.id,
+      o.slug,
+    ]),
   );
 
   if (threads.length === 0) {
@@ -446,9 +448,17 @@ function RunningThreadRow({
 }) {
   const navigate = useNavigate();
   const agent = useVirtualMCP(thread.virtual_mcp_id);
-  // Resolve agent from the current org's cache; for cross-org rows that misses,
-  // so fall back to the server-supplied agent_title.
-  const agentName = agent?.title ?? thread.agent_title ?? "Agent";
+  // Agent identity, in order of fidelity:
+  //  1. useVirtualMCP — full resolve for agents in the CURRENT org.
+  //  2. Decopilot (the default agent) is derivable from any org id with no
+  //     fetch, so cross-org Decopilot rows still get the right name + icon.
+  //  3. agent_title from the server (custom cross-org agents — name only).
+  const decopilot = isDecopilot(thread.virtual_mcp_id)
+    ? getWellKnownDecopilotVirtualMCP(thread.organization_id)
+    : null;
+  const agentName =
+    agent?.title ?? decopilot?.title ?? thread.agent_title ?? "Agent";
+  const agentIcon = agent?.icon ?? decopilot?.icon ?? null;
 
   // Latest message, fetched lazily when the popover mounts, against the THREAD's
   // own org (cross-org threads need their own client). A running thread's newest
@@ -495,7 +505,7 @@ function RunningThreadRow({
       disabled={!orgSlug}
       className="flex w-full items-start gap-2 rounded-md p-2 text-left transition-colors hover:bg-muted disabled:opacity-60"
     >
-      <AgentAvatar icon={agent?.icon ?? null} name={agentName} size="sm" />
+      <AgentAvatar icon={agentIcon} name={agentName} size="sm" />
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-medium text-foreground">
           {thread.title || "Untitled task"}

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -280,17 +280,9 @@ function CustomizeToolbar({
   );
 }
 
-/**
- * "X agents working on N tasks" — live count of in_progress threads in the org,
- * seeded by the /watch connect snapshot and kept fresh by the reactor's
- * running-summary broadcasts. Renders nothing when nothing is running. Hovering
- * reveals the running threads, each with its agent and latest assistant snippet;
- * clicking a row opens that thread.
- */
 const SCOPE_STORAGE_KEY = "running-summary-scope";
 
 function readScope(): RunningScope {
-  // Default to "user" (All my work); only "org" when explicitly chosen.
   try {
     return localStorage.getItem(SCOPE_STORAGE_KEY) === "org" ? "org" : "user";
   } catch {
@@ -298,6 +290,13 @@ function readScope(): RunningScope {
   }
 }
 
+function emptyRunningLabel(scope: RunningScope): string {
+  return scope === "user"
+    ? "Nothing running across your orgs"
+    : "Nothing running in this org";
+}
+
+// "X agents working on N tasks" badge; hover lists the running threads.
 function RunningSummaryLine() {
   const { org } = useProjectContext();
   const [scope, setScopeState] = useState<RunningScope>(readScope);
@@ -310,8 +309,7 @@ function RunningSummaryLine() {
     }
   };
 
-  // Subscribe to both feeds so the badge is visible (and the scope toggle
-  // reachable) whenever EITHER scope has work — switching never unmounts it.
+  // Subscribe to both feeds so the badge stays mounted whenever either has work.
   const orgState = useRunningSummary(org.slug, "org");
   const userState = useRunningSummary(org.slug, "user");
 
@@ -324,13 +322,9 @@ function RunningSummaryLine() {
 
   const state = scope === "user" ? userState : orgState;
   const { totalRunning, agentCount } = state.summary;
-  const emptyLabel =
-    scope === "user"
-      ? "Nothing running across your orgs"
-      : "Nothing running in this org";
   const label =
     totalRunning === 0
-      ? emptyLabel
+      ? emptyRunningLabel(scope)
       : agentCount > 0
         ? `${agentCount} agent${agentCount === 1 ? "" : "s"} working on ${totalRunning} task${totalRunning === 1 ? "" : "s"}`
         : `${totalRunning} task${totalRunning === 1 ? "" : "s"} running`;
@@ -424,9 +418,7 @@ function RunningThreadsList({
   if (threads.length === 0) {
     return (
       <div className="px-2 py-3 text-center text-xs text-muted-foreground">
-        {scope === "user"
-          ? "Nothing running across your orgs."
-          : "Nothing running in this org."}
+        {emptyRunningLabel(scope)}
       </div>
     );
   }
@@ -463,11 +455,8 @@ function RunningThreadRow({
 }) {
   const navigate = useNavigate();
   const agent = useVirtualMCP(thread.virtual_mcp_id);
-  // Agent identity, in order of fidelity:
-  //  1. useVirtualMCP — full resolve for agents in the CURRENT org.
-  //  2. Decopilot (the default agent) is derivable from any org id with no
-  //     fetch, so cross-org Decopilot rows still get the right name + icon.
-  //  3. agent_title from the server (custom cross-org agents — name only).
+  // Fidelity order: current-org resolve → Decopilot (derivable from any org id,
+  // no fetch) → server-provided agent_title for custom cross-org agents.
   const decopilot = isDecopilot(thread.virtual_mcp_id)
     ? getWellKnownDecopilotVirtualMCP(thread.organization_id)
     : null;
@@ -475,9 +464,7 @@ function RunningThreadRow({
     agent?.title ?? decopilot?.title ?? thread.agent_title ?? "Agent";
   const agentIcon = agent?.icon ?? decopilot?.icon ?? null;
 
-  // Latest message, fetched lazily when the popover mounts, against the THREAD's
-  // own org (cross-org threads need their own client). A running thread's newest
-  // message is normally the streaming assistant turn.
+  // Latest message, fetched lazily against the thread's own org (cross-org).
   const client = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
     orgId: thread.organization_id,

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -1,5 +1,6 @@
 import {
   getWellKnownDecopilotVirtualMCP,
+  type RunningThread,
   SELF_MCP_ALIAS_ID,
   useMCPClient,
   useProjectContext,
@@ -10,6 +11,15 @@ import { useQuery, useSuspenseQueries } from "@tanstack/react-query";
 import { type ReactNode, useState } from "react";
 import { Check, LayoutAlt04, Plus, X } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@deco/ui/components/hover-card.tsx";
+import { AgentAvatar } from "@/web/components/agent-icon";
+import { extractTextFromOutput } from "@/web/components/chat/message/parts/utils.ts";
+import { usePanelActions } from "@/web/layouts/shell-layout";
+import { KEYS } from "@/web/lib/query-keys";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Chat } from "@/web/components/chat";
@@ -268,11 +278,13 @@ function CustomizeToolbar({
 /**
  * "X agents working on N tasks" — live count of in_progress threads in the org,
  * seeded by the /watch connect snapshot and kept fresh by the reactor's
- * running-summary broadcasts. Renders nothing when nothing is running.
+ * running-summary broadcasts. Renders nothing when nothing is running. Hovering
+ * reveals the running threads, each with its agent and latest assistant snippet;
+ * clicking a row opens that thread.
  */
 function RunningSummaryLine() {
   const { org } = useProjectContext();
-  const summary = useRunningSummary(org.slug);
+  const { summary, threads } = useRunningSummary(org.slug);
 
   if (summary.totalRunning === 0) {
     return null;
@@ -289,13 +301,119 @@ function RunningSummaryLine() {
       : `${tasks} running`;
 
   return (
-    <div className="mt-3 flex items-center justify-center gap-2 text-sm text-muted-foreground">
-      <span className="relative flex h-2 w-2">
-        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
-        <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
-      </span>
-      {label}
+    <HoverCard openDelay={120} closeDelay={120}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          className="mt-3 flex items-center justify-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <span className="relative flex h-2 w-2">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
+          </span>
+          {label}
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent align="center" className="w-80 p-1">
+        <RunningThreadsList threads={threads} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+function RunningThreadsList({ threads }: { threads: RunningThread[] }) {
+  const { org } = useProjectContext();
+  const { setTaskId } = usePanelActions();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+
+  if (threads.length === 0) {
+    return (
+      <div className="px-2 py-3 text-center text-xs text-muted-foreground">
+        Nothing running right now.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex max-h-80 flex-col gap-0.5 overflow-y-auto">
+      {threads.map((thread) => (
+        <RunningThreadRow
+          key={thread.id}
+          thread={thread}
+          orgSlug={org.slug}
+          client={client}
+          onOpen={() =>
+            setTaskId(thread.id, thread.virtual_mcp_id || undefined)
+          }
+        />
+      ))}
     </div>
+  );
+}
+
+function RunningThreadRow({
+  thread,
+  orgSlug,
+  client,
+  onOpen,
+}: {
+  thread: RunningThread;
+  orgSlug: string;
+  client: ReturnType<typeof useMCPClient>;
+  onOpen: () => void;
+}) {
+  const agent = useVirtualMCP(thread.virtual_mcp_id);
+  // Latest message; fetched lazily when the popover (and thus this row) mounts.
+  // A running thread's newest message is normally the streaming assistant turn.
+  const { data: snippet } = useQuery({
+    queryKey: KEYS.runningThreadLatest(orgSlug, thread.id),
+    queryFn: async () => {
+      if (!client) return null;
+      const result = (await client.callTool({
+        name: "COLLECTION_THREAD_MESSAGES_LIST",
+        arguments: {
+          thread_id: thread.id,
+          limit: 1,
+          orderBy: [{ field: "created_at", direction: "desc" }],
+        },
+      })) as { structuredContent?: { items?: unknown[] }; items?: unknown[] };
+      const items = result.structuredContent?.items ?? result.items ?? [];
+      const latest = items[0] as { role?: string } | undefined;
+      if (!latest || latest.role !== "assistant") return null;
+      return extractTextFromOutput(latest);
+    },
+    staleTime: 5_000,
+  });
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex w-full items-start gap-2 rounded-md p-2 text-left transition-colors hover:bg-muted"
+    >
+      <AgentAvatar
+        icon={agent?.icon ?? null}
+        name={agent?.title ?? "Agent"}
+        size="sm"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-foreground">
+          {thread.title || "Untitled task"}
+        </div>
+        <div className="truncate text-xs text-muted-foreground">
+          {agent?.title ?? "Agent"}
+        </div>
+        {snippet ? (
+          <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+            {snippet}
+          </div>
+        ) : null}
+      </div>
+    </button>
   );
 }
 

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -19,6 +19,7 @@ import {
 } from "@deco/ui/components/hover-card.tsx";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import { extractTextFromOutput } from "@/web/components/chat/message/parts/utils.ts";
+import { OrgIcon } from "@/web/components/account-popover";
 import { KEYS } from "@/web/lib/query-keys";
 import { useNavigate } from "@tanstack/react-router";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
@@ -401,6 +402,13 @@ function ScopeTab({
   );
 }
 
+interface OrgItem {
+  id: string;
+  slug: string;
+  name: string;
+  logo?: string | null;
+}
+
 function RunningThreadsList({
   threads,
   scope,
@@ -409,11 +417,8 @@ function RunningThreadsList({
   scope: RunningScope;
 }) {
   const { data: orgs } = useActiveOrganizations();
-  const slugByOrgId = new Map<string, string>(
-    (orgs ?? []).map((o: { id: string; slug: string }): [string, string] => [
-      o.id,
-      o.slug,
-    ]),
+  const orgById = new Map<string, OrgItem>(
+    (orgs ?? []).map((o: OrgItem): [string, OrgItem] => [o.id, o]),
   );
 
   if (threads.length === 0) {
@@ -428,13 +433,19 @@ function RunningThreadsList({
 
   return (
     <div className="flex max-h-80 flex-col gap-0.5 overflow-y-auto">
-      {threads.map((thread) => (
-        <RunningThreadRow
-          key={`${thread.organization_id}:${thread.id}`}
-          thread={thread}
-          orgSlug={slugByOrgId.get(thread.organization_id)}
-        />
-      ))}
+      {threads.map((thread) => {
+        const org = orgById.get(thread.organization_id);
+        return (
+          <RunningThreadRow
+            key={`${thread.organization_id}:${thread.id}`}
+            thread={thread}
+            orgSlug={org?.slug}
+            org={org ?? null}
+            // Only disambiguate by org in the cross-org "All my work" view.
+            showOrg={scope === "user"}
+          />
+        );
+      })}
     </div>
   );
 }
@@ -442,9 +453,13 @@ function RunningThreadsList({
 function RunningThreadRow({
   thread,
   orgSlug,
+  org,
+  showOrg,
 }: {
   thread: RunningThread;
   orgSlug: string | undefined;
+  org: OrgItem | null;
+  showOrg: boolean;
 }) {
   const navigate = useNavigate();
   const agent = useVirtualMCP(thread.virtual_mcp_id);
@@ -510,8 +525,15 @@ function RunningThreadRow({
         <div className="truncate text-sm font-medium text-foreground">
           {thread.title || "Untitled task"}
         </div>
-        <div className="truncate text-xs text-muted-foreground">
-          {agentName}
+        <div className="flex items-center gap-1 text-xs text-muted-foreground">
+          {showOrg && org ? (
+            <>
+              <OrgIcon org={org} size="xs" />
+              <span className="truncate">{org.name}</span>
+              <span aria-hidden>·</span>
+            </>
+          ) : null}
+          <span className="truncate">{agentName}</span>
         </div>
         {snippet ? (
           <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -1,4 +1,5 @@
 import {
+  buildRunningSummary,
   getWellKnownDecopilotVirtualMCP,
   isDecopilot,
   type RunningThread,
@@ -42,6 +43,7 @@ import { useDecoCredits } from "@/web/hooks/use-deco-credits";
 import { homeNextActionsQueryOptions } from "@/web/hooks/use-home-next-actions";
 import {
   type RunningScope,
+  type RunningState,
   useRunningSummary,
 } from "@/web/hooks/use-running-summary";
 import { organizationSettingsQueryOptions } from "@/web/hooks/use-organization-settings";
@@ -311,7 +313,16 @@ function RunningSummaryLine() {
 
   // Subscribe to both feeds so the badge stays mounted whenever either has work.
   const orgState = useRunningSummary(org.slug, "org");
-  const userState = useRunningSummary(org.slug, "user");
+  const userFeed = useRunningSummary(org.slug, "user");
+  // "All my work" is the cross-org view — the current org already has its own
+  // tab, so drop its threads here to avoid showing them twice.
+  const crossOrgThreads = userFeed.threads.filter(
+    (t) => t.organization_id !== org.id,
+  );
+  const userState: RunningState = {
+    threads: crossOrgThreads,
+    summary: buildRunningSummary(crossOrgThreads),
+  };
 
   if (
     orgState.summary.totalRunning === 0 &&

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -183,6 +183,9 @@ export const KEYS = {
     ["threads", "list-infinite", locator, paramsKey] as const,
   threadMessages: (locator: string, threadId: string) =>
     ["threads", "messages", locator, threadId] as const,
+  // Latest assistant snippet for a running thread (home hover popover).
+  runningThreadLatest: (orgSlug: string, threadId: string) =>
+    ["running-thread-latest", orgSlug, threadId] as const,
   threadModelLogs: (locator: string, dateKey: string) =>
     ["threads", "model-logs", locator, dateKey] as const,
   threadSandbox: (orgKey: string, taskId: string | undefined) =>

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -148,6 +148,7 @@ export {
   createDecopilotFinishEvent,
   createDecopilotThreadStatusEvent,
   DECOPILOT_RUNNING_SUMMARY_EVENT,
+  DECOPILOT_USER_RUNNING_SUMMARY_EVENT,
   buildRunningSummary,
   createDecopilotRunningSummaryEvent,
   type ThreadStatus,
@@ -160,6 +161,7 @@ export {
   type DecopilotEventMap,
   type RunningThread,
   type RunningSummary,
+  type RunningSummaryScope,
   type DecopilotRunningSummaryEvent,
 } from "./types";
 

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -147,6 +147,9 @@ export {
   createDecopilotStepEvent,
   createDecopilotFinishEvent,
   createDecopilotThreadStatusEvent,
+  DECOPILOT_RUNNING_SUMMARY_EVENT,
+  buildRunningSummary,
+  createDecopilotRunningSummaryEvent,
   type ThreadStatus,
   type ThreadDisplayStatus,
   type DecopilotEventType,
@@ -155,6 +158,10 @@ export {
   type DecopilotThreadStatusEvent,
   type DecopilotSSEEvent,
   type DecopilotEventMap,
+  type RunningThread,
+  type RunningAgentSummary,
+  type RunningSummary,
+  type DecopilotRunningSummaryEvent,
 } from "./types";
 
 // Streamable HTTP transport

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -159,7 +159,6 @@ export {
   type DecopilotSSEEvent,
   type DecopilotEventMap,
   type RunningThread,
-  type RunningAgentSummary,
   type RunningSummary,
   type DecopilotRunningSummaryEvent,
 } from "./types";

--- a/packages/mesh-sdk/src/types/decopilot-events.test.ts
+++ b/packages/mesh-sdk/src/types/decopilot-events.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
+  buildRunningSummary,
+  createDecopilotRunningSummaryEvent,
   createDecopilotThreadStatusEvent,
   DECOPILOT_EVENTS,
+  DECOPILOT_RUNNING_SUMMARY_EVENT,
+  type RunningThread,
 } from "./decopilot-events";
 
 describe("createDecopilotThreadStatusEvent", () => {
@@ -74,5 +78,62 @@ describe("createDecopilotThreadStatusEvent — enriched fields", () => {
       branch: null,
     });
     expect(e.data.branch).toBeNull();
+  });
+});
+
+describe("buildRunningSummary", () => {
+  test("returns zeros for no running threads", () => {
+    expect(buildRunningSummary([])).toEqual({
+      totalRunning: 0,
+      agentCount: 0,
+      agents: [],
+    });
+  });
+
+  test("counts tasks and distinct agents, busiest first", () => {
+    const threads: RunningThread[] = [
+      { id: "t1", virtual_mcp_id: "a", title: "Alpha" },
+      { id: "t2", virtual_mcp_id: "a", title: "Alpha" },
+      { id: "t3", virtual_mcp_id: "b", title: "Beta" },
+    ];
+    const summary = buildRunningSummary(threads);
+    expect(summary.totalRunning).toBe(3);
+    expect(summary.agentCount).toBe(2);
+    expect(summary.agents).toEqual([
+      { virtual_mcp_id: "a", title: "Alpha", count: 2 },
+      { virtual_mcp_id: "b", title: "Beta", count: 1 },
+    ]);
+  });
+
+  test("counts agentless threads toward tasks but not agents", () => {
+    const threads: RunningThread[] = [
+      { id: "t1", virtual_mcp_id: "", title: null },
+      { id: "t2", virtual_mcp_id: "a", title: "Alpha" },
+    ];
+    const summary = buildRunningSummary(threads);
+    expect(summary.totalRunning).toBe(2);
+    expect(summary.agentCount).toBe(1);
+  });
+
+  test("backfills a missing title from a later thread of the same agent", () => {
+    const threads: RunningThread[] = [
+      { id: "t1", virtual_mcp_id: "a", title: null },
+      { id: "t2", virtual_mcp_id: "a", title: "Alpha" },
+    ];
+    expect(buildRunningSummary(threads).agents[0]?.title).toBe("Alpha");
+  });
+});
+
+describe("createDecopilotRunningSummaryEvent", () => {
+  test("wraps threads with a derived summary", () => {
+    const threads: RunningThread[] = [
+      { id: "t1", virtual_mcp_id: "a", title: "Alpha" },
+    ];
+    const event = createDecopilotRunningSummaryEvent(threads);
+    expect(event.type).toBe(DECOPILOT_RUNNING_SUMMARY_EVENT);
+    expect(event.source).toBe("decopilot");
+    expect(event.data.threads).toEqual(threads);
+    expect(event.data.summary.totalRunning).toBe(1);
+    expect(event.data.summary.agentCount).toBe(1);
   });
 });

--- a/packages/mesh-sdk/src/types/decopilot-events.test.ts
+++ b/packages/mesh-sdk/src/types/decopilot-events.test.ts
@@ -86,23 +86,18 @@ describe("buildRunningSummary", () => {
     expect(buildRunningSummary([])).toEqual({
       totalRunning: 0,
       agentCount: 0,
-      agents: [],
     });
   });
 
-  test("counts tasks and distinct agents, busiest first", () => {
+  test("counts tasks and distinct agents", () => {
     const threads: RunningThread[] = [
-      { id: "t1", virtual_mcp_id: "a", title: "Alpha" },
-      { id: "t2", virtual_mcp_id: "a", title: "Alpha" },
-      { id: "t3", virtual_mcp_id: "b", title: "Beta" },
+      { id: "t1", virtual_mcp_id: "a", title: "Refactor login" },
+      { id: "t2", virtual_mcp_id: "a", title: "Fix tests" },
+      { id: "t3", virtual_mcp_id: "b", title: "Write docs" },
     ];
     const summary = buildRunningSummary(threads);
     expect(summary.totalRunning).toBe(3);
     expect(summary.agentCount).toBe(2);
-    expect(summary.agents).toEqual([
-      { virtual_mcp_id: "a", title: "Alpha", count: 2 },
-      { virtual_mcp_id: "b", title: "Beta", count: 1 },
-    ]);
   });
 
   test("counts agentless threads toward tasks but not agents", () => {
@@ -113,14 +108,6 @@ describe("buildRunningSummary", () => {
     const summary = buildRunningSummary(threads);
     expect(summary.totalRunning).toBe(2);
     expect(summary.agentCount).toBe(1);
-  });
-
-  test("backfills a missing title from a later thread of the same agent", () => {
-    const threads: RunningThread[] = [
-      { id: "t1", virtual_mcp_id: "a", title: null },
-      { id: "t2", virtual_mcp_id: "a", title: "Alpha" },
-    ];
-    expect(buildRunningSummary(threads).agents[0]?.title).toBe("Alpha");
   });
 });
 

--- a/packages/mesh-sdk/src/types/decopilot-events.test.ts
+++ b/packages/mesh-sdk/src/types/decopilot-events.test.ts
@@ -91,9 +91,24 @@ describe("buildRunningSummary", () => {
 
   test("counts tasks and distinct agents", () => {
     const threads: RunningThread[] = [
-      { id: "t1", virtual_mcp_id: "a", title: "Refactor login" },
-      { id: "t2", virtual_mcp_id: "a", title: "Fix tests" },
-      { id: "t3", virtual_mcp_id: "b", title: "Write docs" },
+      {
+        id: "t1",
+        virtual_mcp_id: "a",
+        title: "Refactor login",
+        organization_id: "o1",
+      },
+      {
+        id: "t2",
+        virtual_mcp_id: "a",
+        title: "Fix tests",
+        organization_id: "o1",
+      },
+      {
+        id: "t3",
+        virtual_mcp_id: "b",
+        title: "Write docs",
+        organization_id: "o2",
+      },
     ];
     const summary = buildRunningSummary(threads);
     expect(summary.totalRunning).toBe(3);
@@ -102,8 +117,8 @@ describe("buildRunningSummary", () => {
 
   test("counts agentless threads toward tasks but not agents", () => {
     const threads: RunningThread[] = [
-      { id: "t1", virtual_mcp_id: "", title: null },
-      { id: "t2", virtual_mcp_id: "a", title: "Alpha" },
+      { id: "t1", virtual_mcp_id: "", title: null, organization_id: "o1" },
+      { id: "t2", virtual_mcp_id: "a", title: "Alpha", organization_id: "o1" },
     ];
     const summary = buildRunningSummary(threads);
     expect(summary.totalRunning).toBe(2);
@@ -114,7 +129,7 @@ describe("buildRunningSummary", () => {
 describe("createDecopilotRunningSummaryEvent", () => {
   test("wraps threads with a derived summary", () => {
     const threads: RunningThread[] = [
-      { id: "t1", virtual_mcp_id: "a", title: "Alpha" },
+      { id: "t1", virtual_mcp_id: "a", title: "Alpha", organization_id: "o1" },
     ];
     const event = createDecopilotRunningSummaryEvent(threads);
     expect(event.type).toBe(DECOPILOT_RUNNING_SUMMARY_EVENT);

--- a/packages/mesh-sdk/src/types/decopilot-events.ts
+++ b/packages/mesh-sdk/src/types/decopilot-events.ts
@@ -99,44 +99,25 @@ export type DecopilotSSEEvent =
 // Running Summary (home "X agents working on N tasks")
 // ============================================================================
 
-/**
- * Connect-time snapshot event written directly to the `/watch` stream (not a
- * broadcast type, so it stays out of `ALL_DECOPILOT_EVENT_TYPES`). Re-fires on
- * every reconnect, and the run reactor broadcasts a fresh one on each thread
- * transition. Clients store the latest `summary` and render it.
- */
 export const DECOPILOT_RUNNING_SUMMARY_EVENT = "decopilot.running.summary";
-/** Same payload, but the per-user (cross-org) scope. Distinct type so a single
- *  `/watch` connection can carry both org and user summaries and the client can
- *  route them. */
+// Per-user (cross-org) scope; distinct type so one /watch connection can carry both.
 export const DECOPILOT_USER_RUNNING_SUMMARY_EVENT =
   "decopilot.running.summary.user";
 
 export type RunningSummaryScope = "org" | "user";
 
-/**
- * A single in_progress thread. `title` is the THREAD's title (the hover row's
- * heading). The agent is resolved client-side from `virtual_mcp_id` when it
- * lives in the current org; for cross-org rows (the per-user feed) the client
- * can't resolve it, so the server fills `agent_title`.
- */
 export interface RunningThread {
   id: string;
   /** Empty string when the thread has no agent bound. */
   virtual_mcp_id: string;
-  /** Thread title; null when untitled. */
   title: string | null;
-  /** Org the thread belongs to — drives cross-org navigation. */
   organization_id: string;
-  /** Agent (connection) title, server-resolved. Present on the cross-org feed;
-   *  omitted on the org feed, where the client resolves it from virtual_mcp_id. */
+  /** Server-resolved agent title; only on the cross-org feed (the client can't resolve a cross-org agent). */
   agent_title?: string | null;
 }
 
 export interface RunningSummary {
-  /** Total threads currently in_progress — the "N tasks". */
   totalRunning: number;
-  /** Distinct agents with at least one in_progress thread — the "X agents". */
   agentCount: number;
 }
 
@@ -149,17 +130,12 @@ export interface DecopilotRunningSummaryEvent {
   time: string;
   data: {
     summary: RunningSummary;
-    /** Per-thread descriptors — drives the hover list and the counts. */
     threads: RunningThread[];
   };
 }
 
-/**
- * Pure aggregation of running threads into the home summary counts. Shared by
- * the server (snapshot + broadcast) and the client so both sides count
- * identically. Threads with no agent bound count toward `totalRunning` but not
- * `agentCount`.
- */
+// Shared by server and client so both count identically. Agentless threads
+// count toward totalRunning but not agentCount.
 export function buildRunningSummary(threads: RunningThread[]): RunningSummary {
   const agentIds = new Set<string>();
   for (const t of threads) {

--- a/packages/mesh-sdk/src/types/decopilot-events.ts
+++ b/packages/mesh-sdk/src/types/decopilot-events.ts
@@ -108,9 +108,10 @@ export type DecopilotSSEEvent =
 export const DECOPILOT_RUNNING_SUMMARY_EVENT = "decopilot.running.summary";
 
 /**
- * A single in_progress thread. `title` is the THREAD's title (used for the
- * hover row); the agent (icon + name) is resolved client-side from
- * `virtual_mcp_id`, so it isn't duplicated here.
+ * A single in_progress thread. `title` is the THREAD's title (the hover row's
+ * heading). The agent is resolved client-side from `virtual_mcp_id` when it
+ * lives in the current org; for cross-org rows (the per-user feed) the client
+ * can't resolve it, so the server fills `agent_title`.
  */
 export interface RunningThread {
   id: string;
@@ -118,6 +119,11 @@ export interface RunningThread {
   virtual_mcp_id: string;
   /** Thread title; null when untitled. */
   title: string | null;
+  /** Org the thread belongs to — drives cross-org navigation. */
+  organization_id: string;
+  /** Agent (connection) title, server-resolved. Present on the cross-org feed;
+   *  omitted on the org feed, where the client resolves it from virtual_mcp_id. */
+  agent_title?: string | null;
 }
 
 export interface RunningSummary {

--- a/packages/mesh-sdk/src/types/decopilot-events.ts
+++ b/packages/mesh-sdk/src/types/decopilot-events.ts
@@ -107,19 +107,17 @@ export type DecopilotSSEEvent =
  */
 export const DECOPILOT_RUNNING_SUMMARY_EVENT = "decopilot.running.summary";
 
-/** A single in_progress thread, with the agent (virtual MCP) it belongs to. */
+/**
+ * A single in_progress thread. `title` is the THREAD's title (used for the
+ * hover row); the agent (icon + name) is resolved client-side from
+ * `virtual_mcp_id`, so it isn't duplicated here.
+ */
 export interface RunningThread {
   id: string;
   /** Empty string when the thread has no agent bound. */
   virtual_mcp_id: string;
-  /** Agent title resolved from the connection; null when unknown/agentless. */
+  /** Thread title; null when untitled. */
   title: string | null;
-}
-
-export interface RunningAgentSummary {
-  virtual_mcp_id: string;
-  title: string | null;
-  count: number;
 }
 
 export interface RunningSummary {
@@ -127,8 +125,6 @@ export interface RunningSummary {
   totalRunning: number;
   /** Distinct agents with at least one in_progress thread — the "X agents". */
   agentCount: number;
-  /** Per-agent breakdown, busiest first. */
-  agents: RunningAgentSummary[];
 }
 
 export interface DecopilotRunningSummaryEvent {
@@ -138,35 +134,23 @@ export interface DecopilotRunningSummaryEvent {
   time: string;
   data: {
     summary: RunningSummary;
-    /** Per-thread descriptors so server and client can recompute identically. */
+    /** Per-thread descriptors — drives the hover list and the counts. */
     threads: RunningThread[];
   };
 }
 
 /**
- * Pure aggregation of running threads into the home summary. Shared by the
- * server (snapshot + broadcast) and the client so both sides count identically.
- * Threads with no agent bound count toward `totalRunning` but not `agentCount`.
+ * Pure aggregation of running threads into the home summary counts. Shared by
+ * the server (snapshot + broadcast) and the client so both sides count
+ * identically. Threads with no agent bound count toward `totalRunning` but not
+ * `agentCount`.
  */
 export function buildRunningSummary(threads: RunningThread[]): RunningSummary {
-  const byAgent = new Map<string, RunningAgentSummary>();
+  const agentIds = new Set<string>();
   for (const t of threads) {
-    const key = t.virtual_mcp_id || "";
-    if (!key) continue;
-    const existing = byAgent.get(key);
-    if (existing) {
-      existing.count++;
-      if (existing.title == null && t.title != null) existing.title = t.title;
-    } else {
-      byAgent.set(key, {
-        virtual_mcp_id: key,
-        title: t.title ?? null,
-        count: 1,
-      });
-    }
+    if (t.virtual_mcp_id) agentIds.add(t.virtual_mcp_id);
   }
-  const agents = [...byAgent.values()].sort((a, b) => b.count - a.count);
-  return { totalRunning: threads.length, agentCount: agents.length, agents };
+  return { totalRunning: threads.length, agentCount: agentIds.size };
 }
 
 export function createDecopilotRunningSummaryEvent(

--- a/packages/mesh-sdk/src/types/decopilot-events.ts
+++ b/packages/mesh-sdk/src/types/decopilot-events.ts
@@ -106,6 +106,13 @@ export type DecopilotSSEEvent =
  * transition. Clients store the latest `summary` and render it.
  */
 export const DECOPILOT_RUNNING_SUMMARY_EVENT = "decopilot.running.summary";
+/** Same payload, but the per-user (cross-org) scope. Distinct type so a single
+ *  `/watch` connection can carry both org and user summaries and the client can
+ *  route them. */
+export const DECOPILOT_USER_RUNNING_SUMMARY_EVENT =
+  "decopilot.running.summary.user";
+
+export type RunningSummaryScope = "org" | "user";
 
 /**
  * A single in_progress thread. `title` is the THREAD's title (the hover row's
@@ -135,7 +142,9 @@ export interface RunningSummary {
 
 export interface DecopilotRunningSummaryEvent {
   id: string;
-  type: typeof DECOPILOT_RUNNING_SUMMARY_EVENT;
+  type:
+    | typeof DECOPILOT_RUNNING_SUMMARY_EVENT
+    | typeof DECOPILOT_USER_RUNNING_SUMMARY_EVENT;
   source: "decopilot";
   time: string;
   data: {
@@ -161,10 +170,14 @@ export function buildRunningSummary(threads: RunningThread[]): RunningSummary {
 
 export function createDecopilotRunningSummaryEvent(
   threads: RunningThread[],
+  scope: RunningSummaryScope = "org",
 ): DecopilotRunningSummaryEvent {
   return {
     id: crypto.randomUUID(),
-    type: DECOPILOT_RUNNING_SUMMARY_EVENT,
+    type:
+      scope === "user"
+        ? DECOPILOT_USER_RUNNING_SUMMARY_EVENT
+        : DECOPILOT_RUNNING_SUMMARY_EVENT,
     source: "decopilot",
     time: new Date().toISOString(),
     data: { summary: buildRunningSummary(threads), threads },

--- a/packages/mesh-sdk/src/types/decopilot-events.ts
+++ b/packages/mesh-sdk/src/types/decopilot-events.ts
@@ -95,6 +95,92 @@ export type DecopilotSSEEvent =
   | DecopilotFinishEvent
   | DecopilotThreadStatusEvent;
 
+// ============================================================================
+// Running Summary (home "X agents working on N tasks")
+// ============================================================================
+
+/**
+ * Connect-time snapshot event written directly to the `/watch` stream (not a
+ * broadcast type, so it stays out of `ALL_DECOPILOT_EVENT_TYPES`). Re-fires on
+ * every reconnect, and the run reactor broadcasts a fresh one on each thread
+ * transition. Clients store the latest `summary` and render it.
+ */
+export const DECOPILOT_RUNNING_SUMMARY_EVENT = "decopilot.running.summary";
+
+/** A single in_progress thread, with the agent (virtual MCP) it belongs to. */
+export interface RunningThread {
+  id: string;
+  /** Empty string when the thread has no agent bound. */
+  virtual_mcp_id: string;
+  /** Agent title resolved from the connection; null when unknown/agentless. */
+  title: string | null;
+}
+
+export interface RunningAgentSummary {
+  virtual_mcp_id: string;
+  title: string | null;
+  count: number;
+}
+
+export interface RunningSummary {
+  /** Total threads currently in_progress — the "N tasks". */
+  totalRunning: number;
+  /** Distinct agents with at least one in_progress thread — the "X agents". */
+  agentCount: number;
+  /** Per-agent breakdown, busiest first. */
+  agents: RunningAgentSummary[];
+}
+
+export interface DecopilotRunningSummaryEvent {
+  id: string;
+  type: typeof DECOPILOT_RUNNING_SUMMARY_EVENT;
+  source: "decopilot";
+  time: string;
+  data: {
+    summary: RunningSummary;
+    /** Per-thread descriptors so server and client can recompute identically. */
+    threads: RunningThread[];
+  };
+}
+
+/**
+ * Pure aggregation of running threads into the home summary. Shared by the
+ * server (snapshot + broadcast) and the client so both sides count identically.
+ * Threads with no agent bound count toward `totalRunning` but not `agentCount`.
+ */
+export function buildRunningSummary(threads: RunningThread[]): RunningSummary {
+  const byAgent = new Map<string, RunningAgentSummary>();
+  for (const t of threads) {
+    const key = t.virtual_mcp_id || "";
+    if (!key) continue;
+    const existing = byAgent.get(key);
+    if (existing) {
+      existing.count++;
+      if (existing.title == null && t.title != null) existing.title = t.title;
+    } else {
+      byAgent.set(key, {
+        virtual_mcp_id: key,
+        title: t.title ?? null,
+        count: 1,
+      });
+    }
+  }
+  const agents = [...byAgent.values()].sort((a, b) => b.count - a.count);
+  return { totalRunning: threads.length, agentCount: agents.length, agents };
+}
+
+export function createDecopilotRunningSummaryEvent(
+  threads: RunningThread[],
+): DecopilotRunningSummaryEvent {
+  return {
+    id: crypto.randomUUID(),
+    type: DECOPILOT_RUNNING_SUMMARY_EVENT,
+    source: "decopilot",
+    time: new Date().toISOString(),
+    data: { summary: buildRunningSummary(threads), threads },
+  };
+}
+
 /** Map from event type string → typed payload (useful for generic handlers) */
 export interface DecopilotEventMap {
   [DECOPILOT_EVENTS.STEP]: DecopilotStepEvent;

--- a/packages/mesh-sdk/src/types/index.ts
+++ b/packages/mesh-sdk/src/types/index.ts
@@ -67,6 +67,7 @@ export {
   createDecopilotFinishEvent,
   createDecopilotThreadStatusEvent,
   DECOPILOT_RUNNING_SUMMARY_EVENT,
+  DECOPILOT_USER_RUNNING_SUMMARY_EVENT,
   buildRunningSummary,
   createDecopilotRunningSummaryEvent,
   type ThreadStatus,
@@ -79,5 +80,6 @@ export {
   type DecopilotEventMap,
   type RunningThread,
   type RunningSummary,
+  type RunningSummaryScope,
   type DecopilotRunningSummaryEvent,
 } from "./decopilot-events";

--- a/packages/mesh-sdk/src/types/index.ts
+++ b/packages/mesh-sdk/src/types/index.ts
@@ -78,7 +78,6 @@ export {
   type DecopilotSSEEvent,
   type DecopilotEventMap,
   type RunningThread,
-  type RunningAgentSummary,
   type RunningSummary,
   type DecopilotRunningSummaryEvent,
 } from "./decopilot-events";

--- a/packages/mesh-sdk/src/types/index.ts
+++ b/packages/mesh-sdk/src/types/index.ts
@@ -66,6 +66,9 @@ export {
   createDecopilotStepEvent,
   createDecopilotFinishEvent,
   createDecopilotThreadStatusEvent,
+  DECOPILOT_RUNNING_SUMMARY_EVENT,
+  buildRunningSummary,
+  createDecopilotRunningSummaryEvent,
   type ThreadStatus,
   type ThreadDisplayStatus,
   type DecopilotEventType,
@@ -74,4 +77,8 @@ export {
   type DecopilotThreadStatusEvent,
   type DecopilotSSEEvent,
   type DecopilotEventMap,
+  type RunningThread,
+  type RunningAgentSummary,
+  type RunningSummary,
+  type DecopilotRunningSummaryEvent,
 } from "./decopilot-events";


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live running summary to the home page: “X agents working on N tasks,” with a hover list and a scope toggle between “This org” and “All my work.” The `/watch` SSE sends org and per‑user snapshots on connect and broadcasts on every run transition, backed by a cross‑pod running set.

- **New Features**
  - Home: running badge with hover list; scope toggle (“This org” / “All my work”); click to open a thread; shows agent avatar and, for cross‑org rows, the org icon; latest assistant snippet loads on hover; cross‑org view hides threads from the current org to avoid duplicates.
  - SSE: `/watch` streams `decopilot.running.summary` (org) and `decopilot.running.summary.user` (per‑user) snapshots on connect when requested; the reactor broadcasts fresh summaries on start/step/finish to org and `user:<id>` channels.
  - Running set: `RunningThreadsStore` with a JetStream KV backend (per‑org key, idle‑entry pruning, TTL) and a DB fallback when NATS is absent; storage adds `summarizeRunning` and `summarizeRunningForUser`; `@decocms/mesh-sdk` adds `DECOPILOT_RUNNING_SUMMARY_EVENT`, `DECOPILOT_USER_RUNNING_SUMMARY_EVENT`, `buildRunningSummary`, and `createDecopilotRunningSummaryEvent`.

- **Refactors**
  - Unified `/watch` SSE pool shared by decopilot, workflows, and the running summary; one cross‑tab connection per org (Web Locks + `BroadcastChannel`), with view filters per consumer.
  - Running‑summary events are sticky and replay to late subscribers; client stores persist across unmounts to avoid flicker; server snapshots are gated by `?types` and can include both org and per‑user scopes.
  - Per‑user summary emission is awaited in the run reactor to prevent stale “All my work” counts on completion; tests drop running‑summary broadcasts to keep lifecycle assertions focused.

<sup>Written for commit 791b47a8caa5d22dc072681ec7dd87380008e5ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

