### PR TITLE
feat(agents): link an agent's system prompt to an org-fs file

### DIFF
--- a/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
@@ -12,6 +12,7 @@ import { getMcpListCache } from "../mcp-list-cache";
 import type { StudioContext } from "../../core/studio-context";
 import type { ConnectionEntity } from "../../tools/connection/schema";
 import type { VirtualMCPEntity } from "../../tools/virtual/schema";
+import { loadInstructionsFileText } from "./instructions-file";
 import { PassthroughClient } from "./passthrough-client";
 import { renderSkillsCatalogBlock } from "./skills-instructions";
 import type { VirtualClientOptions } from "./types";
@@ -139,6 +140,12 @@ export async function createVirtualClientFrom(
     ? ((await renderSkillsCatalogBlock(ctx, virtualMcp)) ?? undefined)
     : undefined;
 
+  // Prompt-linked-to-file: read the linked org-fs file now (async, same seam
+  // as the skills block) so getInstructions() can prefer it over the inline
+  // mirror on every run path. No-op (no read) for agents without a link.
+  const instructionsOverride =
+    (await loadInstructionsFileText(ctx, virtualMcp)) ?? undefined;
+
   // Build aggregator options
   const clientOptions: VirtualClientOptions = {
     connections: loadedConnections,
@@ -147,6 +154,7 @@ export async function createVirtualClientFrom(
     mcpListCache: getMcpListCache() ?? undefined,
     listTimeoutMs: options?.listTimeoutMs,
     skillsBlock,
+    instructionsOverride,
   };
 
   return new PassthroughClient(clientOptions, ctx);

--- a/apps/mesh/src/mcp-clients/virtual-mcp/instructions-file.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/instructions-file.ts
@@ -1,0 +1,39 @@
+/**
+ * Resolves the agent's system prompt from its linked org-fs file
+ * (`metadata.instructionsFile`). Read here (async, factory-side) — NOT inside
+ * the synchronous `getInstructions()` — and stashed on the client options,
+ * the same seam as the skills block, so it reaches both the cluster engine
+ * and the sandbox/desktop daemon. Best-effort: any failure degrades to the
+ * inline `metadata.instructions` mirror, never a failed client creation.
+ */
+
+import type { StudioContext } from "../../core/studio-context";
+import {
+  buildPublicOrgFs,
+  isPublicVolume,
+} from "../../file-storage/public-sets";
+import type { VirtualMCPEntity } from "../../tools/virtual/schema";
+
+export async function loadInstructionsFileText(
+  ctx: StudioContext,
+  virtualMcp: VirtualMCPEntity,
+): Promise<string | null> {
+  const ref = virtualMcp.metadata?.instructionsFile;
+  if (!ref) return null;
+  try {
+    // `public-*` volumes live under the shared public scope, not the org's.
+    const orgFs = isPublicVolume(ref.volume)
+      ? buildPublicOrgFs(ctx)
+      : ctx.orgFs;
+    if (!orgFs) return null;
+    return new TextDecoder().decode(await orgFs.read(ref.volume, ref.path));
+  } catch (err) {
+    console.warn("[virtual-mcp] failed to read linked instructions file", {
+      virtualMcpId: virtualMcp.id,
+      volume: ref.volume,
+      path: ref.path,
+      err,
+    });
+    return null;
+  }
+}

--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -211,7 +211,11 @@ export class PassthroughClient extends GatewayClient {
     // daemon both read instructions; only the cluster runs the richer
     // buildAgentSystemPrompt).
     const base = withKnowledge(
-      this.options.virtualMcp.metadata?.instructions ?? undefined,
+      // The linked instructions file (factory-read) wins over the inline
+      // mirror; the mirror is the fallback when the file is unreadable.
+      this.options.instructionsOverride ??
+        this.options.virtualMcp.metadata?.instructions ??
+        undefined,
       this.options.virtualMcp.metadata?.knowledge,
     );
     // Append the pre-rendered <available-skills> catalog (built async in the

--- a/apps/mesh/src/mcp-clients/virtual-mcp/types.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/types.ts
@@ -25,4 +25,11 @@ export interface VirtualClientOptions {
    * cluster engine and the sandbox/desktop daemon. Only set for agent runtimes.
    */
   skillsBlock?: string;
+  /**
+   * System prompt read from the agent's linked org-fs file
+   * (`metadata.instructionsFile`). Same factory-side async pattern as
+   * `skillsBlock`; when set, `getInstructions()` prefers it over the inline
+   * `metadata.instructions` mirror.
+   */
+  instructionsOverride?: string;
 }

--- a/apps/mesh/src/tools/virtual/update.ts
+++ b/apps/mesh/src/tools/virtual/update.ts
@@ -12,6 +12,7 @@ import {
   requireOrganization,
 } from "../../core/studio-context";
 import { writeAgentPrompts } from "../../file-storage/agent-prompts";
+import { isPublicVolume } from "../../file-storage/public-sets";
 import { VirtualMCPEntitySchema, VirtualMCPUpdateDataSchema } from "./schema";
 import { requireOrgAdminForPinnedField } from "./require-org-admin-for-pin";
 
@@ -77,6 +78,37 @@ export const COLLECTION_VIRTUAL_MCP_UPDATE = defineTool({
 
     if (data.pinned !== undefined && data.pinned !== existing.pinned) {
       requireOrgAdminForPinnedField(ctx);
+    }
+
+    // Prompt-linked-to-file: an actual instructions change writes through to
+    // the linked org-fs file (the runtime source of truth). Gated on the
+    // incoming text differing from BOTH the stored mirror (so unrelated
+    // autosaves echoing an unchanged/stale mirror never clobber external file
+    // edits) and the current file content (so link-time saves don't churn the
+    // change feed). Runs before the row update so a failed write fails the
+    // whole update instead of silently diverging mirror and file. `public-*`
+    // volumes are readonly — the synced file is canonical there, never written.
+    const fileRef = data.metadata?.instructionsFile;
+    const incomingInstructions = input.data.metadata?.instructions;
+    if (
+      fileRef &&
+      typeof incomingInstructions === "string" &&
+      incomingInstructions !== existing.metadata?.instructions &&
+      !isPublicVolume(fileRef.volume) &&
+      ctx.orgFs
+    ) {
+      const fileText = await ctx.orgFs
+        .read(fileRef.volume, fileRef.path)
+        .then((bytes) => new TextDecoder().decode(bytes))
+        .catch(() => null);
+      if (fileText !== incomingInstructions) {
+        await ctx.orgFs.write(
+          fileRef.volume,
+          fileRef.path,
+          incomingInstructions,
+          { actor: userId },
+        );
+      }
     }
 
     const virtualMcp = await ctx.storage.virtualMcps.update(

--- a/apps/mesh/src/web/hooks/use-org-fs.ts
+++ b/apps/mesh/src/web/hooks/use-org-fs.ts
@@ -240,13 +240,23 @@ export async function fetchOrgFsSkillCatalog(
 }
 
 /** Read a file's contents as UTF-8 text (org-fs `/read` endpoint). */
-async function fetchOrgFsText(
+export async function fetchOrgFsText(
   orgSlug: string,
   volume: string,
   path: string,
 ): Promise<string> {
   const res = await fsFetch(fsUrl(orgSlug, volume, "read", { path }));
   return res.text();
+}
+
+/** A text file's content, cached — powers the prompt-linked-file editor. */
+export function useOrgFsReadText(volume: string | null, path: string) {
+  const { org } = useProjectContext();
+  return useQuery({
+    queryKey: KEYS.orgFsReadText(org.id, volume ?? "", path),
+    enabled: volume !== null,
+    queryFn: () => fetchOrgFsText(org.slug, volume ?? "", path),
+  });
 }
 
 /** A text file inside a skill folder, collected for inlining into chat. */

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -409,6 +409,10 @@ export const KEYS = {
     ["org-fs", orgId, volume, "usage"] as const,
   orgFsStat: (orgId: string, volume: string, path: string) =>
     ["org-fs", orgId, volume, "stat", path] as const,
+  // A text file's content (prompt-linked-file editor). Nested under the
+  // volume prefix so write mutations refresh it with the listings.
+  orgFsReadText: (orgId: string, volume: string, path: string) =>
+    ["org-fs", orgId, volume, "read-text", path] as const,
   orgFsPublicSets: (orgId: string) => ["org-fs-public-sets", orgId] as const,
   // Cross-volume recent-files feed (Library home). Separate root key so a
   // volume named like the segment can never collide; mutations invalidate it

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -10,6 +10,8 @@ import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { User } from "@/web/components/user/user";
 import { useMCPAuthStatus } from "@/web/hooks/use-mcp-auth-status";
+import { fetchOrgFsText, useOrgFsReadText } from "@/web/hooks/use-org-fs.ts";
+import { publicSetOf } from "@/web/layouts/library/location";
 
 import {
   authenticateMcp,
@@ -88,6 +90,7 @@ import { IconPicker } from "../../components/icon-picker";
 import { SimpleIconPicker } from "../../components/simple-icon-picker";
 import { Page } from "@/web/components/page";
 import { AddConnectionDialog } from "./add-connection-dialog";
+import { PromptFileLink, type PromptFileRef } from "./prompt-file-link";
 import { FilesSection } from "./files-section";
 import { SubAgentsSection } from "./sub-agents-section";
 import { track } from "@/web/lib/posthog-client";
@@ -1153,6 +1156,29 @@ function VirtualMcpDetailViewWithData({
   // GitHub repo connected (real auth) — instructions become read-only
   const hasGithubRepo = agentHasConnectedGithub(virtualMcp);
 
+  // Prompt linked to an org-fs file: the file is the runtime source of truth
+  // (the update tool writes edits made here through to it); `public-*`
+  // volumes are readonly and lock the editor. Display prefers the fresh file
+  // content over the possibly-stale inline mirror; `promptDraft` holds
+  // in-progress edits until the post-save refetch echoes them back.
+  const promptFile = form.watch("metadata.instructionsFile") ?? null;
+  const promptFileReadOnly =
+    promptFile !== null && publicSetOf(promptFile.volume) !== null;
+  const { data: promptFileText } = useOrgFsReadText(
+    promptFile?.volume ?? null,
+    promptFile?.path ?? "",
+  );
+  const [promptDraft, setPromptDraft] = useState<string | null>(null);
+  // Post-save echo: the refetched file matches the draft — drop it so later
+  // external file updates show through. Render-phase adjust, not an effect.
+  if (promptDraft !== null && promptFileText === promptDraft) {
+    setPromptDraft(null);
+  }
+  const promptDisplayValue = (fieldValue: string | null | undefined) =>
+    promptFile
+      ? (promptDraft ?? promptFileText ?? fieldValue ?? "")
+      : (fieldValue ?? "");
+
   // Repo info for the Runtime card (display-only — loose check is intentional)
   const githubRepoForRuntimeCard = getActiveGithubRepo(virtualMcp);
   const runtimeCardRepo = githubRepoForRuntimeCard
@@ -1178,8 +1204,10 @@ function VirtualMcpDetailViewWithData({
 
   const handleImprovePrompt = async () => {
     if (isImproving) return;
-    const currentInstructions = form.getValues("metadata.instructions");
-    if (!currentInstructions?.trim()) return;
+    const currentInstructions = promptDisplayValue(
+      form.getValues("metadata.instructions"),
+    );
+    if (!currentInstructions.trim()) return;
 
     setIsImproving(true);
     try {
@@ -1270,6 +1298,19 @@ function VirtualMcpDetailViewWithData({
       id: virtualMcp.id,
       data: payload,
     });
+
+    // Refetch the linked prompt file after the server's write-through so the
+    // draft-clearing echo check (above) sees the new content.
+    const linkedFile = formData.metadata?.instructionsFile;
+    if (linkedFile) {
+      queryClient.invalidateQueries({
+        queryKey: KEYS.orgFsReadText(
+          org.id,
+          linkedFile.volume,
+          linkedFile.path,
+        ),
+      });
+    }
 
     // Accumulate into the current edit session and (re)schedule a flush
     // 30s after the last save.
@@ -1548,6 +1589,34 @@ Define step-by-step how the agent should handle requests.
     form.setValue("metadata.instructions", next, { shouldDirty: true });
   };
 
+  const handleLinkPromptFile = async (file: PromptFileRef) => {
+    try {
+      const text = await fetchOrgFsText(org.slug, file.volume, file.path);
+      form.setValue("metadata.instructionsFile", file, { shouldDirty: true });
+      // Mirror the file content at link time so the entity fallback stays
+      // coherent (the server skips the no-op file write).
+      form.setValue("metadata.instructions", text, { shouldDirty: true });
+      setPromptDraft(null);
+      flushAndSave();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to read file.",
+      );
+    }
+  };
+
+  const handleUnlinkPromptFile = () => {
+    // Keep the currently-displayed text inline so unlinking never loses it.
+    form.setValue(
+      "metadata.instructions",
+      promptDisplayValue(form.getValues("metadata.instructions")),
+      { shouldDirty: true },
+    );
+    form.setValue("metadata.instructionsFile", null, { shouldDirty: true });
+    setPromptDraft(null);
+    flushAndSave();
+  };
+
   const addedConnectionIds = new Set(connections.map((c) => c.connection_id));
   const navigate = useNavigate();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -1796,20 +1865,28 @@ Define step-by-step how the agent should handle requests.
                   Instructions
                 </h2>
                 <div className="flex items-center gap-2">
-                  {!form.watch("metadata.instructions")?.trim() && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={handleInsertTemplate}
-                    >
-                      + Prompt template
-                    </Button>
-                  )}
+                  <PromptFileLink
+                    file={promptFile}
+                    readOnly={promptFileReadOnly}
+                    onLink={handleLinkPromptFile}
+                    onUnlink={handleUnlinkPromptFile}
+                  />
+                  {!promptFile &&
+                    !form.watch("metadata.instructions")?.trim() && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleInsertTemplate}
+                      >
+                        + Prompt template
+                      </Button>
+                    )}
                   <Button
                     variant="outline"
                     size="sm"
                     disabled={
                       isImproving ||
+                      promptFileReadOnly ||
                       !form.watch("metadata.instructions")?.trim()
                     }
                     onClick={handleImprovePrompt}
@@ -1826,14 +1903,16 @@ Define step-by-step how the agent should handle requests.
                   <div className="relative rounded-xl card-shadow bg-card focus-within:ring-1 focus-within:ring-ring">
                     <Textarea
                       {...field}
-                      value={field.value ?? ""}
+                      value={promptDisplayValue(field.value)}
                       onChange={(e) => {
+                        if (promptFile) setPromptDraft(e.target.value);
                         field.onChange(e);
                       }}
                       onBlur={() => {
                         field.onBlur();
                         flushAndSave();
                       }}
+                      disabled={promptFileReadOnly}
                       placeholder="Define how this agent should behave, what tone to use, any constraints or guidelines..."
                       className="min-h-[200px] max-h-[360px] overflow-auto resize-none text-base text-muted-foreground placeholder:text-muted-foreground/40 leading-relaxed border-0 shadow-none px-4 py-3 pr-11 focus-visible:ring-0 focus-visible:ring-offset-0 bg-transparent"
                       style={{ boxShadow: "none" }}
@@ -1999,15 +2078,16 @@ Define step-by-step how the agent should handle requests.
               render={({ field }) => (
                 <Textarea
                   {...field}
-                  value={field.value ?? ""}
+                  value={promptDisplayValue(field.value)}
                   onChange={(e) => {
+                    if (promptFile) setPromptDraft(e.target.value);
                     field.onChange(e);
                   }}
                   onBlur={() => {
                     field.onBlur();
                     flushAndSave();
                   }}
-                  disabled={hasGithubRepo}
+                  disabled={hasGithubRepo || promptFileReadOnly}
                   placeholder="Define how this agent should behave, what tone to use, any constraints or guidelines..."
                   className="w-full h-full resize-none text-base text-muted-foreground placeholder:text-muted-foreground/40 leading-relaxed rounded-xl card-shadow px-4 py-3 focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 bg-card border-0"
                   style={{ boxShadow: "none" }}

--- a/apps/mesh/src/web/views/virtual-mcp/prompt-file-link.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/prompt-file-link.tsx
@@ -1,0 +1,143 @@
+/**
+ * Link the agent's system prompt to an org-fs (Library) file.
+ *
+ * Unlinked: a "Link file" dropdown listing recent markdown/text files, with a
+ * search that also spans the readonly `public-*` volumes (git-synced sets).
+ * Linked: a chip with the file name, a lock when the volume is readonly, and
+ * an unlink button. The editor itself stays in the parent — this component
+ * only picks/clears `metadata.instructionsFile`.
+ */
+
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import { Lock01, Paperclip, SearchMd, XClose } from "@untitledui/icons";
+import { useState } from "react";
+import { FileTypeIcon } from "@/web/components/file-type-icon.tsx";
+import {
+  type OrgFsRecentEntry,
+  useOrgFsRecent,
+  useOrgFsSearch,
+} from "@/web/hooks/use-org-fs.ts";
+import { basename } from "@/web/layouts/library/location";
+
+/** Files that make sense as a prompt source. */
+const PROMPT_FILE_RE = /\.(md|mdx|markdown|txt|text)$/i;
+
+export interface PromptFileRef {
+  volume: string;
+  path: string;
+}
+
+export function PromptFileLink({
+  file,
+  readOnly,
+  onLink,
+  onUnlink,
+}: {
+  file: PromptFileRef | null;
+  readOnly: boolean;
+  onLink: (file: PromptFileRef) => void;
+  onUnlink: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  // Recent covers the org's own volumes; search also spans the readonly
+  // public sets — so typing is how git-synced files get found.
+  const { data: recent = [] } = useOrgFsRecent(60, { enabled: open });
+  const { data: searched = [] } = useOrgFsSearch(search.trim());
+
+  if (file) {
+    return (
+      <div
+        className="flex h-8 items-center gap-1.5 rounded-md border bg-muted/50 pl-2 pr-1 text-xs text-muted-foreground"
+        title={
+          readOnly
+            ? `${file.volume}/${file.path} — read-only (synced volume)`
+            : `${file.volume}/${file.path}`
+        }
+      >
+        <FileTypeIcon
+          filename={basename(file.path)}
+          className="h-4 w-3.5 shrink-0"
+        />
+        <span className="max-w-40 truncate">{basename(file.path)}</span>
+        {readOnly && <Lock01 size={12} className="shrink-0" />}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          onClick={onUnlink}
+          aria-label="Unlink prompt file"
+        >
+          <XClose size={12} />
+        </Button>
+      </div>
+    );
+  }
+
+  const pool: OrgFsRecentEntry[] = search.trim() ? searched : recent;
+  const candidates = pool
+    .filter((e) => e.kind !== "dir" && PROMPT_FILE_RE.test(e.path))
+    .slice(0, 8);
+
+  return (
+    <DropdownMenu
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (next) setSearch("");
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Paperclip size={13} />
+          Link file
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72 p-0">
+        <div className="flex items-center gap-2 border-b px-3">
+          <SearchMd size={16} className="shrink-0 text-muted-foreground" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
+            placeholder="Search markdown/text files..."
+            className="h-10 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+        <div className="max-h-64 overflow-y-auto p-1">
+          {candidates.length === 0 ? (
+            <p className="px-2 py-3 text-center text-sm text-muted-foreground">
+              No markdown or text files found.
+            </p>
+          ) : (
+            candidates.map((entry) => (
+              <DropdownMenuItem
+                key={`${entry.volume}/${entry.path}`}
+                onSelect={() => {
+                  setOpen(false);
+                  onLink({ volume: entry.volume, path: entry.path });
+                }}
+              >
+                <FileTypeIcon
+                  filename={basename(entry.path)}
+                  className="h-5 w-4 shrink-0"
+                />
+                <span className="flex-1 truncate">{basename(entry.path)}</span>
+                <span className="max-w-24 truncate text-xs text-muted-foreground">
+                  {entry.volume}
+                </span>
+              </DropdownMenuItem>
+            ))
+          )}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/e2e/tests/agent-prompt-file.spec.ts
+++ b/packages/e2e/tests/agent-prompt-file.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * E2E: agent system prompt linked to an org-fs file
+ * (`metadata.instructionsFile`).
+ *
+ * Contract under test:
+ *   1. The agent's served MCP instructions come from the linked file, not
+ *      the inline `metadata.instructions` mirror.
+ *   2. An instructions edit through COLLECTION_VIRTUAL_MCP_UPDATE writes
+ *      through to the file.
+ *   3. An external file edit (PUT over the fs routes) wins at runtime with
+ *      no row update — the "synced" half of the feature.
+ *   4. An update that does NOT change the prompt (e.g. a title autosave
+ *      echoing the stale mirror) must NOT clobber the external file edit.
+ */
+
+import { signUpViaApi } from "../fixtures/auth-api";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, newApiContext, test } from "../fixtures/test";
+import type { APIRequestContext } from "@playwright/test";
+
+const FILE_PATH = "prompts/agent-prompt.md";
+
+async function readPromptFile(
+  ctx: APIRequestContext,
+  orgSlug: string,
+): Promise<string> {
+  const res = await ctx.get(
+    `/api/${orgSlug}/fs/home/read?path=${encodeURIComponent(FILE_PATH)}`,
+  );
+  expect(res.ok(), `fs read: HTTP ${res.status()}`).toBe(true);
+  return res.text();
+}
+
+async function writePromptFile(
+  ctx: APIRequestContext,
+  orgSlug: string,
+  body: string,
+): Promise<void> {
+  const res = await ctx.put(
+    `/api/${orgSlug}/fs/home/file?path=${encodeURIComponent(FILE_PATH)}`,
+    { headers: { "content-type": "text/markdown" }, data: body },
+  );
+  expect(res.ok(), `fs write: HTTP ${res.status()}`).toBe(true);
+}
+
+/** MCP initialize against the agent's endpoint; returns served instructions. */
+async function agentInstructions(
+  ctx: APIRequestContext,
+  orgSlug: string,
+  agentId: string,
+): Promise<string> {
+  const res = await ctx.post(`/api/${orgSlug}/mcp/virtual-mcp/${agentId}`, {
+    headers: { Accept: "application/json, text/event-stream" },
+    data: {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "e2e", version: "1.0.0" },
+      },
+    },
+  });
+  expect(res.ok(), `initialize: HTTP ${res.status()}`).toBe(true);
+  const envelope = (await res.json()) as {
+    result?: { instructions?: string };
+    error?: { message: string };
+  };
+  expect(envelope.error, envelope.error?.message).toBeUndefined();
+  return envelope.result?.instructions ?? "";
+}
+
+test.describe("agent prompt linked to an org-fs file", () => {
+  test("syncs from the file, writes through, and survives stale mirrors", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+    const org = user.orgSlug;
+
+    await writePromptFile(ctx, org, "You are a pirate.");
+
+    const created = await callSelfMcpTool<{ item: { id: string } }>(
+      ctx,
+      org,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      {
+        data: {
+          title: "Prompt-from-file agent",
+          connections: [],
+          metadata: {
+            instructions: "inline seed (stale mirror)",
+            instructionsFile: { volume: "home", path: FILE_PATH },
+          },
+        },
+      },
+    );
+    const agentId = created.item.id;
+    expect(agentId).toBeTruthy();
+
+    // 1. Runtime serves the file content, not the inline mirror.
+    const served = await agentInstructions(ctx, org, agentId);
+    expect(served).toContain("You are a pirate.");
+    expect(served).not.toContain("inline seed");
+
+    // 2. A prompt edit via the update tool writes through to the file.
+    await callSelfMcpTool(ctx, org, "COLLECTION_VIRTUAL_MCP_UPDATE", {
+      id: agentId,
+      data: { metadata: { instructions: "You are an accountant." } },
+    });
+    expect(await readPromptFile(ctx, org)).toBe("You are an accountant.");
+    expect(await agentInstructions(ctx, org, agentId)).toContain(
+      "You are an accountant.",
+    );
+
+    // 3. An external file edit wins at runtime with no row update.
+    await writePromptFile(ctx, org, "External edit wins.");
+    expect(await agentInstructions(ctx, org, agentId)).toContain(
+      "External edit wins.",
+    );
+
+    // 4. A no-prompt-change update (title autosave echoing the now-stale
+    //    mirror) must NOT clobber the external edit.
+    await callSelfMcpTool(ctx, org, "COLLECTION_VIRTUAL_MCP_UPDATE", {
+      id: agentId,
+      data: {
+        title: "Renamed agent",
+        metadata: { instructions: "You are an accountant." },
+      },
+    });
+    expect(await readPromptFile(ctx, org)).toBe("External edit wins.");
+
+    await ctx.dispose();
+  });
+});

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -542,6 +542,26 @@ const knowledgeMetadataField = z
   );
 
 /**
+ * Reusable `metadata.instructionsFile` field shared by the entity, create, and
+ * update schemas. When set, the agent's system prompt is sourced from this
+ * org-fs file at run time and `instructions` becomes a mirror: kept in sync by
+ * the update tool's write-through and used as a fallback when the file is
+ * unreadable. Files on readonly (`public-*`) volumes make the prompt readonly.
+ */
+const instructionsFileMetadataField = z
+  .object({
+    volume: z
+      .string()
+      .describe("Org filesystem (Library) volume the file lives in"),
+    path: z.string().describe("Path within the volume"),
+  })
+  .nullable()
+  .optional()
+  .describe(
+    "Org-fs markdown/text file the system prompt is synced from. Takes precedence over `instructions` at run time; null/absent = inline instructions.",
+  );
+
+/**
  * Virtual MCP entity schema - single source of truth
  * Compliant with collections binding pattern
  */
@@ -605,6 +625,7 @@ export const VirtualMCPEntitySchema = z.object({
         "Per-user, per-branch sandbox mapping: sandboxMap[userId][branch] -> { sandboxHandle, previewUrl }",
       ),
       knowledge: knowledgeMetadataField,
+      instructionsFile: instructionsFileMetadataField,
       siteSlug: z
         .string()
         .nullable()
@@ -703,6 +724,7 @@ export const VirtualMCPCreateDataSchema = z.object({
         "Per-user, per-branch sandbox mapping: sandboxMap[userId][branch] -> { sandboxHandle, previewUrl }",
       ),
       knowledge: knowledgeMetadataField,
+      instructionsFile: instructionsFileMetadataField,
       siteSlug: z
         .string()
         .nullable()
@@ -782,6 +804,7 @@ export const VirtualMCPUpdateDataSchema = z.object({
         "Per-user, per-branch sandbox mapping: sandboxMap[userId][branch] -> { sandboxHandle, previewUrl }",
       ),
       knowledge: knowledgeMetadataField,
+      instructionsFile: instructionsFileMetadataField,
       siteSlug: z
         .string()
         .nullable()


### PR DESCRIPTION
## What is this contribution about?
Lets an agent's system prompt be sourced from a linked markdown/txt file in the org filesystem (`metadata.instructionsFile`) instead of only the inline `metadata.instructions` mirror. The runtime reads the linked file at agent-load time (same async seam as the skills catalog), so both the cluster engine and the sandbox/desktop daemon pick it up. Editing the prompt in the UI writes through to the file (guarded so a stale-mirror autosave never clobbers an external file edit), and files on readonly `public-*` (GitHub-synced) volumes lock the editor.

## Screenshots/Demonstration
No UI screenshots captured this session — the agent settings "Instructions" section gained a "Link file" control next to Improve/template actions; linking shows a chip with the file name (and a lock icon when the volume is readonly).

## How to Test
1. Open an agent's settings, click "Link file" under Instructions, and pick (or search for) a markdown/text file from the org filesystem.
2. Edit the prompt in the textarea and confirm the linked file's content updates (check via the Library or the fs API).
3. Edit the file externally (e.g. through a GitHub-synced `public-*` set) and reload the agent — confirm the new file content is served as the system prompt and the editor is locked read-only for public volumes.

## Migration Notes
No database migration — `instructionsFile` is a new optional key on the existing JSON `metadata` column.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Link an agent’s system prompt to a markdown/text file in the org filesystem via `metadata.instructionsFile`. The runtime reads the file at load time, edits write back to it, and public (GitHub‑synced) volumes are read‑only.

- **New Features**
  - Runtime prefers the linked file over `metadata.instructions` and reads it at agent load in both the cluster and sandbox.
  - UI adds “Link file” for Instructions; shows a chip when linked, and locks the editor for files on `public-*` volumes; unlink keeps the current text inline.
  - Edits write through to the linked file with safeguards to avoid clobbering external edits; prompt file content is refetched after save.
  - SDK/types updated to include `metadata.instructionsFile`; added E2E tests covering runtime source, write‑through, and external edit precedence.

- **Migration**
  - No DB changes. Adds optional `metadata.instructionsFile` in the existing JSON metadata.

<sup>Written for commit 09e0e6bcebea58b3cc8c69313aaedd76de803c8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

