### PR TITLE
fix(decopilot): clear stuck run-status spinner when live stream is silent

### DIFF
--- a/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
@@ -1723,3 +1723,160 @@ describe("reconnect refetch", () => {
     expect(conn.messages.get().map((m) => m.id)).toEqual(["m-1", "m-2"]);
   });
 });
+
+// ─── stuck-spinner reconcile (fast-run + missed live tail) ───────────────────
+
+describe("stuck spinner reconcile", () => {
+  /** MCP client whose COLLECTION_THREAD_MESSAGES_LIST returns a mutable
+   *  "persisted page" — set it at test time to simulate the server having
+   *  durably written the run's reply. Tolerates any number of refetch calls
+   *  (reconnect refetch + the reconcile poll both hit it). */
+  function makeMutableClient() {
+    let items: unknown[] = [];
+    const calls: Array<{ name: string; arguments: unknown }> = [];
+    return {
+      setItems: (next: unknown[]) => {
+        items = next;
+      },
+      calls,
+      client: {
+        callTool: async (req: { name: string; arguments: unknown }) => {
+          calls.push(req);
+          return { structuredContent: { items, hasMore: false } };
+        },
+      },
+    };
+  }
+
+  test("a refetch that surfaces the persisted reply clears the 'received' spinner without a reload", async () => {
+    let streamSlot = controllableStream();
+    globalThis.fetch = makeFetchMock({
+      stream: () => streamSlot.response,
+      messages: () => new Response("ok", { status: 200 }),
+    }) as unknown as typeof globalThis.fetch;
+
+    const harness = makeMutableClient();
+    const conn = getOrOpenStream("acme", "thread-stuck-clear", {
+      client: harness.client as never,
+    });
+    await new Promise((r) => setTimeout(r, 20)); // bootstrap (empty page)
+
+    // Submit a user turn. The POST 202 sets the "received" spinner; NO stream
+    // chunks ever arrive — the fast-run + purged-JetStream-subject race.
+    await conn.submit(
+      {
+        kind: "message",
+        message: {
+          id: "u-1",
+          role: "user",
+          parts: [{ type: "text", text: "hi" }],
+        },
+      },
+      baseOpts,
+    );
+    expect(conn.runStatusStage.get()).toBe("received");
+    expect(conn.status.get().kind).toBe("submitted");
+
+    // The run completed server-side: the reply is persisted even though the
+    // live tail delivered nothing.
+    harness.setItems([
+      {
+        id: "u-1",
+        role: "user",
+        parts: [{ type: "text", text: "hi" }],
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "a-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "hello" }],
+        created_at: "2026-01-01T00:00:01Z",
+      },
+    ]);
+
+    // Force an SSE reconnect → refetchLatestPage surfaces the persisted reply.
+    streamSlot.close();
+    streamSlot = controllableStream();
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Spinner cleared, run no longer "in flight", reply rendered — no reload.
+    expect(conn.runStatusStage.get()).toBeNull();
+    expect(conn.status.get().kind).toBe("ready");
+    expect(conn.messages.get().map((m) => m.id)).toEqual(["u-1", "a-1"]);
+  });
+
+  test("the reconcile poll clears the spinner when no reconnect ever happens", async () => {
+    // The headline case: the /stream tail stays open (no reconnect) but
+    // delivers 0 chunks. Only the post-POST reconcile poll can surface the
+    // persisted answer. (First poll delay is 1.5s — wait past it.)
+    const stream = controllableStream();
+    globalThis.fetch = makeFetchMock({
+      stream: () => stream.response,
+      messages: () => new Response("ok", { status: 200 }),
+    }) as unknown as typeof globalThis.fetch;
+
+    const harness = makeMutableClient();
+    const conn = getOrOpenStream("acme", "thread-poll-clear", {
+      client: harness.client as never,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    await conn.submit(
+      {
+        kind: "message",
+        message: {
+          id: "u-1",
+          role: "user",
+          parts: [{ type: "text", text: "hi" }],
+        },
+      },
+      baseOpts,
+    );
+    expect(conn.status.get().kind).toBe("submitted");
+
+    harness.setItems([
+      {
+        id: "u-1",
+        role: "user",
+        parts: [{ type: "text", text: "hi" }],
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "a-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "hello" }],
+        created_at: "2026-01-01T00:00:01Z",
+      },
+    ]);
+
+    // The live tail never reconnects; the poll's first tick (~1.5s) reconciles.
+    await new Promise((r) => setTimeout(r, 2500));
+
+    expect(conn.runStatusStage.get()).toBeNull();
+    expect(conn.status.get().kind).toBe("ready");
+    expect(conn.messages.get().map((m) => m.id)).toEqual(["u-1", "a-1"]);
+  });
+
+  test("204 on /stream is transient — keeps refetching instead of dying permanently", async () => {
+    globalThis.fetch = makeFetchMock({
+      stream: () => new Response(null, { status: 204 }),
+    }) as unknown as typeof globalThis.fetch;
+
+    const harness = makeMutableClient();
+    const conn = getOrOpenStream("acme", "thread-204-transient", {
+      client: harness.client as never,
+    });
+
+    // Let the loop run a few 204 → refetch → backoff cycles.
+    await new Promise((r) => setTimeout(r, 400));
+    const callsEarly = harness.calls.length;
+    await new Promise((r) => setTimeout(r, 2200));
+    const callsLate = harness.calls.length;
+
+    // Old behavior: the first 204 `return`ed permanently, so only the initial
+    // loadInitialPage call ever fired (count frozen). The fix retries, so the
+    // refetch count keeps growing — and the loop never routed to error.
+    expect(callsLate).toBeGreaterThan(callsEarly);
+    expect(conn.status.get().kind).not.toBe("error");
+  });
+});

--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -136,6 +136,21 @@ const CLEAN_RECONNECT_DELAY_MS = 50;
  *  idempotency-keyed (workflowID), so a timeout-then-retry is safe. */
 const POST_TIMEOUT_MS = 60_000;
 
+/**
+ * Reconcile-poll backoff (ms). After a POST the live `/stream` tail can miss a
+ * fast run's chunks entirely — the JetStream subject is purged on terminal
+ * status, so if this client's consumer isn't attached during the brief publish
+ * window it sees 0 live chunks and there's nothing to replay. Nothing then
+ * clears the "Request received" spinner even though the answer is already
+ * persisted (the reported hang). While we sit in the `submitted` state with the
+ * spinner up, poll the persisted page on this schedule and clear the spinner
+ * the moment the turn's reply lands. The poll yields immediately once a live
+ * chunk arrives (status flips to `streaming`). */
+const RECONCILE_POLL_DELAYS_MS = [1_500, 2_500, 4_000, 6_000, 8_000] as const;
+/** Bound the poll so an abandoned-but-open tab doesn't reconcile forever.
+ *  ~5 min of coverage (mostly 8s steps) comfortably outlasts a queued run. */
+const RECONCILE_POLL_MAX_ATTEMPTS = 40;
+
 // Browser uses rAF for chunk-coalescing; tests run under Bun where rAF is absent.
 const scheduleFrame: (cb: () => void) => number =
   typeof requestAnimationFrame === "function"
@@ -296,6 +311,22 @@ export class ThreadConnection {
    */
   private waitingForNewRun = false;
   private acceptPreStartRunStatus = true;
+  /**
+   * Active reconcile poll (see runReconcilePoll). At most one runs per
+   * connection — armed after a POST, aborted on a new submit, stop(), or
+   * dispose().
+   */
+  private reconcilePoll: AbortController | null = null;
+  /**
+   * True only between a NEW user-message POST and its reply surfacing. Gates
+   * the stuck-spinner reconcile (see tryClearStuckSpinner) so it fires only for
+   * a fresh turn — whose optimistic last message is the USER row until the
+   * reply lands. A tool-output / approval continuation re-POSTs an assistant
+   * message that is ALREADY the last row, so `last.role === "assistant"` can't
+   * tell "reply arrived" from "still continuing"; those keep the live-stream
+   * behavior untouched.
+   */
+  private awaitingMessageTurn = false;
   /** `start` chunk opened a new assistant turn — don't seed the prior one. */
   private freshRunSubstream = false;
   private client: MCPClient | null;
@@ -334,6 +365,8 @@ export class ThreadConnection {
   }
 
   dispose(): void {
+    this.reconcilePoll?.abort();
+    this.reconcilePoll = null;
     this.abort.abort();
   }
 
@@ -375,11 +408,20 @@ export class ThreadConnection {
 
     this.runStatusStage.set("sending");
     this.status.set({ kind: "submitted" });
+    // Only a fresh user turn is reconcilable (its last row is the optimistic
+    // user message until the reply lands). Continuations re-POST an existing
+    // assistant row, so they opt out of the stuck-spinner reconcile.
+    this.awaitingMessageTurn = action.kind === "message";
 
     const abort = new AbortController();
     this.inflightPost = abort;
     try {
       await this.post(last, opts, abort.signal);
+      // The run is accepted and we're now waiting on the live `/stream` tail.
+      // Arm a DB-reconcile safety net in case that tail never delivers a finish
+      // (fast run + purged JetStream subject) — without it the spinner sticks.
+      // Only for a fresh user turn (see awaitingMessageTurn).
+      if (this.awaitingMessageTurn) this.armReconcilePoll();
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
       this.clearRunStatusStage();
@@ -391,6 +433,9 @@ export class ThreadConnection {
 
   stop(): void {
     this.inflightPost?.abort();
+    this.reconcilePoll?.abort();
+    this.reconcilePoll = null;
+    this.awaitingMessageTurn = false;
     const s = this.status.get();
     if (s.kind === "submitted" || s.kind === "streaming") {
       this.status.set({ kind: "ready" });
@@ -550,8 +595,71 @@ export class ThreadConnection {
       if (payload.hasMore !== undefined) {
         this.hasMoreOlder.set(payload.hasMore);
       }
+      // Safety valve: if this refetch surfaced the active turn's persisted
+      // reply while the live spinner is still up, clear it. The spinner must
+      // never outlive a persisted answer (the reported hang). Every refetch
+      // trigger — reconnect, 204 recovery, the reconcile poll — runs through
+      // here, so this single check covers them all.
+      this.tryClearStuckSpinner();
     } catch (err) {
       console.warn("[chat-store] refetchLatestPage failed:", err);
+    }
+  }
+
+  /**
+   * Clear a "received" spinner that the live `/stream` tail never closed.
+   *
+   * The spinner (and the `submitted` status that renders it) is normally
+   * cleared by the stream's `finish` chunk. A fast run can complete and have
+   * its JetStream subject purged before this client's tail consumer reads any
+   * chunk, so no `finish` ever arrives — yet the answer is persisted. When a
+   * refetch surfaces that persisted assistant reply as the latest message,
+   * treat the run as done. No-op unless we're actually stuck (`submitted`),
+   * so it never interrupts an in-flight live stream (which is `streaming`).
+   */
+  private tryClearStuckSpinner(): void {
+    if (!this.awaitingMessageTurn) return;
+    if (this.status.get().kind !== "submitted") return;
+    const last = this.messages.get().at(-1);
+    if (last?.role !== "assistant") return;
+    this.awaitingMessageTurn = false;
+    this.clearRunStatusStage();
+    this.status.set({ kind: "ready" });
+  }
+
+  /**
+   * Arm the post-POST reconcile poll. Cancels any prior poll so only one runs
+   * per connection. The poll's signal also fires on dispose() via `this.abort`.
+   */
+  private armReconcilePoll(): void {
+    this.reconcilePoll?.abort();
+    const ctrl = new AbortController();
+    this.reconcilePoll = ctrl;
+    const signal = AbortSignal.any([this.abort.signal, ctrl.signal]);
+    void this.runReconcilePoll(signal);
+  }
+
+  /**
+   * Poll the persisted page while a run sits in `submitted` with the spinner
+   * up. Each refetch self-clears the spinner once the reply lands (see
+   * tryClearStuckSpinner). Yields the moment a live chunk arrives (status flips
+   * out of `submitted`), so the cost is a few cheap reads only when the live
+   * tail is silent — exactly the stuck case. Bounded by
+   * RECONCILE_POLL_MAX_ATTEMPTS.
+   */
+  private async runReconcilePoll(signal: AbortSignal): Promise<void> {
+    for (let attempt = 0; attempt < RECONCILE_POLL_MAX_ATTEMPTS; attempt++) {
+      const delay =
+        RECONCILE_POLL_DELAYS_MS[
+          Math.min(attempt, RECONCILE_POLL_DELAYS_MS.length - 1)
+        ]!;
+      await sleep(delay, { signal }).catch(() => {});
+      if (signal.aborted) return;
+      // Only a still-`submitted` turn can be stuck; once a live chunk folds,
+      // status is `streaming`/`ready` and there's nothing to reconcile.
+      if (this.status.get().kind !== "submitted") return;
+      await this.refetchLatestPage();
+      if (this.status.get().kind !== "submitted") return; // reconciled
     }
   }
 
@@ -693,25 +801,38 @@ export class ThreadConnection {
           headers: { accept: "text/event-stream" },
           signal: this.abort.signal,
         });
-        if (resp.status === 204 || !resp.body) return;
-        if (!resp.ok) {
+        if (resp.status === 204 || !resp.body) {
+          // 204 = degraded JetStream buffer on this pod (no live tail right
+          // now). This used to `return` permanently, which stranded the
+          // thread: with no reconnect a run that finished while the tail was
+          // down never surfaced and the "Request received" spinner stuck
+          // forever. Treat it as transient — pull the latest page so a
+          // just-persisted answer shows (refetch self-clears a stuck spinner),
+          // then fall through to a jittered backoff and retry. The buffer
+          // usually recovers, or a later attempt lands on a healthy pod.
+          await this.refetchLatestPage();
+          firstConnect = false;
+          // cleanExit stays false → jittered backoff below (grows toward the
+          // 30s cap so a persistently-degraded pod isn't hammered).
+        } else if (!resp.ok) {
           const text = await resp.text().catch(() => "");
           this.failTo(new Error(text || `GET /stream failed (${resp.status})`));
           return;
-        }
-        attempt = 0;
-        if (!firstConnect) {
-          // On reconnect, refresh the latest page so any messages persisted
-          // while disconnected become visible. Merge is upsert-by-id + sort
-          // by created_at; optimistic local rows survive (their id isn't on
-          // the server yet).
-          await this.refetchLatestPage();
-        }
-        firstConnect = false;
-        cleanExit = await this.consumeStreamSse(resp.body);
-        if (!cleanExit && this.status.get().kind === "error") {
-          // Schema mismatch / parser failure routed through failTo — terminal.
-          return;
+        } else {
+          attempt = 0;
+          if (!firstConnect) {
+            // On reconnect, refresh the latest page so any messages persisted
+            // while disconnected become visible. Merge is upsert-by-id + sort
+            // by created_at; optimistic local rows survive (their id isn't on
+            // the server yet).
+            await this.refetchLatestPage();
+          }
+          firstConnect = false;
+          cleanExit = await this.consumeStreamSse(resp.body);
+          if (!cleanExit && this.status.get().kind === "error") {
+            // Schema mismatch / parser failure routed through failTo — terminal.
+            return;
+          }
         }
       } catch (err) {
         if (this.abort.signal.aborted) return;

--- a/packages/e2e/tests/decopilot-spinner-reconcile.spec.ts
+++ b/packages/e2e/tests/decopilot-spinner-reconcile.spec.ts
@@ -1,0 +1,256 @@
+/**
+ * E2E: the "Request received / accepted and queued" spinner must not outlive a
+ * persisted answer.
+ *
+ * Reproduces the production hang (viktor@decocms.com, "always"): the chat UI
+ * sticks on the run-status spinner "Request received — The run was accepted and
+ * queued" forever even though the run completed server-side and the answer is
+ * persisted. The root cause is stream-delivery, not the backend: a fast run's
+ * live `/stream` tail can deliver 0 chunks (the JetStream subject is purged on
+ * terminal status before this client's consumer reads it), so no `finish` chunk
+ * ever clears the client's `runStatusStage` / `submitted` status.
+ *
+ * Black-box reproduction (HTTP + DB only, no app imports):
+ *   1. Drive the real browser: open an (empty, v2) thread and send a message.
+ *      POST /messages is intercepted → 202 so NO real run dispatches — the
+ *      client enters exactly the post-202 "Request received" spinner state, and
+ *      the live tail stays silent (there are no chunks to deliver), matching the
+ *      0-chunks race.
+ *   2. Assert the stuck spinner is showing.
+ *   3. Seed the persisted reply directly into `thread_message_parts` (+ flip the
+ *      thread terminal), simulating the run that already completed server-side.
+ *   4. Assert the reply renders AND the spinner clears — WITHOUT a page reload.
+ *      The fix's client-side DB reconcile (refetch self-clear + post-POST poll)
+ *      is the only thing that can surface the answer here.
+ *
+ * The precise reconcile logic is unit-covered in thread-connection.test.ts; this
+ * is the black-box contract guard for the user-visible behavior.
+ */
+
+import type { APIRequestContext, Page } from "@playwright/test";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { connectDevDb } from "../fixtures/db";
+import { expect, test } from "../fixtures/test";
+
+const CHAT_INPUT = '[data-chat-input="true"]';
+// Cold-Vite first paint on a fresh sandbox can take 20-40s.
+const CHAT_INPUT_TIMEOUT_MS = 60_000;
+// The run-status spinner's title (apps/.../run-status.ts RUN_STATUS_COPY) — the
+// "received" stage the client enters after the POST 202 and the reported hang.
+const STUCK_SPINNER_TEXT = "Request received";
+
+type Db = Awaited<ReturnType<typeof connectDevDb>>;
+
+async function orgIdForSlug(db: Db, slug: string): Promise<string> {
+  const { rows } = await db.query<{ id: string }>(
+    `SELECT id FROM "organization" WHERE slug = $1`,
+    [slug],
+  );
+  const id = rows[0]?.id;
+  if (!id) throw new Error(`no organization row for slug ${slug}`);
+  return id;
+}
+
+/** Seed an AI provider key so the route renders the composer, not the
+ *  NoAiProviderEmptyState. The key is never exercised (POST is intercepted). */
+async function seedAiProviderKey(
+  request: APIRequestContext,
+  orgSlug: string,
+): Promise<void> {
+  await callSelfMcpTool(request, orgSlug, "AI_PROVIDER_KEY_CREATE", {
+    providerId: "anthropic",
+    label: "spinner-reconcile-e2e",
+    apiKey: "sk-ant-e2e-fake-key-do-not-use",
+  });
+}
+
+/** Create an agent (virtual MCP) + a v2 thread (so the read path folds the
+ *  seeded `thread_message_parts`). Returns the thread id. */
+async function createV2Thread(
+  api: APIRequestContext,
+  db: Db,
+  orgSlug: string,
+  orgId: string,
+): Promise<string> {
+  const agent = await callSelfMcpTool<{ item: { id: string } }>(
+    api,
+    orgSlug,
+    "COLLECTION_VIRTUAL_MCP_CREATE",
+    {
+      data: {
+        title: "Spinner-reconcile E2E Agent",
+        connections: [],
+        status: "active",
+        pinned: false,
+      },
+    },
+  );
+  const thread = await callSelfMcpTool<{ item: { id: string } }>(
+    api,
+    orgSlug,
+    "COLLECTION_THREADS_CREATE",
+    { data: { virtual_mcp_id: agent.item.id, title: "Spinner-reconcile" } },
+  );
+  const threadId = thread.item.id;
+  await db.query(
+    `UPDATE threads SET message_storage_version = 2 WHERE id = $1 AND organization_id = $2`,
+    [threadId, orgId],
+  );
+  return threadId;
+}
+
+/** Persist a finished assistant message (text + finish anchor) for the thread,
+ *  exactly as the durable projector would, and flip the thread terminal — the
+ *  "run already completed server-side" state. */
+async function seedPersistedReply(
+  db: Db,
+  orgId: string,
+  threadId: string,
+  text: string,
+): Promise<void> {
+  const runId = `run_reconcile_e2e_${Date.now()}`;
+  const messageId = `msg_reconcile_e2e_${Date.now()}`;
+  const now = new Date().toISOString();
+  await db.query(
+    `INSERT INTO thread_message_parts
+       (id, seq, org_id, thread_id, run_id, message_id, role, kind, payload, created_at)
+     VALUES
+       ($1, 0, $2, $3, $4, $5, 'assistant', 'text', $6, $7),
+       ($8, 1, $2, $3, $4, $5, 'assistant', 'finish', $9, $7)`,
+    [
+      `${runId}:0`,
+      orgId,
+      threadId,
+      runId,
+      messageId,
+      JSON.stringify({ type: "text", text }),
+      now,
+      `${runId}:1`,
+      JSON.stringify({}),
+    ],
+  );
+  await db.query(
+    `UPDATE threads SET status = 'completed', updated_at = $2 WHERE id = $1`,
+    [threadId, now],
+  );
+}
+
+async function waitForChatInput(page: Page): Promise<void> {
+  await page
+    .locator(CHAT_INPUT)
+    .waitFor({ state: "visible", timeout: CHAT_INPUT_TIMEOUT_MS });
+}
+
+/** Tiptap is contenteditable — type via real keystrokes, then wait for render. */
+async function typeInComposer(page: Page, text: string): Promise<void> {
+  const input = page.locator(CHAT_INPUT);
+  await input.click();
+  await page.keyboard.type(text);
+  await expect(input).toHaveText(text, { timeout: 15_000 });
+}
+
+/** Dismiss the bottom-right release-announcement popover if present — it sits on
+ *  the send button's z-index and intercepts the click. No-op if absent. */
+async function dismissReleaseAnnouncement(page: Page): Promise<void> {
+  const dialog = page.getByRole("dialog", { name: "Release announcement" });
+  if ((await dialog.count()) === 0) return;
+  const closeButton = dialog.getByRole("button").first();
+  if (await closeButton.isVisible().catch(() => false)) {
+    await closeButton.click().catch(() => {});
+  } else {
+    await page.keyboard.press("Escape");
+  }
+  await dialog.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {});
+}
+
+async function submitComposer(page: Page): Promise<void> {
+  await dismissReleaseAnnouncement(page);
+  await page
+    .getByTitle("Send message (Enter)", { exact: true })
+    .first()
+    .click();
+}
+
+test.describe("decopilot run-status spinner reconcile", () => {
+  // Cold Vite + signUp + navigation easily exceeds the 30s default.
+  test.setTimeout(180_000);
+
+  // Pre-mark releases seen so the FloatingReleaseCard popover never intercepts
+  // the send button (mirrors chat-input-draft.spec.ts).
+  test.beforeEach(async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    await seedAiProviderKey(page.context().request, orgSlug);
+    await page.addInitScript(() => {
+      // Mark every known release seen so the FloatingReleaseCard popover never
+      // renders. Keep in lockstep with apps/mesh/src/web/lib/release-feed.ts;
+      // submitComposer also dismisses the dialog at runtime as a fallback.
+      const seenAt = "1970-01-01T00:00:00.000Z";
+      const ids = [
+        "fable-5-suspension",
+        "claude-fable-5",
+        "claude-opus-4-8",
+        "enhanced-sidebar",
+        "smarter-task-delegation",
+        "sidebar-task-groups",
+        "release-channel",
+      ];
+      try {
+        localStorage.setItem(
+          "studio.release-feed.v1",
+          JSON.stringify(Object.fromEntries(ids.map((id) => [id, { seenAt }]))),
+        );
+      } catch {
+        // private mode — ignore
+      }
+    });
+  });
+
+  test("a fast turn's spinner clears once the answer persists, without a reload", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+    const db = await connectDevDb();
+    try {
+      const orgId = await orgIdForSlug(db, orgSlug);
+      const threadId = await createV2Thread(api, db, orgSlug, orgId);
+
+      // Accept the send WITHOUT dispatching a real run: the client enters the
+      // post-202 "Request received" spinner state and the live /stream tail has
+      // nothing to deliver — exactly the 0-chunks race.
+      await page.route("**/decopilot/threads/*/messages", async (route) => {
+        if (route.request().method() !== "POST") return route.continue();
+        await route.fulfill({
+          status: 202,
+          contentType: "application/json",
+          body: JSON.stringify({ taskId: threadId }),
+        });
+      });
+
+      await page.goto(`/${orgSlug}/${threadId}`);
+      await waitForChatInput(page);
+
+      await typeInComposer(page, "hello reconcile");
+      await submitComposer(page);
+
+      // The reported symptom: the run-status spinner is up after the 202.
+      await expect(page.getByText(STUCK_SPINNER_TEXT)).toBeVisible({
+        timeout: 30_000,
+      });
+
+      // The run "completed" server-side: persist the reply + flip the thread
+      // terminal. The live tail still delivers nothing.
+      const replyMarker = `reconciled-reply-${Date.now()}`;
+      await seedPersistedReply(db, orgId, threadId, replyMarker);
+
+      // The fix's DB reconcile surfaces the persisted reply and clears the
+      // spinner — without any page reload.
+      await expect(page.getByText(replyMarker)).toBeVisible({
+        timeout: 30_000,
+      });
+      await expect(page.getByText(STUCK_SPINNER_TEXT)).toBeHidden();
+    } finally {
+      await db.end();
+    }
+  });
+});


### PR DESCRIPTION
## What is this contribution about?
The decopilot chat would stick forever on the run-status spinner **"Request received — The run was accepted and queued"** even though the run completed server-side and the answer was persisted (confirmed read-only on prod: threads terminal, `projected_seq` advanced, assistant parts persisted). Root cause is client stream-delivery, not the backend: a fast run's live `/stream` tail can deliver 0 chunks — the JetStream subject is purged on terminal status before this client's consumer reads it, or a 204 degraded buffer returns permanently with no reconnect — so no `finish` chunk ever clears `runStatusStage`. The fix reconciles the spinner against the persisted DB client-side (all in `thread-connection.ts`): `refetchLatestPage` self-clears a stuck spinner when it surfaces the turn's reply; a bounded post-POST poll surfaces it when no reconnect ever happens; and a 204 on `/stream` is now transient (refetch + backoff-reconnect). It's scoped to fresh user turns via an `awaitingMessageTurn` guard so tool-output/approval continuations keep the live-stream behavior untouched.

## Screenshots/Demonstration
N/A — no visual changes; the spinner simply clears instead of hanging. Behavior is covered by an e2e that drives the real browser.

## How to Test
1. `bun test apps/mesh/src/web/components/chat/store/thread-connection.test.ts` — 3 new cases (refetch-clears, poll-clears, 204-transient), red/green verified against the pre-fix code.
2. e2e: `packages/e2e/tests/decopilot-spinner-reconcile.spec.ts` sends a turn with a silent stream, seeds the persisted reply, and asserts the spinner clears + reply renders **without a reload** (verified locally red on pre-fix / green on fix).
3. Expected: the chat surfaces the persisted answer and drops the spinner within a couple seconds, with no duplicate re-sends.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Decopilot chat spinner stuck on "Request received" when the live `/stream` delivers no chunks. The client now reconciles against persisted messages and treats 204 responses as transient, so the reply shows and the spinner clears without a reload.

- **Bug Fixes**
  - Clear a stuck spinner when `refetchLatestPage` surfaces the persisted assistant reply.
  - Add a bounded post-POST reconcile poll for fresh user turns; cancels on stop/dispose.
  - Treat 204 on `/stream` as transient: refetch latest page and retry with backoff.
  - Scope reconcile to new user messages only; tool-output/approval flows keep live-stream behavior.
  - Add unit tests and an e2e to cover refetch-clear, poll-clear, and 204 recovery.

<sup>Written for commit ba353e80fccc091b1ce66fd5319c3168c71fdf67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

