### PR TITLE
fix(registry): block SSRF via redirect on the primary MCP discovery path

### DIFF
--- a/apps/mesh/src/tools/registry/discover-tools.test.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { isPrivateUrl, parseToolsListResponse } from "./discover-tools";
+import {
+  fetchWithoutRedirects,
+  isPrivateUrl,
+  parseToolsListResponse,
+} from "./discover-tools";
 
 describe("isPrivateUrl", () => {
   it("blocks plain private/loopback/link-local IPv4", () => {
@@ -56,6 +60,29 @@ describe("isPrivateUrl", () => {
     expect(isPrivateUrl("https://example.com/mcp")).toBe(false);
     expect(isPrivateUrl("http://8.8.8.8/")).toBe(false);
     expect(isPrivateUrl("http://[::8.8.8.8]/")).toBe(false);
+  });
+});
+
+describe("fetchWithoutRedirects", () => {
+  it("forces redirect: manual so a remote server can't 3xx to a private address, even if called with redirect: follow", async () => {
+    const calls: RequestInit[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      calls.push(init ?? {});
+      return new Response("ok");
+    }) as typeof fetch;
+
+    try {
+      await fetchWithoutRedirects("http://example.com", {
+        redirect: "follow",
+        headers: { "x-test": "1" },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls[0]?.redirect).toBe("manual");
+    expect(calls[0]?.headers).toEqual({ "x-test": "1" });
   });
 });
 

--- a/apps/mesh/src/tools/registry/discover-tools.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.ts
@@ -191,6 +191,20 @@ export function parseToolsListResponse(text: string): DiscoverTool[] | null {
   }));
 }
 
+/**
+ * A remote MCP server could 3xx-redirect a connection to an internal address
+ * (e.g. a cloud metadata endpoint) to bypass the `isPrivateUrl` guard above,
+ * since `fetch` follows redirects by default. Passed as the SDK client's
+ * `fetch` option, this blocks that bypass the same way `tryRawToolsList`
+ * already does for its own raw fetch.
+ */
+export function fetchWithoutRedirects(
+  input: Parameters<typeof fetch>[0],
+  init?: RequestInit,
+): Promise<Response> {
+  return fetch(input, { ...init, redirect: "manual" });
+}
+
 async function tryRawToolsList(
   url: string,
   timeoutMs: number,
@@ -293,9 +307,11 @@ export const REGISTRY_DISCOVER_TOOLS = defineTool({
           attempt.transport === "sse"
             ? new SSEClientTransport(new URL(attempt.url), {
                 requestInit: { headers },
+                fetch: fetchWithoutRedirects,
               })
             : new StreamableHTTPClientTransport(new URL(attempt.url), {
                 requestInit: { headers },
+                fetch: fetchWithoutRedirects,
               });
 
         await Promise.race([client.connect(transport), makeTimeout()]);


### PR DESCRIPTION
**Source:** bug found while reviewing `apps/mesh/src/tools/registry/discover-tools.ts` (SSRF hardening for `REGISTRY_DISCOVER_TOOLS`).

**Why a maintainer wants this:** `isPrivateUrl` only vets the URL the caller supplies, but the primary connection path (the MCP SDK `Client` over `StreamableHTTPClientTransport`/`SSEClientTransport`) uses the default `fetch`, which follows redirects. A remote MCP server can pass a public URL through the guard, then respond with a 3xx redirect to a private/internal address (e.g. a cloud metadata endpoint like `169.254.169.254`), and the server-side fetch will transparently follow it — bypassing the SSRF guard entirely on this code path. The raw fallback path (`tryRawToolsList`) already defends against exactly this with `redirect: "manual"` (see the comment above it), but the primary SDK path was left exposed.

**Failure scenario:** attacker controls a public MCP server URL that passes `isPrivateUrl`; the server responds to `tools/list` (or the initial SSE/StreamableHTTP connection) with a 3xx redirect to an internal address; the default-fetch SDK client follows it and returns tool metadata sourced from the internal service, leaking its existence/response shape to the caller.

**Fix:** added `fetchWithoutRedirects`, a thin wrapper that forces `redirect: "manual"` regardless of caller-passed options, and passed it as the `fetch` option to both `StreamableHTTPClientTransport` and `SSEClientTransport` constructors (the SDK spreads/uses this custom `fetch` for every internal request in both transports, including the SSE transport's `EventSource`-backed initial connection). A blocked/opaque redirect surfaces as a non-ok response, which the SDK already treats as a connection failure — so this fails closed, matching the existing raw-fallback behavior.

**Regression test:** `discover-tools.test.ts` — new `describe("fetchWithoutRedirects", ...)` stubs `globalThis.fetch` and asserts the wrapper always forces `redirect: "manual"` even when called with `redirect: "follow"`, while still passing through other init fields (e.g. headers).

**To verify:** `bun test apps/mesh/src/tools/registry/discover-tools.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test file above (13 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks an SSRF redirect bypass in MCP tools discovery by forcing no-redirect fetches in the primary SDK path. Prevents following 3xx redirects to private/internal addresses and aligns behavior with the raw fallback.

- **Bug Fixes**
  - Added `fetchWithoutRedirects` to enforce `redirect: "manual"`.
  - Wired it into `SSEClientTransport` and `StreamableHTTPClientTransport` via the SDK client `fetch` option.
  - Redirects now fail the connection (non-ok), closing the bypass around `isPrivateUrl`.
  - Added tests to ensure the wrapper forces manual redirects and preserves other init fields.

<sup>Written for commit 2480ab14a49b86eebf5052c34cf7f9a528a534e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

