### PR TITLE
fix(sandbox): return 400 instead of crashing on malformed WebDAV request paths

### DIFF
--- a/apps/mesh/src/file-storage/mount/webdav.test.ts
+++ b/apps/mesh/src/file-storage/mount/webdav.test.ts
@@ -134,3 +134,12 @@ describe("WebDAV read push-down", () => {
     expect((await dav(new Request("http://dav/nope.txt"))).status).toBe(404);
   });
 });
+
+describe("WebDAV malformed request path", () => {
+  it("400s instead of throwing on invalid percent-encoding", async () => {
+    const fs = memFs();
+    const dav = createWebdavHandler(fs.api);
+    const res = await dav(new Request("http://dav/%zz"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/mesh/src/file-storage/mount/webdav.ts
+++ b/apps/mesh/src/file-storage/mount/webdav.ts
@@ -21,9 +21,16 @@ function xmlEscape(s: string): string {
     .replace(/"/g, "&quot;");
 }
 
-/** URL pathname (possibly encoded, with slashes) → normalized in-volume path. */
+/** URL pathname (possibly encoded, with slashes) → normalized in-volume path.
+ *  Throws OrgFsApiError(400) on invalid percent-encoding (e.g. `%zz`) instead
+ *  of letting decodeURIComponent's URIError escape as an uncaught rejection. */
 function pathFromUrl(req: Request): string {
-  const raw = decodeURIComponent(new URL(req.url).pathname);
+  let raw: string;
+  try {
+    raw = decodeURIComponent(new URL(req.url).pathname);
+  } catch {
+    throw new OrgFsApiError(400, "Malformed request path");
+  }
   return raw.replace(/^\/+/, "").replace(/\/+$/, "");
 }
 
@@ -133,30 +140,31 @@ export function createWebdavHandler(
       : api.stat(p);
 
   return async (req) => {
-    const path = pathFromUrl(req);
     const method = req.method.toUpperCase();
 
-    // mac junk never reaches the backing fs: pretend writes/deletes succeed
-    // (nothing stored), report reads as absent. A MOVE whose *source* is junk
-    // is equally a no-op; a real file moved TO a junk name falls through (a
-    // deliberate rename must not silently lose data).
-    if (isMacJunk(path)) {
-      switch (method) {
-        case "PUT":
-        case "MKCOL":
-        case "MOVE":
-          return new Response(null, { status: 201 });
-        case "DELETE":
-          return new Response(null, { status: 204 });
-        case "GET":
-        case "HEAD":
-        case "PROPFIND":
-          return new Response("Not Found", { status: 404 });
-        // OPTIONS/PROPPATCH/default fall through to the normal handling below.
-      }
-    }
-
     try {
+      const path = pathFromUrl(req);
+
+      // mac junk never reaches the backing fs: pretend writes/deletes succeed
+      // (nothing stored), report reads as absent. A MOVE whose *source* is
+      // junk is equally a no-op; a real file moved TO a junk name falls
+      // through (a deliberate rename must not silently lose data).
+      if (isMacJunk(path)) {
+        switch (method) {
+          case "PUT":
+          case "MKCOL":
+          case "MOVE":
+            return new Response(null, { status: 201 });
+          case "DELETE":
+            return new Response(null, { status: 204 });
+          case "GET":
+          case "HEAD":
+          case "PROPFIND":
+            return new Response("Not Found", { status: 404 });
+          // OPTIONS/PROPPATCH/default fall through to the normal handling below.
+        }
+      }
+
       switch (method) {
         case "OPTIONS":
           return new Response(null, {


### PR DESCRIPTION
A concrete validation gap in the sandbox daemon's in-process WebDAV server (`apps/mesh/src/file-storage/mount/webdav.ts`), which the org-fs mount daemon serves to rclone (loopback-only) to expose org-fs volumes as a real filesystem.

**Bug:** `pathFromUrl()` calls `decodeURIComponent(new URL(req.url).pathname)` to turn the request URL into an in-volume path, but that call was made *before* the handler's `try`/`catch`. A request whose path contains invalid percent-encoding (e.g. `GET /%zz`) makes `decodeURIComponent` throw a `URIError` that escapes uncaught instead of producing a clean HTTP error response — the exact kind of malformed input a filesystem client (buggy rclone cache state, unusual unicode filenames, etc.) can legitimately produce.

**Fix:** `pathFromUrl` now catches the decode error and throws a controlled `OrgFsApiError(400, ...)`, and the call site was moved inside the existing `try`/`catch` (which already maps `OrgFsApiError` to its status via `mapError`). Behavior for every valid path is unchanged — same normalization, same routing.

**Regression test:** added `"400s instead of throwing on invalid percent-encoding"` in `webdav.test.ts`, which reproduces the crash against the real handler (verified it throws before the fix) and asserts a 400 response after.

**Reviewer check:** `bun test apps/mesh/src/file-storage/mount/webdav.test.ts` (7 pass, including the new case).

**Locally verified:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test file above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 400 on malformed WebDAV request paths instead of crashing the sandbox daemon. Prevents uncaught errors when paths have invalid percent-encoding (e.g. `%zz`) while keeping behavior unchanged for valid paths.

- **Bug Fixes**
  - `pathFromUrl` now catches decode errors and throws `OrgFsApiError(400, "Malformed request path")`.
  - Moved URL parsing inside the handler `try/catch` so `mapError` returns a clean response.
  - Added a regression test that asserts a 400 for invalid percent-encoding.

<sup>Written for commit e86f717a2347dbd05c567383058aa920ca857923. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

