### PR TITLE
ci(sandbox): auto-bump studio-sandbox image in deco-apps-cd (stg)

### DIFF
--- a/.github/workflows/release-studio-sandbox.yaml
+++ b/.github/workflows/release-studio-sandbox.yaml
@@ -15,6 +15,10 @@ jobs:
   build-push:
     name: Build & Push studio-sandbox image
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      # true only when a NEW image was actually built + pushed this run.
+      pushed: ${{ steps.tag-check.outputs.exists != 'true' }}
     permissions:
       contents: read
       packages: write
@@ -122,3 +126,39 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+  # GitOps: auto-bump the studio-sandbox image tag in deco-apps-cd, mirroring
+  # release-mesh. We fire the GENERIC `image-bump` repository_dispatch; that
+  # repo's own bump-image.yml self-commits the tag with its native token (no
+  # cross-repo write credential lives here).
+  #
+  # Only STG is bumped: studio-sandbox-stg auto-syncs, so it rolls + tests the
+  # new image automatically. studio-sandbox-prod is auto-sync by default too,
+  # so it's deliberately left to a manual promotion (bump its values file by
+  # hand) — add "apps/studio-sandbox-prod/values.yaml" to `files` only after
+  # gating that app with `syncPolicy.automated: null`, the way deco-studio does.
+  bump-deco-apps-cd:
+    name: Trigger deco-apps-cd bump (stg)
+    needs: build-push
+    if: needs.build-push.outputs.pushed == 'true'
+    runs-on: ubuntu-latest
+    # Reuses DEPLOY_REPO_TOKEN (decobot PAT, admin on decocms/deco-apps-cd) —
+    # same token + mechanism as release-mesh. A convenience that must never red
+    # the release: if the token isn't present the step no-ops and the job passes.
+    env:
+      DISPATCH_TOKEN: ${{ secrets.DEPLOY_REPO_TOKEN }}
+    steps:
+      - name: Skip notice (dispatch token not configured)
+        if: env.DISPATCH_TOKEN == ''
+        run: echo "::notice::DEPLOY_REPO_TOKEN not set — skipping the deco-apps-cd bump."
+      - name: Dispatch image-bump to deco-apps-cd
+        if: env.DISPATCH_TOKEN != ''
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DEPLOY_REPO_TOKEN }}
+          repository: decocms/deco-apps-cd
+          event-type: image-bump
+          client-payload: '{"version": "${{ needs.build-push.outputs.version }}", "repository": "decocms/studio/studio-sandbox", "files": ["apps/studio-sandbox-stg/values.yaml"]}'
+      - name: Summary
+        if: env.DISPATCH_TOKEN != ''
+        run: echo "Dispatched \`image-bump\` (studio-sandbox ${{ needs.build-push.outputs.version }} -> stg) to decocms/deco-apps-cd" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What is this contribution about?
The `studio-sandbox` image builds automatically on merge (`release-studio-sandbox.yaml`), but — unlike the mesh image — nothing bumps its tag in `decocms/deco-apps-cd`, so the deployed tag drifts (currently pinned `1.2.3` while the repo is at `1.3.2`) and sandbox changes never roll out until someone edits the CD repo by hand. This adds the missing GitOps step, mirroring `release-mesh`: when a new image is pushed, fire a generic `image-bump` `repository_dispatch` to `deco-apps-cd` (handled by its existing `bump-image.yml`, which self-commits the tag — no CD-repo change needed). Only `studio-sandbox-stg` is bumped (it auto-syncs → rolls + tests automatically); `studio-sandbox-prod` stays a deliberate manual promotion because it's auto-sync by default, so auto-bumping it would roll prod on every release.

## How to Test
1. Merge → on the next `packages/sandbox/**` change with a version bump, `release-studio-sandbox` builds the image, then the `bump-deco-apps-cd` job dispatches `image-bump` to `deco-apps-cd`.
2. `deco-apps-cd`'s `bump-image.yml` commits the new tag into `apps/studio-sandbox-stg/values.yaml`; ArgoCD (stg auto-sync) rolls it.
3. No new image (version unchanged) → the bump job is skipped (`pushed == 'true'` gate).

## Migration Notes
Needs the existing `DEPLOY_REPO_TOKEN` secret (already used by `release-mesh`); absent → the job no-ops. To later auto-bump prod too, add `apps/studio-sandbox-prod/values.yaml` to `files` **after** setting `syncPolicy.automated: null` on `studio-sandbox-prod` in deco-apps-cd (mirroring `deco-studio`).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically bumps the `studio-sandbox` image tag in `decocms/deco-apps-cd` for staging when a new image is built, keeping stg deploys in sync without manual edits. Mirrors the mesh flow; production stays a manual promotion.

- New Features
  - Adds a `bump-deco-apps-cd` job to `release-studio-sandbox.yaml` that dispatches `image-bump` to `decocms/deco-apps-cd` via `peter-evans/repository-dispatch@v3`.
  - Updates only `apps/studio-sandbox-stg/values.yaml`; prod is not auto-bumped.
  - Runs only when a new image is pushed; safely no-ops if `DEPLOY_REPO_TOKEN` is missing.

- Migration
  - Requires `DEPLOY_REPO_TOKEN`. To later include prod, disable its auto-sync and add `apps/studio-sandbox-prod/values.yaml` to the dispatch payload.

<sup>Written for commit 34ef676d7e0eb85b27211df6fa5b18a04d6b857e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

