### PR TITLE
refactor(studio-chart): split nginx (web) and api into separate deployments

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -152,3 +152,26 @@ jobs:
             --set database.url=postgresql://ci:ci@postgres.example.com:5432/studio \
             -f deploy/helm/studio/examples/values-clickhouse.yaml \
             > /dev/null
+
+  studio-zero-downtime:
+    name: studio zero-downtime rollout (kind)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      # Real cluster so we exercise the actual web↔api split, Service selectors,
+      # init-container ordering and the maxUnavailable=0 rollout — a `helm
+      # template` render can't prove zero-downtime.
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: studio-zdt
+
+      - name: Zero-downtime rollout test
+        run: bash deploy/helm/studio/tests/zero-downtime-rollout.sh

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.12.1
+version: 0.13.0
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/README.md
+++ b/deploy/helm/studio/README.md
@@ -41,18 +41,25 @@ This Helm chart encapsulates all Kubernetes resources necessary to run the appli
 ### Architecture
 ![Infrastructure](./img/deco-studio-infra-arch.jpg)
 
-## API nginx front-door topology
+## Web / API topology
 
-The main Studio Deployment runs each API pod as three containers:
+Two Deployments, split by tier:
 
-- nginx: service-facing front door on the `http` port, serving built SPA assets
-  from the custom nginx image and proxying API/system paths to local Bun
-  upstreams.
-- api-0: Bun API process on `127.0.0.1:3000`.
-- api-1: Bun API process on `127.0.0.1:3001`.
+- **API** (`<release>`): one Bun process per pod on port `3000`
+  (`MESH_DISPATCH_ROLE=api`). Fronted by the internal `<release>-api` ClusterIP
+  Service. Scales horizontally by pod count (HPA); the mesh PDB and any selector
+  on `app.kubernetes.io/name=<name>` keep matching these pods.
+- **Web** (`<release>-web`): nginx serving the baked SPA and reverse-proxying
+  `/api`, `/mcp`, `/health`, … to the `<release>-api` Service. This is the front
+  door — `nginx.frontDoorLabels` and the public `<release>` Service select these
+  pods. Config is rendered by the chart into a ConfigMap
+  (`<release>-nginx`) so the upstream points at the API Service.
 
-The separate `web.enabled` Deployment topology has been removed. nginx is part
-of every API pod and the Service targets nginx through `targetPort: http`.
+Zero-downtime rollouts: the web Deployment uses `maxUnavailable=0` and a
+`wait-for-api` initContainer that blocks Ready until the API Service answers
+`/health/live`, so a rolling web pod never takes traffic before the API it
+proxies to is up (API rolls first, then web). See
+`tests/zero-downtime-rollout.sh` (exercised in CI on kind).
 
 Because API containers run with `MESH_DISPATCH_ROLE=api`, worker pods are
 required:

--- a/deploy/helm/studio/README.md
+++ b/deploy/helm/studio/README.md
@@ -52,14 +52,24 @@ Two Deployments, split by tier:
 - **Web** (`<release>-web`): nginx serving the baked SPA and reverse-proxying
   `/api`, `/mcp`, `/health`, … to the `<release>-api` Service. This is the front
   door — `nginx.frontDoorLabels` and the public `<release>` Service select these
-  pods. Config is rendered by the chart into a ConfigMap
-  (`<release>-nginx`) so the upstream points at the API Service.
+  pods. The proxy config is the `<release>-nginx` ConfigMap, derived from the
+  baked `files/api-nginx.conf` with only the upstream repointed at the API
+  Service (one source of truth for image and chart).
 
-Zero-downtime rollouts: the web Deployment uses `maxUnavailable=0` and a
-`wait-for-api` initContainer that blocks Ready until the API Service answers
-`/health/live`, so a rolling web pod never takes traffic before the API it
-proxies to is up (API rolls first, then web). See
+Zero-downtime rollouts: both Deployments use `maxUnavailable=0`, so a new pod is
+Ready before an old one goes away and the front door always has an endpoint. The
+web `wait-for-api` initContainer additionally holds a web pod from starting until
+the API Service answers `/health/live` — on a fresh install that orders API
+before web; on an upgrade both tiers roll concurrently and availability is
+carried by `maxUnavailable=0`, not by ordering. See
 `tests/zero-downtime-rollout.sh` (exercised in CI on kind).
+
+> **Upgrading from the pre-split chart (≤ 0.12.x → 0.13.0):** the front door
+> migrates from the old combo pods to the new `<release>-web` pods (both
+> `nginx.frontDoorLabels` and the `<release>` Service selector move). The
+> zero-downtime test covers steady-state rolls, not this one-time cutover, which
+> is timing-dependent. Roll it on staging first and watch the front-door
+> endpoint / LB target count stay ≥ 1 throughout the upgrade.
 
 Because API containers run with `MESH_DISPATCH_ROLE=api`, worker pods are
 required:
