### PR TITLE
refactor(deploy)!: rename mesh to studio in helm, compose and images

### DIFF
--- a/.github/workflows/multi-pod.yml
+++ b/.github/workflows/multi-pod.yml
@@ -14,7 +14,7 @@ on:
   pull_request:
     # Multi-pod tests are slow (~7-10 min cold image build + serialized
     # boot + scenarios). Only run on PRs that change code the framework
-    # actually exercises — server-side mesh, dispatch/automations, storage
+    # actually exercises — server-side studio, dispatch/automations, storage
     # schema, or the test infra itself. UI/docs/plugin PRs skip.
     paths:
       - "apps/mesh/src/api/**"
@@ -56,16 +56,16 @@ jobs:
       # No --wait here: the one-shot `migrate` service exits 0 once schemas
       # are created and `--wait` mis-classifies that as a failure. The test
       # suite's beforeAll hook (lib/hooks.ts → cluster.waitReady) polls
-      # /health/live on each mesh pod instead.
+      # /health/live on each studio pod instead.
       - name: Start cluster
         run: docker compose -f tests/multi-pod/docker-compose.yml up -d --build
 
       - name: Run multi-pod scenarios
         run: bun test tests/multi-pod/scenarios/ --serial --timeout 900000
 
-      - name: Dump mesh logs
+      - name: Dump studio logs
         if: failure()
-        run: docker compose -f tests/multi-pod/docker-compose.yml logs mesh-1 mesh-2 mesh-3
+        run: docker compose -f tests/multi-pod/docker-compose.yml logs studio-1 studio-2 studio-3
 
       - name: Dump infra logs
         if: failure()

--- a/.github/workflows/release-sandbox-charts.yaml
+++ b/.github/workflows/release-sandbox-charts.yaml
@@ -156,10 +156,10 @@ jobs:
               echo "  --version ${{ steps.version.outputs.version }} \\"
               echo "  --namespace agent-sandbox-system \\"
               echo "  --set envName=<envName> \\"
-              echo "  --set mesh.namespace=<studio-namespace> \\"
-              echo "  --set mesh.serviceAccountName=<studio-release-name> \\"
-              echo "  --set mesh.serviceName=<studio-release-name> \\"
-              echo "  --set mesh.servicePort=80"
+              echo "  --set studio.namespace=<studio-namespace> \\"
+              echo "  --set studio.serviceAccountName=<studio-release-name> \\"
+              echo "  --set studio.serviceName=<studio-release-name> \\"
+              echo "  --set studio.servicePort=80"
             fi
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sandbox-env
 description: |
   Studio-side resources that consume the agent-sandbox operator: the
-  shared SandboxTemplate, mesh runner RBAC, sandbox-pod NetworkPolicy,
+  shared SandboxTemplate, studio runner RBAC, sandbox-pod NetworkPolicy,
   optional SandboxWarmPool, and optional preview Gateway / HTTPRoute /
   Certificate. Install one release per environment (dev / staging /
   prod / ...). Resource names are suffixed with `envName` so multiple
@@ -40,7 +40,10 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.9.6
+# 0.10.0: mesh.* values block -> studio.* (breaking for values / --set flags;
+# fail-guard on the old key). Prose/comments de-meshed across templates,
+# README, examples and the housekeeper script.
+version: 0.10.0
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.17.8"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -14,7 +14,7 @@ Renders:
 - `SandboxWarmPool` `studio-sandbox-<envName>` (optional)
 - `HorizontalPodAutoscaler` for the warm pool (optional; requires explicit metrics)
 - `Gateway` + `Certificate` `agent-sandbox-preview-<envName>` (optional;
-  per-claim HTTPRoutes are minted by the mesh runner, not by this chart)
+  per-claim HTTPRoutes are minted by the studio runner, not by this chart)
 - `CronJob` + scoped RBAC for idle-claim cleanup (optional)
 
 Requires the [`sandbox-operator`](../sandbox-operator/) chart to already be
@@ -30,19 +30,19 @@ installed (it ships the CRDs + controller).
   sandboxes. Keep these values in the Studio Secret: the sidecar mounts org-fs
   through Studio's authenticated API and must not receive S3 credentials.
 - A named ServiceAccount for the Studio release. Its namespace and name must
-  match `mesh.namespace` and `mesh.serviceAccountName`; this chart grants that
+  match `studio.namespace` and `studio.serviceAccountName`; this chart grants that
   identity the runner permissions in `agent-sandbox-system`.
 - The Studio release must explicitly set
   `STUDIO_SANDBOX_PROVIDER=agent-sandbox`. The default provider is the user's
   linked desktop and is not a production cluster configuration.
-- The studio release for THIS environment must point its mesh runner at
+- The studio release for THIS environment must point its studio runner at
   the env-suffixed SandboxTemplate by setting
   `STUDIO_SANDBOX_TEMPLATE_NAME=studio-sandbox-<envName>` in the studio
-  chart's `configMap.meshConfig`. Without that override the runner falls
+  chart's `configMap.studioConfig`. Without that override the runner falls
   back to `studio-sandbox` (no suffix) and claim creation fails with
   `sandboxtemplate not found`.
 - The studio release must also set `STUDIO_ENV=<envName>` (same envName)
-  so mesh stamps `studio.decocms.com/env=<envName>` on every SandboxClaim,
+  so studio stamps `studio.decocms.com/env=<envName>` on every SandboxClaim,
   pod, and HTTPRoute it creates. The housekeeper's default selectors
   scope sweeps to that env label — without it the housekeeper matches
   zero claims and reaps nothing. Set it for every new installation even when
@@ -101,8 +101,8 @@ helm install sandbox-env-staging \
   --version 0.9.6 \
   --namespace agent-sandbox-system \
   --set envName=staging \
-  --set mesh.namespace=deco-studio-staging \
-  --set mesh.serviceAccountName=deco-studio-staging
+  --set studio.namespace=deco-studio-staging \
+  --set studio.serviceAccountName=deco-studio-staging
 ```
 
 Then point the studio (chart-deco-studio) release for the same env at
@@ -116,14 +116,14 @@ serviceAccount:
   automount: true
 
 configMap:
-  meshConfig:
+  studioConfig:
     STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
     STUDIO_ENV: "staging"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-staging"
     # The next three values are required only when previewGateway.enabled=true.
     STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.preview.staging.example.com"
     # Per-claim HTTPRoute attaches to this Gateway. Both required whenever
-    # previewGateway.enabled=true — without them mesh falls back to its
+    # previewGateway.enabled=true — without them studio falls back to its
     # in-process preview proxy, which the chart no longer wires up.
     # NAMESPACE must match `previewGateway.namespace` from the chart values
     # (no default — different gateway controllers live in different
@@ -144,7 +144,7 @@ Studio uses the sentinel only for the first configuration request after a pool
 pod is bound, then rotates the daemon to a per-claim token. If
 `sentinel.token` is omitted, this chart generates and preserves its own value,
 but Studio cannot consume warm-pool pods until it receives that same value.
-Keep it in a Secret, never `configMap.meshConfig`.
+Keep it in a Secret, never `configMap.studioConfig`.
 
 ### ArgoCD Application (one per env)
 
@@ -163,7 +163,7 @@ spec:
     helm:
       values: |
         envName: staging
-        mesh:
+        studio:
           namespace: deco-studio-staging
           serviceAccountName: deco-studio-staging
   destination:
@@ -202,7 +202,7 @@ re-render from scratch, not a merge.
 ```
 sandbox-env/
 ├── Chart.yaml
-├── values.yaml                          # tunables + envName + mesh.* cross-refs
+├── values.yaml                          # tunables + envName + studio.* cross-refs
 ├── examples/
 │   └── values-kind.yaml                 # local dev overrides
 └── templates/
@@ -212,9 +212,9 @@ sandbox-env/
     ├── sandbox-warm-pool.yaml           # SandboxWarmPool (optional)
     ├── sandbox-warmpool-hpa.yaml         # Warm-pool HPA (optional)
     ├── sandbox-sentinel-secret.yaml      # Initial daemon token
-    ├── sandbox-rbac.yaml                # Role + cross-ns RoleBinding to mesh SA
+    ├── sandbox-rbac.yaml                # Role + cross-ns RoleBinding to studio SA
     ├── sandbox-preview-cert.yaml        # cert-manager Certificate (optional)
