### PR TITLE
refactor(auth): AccessControl — required boundAuth + options-object constructor, drop dead branch

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/automation-context.ts
+++ b/apps/mesh/src/api/routes/decopilot/automation-context.ts
@@ -82,13 +82,12 @@ export function createAutomationContextFactory(
       permissions,
       userId,
     });
-    ctx.access = new AccessControl(
+    ctx.access = new AccessControl({
       userId,
-      undefined, // toolName set later by defineTool
-      ctx.boundAuth,
-      membership.role,
-      "self",
-    );
+      // toolName set later by defineTool; connectionId defaults to "self"
+      boundAuth: ctx.boundAuth,
+      role: membership.role,
+    });
 
     // The base context was built without `req`, so every org-scoped facet
     // (thread storage, object storage, org-fs, asset hoisters) was created

--- a/apps/mesh/src/core/access-control.test.ts
+++ b/apps/mesh/src/core/access-control.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it, vi } from "bun:test";
-import {
-  AccessControl,
-  ForbiddenError,
-  UnauthorizedError,
-} from "./access-control";
+import { AccessControl, ForbiddenError } from "./access-control";
 import type { BoundAuthClient } from "./studio-context";
 import type { Permission } from "../storage/types";
 import { BASIC_USAGE_TOOLS } from "../tools/registry-metadata";
