### PR TITLE
fix(registry): surface an error toast when starting or cancelling a QA run fails

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-dashboard.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-dashboard.tsx
@@ -12,6 +12,7 @@ import {
 import { Badge } from "@deco/ui/components/badge.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Card } from "@deco/ui/components/card.tsx";
+import { toast } from "sonner";
 import {
   useRegistryMonitorConfig,
   useMonitorResults,
@@ -367,11 +368,17 @@ export function MonitorDashboard({
     }
     lastStartRef.current = now;
     const effectiveMode = modeOverride ?? settings.monitorMode;
-    const created = await runStartMutation.mutateAsync({
-      ...settings,
-      monitorMode: effectiveMode,
-    });
-    onRunChange(created.run.id);
+    try {
+      const created = await runStartMutation.mutateAsync({
+        ...settings,
+        monitorMode: effectiveMode,
+      });
+      onRunChange(created.run.id);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to start QA run",
+      );
+    }
   };
 
   const onStart = async () => {
@@ -388,7 +395,13 @@ export function MonitorDashboard({
 
   const onCancel = async () => {
     if (!activeRunId) return;
-    await runCancelMutation.mutateAsync(activeRunId);
+    try {
+      await runCancelMutation.mutateAsync(activeRunId);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to cancel QA run",
+      );
+    }
   };
 
   const isRunning = run?.status === "running";


### PR DESCRIPTION
Bug found reading `apps/mesh/src/web/views/registry/monitor-dashboard.tsx` in the registry-ui-polish focus area ("missing error handling").

`startMonitor()` and `onCancel()` call `runStartMutation.mutateAsync(...)` / `runCancelMutation.mutateAsync(...)` directly with no try/catch, and neither `useMonitorRunStart`/`useMonitorRunCancel` (`apps/mesh/src/web/hooks/registry/use-monitor.ts`) define an `onError`. If `REGISTRY_MONITOR_RUN_START`/`REGISTRY_MONITOR_RUN_CANCEL` rejects (network error, a running-run conflict, any backend validation), the promise rejection is swallowed silently — the "Start QA run"/"Cancel" button just resets to idle with zero user feedback, so a user has no idea their click did nothing. Every sibling mutation call in the same directory (`registry-items-page.tsx`, `monitor-connections-panel.tsx`, `registry-settings-page.tsx`) already wraps its `mutateAsync` in try/catch + `toast.error` — this file was the one outlier missing it.

Fix: wrap both calls in try/catch and show `toast.error` with the thrown message, matching the existing pattern in this directory.

Reviewer command to see the fixed paths: read `apps/mesh/src/web/views/registry/monitor-dashboard.tsx` `startMonitor`/`onCancel` (lines ~363-403).

Verification run locally: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (no new errors — the only tsc errors on this branch are in an unrelated pre-existing untracked file, `apps/mesh/src/storage/types.test.ts`, not touched by this diff). No new test added: the fix is UI-wiring around an existing mutation hook, and a real component test would require mocking `useMonitorRunStart`/`useMonitorRunCancel` with `mock.module`, which falls outside this repo's unit-test tier (no-mocks rule in TESTING.md) — full CI/e2e coverage is out of scope for this bounded fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a `sonner` error toast when starting or cancelling a QA run fails in the Monitor Dashboard, replacing the previous silent failure with clear user feedback.

<sup>Written for commit 62afaf3923f47a7a30b8bf45b4173d816a52240a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

