### PR TITLE
feat(i18n): extract hardcoded strings in ProviderGrid to i18n dictionaries

### DIFF
--- a/apps/mesh/src/web/i18n/en/settings.ts
+++ b/apps/mesh/src/web/i18n/en/settings.ts
@@ -51,4 +51,12 @@ export const settings = {
   "settings.preferences.toolApprovalAuto": "Auto approve",
   "settings.preferences.toolApprovalAutoDescription":
     "Execute all without approval",
+  "settings.providerGrid.recommendedBadge":
+    "Recommended — 100+ models, pay as you go",
+  "settings.providerGrid.customOpenaiCompatibleTitle":
+    "Custom OpenAI-compatible",
+  "settings.providerGrid.customOpenaiCompatibleDescription":
+    "Bring your own model server (advanced)",
+  "settings.providerGrid.moreProviderSingular": "{count} more provider",
+  "settings.providerGrid.moreProvidersPlural": "{count} more providers",
 } as const;

--- a/apps/mesh/src/web/i18n/pt-br/settings.ts
+++ b/apps/mesh/src/web/i18n/pt-br/settings.ts
@@ -53,4 +53,12 @@ export const settings = {
   "settings.preferences.toolApprovalAuto": "Aprovar automaticamente",
   "settings.preferences.toolApprovalAutoDescription":
     "Executa tudo sem aprovação",
+  "settings.providerGrid.recommendedBadge":
+    "Recomendado — mais de 100 modelos, pague conforme o uso",
+  "settings.providerGrid.customOpenaiCompatibleTitle":
+    "OpenAI-compatível personalizado",
+  "settings.providerGrid.customOpenaiCompatibleDescription":
+    "Use seu próprio servidor de modelo (avançado)",
+  "settings.providerGrid.moreProviderSingular": "{count} provedor a mais",
+  "settings.providerGrid.moreProvidersPlural": "{count} provedores a mais",
 } satisfies Record<keyof typeof settingsEn, string>;

--- a/apps/mesh/src/web/views/settings/ai-providers/provider-grid.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/provider-grid.tsx
@@ -6,6 +6,7 @@ import {
   SettingsCardItem,
   SettingsSection,
 } from "@/web/components/settings/settings-section";
+import { useT } from "@/web/i18n/use-t.ts";
 import {
   getPreset,
   OPENAI_COMPATIBLE_PRESETS,
@@ -68,6 +69,7 @@ export function ProviderGrid({
   onSelect,
   onShowAll,
 }: ProviderGridProps) {
+  const t = useT();
   const deco = providers.find((p) => p.id === "deco");
   const CLOUD_ORDER: Record<string, number> = {
     openrouter: 0,
@@ -134,8 +136,10 @@ export function ProviderGrid({
           <ProviderTile
             key="custom"
             logo={openaiCompatible.logo}
-            name="Custom OpenAI-compatible"
-            description="Bring your own model server (advanced)"
+            name={t("settings.providerGrid.customOpenaiCompatibleTitle")}
+            description={t(
+              "settings.providerGrid.customOpenaiCompatibleDescription",
+            )}
             onClick={() =>
               onSelect({
                 kind: "openai-compatible",
@@ -161,7 +165,7 @@ export function ProviderGrid({
           <div className="relative rounded-xl border border-violet-400/30 bg-gradient-to-br from-violet-50/50 via-transparent to-lime-50/30 dark:from-violet-950/20 dark:to-lime-950/10 p-1.5">
             <div className="absolute inset-0 rounded-xl bg-gradient-to-br from-violet-400/5 to-lime-400/5 pointer-events-none" />
             <p className="text-xs font-medium text-violet-700 dark:text-violet-400 mb-1.5 px-2 pt-2 relative">
-              Recommended — 100+ models, pay as you go
+              {t("settings.providerGrid.recommendedBadge")}
             </p>
             <SettingsCard className="relative">
               <ProviderTile
@@ -181,7 +185,15 @@ export function ProviderGrid({
           {shouldPreview && (
             <SettingsCardItem
               onClick={onShowAll}
-              title={`${hiddenCount} more provider${hiddenCount === 1 ? "" : "s"}`}
+              title={
+                hiddenCount === 1
+                  ? t("settings.providerGrid.moreProviderSingular", {
+                      count: hiddenCount,
+                    })
+                  : t("settings.providerGrid.moreProvidersPlural", {
+                      count: hiddenCount,
+                    })
+              }
               action={
                 <ChevronRight size={16} className="text-muted-foreground" />
               }


### PR DESCRIPTION
Follows #4964, the in-flight i18n extraction of the settings area — that PR touches 8 files under `ai-providers/` but not `provider-grid.tsx`, so this component's copy was left hardcoded English and doesn't localize with the rest of Settings.

A maintainer wants this because it closes the last i18n gap in the AI-providers settings screen, keeping the whole area consistent for pt-BR users instead of mixing translated and untranslated strings on the same page.

Changes: the recommended-provider badge ("Recommended — 100+ models, pay as you go"), the "Custom OpenAI-compatible" tile title/description, and the "N more providers" preview row now go through `useT()` with new `settings.providerGrid.*` keys added to both `en/settings.ts` and `pt-br/settings.ts` (the `satisfies Record<keyof typeof settingsEn, string>` constraint on the pt-BR file enforces key parity at compile time). Pure string extraction — no logic or layout changes.

To verify: `bunx tsc --noEmit` in `apps/mesh` (confirms the pt-BR dictionary satisfies the en key set), and load Settings → AI Providers with the language preference set to Portuguese to see the translated copy.

Locally ran: `bun run fmt` and `cd apps/mesh && bunx tsc --noEmit` (both clean). No existing unit test covers this component's rendering (it's plain JSX text, not logic), so no test was added or needed; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted hardcoded copy in `ProviderGrid` to i18n so the AI Providers settings fully localize (including pt-BR). Added `settings.providerGrid.*` keys and wired the component to `useT()`; no logic or layout changes.

- **Refactors**
  - Moved the recommended badge, custom OpenAI-compatible tile title/description, and "N more providers" label to `en/settings.ts` and `pt-br/settings.ts`.
  - Added `settings.providerGrid.recommendedBadge`, `*.customOpenaiCompatibleTitle`, `*.customOpenaiCompatibleDescription`, and singular/plural "more providers" keys with `{count}`.
  - Enforced key parity with `satisfies Record<keyof typeof settingsEn, string>` in `pt-br/settings.ts`.

<sup>Written for commit 4050468de0c06fe8549b5e766a5d59cebda67541. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

