### PR TITLE
refactor(chat): stop double-extracting pending plans/approvals in ChatHighlight

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/index.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/index.tsx
@@ -8,12 +8,8 @@ import {
 } from "@/web/hooks/use-preferences.ts";
 import { useChatPrefs, useChatStream, useChatTask } from "../context";
 import type { RequestOptions } from "../store/thread-connection";
-import { ApprovalHighlight, extractPendingApprovals } from "./approval";
-import {
-  ProposePlanHighlight,
-  extractPendingPlans,
-  selectActivePlan,
-} from "./propose-plan";
+import { ApprovalHighlight } from "./approval";
+import { ProposePlanHighlight, selectActivePlan } from "./propose-plan";
 import { UserAskQuestionHighlight } from "./user-ask-question";
 import { TodosHighlight } from "./todos";
 import { CollapsibleHighlight } from "./collapsible-highlight";
@@ -183,17 +179,6 @@ export function ChatHighlight() {
   const userAskParts = assistantParts.filter(
     (part) => part.type === "tool-user_ask",
   );
-  const pendingPlans = extractPendingPlans(assistantParts);
-  const pendingApprovals = extractPendingApprovals(
-    assistantParts as Array<{
-      type: string;
-      state?: string;
-      approval?: { id: string };
-      toolCallId?: string;
-      toolName?: string;
-      input?: unknown;
-    }>,
-  );
 
   const handleFixInChat = () => {
     if (error) {
@@ -276,7 +261,13 @@ export function ChatHighlight() {
     return <CreditsExhaustedBanner onDismiss={clearError} />;
   }
 
-  const { showError, showWarning, hasApprovals } = flags;
+  const {
+    showError,
+    showWarning,
+    hasApprovals,
+    pendingPlans,
+    pendingApprovals,
+  } = flags;
   const userAskKey = userAskParts.map((p) => p.toolCallId).join("|");
   const planKey = selectActivePlan(pendingPlans)?.toolCallId ?? "";
   const approvalKey = pendingApprovals.map((a) => a.approvalId).join("|");

--- a/apps/mesh/src/web/components/chat/highlight/use-highlight-count.test.ts
+++ b/apps/mesh/src/web/components/chat/highlight/use-highlight-count.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { UIMessage } from "ai";
-import { deriveHighlightFlags } from "./use-highlight-count";
+import { deriveHighlightFlags, type HighlightFlags } from "./use-highlight-count";
 
-const noFlags = {
+const noFlags: HighlightFlags = {
   isCreditExhausted: false,
   hasTodos: false,
   showError: false,
@@ -10,7 +10,9 @@ const noFlags = {
   hasApprovals: false,
   hasPlans: false,
   isWaitingForUserInput: false,
-} as const;
+  pendingPlans: [],
+  pendingApprovals: [],
+};
 
 const baseInput = {
   messages: [] as UIMessage[],

--- a/apps/mesh/src/web/components/chat/highlight/use-highlight-count.ts
+++ b/apps/mesh/src/web/components/chat/highlight/use-highlight-count.ts
@@ -13,8 +13,11 @@
 
 import type { UIMessage } from "ai";
 import { deriveCurrentTodos } from "./derive-current-todos";
-import { extractPendingApprovals } from "./extract-pending-approvals";
-import { extractPendingPlans } from "./extract-pending-plans";
+import {
+  extractPendingApprovals,
+  type PendingApproval,
+} from "./extract-pending-approvals";
+import { extractPendingPlans, type PendingPlan } from "./extract-pending-plans";
 import { isCreditError } from "../is-credit-error";
 import { useChatStream } from "../context";
 
@@ -26,6 +29,10 @@ export interface HighlightFlags {
   hasApprovals: boolean;
   hasPlans: boolean;
   isWaitingForUserInput: boolean;
+  // Exposed so callers that need to render the cards (not just decide
+  // whether to) don't re-run the same extraction over the same parts.
+  pendingPlans: PendingPlan[];
+  pendingApprovals: PendingApproval[];
 }
 
 export interface DeriveHighlightFlagsInput {
@@ -44,6 +51,8 @@ const EMPTY_FLAGS: HighlightFlags = {
   hasApprovals: false,
   hasPlans: false,
   isWaitingForUserInput: false,
+  pendingPlans: [],
+  pendingApprovals: [],
 };
 
 export function deriveHighlightFlags(
@@ -111,6 +120,8 @@ export function deriveHighlightFlags(
     hasApprovals,
     hasPlans,
     isWaitingForUserInput,
+    pendingPlans,
+    pendingApprovals,
   };
 }
 


### PR DESCRIPTION
**Source:** reduction found while hunting for redundant traversals in the chat-highlight pipeline (assigned focus area), not tied to a specific issue.

**Payoff:** `ChatHighlight()` called `extractPendingPlans`/`extractPendingApprovals` directly on `assistantParts`, while `useHighlightFlags()` — invoked in the very same render — already ran the identical extraction internally, using it only to derive the `hasPlans`/`hasApprovals` booleans and discarding the resulting arrays. Every render of the chat highlight stack walked the same last-message parts twice to get the same result.

**Fix:** `HighlightFlags` (from `use-highlight-count.ts`) now also exposes the already-computed `pendingPlans`/`pendingApprovals` arrays it derives internally. `ChatHighlight` reads them off `flags` instead of recomputing them, removing the duplicate `extractPendingPlans`/`extractPendingApprovals` calls and their now-unused imports. Net: -23/+27 lines (test fixture had to add the two new always-empty-by-default fields), pure dedup — no new logic, no behavior change. Confirmed by keeping every existing `deriveHighlightFlags` unit test passing unmodified in substance (only added the two new fields to the expected-flags fixture).

**Reviewer check:** `cd apps/mesh && bun test src/web/components/chat/highlight/use-highlight-count.test.ts` (9 pass) and `bunx tsc --noEmit` (clean).

**Local verification:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, and the targeted test file above all pass. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop double-extracting pending plans/approvals in `ChatHighlight` by reading `pendingPlans` and `pendingApprovals` from `useHighlightFlags`. Removes redundant traversal of assistant parts with no behavior change.

- **Refactors**
  - `HighlightFlags` now exposes `pendingPlans` and `pendingApprovals`.
  - `ChatHighlight` uses these from `flags`; removed direct `extractPendingPlans`/`extractPendingApprovals` calls and imports.
  - Updated tests to include the two new fields in fixtures.

<sup>Written for commit 5d92fb03b4ede26bdc973bec0e35ac035ddd4d02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

