### PR TITLE
refactor(web): rename mesh references to studio in web client

### DIFF
--- a/apps/mesh/index.html
+++ b/apps/mesh/index.html
@@ -6,7 +6,7 @@
       // Reload once on modulepreload 404 (rolling deployment — old pod missing new chunk).
       // Shares the cooldown key with ChunkErrorBoundary to prevent double-reload loops.
       window.addEventListener('vite:preloadError', function() {
-        var key = '__mesh_chunk_reload_ts';
+        var key = '__studio_chunk_reload_ts';
         var last = sessionStorage.getItem(key);
         var now = Date.now();
         if (!last || now - Number(last) > 10000) {
@@ -19,7 +19,10 @@
       // Apply dark mode class before first paint to prevent flash
       (function() {
         try {
-          var p = JSON.parse(localStorage.getItem("mesh:user:preferences") || "{}");
+          // "mesh:" fallback: this runs before the bundle's one-time key
+          // migration (localstorage-keys.ts), so the very first load after
+          // the rename still finds the old key.
+          var p = JSON.parse(localStorage.getItem("studio:user:preferences") || localStorage.getItem("mesh:user:preferences") || "{}");
           var theme = p.theme || "system";
           var isDark = theme === "dark" || (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
           if (isDark) {

--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -232,7 +232,7 @@ function ThemeSoundVersionBar({
           )}
         </button>
         <span className="text-xs text-muted-foreground/60">
-          v{__MESH_VERSION__}
+          v{__STUDIO_VERSION__}
         </span>
       </div>
     </div>

--- a/apps/mesh/src/web/components/chat/select-model/decopilot.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/decopilot.tsx
@@ -159,7 +159,7 @@ function groupByTier(
 // Model Shortlist (localStorage)
 // ============================================================================
 
-const SHORTLIST_KEY_PREFIX = "mesh:model-shortlist:";
+const SHORTLIST_KEY_PREFIX = "studio:model-shortlist:";
 
 const DEFAULT_SHORTLIST = new Set([
   // Smarter

--- a/apps/mesh/src/web/components/error-boundary.tsx
+++ b/apps/mesh/src/web/components/error-boundary.tsx
@@ -5,7 +5,7 @@ import { captureException } from "@/web/lib/posthog-client";
 import { ArchivedOrgScreen } from "@/web/components/archived-org-screen";
 import { NoPermissionState } from "@/web/components/no-permission-state";
 
-const CHUNK_RELOAD_KEY = "__mesh_chunk_reload_ts";
+const CHUNK_RELOAD_KEY = "__studio_chunk_reload_ts";
 
 function isArchivedOrgError(error: Error | null): boolean {
   return error?.message === "Organization is archived";

--- a/apps/mesh/src/web/components/file-preview.tsx
+++ b/apps/mesh/src/web/components/file-preview.tsx
@@ -5,7 +5,7 @@
  * (toolbar, close) and data fetching.
  *
  * Rendering strategy by extension:
- *   - image → <img> (same-origin URL, bytes proxied by studio; no CORS needed)
+ *   - image → <img> (same-origin URL, bytes proxied by Studio; no CORS needed)
  *   - pdf   → <iframe> (browser-native viewer; NOT sandboxed — a sandbox
  *             without allow-scripts would disable Chrome's PDF plugin)
  *   - html  → <iframe sandbox="allow-scripts"> (untrusted; opaque-origin sandbox)

--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -7,6 +7,7 @@ import {
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Suspense, useDeferredValue, useState } from "react";
+import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import { useDebouncedValue } from "@/web/hooks/use-debounced-value.ts";
 import {
   useMutation,
@@ -395,7 +396,10 @@ function PickerContent({
 
       toast.success(`Imported ${repo.name} from GitHub`);
       onComplete();
-      localStorage.setItem("mesh:sidebar-open", JSON.stringify(false));
+      localStorage.setItem(
+        LOCALSTORAGE_KEYS.sidebarOpen(),
+        JSON.stringify(false),
+      );
       navigateToAgent(virtualMcpId);
     },
     onError: (error) => {

--- a/apps/mesh/src/web/components/import-from-deco-dialog.tsx
+++ b/apps/mesh/src/web/components/import-from-deco-dialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import { toast } from "sonner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -371,7 +372,10 @@ export function ImportFromDecoDialog({
       queryClient.invalidateQueries({ queryKey: KEYS.projects(org.id) });
       toast.success(`Imported ${slug} from deco.cx`);
       handleClose(false);
-      localStorage.setItem("mesh:sidebar-open", JSON.stringify(false));
+      localStorage.setItem(
+        LOCALSTORAGE_KEYS.sidebarOpen(),
+        JSON.stringify(false),
+      );
       navigateToAgent(virtualMcpId);
     },
     onError: (err) => {

--- a/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
+++ b/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
@@ -5,7 +5,7 @@ interface RunBlockInput {
   props: Record<string, unknown>;
 }
 
-/** Sandbox coordinates the studio preview-invoke proxy route is keyed by. */
+/** Sandbox coordinates the Studio preview-invoke proxy route is keyed by. */
 export interface RunBlockSandboxRef {
   orgSlug: string;
   virtualMcpId: string;
@@ -21,7 +21,7 @@ const RUN_TIMEOUT_MS = 30_000;
  * block-ref body (`{ __resolveType, ...props }`). The proxy re-issues it as
  * `POST <preview>/deco/invoke/<resolveType>` with the props as JSON body.
  *
- * Going through the studio (same-origin) instead of fetching the preview
+ * Going through Studio (same-origin) instead of fetching the preview
  * directly keeps the browser out of CORS territory — previews don't send
  * `Access-Control-Allow-Origin` for `/deco/invoke`.
  */
@@ -110,7 +110,7 @@ async function invokeBlock(
 }
 
 /**
- * Invoke a loader/action against the running sandbox preview (via the studio
+ * Invoke a loader/action against the running sandbox preview (via Studio
  * preview-invoke proxy) and return its structured result.
  */
 export function useRunBlock(ref: RunBlockSandboxRef) {

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -1,7 +1,7 @@
 /**
- * Single SSE connection to studio's `/api/:org/sandbox/:virtualMcpId/:branch/events`, fanned out via context.
+ * Single SSE connection to Studio's `/api/:org/sandbox/:virtualMcpId/:branch/events`, fanned out via context.
  *
- * Keyed on `(virtualMcpId, branch)` — studio derives the userId from the
+ * Keyed on `(virtualMcpId, branch)` — Studio derives the userId from the
  * authenticated session and composes the same claim handle a racing
  * SANDBOX_START would. The stream emits in two phases on one connection:
  *
@@ -130,21 +130,6 @@ const DAEMON_EVENT_TYPES: readonly DaemonEventName[] = [
 // `log` is broadcast separately — same SSE stream, different shape.
 const LOG_EVENT = "log" as const;
 
-/** True when `queryKey` is a cached live-meta entry for this org/vmid/branch, regardless of its previewUrl suffix. */
-export function isLiveMetaKeyForScope(
-  queryKey: readonly unknown[],
-  orgSlug: string,
-  virtualMcpId: string,
-  branch: string,
-): boolean {
-  return (
-    queryKey[0] === "live-meta" &&
-    queryKey[1] === orgSlug &&
-    queryKey[2] === virtualMcpId &&
-    queryKey[3] === branch
-  );
-}
-
 export function buildDirectDaemonEventsUrl(
   previewUrl: string | null | undefined,
 ): string | null {
@@ -270,7 +255,7 @@ export function SandboxEventsProvider({
 
     const handleGone = () => {
       // The sandbox is gone (idle-evicted, SANDBOX_DELETE'd, or its pod terminated
-      // and studio has stopped finding the handle). Everything we've cached is
+      // and Studio has stopped finding the handle). Everything we've cached is
       // about to be stale, so reset.
       setNotFound(true);
       setPhase(null);
@@ -397,13 +382,14 @@ export function SandboxEventsProvider({
               liveMetaDebounceTimer = setTimeout(() => {
                 liveMetaDebounceTimer = null;
                 void queryClient.invalidateQueries({
-                  predicate: (query) =>
-                    isLiveMetaKeyForScope(
-                      query.queryKey,
-                      org.slug,
-                      virtualMcpId,
-                      branch,
-                    ),
+                  predicate: (query) => {
+                    const key = query.queryKey;
+                    return (
+                      key[0] === "live-meta" &&
+                      typeof key[1] === "string" &&
+                      key[1].startsWith(`${cacheKey}/`)
+                    );
+                  },
                 });
               }, 1_000);
             }

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
@@ -39,7 +39,7 @@ const KIND_LABELS: Record<PathParamKind, { noun: string; heading: string }> = {
 };
 
 /**
- * Invoke a loader via the studio preview-invoke proxy (same-origin,
+ * Invoke a loader via the Studio preview-invoke proxy (same-origin,
  * authenticated) — the same route useRunBlock uses. Fetching the preview
  * origin directly would hit CORS: previews don't send
  * `Access-Control-Allow-Origin` for `/deco/invoke`.

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -234,7 +234,7 @@ function PublishDialogBody({
       try {
         await loadGitState();
       } catch (error) {
-        // Preview can stay live via the gateway while studio's daemon proxy
+        // Preview can stay live via the gateway while Studio's daemon proxy
         // still holds a stale handle. Re-provision once, then retry — same
         // self-heal path as preview.tsx's notFound → SANDBOX_START flow.
         if (isSandboxUnreachable(error) && !reprovisionAttemptedRef.current) {
@@ -497,7 +497,7 @@ function PublishDialogBody({
               {openPrFromCommits ? "Submit for review" : publishLabel}
             </p>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-success" />
+              <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-green-500" />
               {diffCount} {diffCount === 1 ? "change" : "changes"}{" "}
               {openPrFromCommits ? "in this PR" : "to publish"}
             </div>

--- a/apps/mesh/src/web/components/version-check-dialog.tsx
+++ b/apps/mesh/src/web/components/version-check-dialog.tsx
@@ -43,7 +43,7 @@ export function nextDrift(
  * Polls /api/config on its own (short-lived, unlike the Infinity-staleTime
  * publicConfig query used for boot) and prompts a refresh once the deployed
  * server version drifts — consistently, across repeated polls — from this
- * bundle's build-time __MESH_VERSION__.
+ * bundle's build-time __STUDIO_VERSION__.
  */
 export function VersionCheckDialog() {
   const { data: serverVersion, dataUpdatedAt } = useQuery({
@@ -69,7 +69,7 @@ export function VersionCheckDialog() {
 
   if (dataUpdatedAt !== lastCheckedAt) {
     setLastCheckedAt(dataUpdatedAt);
-    setDrift((prev) => nextDrift(prev, serverVersion, __MESH_VERSION__));
+    setDrift((prev) => nextDrift(prev, serverVersion, __STUDIO_VERSION__));
   }
 
   const isStale = drift.count >= CONFIRMATIONS_REQUIRED;

--- a/apps/mesh/src/web/globals.d.ts
+++ b/apps/mesh/src/web/globals.d.ts
@@ -1,4 +1,4 @@
-declare const __MESH_VERSION__: string;
+declare const __STUDIO_VERSION__: string;
 
 declare module "*?raw" {
   const content: string;

--- a/apps/mesh/src/web/hooks/use-binding.ts
+++ b/apps/mesh/src/web/hooks/use-binding.ts
@@ -8,7 +8,7 @@ import type { ConnectionEntity } from "@/tools/connection/schema";
  * When a binding field declares `__type: "@deco/llm"`, we resolve it to the
  * builtin "LLMS" binding and match connections by their tools instead of
  * falling back to app-name matching (which doesn't work for built-in bindings
- * like the Mesh MCP).
+ * like the Studio MCP).
  */
 const BINDING_TYPE_TO_BUILTIN: Record<string, string> = {
   "@deco/llm": "LLMS",

--- a/apps/mesh/src/web/hooks/use-file-picker.ts
+++ b/apps/mesh/src/web/hooks/use-file-picker.ts
@@ -76,10 +76,10 @@ export interface UploadResult {
 }
 
 /**
- * Upload a file to a configured bucket via the studio proxy endpoint. We
+ * Upload a file to a configured bucket via the Studio proxy endpoint. We
  * don't presign + PUT directly from the browser because that requires
  * per-bucket CORS configuration on every customer bucket (S3, GCS, R2),
- * which is too much friction for a CMS. The proxy streams through studio
+ * which is too much friction for a CMS. The proxy streams through Studio
  * once and avoids the cross-origin problem entirely.
  *
  * The file is sent as the raw POST body (NOT multipart) so the server

--- a/apps/mesh/src/web/hooks/use-list-state.ts
+++ b/apps/mesh/src/web/hooks/use-list-state.ts
@@ -67,7 +67,7 @@ export function useListState<T extends ListStateEntity>(
   const [filters, setFilters] = usePersistedFilters(filterPersistKey);
 
   // Filter bar visibility (persisted)
-  const filterBarVisibilityKey = `mesh-${resource}-filter-visible-${namespace}`;
+  const filterBarVisibilityKey = `studio-${resource}-filter-visible-${namespace}`;
   const [filterBarVisible, setFilterBarVisibleState] = useState(() => {
     const stored = globalThis.localStorage?.getItem(filterBarVisibilityKey);
     return stored === "true";
@@ -84,7 +84,7 @@ export function useListState<T extends ListStateEntity>(
 
   // View mode (persisted)
   const [viewMode, setViewMode] = useViewMode(
-    `mesh-${resource}-${namespace}`,
+    `studio-${resource}-${namespace}`,
     defaultViewMode,
   );
 

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -1,3 +1,7 @@
+// Must be the first import: its module init migrates pre-rename "mesh:*"
+// localStorage keys before anything (e.g. providers.tsx's module-scope
+// hydrateQueryClient) reads localStorage.
+import "@/web/lib/localstorage-keys";
 import { createRoot } from "react-dom/client";
 import { StrictMode, Suspense } from "react";
 import { Providers } from "@/web/providers/providers";

--- a/apps/mesh/src/web/layouts/library/skill.ts
+++ b/apps/mesh/src/web/layouts/library/skill.ts
@@ -1,6 +1,6 @@
 /**
  * SKILL.md parsing for the Library — re-exported from the shared harness
- * module (`@decocms/harness/skills/skill-md`) so the web UI and the studio
+ * module (`@decocms/harness/skills/skill-md`) so the web UI and the Studio
  * server-side skill catalog parse identically.
  */
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/preview-drawer-host.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/preview-drawer-host.tsx
@@ -20,7 +20,7 @@ import { PreviewDrawer } from "@/web/components/sandbox/preview/drawer/drawer";
 
 const STORAGE_KEY = (id: string) => `preview-drawer:${id}`;
 
-// Clone aborts (exit 128) when the GitHub token studio handed the orchestrator is
+// Clone aborts (exit 128) when the GitHub token Studio handed the orchestrator is
 // stale/invalid. A restart re-mints a fresh installation token, so auto
 // stop+start once per VM to recover. Match the auth-specific lines, not the
 // bare exit code (which covers unrelated git failures).

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -339,7 +339,7 @@ export function SettingsSidebar() {
       {/* Version */}
       <div className="mt-auto px-4 pb-1">
         <span className="text-xs text-muted-foreground/50">
-          v{__MESH_VERSION__}
+          v{__STUDIO_VERSION__}
         </span>
       </div>
     </Sidebar>
@@ -407,7 +407,7 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
       {/* Version */}
       <div className="px-4 pb-3 pt-1 border-t border-border/50">
         <span className="text-xs text-muted-foreground/50">
-          v{__MESH_VERSION__}
+          v{__STUDIO_VERSION__}
         </span>
       </div>
     </div>

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -266,17 +266,17 @@ function ShellLayoutContent() {
       // across tabs. We rely on the URL slug (mounted under /api/:org/...)
       // for org resolution instead.
       // Marked for the perf_app_bootstrap timing event (see posthog-client).
-      performance.mark("mesh:active-org-fetch:start");
+      performance.mark("studio:active-org-fetch:start");
       const { data } = await authClient.organization
         .getFullOrganization({
           query: { organizationSlug: org },
         })
         .finally(() => {
-          performance.mark("mesh:active-org-fetch:end");
+          performance.mark("studio:active-org-fetch:end");
           performance.measure(
-            "mesh:active-org-fetch",
-            "mesh:active-org-fetch:start",
-            "mesh:active-org-fetch:end",
+            "studio:active-org-fetch",
+            "studio:active-org-fetch:start",
+            "studio:active-org-fetch:end",
           );
         });
 

--- a/apps/mesh/src/web/lib/html-resource-persist.ts
+++ b/apps/mesh/src/web/lib/html-resource-persist.ts
@@ -22,7 +22,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { UI_RESOURCE_HTML_KEY } from "@decocms/mesh-sdk";
 
-const DB_NAME = "mesh-ui-resources";
+const DB_NAME = "studio-ui-resources";
 const STORE = "html";
 const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const MAX_ENTRIES = 50; // bound the store; prune oldest beyond this on restore
@@ -71,6 +71,13 @@ export async function restoreHtmlResourceCache(
   queryClient: QueryClient,
 ): Promise<void> {
   if (typeof indexedDB === "undefined") return;
+  // Pre-rename DB: it's a pure cache (server ETag revalidates every read), so
+  // no migration — just drop it so it doesn't linger.
+  try {
+    indexedDB.deleteDatabase("mesh-ui-resources");
+  } catch {
+    // ignore
+  }
   try {
     const db = await openDb();
     const store = tx(db, "readonly");

--- a/apps/mesh/src/web/lib/localstorage-keys.test.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { migrateLegacyLocalStorageKeys } from "./localstorage-keys";
+
+function fakeStorage(initial: Record<string, string>) {
+  const map = new Map(Object.entries(initial));
+  return {
+    map,
+    get length() {
+      return map.size;
+    },
+    key: (i: number) => [...map.keys()][i] ?? null,
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+  };
+}
+
+describe("migrateLegacyLocalStorageKeys", () => {
+  test("copies mesh:* and mesh-* keys to studio names and removes the old ones", () => {
+    const storage = fakeStorage({
+      "mesh:user:preferences": '{"theme":"dark"}',
+      "mesh-connections-org1": "table",
+      "sidebar.group-order.o.u": "keep-me",
+    });
+    migrateLegacyLocalStorageKeys(storage);
+    expect(Object.fromEntries(storage.map)).toEqual({
+      "studio:user:preferences": '{"theme":"dark"}',
+      "studio-connections-org1": "table",
+      "sidebar.group-order.o.u": "keep-me",
+    });
+  });
+
+  test("never overwrites an existing studio:* value", () => {
+    const storage = fakeStorage({
+      "mesh:last-org-slug": "old-org",
+      "studio:last-org-slug": "new-org",
+    });
+    migrateLegacyLocalStorageKeys(storage);
+    expect(storage.getItem("studio:last-org-slug")).toBe("new-org");
+    expect(storage.getItem("mesh:last-org-slug")).toBeNull();
+  });
+});

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -1,33 +1,72 @@
 import type { ProjectLocator } from "@decocms/mesh-sdk";
 
 /**
- * Known localStorage keys for the studio app.
+ * Known localStorage keys for the Studio app.
  * When adding a new use of useLocalStorage, add the key to this object.
  * This is used to avoid inline key definitions and to ensure consistency.
  */
 export const LOCALSTORAGE_KEYS = {
   chatSelectedImageModel: (locator: ProjectLocator) =>
-    `mesh:chat:selectedImageModel:${locator}`,
+    `studio:chat:selectedImageModel:${locator}`,
   chatSelectedWebSearchModel: (locator: ProjectLocator) =>
-    `mesh:chat:selectedWebSearchModel:${locator}`,
+    `studio:chat:selectedWebSearchModel:${locator}`,
   chatSelectedDeepResearchModel: (locator: ProjectLocator) =>
-    `mesh:chat:selectedDeepResearchModel:${locator}`,
+    `studio:chat:selectedDeepResearchModel:${locator}`,
   chatSimpleModeTier: (locator: ProjectLocator) =>
-    `mesh:chat:simpleModeTier:${locator}`,
+    `studio:chat:simpleModeTier:${locator}`,
   chatLastAgentOption: (locator: ProjectLocator) =>
-    `mesh:chat:lastAgentOption:${locator}`,
+    `studio:chat:lastAgentOption:${locator}`,
   chatAutosend: (locator: ProjectLocator | string, taskId: string) =>
-    `mesh:chat:autosend:${locator}:${taskId}`,
+    `studio:chat:autosend:${locator}:${taskId}`,
   chatDraft: (locator: ProjectLocator | string, taskKey: string) =>
-    `mesh:chat:draft:${locator}:${taskKey}`,
-  sidePanelWidth: () => `mesh:side-panel:width`,
-  sidebarOpen: () => `mesh:sidebar-open`,
-  preferences: () => `mesh:user:preferences`,
-  lastOrgSlug: () => `mesh:last-org-slug`,
-  lastLocation: () => `mesh:last-location`,
-  connectionsTab: (org: string) => `mesh:connections:tab:${org}`,
+    `studio:chat:draft:${locator}:${taskKey}`,
+  sidePanelWidth: () => `studio:side-panel:width`,
+  sidebarOpen: () => `studio:sidebar-open`,
+  preferences: () => `studio:user:preferences`,
+  lastOrgSlug: () => `studio:last-org-slug`,
+  lastLocation: () => `studio:last-location`,
+  connectionsTab: (org: string) => `studio:connections:tab:${org}`,
   taskLastViewed: (locator: ProjectLocator) =>
-    `mesh:chat:task-last-viewed:${locator}`,
+    `studio:chat:task-last-viewed:${locator}`,
   sidebarGroupOrder: (orgId: string, userId: string) =>
     `sidebar.group-order.${orgId}.${userId}`,
 } as const;
+
+/**
+ * One-time migration of pre-rename localStorage keys ("mesh:*", plus the
+ * "mesh-*" list-state keys) to their "studio:*" / "studio-*" names, so users
+ * keep their persisted UI state across the rename. The new key wins when both
+ * exist; the old key is removed either way. Runs at module init —
+ * `src/web/index.tsx` imports this module first, before anything reads
+ * localStorage.
+ */
+export function migrateLegacyLocalStorageKeys(
+  storage: Pick<
+    Storage,
+    "length" | "key" | "getItem" | "setItem" | "removeItem"
+  >,
+): void {
+  const legacy: string[] = [];
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i);
+    if (key?.startsWith("mesh:") || key?.startsWith("mesh-")) {
+      legacy.push(key);
+    }
+  }
+  for (const oldKey of legacy) {
+    const newKey = `studio${oldKey.slice("mesh".length)}`;
+    const value = storage.getItem(oldKey);
+    if (value !== null && storage.getItem(newKey) === null) {
+      storage.setItem(newKey, value);
+    }
+    storage.removeItem(oldKey);
+  }
+}
+
+try {
+  if (globalThis.localStorage) {
+    migrateLegacyLocalStorageKeys(globalThis.localStorage);
+  }
+} catch {
+  // No localStorage (tests/SSR) or quota error — never block boot over UI state.
+}

--- a/apps/mesh/src/web/lib/posthog-client.test.ts
+++ b/apps/mesh/src/web/lib/posthog-client.test.ts
@@ -218,7 +218,7 @@ describe("posthog-client.identifyUser LP merge", () => {
 
   test("aliases the stashed LP distinct_id after identify, then clears it", () => {
     const store = stubLocalStorage({
-      "mesh:lp-distinct-id": JSON.stringify({
+      "studio:lp-distinct-id": JSON.stringify({
         id: "lp-anon-1",
         ts: Date.now(),
       }),
@@ -227,12 +227,12 @@ describe("posthog-client.identifyUser LP merge", () => {
     identifyUser("user_42", { email: "x@y.com" });
     expect(identifyCalls).toHaveLength(1);
     expect(aliasCalls).toEqual([["lp-anon-1"]]);
-    expect(store["mesh:lp-distinct-id"]).toBeUndefined(); // one-shot
+    expect(store["studio:lp-distinct-id"]).toBeUndefined(); // one-shot
   });
 
   test("second login does not re-alias (stash consumed)", () => {
     stubLocalStorage({
-      "mesh:lp-distinct-id": JSON.stringify({
+      "studio:lp-distinct-id": JSON.stringify({
         id: "lp-anon-1",
         ts: Date.now(),
       }),
@@ -245,7 +245,7 @@ describe("posthog-client.identifyUser LP merge", () => {
 
   test("ignores an expired stash", () => {
     stubLocalStorage({
-      "mesh:lp-distinct-id": JSON.stringify({
+      "studio:lp-distinct-id": JSON.stringify({
         id: "lp-anon-1",
         ts: Date.now() - 25 * 60 * 60 * 1000,
       }),
@@ -256,7 +256,7 @@ describe("posthog-client.identifyUser LP merge", () => {
   });
 
   test("ignores a corrupt stash and no localStorage at all", () => {
-    stubLocalStorage({ "mesh:lp-distinct-id": "not-json" });
+    stubLocalStorage({ "studio:lp-distinct-id": "not-json" });
     initPostHog("phc_test", "https://us.i.posthog.com");
     identifyUser("user_42");
     expect(aliasCalls).toHaveLength(0);

--- a/apps/mesh/src/web/lib/posthog-client.ts
+++ b/apps/mesh/src/web/lib/posthog-client.ts
@@ -18,7 +18,7 @@ let initialized = false;
 let lastOrgGroupKey: string | null = null;
 let bootstrapTimingSent = false;
 
-const LP_DISTINCT_ID_STASH = "mesh:lp-distinct-id";
+const LP_DISTINCT_ID_STASH = "studio:lp-distinct-id";
 const REPORT_LINK_TOKEN_PATH = "/api/_reports/link-token/";
 // How long a stashed LP id stays mergeable. Long enough for "clicked the CTA
 // this morning, signed up tonight"; short enough that a shared machine can't
@@ -275,8 +275,8 @@ export function flushBootstrapTiming() {
       ? Math.round(nav.domContentLoadedEventEnd)
       : undefined,
     // SPA bootstrap phases that gate first paint (the suspense chain).
-    config_fetch_ms: measure("mesh:config-fetch"),
-    active_org_fetch_ms: measure("mesh:active-org-fetch"),
+    config_fetch_ms: measure("studio:config-fetch"),
+    active_org_fetch_ms: measure("studio:active-org-fetch"),
     // Whole thing: navigation start → shell rendered.
     time_to_shell_ms: Math.round(performance.now()),
     // Did localStorage hydration spare us the cold fetches this load?

--- a/apps/mesh/src/web/lib/query-persist.ts
+++ b/apps/mesh/src/web/lib/query-persist.ts
@@ -15,7 +15,7 @@
 import { type QueryClient, dehydrate, hydrate } from "@tanstack/react-query";
 import { clearHtmlResourceCache } from "./html-resource-persist";
 
-const STORAGE_KEY = "mesh:rq-cache";
+const STORAGE_KEY = "studio:rq-cache";
 const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h
 const WRITE_DEBOUNCE_MS = 1000;
 
@@ -89,7 +89,7 @@ export function hydrateQueryClient(queryClient: QueryClient): void {
 
     const stale =
       !parsed.timestamp || Date.now() - parsed.timestamp > MAX_AGE_MS;
-    if (parsed.buster !== __MESH_VERSION__ || stale || !parsed.state) {
+    if (parsed.buster !== __STUDIO_VERSION__ || stale || !parsed.state) {
       window.localStorage.removeItem(STORAGE_KEY);
       return;
     }
@@ -121,7 +121,7 @@ export function persistQueryClient(queryClient: QueryClient): () => void {
       window.localStorage.setItem(
         STORAGE_KEY,
         JSON.stringify({
-          buster: __MESH_VERSION__,
+          buster: __STUDIO_VERSION__,
           timestamp: Date.now(),
           state,
         }),

--- a/apps/mesh/src/web/providers/theme-provider.tsx
+++ b/apps/mesh/src/web/providers/theme-provider.tsx
@@ -12,7 +12,7 @@ import { KEYS } from "@/web/lib/query-keys";
 import { usePreferences } from "@/web/hooks/use-preferences";
 
 async function fetchPublicConfig(): Promise<PublicConfig> {
-  performance.mark("mesh:config-fetch:start");
+  performance.mark("studio:config-fetch:start");
   try {
     const response = await fetch("/api/config");
     if (!response.ok) {
@@ -24,11 +24,11 @@ async function fetchPublicConfig(): Promise<PublicConfig> {
     }
     return data.config;
   } finally {
-    performance.mark("mesh:config-fetch:end");
+    performance.mark("studio:config-fetch:end");
     performance.measure(
-      "mesh:config-fetch",
-      "mesh:config-fetch:start",
-      "mesh:config-fetch:end",
+      "studio:config-fetch",
+      "studio:config-fetch:start",
+      "studio:config-fetch:end",
     );
   }
 }
@@ -41,7 +41,7 @@ function injectThemeVariables(theme: PublicConfig["theme"]) {
   if (!theme) return;
 
   // Remove any previously injected theme style
-  const existingStyle = document.getElementById("mesh-theme-overrides");
+  const existingStyle = document.getElementById("studio-theme-overrides");
   if (existingStyle) {
     existingStyle.remove();
   }
@@ -67,7 +67,7 @@ function injectThemeVariables(theme: PublicConfig["theme"]) {
   // Only inject if we have rules
   if (cssRules.length > 0) {
     const style = document.createElement("style");
-    style.id = "mesh-theme-overrides";
+    style.id = "studio-theme-overrides";
     style.textContent = cssRules.join("\n\n");
     document.head.appendChild(style);
   }

--- a/apps/mesh/vite.config.ts
+++ b/apps/mesh/vite.config.ts
@@ -18,7 +18,7 @@ const bunServerTarget = `http://localhost:${process.env.PORT || "3000"}`;
 
 export default defineConfig({
   define: {
-    __MESH_VERSION__: JSON.stringify(pkg.version),
+    __STUDIO_VERSION__: JSON.stringify(pkg.version),
   },
   build: {
     outDir: "dist/client",

--- a/packages/e2e/tests/commerce-onboarding.spec.ts
+++ b/packages/e2e/tests/commerce-onboarding.spec.ts
@@ -467,7 +467,7 @@ test.describe("Commerce onboarding route isolation", () => {
     );
 
     const sidebarOpen = await page.evaluate(() =>
-      window.localStorage.getItem("mesh:sidebar-open"),
+      window.localStorage.getItem("studio:sidebar-open"),
     );
     expect(sidebarOpen).toBe("false");
   });


### PR DESCRIPTION
Part of the de-mesh migration (task 07: web UI). Renames the remaining "mesh" references in `apps/mesh/src/web` + the Vite client config to "studio".

## Summary

- **localStorage keys**: every `mesh:*` key in `LOCALSTORAGE_KEYS` (and the inline `mesh-*` list-state keys in `use-list-state.ts`, the posthog LP-stash key, the react-query bootstrap cache key, the model-shortlist key) renamed to `studio:*` / `studio-*`.
- **`__MESH_VERSION__` → `__STUDIO_VERSION__`**: the Vite `define` and all usages (version display, react-query cache buster, version-drift check) renamed together.
- Inline `"mesh:sidebar-open"` string literals now use `LOCALSTORAGE_KEYS.sidebarOpen()` instead of re-declaring the key.
- Other client-local identifiers renamed: `performance.mark/measure` names, sessionStorage chunk-reload cooldown key (`__mesh_chunk_reload_ts` — 10s cooldown, not worth migrating), theme-override `<style>` id, IndexedDB UI-resource cache DB name (pure cache: old DB is deleted, server ETag revalidation repopulates it), and prose comments that called the app "mesh".

## localStorage migration (no lost UI state)

Users have persisted UI state (theme, drafts, sidebar, model picks, filters) under the old keys, so `localstorage-keys.ts` now runs a **one-time sweep at module init**: every existing `mesh:*` / `mesh-*` key is copied to its `studio` name (the new key wins if it already exists) and the old key is removed. Two ordering guarantees:

- `src/web/index.tsx` imports `localstorage-keys` **first**, so the sweep runs before `providers.tsx`'s module-scope `hydrateQueryClient` (or anything else) reads localStorage.
- The `index.html` pre-paint dark-mode script runs before the bundle, so it keeps a `mesh:user:preferences` read fallback for the very first load after the rename.

Covered by a unit test (`localstorage-keys.test.ts`).

## What stayed (wire contracts / out of scope)

- `mcp.mesh` registry `_meta` key — server payload contract; the `meshMeta` / `RegistryMeshMeta` identifiers that mirror it keep their names on purpose.
- `x-mesh-client` header and `MESH_API_KEY` / `MESH_BASE_URL` / `MESH_ORG` / `MESH_AGENT_ID` in generated MCP-client config snippets — env vars are task 06's scope.
- `@decocms/mesh-sdk` package imports and `@/api/.../mesh-storage-uri` (server-side, other tasks).
- One stale `__MESH_VERSION__` mention remains in a comment in `src/api/routes/public-config.ts` (outside this task's scope — src/api).

## Breaking changes

None over the wire. Browser-persisted keys are renamed with an in-place migration; the only deliberately unmigrated items are two pure caches (IndexedDB UI-resource HTML, chunk-reload cooldown) that self-repopulate.

## Testing

- `bun run fmt`, `bun run lint` (30 warnings — identical to baseline), `bun run check` all pass.
- `bun test apps/mesh/src/web` — 1620 pass / 22 fail, the same 22 DOM-dependent failures exist on baseline (verified via stash); this branch adds 2 new passing tests.
- `bun run --cwd=apps/mesh build:client` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed remaining “mesh” references in the web client to “studio” and added a one-time migration for persisted browser state. No user-facing breakage; build-time version define switched to `__STUDIO_VERSION__`.

- **Refactors**
  - Renamed client-local identifiers to “studio”: localStorage keys (incl. shortlist, list-state, and react-query persist key), performance marks, sessionStorage chunk-reload key, theme override style id, IndexedDB UI cache DB (old DB dropped), and PostHog LP stash key.
  - Switched `__MESH_VERSION__` → `__STUDIO_VERSION__` and updated all usages (UI version, react-query cache buster, version drift check).
  - Replaced inline `"mesh:sidebar-open"` with `LOCALSTORAGE_KEYS.sidebarOpen()`; updated the remaining e2e read to use `studio:sidebar-open`.
  - Simplified sandbox live-meta query invalidation (removed helper; no behavior change).

- **Migration**
  - On boot, a one-time sweep copies `mesh:*` and `mesh-*` keys to `studio:*`/`studio-*` (new key wins) and removes old keys; `index.html` keeps a first-load theme fallback since it runs before the bundle, and `index.tsx` imports the migration first.
  - Wire contracts unchanged: `mcp.mesh` registry meta, `x-mesh-client` header, `MESH_*` envs, and `@decocms/mesh-sdk` remain as-is.

<sup>Written for commit 7d91cda885dbcaa78b581dbf3a925b168960b6cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

