### PR TITLE
fix(sections-editor): cancel pending section/rule autosave timers on page switch

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -258,6 +258,11 @@ export function SectionsEditor({
     virtualMcpId,
     branch,
   });
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const ruleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sectionRuleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   // Reset form state when the active page or global block changes
   const [prevPath, setPrevPath] = useState(currentPath);
@@ -270,6 +275,15 @@ export function SectionsEditor({
     prevGlobalBlockKey !== activeGlobalBlockKey
   ) {
     queueMicrotask(() => pageBlockSave.flush());
+    // Cancel pending section/rule autosave timers — they read the latest
+    // render's decofile via latestRef, so left running across a page switch
+    // they'd write this page's stale edit into the new page's section at the
+    // same index instead of just being dropped.
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (ruleDebounceRef.current) clearTimeout(ruleDebounceRef.current);
+    if (sectionRuleDebounceRef.current) {
+      clearTimeout(sectionRuleDebounceRef.current);
+    }
     setPrevPath(currentPath);
     setPrevPageBlockKey(activePageBlockKey);
     setPrevGlobalBlockKey(activeGlobalBlockKey);
@@ -303,11 +317,6 @@ export function SectionsEditor({
   });
   const deleteBlock = useDeleteBlock({ orgSlug, virtualMcpId, branch });
   const [renameVariantPending, setRenameVariantPending] = useState(false);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const ruleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const sectionRuleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
   // Accumulates pending page header field changes to avoid losing edits
   const pendingPageFieldsRef = useRef<Record<string, string>>({});
 


### PR DESCRIPTION
A bug, not from an issue — found while reading `sections-editor.tsx`'s page/global-block reset effect.

**Failure scenario:** the section-form autosave (`scheduleAutoSave`), the page-variant-rule autosave (`scheduleRuleSave`), and the section-variant-rule autosave (`scheduleSectionRuleSave`) are each a hand-rolled `setTimeout` debounce (`debounceRef` / `ruleDebounceRef` / `sectionRuleDebounceRef`) whose callback reads the *current* render's state via `latestRef.current` when it fires, not the state at schedule time. The existing reset block (when `currentPath`/`activePageBlockKey`/`activeGlobalBlockKey` changes) already flushes the header/SEO debounced saver (`pageBlockSave.flush()`), but never cancelled these three timers. So: edit a field on page A, navigate to page B within the 700ms debounce window, and when the timer fires it reads page B's freshest `rawSections`/`activePageKey` from `latestRef` and writes page A's stale form value into page B's section at the same index — silently corrupting an unrelated page's content, with page A's real edit lost.

**Fix:** cancel all three timers in the same reset block that already flushes `pageBlockSave`, mirroring that existing cleanup. Had to hoist the three `useRef` declarations above the reset block (they were declared further down in source, after the block that now needs them) — no behavior change, same hooks called every render in the same relative order.

**Verification:** `bunx tsc --noEmit` in `apps/mesh` is green. No regression test added — reproducing this requires rendering the full `SectionsEditor` component with its network hooks (`useDecofile`, `useLiveMeta`, etc.) mocked, which falls outside this repo's unit-test tier (pure logic only, no mocks per TESTING.md) and there's no existing RTL harness for this component to extend; a real e2e repro needs the sandbox/Postgres infra this environment doesn't have. Reviewer can confirm by reading the reset block: `debounceRef`/`ruleDebounceRef`/`sectionRuleDebounceRef` are now cleared alongside `pageBlockSave.flush()` on the same page-switch condition.

Full CI validates the rest (lint, full typecheck, unit suite).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent cross-page autosave corruption by canceling pending section and rule debounce timers when switching pages or global blocks. This stops stale edits from being applied to the newly opened page.

- **Bug Fixes**
  - Clear `debounceRef`, `ruleDebounceRef`, and `sectionRuleDebounceRef` in the page/global-block reset path alongside `pageBlockSave.flush()`.
  - Hoisted the three `useRef` declarations above the reset block to enable clearing; hook order remains unchanged.

<sup>Written for commit 14bccfa96a8547967e50616df6f797d135215f20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

