### PR TITLE
test(sections-editor): cover rich-text link URL-scheme validation

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/rich-text-link-validation.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/rich-text-link-validation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { isSafeLinkUrl, normalizeLinkUrl } from "./rich-text-link-validation";
+
+describe("isSafeLinkUrl", () => {
+  test("allows safe protocols", () => {
+    expect(isSafeLinkUrl("https://example.com")).toBe(true);
+    expect(isSafeLinkUrl("http://example.com")).toBe(true);
+    expect(isSafeLinkUrl("mailto:a@example.com")).toBe(true);
+    expect(isSafeLinkUrl("tel:+15551234567")).toBe(true);
+    expect(isSafeLinkUrl("ftp://example.com/f")).toBe(true);
+  });
+
+  test("allows relative, dotted, and fragment links", () => {
+    expect(isSafeLinkUrl("/pages/about")).toBe(true);
+    expect(isSafeLinkUrl("./sibling")).toBe(true);
+    expect(isSafeLinkUrl("#section")).toBe(true);
+  });
+
+  test("blocks script-executing protocols, including case and whitespace bypasses", () => {
+    expect(isSafeLinkUrl("javascript:alert(1)")).toBe(false);
+    expect(isSafeLinkUrl("JavaScript:alert(1)")).toBe(false);
+    expect(isSafeLinkUrl(`java${String.fromCharCode(9)}script:alert(1)`)).toBe(
+      false,
+    );
+    expect(isSafeLinkUrl(`java${String.fromCharCode(10)}script:alert(1)`)).toBe(
+      false,
+    );
+    expect(isSafeLinkUrl(" javascript:alert(1)")).toBe(false);
+    expect(isSafeLinkUrl("data:text/html,<script>alert(1)</script>")).toBe(
+      false,
+    );
+    expect(isSafeLinkUrl("vbscript:msgbox(1)")).toBe(false);
+  });
+
+  test("rejects other unlisted protocols", () => {
+    expect(isSafeLinkUrl("ws://example.com")).toBe(false);
+    expect(isSafeLinkUrl("chrome-extension://abc/x")).toBe(false);
+  });
+});
+
+describe("normalizeLinkUrl", () => {
+  test("trims whitespace", () => {
+    expect(normalizeLinkUrl("  https://example.com  ")).toBe(
+      "https://example.com",
+    );
+  });
+
+  test("defaults a bare domain to https", () => {
+    expect(normalizeLinkUrl("example.com")).toBe("https://example.com");
+  });
+
+  test("passes through relative, dotted, and fragment links unchanged", () => {
+    expect(normalizeLinkUrl("/pages/about")).toBe("/pages/about");
+    expect(normalizeLinkUrl("./sibling")).toBe("./sibling");
+    expect(normalizeLinkUrl("#section")).toBe("#section");
+  });
+
+  test("passes through an already-scoped dangerous URL unchanged, leaving isSafeLinkUrl to reject it", () => {
+    expect(normalizeLinkUrl("javascript:alert(1)")).toBe("javascript:alert(1)");
+    expect(isSafeLinkUrl(normalizeLinkUrl("javascript:alert(1)"))).toBe(false);
+  });
+
+  test("returns empty for blank input", () => {
+    expect(normalizeLinkUrl("   ")).toBe("");
+  });
+});


### PR DESCRIPTION
Adds regression coverage for `isSafeLinkUrl`/`normalizeLinkUrl` in `apps/mesh/src/web/components/sections-editor/rich-text-link-validation.ts`.

**Source**: no issue/PR — a gap found while auditing the sections-editor directory: this file had zero test coverage.

**Why a maintainer wants it**: `isSafeLinkUrl` is the sole guard preventing a rich-text link inserted through the CMS editor from carrying a `javascript:`/`data:`/`vbscript:` URL. Since links are rendered into `<a href>` for every visitor of the published page, a regression here (e.g. someone "simplifying" the protocol check, or an allowlist typo) would reopen a stored-XSS vector with no test to catch it.

**Trust-boundary justification (C4 gate)**: this directly meets the *security/privacy* bar — it validates an untrusted, user-typed URL that crosses into rendered HTML served to site visitors, and its explicit purpose (per its own docstring) is blocking script-executing protocols.

**What the test covers**: allowed protocols (https/http/mailto/tel/ftp) and relative/fragment links; blocked protocols including case-variant (`JavaScript:`) and whitespace-in-scheme bypass attempts (`java\tscript:`, `java\nscript:`, leading space) that are known real-world sanitizer-bypass techniques, plus other unlisted protocols (`ws:`, `chrome-extension:`); and `normalizeLinkUrl`'s trim/bare-domain/pass-through behavior, confirming a dangerous URL that passes through `normalizeLinkUrl` unchanged still gets rejected by `isSafeLinkUrl`. I manually verified each bypass case against the actual implementation before writing the assertions (all currently pass — this is a coverage gap being closed, not a bug fix).

**Command a reviewer runs**: `bun test apps/mesh/src/web/components/sections-editor/rich-text-link-validation.test.ts`

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` in `apps/mesh` (clean), and the targeted test file above (9 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests for `isSafeLinkUrl` and `normalizeLinkUrl` in the sections editor to ensure only safe link schemes are allowed and dangerous ones are blocked. Covers allowed protocols (https/http/mailto/tel/ftp), relative/fragment paths, blocks case/whitespace-bypass variants and other unlisted schemes, and verifies normalization behavior without weakening rejection.

<sup>Written for commit 6634b0054a7f4c3a1d7db843b6abe0fde1a10571. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

