### PR TITLE
fix(agent-icon): add aria-label to icon-only icon/color picker triggers

### DIFF
--- a/apps/mesh/src/web/components/icon-picker.tsx
+++ b/apps/mesh/src/web/components/icon-picker.tsx
@@ -124,6 +124,7 @@ export function IconPicker({
         <button
           type="button"
           data-testid="icon-picker-trigger"
+          aria-label="Change icon"
           disabled={disabled}
           className={cn(
             "relative group overflow-hidden",
@@ -232,6 +233,7 @@ function ColorPickerDropdown({
             "ring-foreground/20",
           )}
           title="Change color"
+          aria-label="Change color"
         />
       </PopoverTrigger>
       <PopoverContent
@@ -318,6 +320,7 @@ function IconsTab({
           onClick={onRandom}
           className="h-8 w-8 flex items-center justify-center rounded-md border border-border hover:bg-accent transition-colors shrink-0"
           title="Random icon"
+          aria-label="Random icon"
         >
           <Shuffle01 size={14} className="text-muted-foreground" />
         </button>

--- a/apps/mesh/src/web/components/simple-icon-picker.tsx
+++ b/apps/mesh/src/web/components/simple-icon-picker.tsx
@@ -69,6 +69,7 @@ export function SimpleIconPicker({
       <PopoverTrigger asChild>
         <button
           type="button"
+          aria-label="Change icon"
           disabled={disabled}
           className={cn(
             "size-7 shrink-0 rounded-md transition-colors flex items-center justify-center",


### PR DESCRIPTION
## Why
This follows the same accessibility-hardening pattern as #4903, #4907, #4915, #4922 (icon-only controls with no accessible name). Four icon-only trigger buttons in the agent-icon UI helpers had no `aria-label` and, in two cases, no `title` either — so a screen reader announces them as a bare "button" with no indication of what they do:

- `apps/mesh/src/web/components/icon-picker.tsx`: the main avatar trigger button (no label at all), the color-swatch dropdown trigger (had `title="Change color"` only), and the random-icon button (had `title="Random icon"` only).
- `apps/mesh/src/web/components/simple-icon-picker.tsx`: the icon-only trigger button (no label or title at all).

I deliberately left the per-icon grid buttons (`title={iconName}`) alone — each already carries a distinct accessible name via `title`, so touching all of them would balloon the diff for no accessibility gain.

Note: I looked at the 16-color raw Tailwind palette in `agent-icon.tsx` (flagged as high design-token debt) but skipped it — PR #4910 tried collapsing it to semantic tokens and PR #4928 had to revert it days later because it made icon glyphs disappear and broke legacy persisted color names. Not re-attempting that.

## Fix
Added `aria-label` to the four icon-only buttons listed above. Pure additive attribute change — no logic, styling, or behavior touched.

## How to confirm
Open the agent-icon picker (e.g. agent settings) and the simple icon picker, then inspect the trigger/color/random buttons in the accessibility tree (or with a screen reader) — each now announces its action instead of just "button".

## Verification
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — clean (exit 0)
- No logic branch was touched (static JSX attribute additions only), so no regression test is needed; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-labels to icon-only triggers in `apps/mesh` icon pickers so screen readers announce “Change icon”, “Change color”, and “Random icon” instead of just “button”. Accessibility-only change with no logic, styling, or behavior changes.

<sup>Written for commit 6d1efe4ceb81853c3609383b26eb4cc22a66cfca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