-    ├── sandbox-preview-gateway.yaml     # Gateway only — per-claim HTTPRoutes are minted by mesh
+    ├── sandbox-preview-gateway.yaml     # Gateway only — per-claim HTTPRoutes are minted by studio
     └── sandbox-housekeeper.yaml         # Idle cleanup CronJob + RBAC (optional)
 ```
 
@@ -238,8 +238,8 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `warmPool.autoscaling.enabled` | `false` | HPA; requires at least one explicit metric |
 | `previewGateway.enabled` | `false` | wildcard `*.preview.<domain>` Gateway + cert |
 | `housekeeper.enabled` | `false` | idle-claim and orphan cleanup CronJob |
-| `mesh.namespace` | `deco-studio` | studio release namespace (this env's) |
-| `mesh.serviceAccountName` | `deco-studio` | Studio ServiceAccount that gets the RoleBinding |
-| `mesh.serviceName` | `deco-studio` | _deprecated, unused since per-claim HTTPRoutes_ |
-| `mesh.servicePort` | `80` | _deprecated, unused since per-claim HTTPRoutes_ |
-| `mesh.podSelectorLabels` | `chart-deco-studio` / `deco-studio` | _deprecated, unused since chart-managed NetworkPolicy removal_ |
+| `studio.namespace` | `deco-studio` | studio release namespace (this env's) |
+| `studio.serviceAccountName` | `deco-studio` | Studio ServiceAccount that gets the RoleBinding |
+| `studio.serviceName` | `deco-studio` | _deprecated, unused since per-claim HTTPRoutes_ |
+| `studio.servicePort` | `80` | _deprecated, unused since per-claim HTTPRoutes_ |
+| `studio.podSelectorLabels` | `chart-deco-studio` / `deco-studio` | _deprecated, unused since chart-managed NetworkPolicy removal_ |

--- a/deploy/helm/sandbox-env/examples/values-kind-warmpool.yaml
+++ b/deploy/helm/sandbox-env/examples/values-kind-warmpool.yaml
@@ -4,7 +4,7 @@
 # reap (we ran with idleTtlSeconds=60 + schedule="*/1 * * * *") fights
 # with active dev sessions: claim gets reaped during a coffee break,
 # warm pool replenishes a fresh pod, the next VM_START provisions
-# against a different pod, and mesh's in-memory K8sRecord points at
+# against a different pod, and studio's in-memory K8sRecord points at
 # the deleted one until restart. Disabling the housekeeper takes
 # eviction out of the loop so warm-pool adoption is the only moving
 # part during normal dev.

--- a/deploy/helm/sandbox-env/examples/values-kind.yaml
+++ b/deploy/helm/sandbox-env/examples/values-kind.yaml
@@ -28,7 +28,7 @@ resources:
 readOnlyRootFilesystem: false
 
 # ── no preview Gateway in kind ─────────────────────────────────────────
-# Mesh's HTTP edge handles preview routing in-process via
+# Studio's HTTP edge handles preview routing in-process via
 # apps/mesh/src/sandbox/preview-proxy.ts: it reads the Host header,
 # extracts the sandbox handle, and reverse-proxies to the in-cluster
 # daemon Service.
@@ -39,11 +39,11 @@ previewGateway:
 warmPool:
   enabled: false
 
-# ── mesh cross-references (point at the kind studio install) ───────────
+# ── studio cross-references (point at the kind studio install) ───────────
 # studio kind install conventionally lands in `deco-studio` namespace
 # with release name `deco-studio`. Override here if you `helm install`
 # studio under a different name/namespace.
-mesh:
+studio:
   namespace: "deco-studio"
   serviceAccountName: "deco-studio"
   serviceName: "deco-studio"

--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
@@ -106,7 +106,7 @@ probe_daemon() {
   case "$code" in
     2*)
       # Warm-pool pods boot with claimed=false and must not be reaped before
-      # mesh delivers a workload via POST /_sandbox/config. Older daemons
+      # studio delivers a workload via POST /_sandbox/config. Older daemons
       # omit the field; treat absent as claimed=true to preserve existing
       # behaviour on cold-start deployments.
       claimed=$(sed -n 's/.*"claimed"[[:space:]]*:[[:space:]]*\(true\|false\).*/\1/p' "$body")
@@ -180,7 +180,7 @@ kubectl get sandboxclaims -n "$NS" -l "$CLAIM_SELECTOR" \
   > "$CLAIMS_FILE" 2>/dev/null || true
 
 # Selector-mismatch detector: silent `claims=0` hides a missing STUDIO_ENV
-# on mesh. Warn loudly and gate orphan GC off so we don't nuke routes whose
+# on studio. Warn loudly and gate orphan GC off so we don't nuke routes whose
 # claims are present but unlabeled.
 selector_mismatch=0
 if ! [ -s "$CLAIMS_FILE" ]; then
@@ -188,7 +188,7 @@ if ! [ -s "$CLAIMS_FILE" ]; then
     -l "app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox" \
     -o name 2>/dev/null | wc -l | tr -d ' ' || echo 0)
   if [ "${unscoped:-0}" -gt 0 ]; then
-    log "WARN selector matched zero claims but ${unscoped} studio-managed claim(s) exist in ${NS} — verify STUDIO_ENV is set on the mesh deployment and matches the chart's envName (current selector: ${CLAIM_SELECTOR})"
+    log "WARN selector matched zero claims but ${unscoped} studio-managed claim(s) exist in ${NS} — verify STUDIO_ENV is set on the studio deployment and matches the chart's envName (current selector: ${CLAIM_SELECTOR})"
     selector_mismatch=1
   fi
 fi

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -38,7 +38,7 @@ keying off `app.kubernetes.io/name` get a single coherent label.
 {{- end }}
 
 {{/*
-Mesh runner Role / RoleBinding name. Stays under 63 chars even with a
+Studio runner Role / RoleBinding name. Stays under 63 chars even with a
 32-char envName.
 */}}
 {{- define "sandbox-env.runnerRoleName" -}}
@@ -173,7 +173,7 @@ worth catching at template time rather than letting the API server reject
 {{- end }}
 
 {{/*
-Default housekeeper selectors. Mirror the labels mesh stamps in runner.ts
+Default housekeeper selectors. Mirror the labels studio stamps in runner.ts
 (`studio.decocms.com/env=<envName>` requires STUDIO_ENV); during phased
 rollout, .Values.housekeeper.{claimSelector,podSelector} can be overridden
 to drop the env scope. README has copy-paste values.
@@ -188,7 +188,7 @@ to drop the env scope. README has copy-paste values.
 
 {{/*
 Sentinel-token Secret name. Holds the bearer baked into pool-pod env via
-`valueFrom.secretKeyRef`; mesh reads the same secret out-of-band (env var
+`valueFrom.secretKeyRef`; studio reads the same secret out-of-band (env var
 sourced from this Secret in the studio chart) so both sides agree on the
 sentinel without it landing in any chart values.yaml.
 */}}

--- a/deploy/helm/sandbox-env/templates/sandbox-preview-gateway.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-preview-gateway.yaml
@@ -13,7 +13,7 @@
 {{- $previewName := include "sandbox-env.previewName" . }}
 {{- $infra := .Values.previewGateway.infrastructure | default dict }}
 # Wildcard preview-URL ingress. The Gateway fronts `*.<domain>`; per-claim
-# HTTPRoutes are minted by the mesh runner against this Gateway and route
+# HTTPRoutes are minted by the studio runner against this Gateway and route
 # directly to each sandbox's headless Service at port 9000 (daemon owns the
 # public surface — routing straight at the dev port 3000 would bypass CSP/HMR
 # rewrites and break iframe embedding + SSE).
@@ -26,15 +26,15 @@
 #                  plaintext to Envoy over a trusted hop. No Certificate.
 #
 # This chart creates ONLY the Gateway (+ optional Certificate). It deliberately
-# does NOT render a wildcard HTTPRoute backed by mesh — keeping mesh in the
+# does NOT render a wildcard HTTPRoute backed by studio — keeping studio in the
 # request path was the previous design, and it's been replaced by per-claim
-# routing. Mesh now creates one HTTPRoute per SandboxClaim in
+# routing. Studio now creates one HTTPRoute per SandboxClaim in
 # `agent-sandbox-system` (same namespace as the operator's Service, no
 # ReferenceGrant needed) and tears it down on claim delete. RBAC for that
 # lives in templates/sandbox-rbac.yaml.
 #
 # Browser → (LB) → Gateway → HTTPRoute(handle) → Service(handle):9000 → pod.
-# Mesh is no longer the data-path proxy.
+# Studio is no longer the data-path proxy.
 #
 # AUTH MODEL — read before exposing this. The Host header carries the
 # sandbox handle, which is the *only* authorization on the preview path
@@ -92,7 +92,7 @@ spec:
       allowedRoutes:
         namespaces:
           # Per-claim HTTPRoutes live in `agent-sandbox-system` (same
-          # namespace as the operator-created Service they back) so mesh
+          # namespace as the operator-created Service they back) so studio
           # can write them with the same Role used for SandboxClaim
           # CRUD. Without this selector the routes would silently drop.
           from: Selector
@@ -113,7 +113,7 @@ spec:
       allowedRoutes:
         namespaces:
           # Per-claim HTTPRoutes live in `agent-sandbox-system` (same
-          # namespace as the operator-created Service they back) so mesh
+          # namespace as the operator-created Service they back) so studio
           # can write them with the same Role used for SandboxClaim
           # CRUD. Without this selector the routes would silently drop.
           from: Selector

--- a/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
@@ -1,4 +1,4 @@
-# RBAC for the mesh ServiceAccount to drive the agent-sandbox operator from
+# RBAC for the studio ServiceAccount to drive the agent-sandbox operator from
 # inside the cluster. The runner (packages/sandbox/server/provider/agent-sandbox/) needs:
 #   - sandboxclaims CRUD/patch (per-tenant claim lifecycle, idle TTL refresh)
 #   - sandboxes get/list/watch (waitForSandboxReady streams `?watch=true`)
@@ -9,16 +9,16 @@
 # Why pods/portforward is here even with the preview Gateway:
 #   The runner has *two* traffic paths and the Gateway only covers one.
 #     1. Browser → preview URL: Gateway terminates `*.preview.<domain>`
-#        and forwards to the mesh Service, which then reverse-proxies to
+#        and forwards to the studio Service, which then reverse-proxies to
 #        the sandbox Service (`<handle>.<ns>.svc.cluster.local:9000`).
 #        No portforward involved.
-#     2. Mesh runner → sandbox daemon (control plane): the runner calls
+#     2. Studio runner → sandbox daemon (control plane): the runner calls
 #        the daemon's HTTP API directly (probeDaemonHealth, daemonBash,
 #        waitForDaemonReady) on every code-execution. This path uses
 #        portforward unconditionally — see runner.ts:openForwarder. It
-#        works the same whether mesh runs in-cluster or on a developer's
+#        works the same whether studio runs in-cluster or on a developer's
 #        desktop, and routes through the apiserver so we don't have to
-#        open daemon ingress on 9000 to mesh's pod selector.
+#        open daemon ingress on 9000 to studio's pod selector.
 #   In production we *could* switch path 2 to in-cluster Service DNS and
 #   drop portforward from this Role; the daemon already enforces its own
 #   bearer-token check. That's tracked as a future hardening pass and is
@@ -31,10 +31,13 @@
 # operator revision adds a write port, scope this rule to sandbox pods
 # only (resourceNames or relabel via mutating webhook).
 #
-# Scope: Role in agent-sandbox-system (the operator's namespace). The mesh
-# ServiceAccount lives in `mesh.namespace` (per values) and the RoleBinding
+# Scope: Role in agent-sandbox-system (the operator's namespace). The studio
+# ServiceAccount lives in `studio.namespace` (per values) and the RoleBinding
 # crosses namespaces by referencing it explicitly. Keeps blast radius of a
-# mesh compromise limited to the sandbox namespace.
+# studio compromise limited to the sandbox namespace.
+{{- if .Values.mesh }}
+{{- fail "sandbox-env: the mesh.* values block was renamed to studio.* — rename the key in your values" -}}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -68,7 +71,7 @@ rules:
   # SandboxClaim (same name, same namespace) so the wildcard Gateway in
   # `istio-system` (or wherever `previewGateway.namespace` points) can
   # route `<handle>.<domain>` traffic directly to the operator-created
-  # headless Service — bypassing mesh as a proxy. `delete` mirrors the
+  # headless Service — bypassing studio as a proxy. `delete` mirrors the
   # claim teardown path. `patch` is required because the runner upserts
   # the route via Server-Side Apply (`applyHttpRoute`) — apply-patch is a
   # content type, but the verb on the resource is still PATCH. Without it
@@ -85,7 +88,7 @@ rules:
   # Service declares at least one port, so the runner Server-Side Applies
   # `port: 9000` onto the Service right after the SandboxClaim becomes
   # Ready and before creating the HTTPRoute. SSA is used over a plain
-  # PATCH so that mesh becomes the recorded field manager for
+  # PATCH so that studio becomes the recorded field manager for
   # `spec.ports[name=daemon]` — if a future operator revision tries to
   # reset ports[] under its own field manager, the API server surfaces a
   # managed-fields conflict instead of silently breaking routing in prod.
@@ -110,8 +113,8 @@ metadata:
     {{- include "sandbox-env.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ required "mesh.serviceAccountName is required" .Values.mesh.serviceAccountName }}
-    namespace: {{ required "mesh.namespace is required" .Values.mesh.namespace }}
+    name: {{ required "studio.serviceAccountName is required" .Values.studio.serviceAccountName }}
+    namespace: {{ required "studio.namespace is required" .Values.studio.namespace }}
 roleRef:
   kind: Role
   name: {{ include "sandbox-env.runnerRoleName" . }}

--- a/deploy/helm/sandbox-env/templates/sandbox-sentinel-secret.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-sentinel-secret.yaml
@@ -1,19 +1,19 @@
 # Sentinel bearer token shared by every pool-pod in this env. Mounted into
 # the daemon container as DAEMON_TOKEN via the SandboxTemplate's env, so
 # pool pods boot with a known auth and accept their first POST /config from
-# mesh. Mesh authenticates that first call with the same token (sourced
+# studio. Studio authenticates that first call with the same token (sourced
 # from the same Secret on its end) and immediately rotates to a per-claim
 # token via `auth.rotateToken`. After rotation, the sentinel is no longer
 # accepted by that pod.
 #
 # Trust window — pod boot → first rotation: NetworkPolicy is the secrecy
-# boundary (only mesh can reach :9000 in `agent-sandbox-system`). The
-# window is short (mesh races to rotate as soon as `waitForDaemonReady`
+# boundary (only studio can reach :9000 in `agent-sandbox-system`). The
+# window is short (studio races to rotate as soon as `waitForDaemonReady`
 # returns) and same-shape as today's per-claim env injection.
 #
 # Lifecycle: generated once at install (`randAlphaNum 64`), preserved
 # across `helm upgrade` via the helper's `lookup`. Rotate by deleting the
-# Secret and re-upgrading — pool pods will bounce, mesh's existing claims
+# Secret and re-upgrading — pool pods will bounce, studio's existing claims
 # keep using their already-rotated per-claim tokens until they're
 # re-provisioned.
 apiVersion: v1

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -1,10 +1,10 @@
-# Shared SandboxTemplate consumed by every SandboxClaim the mesh runner
+# Shared SandboxTemplate consumed by every SandboxClaim the studio runner
 # creates for THIS environment. Resource ceilings come from values.resources.
 #
 # Hardcoded to the operator's own namespace (agent-sandbox-system) — the CRDs
 # ship with that as the install target, and the operator's RBAC watches it by
 # default. The template *name* is suffixed with envName so multiple
-# environments' SandboxTemplates coexist; mesh in this env must reference
+# environments' SandboxTemplates coexist; studio in this env must reference
 # the suffixed name via STUDIO_SANDBOX_TEMPLATE_NAME.
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxTemplate
@@ -18,7 +18,7 @@ spec:
   # `claim.spec.warmpool != "none"`, so warm-pool consumption requires
   # all claim env to come from the template. We bake a *sentinel* bearer
   # token (rendered into a Secret by sandbox-sentinel-secret.yaml) and
-  # rotate to a per-claim token post-bind via mesh's first
+  # rotate to a per-claim token post-bind via studio's first
   # POST /_sandbox/config call. envVarsInjectionPolicy stays Allowed
   # so single-env deploys that haven't yet adopted the sentinel can still
   # provision cold (warmpool=none) with claim env.
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       labels:
         # Per-env name so each env's NetworkPolicy podSelector matches only
-        # its own pods. Mesh runner stamps the same value via
+        # its own pods. Studio runner stamps the same value via
         # SandboxClaim.additionalPodMetadata (driven by
         # STUDIO_SANDBOX_TEMPLATE_NAME pointing at the env-suffixed
         # template) — keep these in lockstep.

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -7,17 +7,17 @@
 # needs to use the operator — every resource name is suffixed with
 # `envName` so multiple releases coexist in `agent-sandbox-system`.
 #
-# Cross-chart wiring lives under `mesh.*`: tell this chart where the studio
+# Cross-chart wiring lives under `studio.*`: tell this chart where the studio
 # release for THIS environment runs so the RBAC RoleBinding, NetworkPolicy
 # ingress selector, and preview HTTPRoute backendRef can reach it. There is
 # no runtime coupling back the other way — studio consumes nothing from
 # this chart at install time; it simply talks to the operator's CRDs and
 # the daemon Service the operator creates per SandboxClaim.
 #
-# Mesh side: the studio install for THIS environment must point its runner
+# Studio side: the studio install for THIS environment must point its runner
 # at the env-suffixed SandboxTemplate by setting
 #   STUDIO_SANDBOX_TEMPLATE_NAME=studio-sandbox-<envName>
-# in the studio chart's `configMap.meshConfig`. Without that override mesh
+# in the studio chart's `configMap.studioConfig`. Without that override studio
 # falls back to "studio-sandbox" (no suffix) and claim creation will fail
 # with "sandboxtemplate not found".
 
@@ -138,7 +138,7 @@ netinit:
 
 # ── sandbox-pod scheduling ─────────────────────────────────────────────
 # Pin sandbox pods to a dedicated NodePool so a container escape lands on
-# a node that has no mesh / postgres / NATS / OTel pods on it. Pair with a
+# a node that has no studio / postgres / NATS / OTel pods on it. Pair with a
 # Karpenter NodePool that taints + labels matching nodes; see README.md
 # for the snippet. Empty defaults run sandbox pods on whatever the
 # scheduler picks.
@@ -196,7 +196,7 @@ dnsConfig:
 # filesystem volumes (skills + outputs + home) at /app/org/* via
 # WebDAV→rclone, propagated into the unprivileged sandbox container
 # (Bidirectional → HostToContainer). The mount config arrives post-bind:
-# mesh POSTs it to the daemon's /_sandbox/orgfs-config, which relays it onto
+# studio POSTs it to the daemon's /_sandbox/orgfs-config, which relays it onto
 # the shared /run/orgfs control volume the sidecar watches (warm-pool claims
 # reject spec.env, so boot env can't carry it).
 #
@@ -210,9 +210,9 @@ dnsConfig:
 #
 # disableFsSidecar (opt-out, default false): a DEBUG escape hatch — drops
 # the sidecar + its mounts entirely and restores userns remap
-# (hostUsers: false). The mesh side still teaches `org/` paths, so this is
+# (hostUsers: false). The studio side still teaches `org/` paths, so this is
 # for low-level pod/mount debugging, not a supported org-fs-off mode. NOT
-# used in prod. (Mirror the mesh-side DISABLE_ORGFS_MOUNTS flag, which
+# used in prod. (Mirror the studio-side DISABLE_ORGFS_MOUNTS flag, which
 # skips minting the mount config without removing the sidecar.)
 disableFsSidecar: false
 
@@ -324,16 +324,16 @@ warmPool:
 # ── preview URL gateway (optional) ─────────────────────────────────────
 # Wildcard preview-URL ingress. Renders an Istio Gateway (HTTPS, terminates
 # `*.<domain>`) + a cert-manager Certificate. Per-claim HTTPRoutes are NOT
-# rendered here — the mesh runner mints one HTTPRoute per SandboxClaim in
+# rendered here — the studio runner mints one HTTPRoute per SandboxClaim in
 # `agent-sandbox-system` and tears it down on claim delete, so each preview
-# URL routes directly to its sandbox Service:9000. Mesh is no longer in
+# URL routes directly to its sandbox Service:9000. Studio is no longer in
 # the data path; it only writes the routing config.
 #
-# Wiring on the studio side (chart-deco-studio configMap.meshConfig):
+# Wiring on the studio side (chart-deco-studio configMap.studioConfig):
 #   STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.<domain>"
 #   STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME: "agent-sandbox-preview-<envName>"
 #   STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE: "<previewGateway.namespace>"
-# Without those, mesh falls back to in-process proxying via its own Service
+# Without those, studio falls back to in-process proxying via its own Service
 # (the previous design). That fallback also requires a separate cluster-wide
 # HTTPRoute that this chart no longer creates.
 #
@@ -349,7 +349,7 @@ previewGateway:
   # ambient/sidecar default to "istio". Confirm with
   # `kubectl get gatewayclasses` before flipping enabled=true.
   gatewayClassName: "istio"
-  # Namespace where the Gateway + HTTPRoute land. Mesh's existing gateway
+  # Namespace where the Gateway + HTTPRoute land. Studio's existing gateway
   # typically lives in `istio-system`; some setups use a dedicated
   # `gateway` ns. The cert Secret is created in the same ns.
   namespace: "istio-system"
@@ -387,22 +387,22 @@ previewGateway:
     annotations: {}
     labels: {}
 
-# ── mesh cross-references ──────────────────────────────────────────────
+# ── studio cross-references ──────────────────────────────────────────────
 # Tells this chart where the chart-deco-studio release for THIS
 # environment runs so the RBAC RoleBinding, NetworkPolicy ingress
 # selector, and preview-Gateway HTTPRoute backendRef all point at it.
 # These values must match the namespace + release-name + service-port of
 # the studio install for the same env.
-mesh:
-  # Namespace where the studio release runs. The mesh ServiceAccount and
-  # mesh Service are looked up here.
+studio:
+  # Namespace where the studio release runs. The studio ServiceAccount and
+  # studio Service are looked up here.
   namespace: "deco-studio"
-  # Name of the mesh ServiceAccount that gets the RoleBinding allowing
+  # Name of the studio ServiceAccount that gets the RoleBinding allowing
   # SandboxClaim CRUD + portforward against agent-sandbox-system.
   # Conventionally the studio release name (chart.fullname).
   serviceAccountName: "deco-studio"
   # DEPRECATED — removal target: chart 0.8.0. Per-claim HTTPRoutes are
-  # minted by mesh now, so the cluster-wide preview backendRef is gone
+  # minted by studio now, so the cluster-wide preview backendRef is gone
   # and these three keys are unused. Kept one minor to not break overrides.
   serviceName: "deco-studio"
   servicePort: 80
@@ -432,7 +432,7 @@ housekeeper:
   ttlSecondsAfterFinished: 300
 
   # Empty = use env-scoped defaults from the housekeeper{Claim,Pod}Selector
-  # helpers. Override during phased rollout (before mesh propagates
+  # helpers. Override during phased rollout (before studio propagates
   # STUDIO_ENV) — the env-scoped default matches zero claims without the
   # label. README has the unscoped copy-paste.
   claimSelector: ""

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.12.2
+version: 0.13.0
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/README.md
+++ b/deploy/helm/studio/README.md
@@ -54,7 +54,7 @@ The main Studio Deployment runs each API pod as three containers:
 The separate `web.enabled` Deployment topology has been removed. nginx is part
 of every API pod and the Service targets nginx through `targetPort: http`.
 
-Because API containers run with `MESH_DISPATCH_ROLE=api`, worker pods are
+Because API containers run with `STUDIO_DISPATCH_ROLE=api`, worker pods are
 required:
 
 ```yaml