@@ -45,13 +41,21 @@ const createMockBoundAuth = (permissions: Permission): BoundAuthClient => {
 describe("AccessControl", () => {
   describe("grant", () => {
     it("should grant access unconditionally", () => {
-      const ac = new AccessControl();
+      const ac = new AccessControl(
+        undefined,
+        undefined,
+        createMockBoundAuth({}),
+      );
       ac.grant();
       expect(ac.granted()).toBe(true);
     });
 
     it("should allow multiple grant calls", () => {
-      const ac = new AccessControl();
+      const ac = new AccessControl(
+        undefined,
+        undefined,
+        createMockBoundAuth({}),
+      );
       ac.grant();
       ac.grant();
       expect(ac.granted()).toBe(true);
@@ -214,15 +218,18 @@ describe("AccessControl", () => {
       );
     });
 
-    it("should deny access when no userId or permissions", async () => {
+    it("should deny an unauthenticated principal (no userId, no role)", async () => {
+      // boundAuth is always present (built per-request); an anonymous caller has
+      // no userId/role and is denied by the permission check (403). The 401 for
+      // truly-unauthenticated requests is enforced upstream by requireAuth.
       const ac = new AccessControl(
         undefined, // No user
         "TEST_TOOL",
-        undefined, // No boundAuth
-        undefined,
+        createMockBoundAuth({}), // present, but grants nothing
+        undefined, // No role
       );
 
-      await expect(ac.check()).rejects.toThrow(UnauthorizedError);
+      await expect(ac.check()).rejects.toThrow(ForbiddenError);
     });
   });
 
@@ -293,12 +300,20 @@ describe("AccessControl", () => {
 
   describe("granted", () => {
     it("should return false initially", () => {
-      const ac = new AccessControl();
+      const ac = new AccessControl(
+        undefined,
+        undefined,
+        createMockBoundAuth({}),
+      );
       expect(ac.granted()).toBe(false);
     });
 
     it("should return true after grant", () => {
-      const ac = new AccessControl();
+      const ac = new AccessControl(
+        undefined,
+        undefined,
+        createMockBoundAuth({}),
+      );
       ac.grant();
       expect(ac.granted()).toBe(true);
     });
@@ -381,17 +396,6 @@ describe("AccessControl", () => {
 
       await expect(ac.check()).rejects.toThrow(ForbiddenError);
       expect(ac.granted()).toBe(false);
-    });
-
-    it("should deny access when no BoundAuthClient provided", async () => {
-      const ac = new AccessControl(
-        "user_1",
-        "TEST_TOOL",
-        undefined, // No bound auth
-        "user",
-      );
-
-      await expect(ac.check()).rejects.toThrow(ForbiddenError);
     });
   });
 });

--- a/apps/mesh/src/core/access-control.test.ts
+++ b/apps/mesh/src/core/access-control.test.ts
@@ -41,21 +41,13 @@ const createMockBoundAuth = (permissions: Permission): BoundAuthClient => {
 describe("AccessControl", () => {
   describe("grant", () => {
     it("should grant access unconditionally", () => {
-      const ac = new AccessControl(
-        undefined,
-        undefined,
-        createMockBoundAuth({}),
-      );
+      const ac = new AccessControl({ boundAuth: createMockBoundAuth({}) });
       ac.grant();
       expect(ac.granted()).toBe(true);
     });
 
     it("should allow multiple grant calls", () => {
-      const ac = new AccessControl(
-        undefined,
-        undefined,
-        createMockBoundAuth({}),
-      );
+      const ac = new AccessControl({ boundAuth: createMockBoundAuth({}) });
       ac.grant();
       ac.grant();
       expect(ac.granted()).toBe(true);
@@ -64,61 +56,59 @@ describe("AccessControl", () => {
 
   describe("check", () => {
     it("should grant access when permission exists", async () => {
-      const ac = new AccessControl(
-        "user_1",
-        "TEST_TOOL",
-        createMockBoundAuth({ self: ["TEST_TOOL"] }), // Has permission on self connection
-        "user",
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        toolName: "TEST_TOOL",
+        boundAuth: createMockBoundAuth({ self: ["TEST_TOOL"] }), // Has permission on self connection
+        role: "user",
+      });
 
       await ac.check();
       expect(ac.granted()).toBe(true);
     });
 
     it("should deny access when permission missing", async () => {
-      const ac = new AccessControl(
-        "user_1",
-        "TEST_TOOL",
-        createMockBoundAuth({ self: ["OTHER_TOOL"] }), // Has OTHER_TOOL but not TEST_TOOL
-        "user",
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        toolName: "TEST_TOOL",
+        boundAuth: createMockBoundAuth({ self: ["OTHER_TOOL"] }), // Has OTHER_TOOL but not TEST_TOOL
+        role: "user",
+      });
 
       await expect(ac.check()).rejects.toThrow(ForbiddenError);
       expect(ac.granted()).toBe(false);
     });
 
     it("should check current tool name by default", async () => {
-      const ac = new AccessControl(
-        "user_1",
-        "MY_TOOL",
-        createMockBoundAuth({ self: ["MY_TOOL"] }), // Permission on self connection
-        "user",
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        toolName: "MY_TOOL",
+        boundAuth: createMockBoundAuth({ self: ["MY_TOOL"] }), // Permission on self connection
+        role: "user",
+      });
 
       await ac.check();
       expect(ac.granted()).toBe(true);
     });
 
     it("should check specific resources when provided", async () => {
-      const ac = new AccessControl(
-        "user_1",
-        undefined,
-        createMockBoundAuth({ conn_123: ["SEND_MESSAGE"] }),
-        "user",
-        "conn_123", // Checking conn_123
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        boundAuth: createMockBoundAuth({ conn_123: ["SEND_MESSAGE"] }),
+        role: "user",
+        connectionId: "conn_123", // Checking conn_123
+      });
 
       await ac.check("SEND_MESSAGE");
       expect(ac.granted()).toBe(true);
     });
 
     it("should use OR logic for multiple resources", async () => {
-      const ac = new AccessControl(
-        "user_1",
-        undefined,
-        createMockBoundAuth({ self: ["TOOL2"] }), // Has TOOL2 on self connection
-        "user",
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        boundAuth: createMockBoundAuth({ self: ["TOOL2"] }), // Has TOOL2 on self connection
+        role: "user",
+      });
 
       // Has TOOL2 but not TOOL1 - should succeed (OR logic)
       await ac.check("TOOL1", "TOOL2");
@@ -127,7 +117,10 @@ describe("AccessControl", () => {
 
     it("should skip check if already granted", async () => {
       const mockBoundAuth = createMockBoundAuth({});
-      const ac = new AccessControl("user_1", undefined, mockBoundAuth);
+      const ac = new AccessControl({
+        userId: "user_1",
+        boundAuth: mockBoundAuth,
+      });
 
       ac.grant(); // Grant first
 
@@ -136,12 +129,12 @@ describe("AccessControl", () => {
     });
 
     it("should bypass checks for admin role", async () => {
-      const ac = new AccessControl(
-        "user_1",
-        "TEST_TOOL",
-        createMockBoundAuth({}), // No permissions
-        "admin", // Admin role
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        toolName: "TEST_TOOL",
+        boundAuth: createMockBoundAuth({}), // No permissions
+        role: "admin", // Admin role
+      });
 
       await ac.check();
       expect(ac.granted()).toBe(true);
@@ -156,21 +149,21 @@ describe("AccessControl", () => {
         isApiKeyPrincipal: true,
       } as BoundAuthClient;
 
-      const allowed = new AccessControl(
-        "user_1",
-        "ORGANIZATION_GET",
-        keyBoundAuth,
-        "admin", // owner is an admin — must NOT grant beyond the allowlist
-      );
+      const allowed = new AccessControl({
+        userId: "user_1",
+        toolName: "ORGANIZATION_GET",
+        boundAuth: keyBoundAuth,
+        role: "admin", // owner is an admin — must NOT grant beyond the allowlist
+      });
       await allowed.check();
       expect(allowed.granted()).toBe(true);
 
-      const denied = new AccessControl(
-        "user_1",
-        "API_KEY_CREATE", // out of scope — the exact escalation we are blocking
-        keyBoundAuth,
-        "admin",
-      );
+      const denied = new AccessControl({
+        userId: "user_1",
+        toolName: "API_KEY_CREATE", // out of scope — the exact escalation we are blocking
+        boundAuth: keyBoundAuth,
+        role: "admin",
+      });
       await expect(denied.check()).rejects.toThrow(ForbiddenError);
       expect(denied.granted()).toBe(false);
     });
@@ -182,36 +175,36 @@ describe("AccessControl", () => {
         isApiKeyPrincipal: false,
       } as BoundAuthClient;
 
-      const ac = new AccessControl(
-        "user_1",
-        "API_KEY_CREATE",
+      const ac = new AccessControl({
+        userId: "user_1",
+        toolName: "API_KEY_CREATE",
         boundAuth,
-        "owner",
-      );
+        role: "owner",
+      });
       await ac.check();
       expect(ac.granted()).toBe(true);
     });
 
     it("should check connection-specific permissions", async () => {
-      const ac = new AccessControl(
-        "user_1",
-        "SEND_MESSAGE",
-        createMockBoundAuth({ conn_123: ["SEND_MESSAGE"] }),
-        "user",
-        "conn_123", // Connection ID
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        toolName: "SEND_MESSAGE",
+        boundAuth: createMockBoundAuth({ conn_123: ["SEND_MESSAGE"] }),
+        role: "user",
+        connectionId: "conn_123", // Connection ID
+      });
 
       await ac.check("SEND_MESSAGE");
       expect(ac.granted()).toBe(true);
     });
 
     it("should throw when no resources specified", async () => {
-      const ac = new AccessControl(
-        "user_1",
-        undefined, // No tool name
-        createMockBoundAuth({}),
-        "user",
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        // No tool name
+        boundAuth: createMockBoundAuth({}),
+        role: "user",
+      });
 
       await expect(ac.check()).rejects.toThrow(
         "No resources specified for access check",
@@ -222,12 +215,11 @@ describe("AccessControl", () => {
       // boundAuth is always present (built per-request); an anonymous caller has
       // no userId/role and is denied by the permission check (403). The 401 for
       // truly-unauthenticated requests is enforced upstream by requireAuth.
-      const ac = new AccessControl(
-        undefined, // No user
-        "TEST_TOOL",
-        createMockBoundAuth({}), // present, but grants nothing
-        undefined, // No role
-      );
+      const ac = new AccessControl({
+        // No user, no role
+        toolName: "TEST_TOOL",
+        boundAuth: createMockBoundAuth({}), // present, but grants nothing
+      });
 
       await expect(ac.check()).rejects.toThrow(ForbiddenError);
     });
@@ -244,12 +236,12 @@ describe("AccessControl", () => {
     const tool = [...BASIC_USAGE_TOOLS][0];
 
     it("grants a basic-usage tool to an authenticated member, regardless of role", async () => {
-      const ac = new AccessControl(
-        "user_1", // authenticated principal
-        tool,
-        createMockBoundAuth({}), // role grants nothing explicitly
-        "some-custom-role", // a member (role set), not owner/admin
-      );
+      const ac = new AccessControl({
+        userId: "user_1", // authenticated principal
+        toolName: tool,
+        boundAuth: createMockBoundAuth({}), // role grants nothing explicitly
+        role: "some-custom-role", // a member (role set), not owner/admin
+      });
 
       await ac.check();
       expect(ac.granted()).toBe(true);
@@ -259,24 +251,24 @@ describe("AccessControl", () => {
       // boundAuth is constructed for every request, so it must never be treated
       // as authentication. With no userId the grant must not fire. (Before the
       // userId guard, a role-but-no-principal state would have leaked here.)
-      const ac = new AccessControl(
-        undefined, // no authenticated principal
-        tool,
-        createMockBoundAuth({}), // boundAuth present, as it always is
-        "some-custom-role", // role present, but the principal is not verified
-      );
+      const ac = new AccessControl({
+        // no authenticated principal
+        toolName: tool,
+        boundAuth: createMockBoundAuth({}), // boundAuth present, as it always is
+        role: "some-custom-role", // role present, but the principal is not verified
+      });
 
       await expect(ac.check()).rejects.toThrow(ForbiddenError);
       expect(ac.granted()).toBe(false);
     });
 
     it("does NOT grant basic-usage to an authenticated non-member (no role)", async () => {
-      const ac = new AccessControl(
-        "user_1",
-        tool,
-        createMockBoundAuth({}),
-        undefined, // not a member of this org → no role
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        toolName: tool,
+        boundAuth: createMockBoundAuth({}),
+        // not a member of this org → no role
+      });
 
       await expect(ac.check()).rejects.toThrow(ForbiddenError);
       expect(ac.granted()).toBe(false);
@@ -291,7 +283,12 @@ describe("AccessControl", () => {
         isApiKeyPrincipal: true,
       } as BoundAuthClient;
 
-      const ac = new AccessControl("user_1", tool, keyBoundAuth, "admin");
+      const ac = new AccessControl({
+        userId: "user_1",
+        toolName: tool,
+        boundAuth: keyBoundAuth,
+        role: "admin",
+      });
 
       await expect(ac.check()).rejects.toThrow(ForbiddenError);
       expect(ac.granted()).toBe(false);
@@ -300,43 +297,35 @@ describe("AccessControl", () => {
 
   describe("granted", () => {
     it("should return false initially", () => {
-      const ac = new AccessControl(
-        undefined,
-        undefined,
-        createMockBoundAuth({}),
-      );
+      const ac = new AccessControl({ boundAuth: createMockBoundAuth({}) });
       expect(ac.granted()).toBe(false);
     });
 
     it("should return true after grant", () => {
-      const ac = new AccessControl(
-        undefined,
-        undefined,
-        createMockBoundAuth({}),
-      );
+      const ac = new AccessControl({ boundAuth: createMockBoundAuth({}) });
       ac.grant();
       expect(ac.granted()).toBe(true);
     });
 
     it("should return true after successful check", async () => {
-      const ac = new AccessControl(
-        "user_1",
-        "TEST_TOOL",
-        createMockBoundAuth({ self: ["TEST_TOOL"] }), // Permission on self connection
-        "user",
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        toolName: "TEST_TOOL",
+        boundAuth: createMockBoundAuth({ self: ["TEST_TOOL"] }), // Permission on self connection
+        role: "user",
+      });
 
       await ac.check();
       expect(ac.granted()).toBe(true);
     });
 
     it("should return false after failed check", async () => {
-      const ac = new AccessControl(
-        "user_1",
-        "TEST_TOOL",
-        createMockBoundAuth({}), // No permissions
-        "user", // Not admin
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        toolName: "TEST_TOOL",
+        boundAuth: createMockBoundAuth({}), // No permissions
+        role: "user", // Not admin
+      });
 
       try {
         await ac.check();
@@ -352,12 +341,12 @@ describe("AccessControl", () => {
     it("should use BoundAuthClient hasPermission when available", async () => {
       const mockBoundAuth = createMockBoundAuth({ self: ["TEST_TOOL"] });
 
-      const ac = new AccessControl(
-        "user_1",
-        "TEST_TOOL",
-        mockBoundAuth,
-        "user",
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        toolName: "TEST_TOOL",
+        boundAuth: mockBoundAuth,
+        role: "user",
+      });
 
       await ac.check();
 
@@ -387,12 +376,12 @@ describe("AccessControl", () => {
         },
       } as unknown as BoundAuthClient;
 
-      const ac = new AccessControl(
-        "user_1",
-        "TEST_TOOL",
-        mockBoundAuth,
-        "user",
-      );
+      const ac = new AccessControl({
+        userId: "user_1",
+        toolName: "TEST_TOOL",
+        boundAuth: mockBoundAuth,
+        role: "user",
+      });
 
       await expect(ac.check()).rejects.toThrow(ForbiddenError);
       expect(ac.granted()).toBe(false);

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -50,22 +50,45 @@ export class ForbiddenError extends Error {
  * Delegates all permission checks to Better Auth's Organization plugin
  * via the BoundAuthClient (which encapsulates HTTP headers)
  */
-export class AccessControl {
-  private _granted: boolean = false;
+export interface AccessControlOptions {
+  /** Authenticated principal id; undefined for an anonymous caller. */
+  userId?: string;
+  /** Tool being checked. May be unset here and supplied later via setToolName(). */
+  toolName?: string;
+  /**
+   * Bound auth client. Built by the context factory for EVERY request (even
+   * anonymous), so it's a required dependency — an anonymous principal just has
+   * no role/perms and is denied by the permission check, not by a missing client.
+   */
+  boundAuth: BoundAuthClient;
+  /** Caller's role for the effective org (drives the built-in admin/owner bypass). */
+  role?: string;
+  /**
+   * Permission resource key: "self" for management tools, "conn_<id>" for a
+   * specific connection. Defaults to "self".
+   */
+  connectionId?: string;
+  /** Path-resolved org id (overrides the session's active org). */
+  organizationId?: string;
+}
 
-  constructor(
-    // userId/toolName may be undefined (anonymous principal; tool name set later
-    // via setToolName) but are passed positionally, so they're required params.
-    private userId: string | undefined,
-    private toolName: string | undefined,
-    // Always built by the context factory for EVERY request (even anonymous), so
-    // it's a required dependency — an anonymous principal just has no role/perms
-    // and is denied by the permission check, not by a missing client.
-    private boundAuth: BoundAuthClient,
-    private role?: string, // From user session (for built-in role bypass)
-    private connectionId: string = "self", // For connection-specific checks (matches permission resource key)
-    private organizationId?: string, // Path-resolved org (overrides session active org)
-  ) {}
+export class AccessControl {
+  private _granted = false;
+  private userId?: string;
+  private toolName?: string;
+  private boundAuth: BoundAuthClient;
+  private role?: string;
+  private connectionId: string;
+  private organizationId?: string;
+
+  constructor(opts: AccessControlOptions) {
+    this.userId = opts.userId;
+    this.toolName = opts.toolName;
+    this.boundAuth = opts.boundAuth;
+    this.role = opts.role;
+    this.connectionId = opts.connectionId ?? "self";
+    this.organizationId = opts.organizationId;
+  }
 
   setToolName(toolName: string): void {
     this.toolName = toolName;

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -9,19 +9,12 @@
  * 4. Tools can manually grant access for custom logic
  */
 
-import { MCP_MESH_KEY } from "@/core/constants";
 import { BASIC_USAGE_TOOLS } from "@/tools/registry-metadata";
 import type { BoundAuthClient } from "./studio-context";
 
 // ============================================================================
 // Types
 // ============================================================================
-
-/**
- * Callback to get tool metadata for public tool check.
- * Scoped to the current tool being accessed.
- */
-export type GetToolMetaFn = () => Promise<Record<string, unknown> | undefined>;
 
 // ============================================================================
 // Errors
@@ -61,12 +54,16 @@ export class AccessControl {
   private _granted: boolean = false;
 
   constructor(
-    private userId?: string,
-    private toolName?: string,
-    private boundAuth?: BoundAuthClient, // Bound auth client for permission checks
+    // userId/toolName may be undefined (anonymous principal; tool name set later
+    // via setToolName) but are passed positionally, so they're required params.
+    private userId: string | undefined,
+    private toolName: string | undefined,
+    // Always built by the context factory for EVERY request (even anonymous), so
+    // it's a required dependency — an anonymous principal just has no role/perms
+    // and is denied by the permission check, not by a missing client.
+    private boundAuth: BoundAuthClient,
     private role?: string, // From user session (for built-in role bypass)
     private connectionId: string = "self", // For connection-specific checks (matches permission resource key)
-    private getToolMeta?: GetToolMetaFn, // Optional callback for public tool check
     private organizationId?: string, // Path-resolved org (overrides session active org)
   ) {}
 
@@ -117,7 +114,6 @@ export class AccessControl {
    * @param resources - Resources to check (OR logic)
    * If omitted, checks the current tool name
    *
-   * @throws UnauthorizedError if not authenticated (401)
    * @throws ForbiddenError if access is denied (403)
    *
    * @example
@@ -134,18 +130,6 @@ export class AccessControl {
     if (this.toolName?.startsWith("MESH_PUBLIC_")) {
       this.grant();
       return;
-    }
-
-    // Check if authenticated first (401)
-    if (!this.userId && !this.boundAuth) {
-      // Check if tool is public before throwing
-      if (this.getToolMeta && (await this.isToolPublic())) {
-        this.grant();
-        return;
-      }
-      throw new UnauthorizedError(
-        "Authentication required. Please provide a valid OAuth token or API key.",
-      );
     }
 
     // Determine what to check
@@ -176,17 +160,12 @@ export class AccessControl {
    * Delegates to Better Auth's Organization plugin via boundAuth
    */
   private async checkResource(resource: string): Promise<boolean> {
-    // No user or bound auth = deny
-    if (!this.userId && !this.boundAuth) {
-      return false;
-    }
-
     // Two kinds of principal, each with its OWN self-contained rule:
     //   - API key   → the key's stored allowlist is the whole decision. It is a
     //     capability, not a member: no role, no basic-usage, no Better Auth.
     //   - everyone else (session / MCP OAuth / mesh JWT) → membership floor +
     //     admin/owner bypass + Better Auth grants.
-    return this.boundAuth?.isApiKeyPrincipal
+    return this.boundAuth.isApiKeyPrincipal
       ? this.checkApiKeyAccess(resource)
       : this.checkMemberAccess(resource);
   }
@@ -198,9 +177,6 @@ export class AccessControl {
    * See auth/api-key-permissions.ts (`checkApiKeyPermission`).
    */
   private async checkApiKeyAccess(resource: string): Promise<boolean> {
-    // `isApiKeyPrincipal` is only set on a real bound client, so this is
-    // defensive; the dispatcher already routed non-bound principals away.
-    if (!this.boundAuth) return false;
     return this.boundAuth.hasPermission({ [this.connectionId]: [resource] });
   }
 
@@ -222,9 +198,6 @@ export class AccessControl {
     if (this.role === "admin" || this.role === "owner") {
       return true;
     }
-    if (!this.boundAuth) {
-      return false;
-    }
     // Pass `this.role` so boundAuth can resolve built-in roles in-memory (no
     // Better Auth round-trip); admin/owner already returned above, so this only
     // accelerates the `user` role. `organizationId` (path-resolved org) makes
@@ -233,25 +206,6 @@ export class AccessControl {
       { [this.connectionId]: [resource] },
       { organizationId: this.organizationId, role: this.role },
     );
-  }
-
-  /**
-   * Check if the current tool is marked as public via _meta["mcp.mesh"].public_tool
-   */
-  private async isToolPublic(): Promise<boolean> {
-    if (this.toolName?.startsWith("MESH_PUBLIC_")) return true;
-    if (!this.getToolMeta) return false;
-    try {
-      const meta = await this.getToolMeta();
-      if (!meta) return false;
-      const meshMeta = meta[MCP_MESH_KEY] as
-        | Record<string, unknown>
-        | undefined;
-      const value = meshMeta?.public_tool;
-      return value === true || value === "true";
-    } catch {
-      return false;
-    }
   }
 
   /**

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -1400,14 +1400,13 @@ export async function createStudioContextFactory(
       : getBaseUrl();
 
     // Create AccessControl instance with bound auth client
-    const access = new AccessControl(
-      meshAuth.user?.id,
-      undefined, // toolName set later by defineTool
-      boundAuth, // Bound auth client for permission checks
-      authResult.role, // Role from session (for built-in role bypass)
-      "self", // Default connectionId for management APIs (matches permission resource key)
-      organization?.id, // Path-resolved/auth-resolved org for permission checks
-    );
+    const access = new AccessControl({
+      userId: meshAuth.user?.id,
+      // toolName set later by defineTool; connectionId defaults to "self"
+      boundAuth, // bound auth client for permission checks
+      role: authResult.role, // from session (built-in role bypass)
+      organizationId: organization?.id, // path-resolved/auth-resolved org
+    });
 
     const storage = {
       ...baseStorage,

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -1406,7 +1406,6 @@ export async function createStudioContextFactory(
       boundAuth, // Bound auth client for permission checks
       authResult.role, // Role from session (for built-in role bypass)
       "self", // Default connectionId for management APIs (matches permission resource key)
-      undefined, // getToolMeta set later by defineTool
       organization?.id, // Path-resolved/auth-resolved org for permission checks
     );
 

--- a/apps/mesh/src/core/studio-context.ts
+++ b/apps/mesh/src/core/studio-context.ts
@@ -92,14 +92,16 @@ export interface BoundAuthClient {
   ): Promise<boolean>;
 
   /**
-   * True when the principal authenticated with an API key. Such a principal is
+   * Whether the principal authenticated with an API key. An API-key principal is
    * authorized SOLELY by the key's stored allowlist — it must NOT inherit the
    * owner's admin/owner role. Both `hasPermission` here and the role bypass in
    * `AccessControl.checkResource` read this single flag so every call site
-   * (REST + MCP) agrees. Absent/false for browser sessions, MCP OAuth, and mesh
-   * JWTs, which keep the role-based behavior.
+   * (REST + MCP) agrees. `false` for browser sessions, MCP OAuth, and mesh JWTs.
+   *
+   * Required: `createBoundAuthClient` (the sole producer) always sets it, so the
+   * invariant "every bound client knows its principal kind" is in the type.
    */
-  isApiKeyPrincipal?: boolean;
+  isApiKeyPrincipal: boolean;
 
   // Organization APIs (bound with headers)
   organization: {

--- a/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
+++ b/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
@@ -160,14 +160,14 @@ export class AuthTransport extends WrapperTransport {
     // session-derived ones. The session's active-org role may not match the
     // org in the URL — e.g. owner of /api/foo with no/different active org
     // would otherwise lose the admin/owner bypass and 403 on every tool call.
-    const connectionAccessControl = new AccessControl(
-      ctx.auth.user?.id ?? ctx.auth.apiKey?.userId,
-      toolName, // Tool being called
-      ctx.boundAuth, // Bound auth client (encapsulates headers)
-      ctx.organization?.role ?? ctx.auth.user?.role, // Role for built-in role bypass
-      connection.id, // Connection ID for permission check
-      ctx.organization?.id, // Path-resolved org for permission checks
-    );
+    const connectionAccessControl = new AccessControl({
+      userId: ctx.auth.user?.id ?? ctx.auth.apiKey?.userId,
+      toolName, // tool being called
+      boundAuth: ctx.boundAuth, // encapsulates headers
+      role: ctx.organization?.role ?? ctx.auth.user?.role, // built-in role bypass
+      connectionId: connection.id, // permission resource key
+      organizationId: ctx.organization?.id, // path-resolved org
+    });
 
     await connectionAccessControl.check(toolName);
   }

--- a/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
+++ b/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
@@ -152,15 +152,9 @@ export class AuthTransport extends WrapperTransport {
       );
     }
 
-    // Create getToolMeta callback for AccessControl
-    const getToolMeta = async () => {
-      const toolsMap = await this.ensureToolsMap();
-      const tool = toolsMap.get(toolName);
-      return tool?._meta as Record<string, unknown> | undefined;
-    };
-
     // Create AccessControl with connectionId set
     // This checks: does user have permission for this TOOL on this CONNECTION?
+    // (Public tools were already short-circuited by `isPublicTool` above.)
     //
     // Prefer the path-resolved org+role (set by resolveOrgFromPath) over the
     // session-derived ones. The session's active-org role may not match the
@@ -172,7 +166,6 @@ export class AuthTransport extends WrapperTransport {
       ctx.boundAuth, // Bound auth client (encapsulates headers)
       ctx.organization?.role ?? ctx.auth.user?.role, // Role for built-in role bypass
       connection.id, // Connection ID for permission check
-      getToolMeta, // Callback for public tool check
       ctx.organization?.id, // Path-resolved org for permission checks
     );
 


### PR DESCRIPTION
Follow-up to #4180 (the `isApiKeyPrincipal` flag there raised: why is `boundAuth` optional / why are these args positional at all?).

Two related cleanups to `AccessControl`, both stemming from "`boundAuth` is always present at runtime":

## 1. `boundAuth` is now required + dead branch removed

`boundAuth` is built by the context factory for **every** request (even anonymous — no role/perms, then denied by the permission check). So it's never absent, yet it was typed optional, leaving dead guards and an unreachable branch.

- **Removed the dead `!userId && !boundAuth` branch in `check()`** — the `UnauthorizedError` 401 + public-tool fallback. It only ran when `boundAuth` was missing (impossible). Anonymous callers already get 403 via the permission path; public tools are gated by the MCP transport's own `isPublicTool` (`auth.ts`) and the `MESH_PUBLIC_` prefix. With it went the now-unused `isToolPublic`, the `getToolMeta` param, the `GetToolMetaFn` type, and the `MCP_MESH_KEY` import.
- Dropped the dead `if (!boundAuth) return false` guards in `checkResource` / `checkApiKeyAccess` / `checkMemberAccess`.

## 2. Single options-object constructor

The 6-positional constructor required three leading optionals and passing `undefined` to reach `boundAuth` — a footgun. Replaced with one `AccessControlOptions` object: `boundAuth` required, everything else named/optional, `connectionId` defaulting to `"self"`. TypeScript flagged every call site; all updated (`context-factory`, MCP transport, `automation-context`, unit tests).

**No behavior change** — the removed branch never executed in prod; the rest is a pure call-shape refactor. Tests that constructed `AccessControl` without a `boundAuth` now pass a mock (grant/granted), or were deleted (the "no BoundAuthClient" case, which can no longer happen).

## Heads-up / follow-up decision
Removing the dead branch removed the **last** `throw new UnauthorizedError` in the repo, so the type is now never thrown (its `instanceof` catches in `tools-rest.ts`/`org-fs.ts` are dead). Left as-is. Open question: drop `UnauthorizedError` + those catches, or restore 401 semantics for unauthenticated callers (anon → 401 vs today's 403)?

`tsc` + `oxlint` clean; auth+core unit tests green (except the pre-existing DB-gated `context-factory.integration.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
