### PR TITLE
refactor: rename MESH_* env vars to STUDIO_* with fallback

### DIFF
--- a/apps/docs/client/src/components/architecture-model.ts
+++ b/apps/docs/client/src/components/architecture-model.ts
@@ -214,7 +214,7 @@ const NODES: Record<string, Node> = {
     tag: "role=worker · dbos",
     replicas: true,
     role: "Run executor",
-    desc: "MESH_DISPATCH_ROLE=worker. Dequeues the DBOS queues it listens on (THREAD_GATE serial-per-thread; AUTOMATIONS per-org) via listenQueues — set by env — and runs the agent loop: streamText, model → tool → repeat, ~200 steps. Calls MCP tools in-process and the sandbox daemon for fs/git/bash. CPU-bound. Scales horizontally; pools can be split per queue to run different DBOS workflows with their own resources.",
+    desc: "STUDIO_DISPATCH_ROLE=worker. Dequeues the DBOS queues it listens on (THREAD_GATE serial-per-thread; AUTOMATIONS per-org) via listenQueues — set by env — and runs the agent loop: streamText, model → tool → repeat, ~200 steps. Calls MCP tools in-process and the sandbox daemon for fs/git/bash. CPU-bound. Scales horizontally; pools can be split per queue to run different DBOS workflows with their own resources.",
     facts: [
       ["Drives", "the agent loop"],
       ["Queues", "DBOS listenQueues (env)"],

--- a/apps/docs/client/src/content/deco-studio/en/studio/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/architecture.mdx
@@ -56,11 +56,11 @@ These three deployments are separate and scale on their own. The web tier was sp
 | Tier | Deployment | Responsibility |
 | --- | --- | --- |
 | **Web** | nginx | Serves the React SPA and reverse-proxies `/api`, `/mcp`, `/oauth-proxy`, `/.well-known` to the API Service. Port 8080. |
-| **API** | Hono, `MESH_DISPATCH_ROLE=api` | HTTP routes, Better Auth, the MCP proxy, access control. **Enqueues** Decopilot runs onto DBOS queues and tails NATS to stream output back to the UI. Stateless. **Does not run the agent loop.** |
-| **Worker** | Hono, `MESH_DISPATCH_ROLE=worker` | **Dequeues** DBOS queues (via `listenQueues`) and **runs the agent loop** (`streamText`: model → tool → repeat). CPU-bound. These are the run executors; scale horizontally. |
+| **API** | Hono, `STUDIO_DISPATCH_ROLE=api` | HTTP routes, Better Auth, the MCP proxy, access control. **Enqueues** Decopilot runs onto DBOS queues and tails NATS to stream output back to the UI. Stateless. **Does not run the agent loop.** |
+| **Worker** | Hono, `STUDIO_DISPATCH_ROLE=worker` | **Dequeues** DBOS queues (via `listenQueues`) and **runs the agent loop** (`streamText`: model → tool → repeat). CPU-bound. These are the run executors; scale horizontally. |
 
 <Callout type="note">
-  The split is by role, not by image — both run the same build. `MESH_DISPATCH_ROLE` decides whether a pod listens on the DBOS queues (`worker`) or only serves HTTP and enqueues (`api`). A single-deployment setup can use `all`.
+  The split is by role, not by image — both run the same build. `STUDIO_DISPATCH_ROLE` decides whether a pod listens on the DBOS queues (`worker`) or only serves HTTP and enqueues (`api`). A single-deployment setup can use `all`.
 </Callout>
 
 The set of queues a worker pod listens on is configured by env (`listenQueues`). Because of that, worker pools can be split per DBOS queue — running different workflows on separate pools with their own resources and scaling.

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/architecture.mdx
@@ -56,11 +56,11 @@ Esses três deployments são separados e escalam por conta própria. A camada de
 | Camada | Deployment | Responsabilidade |
 | --- | --- | --- |
 | **Web** | nginx | Serve a SPA em React e faz reverse-proxy de `/api`, `/mcp`, `/oauth-proxy`, `/.well-known` para o Service da API. Porta 8080. |
-| **API** | Hono, `MESH_DISPATCH_ROLE=api` | Rotas HTTP, Better Auth, o MCP proxy, controle de acesso. **Enfileira** runs do Decopilot nas queues do DBOS e acompanha o NATS para fazer streaming do output de volta para a UI. Stateless. **Não roda o agent loop.** |
-| **Worker** | Hono, `MESH_DISPATCH_ROLE=worker` | **Desenfileira** as queues do DBOS (via `listenQueues`) e **roda o agent loop** (`streamText`: model → tool → repete). Limitado por CPU. São os executores de run; escalam horizontalmente. |
+| **API** | Hono, `STUDIO_DISPATCH_ROLE=api` | Rotas HTTP, Better Auth, o MCP proxy, controle de acesso. **Enfileira** runs do Decopilot nas queues do DBOS e acompanha o NATS para fazer streaming do output de volta para a UI. Stateless. **Não roda o agent loop.** |
+| **Worker** | Hono, `STUDIO_DISPATCH_ROLE=worker` | **Desenfileira** as queues do DBOS (via `listenQueues`) e **roda o agent loop** (`streamText`: model → tool → repete). Limitado por CPU. São os executores de run; escalam horizontalmente. |
 
 <Callout type="note">
-  A separação é por role, não por imagem — ambos rodam o mesmo build. `MESH_DISPATCH_ROLE` decide se um pod escuta as queues do DBOS (`worker`) ou apenas serve HTTP e enfileira (`api`). Um setup de deployment único pode usar `all`.
+  A separação é por role, não por imagem — ambos rodam o mesmo build. `STUDIO_DISPATCH_ROLE` decide se um pod escuta as queues do DBOS (`worker`) ou apenas serve HTTP e enfileira (`api`). Um setup de deployment único pode usar `all`.
 </Callout>
 
 O conjunto de queues que um pod worker escuta é configurado por env (`listenQueues`). Por isso, os pools de workers podem ser separados por queue do DBOS — rodando workflows diferentes em pools separados com seus próprios recursos e escalonamento.

--- a/apps/mesh/scripts/smoke-link.ts
+++ b/apps/mesh/scripts/smoke-link.ts
@@ -8,18 +8,22 @@
  * Run with: `bun run smoke:link` from `apps/mesh/`.
  *
  * Required env:
- *   MESH_TEST_SESSION  Bearer token for an authenticated session
+ *   STUDIO_TEST_SESSION  Bearer token for an authenticated session
  *
  * Optional env:
- *   MESH_BASE_URL      Cluster base URL (default http://localhost:4000)
+ *   STUDIO_BASE_URL      Cluster base URL (default http://localhost:4000)
  */
 
 async function main(): Promise<void> {
-  const baseUrl = process.env.MESH_BASE_URL ?? "http://localhost:4000";
-  const token = process.env.MESH_TEST_SESSION ?? "";
+  const baseUrl =
+    process.env.STUDIO_BASE_URL ??
+    process.env.MESH_BASE_URL ??
+    "http://localhost:4000";
+  const token =
+    process.env.STUDIO_TEST_SESSION ?? process.env.MESH_TEST_SESSION ?? "";
   if (!token) {
     console.error(
-      "smoke: MESH_TEST_SESSION is not set — pass a bearer token for an authenticated session.",
+      "smoke: STUDIO_TEST_SESSION is not set — pass a bearer token for an authenticated session.",
     );
     process.exit(2);
   }

--- a/apps/mesh/src/auth/dev-link-session.ts
+++ b/apps/mesh/src/auth/dev-link-session.ts
@@ -16,7 +16,7 @@
  *
  * Idempotent — exits early if the session file already exists.
  *
- * Only runs when `MESH_ALLOW_LOCALHOST_LINKS=1` is set, which we
+ * Only runs when `STUDIO_ALLOW_LOCALHOST_LINKS=1` is set, which we
  * default to in `bun run dev`. Production never sets that flag.
  */
 

--- a/apps/mesh/src/auth/jwt.ts
+++ b/apps/mesh/src/auth/jwt.ts
@@ -5,7 +5,8 @@
  * - Decoded directly by downstream services to read payload
  * - Verified by downstream services using the shared secret
  *
- * The secret is loaded from MESH_JWT_SECRET environment variable.
+ * The secret is loaded from the STUDIO_JWT_SECRET environment variable
+ * (legacy MESH_JWT_SECRET still honored).
  * If not set, a random secret is generated (not persistent across restarts).
  */
 
@@ -25,13 +26,13 @@ function getSecret(): Uint8Array {
   }
 
   const settings = getSettings();
-  const envSecret = settings.meshJwtSecret ?? settings.betterAuthSecret;
+  const envSecret = settings.studioJwtSecret ?? settings.betterAuthSecret;
   if (envSecret) {
     jwtSecret = new TextEncoder().encode(envSecret);
   } else {
     // Generate a random secret - note: not persistent across restarts
     console.warn(
-      "MESH_JWT_SECRET not set - generating random secret (not persistent)",
+      "STUDIO_JWT_SECRET not set - generating random secret (not persistent)",
     );
     jwtSecret = new Uint8Array(randomBytes(32));
   }
@@ -114,7 +115,7 @@ export async function verifyMeshToken(
 /**
  * Mint a gateway-compatible Mesh JWT for the given user.
  *
- * Uses the same MESH_JWT_SECRET and payload shape that the AI Gateway's
+ * Uses the same STUDIO_JWT_SECRET and payload shape that the AI Gateway's
  * verifyMeshJwt() expects: { iss: "mesh", sub: userId }.
  * This is intentionally simpler than issueMeshToken — downstream services
  * only need the user identity, not the full proxy-token metadata.
@@ -129,10 +130,10 @@ export async function mintGatewayJwt(
   expiresIn = 3600,
 ): Promise<string> {
   const settings = getSettings();
-  const gwSecret = settings.meshJwtSecret ?? settings.betterAuthSecret;
+  const gwSecret = settings.studioJwtSecret ?? settings.betterAuthSecret;
   if (!gwSecret) {
     throw new Error(
-      "A deterministic JWT secret is required to mint gateway JWTs — set MESH_JWT_SECRET or BETTER_AUTH_SECRET",
+      "A deterministic JWT secret is required to mint gateway JWTs — set STUDIO_JWT_SECRET or BETTER_AUTH_SECRET",
     );
   }
   const secret = new TextEncoder().encode(gwSecret);

--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -279,7 +279,7 @@ if (command === "link") {
   const { runLinkCommand } = await import("./cli/commands/link");
   // Optional positional: the studio to link against (auth target + cluster
   // websocket), e.g. https://studio-stg.decocms.com. When omitted, falls back
-  // to MESH_CLUSTER_URL / https://studio.decocms.com (resolved in runLinkCommand).
+  // to STUDIO_CLUSTER_URL / https://studio.decocms.com (resolved in runLinkCommand).
   const studioArg = positionals[1];
   let studioUrl: string | undefined;
   if (studioArg !== undefined) {

--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -14,6 +14,7 @@ import { closeSync, mkdirSync, openSync, writeSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { ensureSession } from "../lib/ensure-session";
+import { envWithFallback } from "../../settings/env-fallback";
 import { startLinkDaemon, type LinkDaemonMonitor } from "../../link-daemon";
 import { formatLogLine } from "../format-log-line";
 import { isPortInUse } from "../lib/port-wait";
@@ -126,7 +127,7 @@ export async function runLinkCommand(
     join(homedir(), "deco");
   const clusterBaseUrl =
     opts.clusterBaseUrl ??
-    process.env.MESH_CLUSTER_URL ??
+    envWithFallback(process.env, "STUDIO_CLUSTER_URL", "MESH_CLUSTER_URL") ??
     "https://studio.decocms.com";
 
   let restoreConsole: (() => void) | undefined;

--- a/apps/mesh/src/core/server-constants.ts
+++ b/apps/mesh/src/core/server-constants.ts
@@ -6,6 +6,7 @@
  */
 
 import { getSettings } from "../settings";
+import { envWithFallback } from "../settings/env-fallback";
 
 /**
  * Get the base URL for the server.
@@ -39,11 +40,15 @@ export function getInternalUrl(): string {
  * (remote harness dispatch), which talks back to the cluster over the
  * public network from the user's desktop.
  *
- * Uses `MESH_PUBLIC_URL` when set, otherwise falls back to `BASE_URL`
- * (the same hostname the server advertises to browsers and OAuth clients).
- * Falls back to `getBaseUrl()` so production deployments without a
- * separate public-URL setting still work.
+ * Uses `STUDIO_PUBLIC_URL` when set (legacy `MESH_PUBLIC_URL` still
+ * honored), otherwise falls back to `BASE_URL` (the same hostname the
+ * server advertises to browsers and OAuth clients). Falls back to
+ * `getBaseUrl()` so production deployments without a separate
+ * public-URL setting still work.
  */
 export function getPublicUrl(): string {
-  return process.env.MESH_PUBLIC_URL ?? getBaseUrl();
+  return (
+    envWithFallback(process.env, "STUDIO_PUBLIC_URL", "MESH_PUBLIC_URL") ??
+    getBaseUrl()
+  );
 }

--- a/apps/mesh/src/file-storage/share-password.ts
+++ b/apps/mesh/src/file-storage/share-password.ts
@@ -64,7 +64,7 @@ function getSigningKey(): Buffer {
   let secret: string | undefined;
   try {
     const settings = getSettings();
-    secret = settings.meshJwtSecret ?? settings.betterAuthSecret;
+    secret = settings.studioJwtSecret ?? settings.betterAuthSecret;
   } catch {
     // Settings not initialized (e.g. unit tests) — fall back like auth/jwt.ts.
     secret = undefined;

--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -53,7 +53,7 @@ function withSslmode(url: string, ssl: boolean): string {
   return u.toString();
 }
 // ── Pod dispatch role (horizontal split) ────────────────────────────────────
-// `settings.dispatchRole` (from `MESH_DISPATCH_ROLE`, resolved in
+// `settings.dispatchRole` (from `STUDIO_DISPATCH_ROLE`, resolved in
 // resolve-config) selects which DBOS queues this pod DEQUEUES (via the SDK's
 // `listenQueues` filter). It lets you run two Deployments off the SAME
 // image/DB/auth and scale them independently:

--- a/apps/mesh/src/services/ensure-services.ts
+++ b/apps/mesh/src/services/ensure-services.ts
@@ -1249,7 +1249,7 @@ async function ensureLink(inputs: EnsureLinkInputs): Promise<EnsureLinkResult> {
       cwd: inputs.repoRoot,
       env: {
         ...process.env,
-        MESH_CLUSTER_URL: inputs.clusterUrl,
+        STUDIO_CLUSTER_URL: inputs.clusterUrl,
         DATA_DIR: inputs.linkDataDir,
         DECOCMS_HOME: inputs.linkDataDir,
         // Suppress the plain banner — the parent dev/serve already shows one.

--- a/apps/mesh/src/settings/env-fallback.test.ts
+++ b/apps/mesh/src/settings/env-fallback.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { envWithFallback } from "./env-fallback";
+
+describe("envWithFallback", () => {
+  it("prefers the new name", () => {
+    expect(
+      envWithFallback({ STUDIO_X: "new", MESH_X: "old" }, "STUDIO_X", "MESH_X"),
+    ).toBe("new");
+  });
+
+  it("falls back to the deprecated name", () => {
+    expect(envWithFallback({ MESH_X: "old" }, "STUDIO_X", "MESH_X")).toBe(
+      "old",
+    );
+  });
+
+  it("treats empty strings as unset", () => {
+    expect(
+      envWithFallback({ STUDIO_X: "", MESH_X: "old" }, "STUDIO_X", "MESH_X"),
+    ).toBe("old");
+    expect(
+      envWithFallback({ STUDIO_X: "", MESH_X: "" }, "STUDIO_X", "MESH_X"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when neither is set", () => {
+    expect(envWithFallback({}, "STUDIO_X", "MESH_X")).toBeUndefined();
+  });
+});

--- a/apps/mesh/src/settings/env-fallback.ts
+++ b/apps/mesh/src/settings/env-fallback.ts
@@ -1,0 +1,25 @@
+/**
+ * Read an env var by its new STUDIO_* name, falling back to the deprecated
+ * MESH_* name so existing deploys keep working. Warns once per legacy name.
+ */
+
+const warned = new Set<string>();
+
+export function envWithFallback(
+  env: Record<string, string | undefined>,
+  newName: string,
+  deprecatedName: string,
+): string | undefined {
+  const value = env[newName];
+  if (value !== undefined && value !== "") return value;
+
+  const legacy = env[deprecatedName];
+  if (legacy === undefined || legacy === "") return undefined;
+  if (!warned.has(deprecatedName)) {
+    warned.add(deprecatedName);
+    console.warn(
+      `Environment variable ${deprecatedName} is deprecated — rename it to ${newName}.`,
+    );
+  }
+  return legacy;
+}

--- a/apps/mesh/src/settings/resolve-config.test.ts
+++ b/apps/mesh/src/settings/resolve-config.test.ts
@@ -116,3 +116,41 @@ describe("resolveShutdownDrainMs", () => {
     expect(resolveShutdownDrainMs("api", forceExitMs, "0")).toBe(0);
   });
 });
+
+describe("resolveConfig STUDIO_* env vars with MESH_* fallback", () => {
+  it("reads STUDIO_JWT_SECRET, preferring it over MESH_JWT_SECRET", () => {
+    const result = resolveConfig(flags, {
+      STUDIO_JWT_SECRET: "new-secret",
+      MESH_JWT_SECRET: "old-secret",
+    });
+
+    expect(result.settings.studioJwtSecret).toBe("new-secret");
+  });
+
+  it("falls back to legacy MESH_JWT_SECRET", () => {
+    const result = resolveConfig(flags, { MESH_JWT_SECRET: "old-secret" });
+
+    expect(result.settings.studioJwtSecret).toBe("old-secret");
+  });
+
+  it("reads STUDIO_DISPATCH_ROLE, preferring it over MESH_DISPATCH_ROLE", () => {
+    const result = resolveConfig(flags, {
+      STUDIO_DISPATCH_ROLE: "worker",
+      MESH_DISPATCH_ROLE: "api",
+    });
+
+    expect(result.settings.dispatchRole).toBe("worker");
+  });
+
+  it("falls back to legacy MESH_DISPATCH_ROLE", () => {
+    const result = resolveConfig(flags, { MESH_DISPATCH_ROLE: "api" });
+
+    expect(result.settings.dispatchRole).toBe("api");
+  });
+
+  it("defaults dispatch role to all when neither is set", () => {
+    const result = resolveConfig(flags, {});
+
+    expect(result.settings.dispatchRole).toBe("all");
+  });
+});

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -5,13 +5,14 @@
  */
 
 import { homedir } from "os";
+import { envWithFallback } from "./env-fallback";
 import type { CliFlags, DispatchRole, Settings } from "./types";
 
 type SandboxProviderKind = Settings["sandboxProviderKind"];
 
 const DISPATCH_ROLES = new Set<DispatchRole>(["all", "worker", "api"]);
 
-/** Normalize `MESH_DISPATCH_ROLE`; anything unknown coerces to the safe "all". */
+/** Normalize `STUDIO_DISPATCH_ROLE`; anything unknown coerces to the safe "all". */
 function resolveDispatchRole(raw: string | undefined): DispatchRole {
   const role = (raw ?? "").trim();
   return DISPATCH_ROLES.has(role as DispatchRole)
@@ -145,7 +146,11 @@ export function resolveConfig(
     // Auth & Secrets
     betterAuthSecret: envVars.BETTER_AUTH_SECRET || "",
     encryptionKey: envVars.ENCRYPTION_KEY || "",
-    meshJwtSecret: envVars.MESH_JWT_SECRET,
+    studioJwtSecret: envWithFallback(
+      envVars,
+      "STUDIO_JWT_SECRET",
+      "MESH_JWT_SECRET",
+    ),
     localMode,
     disableRateLimit: toBool(envVars.DISABLE_RATE_LIMIT),
     studioProvisionSecretKey: envVars.STUDIO_PROVISION_SECRET_KEY,
@@ -223,7 +228,9 @@ export function resolveConfig(
     isCli: true,
     noTui: flags.noTui === true,
     podName: envVars.POD_NAME ?? crypto.randomUUID(),
-    dispatchRole: resolveDispatchRole(envVars.MESH_DISPATCH_ROLE),
+    dispatchRole: resolveDispatchRole(
+      envWithFallback(envVars, "STUDIO_DISPATCH_ROLE", "MESH_DISPATCH_ROLE"),
+    ),
     sandboxProviderKind: resolveSandboxProviderKind(
       envVars.STUDIO_SANDBOX_PROVIDER,
     ),

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -23,7 +23,7 @@ export interface Settings {
   // Auth & Secrets
   betterAuthSecret: string;
   encryptionKey: string;
-  meshJwtSecret: string | undefined;
+  studioJwtSecret: string | undefined;
   localMode: boolean;
   disableRateLimit: boolean;
   studioProvisionSecretKey: string | undefined; // Secret key to call the Deco AI Gateway API to provision keys

--- a/apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx
@@ -307,8 +307,10 @@ function EnvVarsBlock({
 }) {
   const [copied, setCopied] = useState(false);
   const meshUrl = window.location.origin;
-  const keyLine = apiKey ? `MESH_API_KEY=${apiKey}` : `MESH_API_KEY=<api-key>`;
-  const urlLine = `MESH_BASE_URL=${meshUrl}`;
+  const keyLine = apiKey
+    ? `STUDIO_API_KEY=${apiKey}`
+    : `STUDIO_API_KEY=<api-key>`;
+  const urlLine = `STUDIO_BASE_URL=${meshUrl}`;
   const envBlock = `${keyLine}\n${urlLine}`;
 
   const handleCopy = async () => {
@@ -394,10 +396,10 @@ function ChatBridgeSectionInner({
   const baseUrl = window.location.origin;
 
   const envBlock = [
-    `MESH_BASE_URL=${baseUrl}`,
-    `MESH_ORG=${org.slug}`,
-    `MESH_AGENT_ID=${mcpId}`,
-    `MESH_API_KEY=${apiKey ?? "<api-key>"}`,
+    `STUDIO_BASE_URL=${baseUrl}`,
+    `STUDIO_ORG=${org.slug}`,
+    `STUDIO_AGENT_ID=${mcpId}`,
+    `STUDIO_API_KEY=${apiKey ?? "<api-key>"}`,
   ].join("\n");
 
   const handleGenerateKey = async () => {

--- a/packages/mesh-sdk/README.md
+++ b/packages/mesh-sdk/README.md
@@ -46,7 +46,7 @@ const client = await createMCPClient({
   meshUrl: "https://mesh.your-company.com",  // Your Mesh server URL
   connectionId: "self",                       // "self" for management API
   orgId: "org_xxxxx",                         // Your organization ID
-  token: process.env.MESH_API_KEY,            // API key from environment
+  token: process.env.STUDIO_API_KEY,            // API key from environment
 });
 
 // List connections
@@ -88,16 +88,16 @@ import { createMCPClient } from "@decocms/mesh-sdk";
 
 const app = new Hono();
 
-const MESH_URL = process.env.MESH_URL!;
-const ORG_ID = process.env.MESH_ORG_ID!;
-const API_KEY = process.env.MESH_API_KEY!;
+const STUDIO_URL = process.env.STUDIO_URL!;
+const ORG_ID = process.env.STUDIO_ORG_ID!;
+const API_KEY = process.env.STUDIO_API_KEY!;
 
 let meshClient: Awaited<ReturnType<typeof createMCPClient>> | null = null;
 
 async function getMeshClient() {
   if (!meshClient) {
     meshClient = await createMCPClient({
-      meshUrl: MESH_URL,
+      meshUrl: STUDIO_URL,
       connectionId: "self",
       orgId: ORG_ID,
       token: API_KEY,
@@ -175,7 +175,7 @@ const client = await createMCPClient({
   meshUrl: "https://mesh.your-company.com",
   connectionId: "self",
   orgId: process.env.ORG_ID!,
-  token: process.env.MESH_API_KEY!,
+  token: process.env.STUDIO_API_KEY!,
 });
 
 // List Virtual MCPs (agents)
@@ -200,7 +200,7 @@ const specificClient = await createMCPClient({
   meshUrl: "https://mesh.your-company.com",
   connectionId: "conn_xxx",  // Target connection ID
   orgId: process.env.ORG_ID!,
-  token: process.env.MESH_API_KEY!,
+  token: process.env.STUDIO_API_KEY!,
 });
 
 const result = await specificClient.callTool({
@@ -221,7 +221,7 @@ const client = await createMCPClient({
   meshUrl: "https://studio.example.com",  // Required for external apps
   connectionId: "self",                  // "self" for management API, or connection ID
   orgId: "org_xxx",                      // Organization ID
-  token: process.env.MESH_API_KEY,       // API key from environment
+  token: process.env.STUDIO_API_KEY,       // API key from environment
 });
 ```
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -146,7 +146,7 @@ const getUserDataTool = createPrivateTool({
   }),
   execute: async ({ runtimeContext }) => {
     // ensureAuthenticated is called automatically
-    const user = runtimeContext.env.MESH_REQUEST_CONTEXT.ensureAuthenticated();
+    const user = runtimeContext.env.STUDIO_REQUEST_CONTEXT.ensureAuthenticated();
     return { userId: user.id, email: user.email };
   },
 });
@@ -361,7 +361,7 @@ export default withRuntime({
       inputSchema: z.object({ sql: z.string() }),
       execute: async ({ context, runtimeContext }) => {
         // Access resolved bindings from state
-        const { database } = runtimeContext.env.MESH_REQUEST_CONTEXT.state;
+        const { database } = runtimeContext.env.STUDIO_REQUEST_CONTEXT.state;
         return database.QUERY({ sql: context.sql });
       },
     }),
@@ -403,7 +403,7 @@ export default withRuntime({
     onInstall: async (env, { vault }) => {
       if (!vault) return;
 
-      const { github } = env.MESH_REQUEST_CONTEXT.state;
+      const { github } = env.STUDIO_REQUEST_CONTEXT.state;
       const client = createStudioVaultClient(vault);
       const token = await client.getAccessToken(github);
 
@@ -448,7 +448,7 @@ export default withRuntime({
     onInstall: async (env, { vault }) => {
       if (!vault) return;
 
-      const { github } = env.MESH_REQUEST_CONTEXT.state;
+      const { github } = env.STUDIO_REQUEST_CONTEXT.state;
       const client = createStudioVaultClient(vault);
       const configuration = await client.getConfiguration(github);
       const apiKey = configuration.state.apiKey;
@@ -643,8 +643,8 @@ const myTool = createTool({
   execute: async ({ runtimeContext }) => {
     const { env, req } = runtimeContext;
     
-    // Access MESH_REQUEST_CONTEXT for auth and bindings
-    const ctx = env.MESH_REQUEST_CONTEXT;
+    // Access STUDIO_REQUEST_CONTEXT for auth and bindings
+    const ctx = env.STUDIO_REQUEST_CONTEXT;
     
     // Get authenticated user (throws if not authenticated)
     const user = ctx.ensureAuthenticated();
@@ -703,7 +703,7 @@ const getProfileTool = createPrivateTool({
     name: z.string(),
   }),
   execute: async ({ runtimeContext }) => {
-    const user = runtimeContext.env.MESH_REQUEST_CONTEXT.ensureAuthenticated();
+    const user = runtimeContext.env.STUDIO_REQUEST_CONTEXT.ensureAuthenticated();
     return {
       id: user.id,
       email: user.email,

--- a/packages/runtime/src/agents.ts
+++ b/packages/runtime/src/agents.ts
@@ -216,7 +216,7 @@ export function makeCreateAgent(
 ): (input: CreateAgentInput) => Promise<CreateAgentResult> {
   return async (input) => {
     if (!meshUrl) {
-      throw new Error("createAgent: missing meshUrl in MESH_REQUEST_CONTEXT");
+      throw new Error("createAgent: missing meshUrl in STUDIO_REQUEST_CONTEXT");
     }
     const self = createMeshSelfClient(meshUrl, token);
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -60,7 +60,10 @@ export interface DefaultEnv<
   TSchema extends z.ZodTypeAny = any,
   TBindings extends BindingRegistry = BindingRegistry,
 > {
+  /** @deprecated Use `STUDIO_REQUEST_CONTEXT` instead. */
   MESH_REQUEST_CONTEXT: RequestContext<TSchema, TBindings>;
+  /** Preferred alias of `MESH_REQUEST_CONTEXT` — both point to the same object. */
+  STUDIO_REQUEST_CONTEXT?: RequestContext<TSchema, TBindings>;
   MESH_APP_DEPLOYMENT_ID: string;
   IS_LOCAL: boolean;
   MESH_URL?: string;
@@ -265,7 +268,8 @@ export const withBindings = <TEnv>({
     } as unknown as RequestContext<any>;
   }
 
-  env.MESH_REQUEST_CONTEXT = context;
+  env.STUDIO_REQUEST_CONTEXT = context;
+  env.MESH_REQUEST_CONTEXT = context; // deprecated alias, kept for existing apps
   context.state = initializeBindings(context);
 
   withDefaultBindings({

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -235,7 +235,8 @@ export type CreatedResource = {
  * @throws Error if no request context or user is not authenticated
  */
 export function ensureAuthenticated(ctx: AppContext): User {
-  const reqCtx = ctx?.env?.MESH_REQUEST_CONTEXT;
+  const reqCtx =
+    ctx?.env?.STUDIO_REQUEST_CONTEXT ?? ctx?.env?.MESH_REQUEST_CONTEXT;
   if (!reqCtx) {
     throw new Error("Unauthorized: missing request context");
   }
@@ -615,7 +616,9 @@ type ResolvedMCPServerOptions<TSchema extends ZodTypeAny = never> =
   CreateMCPServerOptions<any, TSchema>; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 const getMeshCtx = (input: { runtimeContext: AppContext }) => {
-  const ctx = input.runtimeContext.env.MESH_REQUEST_CONTEXT;
+  const ctx =
+    input.runtimeContext.env.STUDIO_REQUEST_CONTEXT ??
+    input.runtimeContext.env.MESH_REQUEST_CONTEXT;
   return {
     connectionId: ctx?.connectionId,
     meshUrl: ctx?.meshUrl,
@@ -697,7 +700,9 @@ const toolsFor = <TSchema extends ZodTypeAny = never>({
             outputSchema: OnEventsOutputSchema,
             execute: async (input) => {
               const env = input.runtimeContext.env;
-              const state = env.MESH_REQUEST_CONTEXT?.state as z.infer<TSchema>;
+              const state = (
+                env.STUDIO_REQUEST_CONTEXT ?? env.MESH_REQUEST_CONTEXT
+              )?.state as z.infer<TSchema>;
               const { connectionId } = getMeshCtx(input);
               return Event.execute(
                 events.handlers!,

--- a/packages/runtime/src/trigger-storage.ts
+++ b/packages/runtime/src/trigger-storage.ts
@@ -31,8 +31,8 @@ interface StudioKVOptions {
  * const triggers = createTriggers({
  *   definitions: [...],
  *   storage: new StudioKV({
- *     url: process.env.MESH_URL!,
- *     apiKey: process.env.MESH_API_KEY!,
+ *     url: process.env.STUDIO_URL!,
+ *     apiKey: process.env.STUDIO_API_KEY!,
  *   }),
  * });
  * ```

--- a/packages/runtime/src/triggers.test.ts
+++ b/packages/runtime/src/triggers.test.ts
@@ -259,6 +259,19 @@ describe("createTriggers", () => {
       }),
     ).rejects.toThrow("Connection ID not available");
   });
+
+  it("TRIGGER_CONFIGURE reads connectionId from STUDIO_REQUEST_CONTEXT", async () => {
+    const configureTool = triggers.tools()[1];
+    const result = (await configureTool.execute({
+      context: { type: "github.push", params: {}, enabled: false },
+      runtimeContext: {
+        env: { STUDIO_REQUEST_CONTEXT: { connectionId: "conn-studio" } },
+        ctx: { waitUntil: () => {} },
+        // biome-ignore lint: test mocks don't need full type compliance
+      } as any,
+    })) as { success: boolean };
+    expect(result.success).toBe(true);
+  });
 });
 
 describe("createTriggers with storage", () => {

--- a/packages/runtime/src/triggers.ts
+++ b/packages/runtime/src/triggers.ts
@@ -224,8 +224,10 @@ export function createTriggers<const TDefs extends TriggerDef[]>(
     inputSchema: TriggerConfigureInputSchema,
     outputSchema: z.object({ success: z.boolean() }),
     execute: async ({ context, runtimeContext }) => {
-      const connectionId = (runtimeContext?.env as unknown as DefaultEnv)
-        ?.MESH_REQUEST_CONTEXT?.connectionId;
+      const env = runtimeContext?.env as unknown as DefaultEnv | undefined;
+      const connectionId = (
+        env?.STUDIO_REQUEST_CONTEXT ?? env?.MESH_REQUEST_CONTEXT
+      )?.connectionId;
 
       if (!connectionId) {
         throw new Error("Connection ID not available");

--- a/tests/resilience/docker-compose.yml
+++ b/tests/resilience/docker-compose.yml
@@ -117,7 +117,7 @@ services:
     command: ["bun", "run", "/app/tests/resilience/link-daemon-entrypoint.ts"]
     environment:
       NODE_ENV: production
-      MESH_CLUSTER_URL: http://toxiproxy:3011
+      STUDIO_CLUSTER_URL: http://toxiproxy:3011
       DAEMON_API_KEY: "${DAEMON_API_KEY:-}"
       DATA_DIR: /app/data/link-daemon
       LINK_DAEMON_PORT: "4500"

--- a/tests/resilience/link-daemon-entrypoint.ts
+++ b/tests/resilience/link-daemon-entrypoint.ts
@@ -3,7 +3,7 @@
  *
  * Runs inside the `link-daemon` container. Authenticates with a pre-minted
  * Better Auth API key (injected as DAEMON_API_KEY by the test that mints it),
- * dials studio through the Toxiproxy `studio_ws` proxy (MESH_CLUSTER_URL), and
+ * dials studio through the Toxiproxy `studio_ws` proxy (STUDIO_CLUSTER_URL), and
  * spawns real sandboxes on demand. No OAuth.
  *
  * The session is persisted to disk under `DATA_DIR` before the daemon starts.
@@ -36,7 +36,7 @@ export function buildDaemonSession(input: {
 
 async function main(): Promise<void> {
   const apiKey = process.env.DAEMON_API_KEY ?? "";
-  const clusterUrl = process.env.MESH_CLUSTER_URL ?? "http://toxiproxy:3010";
+  const clusterUrl = process.env.STUDIO_CLUSTER_URL ?? "http://toxiproxy:3010";
   const dataDir = process.env.DATA_DIR ?? "/app/data/link-daemon";
   const port = Number(process.env.LINK_DAEMON_PORT ?? "4500");
 


### PR DESCRIPTION
De-mesh migration task 06: env vars. All `MESH_*` environment variables are renamed to `STUDIO_*`. Reads go through central points that prefer the new name and fall back to the legacy one with a one-time deprecation warning (`envWithFallback` in `apps/mesh/src/settings/env-fallback.ts`), so existing deploys keep working unchanged.

## Renames

| Old | New | Fallback? |
|---|---|---|
| `MESH_JWT_SECRET` | `STUDIO_JWT_SECRET` | yes (resolve-config, warns once) |
| `MESH_DISPATCH_ROLE` | `STUDIO_DISPATCH_ROLE` | yes (resolve-config, warns once) |
| `MESH_PUBLIC_URL` | `STUDIO_PUBLIC_URL` | yes (`getPublicUrl`, warns once) |
| `MESH_CLUSTER_URL` | `STUDIO_CLUSTER_URL` | yes (`deco link`, warns once); dev-spawned link daemon + resilience compose now emit the new name |
| `MESH_TEST_SESSION` / `MESH_BASE_URL` (smoke script) | `STUDIO_TEST_SESSION` / `STUDIO_BASE_URL` | yes (silent `??`, dev-only script) |
| `MESH_API_KEY` / `MESH_BASE_URL` / `MESH_ORG` / `MESH_AGENT_ID` (UI-generated .env snippets) | `STUDIO_*` equivalents | consumer (`@decocms/typegen`) already reads `STUDIO_*` first with `MESH_*` fallback; docs already use `STUDIO_*` |
| `env.MESH_REQUEST_CONTEXT` (runtime SDK) | `env.STUDIO_REQUEST_CONTEXT` | yes — `withBindings` sets **both** keys to the same object; internal reads prefer new then old; old key kept on `DefaultEnv` as `@deprecated` so existing apps compile and run |
| `settings.meshJwtSecret` | `settings.studioJwtSecret` | clean rename — in-memory only, resolved from env at boot, never persisted |

Docs (`architecture.mdx` en/pt, architecture model, runtime/mesh-sdk READMEs) updated to the `STUDIO_*` names.

## Left for task 09 (would break running clusters)

- **Helm chart still sets `MESH_DISPATCH_ROLE`** (`deploy/helm/studio/templates/*.yaml`, `_helpers.tpl` reserved-name checks, chart README). The chart is an external contract: an upgraded chart setting `STUDIO_DISPATCH_ROLE` against an older app image (no fallback) would silently coerce every pod to role `all`, breaking the api/worker split. New app images read both names, so the chart can flip safely in task 09.
- Runtime SDK legacy env keys nothing in this repo reads (`MESH_URL`, `MESH_RUNTIME_TOKEN`, `MESH_APP_NAME`, `MESH_APP_DEPLOYMENT_ID` on `DefaultEnv`) are set by external hosts — renaming them is an SDK-major concern, out of scope here.
- Non-env `MESH`/mesh identifiers (`MCP_MESH_KEY` metadata key, `MESH_PUBLIC_` tool prefix, `__MESH_VERSION__` build constant, `mesh-storage://` URIs, `x-mesh-token`) belong to other de-mesh tasks (#4619, #4622, #4627) and are untouched.

## Breaking changes

None. Every rename either has a runtime fallback on the read side or only changes emitted examples/snippets whose documented consumers already accept both names.

## Testing

- New unit tests: `env-fallback.test.ts` (precedence, empty-string, unset), `resolve-config.test.ts` (STUDIO/MESH precedence + fallback for JWT secret and dispatch role), `triggers.test.ts` (`STUDIO_REQUEST_CONTEXT` read; existing tests keep covering the `MESH_REQUEST_CONTEXT` fallback).
- `bun test apps/mesh/src/settings packages/runtime` — 107 pass, 0 fail.
- `bun run check` — all workspaces pass. `bun run lint` — 30 warnings, identical to main baseline. `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed all MESH_* env vars to STUDIO_* with centralized fallback and one-time deprecation warnings. Updated the runtime SDK, CLI, docs, and UI snippets to prefer STUDIO_* without breaking existing deploys.

- **Refactors**
  - Added envWithFallback to prefer STUDIO_* and fall back to MESH_* with a single warn.
  - Switched reads to STUDIO_JWT_SECRET, STUDIO_DISPATCH_ROLE, STUDIO_PUBLIC_URL, and STUDIO_CLUSTER_URL; kept MESH_* fallback where relevant.
  - Runtime now sets env.STUDIO_REQUEST_CONTEXT alongside the deprecated MESH_REQUEST_CONTEXT and reads new-then-old across helpers/tools/triggers.
  - Updated docs/READMEs and .env snippets to STUDIO_*; added tests for fallback and precedence.

- **Migration**
  - No breaking changes; legacy MESH_* still work with a deprecation warning. Rename to STUDIO_* when convenient.
  - Helm chart remains on MESH_DISPATCH_ROLE for now; change will happen in a later task to avoid breaking older images.
  - For runtime apps, use env.STUDIO_REQUEST_CONTEXT; MESH_REQUEST_CONTEXT is kept as a deprecated alias.

<sup>Written for commit f2ba73bc7c2af4c498d7bd777e37e321183edc32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