@@ -369,7 +369,7 @@ app.kubernetes.io/instance: deco-studio
 
 The API Deployment always renders nginx plus two Bun API containers. nginx owns
 the service-facing `http` port and proxies API/system paths to `api-0` and
-`api-1` on localhost. The Bun API containers run with `MESH_DISPATCH_ROLE=api`,
+`api-1` on localhost. The Bun API containers run with `STUDIO_DISPATCH_ROLE=api`,
 so they do not dequeue worker-only run queues.
 
 #### Conditional Structure
@@ -486,8 +486,8 @@ sessionAffinity: {{ .Values.service.sessionAffinity }}
 
 ```yaml
 data:
-  NODE_ENV: {{ .Values.configMap.meshConfig.NODE_ENV | quote }}
-  PORT: {{ .Values.configMap.meshConfig.PORT | quote }}
+  NODE_ENV: {{ .Values.configMap.studioConfig.NODE_ENV | quote }}
+  PORT: {{ .Values.configMap.studioConfig.PORT | quote }}
 ```
 - `| quote` ensures values are valid strings in YAML
 - **Security**: `DATABASE_URL` is not written to the ConfigMap for the required
@@ -819,7 +819,7 @@ database:
     -----END CERTIFICATE-----
 
 configMap:
-  meshConfig:
+  studioConfig:
     DATABASE_PG_SSL: "true"
     NODE_EXTRA_CA_CERTS: "/etc/ssl/certs/ca-cert.pem"  # Path where certificate will be mounted
 ```
@@ -862,7 +862,7 @@ database:
     -----END CERTIFICATE-----
 
 configMap:
-  meshConfig:
+  studioConfig:
     DATABASE_PG_SSL: "true"
     NODE_EXTRA_CA_CERTS: "/etc/ssl/certs/ca-cert.pem"
 ```