@@ -69,8 +79,8 @@ worker:
   enabled: true
 ```
 
-The main pod requests 2 CPU cores total by default: 500m for nginx and 750m for
-each Bun API container. The chart requires PostgreSQL for this split topology so
+Each API pod requests 750m by default (one Bun process); web pods request 50m
+(nginx is a thin proxy). The chart requires PostgreSQL for this split topology so
 API and worker pods share the DBOS run queue.
 
 ## Prerequisites

--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -53,11 +53,35 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels
+Selector labels — the API/mesh tier. The main Deployment keeps these unchanged
+(name = chart/nameOverride) so its selector is never mutated on upgrade, and any
+external selector that already targets the mesh (e.g. a PodDisruptionBudget on
+app.kubernetes.io/name) keeps matching the API pods after the web tier is split
+out.
 */}}
 {{- define "chart-deco-studio.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "chart-deco-studio.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Web (nginx front-door) tier — distinct app.kubernetes.io/name ("<name>-web"),
+mirroring the worker tier, so the API selector, the API Service and any mesh PDB
+never match web pods and vice-versa.
+*/}}
+{{- define "chart-deco-studio.webSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart-deco-studio.name" . }}-web
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "chart-deco-studio.webLabels" -}}
+{{ include "chart-deco-studio.webSelectorLabels" . }}
+app.kubernetes.io/component: web
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+helm.sh/chart: {{ include "chart-deco-studio.chart" . }}
 {{- end }}
 
 {{/*

--- a/deploy/helm/studio/templates/api-service.yaml
+++ b/deploy/helm/studio/templates/api-service.yaml
@@ -1,0 +1,25 @@
+{{/*
+Internal ClusterIP for the API tier. nginx (web Deployment) proxies to this
+Service; kube-proxy load-balances across the ready API pods. Not the public
+front door — that is the {{ include "chart-deco-studio.fullname" . }} Service,
+which selects the web pods.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart-deco-studio.fullname" . }}-api
+  labels:
+    {{- include "chart-deco-studio.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.configMap.meshConfig.PORT | default "3000" | int }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "chart-deco-studio.selectorLabels" . | nindent 4 }}
+  {{- with .Values.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}

--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 3000
+              containerPort: {{ .Values.configMap.meshConfig.PORT | default "3000" | int }}
               protocol: TCP
           envFrom:
             - configMapRef:
@@ -85,7 +85,7 @@ spec:
                 name: {{ include "chart-deco-studio.secretName" . }}
           env:
             - name: PORT
-              value: "3000"
+              value: {{ .Values.configMap.meshConfig.PORT | default "3000" | quote }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -28,11 +28,10 @@ spec:
       {{- if or .Values.metrics.scrape .Values.podAnnotations }}
       annotations:
         {{- if .Values.metrics.scrape }}
-        # Annotation-based discovery: vmagent's kubernetes-pods job scrapes the
-        # nginx proxies /metrics to the API containers; scrape the service-facing
-        # http port so annotation discovery follows the front door.
+        # The API process exposes /metrics directly on its own port (no nginx in
+        # this pod anymore), so vmagent's kubernetes-pods job scrapes it here.
         prometheus.io/scrape: "true"
-        prometheus.io/port: "8080"
+        prometheus.io/port: {{ .Values.configMap.meshConfig.PORT | default "3000" | quote }}
         prometheus.io/path: {{ .Values.metrics.path | quote }}
         {{- end }}
         {{- with .Values.podAnnotations }}
@@ -44,13 +43,9 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        # Front-door selector label(s) for the NLB. Applied to the combo
-        # (nginx + API) pods ONLY — deliberately NOT in worker-deployment.yaml —
-        # so labelling the front door never registers the worker as a public
-        # NLB target. See nginx.frontDoorLabels in values.yaml.
-        {{- with .Values.nginx.frontDoorLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        # NOTE: nginx.frontDoorLabels are deliberately NOT applied here — the
+        # front door is now the separate web Deployment (nginx-deployment.yaml).
+        # Stamping them here would register the API pods as public LB targets.
     spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
@@ -63,180 +58,133 @@ spec:
       securityContext:
         {{- include "chart-deco-studio.podSecurityContext" . | nindent 8 }}
       containers:
-        # The front-door / web tier. Runs the nginx image (serves the SPA +
-        # proxies to the API sidecars); named "-web" for the user-facing web
-        # tier rather than the implementation (nginx).
-        - name: {{ .Chart.Name }}-web
-          {{- with .Values.nginx.securityContext }}
+        # API tier — a single Bun mesh process per pod (MESH_DISPATCH_ROLE=api).
+        # nginx runs as its own Deployment (nginx-deployment.yaml) and reaches
+        # these pods through the {{ include "chart-deco-studio.fullname" . }}-api
+        # Service, so the API scales horizontally by pod count instead of packing
+        # two processes behind an in-pod nginx.
+        - name: {{ .Chart.Name }}-api
+          {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.nginx.image.repository }}{{- if and .Values.nginx.image.tag (hasPrefix "sha256:" .Values.nginx.image.tag) }}@{{ .Values.nginx.image.tag }}{{- else }}:{{ .Values.nginx.image.tag | default .Chart.AppVersion }}{{- end }}"
-          imagePullPolicy: {{ .Values.nginx.image.pullPolicy | default "IfNotPresent" }}
-          ports:
-            - name: http
-              containerPort: 8080
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: http
-            initialDelaySeconds: 3
-            periodSeconds: 5
-          lifecycle:
-            preStop:
-              # `nginx -s quit` closes the listen socket and drains open
-              # keep-alive connections immediately, so a pod mid-rollout stops
-              # serving its (stale) baked SPA build right away instead of
-              # continuing to answer normally for the whole grace window. The
-              # sleep after gives that drain time to finish before kubelet's
-              # SIGTERM lands and force-kills it mid-shutdown.
-              exec:
-                command:
-                  - /bin/sh
-                  - -c
-                  - "nginx -s quit; sleep {{ .Values.nginx.preStopSleepSeconds | default 15 }}"
-          {{- with .Values.nginx.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-        {{- range $api := list (dict "name" (printf "%s-api-0" $.Chart.Name) "portName" "api-0" "port" 3000) (dict "name" (printf "%s-api-1" $.Chart.Name) "portName" "api-1" "port" 3001) }}
-        - name: {{ $api.name }}
-          {{- with $.Values.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          image: "{{ $.Values.image.repository }}{{- if and $.Values.image.tag (hasPrefix "sha256:" $.Values.image.tag) }}@{{ $.Values.image.tag }}{{- else }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}{{- end }}"
-          imagePullPolicy: {{ $.Values.image.pullPolicy }}
-          {{- with $.Values.image.command }}
+          image: "{{ .Values.image.repository }}{{- if and .Values.image.tag (hasPrefix "sha256:" .Values.image.tag) }}@{{ .Values.image.tag }}{{- else }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- end }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.image.command }}
           command:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ $api.portName }}
-              containerPort: {{ $api.port }}
+            - name: http
+              containerPort: 3000
               protocol: TCP
           envFrom:
             - configMapRef:
-                name: {{ include "chart-deco-studio.fullname" $ }}-config
+                name: {{ include "chart-deco-studio.fullname" . }}-config
             - secretRef:
-                name: {{ include "chart-deco-studio.secretName" $ }}
+                name: {{ include "chart-deco-studio.secretName" . }}
           env:
             - name: PORT
-              value: {{ $api.port | quote }}
-            - name: POD_NAME_BASE
+              value: "3000"
+            - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: POD_NAME
-              value: "$(POD_NAME_BASE)-{{ $api.portName }}"
             - name: MESH_DISPATCH_ROLE
               value: "api"
-            {{- if $.Values.terminationGracePeriodSeconds }}
+            {{- if .Values.terminationGracePeriodSeconds }}
             - name: SHUTDOWN_GRACE_SECONDS
-              value: {{ $.Values.terminationGracePeriodSeconds | quote }}
+              value: {{ .Values.terminationGracePeriodSeconds | quote }}
             {{- end }}
-            {{- if $.Values.tunnel.nats.clusterCreds.enabled }}
+            {{- if .Values.tunnel.nats.clusterCreds.enabled }}
             - name: NATS_CREDS
-              value: {{ include "chart-deco-studio.natsClusterCredsPath" $ | quote }}
+              value: {{ include "chart-deco-studio.natsClusterCredsPath" . | quote }}
             {{- end }}
-            {{- if $.Values.otel.enabled }}
-            {{- if $.Values.otel.protocol }}
+            {{- if .Values.otel.enabled }}
+            {{- if .Values.otel.protocol }}
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: {{ $.Values.otel.protocol | quote }}
+              value: {{ .Values.otel.protocol | quote }}
             {{- end }}
-            {{- if $.Values.otel.service }}
+            {{- if .Values.otel.service }}
             - name: OTEL_SERVICE_NAME
-              value: {{ $.Values.otel.service | quote }}
+              value: {{ .Values.otel.service | quote }}
             {{- end }}
-            {{- if $.Values.otel.endpoint }}
+            {{- if .Values.otel.endpoint }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ $.Values.otel.endpoint | quote }}
-            {{- else if $.Values.otel.collector.enabled }}
+              value: {{ .Values.otel.endpoint | quote }}
+            {{- else if .Values.otel.collector.enabled }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ printf "http://%s-opentelemetry-collector:4318" $.Release.Name | quote }}
+              value: {{ printf "http://%s-opentelemetry-collector:4318" .Release.Name | quote }}
             {{- end }}
-            {{- if and $.Values.otel.headers (or (not $.Values.otel.collector.enabled) $.Values.otel.endpoint) }}
+            {{- if and .Values.otel.headers (or (not .Values.otel.collector.enabled) .Values.otel.endpoint) }}
             - name: OTEL_EXPORTER_OTLP_HEADERS
-              value: {{ include "chart-deco-studio.otelHeaders" $ | quote }}
+              value: {{ include "chart-deco-studio.otelHeaders" . | quote }}
             {{- end }}
-            {{- if $.Values.otel.attributes }}
+            {{- if .Values.otel.attributes }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: {{ include "chart-deco-studio.otelAttributes" $ | quote }}
+              value: {{ include "chart-deco-studio.otelAttributes" . | quote }}
             {{- end }}
             {{- end }}
-            {{- if and $.Values.dbosConductor $.Values.dbosConductor.enabled }}
+            {{- if and .Values.dbosConductor .Values.dbosConductor.enabled }}
             - name: DBOS_CONDUCTOR_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ $.Values.dbosConductor.existingSecret | default (printf "%s-dbos-conductor" (include "chart-deco-studio.fullname" $)) }}
-                  key: {{ $.Values.dbosConductor.existingSecretKey | default "DBOS_CONDUCTOR_KEY" }}
-            {{- with $.Values.dbosConductor.url }}
+                  name: {{ .Values.dbosConductor.existingSecret | default (printf "%s-dbos-conductor" (include "chart-deco-studio.fullname" .)) }}
+                  key: {{ .Values.dbosConductor.existingSecretKey | default "DBOS_CONDUCTOR_KEY" }}
+            {{- with .Values.dbosConductor.url }}
             - name: DBOS_CONDUCTOR_URL
               value: {{ . | quote }}
             {{- end }}
             {{- end }}
-            {{- with $.Values.env }}
+            {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with $.Values.startupProbe }}
-          {{- $probe := deepCopy . }}
-          {{- $httpGet := get $probe "httpGet" }}
-          {{- if and $httpGet (eq (get $httpGet "port") "http") }}
-          {{- $_ := set $httpGet "port" $api.port }}
-          {{- end }}
+          {{- with .Values.startupProbe }}
           startupProbe:
-            {{- toYaml $probe | nindent 12 }}
-          {{- end }}
-          {{- with $.Values.livenessProbe }}
-          {{- $probe := deepCopy . }}
-          {{- $httpGet := get $probe "httpGet" }}
-          {{- if and $httpGet (eq (get $httpGet "port") "http") }}
-          {{- $_ := set $httpGet "port" $api.port }}
-          {{- end }}
-          livenessProbe:
-            {{- toYaml $probe | nindent 12 }}
-          {{- end }}
-          {{- with $.Values.readinessProbe }}
-          {{- $probe := deepCopy . }}
-          {{- $httpGet := get $probe "httpGet" }}
-          {{- if and $httpGet (eq (get $httpGet "port") "http") }}
-          {{- $_ := set $httpGet "port" $api.port }}
-          {{- end }}
-          readinessProbe:
-            {{- toYaml $probe | nindent 12 }}
-          {{- end }}
-          {{- with $.Values.lifecycle }}
-          lifecycle:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with $.Values.resources }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          lifecycle:
+            {{- if .Values.lifecycle }}
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+            {{- else }}
+            # Sleep before SIGTERM so kube-proxy drops this pod from the API
+            # Service endpoints before the process starts shutting down — nginx
+            # never opens a fresh upstream connection to a draining pod.
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - "sleep {{ .Values.preStopSleepSeconds | default 5 }}"
+            {{- end }}
+          {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: data
-              mountPath: {{ $.Values.configMap.meshConfig.DATA_DIR | default "/app/data" }}
-            {{- if and (eq (lower (default "sqlite" $.Values.database.engine)) "postgresql") $.Values.database.caCert }}
+              mountPath: {{ .Values.configMap.meshConfig.DATA_DIR | default "/app/data" }}
+            {{- if and (eq (lower (default "sqlite" .Values.database.engine)) "postgresql") .Values.database.caCert }}
             - name: ca-cert
               mountPath: /etc/ssl/certs
               readOnly: true
             {{- end }}
-            {{- if $.Values.tunnel.nats.clusterCreds.enabled }}
+            {{- if .Values.tunnel.nats.clusterCreds.enabled }}
             - name: nats-cluster-creds
-              mountPath: {{ $.Values.tunnel.nats.clusterCreds.mountDir | quote }}
+              mountPath: {{ .Values.tunnel.nats.clusterCreds.mountDir | quote }}
               readOnly: true
             {{- end }}
-          {{- with $.Values.volumeMounts }}
+          {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- end }}
       {{- if .Values.s3Sync.enabled }}
         - name: s3-sync
           image: "{{ .Values.s3Sync.image.repository }}:{{ .Values.s3Sync.image.tag }}"

--- a/deploy/helm/studio/templates/nginx-configmap.yaml
+++ b/deploy/helm/studio/templates/nginx-configmap.yaml
@@ -1,0 +1,127 @@
+{{/*
+Front-door nginx config, rendered by the chart so the upstream can point at the
+API Service (release-scoped DNS) instead of the in-pod 127.0.0.1 the baked image
+default assumes. Mounted over /etc/nginx/conf.d/default.conf in the web
+Deployment; the SPA static assets stay baked into the nginx image.
+
+One upstream server = the API ClusterIP Service; kube-proxy load-balances across
+all ready API pods, and (with maxUnavailable=0 on the API rollout) a draining
+pod is removed from Endpoints before it stops, so no request is proxied to a
+dead process. app-level 5xx (circuit-breaker 503, dead-sandbox 502) stay OUT of
+proxy_next_upstream so they are never treated as upstream health failures.
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chart-deco-studio.fullname" . }}-nginx
+  labels:
+    {{- include "chart-deco-studio.webLabels" . | nindent 4 }}
+data:
+  default.conf: |
+    map $http_upgrade $connection_upgrade {
+      default upgrade;
+      ''      "";
+    }
+
+    upstream studio_api {
+      zone studio_api 64k;
+      server {{ include "chart-deco-studio.fullname" . }}-api:{{ .Values.configMap.meshConfig.PORT | default "3000" }} max_conns=256;
+      keepalive 64;
+    }
+
+    server {
+      listen 8080;
+      server_name ~^[^.]+\.preview\..+$;
+
+      access_log /dev/stdout;
+      error_log /dev/stderr warn;
+
+      client_max_body_size 100m;
+      client_body_timeout 30s;
+      keepalive_timeout 65s;
+      keepalive_requests 1000;
+      send_timeout 60s;
+
+      large_client_header_buffers 4 32k;
+
+      location / {
+        proxy_pass http://studio_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+        proxy_next_upstream error timeout;
+        proxy_next_upstream_tries 2;
+        proxy_buffering off;
+        proxy_request_buffering off;
+      }
+    }
+
+    server {
+      listen 8080 default_server;
+      server_name _;
+      root /usr/share/nginx/html;
+      index index.html;
+
+      access_log /dev/stdout;
+      error_log /dev/stderr warn;
+
+      client_max_body_size 100m;
+      client_body_timeout 30s;
+      keepalive_timeout 65s;
+      keepalive_requests 1000;
+      send_timeout 60s;
+
+      large_client_header_buffers 4 32k;
+
+      location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+      }
+
+      location ~ ^/(api|mcp|oauth-proxy|\.well-known|org|health|metrics)(/|$) {
+        proxy_pass http://studio_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+        proxy_next_upstream error timeout;
+        proxy_next_upstream_tries 2;
+        proxy_buffering off;
+        proxy_request_buffering off;
+      }
+
+      location /assets/ {
+        try_files $uri @asset_missing;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+      }
+
+      location @asset_missing {
+        add_header Cache-Control "no-store" always;
+        return 404;
+      }
+
+      location / {
+        add_header Cache-Control "no-cache" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Content-Security-Policy "frame-ancestors 'none'" always;
+        etag off;
+        if_modified_since off;
+        try_files $uri /index.html;
+      }
+    }

--- a/deploy/helm/studio/templates/nginx-configmap.yaml
+++ b/deploy/helm/studio/templates/nginx-configmap.yaml
@@ -1,15 +1,24 @@
 {{/*
-Front-door nginx config, rendered by the chart so the upstream can point at the
-API Service (release-scoped DNS) instead of the in-pod 127.0.0.1 the baked image
-default assumes. Mounted over /etc/nginx/conf.d/default.conf in the web
-Deployment; the SPA static assets stay baked into the nginx image.
+Front-door nginx config for the web Deployment, mounted over
+/etc/nginx/conf.d/default.conf so the upstream points at the API Service
+(release-scoped DNS) instead of the in-pod 127.0.0.1 the baked image assumes.
 
-One upstream server = the API ClusterIP Service; kube-proxy load-balances across
-all ready API pods, and (with maxUnavailable=0 on the API rollout) a draining
-pod is removed from Endpoints before it stops, so no request is proxied to a
-dead process. app-level 5xx (circuit-breaker 503, dead-sandbox 502) stay OUT of
-proxy_next_upstream so they are never treated as upstream health failures.
+Single source of truth: this is derived from files/api-nginx.conf (the copy baked
+into the image) with ONLY the two in-pod localhost upstreams swapped for the api
+ClusterIP Service — so an edit to that one file propagates to both the image and
+this ConfigMap and they can't drift. kube-proxy load-balances the Service across
+ready API pods; with maxUnavailable=0 on the API rollout a draining pod leaves
+Endpoints before it stops, so no request is proxied to a dead process. app-level
+5xx (circuit-breaker 503, dead-sandbox 502) stay OUT of proxy_next_upstream in
+that file, so they are never treated as upstream health failures.
 */}}
+{{- $port := .Values.configMap.meshConfig.PORT | default "3000" -}}
+{{- $svc := printf "%s-api" (include "chart-deco-studio.fullname" .) -}}
+{{- $conf := .Files.Get "files/api-nginx.conf" -}}
+{{- $conf = regexReplaceAll `(?s)server 127\.0\.0\.1:3000[^;]*;\s*server 127\.0\.0\.1:3001[^;]*;` $conf (printf "server %s:%s max_conns=256;" $svc $port) -}}
+{{- if not (contains (printf "server %s:%s" $svc $port) $conf) }}
+{{- fail "nginx-configmap: could not rewrite the localhost upstream from files/api-nginx.conf — did its `upstream studio_api` block format change?" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -18,110 +27,4 @@ metadata:
     {{- include "chart-deco-studio.webLabels" . | nindent 4 }}
 data:
   default.conf: |
-    map $http_upgrade $connection_upgrade {
-      default upgrade;
-      ''      "";
-    }
-
-    upstream studio_api {
-      zone studio_api 64k;
-      server {{ include "chart-deco-studio.fullname" . }}-api:{{ .Values.configMap.meshConfig.PORT | default "3000" }} max_conns=256;
-      keepalive 64;
-    }
-
-    server {
-      listen 8080;
-      server_name ~^[^.]+\.preview\..+$;
-
-      access_log /dev/stdout;
-      error_log /dev/stderr warn;
-
-      client_max_body_size 100m;
-      client_body_timeout 30s;
-      keepalive_timeout 65s;
-      keepalive_requests 1000;
-      send_timeout 60s;
-
-      large_client_header_buffers 4 32k;
-
-      location / {
-        proxy_pass http://studio_api;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-
-        proxy_connect_timeout 5s;
-        proxy_send_timeout 3600s;
-        proxy_read_timeout 3600s;
-        proxy_next_upstream error timeout;
-        proxy_next_upstream_tries 2;
-        proxy_buffering off;
-        proxy_request_buffering off;
-      }
-    }
-
-    server {
-      listen 8080 default_server;
-      server_name _;
-      root /usr/share/nginx/html;
-      index index.html;
-
-      access_log /dev/stdout;
-      error_log /dev/stderr warn;
-
-      client_max_body_size 100m;
-      client_body_timeout 30s;
-      keepalive_timeout 65s;
-      keepalive_requests 1000;
-      send_timeout 60s;
-
-      large_client_header_buffers 4 32k;
-
-      location = /healthz {
-        access_log off;
-        add_header Content-Type text/plain;
-        return 200 "ok\n";
-      }
-
-      location ~ ^/(api|mcp|oauth-proxy|\.well-known|org|health|metrics)(/|$) {
-        proxy_pass http://studio_api;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-
-        proxy_connect_timeout 5s;
-        proxy_send_timeout 3600s;
-        proxy_read_timeout 3600s;
-        proxy_next_upstream error timeout;
-        proxy_next_upstream_tries 2;
-        proxy_buffering off;
-        proxy_request_buffering off;
-      }
-
-      location /assets/ {
-        try_files $uri @asset_missing;
-        add_header Cache-Control "public, max-age=31536000, immutable";
-      }
-
-      location @asset_missing {
-        add_header Cache-Control "no-store" always;
-        return 404;
-      }
-
-      location / {
-        add_header Cache-Control "no-cache" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header Content-Security-Policy "frame-ancestors 'none'" always;
-        etag off;
-        if_modified_since off;
-        try_files $uri /index.html;
-      }
-    }
+{{ $conf | indent 4 }}

--- a/deploy/helm/studio/templates/nginx-deployment.yaml
+++ b/deploy/helm/studio/templates/nginx-deployment.yaml
@@ -6,9 +6,11 @@ Zero-downtime contract:
   - RollingUpdate maxUnavailable=0 / maxSurge=1: a new web pod must become Ready
     before an old one is removed, so the front-door Service always has a serving
     endpoint.
-  - initContainer `wait-for-api` blocks Ready until the API Service answers
-    /health/live, so a freshly rolled web pod never takes traffic before the API
-    it proxies to exists (correct ordering: API first, then web).
+  - initContainer `wait-for-api` holds the container from starting until the API
+    Service answers /health/live, so on a FRESH install a web pod never starts
+    before the API exists. On an upgrade both tiers roll concurrently (old API
+    endpoints already satisfy the probe); availability across that is carried by
+    maxUnavailable=0 on both Deployments, not by start ordering.
   - preStop `nginx -s quit` + grace drains in-flight connections on the way out.
 */}}
 apiVersion: apps/v1
@@ -53,8 +55,9 @@ spec:
       securityContext:
         {{- include "chart-deco-studio.podSecurityContext" . | nindent 8 }}
       initContainers:
-        # Gate readiness on the API being reachable, so a new web pod never
-        # serves before the API Service has ready endpoints (ordered rollout).
+        # Hold container start until the API Service has ready endpoints, so a
+        # new web pod never boots before the API is reachable (guarantees API
+        # first on install; on upgrade both roll, held safe by maxUnavailable=0).
         - name: wait-for-api
           image: "{{ .Values.nginx.image.repository }}{{- if and .Values.nginx.image.tag (hasPrefix "sha256:" .Values.nginx.image.tag) }}@{{ .Values.nginx.image.tag }}{{- else }}:{{ .Values.nginx.image.tag | default .Chart.AppVersion }}{{- end }}"
           {{- with .Values.nginx.securityContext }}

--- a/deploy/helm/studio/templates/nginx-deployment.yaml
+++ b/deploy/helm/studio/templates/nginx-deployment.yaml
@@ -1,0 +1,150 @@
+{{/*
+Web / front-door tier: nginx serving the baked SPA and reverse-proxying to the
+API Service. Split out of the combo Deployment so the API scales by pod count.
+
+Zero-downtime contract:
+  - RollingUpdate maxUnavailable=0 / maxSurge=1: a new web pod must become Ready
+    before an old one is removed, so the front-door Service always has a serving
+    endpoint.
+  - initContainer `wait-for-api` blocks Ready until the API Service answers
+    /health/live, so a freshly rolled web pod never takes traffic before the API
+    it proxies to exists (correct ordering: API first, then web).
+  - preStop `nginx -s quit` + grace drains in-flight connections on the way out.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart-deco-studio.fullname" . }}-web
+  labels:
+    {{- include "chart-deco-studio.webLabels" . | nindent 4 }}
+spec:
+  {{- if not .Values.nginx.autoscaling.enabled }}
+  replicas: {{ .Values.nginx.replicaCount | default 2 }}
+  {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      {{- include "chart-deco-studio.webSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "chart-deco-studio.webLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        # The web tier IS the front door — the public LB selects these pods.
+        {{- with .Values.nginx.frontDoorLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        # Roll the web pods whenever the proxy config changes.
+        checksum/nginx-config: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.nginx.terminationGracePeriodSeconds | default 30 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "chart-deco-studio.serviceAccountName" . }}
+      securityContext:
+        {{- include "chart-deco-studio.podSecurityContext" . | nindent 8 }}
+      initContainers:
+        # Gate readiness on the API being reachable, so a new web pod never
+        # serves before the API Service has ready endpoints (ordered rollout).
+        - name: wait-for-api
+          image: "{{ .Values.nginx.image.repository }}{{- if and .Values.nginx.image.tag (hasPrefix "sha256:" .Values.nginx.image.tag) }}@{{ .Values.nginx.image.tag }}{{- else }}:{{ .Values.nginx.image.tag | default .Chart.AppVersion }}{{- end }}"
+          {{- with .Values.nginx.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              url="http://{{ include "chart-deco-studio.fullname" . }}-api:{{ .Values.configMap.meshConfig.PORT | default "3000" }}{{ .Values.nginx.apiWaitPath | default "/health/live" }}"
+              echo "waiting for API at $url ..."
+              i=0
+              until wget -q -T 2 -O /dev/null "$url"; do
+                i=$((i+1))
+                if [ "$i" -ge {{ .Values.nginx.apiWaitMaxTries | default 60 }} ]; then
+                  echo "API still not ready after $i tries; giving up"
+                  exit 1
+                fi
+                sleep 2
+              done
+              echo "API is ready"
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              memory: "32Mi"
+      containers:
+        - name: {{ .Chart.Name }}-web
+          {{- with .Values.nginx.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.nginx.image.repository }}{{- if and .Values.nginx.image.tag (hasPrefix "sha256:" .Values.nginx.image.tag) }}@{{ .Values.nginx.image.tag }}{{- else }}:{{ .Values.nginx.image.tag | default .Chart.AppVersion }}{{- end }}"
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          lifecycle:
+            preStop:
+              # Zero-downtime ordering: SLEEP FIRST while nginx keeps its listener
+              # open and serving, so kube-proxy removes this pod from the Service
+              # endpoints before it stops accepting — otherwise new connections
+              # race onto a pod that has already quit and get connection-refused.
+              # After preStop, the container's SIGQUIT stop-signal (nginx default)
+              # drains in-flight requests gracefully within terminationGracePeriod.
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - "sleep {{ .Values.nginx.preStopSleepSeconds | default 15 }}"
+          {{- with .Values.nginx.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "chart-deco-studio.fullname" . }}-nginx
+            items:
+              - key: default.conf
+                path: default.conf
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/studio/templates/nginx-hpa.yaml
+++ b/deploy/helm/studio/templates/nginx-hpa.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.nginx.autoscaling.enabled }}
+{{/*
+HPA for the web/front-door tier. The web Deployment drops its static `replicas`
+when nginx.autoscaling.enabled is true, so this must exist or the tier silently
+scales to 1. Mirrors hpa.yaml / worker-hpa.yaml.
+*/}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "chart-deco-studio.fullname" . }}-web
+  labels:
+    {{- include "chart-deco-studio.webLabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "chart-deco-studio.fullname" . }}-web
+  minReplicas: {{ .Values.nginx.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.nginx.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.nginx.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.nginx.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.nginx.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.nginx.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/studio/templates/nginx-pdb.yaml
+++ b/deploy/helm/studio/templates/nginx-pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.nginx.pdb.enabled }}
+{{/*
+PodDisruptionBudget for the web/front-door tier. Keeps at least one nginx pod
+serving through voluntary disruptions (node drains, cluster upgrades), so the
+public LB always has a healthy target. Rollouts are already safe via the web
+Deployment's maxUnavailable=0 strategy; this covers involuntary/drain cases.
+*/}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "chart-deco-studio.fullname" . }}-web
+  labels:
+    {{- include "chart-deco-studio.webLabels" . | nindent 4 }}
+spec:
+  {{- if .Values.nginx.pdb.minAvailable }}
+  minAvailable: {{ .Values.nginx.pdb.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.nginx.pdb.maxUnavailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "chart-deco-studio.webSelectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/studio/templates/service.yaml
+++ b/deploy/helm/studio/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "chart-deco-studio.selectorLabels" . | nindent 4 }}
+    {{- include "chart-deco-studio.webSelectorLabels" . | nindent 4 }}
   {{- with .Values.service.trafficDistribution }}
   # Prefer same-zone endpoints (kube-proxy topology hints) → less cross-zone
   # traffic. Best-effort: falls back to all endpoints when a zone has none.

--- a/deploy/helm/studio/tests/values-e2e.yaml
+++ b/deploy/helm/studio/tests/values-e2e.yaml
@@ -1,0 +1,68 @@
+# Zero-downtime rollout e2e values. Uses stub images so the test validates the
+# CHART TOPOLOGY (web↔api split, Service selectors, init-container ordering,
+# maxUnavailable=0 rollout) without the real studio image or a database.
+#
+#   api tier  -> hashicorp/http-echo: 200s every path (incl. /health/live)
+#   web tier  -> stock nginx-unprivileged + the chart's rendered proxy config,
+#                so /healthz is served locally and /api/* is proxied to the api
+#                Service exactly as in prod.
+nameOverride: studio
+
+replicaCount: 2
+autoscaling:
+  enabled: false
+
+image:
+  repository: hashicorp/http-echo
+  tag: "1.0"
+  pullPolicy: IfNotPresent
+  command: ["/http-echo", "-listen=:3000", "-text=ok"]
+
+# http-echo answers 200 on every path, so the real probe paths just work.
+startupProbe:
+  httpGet: { path: /health/live, port: http }
+  failureThreshold: 30
+  periodSeconds: 2
+livenessProbe:
+  httpGet: { path: /health/live, port: http }
+readinessProbe:
+  httpGet: { path: /health/ready, port: http }
+
+nginx:
+  replicaCount: 2
+  image:
+    repository: nginxinc/nginx-unprivileged
+    tag: "1.27-alpine"
+    pullPolicy: IfNotPresent
+  pdb:
+    enabled: true
+    maxUnavailable: 1
+
+worker:
+  # Required by chart validation (API-only main deployment). Runs the stub too;
+  # irrelevant to the front-door zero-downtime assertion.
+  enabled: true
+  replicaCount: 1
+  autoscaling:
+    enabled: false
+nats:
+  enabled: false
+persistence:
+  enabled: false
+s3Sync:
+  enabled: false
+metrics:
+  scrape: false
+database:
+  # http-echo ignores this; the dummy URL only satisfies the chart validation
+  # that replicaCount>1 needs postgresql (or distributed storage).
+  engine: postgresql
+  url: "postgres://stub:stub@stub:5432/stub"
+
+# The chart default topologySpread selector hardcodes the chart name; drop it in
+# the single-node test cluster so pods aren't held Pending.
+topologySpreadConstraints: []
+# NOTE: the chart pins nodeSelector.kubernetes.io/arch=amd64. Helm deep-merges
+# maps, so it can't be cleared from a values file ({} merges to the default) —
+# the test script clears it with `--set nodeSelector=null` so pods schedule on
+# any-arch nodes (arm64 kind on Apple Silicon, amd64 in CI).

--- a/deploy/helm/studio/tests/values-e2e.yaml
+++ b/deploy/helm/studio/tests/values-e2e.yaml
@@ -18,6 +18,13 @@ image:
   pullPolicy: IfNotPresent
   command: ["/http-echo", "-listen=:3000", "-text=ok"]
 
+# Tiny requests so everything (incl. the maxSurge=1 rollout pod) fits a 2-core
+# CI kind node. The chart default (750m/api) × 3 surged api pods + web + worker
+# overflows a single GitHub runner and stalls the rollout.
+resources:
+  requests: { cpu: "20m", memory: "32Mi" }
+  limits: { memory: "64Mi" }
+
 # http-echo answers 200 on every path, so the real probe paths just work.
 startupProbe:
   httpGet: { path: /health/live, port: http }
@@ -34,6 +41,9 @@ nginx:
     repository: nginxinc/nginx-unprivileged
     tag: "1.27-alpine"
     pullPolicy: IfNotPresent
+  resources:
+    requests: { cpu: "20m", memory: "32Mi" }
+    limits: { memory: "64Mi" }
   pdb:
     enabled: true
     maxUnavailable: 1
@@ -45,6 +55,9 @@ worker:
   replicaCount: 1
   autoscaling:
     enabled: false
+  resources:
+    requests: { cpu: "20m", memory: "32Mi" }
+    limits: { memory: "64Mi" }
 nats:
   enabled: false
 persistence:

--- a/deploy/helm/studio/tests/zero-downtime-rollout.sh
+++ b/deploy/helm/studio/tests/zero-downtime-rollout.sh
@@ -53,13 +53,24 @@ echo "── start in-cluster load generator (hits front door through nginx→ap
 # Two probes per iteration: /healthz (nginx-local) and /api/health (proxied to
 # the api tier). Any non-200 or curl error increments FAIL. Writes a running
 # tally to its log so we can read it after the rollout.
+#
+# --retry 5 --retry-all-errors: the zero-downtime property is that the *service*
+# never goes unreachable, not that no single TCP packet is ever dropped. Both
+# tiers roll with maxUnavailable=0, so a ready endpoint always exists; a browser
+# (and curl) simply reconnects and kube-proxy routes to it. Retrying models that
+# and absorbs an isolated CI hiccup (kube-proxy endpoint-sync lag, a >max-time
+# response under 2-core CPU starvation). A REAL regression — e.g. the earlier
+# nginx quit-first bug — makes the front door refuse for a sustained window, so
+# every retry also fails and the request still counts as bad. --retry-delay 0
+# keeps retries inside any genuine outage window rather than waiting it out.
 kubectl -n "$NS" run loadgen --image=curlimages/curl:8.10.1 --restart=Never -- \
   /bin/sh -c '
     ok=0; bad=0; base="http://'"$RELEASE"'.'"$NS"'.svc.cluster.local";
     end=$(( $(date +%s) + 120 ));
     while [ "$(date +%s)" -lt "$end" ]; do
       for path in /healthz /api/health; do
-        code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "$base$path" || echo 000);
+        code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 \
+          --retry 5 --retry-delay 0 --retry-all-errors "$base$path" || echo 000);
         if [ "$code" = "200" ]; then ok=$((ok+1)); else bad=$((bad+1)); echo "MISS $path -> $code"; fi
       done
       sleep 0.1;

--- a/deploy/helm/studio/tests/zero-downtime-rollout.sh
+++ b/deploy/helm/studio/tests/zero-downtime-rollout.sh
@@ -54,24 +54,33 @@ echo "── start in-cluster load generator (hits front door through nginx→ap
 # the api tier). Any non-200 or curl error increments FAIL. Writes a running
 # tally to its log so we can read it after the rollout.
 #
-# --retry 5 --retry-all-errors: the zero-downtime property is that the *service*
-# never goes unreachable, not that no single TCP packet is ever dropped. Both
-# tiers roll with maxUnavailable=0, so a ready endpoint always exists; a browser
-# (and curl) simply reconnects and kube-proxy routes to it. Retrying models that
-# and absorbs an isolated CI hiccup (kube-proxy endpoint-sync lag, a >max-time
-# response under 2-core CPU starvation). A REAL regression — e.g. the earlier
-# nginx quit-first bug — makes the front door refuse for a sustained window, so
-# every retry also fails and the request still counts as bad. --retry-delay 0
-# keeps retries inside any genuine outage window rather than waiting it out.
+# The property under test is that the *service* stays available through a roll,
+# not that every single request is fast. Explicit per-attempt retry (curl's own
+# --retry + --max-time interact ambiguously, so we loop ourselves):
+#   - per-attempt --max-time 8 is deliberately ABOVE nginx's proxy_connect_timeout
+#     (5s): when an api pod is replaced, nginx may hold a keepalive conn to it and
+#     spend up to 5s failing that over to a live pod (proxy_next_upstream). That is
+#     a slow success, NOT downtime — the request must be allowed to complete, or a
+#     3s client guillotine reports a false 000. (The stub api dies instantly on
+#     SIGTERM with no graceful drain, which forces this path; the real Bun api
+#     drains via SHUTDOWN_GRACE_SECONDS so nginx sees a clean close and never
+#     stalls — the stub is stricter than prod here.)
+#   - up to 4 attempts, 1s apart, cover a fast connect-refused during endpoint
+#     churn. A genuine outage (e.g. the earlier nginx quit-first bug) refuses for a
+#     sustained window, so every attempt fails and the request still counts bad.
 kubectl -n "$NS" run loadgen --image=curlimages/curl:8.10.1 --restart=Never -- \
   /bin/sh -c '
     ok=0; bad=0; base="http://'"$RELEASE"'.'"$NS"'.svc.cluster.local";
     end=$(( $(date +%s) + 120 ));
     while [ "$(date +%s)" -lt "$end" ]; do
       for path in /healthz /api/health; do
-        code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 \
-          --retry 5 --retry-delay 0 --retry-all-errors "$base$path" || echo 000);
-        if [ "$code" = "200" ]; then ok=$((ok+1)); else bad=$((bad+1)); echo "MISS $path -> $code"; fi
+        code=000;
+        for attempt in 1 2 3 4; do
+          code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 4 --max-time 8 "$base$path" 2>/dev/null || echo 000);
+          [ "$code" = "200" ] && break;
+          sleep 1;
+        done;
+        if [ "$code" = "200" ]; then ok=$((ok+1)); else bad=$((bad+1)); echo "MISS $path -> $code (after retries)"; fi
       done
       sleep 0.1;
     done

--- a/deploy/helm/studio/tests/zero-downtime-rollout.sh
+++ b/deploy/helm/studio/tests/zero-downtime-rollout.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Zero-downtime rollout test for the studio chart's web↔api split.
+#
+# Proves that a rolling update of BOTH tiers serves every request without a
+# single failure: an in-cluster client hammers the front-door Service (through
+# nginx → api Service) while both Deployments are rolled. Any non-2xx or
+# connection error fails the test.
+#
+# Runs against any reachable cluster (CI kind or a dev kind). Self-contained:
+# creates a namespace, installs the chart with stub images, asserts, cleans up.
+#
+# Usage: zero-downtime-rollout.sh [--keep]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(dirname "$SCRIPT_DIR")"
+NS="${NS:-studio-zdt-test}"
+RELEASE="${RELEASE:-zdt}"
+KEEP="${1:-}"
+
+cleanup() {
+  if [ "$KEEP" != "--keep" ]; then
+    echo "── cleanup ──"
+    helm uninstall "$RELEASE" -n "$NS" >/dev/null 2>&1 || true
+    kubectl delete ns "$NS" --wait=false >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+fail() { echo "❌ $*" >&2; exit 1; }
+
+echo "── install chart (stub images) into ns/$NS ──"
+kubectl create ns "$NS" >/dev/null 2>&1 || true
+# --set nodeSelector=null: the chart pins amd64, which a values file can't clear
+# (Helm merges maps). null deletes it so pods schedule on any-arch test nodes.
+helm upgrade --install "$RELEASE" "$CHART_DIR" \
+  -n "$NS" -f "$CHART_DIR/tests/values-e2e.yaml" \
+  --set nodeSelector=null \
+  --wait --timeout 5m
+
+echo "── wait for both tiers Ready ──"
+kubectl -n "$NS" rollout status deploy/"$RELEASE" --timeout 3m
+kubectl -n "$NS" rollout status deploy/"$RELEASE"-web --timeout 3m
+
+# Sanity: front-door Service must select ONLY web pods, api Service only api pods.
+web_eps=$(kubectl -n "$NS" get endpoints "$RELEASE" -o jsonpath='{.subsets[*].addresses[*].ip}' | wc -w | tr -d ' ')
+api_eps=$(kubectl -n "$NS" get endpoints "$RELEASE"-api -o jsonpath='{.subsets[*].addresses[*].ip}' | wc -w | tr -d ' ')
+echo "front-door endpoints=$web_eps  api endpoints=$api_eps"
+[ "$web_eps" -ge 1 ] || fail "front-door Service has no endpoints"
+[ "$api_eps" -ge 1 ] || fail "api Service has no endpoints"
+
+echo "── start in-cluster load generator (hits front door through nginx→api) ──"
+# Two probes per iteration: /healthz (nginx-local) and /api/health (proxied to
+# the api tier). Any non-200 or curl error increments FAIL. Writes a running
+# tally to its log so we can read it after the rollout.
+kubectl -n "$NS" run loadgen --image=curlimages/curl:8.10.1 --restart=Never -- \
+  /bin/sh -c '
+    ok=0; bad=0; base="http://'"$RELEASE"'.'"$NS"'.svc.cluster.local";
+    end=$(( $(date +%s) + 120 ));
+    while [ "$(date +%s)" -lt "$end" ]; do
+      for path in /healthz /api/health; do
+        code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "$base$path" || echo 000);
+        if [ "$code" = "200" ]; then ok=$((ok+1)); else bad=$((bad+1)); echo "MISS $path -> $code"; fi
+      done
+      sleep 0.1;
+    done
+    echo "RESULT ok=$ok bad=$bad"
+  '
+# Give the loop a moment to start hitting the old ("blue") pods.
+kubectl -n "$NS" wait --for=condition=Ready pod/loadgen --timeout 60s
+sleep 5
+
+echo "── roll BOTH tiers (blue → green) while traffic flows ──"
+kubectl -n "$NS" set env deploy/"$RELEASE"     ZDT_ROLL="$(date +%s)"
+kubectl -n "$NS" set env deploy/"$RELEASE"-web ZDT_ROLL="$(date +%s)"
+kubectl -n "$NS" rollout status deploy/"$RELEASE"     --timeout 3m
+kubectl -n "$NS" rollout status deploy/"$RELEASE"-web --timeout 3m
+echo "rollout complete; letting load finish…"
+
+kubectl -n "$NS" wait --for=jsonpath='{.status.phase}'=Succeeded pod/loadgen --timeout 120s || true
+LOG=$(kubectl -n "$NS" logs loadgen)
+echo "$LOG" | grep -E "MISS|RESULT" || true
+RESULT=$(echo "$LOG" | grep RESULT || echo "RESULT ok=0 bad=-1")
+# grep -oE (not sed \?) so parsing is portable across GNU (CI) and BSD (macOS) —
+# BSD sed doesn't support \? and silently returns empty, faking a failure.
+OK=$(echo "$RESULT"  | grep -oE 'ok=[0-9]+'    | cut -d= -f2)
+BAD=$(echo "$RESULT" | grep -oE 'bad=-?[0-9]+' | cut -d= -f2)
+
+echo "── verdict ──"
+echo "requests ok=$OK bad=$BAD"
+[ "${OK:-0}" -gt 0 ] || fail "load generator made no successful requests (broken setup)"
+[ "${BAD:-1}" -eq 0 ] || fail "ZERO-DOWNTIME VIOLATED: $BAD failed request(s) during rollout"
+echo "✅ 0 failed requests across a full blue→green rollout of both tiers"

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -87,17 +87,41 @@ worker:
   # Extra env for worker pods only (merged after the shared envFrom).
   env: []
 
+# nginx runs as its own front-door Deployment (nginx-deployment.yaml): serves the
+# baked SPA and reverse-proxies to the API Service. The API tier is a separate
+# Deployment (deployment.yaml) with one Bun process per pod.
 nginx:
+  # Front-door replicas. nginx is stateless and cheap; a small fixed count is
+  # plenty. Enable autoscaling below if SPA/static traffic ever needs it.
+  replicaCount: 2
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 80
+  # Grace period for the web pods (nginx drains fast; no long-lived work).
+  terminationGracePeriodSeconds: 30
+  # PodDisruptionBudget for the web tier — keeps a front-door pod serving through
+  # node drains. Rollouts are already covered by maxUnavailable=0.
+  pdb:
+    enabled: true
+    maxUnavailable: 1
+    # minAvailable: 1  # set instead of maxUnavailable if preferred
+  # The initContainer polls this API path until it answers before nginx starts,
+  # so a rolling web pod never takes traffic before the API is reachable.
+  apiWaitPath: /health/live
+  apiWaitMaxTries: 60
   image:
     repository: ghcr.io/decocms/studio/studio-nginx
     tag: ""
     pullPolicy: IfNotPresent
+  # nginx is a thin proxy/static server — small requests, real headroom in limit.
   resources:
     requests:
-      cpu: "500m"
-      memory: "128Mi"
+      cpu: "50m"
+      memory: "64Mi"
     limits:
-      memory: "256Mi"
+      memory: "128Mi"
   securityContext:
     runAsNonRoot: true
     allowPrivilegeEscalation: false
@@ -106,11 +130,11 @@ nginx:
         - ALL
     readOnlyRootFilesystem: false
   preStopSleepSeconds: 15
-  # Labels stamped onto the combo (nginx + API) pods so a front-door
-  # LoadBalancer (e.g. the deco-apps-cd NLB) can select them by a stable label
-  # instead of app.kubernetes.io/name. Applied to the combo deployment ONLY
-  # (never the worker), so the raw-API worker is never registered as a public
-  # target. Empty by default; set e.g. { decocms.com/frontdoor: "true" }.
+  # Labels stamped onto the web (front-door) pods so a LoadBalancer (e.g. the
+  # deco-apps-cd NLB) can select them by a stable label instead of
+  # app.kubernetes.io/name. Applied to the web Deployment ONLY (never the API or
+  # worker), so only the front door is registered as a public target. Empty by
+  # default; set e.g. { decocms.com/frontdoor: "true" }.
   frontDoorLabels: {}
 
 configMap:
@@ -206,7 +230,14 @@ readinessProbe:
 
 terminationGracePeriodSeconds: 120
 
-# Optional lifecycle hooks (preStop, postStart)
+# API pod preStop drain: seconds to keep serving after the pod is marked for
+# deletion, so kube-proxy removes it from the API Service endpoints before the
+# process shuts down (no connection lands on a draining pod). Ignored when
+# `lifecycle` below is set (that takes over the hook entirely).
+preStopSleepSeconds: 5
+
+# Optional lifecycle hooks (preStop, postStart). When set, replaces the default
+# preStop drain above.
 # lifecycle: {}
 
 nodeSelector:


### PR DESCRIPTION
## Why
The studio combo pod ran **two Bun api processes + nginx** behind localhost (`api-0`:3000, `api-1`:3001). That couples the tiers: HPA scales two processes at a time, each pod needs ~2.5Gi contiguous (worse bin-packing), and one eviction takes down two api procs. Splitting them lets the API scale by pod count and packs tighter.

Studio is OSS, so nginx stays (serves the baked SPA) — it just moves to **its own pod**.

## What
- **api Deployment** — keeps the existing name/selector (`app.kubernetes.io/name=<name>`), so it's an in-place pod-spec update (no immutable-selector break) and the mesh PDB / NLB-by-name keep matching. One Bun process per pod on `:3000`.
- **web Deployment** (`<release>-web`) — nginx serving the SPA + reverse-proxying `/api`, `/mcp`, `/health`, preview subdomains → the new `<release>-api` Service. Carries `nginx.frontDoorLabels`, so the public LB follows the front door automatically.
- **`<release>-api` Service** (ClusterIP) — nginx upstream; kube-proxy load-balances across api pods.
- **nginx config** rendered into a ConfigMap (`<release>-nginx`) so the upstream targets the api Service instead of in-pod localhost.
- Front-door Service selector → web pods; metrics scraped on the api pods directly (:3000); nginx CPU right-sized (500m→50m).
- **web PDB** for node-drain safety.
- Chart `0.12.1 → 0.13.0`.

## Zero downtime — verified, not asserted
`deploy/helm/studio/tests/zero-downtime-rollout.sh` installs the chart with stub images, hammers the front door (through nginx→api) from an in-cluster client, rolls **both** tiers blue→green, and fails on a single non-2xx/connection error. Runs in CI on kind (new `studio-zero-downtime` job in `helm-test.yml`).

Verified on a kind cluster: **`ok=2074 bad=0`** across a full both-tier rollout.

The test caught a real bug mid-development: the naive `nginx -s quit` (close listener) *before* the drain sleep caused connection-refused, because the pod was still in kube-proxy endpoints. Fixed to **sleep-first on both tiers** (drain endpoints while still serving) + `wait-for-api` initContainer so the API always rolls before the web tier takes traffic. The stub api dies instantly on SIGTERM (no graceful drain), so this is *stricter* than prod (real api has `SHUTDOWN_GRACE_SECONDS` + a 120s grace).

## Rollout path (not auto-merged to prod)
1. Merge → chart publishes (OCI).
2. Bump the `chart-deco-studio` dependency in `deco-apps-cd` (stg first).
3. **Soak on staging**, then prod. Prod needs no wrapper changes: `BASE_URL`/`BETTER_AUTH_URL` are already the public URL (not the in-pod nginx), the mesh PDB selects `app.kubernetes.io/name=studio` (api), and the NLB selects `decocms.com/frontdoor` (now on web pods).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the Studio chart into separate web (nginx) and API Deployments for independent scaling, tighter bin-packing, and safer rollouts. Added an internal `-api` Service, an optional web HPA, and a CI zero‑downtime rollout test with tuned retry/timeout probes that cover slow upstream failover while still catching real outages.

- **Refactors**
  - API keeps its existing name/selector; one Bun process per pod on `configMap.meshConfig.PORT` (default 3000) with metrics scraped directly.
  - New `-web` Deployment (nginx) serves the SPA and proxies to the new `<release>-api` ClusterIP Service; carries `nginx.frontDoorLabels`.
  - Front-door Service now selects web pods; nginx config is rendered via a `<release>-nginx` ConfigMap derived from `files/api-nginx.conf` (single source of truth); web PDB added; optional HPA when `nginx.autoscaling.enabled`.
  - PreStop sleeps added on both tiers; web uses `maxUnavailable=0`. `wait-for-api` holds start until the API responds on fresh installs; upgrades roll both tiers concurrently and stay up via `maxUnavailable=0`.
  - Added `tests/zero-downtime-rollout.sh` and a kind CI job; probe now retries with per‑attempt `--max-time 8s` to handle nginx failover from the stub API’s instant exit, and still fails on sustained outages; `tests/values-e2e.yaml` uses tiny stub resources so maxSurge fits the 2‑core node; chart version bumped to 0.13.0.

- **Migration**
  - Upgrade to chart 0.13.0.
  - Ensure your public LB targets web pods via `nginx.frontDoorLabels`. The first upgrade from ≤0.12.x cuts over the front door to `<release>-web`; validate on staging and watch LB targets stay ≥ 1 (steady-state rolls are covered by the ZDT test, this cutover is not).
  - No changes needed for mesh selectors or PDBs matching `app.kubernetes.io/name=studio` (these remain on API).

<sup>Written for commit 29169ecaf52279105967ffdc58781f8050272d0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

