### PR TITLE
refactor(agent-icon): remove unused aria-label prop from presentational component

### DIFF
--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -294,7 +294,6 @@ interface AgentAvatarProps {
   name: string;
   size?: AgentAvatarSize;
   className?: string;
-  "aria-label"?: string;
 }
 
 /** Colored background + centered icon — shared by all icon-rendering paths. */
@@ -303,13 +302,11 @@ function IconAvatar({
   color,
   size,
   className,
-  "aria-label": ariaLabel,
 }: {
   Icon: IconComponent;
   color: AgentIconColor;
   size: AgentAvatarSize;
   className?: string;
-  "aria-label"?: string;
 }) {
   const sizeConfig = SIZES[size];
   return (
@@ -322,7 +319,6 @@ function IconAvatar({
         "flex items-center justify-center shrink-0 outline-none ring-0 shadow-none",
         className,
       )}
-      aria-label={ariaLabel}
     >
       <Icon size={sizeConfig.icon} />
     </div>
@@ -334,7 +330,6 @@ export function AgentAvatar({
   name,
   size = "md",
   className,
-  "aria-label": ariaLabel,
 }: AgentAvatarProps) {
   const parsed = parseIconString(icon);
 
@@ -344,13 +339,7 @@ export function AgentAvatar({
     const Icon = IconComp ?? getDeterministicIcon(name).IconComp;
 
     return (
-      <IconAvatar
-        Icon={Icon}
-        color={color}
-        size={size}
-        className={className}
-        aria-label={ariaLabel}
-      />
+      <IconAvatar Icon={Icon} color={color} size={size} className={className} />
     );
   }
 
@@ -365,7 +354,6 @@ export function AgentAvatar({
         name={name}
         size={size}
         className={className}
-        aria-label={ariaLabel}
       />
     );
   }
@@ -379,7 +367,6 @@ export function AgentAvatar({
       color={color}
       size={size}
       className={className}
-      aria-label={ariaLabel}
     />
   );
 }
@@ -408,14 +395,12 @@ function AgentAvatarImage({
   name,
   size = "md",
   className,
-  "aria-label": ariaLabel,
 }: {
   url: string;
   color?: string;
   name: string;
   size?: AgentAvatarSize;
   className?: string;
-  "aria-label"?: string;
 }) {
   const [errored, setErrored] = useState(false);
   const sizeConfig = SIZES[size];
@@ -429,7 +414,6 @@ function AgentAvatarImage({
         color={color}
         size={size}
         className={className}
-        aria-label={ariaLabel}
       />
     );
   }
@@ -443,7 +427,6 @@ function AgentAvatarImage({
         "shrink-0 overflow-hidden outline-none ring-0 shadow-none",
         className,
       )}
-      aria-label={ariaLabel}
     >
       <img
         src={url}


### PR DESCRIPTION
## Summary
Removed the `aria-label` prop from `AgentAvatar` and its internal components (`IconAvatar`, `AgentAvatarImage`). The component is purely presentational and should not accept accessibility labels — these should be applied to interactive parent elements (buttons, links) wrapping the avatar instead.

## Why
The component accepted an `aria-label` prop but passed it to non-interactive div elements, which is semantically incorrect. No code was using this prop, so it was dead code. Parent components should handle accessibility labels on their own interactive elements.

## Changes
- Removed `aria-label` prop from `AgentAvatarProps` interface
- Removed `aria-label` parameter and usage from `IconAvatar`, `AgentAvatar`, and `AgentAvatarImage` functions
- No behavior change; tests pass

## Verification
- `bun run fmt` — passed
- `cd apps/mesh && bunx tsc --noEmit` — no errors
- `bun test ./apps/mesh/src/web/components/agent-icon.test.tsx` — 2 pass
- `git grep AgentAvatar.*aria-label` — no remaining usages

Net diff: -17 lines

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `aria-label` prop from `AgentAvatar`, `IconAvatar`, and `AgentAvatarImage` to match semantic HTML. The avatar is presentational, so labels belong on the interactive parent (button or link); no behavior change.

<sup>Written for commit 75877750c64866ac705cbe8d8380b30b25480649. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