@@ -884,7 +884,7 @@ autoscaling:
 
 ```yaml
 configMap:
-  meshConfig:
+  studioConfig:
     NODE_ENV: "production"
     PORT: "3000"
     HOST: "0.0.0.0"
@@ -1000,7 +1000,7 @@ clickhouse-cluster:
 
 The embedded operator must be scoped to the install namespace via `clickhouse-operator.controller.watchNamespaces` — the chart fails at render time (with the exact namespace in the message) if it is empty or doesn't include the release namespace. The upstream chart only accepts a static list, so it can't be derived automatically. For a cluster-wide operator, install `clickhouse-operator-helm` separately and enable only `clickhouse-cluster` here.
 
-When the CR is enabled, `CLICKHOUSE_URL` is auto-derived to `http://<cr-name>-clickhouse-headless:8123` (no password on the `default` user out of the box). An explicit `CLICKHOUSE_URL` in `configMap.meshConfig` or in the Secret takes precedence — the Secret is the place for an authenticated URL (`http://default:<pass>@...`) paired with `clickhouse.spec.settings.defaultUserPassword`.
+When the CR is enabled, `CLICKHOUSE_URL` is auto-derived to `http://<cr-name>-clickhouse-headless:8123` (no password on the `default` user out of the box). An explicit `CLICKHOUSE_URL` in `configMap.studioConfig` or in the Secret takes precedence — the Secret is the place for an authenticated URL (`http://default:<pass>@...`) paired with `clickhouse.spec.settings.defaultUserPassword`.
 
 Telemetry gets **into** ClickHouse via the in-cluster OTel collector's `clickhouse` exporter, and the dashboard reads the `studio_monitoring_logs` view, which is provisioned once by hand — see `examples/values-clickhouse.yaml` for the full wiring and `apps/mesh/src/monitoring/clickhouse-setup.md` for the view DDL. Backups are your responsibility (single-node ClickHouse has no replication).
 
@@ -1200,7 +1200,7 @@ persistence:
   storageClass: "efs"
 
 configMap:
-  meshConfig:
+  studioConfig:
     NODE_ENV: "production"
     BASE_URL: "https://studio.example.com"
 ```
@@ -1278,7 +1278,7 @@ database:
     -----END CERTIFICATE-----
 
 configMap:
-  meshConfig:
+  studioConfig:
     DATABASE_PG_SSL: "true"
     NODE_EXTRA_CA_CERTS: "/etc/ssl/certs/ca-cert.pem"
 

--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -112,6 +112,7 @@ Resolves DATABASE_URL honoring database engine configuration.
 {{- if eq (lower (default "sqlite" .Values.database.engine)) "postgresql" -}}
 {{- required "database.url deve ser definido quando database.engine=postgresql" .Values.database.url | trim -}}
 {{- else -}}
+{{/* Keep "mesh.db": it is a persisted sqlite file on existing volumes — renaming it would orphan data on running deployments. */}}
 /app/data/mesh.db
 {{- end -}}
 {{- end }}
@@ -134,6 +135,9 @@ Global validations to ensure scaling requirements are met.
 {{- if and $usesPostgres (not .Values.database.url) (not .Values.secret.secretName) (not .Values.externalSecret.enabled) }}
 {{- fail "chart-deco-studio: defina database.url quando database.engine=postgresql ou use secret.secretName para fornecer DATABASE_URL via Secret" -}}
 {{- end }}
+{{- if .Values.configMap.meshConfig }}
+{{- fail "chart-deco-studio: configMap.meshConfig was renamed to configMap.studioConfig — rename the key in your values" -}}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -150,14 +154,14 @@ there must be a worker deployment to pick up run queues.
 {{- end }}
 {{- range $env := .Values.env }}
 {{- $name := get $env "name" | default "" -}}
-{{- if or (eq $name "PORT") (eq $name "MESH_DISPATCH_ROLE") (eq $name "POD_NAME") (eq $name "POD_NAME_BASE") }}
-{{- fail (printf "chart-deco-studio: env contains reserved variable %s; API container PORT, MESH_DISPATCH_ROLE, POD_NAME, and POD_NAME_BASE are managed by the chart." $name) -}}
+{{- if or (eq $name "PORT") (eq $name "STUDIO_DISPATCH_ROLE") (eq $name "MESH_DISPATCH_ROLE") (eq $name "POD_NAME") (eq $name "POD_NAME_BASE") }}
+{{- fail (printf "chart-deco-studio: env contains reserved variable %s; API container PORT, STUDIO_DISPATCH_ROLE (and its MESH_ alias), POD_NAME, and POD_NAME_BASE are managed by the chart." $name) -}}
 {{- end }}
 {{- end }}
 {{- range $env := .Values.worker.env }}
 {{- $name := get $env "name" | default "" -}}
-{{- if or (eq $name "PORT") (eq $name "MESH_DISPATCH_ROLE") }}
-{{- fail (printf "chart-deco-studio: worker.env contains reserved variable %s; worker PORT and MESH_DISPATCH_ROLE are managed by the chart." $name) -}}
+{{- if or (eq $name "PORT") (eq $name "STUDIO_DISPATCH_ROLE") (eq $name "MESH_DISPATCH_ROLE") }}
+{{- fail (printf "chart-deco-studio: worker.env contains reserved variable %s; worker PORT and STUDIO_DISPATCH_ROLE (and its MESH_ alias) are managed by the chart." $name) -}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/studio/templates/configmap-s3-sync.yaml
+++ b/deploy/helm/studio/templates/configmap-s3-sync.yaml
@@ -13,7 +13,7 @@ data:
     BUCKET={{ required "s3Sync.bucket is required when s3Sync.enabled=true" .Values.s3Sync.bucket | quote }}
     REGION={{ .Values.s3Sync.region | quote }}
     PREFIX={{ .Values.s3Sync.prefix | quote }}
-    DATA_DIR={{ .Values.configMap.meshConfig.DATA_DIR | default "/app/data" | quote }}
+    DATA_DIR={{ .Values.configMap.studioConfig.DATA_DIR | default "/app/data" | quote }}
     DIRS={{ join " " .Values.s3Sync.syncDirs | quote }}
     POLL_INTERVAL={{ .Values.s3Sync.interval | default 60 }}
 

--- a/deploy/helm/studio/templates/configmap.yaml
+++ b/deploy/helm/studio/templates/configmap.yaml
@@ -5,19 +5,19 @@ metadata:
   labels:
     {{- include "chart-deco-studio.labels" . | nindent 4 }}
 data:
-  {{- toYaml .Values.configMap.meshConfig | nindent 2 }}
+  {{- toYaml .Values.configMap.studioConfig | nindent 2 }}
   {{- $autoNatsUrl := "" }}
   {{- if .Values.nats.enabled }}
   {{- $autoNatsUrl = printf "nats://%s-nats:4222" .Release.Name }}
   {{- end }}
-  {{- $natsUrl := .Values.configMap.meshConfig.NATS_URL | default $autoNatsUrl }}
-  {{- if and $natsUrl (not (hasKey .Values.configMap.meshConfig "NATS_URL")) }}
+  {{- $natsUrl := .Values.configMap.studioConfig.NATS_URL | default $autoNatsUrl }}
+  {{- if and $natsUrl (not (hasKey .Values.configMap.studioConfig "NATS_URL")) }}
   NATS_URL: {{ $natsUrl | quote }}
   {{- end }}
   {{- /* Auto-derive CLICKHOUSE_URL from the embedded ClickHouseCluster. An
-  explicit value in meshConfig or in the Secret (envFrom lists the Secret
+  explicit value in studioConfig or in the Secret (envFrom lists the Secret
   last, so it wins) takes precedence — use the Secret for authenticated URLs. */}}
-  {{- if and (eq (include "chart-deco-studio.clickhouseEnabled" .) "true") (not (hasKey .Values.configMap.meshConfig "CLICKHOUSE_URL")) }}
+  {{- if and (eq (include "chart-deco-studio.clickhouseEnabled" .) "true") (not (hasKey .Values.configMap.studioConfig "CLICKHOUSE_URL")) }}
   CLICKHOUSE_URL: {{ printf "http://%s-clickhouse-headless:8123" (include "chart-deco-studio.clickhouseCrName" .) | quote }}
   {{- end }}
   {{- if .Values.tunnel.nats.publicUrl }}

--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -130,6 +130,11 @@ spec:
                   fieldPath: metadata.name
             - name: POD_NAME
               value: "$(POD_NAME_BASE)-{{ $api.portName }}"
+            # STUDIO_DISPATCH_ROLE is the canonical name; the MESH_ alias is
+            # kept for images that predate the STUDIO_* env fallback. Drop it
+            # once all deployed images read STUDIO_*.
+            - name: STUDIO_DISPATCH_ROLE
+              value: "api"
             - name: MESH_DISPATCH_ROLE
               value: "api"
             {{- if $.Values.terminationGracePeriodSeconds }}
@@ -216,7 +221,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: data
-              mountPath: {{ $.Values.configMap.meshConfig.DATA_DIR | default "/app/data" }}
+              mountPath: {{ $.Values.configMap.studioConfig.DATA_DIR | default "/app/data" }}
             {{- if and (eq (lower (default "sqlite" $.Values.database.engine)) "postgresql") $.Values.database.caCert }}
             - name: ca-cert
               mountPath: /etc/ssl/certs
@@ -246,7 +251,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: data
-              mountPath: {{ .Values.configMap.meshConfig.DATA_DIR | default "/app/data" }}
+              mountPath: {{ .Values.configMap.studioConfig.DATA_DIR | default "/app/data" }}
             - name: s3-sync-script
               mountPath: /scripts
               readOnly: true

--- a/deploy/helm/studio/templates/worker-deployment.yaml
+++ b/deploy/helm/studio/templates/worker-deployment.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.worker.enabled }}
 {{/*
 Agent-loop worker Deployment. Same image / DB / auth as the main Deployment,
-but MESH_DISPATCH_ROLE=worker so it dequeues ONLY the agent/automation run
+but STUDIO_DISPATCH_ROLE=worker so it dequeues ONLY the agent/automation run
 queues. It carries a distinct `app.kubernetes.io/name` ("<name>-worker") so the
 main Deployment selector and the Service selector do NOT match its pods —
 workers never get LB/HTTP traffic; they only pull work from the DBOS queue.
@@ -41,7 +41,7 @@ spec:
         # if vmagent's kubernetes-pods job scrapes this pod too — same block as
         # the API deployment.
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ .Values.configMap.meshConfig.PORT | default "3000" | quote }}
+        prometheus.io/port: {{ .Values.configMap.studioConfig.PORT | default "3000" | quote }}
         prometheus.io/path: {{ .Values.metrics.path | quote }}
         {{- end }}
         {{- with .Values.podAnnotations }}
@@ -84,7 +84,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.configMap.meshConfig.PORT | default "3000" | int }}
+              containerPort: {{ .Values.configMap.studioConfig.PORT | default "3000" | int }}
               protocol: TCP
           envFrom:
             - configMapRef:
@@ -94,7 +94,12 @@ spec:
           env:
             # Role: dequeue only the agent/automation run queues.
             - name: PORT
-              value: {{ .Values.configMap.meshConfig.PORT | default "3000" | quote }}
+              value: {{ .Values.configMap.studioConfig.PORT | default "3000" | quote }}
+            # STUDIO_DISPATCH_ROLE is the canonical name; the MESH_ alias is
+            # kept for images that predate the STUDIO_* env fallback. Drop it
+            # once all deployed images read STUDIO_*.
+            - name: STUDIO_DISPATCH_ROLE
+              value: worker
             - name: MESH_DISPATCH_ROLE
               value: worker
             {{- if .Values.terminationGracePeriodSeconds }}
@@ -166,7 +171,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: data
-              mountPath: {{ .Values.configMap.meshConfig.DATA_DIR | default "/app/data" }}
+              mountPath: {{ .Values.configMap.studioConfig.DATA_DIR | default "/app/data" }}
             {{- if and (eq (lower (default "sqlite" .Values.database.engine)) "postgresql") .Values.database.caCert }}
             - name: ca-cert
               mountPath: /etc/ssl/certs

--- a/deploy/helm/studio/templates/worker-service.yaml
+++ b/deploy/helm/studio/templates/worker-service.yaml
@@ -21,6 +21,6 @@ spec:
     app.kubernetes.io/instance: {{ .Release.Name }}
   ports:
     - name: http
-      port: {{ .Values.configMap.meshConfig.PORT | default "3000" | int }}
-      targetPort: {{ .Values.configMap.meshConfig.PORT | default "3000" | int }}
+      port: {{ .Values.configMap.studioConfig.PORT | default "3000" | int }}
+      targetPort: {{ .Values.configMap.studioConfig.PORT | default "3000" | int }}
 {{- end }}

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -73,7 +73,7 @@ worker:
   # a distinct `app.kubernetes.io/name` (`<name>-worker`), so the main Service
   # selector does not match them.
   # When true, render a second Deployment (`<fullname>-worker`) that dequeues
-  # only the agent/automation run queues (MESH_DISPATCH_ROLE=worker). Required
+  # only the agent/automation run queues (STUDIO_DISPATCH_ROLE=worker). Required
   # because the main Deployment now runs API-only containers behind nginx.
   enabled: true
   replicaCount: 2
@@ -117,7 +117,7 @@ nginx:
   frontDoorLabels: {}
 
 configMap:
-  meshConfig:
+  studioConfig:
     NODE_ENV: "production"
     PORT: "3000"
     HOST: "0.0.0.0"
@@ -303,7 +303,7 @@ s3Sync:
 
 # NATS subchart (https://artifacthub.io/packages/helm/nats/nats)
 # When enabled, NATS_URL is automatically set to nats://<release-name>-nats:4222
-# unless overridden via configMap.meshConfig.NATS_URL
+# unless overridden via configMap.studioConfig.NATS_URL
 tunnel:
   nats:
     publicUrl: "" # e.g. wss://nats.example.com
@@ -351,7 +351,7 @@ nats:
 #     KeeperCluster) CRs. Needs the operator (embedded or pre-existing).
 # When the CR is enabled, CLICKHOUSE_URL is auto-derived to
 # http://<cr-name>-clickhouse-headless:8123 unless set in
-# configMap.meshConfig or in the Secret (Secret wins — use it for an
+# configMap.studioConfig or in the Secret (Secret wins — use it for an
 # authenticated URL, see examples/values-clickhouse.yaml).
 # The dashboard reads the studio_monitoring_logs VIEW — provision it once
 # (apps/mesh/src/monitoring/clickhouse-setup.md).

--- a/tests/multi-pod/docker-compose.yml
+++ b/tests/multi-pod/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   # Mock OpenAI-compatible AI provider. Scenarios that need to drive the
   # decopilot dispatch pipeline (POST /messages → streamText → JetStream
   # pump → /attach tail) point an `openai-compatible` credential at this
-  # service via `http://mock-ai:9000/v1`. No external port — only mesh
+  # service via `http://mock-ai:9000/v1`. No external port — only studio
   # pods talk to it.
   mock-ai:
     build:
@@ -45,13 +45,13 @@ services:
       start_period: 5s
 
   # External S3 (object store). Runs as its OWN container so it survives a
-  # mesh pod SIGKILL+restart — the rollout-churn scenario needs pods to reboot
-  # cleanly, and mesh's DECOCMS_LOCAL_MODE otherwise spawns an embedded MinIO
+  # studio pod SIGKILL+restart — the rollout-churn scenario needs pods to reboot
+  # cleanly, and studio's DECOCMS_LOCAL_MODE otherwise spawns an embedded MinIO
   # *child* that dies with the container and races/crashes on reprovision. With
   # S3_ENDPOINT + bucket + creds set below, ensureServices takes the external
   # path (skipMinio) and never manages an embedded instance. Also faithful to
   # prod, which uses external S3. No healthcheck: the minio server image ships
-  # no curl/wget/shell to probe with, and mesh's provisionMinioBucket already
+  # no curl/wget/shell to probe with, and studio's provisionMinioBucket already
   # retries the startup ECONNREFUSED race.
   minio:
     image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
@@ -60,7 +60,7 @@ services:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
 
-  # Migrations run once before any mesh pod starts. Pods themselves skip the
+  # Migrations run once before any studio pod starts. Pods themselves skip the
   # migration step (we override the entrypoint with a direct start command) to
   # avoid races on parallel boot.
   migrate:
@@ -75,7 +75,7 @@ services:
       postgres:
         condition: service_healthy
 
-  mesh-1: &mesh
+  studio-1: &studio
     build:
       context: ../../
       dockerfile: tests/resilience/Dockerfile.studio
@@ -93,11 +93,11 @@ services:
     # service. The `migrate` service is the single source of truth for
     # schema state; pods read-only at boot.
     command: ["bun", "run", "src/cli.ts", "--no-tui", "--skip-migrations"]
-    environment: &mesh-env
+    environment: &studio-env
       NODE_ENV: production
       PORT: "3000"
       HOST: 0.0.0.0
-      POD_NAME: mesh-1
+      POD_NAME: studio-1
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
       NATS_URL: nats://nats:4222
       BETTER_AUTH_SECRET: test-secret-for-multi-pod-tests
@@ -121,10 +121,10 @@ services:
     ports:
       - "127.0.0.1:13001:3000"
     # POD_NAME makes `run_owner_pod` match the compose service name
-    # ("mesh-1"), so scenarios that need to identify the dispatch owner
+    # ("studio-1"), so scenarios that need to identify the dispatch owner
     # (e.g. pod-death-dbos-replay) can map straight from a thread row
     # to a docker compose target without an extra UUID-to-service hop.
-    # Mesh defaults this to a random UUID when unset.
+    # Studio defaults this to a random UUID when unset.
     depends_on:
       postgres:
         condition: service_healthy
@@ -141,18 +141,18 @@ services:
       start_period: 60s
       retries: 20
 
-  # mesh-2 and mesh-3 wait for the previous pod to be healthy before
+  # studio-2 and studio-3 wait for the previous pod to be healthy before
   # starting. This serializes *first-boot* DBOS migrations: even with
-  # mesh's own --skip-migrations, DBOS still runs its system-schema
+  # studio's own --skip-migrations, DBOS still runs its system-schema
   # migrations on `DBOS.launch()` and three parallel boots race on
   # inserts into `dbos.dbos_migrations` (unique-constraint violations
   # crash pods 2/3). Once the schema exists, subsequent boots are
   # idempotent — restarting a single pod mid-test stays fast.
-  mesh-2:
-    <<: *mesh
+  studio-2:
+    <<: *studio
     environment:
-      <<: *mesh-env
-      POD_NAME: mesh-2
+      <<: *studio-env
+      POD_NAME: studio-2
     ports:
       - "127.0.0.1:13002:3000"
     depends_on:
@@ -164,14 +164,14 @@ services:
         condition: service_started
       migrate:
         condition: service_completed_successfully
-      mesh-1:
+      studio-1:
         condition: service_healthy
 
-  mesh-3:
-    <<: *mesh
+  studio-3:
+    <<: *studio
     environment:
-      <<: *mesh-env
-      POD_NAME: mesh-3
+      <<: *studio-env
+      POD_NAME: studio-3
     ports:
       - "127.0.0.1:13003:3000"
     depends_on:
@@ -183,5 +183,5 @@ services:
         condition: service_started
       migrate:
         condition: service_completed_successfully
-      mesh-2:
+      studio-2:
         condition: service_healthy

--- a/tests/multi-pod/lib/cluster.ts
+++ b/tests/multi-pod/lib/cluster.ts
@@ -23,7 +23,7 @@ async function compose(...args: string[]): Promise<void> {
 }
 
 /**
- * Bring the cluster up and wait until all mesh pods report /health/live.
+ * Bring the cluster up and wait until all studio pods report /health/live.
  *
  * We don't pass `--wait` to docker compose because the one-shot `migrate`
  * service (`Exited 0` once schemas are created) is mis-classified as a

--- a/tests/multi-pod/lib/hooks.ts
+++ b/tests/multi-pod/lib/hooks.ts
@@ -2,7 +2,7 @@
  * Standard test hooks for multi-pod scenarios.
  *
  * Call `registerTestHooks()` at the top of each scenario file. It (1)
- * restarts any mesh pods that were left stopped by a previous scenario
+ * restarts any studio pods that were left stopped by a previous scenario
  * (the pod-death scenarios SIGKILL pods and don't currently restore
  * them themselves) and (2) waits for every pod to report /health/live
  * before any test body runs.
@@ -37,7 +37,7 @@ async function restoreStoppedPods(): Promise<void> {
   // Fail loudly: if compose can't even list services (daemon down,
   // compose file moved, etc.), silently treating it as "no pods to
   // restore" turns the real failure into a 2-minute waitReady timeout
-  // with a misleading "mesh-1 not healthy" message.
+  // with a misleading "studio-1 not healthy" message.
   if (code !== 0) {
     throw new Error(
       `docker compose ps failed (exit ${code}): ${err.trim() || out.trim() || "<no output>"}`,

--- a/tests/multi-pod/lib/pod.ts
+++ b/tests/multi-pod/lib/pod.ts
@@ -3,7 +3,7 @@
  * death, restart, or to inspect logs for assertions.
  *
  * Failure-injection helpers (kill, stop, restart) operate on the compose
- * service name (e.g. "mesh-1"); the test never speaks Docker directly.
+ * service name (e.g. "studio-1"); the test never speaks Docker directly.
  */
 
 import type { PodName } from "./pods";

