### PR TITLE
fix(helm): set a memory limit on the studio worker Deployment

### DIFF
--- a/deploy/helm/studio/README.md
+++ b/deploy/helm/studio/README.md
@@ -695,10 +695,19 @@ nginx:
       cpu: "500m"
     limits:
       memory: "256Mi"
+
+worker:
+  resources:
+    requests:
+      cpu: "1"
+      memory: 1Gi
+    limits:
+      memory: 1Gi
 ```
 
 `resources` applies to each Bun API container. With two API containers plus
-nginx, the main pod requests 2 CPU cores by default.
+nginx, the main pod requests 2 CPU cores by default. `worker.resources`
+applies to the separate worker Deployment's container.
 
 ### Health Checks
 

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -82,6 +82,8 @@ worker:
     requests:
       cpu: "1"
       memory: 1Gi
+    limits:
+      memory: 1Gi
   autoscaling:
     enabled: true
     minReplicas: 2


### PR DESCRIPTION
The studio chart's `worker.resources` (deploy/helm/studio/values.yaml) only set `requests` — no `limits` — unlike every other container resource block in this same chart (main API `resources`, `nginx.resources`, `s3Sync.resources`), which all pin `limits.memory == requests.memory`.

Why it matters: worker pods are CPU-bound on LLM streams and autoscale 2-30 replicas; with no memory ceiling a single worker pod leaking or spiking memory can OOM the node instead of being contained/OOM-killed on its own cgroup, which is exactly the resource-limit hardening this repo's helm charts otherwise enforce everywhere else (see `deploy/helm/sandbox-env/values.yaml`, which sets both requests and limits on all three of its resource blocks).

Change: add `limits.memory: 1Gi` to `worker.resources` (matching its existing `requests.memory: 1Gi`), and document it in the README's Resources section alongside the existing main/nginx examples.

How to verify: `cd deploy/helm/studio && helm lint . --set database.url=postgresql://x` and `helm template studio . --set database.url=postgresql://x --show-only templates/worker-deployment.yaml | grep -A4 resources:` — shows the worker container now renders `limits: memory: 1Gi` alongside its requests.

Locally ran: `helm lint` (0 charts failed) and `helm template` diffed against the prior render — confirmed the only change is the new `limits.memory` block, everything else byte-identical. No app code touched, so no `tsc`/`bun test` needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a 1Gi memory limit on the Studio worker Deployment to match its request and align with other containers, preventing runaway memory from OOMing nodes. Also updates the README to document the worker resources.

- **Bug Fixes**
  - Add `worker.resources.limits.memory: 1Gi` in `deploy/helm/studio/values.yaml` to match `requests.memory`.
  - Update `deploy/helm/studio/README.md` with a worker resources example and note that `worker.resources` applies to the worker Deployment.

<sup>Written for commit a6a8cce5b4c096576c6743014aeafb1d7710f98d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

