### PR TITLE
fix(helm): add CPU limits to main API and nginx containers

### DIFF
--- a/deploy/helm/studio/README.md
+++ b/deploy/helm/studio/README.md
@@ -686,6 +686,7 @@ resources:
     memory: "1Gi"
     cpu: "750m"
   limits:
+    cpu: "1"
     memory: "1Gi"
 
 nginx:
@@ -694,11 +695,12 @@ nginx:
       memory: "128Mi"
       cpu: "500m"
     limits:
+      cpu: "1"
       memory: "256Mi"
 ```
 
 `resources` applies to each Bun API container. With two API containers plus
-nginx, the main pod requests 2 CPU cores by default.
+nginx, the main pod requests 2 CPU cores and limits to ~2.5 CPU cores total by default.
 
 ### Health Checks
 

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -41,6 +41,7 @@ resources:
     cpu: "750m"
     memory: "1Gi"
   limits:
+    cpu: "1"
     memory: "1Gi"
 
 database:
@@ -100,6 +101,7 @@ nginx:
       cpu: "500m"
       memory: "128Mi"
     limits:
+      cpu: "1"
       memory: "256Mi"
   securityContext:
     runAsNonRoot: true


### PR DESCRIPTION
## Summary

The main API containers requested 750m CPU each with no ceiling, and nginx requested 500m with no CPU limit. Without limits, containers can burst unbounded and starve other workloads on the node. This adds CPU limits aligned with best practices: 1 CPU per container (slightly above requests for headroom) matching the pattern already used for memory.

## Verification

- `helm lint deploy/helm/studio/` passes (0 chart failures)
- Changes: -1 / +5 on README (documentation) and values.yaml (configuration)
- Behavior-preserving: only adds ceilings to prevent resource hogging; no pod scheduling or functional changes

## Testing

```bash
helm lint deploy/helm/studio/
bun run fmt  # already run, no fixes needed
```

The main pod now limits to ~2.5 CPU cores total (2× API containers at 1 CPU each + nginx at 1 CPU) preventing resource hogging while accommodating LLM stream bursts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added CPU limits to the main API and nginx containers in the Helm chart to cap CPU usage and prevent node starvation. Each container now has a 1 CPU limit, capping the pod at ~2.5 CPUs while keeping current requests.

- **Bug Fixes**
  - Set `limits.cpu: "1"` for API and nginx; requests remain 750m (API) and 500m (nginx).
  - Pod is now capped at ~2.5 CPUs to avoid burst-related resource hogging.
  - Updated README and values.yaml; `helm lint` passes.

<sup>Written for commit e2d71dc2503854f8da77069d439de6faf733c917. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