--- a/tests/multi-pod/lib/pods.ts
+++ b/tests/multi-pod/lib/pods.ts
@@ -1,16 +1,16 @@
 /**
  * Pod registry for multi-pod tests.
  *
- * One source of truth for which mesh services exist, what their compose
+ * One source of truth for which studio services exist, what their compose
  * service names are, and which host port they expose. Tests pick a pod by
- * name (`PODS.MESH_1`) and `client.ts` / `pod.ts` look up the port or
+ * name (`PODS.STUDIO_1`) and `client.ts` / `pod.ts` look up the port or
  * service from this map.
  *
  * Keep in sync with `docker-compose.yml` — adding a pod means appending it
  * here and to the compose file.
  */
 
-export type PodName = "mesh-1" | "mesh-2" | "mesh-3";
+export type PodName = "studio-1" | "studio-2" | "studio-3";
 
 export interface PodInfo {
   /** Compose service name (used by docker compose CLI). */
@@ -22,9 +22,21 @@ export interface PodInfo {
 }
 
 export const PODS: Record<string, PodInfo> = {
-  MESH_1: { service: "mesh-1", port: 13001, baseUrl: "http://127.0.0.1:13001" },
-  MESH_2: { service: "mesh-2", port: 13002, baseUrl: "http://127.0.0.1:13002" },
-  MESH_3: { service: "mesh-3", port: 13003, baseUrl: "http://127.0.0.1:13003" },
+  STUDIO_1: {
+    service: "studio-1",
+    port: 13001,
+    baseUrl: "http://127.0.0.1:13001",
+  },
+  STUDIO_2: {
+    service: "studio-2",
+    port: 13002,
+    baseUrl: "http://127.0.0.1:13002",
+  },
+  STUDIO_3: {
+    service: "studio-3",
+    port: 13003,
+    baseUrl: "http://127.0.0.1:13003",
+  },
 } as const;
 
 export const ALL_PODS: PodInfo[] = Object.values(PODS);

--- a/tests/multi-pod/lib/setup.ts
+++ b/tests/multi-pod/lib/setup.ts
@@ -38,7 +38,7 @@ export interface MockProvider {
   modelId: string;
 }
 
-/** The internal URL mesh pods use to reach the mock-ai container. */
+/** The internal URL studio pods use to reach the mock-ai container. */
 const MOCK_AI_INTERNAL_URL = "http://mock-ai:9000/v1";
 const MOCK_AI_MODEL_ID = "mock-model";
 
@@ -112,7 +112,7 @@ export async function bootstrapSession(pod: PodInfo): Promise<Session> {
   if (refreshed) cookie = refreshed;
 
   // 4. Mint an API key via the built-in API_KEY_CREATE MCP tool. The
-  // `{orgId}_self` endpoint is mesh's internal MCP namespace.
+  // `{orgId}_self` endpoint is studio's internal MCP namespace.
   const apiKeyRes = await mcpCall<{ key?: string }>(pod, orgId, cookie, {
     name: "API_KEY_CREATE",
     arguments: {

--- a/tests/multi-pod/mock-ai/server.ts
+++ b/tests/multi-pod/mock-ai/server.ts
@@ -3,7 +3,7 @@
  *
  * Two surfaces:
  *
- *   1. OpenAI-compatible (`/v1/...`) — mesh's `openai-compatible` adapter
+ *   1. OpenAI-compatible (`/v1/...`) — studio's `openai-compatible` adapter
  *      wraps `@ai-sdk/openai` against a custom baseURL, so pointing a
  *      credential's JSON at this server is enough to drive the full
  *      decopilot dispatch pipeline (streamText → onChunk → JetStream
@@ -14,7 +14,7 @@
  *      POST /v1/chat/completions      — SSE stream of OpenAI-shaped chunks
  *
  *   2. Gemini Interactions API (`/v1beta/interactions`) — the async path
- *      mesh uses for Gemini Deep Research models (web_search tool). The
+ *      studio uses for Gemini Deep Research models (web_search tool). The
  *      adapter at `apps/mesh/src/ai-providers/adapters/gemini-interactions.ts`
  *      points at this URL when `GEMINI_INTERACTIONS_URL` is set.
  *
@@ -25,7 +25,7 @@
  *                                       `failed` on hint).
  *
  * Test-time control comes from the user message text / interaction
- * `input` field — mesh doesn't propagate request headers to outbound
+ * `input` field — studio doesn't propagate request headers to outbound
  * provider calls, so we encode hints in the prompt instead. Recognized
  * forms:
  *
@@ -158,7 +158,7 @@ async function streamCompletion(req: Request): Promise<Response> {
 // ============================================================================
 
 /**
- * In-memory state for each submitted interaction. The mesh side persists
+ * In-memory state for each submitted interaction. The studio side persists
  * the `id` in `async_research_jobs` and polls until terminal, so the
  * mock only needs to keep the contract — no durability across restarts.
  */

--- a/tests/multi-pod/scenarios/api-key-cross-pod.test.ts
+++ b/tests/multi-pod/scenarios/api-key-cross-pod.test.ts
@@ -72,7 +72,7 @@ async function listThreads(
 
 describe("API key cross-pod", () => {
   test("API key minted on pod-1 authenticates on every pod", async () => {
-    const { orgId, apiKey } = await bootstrapSession(PODS.MESH_1);
+    const { orgId, apiKey } = await bootstrapSession(PODS.STUDIO_1);
 
     // The same Bearer key should resolve to the same org on every pod,
     // because API-key lookups go through the shared API-key table — not

--- a/tests/multi-pod/scenarios/attach-cross-pod.test.ts
+++ b/tests/multi-pod/scenarios/attach-cross-pod.test.ts
@@ -34,9 +34,9 @@
  * coverage of all three.
  *
  * ── unified-control-plane T9 extension ────────────────────────────────
- * This cluster's `docker-compose.yml` pins every mesh pod to
+ * This cluster's `docker-compose.yml` pins every studio pod to
  * `STUDIO_SANDBOX_PROVIDER=agent-sandbox` (see that file's comment on the
- * `mesh-1` service), so `resolveDispatchTarget` short-circuits every
+ * `studio-1` service), so `resolveDispatchTarget` short-circuits every
  * dispatch in this suite to HOSTED execution — this test already drives a
  * hosted streaming turn through the (now v4) gate: dispatch →
  * `hostedHarnessWorkflow` (detached, not awaited) → `consumeRunProjection`
@@ -67,7 +67,7 @@ import {
 
 registerTestHooks();
 
-// Encoded in the prompt — mesh strips request headers before calling
+// Encoded in the prompt — studio strips request headers before calling
 // the provider, so hints live in the message text instead. mock-ai
 // parses "slow:NxMS" to mean N chunks at M ms intervals.
 const MOCK_HINT = "slow:5x500"; // ~2.5s total run
@@ -75,7 +75,7 @@ const MOCK_HINT = "slow:5x500"; // ~2.5s total run
 /** Collect SSE payloads from /attach until `predicate` is satisfied or
  *  the timeout fires. Aborts the underlying request on either outcome. */
 async function collectAttachUntil(
-  pod: (typeof PODS)["MESH_2"],
+  pod: (typeof PODS)["STUDIO_2"],
   orgSlug: string,
   threadId: string,
   apiKey: string,
@@ -113,11 +113,11 @@ async function collectAttachUntil(
 
 describe("cross-pod /attach", () => {
   test("attach on non-POST pods receives buffered chunks from the live run", async () => {
-    const session = await bootstrapSession(PODS.MESH_1);
-    await wireMockProvider(PODS.MESH_1, session);
-    const { virtualMcpId } = await createTestAgent(PODS.MESH_1, session);
+    const session = await bootstrapSession(PODS.STUDIO_1);
+    await wireMockProvider(PODS.STUDIO_1, session);
+    const { virtualMcpId } = await createTestAgent(PODS.STUDIO_1, session);
     const { threadId } = await createTestThread(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       virtualMcpId,
     );
@@ -135,7 +135,7 @@ describe("cross-pod /attach", () => {
     };
 
     const postRes = await postJson(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       `/api/${session.orgSlug}/decopilot/threads/${threadId}/messages`,
       messageBody,
       { auth: { apiKey: session.apiKey } },
@@ -151,7 +151,7 @@ describe("cross-pod /attach", () => {
     // mock's first chunk-delay tick, the test attaches would still
     // see chunk-1 live via `"new"` and the bug wouldn't manifest.
     await collectAttachUntil(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session.orgSlug,
       threadId,
       session.apiKey,
@@ -168,7 +168,7 @@ describe("cross-pod /attach", () => {
     // happy path).
     const [pod2Joined, pod3Joined] = await Promise.all([
       collectAttachUntil(
-        PODS.MESH_2,
+        PODS.STUDIO_2,
         session.orgSlug,
         threadId,
         session.apiKey,
@@ -176,7 +176,7 @@ describe("cross-pod /attach", () => {
         15_000,
       ),
       collectAttachUntil(
-        PODS.MESH_3,
+        PODS.STUDIO_3,
         session.orgSlug,
         threadId,
         session.apiKey,

--- a/tests/multi-pod/scenarios/automation-webhook.test.ts
+++ b/tests/multi-pod/scenarios/automation-webhook.test.ts
@@ -173,7 +173,7 @@ async function addWebhookTrigger(
 /**
  * Build the webhook URL targeting a specific pod's host port. We don't
  * reuse the URL returned by AUTOMATION_TRIGGER_ADD because that one is
- * stamped with whatever `BASE_URL` the mesh process saw at mint time
+ * stamped with whatever `BASE_URL` the studio process saw at mint time
  * (the in-container `http://localhost:3000` in compose) — useless from
  * the test process, and we want to deliberately POST against a chosen
  * pod for the cross-pod assertion.
@@ -248,27 +248,27 @@ describe("automation webhook trigger (e2e through the real cluster)", () => {
   test("POST to a webhook trigger on pod-2 fires the automation and the run completes", async () => {
     // Setup runs against pod-1; the webhook POST itself targets pod-2 to
     // exercise the cross-pod path.
-    const session = await bootstrapSession(PODS.MESH_1);
-    await wireMockProvider(PODS.MESH_1, session);
-    const { virtualMcpId } = await createTestAgent(PODS.MESH_1, session);
+    const session = await bootstrapSession(PODS.STUDIO_1);
+    await wireMockProvider(PODS.STUDIO_1, session);
+    const { virtualMcpId } = await createTestAgent(PODS.STUDIO_1, session);
 
     const automation = await createAgentAutomation(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       virtualMcpId,
     );
     expect(automation.active).toBe(true);
 
     const trigger = await addWebhookTrigger(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       automation.id,
     );
     const token = trigger.webhook!.token;
 
     // -------- cross-pod fire --------
-    const url = webhookUrlFor(PODS.MESH_2, session, trigger.id);
-    const res = await postWebhook(PODS.MESH_2, url, token, {
+    const url = webhookUrlFor(PODS.STUDIO_2, session, trigger.id);
+    const res = await postWebhook(PODS.STUDIO_2, url, token, {
       source: "e2e-test",
       ping: "pong",
     });
@@ -283,7 +283,7 @@ describe("automation webhook trigger (e2e through the real cluster)", () => {
     // hop. 30s is generous and matches the budget used elsewhere in
     // this suite.
     const completed = await waitForCompletedRun(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       trigger.id,
       30_000,
@@ -292,16 +292,16 @@ describe("automation webhook trigger (e2e through the real cluster)", () => {
   }, 60_000);
 
   test("AUTOMATION_TRIGGER_ROTATE_TOKEN revokes the old token and the new one fires", async () => {
-    const session = await bootstrapSession(PODS.MESH_1);
-    await wireMockProvider(PODS.MESH_1, session);
-    const { virtualMcpId } = await createTestAgent(PODS.MESH_1, session);
+    const session = await bootstrapSession(PODS.STUDIO_1);
+    await wireMockProvider(PODS.STUDIO_1, session);
+    const { virtualMcpId } = await createTestAgent(PODS.STUDIO_1, session);
     const automation = await createAgentAutomation(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       virtualMcpId,
     );
     const trigger = await addWebhookTrigger(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       automation.id,
     );
@@ -313,7 +313,7 @@ describe("automation webhook trigger (e2e through the real cluster)", () => {
     // to fire on any key whose id != trigger.api_key_id. That's what
     // we're nailing down here.
     const rotated = await mcpCall<RotatedToken>(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       "AUTOMATION_TRIGGER_ROTATE_TOKEN",
       { trigger_id: trigger.id },
@@ -321,21 +321,21 @@ describe("automation webhook trigger (e2e through the real cluster)", () => {
     expect(rotated.token).toBeTruthy();
     expect(rotated.token).not.toBe(oldToken);
 
-    const url = webhookUrlFor(PODS.MESH_1, session, trigger.id);
+    const url = webhookUrlFor(PODS.STUDIO_1, session, trigger.id);
 
     // Old token: must be refused. Acceptable codes are 401 (key was
     // revoked outright OR key.id doesn't match trigger.api_key_id any
     // more) or 403 (key still validates but its scoped permission was
     // dropped). Both are correct outcomes; the *wrong* outcome is 202.
-    const oldRes = await postWebhook(PODS.MESH_1, url, oldToken, {});
+    const oldRes = await postWebhook(PODS.STUDIO_1, url, oldToken, {});
     expect([401, 403]).toContain(oldRes.status);
 
     // New token: should fire end-to-end like a fresh trigger.
-    const newRes = await postWebhook(PODS.MESH_1, url, rotated.token, {
+    const newRes = await postWebhook(PODS.STUDIO_1, url, rotated.token, {
       ping: "after-rotate",
     });
     expect(newRes.status).toBe(202);
 
-    await waitForCompletedRun(PODS.MESH_1, session, trigger.id, 30_000);
+    await waitForCompletedRun(PODS.STUDIO_1, session, trigger.id, 30_000);
   }, 60_000);
 });

--- a/tests/multi-pod/scenarios/cluster-smoke.test.ts
+++ b/tests/multi-pod/scenarios/cluster-smoke.test.ts
@@ -5,7 +5,7 @@
  * failure before we trust any higher-level scenario:
  *
  *   1. All three pods respond to /health/live independently.
- *      → compose works, ports map, mesh boots, migrations ran once.
+ *      → compose works, ports map, studio boots, migrations ran once.
  *
  *   2. /health/ready agrees on the *same* nats and postgres dependencies.
  *      → all pods see the same shared infra (not three independent stacks).
@@ -45,9 +45,9 @@ describe("cluster smoke", () => {
   });
 
   test("session created on pod-1 is recognized on pod-2 and pod-3", async () => {
-    const session = await bootstrapSession(PODS.MESH_1);
+    const session = await bootstrapSession(PODS.STUDIO_1);
 
-    for (const pod of [PODS.MESH_2, PODS.MESH_3]) {
+    for (const pod of [PODS.STUDIO_2, PODS.STUDIO_3]) {
       const res = await fetchOn(pod, "/api/auth/get-session", {
         auth: { cookie: session.cookie },
       });

--- a/tests/multi-pod/scenarios/pod-death-dbos-replay.test.ts
+++ b/tests/multi-pod/scenarios/pod-death-dbos-replay.test.ts
@@ -145,11 +145,11 @@ function openAttachWatcher(
 
 describe("pod-death + DBOS replay", () => {
   test.skip("killing the owning pod mid-stream still delivers the final chunk via a survivor", async () => {
-    const session = await bootstrapSession(PODS.MESH_1);
-    await wireMockProvider(PODS.MESH_1, session);
-    const { virtualMcpId } = await createTestAgent(PODS.MESH_1, session);
+    const session = await bootstrapSession(PODS.STUDIO_1);
+    await wireMockProvider(PODS.STUDIO_1, session);
+    const { virtualMcpId } = await createTestAgent(PODS.STUDIO_1, session);
     const { threadId } = await createTestThread(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       virtualMcpId,
     );
@@ -166,7 +166,7 @@ describe("pod-death + DBOS replay", () => {
       tier: "smart",
     };
     const postRes = await postJson(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       `/api/${session.orgSlug}/decopilot/threads/${threadId}/messages`,
       messageBody,
       { auth: { apiKey: session.apiKey } },
@@ -203,7 +203,7 @@ describe("pod-death + DBOS replay", () => {
     )
       .then(() => getThreadRunOwnerPod(threadId))
       .then((v) => v as PodName);
-    expect(["mesh-1", "mesh-2", "mesh-3"]).toContain(ownerRaw);
+    expect(["studio-1", "studio-2", "studio-3"]).toContain(ownerRaw);
 
     console.log(`  → run owned by ${ownerRaw}; SIGKILLing it`);
     await kill(ownerRaw);

--- a/tests/multi-pod/scenarios/projector-parity.test.ts
+++ b/tests/multi-pod/scenarios/projector-parity.test.ts
@@ -42,7 +42,7 @@
  *
  * ── PREREQUISITES (why every body stays `test.skip`) ─────────────────
  * 1. `tests/multi-pod/docker-compose.yml` must export the Phase A flag
- *    on every mesh pod:
+ *    on every studio pod:
  *      - LINK_DURABLE_PROJECTOR=true   (start the standalone DB-writer,
  *                                       leader-elected; default-off today)
  *    Without it `app.ts` never constructs the `ProjectorLeadership` /
@@ -51,8 +51,8 @@
  *
  * 2. Leader-acquire observability. `selectLeader` is the
  *    lexicographically-lowest alive podId, so with services
- *    {mesh-1,mesh-2,mesh-3} the initial leader is deterministically
- *    `mesh-1`. SINGLE-ACTIVE (c) and FAILOVER (d) assert on a leader
+ *    {studio-1,studio-2,studio-3} the initial leader is deterministically
+ *    `studio-1`. SINGLE-ACTIVE (c) and FAILOVER (d) assert on a leader
  *    log line — `app.ts`'s `onAcquire`/`onRelease` must emit a stable,
  *    greppable marker (e.g. `[DurableProjector] leader acquired` /
  *    `released`). The markers below (`LEADER_ACQUIRED_LOG`) are the
@@ -90,7 +90,7 @@ import {
 
 registerTestHooks();
 
-// mesh strips request headers before calling the provider, so the run
+// studio strips request headers before calling the provider, so the run
 // shape is encoded in the message text. mock-ai parses "many:N" → N
 // chunks at the default 50ms cadence; "slow:NxMS" → N chunks every MS.
 const FAST_HINT = "many:6"; // 6 chunks — a deterministic small run.
@@ -107,8 +107,8 @@ const POISON_HINT = "poison:final";
 const LEADER_ACQUIRED_LOG = "[DurableProjector] leader acquired";
 
 // selectLeader = lexicographically-lowest alive podId, so the first
-// leader across {mesh-1,mesh-2,mesh-3} is deterministically mesh-1.
-const INITIAL_LEADER: PodName = "mesh-1";
+// leader across {studio-1,studio-2,studio-3} is deterministically studio-1.
+const INITIAL_LEADER: PodName = "studio-1";
 
 /** Fire-and-forget a streaming turn; returns once the POST is accepted. */
 async function postTurn(
@@ -172,16 +172,16 @@ function sqlLit(v: string): string {
 describe("durable-projector parity + leader-failover + poison", () => {
   // (a) PARITY + (b) STATUS + (c) SINGLE-ACTIVE on a clean run.
   test.skip("[parity] projector persists the same parts + completed status as inline, on exactly one leader", async () => {
-    const session = await bootstrapSession(PODS.MESH_1);
-    await wireMockProvider(PODS.MESH_1, session);
-    const { virtualMcpId } = await createTestAgent(PODS.MESH_1, session);
+    const session = await bootstrapSession(PODS.STUDIO_1);
+    await wireMockProvider(PODS.STUDIO_1, session);
+    const { virtualMcpId } = await createTestAgent(PODS.STUDIO_1, session);
     const { threadId } = await createTestThread(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       virtualMcpId,
     );
 
-    await postTurn(PODS.MESH_1, session, virtualMcpId, threadId, FAST_HINT);
+    await postTurn(PODS.STUDIO_1, session, virtualMcpId, threadId, FAST_HINT);
 
     // (b) STATUS — the projector writes `completed` on the {done}
     // sentinel, AFTER parts. Wait for that terminal write.
@@ -214,7 +214,7 @@ describe("durable-projector parity + leader-failover + poison", () => {
     expect(kinds.length).toBeGreaterThan(0);
 
     // (c) SINGLE-ACTIVE — exactly one pod logs leader-acquire, and it is
-    // the lexicographically-lowest alive pod (mesh-1 at clean boot).
+    // the lexicographically-lowest alive pod (studio-1 at clean boot).
     const acquiredOn = await Promise.all(
       ALL_PODS.map((p) => logsContain(p.service, LEADER_ACQUIRED_LOG)),
     );
@@ -226,17 +226,17 @@ describe("durable-projector parity + leader-failover + poison", () => {
   // (d) FAILOVER — kill the leader mid-run; a standby acquires leadership
   // and replays the run from JetStream to `completed` with all parts.
   test.skip("[failover] killing the leader mid-run hands off; the standby replays to completed", async () => {
-    const session = await bootstrapSession(PODS.MESH_1);
-    await wireMockProvider(PODS.MESH_1, session);
-    const { virtualMcpId } = await createTestAgent(PODS.MESH_1, session);
+    const session = await bootstrapSession(PODS.STUDIO_1);
+    await wireMockProvider(PODS.STUDIO_1, session);
+    const { virtualMcpId } = await createTestAgent(PODS.STUDIO_1, session);
     const { threadId } = await createTestThread(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       virtualMcpId,
     );
 
     // A long run so the leader is still consuming when we kill it.
-    await postTurn(PODS.MESH_1, session, virtualMcpId, threadId, SLOW_HINT);
+    await postTurn(PODS.STUDIO_1, session, virtualMcpId, threadId, SLOW_HINT);
 
     // Wait until the leader is actually running the consumer (so the
     // kill targets a live leader, not a pre-acquire pod).
@@ -255,7 +255,7 @@ describe("durable-projector parity + leader-failover + poison", () => {
     });
 
     // SIGKILL the leader. The heartbeat watcher + the 15s poll re-elect
-    // the next-lowest alive pod (mesh-2), whose onAcquire starts the
+    // the next-lowest alive pod (studio-2), whose onAcquire starts the
     // consumer; an explicit-ack durable consumer replays unacked
     // messages from the file-backed stream.
     await kill(INITIAL_LEADER);
@@ -293,19 +293,19 @@ describe("durable-projector parity + leader-failover + poison", () => {
   // (e) POISON — an un-projectable run is marked failed via the DLQ path
   // and does NOT wedge the consumer (a later healthy run still completes).
   test.skip("[poison] an un-projectable run is failed via DLQ without wedging later runs", async () => {
-    const session = await bootstrapSession(PODS.MESH_1);
-    await wireMockProvider(PODS.MESH_1, session);
-    const { virtualMcpId } = await createTestAgent(PODS.MESH_1, session);
+    const session = await bootstrapSession(PODS.STUDIO_1);
+    await wireMockProvider(PODS.STUDIO_1, session);
+    const { virtualMcpId } = await createTestAgent(PODS.STUDIO_1, session);
 
     // Poison run: the projector's terminal write throws; projectRun
     // exhausts retries → onDlq → onRunErrored → status='failed'.
     const { threadId: poisonThread } = await createTestThread(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       virtualMcpId,
     );
     await postTurn(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       virtualMcpId,
       poisonThread,
@@ -327,12 +327,12 @@ describe("durable-projector parity + leader-failover + poison", () => {
     // (published AFTER the poison) still reaches completed. Same org so
     // it shares the single leader-elected consumer.
     const { threadId: healthyThread } = await createTestThread(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       virtualMcpId,
     );
     await postTurn(
-      PODS.MESH_1,
+      PODS.STUDIO_1,
       session,
       virtualMcpId,
       healthyThread,

--- a/tests/multi-pod/scenarios/rollout-churn.test.ts
+++ b/tests/multi-pod/scenarios/rollout-churn.test.ts
@@ -60,17 +60,17 @@ async function runThroughRollingDeploy(): Promise<{
   status: string | null;
   renderable: number;
 }> {
-  const session = await bootstrapSession(PODS.MESH_1);
-  await wireMockProvider(PODS.MESH_1, session);
-  const { virtualMcpId } = await createTestAgent(PODS.MESH_1, session);
+  const session = await bootstrapSession(PODS.STUDIO_1);
+  await wireMockProvider(PODS.STUDIO_1, session);
+  const { virtualMcpId } = await createTestAgent(PODS.STUDIO_1, session);
   const { threadId } = await createTestThread(
-    PODS.MESH_1,
+    PODS.STUDIO_1,
     session,
     virtualMcpId,
   );
 
   const postRes = await postJson(
-    PODS.MESH_1,
+    PODS.STUDIO_1,
     `/api/${session.orgSlug}/decopilot/threads/${threadId}/messages`,
     {
       messages: [

--- a/tests/multi-pod/scenarios/session-rehoming.test.ts
+++ b/tests/multi-pod/scenarios/session-rehoming.test.ts
@@ -37,7 +37,7 @@ async function getSessionUserId(
 
 describe("session rehoming", () => {
   test("sign-out on pod-2 invalidates the cookie on every pod", async () => {
-    const session = await bootstrapSession(PODS.MESH_1);
+    const session = await bootstrapSession(PODS.STUDIO_1);
 
     // Baseline: cookie is valid on all three pods. If this fails, the
     // smoke test would already have flagged it — but we want a fresh
@@ -51,7 +51,7 @@ describe("session rehoming", () => {
     // That's the load-bearing assertion: the invalidation isn't local to
     // the pod that minted the session.
     await postJson(
-      PODS.MESH_2,
+      PODS.STUDIO_2,
       "/api/auth/sign-out",
       {},
       { auth: { cookie: session.cookie } },


### PR DESCRIPTION
## Summary

De-mesh task 09 (deploy / infra). The chart name (`chart-deco-studio`) and image names (`ghcr.io/decocms/studio/*`) were already renamed in the repo-rename pass, so this PR finishes the remaining "mesh" identifiers in `deploy/`, `tests/multi-pod` and the CI wiring that references them.

Out of scope (owned by other open de-mesh PRs / task 10): `apps/mesh` directory paths, `MESH_*` env vars in `tests/resilience` (#4645), `@decocms/mesh` npm package + `release-mesh.yaml` / `publish-mesh-sdk-npm.yaml` workflow names (#4653 / task 10).

## External-contract renames — ops coordination required

| Contract | Old | New | Coordination requirement |
|---|---|---|---|
| chart-deco-studio values key | `configMap.meshConfig` | `configMap.studioConfig` | **Breaking.** Rename the key in every environment values file before upgrading to chart 0.13.0. A template fail-guard rejects the old key with an explicit message, so an un-migrated upgrade fails loudly at render time instead of shipping an empty ConfigMap. |
| chart-deco-studio dispatch-role env | `MESH_DISPATCH_ROLE` | `STUDIO_DISPATCH_ROLE` (canonical) + `MESH_DISPATCH_ROLE` kept as alias | **None yet — deliberately dual-set.** The chart sets both names to the same value, so it works with images both before and after #4645 (the `STUDIO_*` fallback). No image/chart ordering constraint. Follow-up: drop the `MESH_` alias once all deployed images read `STUDIO_*`. Both names are now reserved (chart rejects them in `env` / `worker.env`). |
| sandbox-env values block | `mesh.*` (`mesh.namespace`, `mesh.serviceAccountName`, `mesh.serviceName`, `mesh.servicePort`, `mesh.podSelectorLabels`) | `studio.*` | **Breaking.** Update values files / `--set mesh.*` flags to `studio.*` before upgrading to chart 0.10.0. Fail-guard rejects the old block. The `release-sandbox-charts.yaml` install snippet now prints `--set studio.*`. |
| sqlite volume path | `/app/data/mesh.db` | **unchanged** | Intentionally kept: it is a persisted file on existing volumes; renaming it would orphan data on running single-node deployments. A template comment documents this. |
| Chart names / release names / image names | `chart-deco-studio`, `ghcr.io/decocms/studio/{studio,studio-nginx,s3-sync}` | unchanged | Already renamed in a previous pass — no action. |
| multi-pod compose services | `mesh-1/2/3` | `studio-1/2/3` | Test-infra only, no running-cluster impact. |

Chart version bumps: `chart-deco-studio` 0.12.2 → **0.13.0**, `sandbox-env` 0.9.5 → **0.10.0** (both breaking-values releases).

## Changes

- **deploy/helm/studio**: `meshConfig` → `studioConfig` across values/templates/README; dual `STUDIO_DISPATCH_ROLE`/`MESH_DISPATCH_ROLE` env in API + worker deployments; reserved-var validation covers both names; fail-guard for the old values key.
- **deploy/helm/sandbox-env**: `mesh.*` → `studio.*` values block (+ fail-guard); prose/comments de-meshed in templates, values, README, examples, housekeeper script; Chart description updated.
- **deploy/helm/sandbox-operator**: README prose.
- **tests/multi-pod**: compose services/anchors/`POD_NAME` `mesh-N` → `studio-N`; `PODS.MESH_N` → `PODS.STUDIO_N`, `PodName` type and scenario literals renamed (lexicographic leader ordering `studio-1 < studio-2 < studio-3` is preserved, so projector-parity assumptions hold).
- **.github/workflows**: `multi-pod.yml` log-dump service names; `release-sandbox-charts.yaml` install snippet.
- `tests/resilience` needed no changes (its compose has no mesh service names; `MESH_CLUSTER_URL` there belongs to #4645).

## Testing

- `helm lint` + `helm template` on both charts (default, postgres, and `examples/values-kind.yaml` values) — render OK; both fail-guards and the reserved-var check verified to fail with the intended messages; rendered manifests show both dispatch-role vars.
- `docker compose -f tests/multi-pod/docker-compose.yml config -q` and `... tests/resilience/docker-compose.yml config -q` — OK.
- `bun run fmt` (clean), `bun run lint` (0 errors), `bun run check` (all workspaces pass).
- Multi-pod/resilience docker suites not run locally (Docker-compose build of the full app); the renames there are mechanical and covered by CI's multi-pod job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed remaining "mesh" identifiers to "studio" across Helm charts, Docker Compose (multi-pod), and CI. Bumps `chart-deco-studio` to 0.13.0 and `sandbox-env` to 0.10.0 with fail-guards; update values before upgrading.

- **Migration**
  - `chart-deco-studio`: rename `configMap.meshConfig` → `configMap.studioConfig` (templates hard-fail on the old key). Chart sets both `STUDIO_DISPATCH_ROLE` (canonical) and `MESH_DISPATCH_ROLE` (alias); both names are reserved in `env` and `worker.env`. SQLite path stays `/app/data/mesh.db`.
  - `sandbox-env`: rename `mesh.*` → `studio.*` (namespace, serviceAccountName, serviceName, servicePort) before upgrading; the chart fails if `mesh.*` is present. Release snippet now prints `--set studio.*`.
  - Scripts/ops: multi-pod services are now `studio-1/2/3`.

- **Refactors**
  - `deploy/helm/studio`: values/README/templates moved to `studioConfig`; explicit fail on `configMap.meshConfig`; API and worker deployments set `STUDIO_DISPATCH_ROLE` + `MESH_DISPATCH_ROLE`; reserved-var checks updated.
  - `deploy/helm/sandbox-env`: prose/comments de-meshed across templates, values, README, examples, housekeeper; RBAC adds a fail-guard if `.Values.mesh` is set; preview Gateway docs clarified.
  - CI/tests: `mesh-1/2/3` → `studio-1/2/3` in compose, constants, scenarios; workflow log-dump targets updated.

<sup>Written for commit c35dc4d2921d892c15286d59f73fa2356c4bf37e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

