### PR TITLE
fix(sandbox-preview): add aria-label to param-picker chip and extract shared badge styling

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
@@ -38,6 +38,10 @@ const KIND_LABELS: Record<PathParamKind, { noun: string; heading: string }> = {
   category: { noun: "category", heading: "Categories" },
 };
 
+// Styling for parameter label badges (both the button and the inline badge in modal)
+const PARAM_LABEL_CLASS =
+  "rounded-sm bg-violet-500/15 px-1 py-0.5 text-[12px] text-violet-600 dark:text-violet-400";
+
 /**
  * Invoke a loader via the studio preview-invoke proxy (same-origin,
  * authenticated) — the same route useRunBlock uses. Fetching the preview
@@ -259,8 +263,9 @@ export function PathParamPickerChip({
           chip must not let clicks bubble. */}
       <button
         type="button"
+        aria-label={`Edit value for ${paramLabel}`}
         title={`Value for ${paramLabel} — click to pick`}
-        className="max-w-64 shrink-0 cursor-pointer truncate rounded-sm bg-violet-500/15 px-1 py-0.5 text-[12px] text-violet-600 hover:bg-violet-500/25 dark:text-violet-400"
+        className={`max-w-64 shrink-0 cursor-pointer truncate hover:bg-violet-500/25 ${PARAM_LABEL_CLASS}`}
         onClick={(e) => {
           e.stopPropagation();
           handleOpenChange(true);
@@ -283,7 +288,7 @@ export function PathParamPickerChip({
             <SearchSm size={16} className="shrink-0 text-foreground" />
             <span className="text-sm font-medium text-foreground">
               Pick a value for{" "}
-              <span className="rounded-sm bg-violet-500/15 px-1 py-0.5 font-mono text-[12px] text-violet-600 dark:text-violet-400">
+              <span className={`font-mono ${PARAM_LABEL_CLASS}`}>
                 {paramLabel}
               </span>
             </span>


### PR DESCRIPTION
## Summary

Adds missing `aria-label` to the path-param picker button for better screen reader support. Extracts the repeated parameter label styling (used in both the button and modal header badge) into a shared constant to ensure visual consistency and eliminate duplication.

## What changed

- Added `aria-label` attribute to the interactive path-param picker button (improves a11y for screen reader users)
- Extracted parameter label badge styling (`PARAM_LABEL_CLASS` constant) to eliminate duplication
- Both the button and the modal header badge now use the shared constant, ensuring they stay visually consistent

## Test plan

- `bun run fmt` ✓
- `bunx tsc --noEmit` in apps/mesh ✓
- `bun test apps/mesh/src/web/components/sandbox/preview/path-param-picker.test.ts` ✓ (40 pass)

## Verification

Behavior-preserving refactor:
- No logic changes, only styling extraction and a11y attribute addition
- All existing path-param picker tests pass
- TypeScript type check passes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an aria-label to the path‑param picker chip button to improve screen reader support. Extracts shared parameter badge styling into a constant used by both the chip and the modal header to keep visuals consistent and remove duplication.

<sup>Written for commit a53ee85f614f190cfabf62d8d133c594ae4760e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

