### PR TITLE
refactor(auth): rename mesh token symbols to studio with back-compat

### DIFF
--- a/apps/mesh/src/auth/jwt.test.ts
+++ b/apps/mesh/src/auth/jwt.test.ts
@@ -12,23 +12,26 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "bun:test";
 import { decodeJwt } from "jose";
 import {
-  issueMeshToken,
-  verifyMeshToken,
-  type MeshJwtPayload,
-  type MeshTokenPayload,
+  getStudioTokenFromHeaders,
+  issueStudioToken,
+  LEGACY_STUDIO_TOKEN_HEADER,
+  STUDIO_TOKEN_HEADER,
+  verifyStudioToken,
+  type StudioJwtPayload,
+  type StudioTokenPayload,
 } from "./jwt";
 
-const decodeMeshToken = (token: string): MeshJwtPayload =>
-  decodeJwt<MeshTokenPayload>(token);
+const decodeStudioToken = (token: string): StudioJwtPayload =>
+  decodeJwt<StudioTokenPayload>(token);
 
 // ============================================================================
 // JWT Utility Tests
 // ============================================================================
 
 describe("JWT Utility Functions", () => {
-  describe("issueMeshToken", () => {
+  describe("issueStudioToken", () => {
     it("should issue a valid JWT token with all payload fields", async () => {
-      const payload: MeshTokenPayload = {
+      const payload: StudioTokenPayload = {
         sub: "user_123",
         permissions: {
           conn_456: ["SEND_MESSAGE", "LIST_THREADS"],
@@ -43,7 +46,7 @@ describe("JWT Utility Functions", () => {
         },
       };
 
-      const token = await issueMeshToken(payload);
+      const token = await issueStudioToken(payload);
 
       expect(token).toBeDefined();
       expect(typeof token).toBe("string");
@@ -51,7 +54,7 @@ describe("JWT Utility Functions", () => {
     });
 
     it("should issue token with default 5 minute expiration", async () => {
-      const payload: MeshTokenPayload = {
+      const payload: StudioTokenPayload = {
         sub: "user_123",
         permissions: {},
         metadata: {
@@ -60,8 +63,8 @@ describe("JWT Utility Functions", () => {
         },
       };
 
-      const token = await issueMeshToken(payload);
-      const decoded = decodeMeshToken(token);
+      const token = await issueStudioToken(payload);
+      const decoded = decodeStudioToken(token);
 
       expect(decoded.exp).toBeDefined();
       expect(decoded.iat).toBeDefined();
@@ -73,7 +76,7 @@ describe("JWT Utility Functions", () => {
     });
 
     it("should issue token with custom expiration", async () => {
-      const payload: MeshTokenPayload = {
+      const payload: StudioTokenPayload = {
         sub: "user_123",
         permissions: {},
         metadata: {
@@ -82,8 +85,8 @@ describe("JWT Utility Functions", () => {
         },
       };
 
-      const token = await issueMeshToken(payload, "1h");
-      const decoded = decodeMeshToken(token);
+      const token = await issueStudioToken(payload, "1h");
+      const decoded = decodeStudioToken(token);
 
       // Expiration should be ~1 hour from now
       const oneHourInSeconds = 60 * 60;
@@ -92,7 +95,7 @@ describe("JWT Utility Functions", () => {
     });
 
     it("should include all custom payload fields in token", async () => {
-      const payload: MeshTokenPayload = {
+      const payload: StudioTokenPayload = {
         sub: "user_test_123",
         permissions: {
           conn_abc: ["TOOL_A", "TOOL_B"],
@@ -107,8 +110,8 @@ describe("JWT Utility Functions", () => {
         },
       };
 
-      const token = await issueMeshToken(payload);
-      const decoded = decodeMeshToken(token);
+      const token = await issueStudioToken(payload);
+      const decoded = decodeStudioToken(token);
 
       expect(decoded.sub).toBe("user_test_123");
       expect(decoded.permissions).toEqual({
@@ -123,9 +126,9 @@ describe("JWT Utility Functions", () => {
     });
   });
 
-  describe("verifyMeshToken", () => {
+  describe("verifyStudioToken", () => {
     it("should verify and return payload for valid token", async () => {
-      const payload: MeshTokenPayload = {
+      const payload: StudioTokenPayload = {
         sub: "user_123",
         permissions: { conn_456: ["*"] },
         metadata: {
@@ -134,8 +137,8 @@ describe("JWT Utility Functions", () => {
         },
       };
 
-      const token = await issueMeshToken(payload);
-      const verified = await verifyMeshToken(token);
+      const token = await issueStudioToken(payload);
+      const verified = await verifyStudioToken(token);
 
       expect(verified).toBeDefined();
       expect(verified?.sub).toBe("user_123");
@@ -146,13 +149,13 @@ describe("JWT Utility Functions", () => {
 
     it("should return undefined for invalid token", async () => {
       const invalidToken = "invalid.token.here";
-      const verified = await verifyMeshToken(invalidToken);
+      const verified = await verifyStudioToken(invalidToken);
 
       expect(verified).toBeUndefined();
     });
 
     it("should return undefined for tampered token", async () => {
-      const payload: MeshTokenPayload = {
+      const payload: StudioTokenPayload = {
         sub: "user_123",
         permissions: {},
         metadata: {
@@ -161,14 +164,14 @@ describe("JWT Utility Functions", () => {
         },
       };
 
-      const token = await issueMeshToken(payload);
+      const token = await issueStudioToken(payload);
 
       // Tamper with the payload part (second segment)
       const parts = token.split(".");
       parts[1] = "tampered_payload_data";
       const tamperedToken = parts.join(".");
 
-      const verified = await verifyMeshToken(tamperedToken);
+      const verified = await verifyStudioToken(tamperedToken);
       expect(verified).toBeUndefined();
     });
 
@@ -178,7 +181,7 @@ describe("JWT Utility Functions", () => {
       const fakeToken =
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyIsInBlcm1pc3Npb25zIjp7fSwibWV0YWRhdGEiOnsibWVzaFVybCI6Imh0dHBzOi8vbWVzaC5leGFtcGxlLmNvbSIsImNvbm5lY3Rpb25JZCI6ImNvbm5fNDU2In19.fake_signature";
 
-      const verified = await verifyMeshToken(fakeToken);
+      const verified = await verifyStudioToken(fakeToken);
       expect(verified).toBeUndefined();
     });
   });
@@ -190,7 +193,7 @@ describe("JWT Utility Functions", () => {
 
 describe("Token Payload Structure", () => {
   it("should support empty permissions object", async () => {
-    const payload: MeshTokenPayload = {
+    const payload: StudioTokenPayload = {
       sub: "user_123",
       permissions: {},
       metadata: {
@@ -199,14 +202,14 @@ describe("Token Payload Structure", () => {
       },
     };
 
-    const token = await issueMeshToken(payload);
-    const decoded = decodeMeshToken(token);
+    const token = await issueStudioToken(payload);
+    const decoded = decodeStudioToken(token);
 
     expect(decoded.permissions).toEqual({});
   });
 
   it("should support multiple connections in permissions", async () => {
-    const payload: MeshTokenPayload = {
+    const payload: StudioTokenPayload = {
       sub: "user_123",
       permissions: {
         conn_1: ["TOOL_A"],
@@ -219,8 +222,8 @@ describe("Token Payload Structure", () => {
       },
     };
 
-    const token = await issueMeshToken(payload);
-    const decoded = decodeMeshToken(token);
+    const token = await issueStudioToken(payload);
+    const decoded = decodeStudioToken(token);
 
     expect(Object.keys(decoded.permissions as object).length).toBe(3);
     expect((decoded.permissions as Record<string, string[]>)["conn_1"]).toEqual(
@@ -235,7 +238,7 @@ describe("Token Payload Structure", () => {
   });
 
   it("should support undefined state in metadata", async () => {
-    const payload: MeshTokenPayload = {
+    const payload: StudioTokenPayload = {
       sub: "user_123",
       permissions: {},
       metadata: {
@@ -245,14 +248,14 @@ describe("Token Payload Structure", () => {
       },
     };
 
-    const token = await issueMeshToken(payload);
-    const decoded = decodeMeshToken(token);
+    const token = await issueStudioToken(payload);
+    const decoded = decodeStudioToken(token);
 
     expect(decoded.metadata?.state).toBeUndefined();
   });
 
   it("should support complex state objects in metadata", async () => {
-    const payload: MeshTokenPayload = {
+    const payload: StudioTokenPayload = {
       sub: "user_123",
       permissions: {},
       metadata: {
@@ -274,8 +277,8 @@ describe("Token Payload Structure", () => {
       },
     };
 
-    const token = await issueMeshToken(payload);
-    const decoded = decodeMeshToken(token);
+    const token = await issueStudioToken(payload);
+    const decoded = decodeStudioToken(token);
 
     expect(decoded.metadata?.state).toEqual(payload.metadata?.state);
   });
@@ -297,7 +300,7 @@ describe("Token Expiration", () => {
   it("should reject expired token on verification", async () => {
     vi.useRealTimers(); // Need real timers for token issuance
 
-    const payload: MeshTokenPayload = {
+    const payload: StudioTokenPayload = {
       sub: "user_123",
       permissions: {},
       metadata: {
@@ -307,24 +310,24 @@ describe("Token Expiration", () => {
     };
 
     // Issue token with very short expiration
-    const token = await issueMeshToken(payload, "2s");
+    const token = await issueStudioToken(payload, "2s");
 
     // Token should be valid immediately
-    const validResult = await verifyMeshToken(token);
+    const validResult = await verifyStudioToken(token);
     expect(validResult).toBeDefined();
 
     // Wait for token to expire (3s gives ample buffer on loaded CI runners)
     await new Promise((resolve) => setTimeout(resolve, 3000));
 
     // Token should now be invalid
-    const expiredResult = await verifyMeshToken(token);
+    const expiredResult = await verifyStudioToken(token);
     expect(expiredResult).toBeUndefined();
   });
 
   it("should decode expired token (decode doesn't verify)", async () => {
     vi.useRealTimers();
 
-    const payload: MeshTokenPayload = {
+    const payload: StudioTokenPayload = {
       sub: "user_123",
       permissions: {},
       metadata: {
@@ -333,13 +336,13 @@ describe("Token Expiration", () => {
       },
     };
 
-    const token = await issueMeshToken(payload, "1s");
+    const token = await issueStudioToken(payload, "1s");
 
     // Wait for expiration
     await new Promise((resolve) => setTimeout(resolve, 1500));
 
     // Decode should still work (no verification)
-    const decoded = decodeMeshToken(token);
+    const decoded = decodeStudioToken(token);
     expect(decoded.sub).toBe("user_123");
   });
 });
@@ -350,7 +353,7 @@ describe("Token Expiration", () => {
 
 describe("Security", () => {
   it("should use HS256 algorithm", async () => {
-    const payload: MeshTokenPayload = {
+    const payload: StudioTokenPayload = {
       sub: "user_123",
       permissions: {},
       metadata: {
@@ -359,7 +362,7 @@ describe("Security", () => {
       },
     };
 
-    const token = await issueMeshToken(payload);
+    const token = await issueStudioToken(payload);
 
     // Decode header to check algorithm
     const headerPart = token.split(".")[0]!;
@@ -370,7 +373,7 @@ describe("Security", () => {
   });
 
   it("should include issued at (iat) claim", async () => {
-    const payload: MeshTokenPayload = {
+    const payload: StudioTokenPayload = {
       sub: "user_123",
       permissions: {},
       metadata: {
@@ -380,17 +383,17 @@ describe("Security", () => {
     };
 
     const beforeIssue = Math.floor(Date.now() / 1000);
-    const token = await issueMeshToken(payload);
+    const token = await issueStudioToken(payload);
     const afterIssue = Math.floor(Date.now() / 1000);
 
-    const decoded = decodeMeshToken(token);
+    const decoded = decodeStudioToken(token);
 
     expect(decoded.iat).toBeGreaterThanOrEqual(beforeIssue);
     expect(decoded.iat).toBeLessThanOrEqual(afterIssue);
   });
 
   it("should include expiration (exp) claim", async () => {
-    const payload: MeshTokenPayload = {
+    const payload: StudioTokenPayload = {
       sub: "user_123",
       permissions: {},
       metadata: {
@@ -399,15 +402,15 @@ describe("Security", () => {
       },
     };
 
-    const token = await issueMeshToken(payload);
-    const decoded = decodeMeshToken(token);
+    const token = await issueStudioToken(payload);
+    const decoded = decodeStudioToken(token);
 
     expect(decoded.exp).toBeDefined();
     expect(typeof decoded.exp).toBe("number");
   });
 
   it("should produce different tokens for same payload (due to iat)", async () => {
-    const payload: MeshTokenPayload = {
+    const payload: StudioTokenPayload = {
       sub: "user_123",
       permissions: {},
       metadata: {
@@ -416,17 +419,84 @@ describe("Security", () => {
       },
     };
 
-    const token1 = await issueMeshToken(payload);
+    const token1 = await issueStudioToken(payload);
 
     // Small delay to ensure different iat
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    const token2 = await issueMeshToken(payload);
+    const token2 = await issueStudioToken(payload);
 
     // Tokens should be different due to different iat
     // Note: They might be same if issued in same second
     // This is acceptable behavior
     expect(token1).toBeDefined();
     expect(token2).toBeDefined();
+  });
+});
+
+// ============================================================================
+// Back-compat (Mesh -> Studio rename) Tests
+// ============================================================================
+
+describe("Back-compat with pre-rename wire format", () => {
+  const payload: StudioTokenPayload = {
+    sub: "user_123",
+    permissions: {},
+    metadata: {
+      meshUrl: "https://mesh.example.com",
+      connectionId: "conn_456",
+    },
+  };
+
+  describe("getStudioTokenFromHeaders", () => {
+    it("reads the new x-studio-token header", () => {
+      const headers = new Headers({ [STUDIO_TOKEN_HEADER]: "new-token" });
+      expect(getStudioTokenFromHeaders(headers)).toBe("new-token");
+    });
+
+    it("still accepts the legacy x-mesh-token header", () => {
+      const headers = new Headers({
+        [LEGACY_STUDIO_TOKEN_HEADER]: "old-token",
+      });
+      expect(getStudioTokenFromHeaders(headers)).toBe("old-token");
+    });
+
+    it("prefers the new header when both are present", () => {
+      const headers = new Headers({
+        [STUDIO_TOKEN_HEADER]: "new-token",
+        [LEGACY_STUDIO_TOKEN_HEADER]: "old-token",
+      });
+      expect(getStudioTokenFromHeaders(headers)).toBe("new-token");
+    });
+
+    it("returns null when neither header is present", () => {
+      expect(getStudioTokenFromHeaders(new Headers())).toBeNull();
+    });
+  });
+
+  it("issues tokens without iss/aud, matching the pre-rename format", async () => {
+    // Pre-rename issueMeshToken never set iss/aud. Locking that here means
+    // tokens issued before the rename verify identically to new ones, and
+    // pre-rename verifiers accept tokens issued after it.
+    const token = await issueStudioToken(payload);
+    const decoded = decodeStudioToken(token);
+
+    expect(decoded.iss).toBeUndefined();
+    expect(decoded.aud).toBeUndefined();
+    expect(await verifyStudioToken(token)).toBeDefined();
+  });
+
+  it("keeps the legacy meshUrl claim key on the wire", async () => {
+    const token = await issueStudioToken(payload);
+
+    // The raw JWT payload must literally contain the old claim key —
+    // deployed downstream apps and already-issued tokens depend on it.
+    const rawPayload = JSON.parse(
+      Buffer.from(token.split(".")[1]!, "base64url").toString(),
+    );
+    expect(rawPayload.metadata.meshUrl).toBe("https://mesh.example.com");
+
+    const verified = await verifyStudioToken(token);
+    expect(verified?.metadata?.meshUrl).toBe("https://mesh.example.com");
   });
 });

--- a/apps/mesh/src/auth/jwt.ts
+++ b/apps/mesh/src/auth/jwt.ts
@@ -39,13 +39,37 @@ function getSecret(): Uint8Array {
   return jwtSecret;
 }
 
+/** Header carrying the Studio proxy token to/from downstream apps. */
+export const STUDIO_TOKEN_HEADER = "x-studio-token";
+/** @deprecated Legacy header name; accepted (and dual-sent) during the de-mesh deprecation window. */
+export const LEGACY_STUDIO_TOKEN_HEADER = "x-mesh-token";
+
+/**
+ * Read the Studio proxy token from request headers.
+ * Prefers `x-studio-token`; still accepts the legacy `x-mesh-token` (old
+ * clients keep working until they upgrade) with a deprecation log.
+ */
+export function getStudioTokenFromHeaders(headers: Headers): string | null {
+  const token = headers.get(STUDIO_TOKEN_HEADER);
+  if (token) return token;
+  const legacy = headers.get(LEGACY_STUDIO_TOKEN_HEADER);
+  if (legacy) {
+    console.log("deprecated header", { header: LEGACY_STUDIO_TOKEN_HEADER });
+  }
+  return legacy;
+}
+
 /**
  * Studio proxy token payload
+ *
+ * Wire-format note: claim keys (including `metadata.meshUrl`) are persisted in
+ * already-issued tokens and read by deployed downstream apps — only the local
+ * TypeScript symbols were renamed from Mesh* to Studio*.
  */
-export interface MeshTokenPayload {
+export interface StudioTokenPayload {
   /** User ID who initiated the request */
   sub: string;
-  /** User identity propagated to downstream apps via x-mesh-token */
+  /** User identity propagated to downstream apps via x-studio-token */
   user?: {
     id: string;
     email?: string;
@@ -56,7 +80,7 @@ export interface MeshTokenPayload {
   metadata?: {
     /** Configuration state */
     state?: Record<string, unknown>;
-    /** Studio instance URL */
+    /** Studio instance URL. Claim key stays `meshUrl` — persisted wire data. */
     meshUrl: string;
     /** Connection ID this token was issued for */
     connectionId: string;
@@ -71,17 +95,20 @@ export interface MeshTokenPayload {
   permissions: Record<string, string[]>;
 }
 
-export type MeshJwtPayload = JWTPayload & MeshTokenPayload;
+export type StudioJwtPayload = JWTPayload & StudioTokenPayload;
 
 /**
- * Issue a signed JWT with studio token payload
+ * Issue a signed JWT with Studio token payload
+ *
+ * Wire-format note: no `iss`/`aud` is set (and never was), so tokens issued
+ * before the Mesh→Studio rename keep verifying until they expire.
  *
  * @param payload - The token payload
  * @param expiresIn - Expiration time (default: 5 minutes)
  * @returns Signed JWT string
  */
-export async function issueMeshToken(
-  payload: MeshTokenPayload,
+export async function issueStudioToken(
+  payload: StudioTokenPayload,
   expiresIn: string = "5m",
 ): Promise<string> {
   const secret = getSecret();
@@ -94,18 +121,18 @@ export async function issueMeshToken(
 }
 
 /**
- * Verify and decode a studio token
+ * Verify and decode a Studio token
  *
  * @param token - JWT string to verify
  * @returns Decoded payload if valid, undefined if invalid
  */
-export async function verifyMeshToken(
+export async function verifyStudioToken(
   token: string,
-): Promise<MeshJwtPayload | undefined> {
+): Promise<StudioJwtPayload | undefined> {
   try {
     const secret = getSecret();
     const { payload } = await jwtVerify(token, secret);
-    return payload as MeshJwtPayload;
+    return payload as StudioJwtPayload;
   } catch {
     return undefined;
   }
@@ -116,7 +143,7 @@ export async function verifyMeshToken(
  *
  * Uses the same MESH_JWT_SECRET and payload shape that the AI Gateway's
  * verifyMeshJwt() expects: { iss: "mesh", sub: userId }.
- * This is intentionally simpler than issueMeshToken — downstream services
+ * This is intentionally simpler than issueStudioToken — downstream services
  * only need the user identity, not the full proxy-token metadata.
  *
  * @param userId - The authenticated user's ID
@@ -137,6 +164,8 @@ export async function mintGatewayJwt(
   }
   const secret = new TextEncoder().encode(gwSecret);
   return await new SignJWT({
+    // ponytail: `iss: "mesh"` is the AI Gateway's wire contract (its verifyMeshJwt
+    // requires it) — rename only once the gateway accepts "studio" too.
     iss: "mesh",
     sub: userId,
     ...(email && { email }),

--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -160,9 +160,9 @@ export async function seedOrgDb(organizationId: string, createdBy: string) {
       decoAiGatewayAdapter.provisionKey
     ) {
       try {
-        const meshJwt = await mintGatewayJwt(createdBy);
+        const studioJwt = await mintGatewayJwt(createdBy);
         const apiKey = await decoAiGatewayAdapter.provisionKey(
-          meshJwt,
+          studioJwt,
           organizationId,
         );
         const aiProviderKeyStorage = new AIProviderKeyStorage(

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -11,7 +11,7 @@
 
 import { SpanStatusCode, type Meter, type Tracer } from "@opentelemetry/api";
 import type { Kysely } from "kysely";
-import { verifyMeshToken } from "../auth/jwt";
+import { getStudioTokenFromHeaders, verifyStudioToken } from "../auth/jwt";
 import { CredentialVault } from "../encryption/credential-vault";
 import { getSettings } from "../settings";
 import { getBaseUrl } from "./server-constants";
@@ -595,11 +595,11 @@ async function resolveOnBehalfOfUser(
   apiKeyOrgId: string | undefined,
   memberRoleCache?: MemberRoleCache,
 ): Promise<AuthenticatedUser | undefined> {
-  const meshToken = req.headers.get("x-mesh-token");
-  if (!meshToken) return undefined;
+  const studioToken = getStudioTokenFromHeaders(req.headers);
+  if (!studioToken) return undefined;
 
   const payload = await timings.measure("auth_verify_onbehalf_mesh_jwt", () =>
-    verifyMeshToken(meshToken),
+    verifyStudioToken(studioToken),
   );
   if (!payload?.sub) return undefined;
 
@@ -758,7 +758,7 @@ async function authenticateRequest(
     // These are issued by studio for downstream services calling back
     try {
       const meshJwtPayload = await timings.measure("auth_verify_mesh_jwt", () =>
-        verifyMeshToken(token),
+        verifyStudioToken(token),
       );
 
       if (meshJwtPayload) {

--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -6,7 +6,11 @@
  */
 
 import { extractConnectionPermissions } from "@/auth/configuration-scopes";
-import { issueMeshToken } from "@/auth/jwt";
+import {
+  issueStudioToken,
+  LEGACY_STUDIO_TOKEN_HEADER,
+  STUDIO_TOKEN_HEADER,
+} from "@/auth/jwt";
 import type { StudioContext } from "@/core/studio-context";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { getValidDownstreamAccessToken } from "@/oauth/token-refresh";
@@ -108,7 +112,7 @@ async function _buildRequestHeaders(
   // creator. Better solution: create a dedicated "Decopilot" service user per organization
   // for automated actions, so they're properly distinguished from real user activity.
   const [configurationToken, error] = userId
-    ? await issueMeshToken({
+    ? await issueStudioToken({
         sub: userId,
         user: {
           id: userId,
@@ -200,7 +204,10 @@ async function _buildRequestHeaders(
 
   // Add configuration token if issued
   if (configurationToken) {
-    headers["x-mesh-token"] = configurationToken;
+    headers[STUDIO_TOKEN_HEADER] = configurationToken;
+    // ponytail: dual-send the legacy header while deployed downstream apps
+    // still read x-mesh-token; drop after the deprecation window.
+    headers[LEGACY_STUDIO_TOKEN_HEADER] = configurationToken;
   }
 
   return headers;

--- a/packages/runtime/src/bindings.ts
+++ b/packages/runtime/src/bindings.ts
@@ -246,6 +246,8 @@ export const proxyConnectionForId = (
 
   if (ctx.token) {
     headers ??= {};
+    headers["x-studio-token"] = ctx.token;
+    // Legacy header, dual-sent so older Studio deployments keep working.
     headers["x-mesh-token"] = ctx.token;
   }
 

--- a/packages/runtime/src/decopilot.ts
+++ b/packages/runtime/src/decopilot.ts
@@ -134,6 +134,8 @@ export async function streamAgent(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      "x-studio-token": token,
+      // Legacy header, dual-sent so older Studio deployments keep working.
       "x-mesh-token": token,
       Authorization: `Bearer ${token}`,
     },

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -410,7 +410,10 @@ export const withRuntime = <
         authToken: req.headers.get("authorization") ?? null,
         env: { ...process.env, ...env },
         server,
-        tokenOrContext: req.headers.get("x-mesh-token") ?? undefined,
+        tokenOrContext:
+          req.headers.get("x-studio-token") ??
+          req.headers.get("x-mesh-token") ??
+          undefined,
         url: req.url,
       });
 


### PR DESCRIPTION
## Summary

Part of the de-mesh migration (task 04-jwt-tokens). Renames the proxy-token symbols in `apps/mesh/src/auth/jwt.ts` — `MeshTokenPayload` → `StudioTokenPayload`, `MeshJwtPayload` → `StudioJwtPayload`, `issueMeshToken` → `issueStudioToken`, `verifyMeshToken` → `verifyStudioToken` — and updates all callers (`context-factory.ts`, `mcp-clients/outbound/headers.ts`, test-local `decodeMeshToken` → `decodeStudioToken`, local `meshJwt` var in `auth/org.ts`).

## Back-compat guarantees (wire contracts)

- **Header**: new `x-studio-token` is emitted everywhere; the legacy `x-mesh-token` is **still accepted** via `getStudioTokenFromHeaders()` (new header wins when both present) with a `deprecated header` log. All senders **dual-send** both headers during the deprecation window — mesh's outbound header builder plus `packages/runtime` (`decopilot.ts`, `bindings.ts`) — so old runtime ↔ new Studio and new runtime ↔ old Studio both keep working. `packages/runtime`'s inbound reader also falls back to the old header. No `x-mesh-token` senders exist in `packages/sandbox` (verified by repo-wide grep).
- **Issuer/audience**: proxy tokens never set `iss`/`aud` (before or after), so **tokens issued before this change verify unchanged until they expire**. A new test locks the no-`iss`/`aud` wire format.
- **Claim keys**: the `metadata.meshUrl` claim key is **left as-is** (simpler option — it's persisted in already-issued tokens and read by deployed downstream apps); only local TypeScript symbols were renamed. A new test asserts the raw JWT still carries `meshUrl`.

## Deliberately unchanged (and why)

- `mintGatewayJwt` keeps `iss: "mesh"` — that's the **external AI Gateway's** contract (`verifyMeshJwt` requires it); we can't dual-emit an issuer, so renaming needs a coordinated gateway change first (marked with a `ponytail:` comment).
- `settings.meshJwtSecret` / `MESH_JWT_SECRET` env var — deploy contract owned by the settings/env de-mesh task, referenced from outside `src/auth` (settings, file-storage).
- Comment-only `x-mesh-token` mentions, the `meshJwtPayload` local var, and log/timing labels (`auth_verify_mesh_jwt`) — left untouched to avoid overlapping open PRs #4617 (comments/logs) and #4619 (context renames).
- `x-mesh-run-metadata` header and `spec/001.md` — separate wire contract / historical spec, out of this task's scope.

## Breaking changes

None. Old headers, old tokens, and old claim keys all keep working; removal of the legacy header acceptance/dual-send is follow-up work after the deprecation window.

## Testing

- `bun test apps/mesh/src/auth` — 71 pass, 0 fail (includes new back-compat tests: legacy header accepted, new header preferred, no-iss/aud wire format locked, `meshUrl` claim key present on the wire)
- `bun test packages/runtime` — 66 pass, 0 fail
- `bun test` on touched core files — the single `context-factory.integration.test.ts` failure is a pre-existing local DB-connection failure (fails identically with changes stashed)
- `bun run check` — clean; `bun run lint` — 0 errors (30 pre-existing warnings in unrelated files); `bun run fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed Mesh proxy-token symbols and headers to Studio with full wire back-compat. Adds and prefers `x-studio-token`, while dual-sending `x-mesh-token` so mixed deployments keep working.

- **Refactors**
  - Renamed Mesh* → Studio* in `apps/mesh/src/auth/jwt.ts` and updated callers across `apps/mesh` and `packages/runtime`.
  - Added `STUDIO_TOKEN_HEADER`/`LEGACY_STUDIO_TOKEN_HEADER` and `getStudioTokenFromHeaders()` (logs when legacy header is used).
  - Outbound now sets both headers in `apps/mesh/src/mcp-clients/outbound/headers.ts` and `packages/runtime` (`decopilot.ts`, `bindings.ts`); inbound prefers the new header via `getStudioTokenFromHeaders()` in `apps/mesh/src/core/context-factory.ts` and in `packages/runtime/src/index.ts` with legacy fallback.
  - Kept `mintGatewayJwt` with `iss: "mesh"` to match the external AI Gateway contract.

- **Migration**
  - No breaking changes: tokens still omit `iss`/`aud`, and `metadata.meshUrl` remains unchanged.
  - Clients can start sending `x-studio-token` now; legacy header acceptance/dual-send will be removed after the deprecation window.

<sup>Written for commit 031583ed2ba097fb2a536bb1413d9294351b0bb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

