### PR TITLE
refactor(sandbox-preview): extract param label badge styling to constant

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
@@ -34,6 +34,9 @@ import {
 
 const PICKER_FETCH_TIMEOUT_MS = 10_000;
 
+const PARAM_LABEL_BADGE =
+  "rounded-sm bg-violet-500/15 px-1 py-0.5 text-[12px] text-violet-600 dark:text-violet-400";
+
 const KIND_LABELS: Record<PathParamKind, { noun: string; heading: string }> = {
   product: { noun: "product", heading: "Products" },
   category: { noun: "category", heading: "Categories" },
@@ -267,7 +270,10 @@ export function PathParamPickerChip({
         title={t("sandbox.pathParamPickerChip.buttonTitle", {
           paramLabel,
         })}
-        className="max-w-64 shrink-0 cursor-pointer truncate rounded-sm bg-violet-500/15 px-1 py-0.5 text-[12px] text-violet-600 hover:bg-violet-500/25 dark:text-violet-400"
+        className={cn(
+          PARAM_LABEL_BADGE,
+          "max-w-64 shrink-0 cursor-pointer truncate hover:bg-violet-500/25",
+        )}
         onClick={(e) => {
           e.stopPropagation();
           handleOpenChange(true);
@@ -294,7 +300,7 @@ export function PathParamPickerChip({
             <SearchSm size={16} className="shrink-0 text-foreground" />
             <span className="text-sm font-medium text-foreground">
               {t("sandbox.pathParamPickerChip.pickValueHeading")}{" "}
-              <span className="rounded-sm bg-violet-500/15 px-1 py-0.5 font-mono text-[12px] text-violet-600 dark:text-violet-400">
+              <span className={cn(PARAM_LABEL_BADGE, "font-mono")}>
                 {paramLabel}
               </span>
             </span>

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, SearchSm } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.js";
 import {
   Command,
   CommandEmpty,


### PR DESCRIPTION
## Summary

Extract the repeated `rounded-sm bg-violet-500/15 px-1 py-0.5 text-[12px] text-violet-600 dark:text-violet-400` class string into a `PARAM_LABEL_BADGE` constant in `path-param-picker-chip.tsx`. Both the button chip (line 270) and the modal header badge (line 297) use identical base styling—consolidating reduces duplication and ensures visual consistency across both usages.

## Verification

- Behavior-preserving: visual rendering and interaction unchanged; styles applied identically via `cn()` utility
- `-4 / +7` net change (8 lines changed total, -11 bytes overall); extracts one unified source of truth
- `bun run fmt` passes; `bunx tsc --noEmit` passes in apps/mesh; related path-param-picker tests pass (40 tests)

## Technical details

The constant consolidation:
- Eliminates copy-pasted styling strings across two JSX nodes
- Uses `cn(PARAM_LABEL_BADGE, ...)` to compose base badge with variant classes (e.g., `hover:bg-violet-500/25`, `font-mono`)
- No functional changes; same CSS classes rendered in the same order

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted param badge styles into `PARAM_LABEL_BADGE` in `path-param-picker-chip.tsx` and added the missing `cn` import. No behavior changes; chip and modal remain consistent.

<sup>Written for commit 9ff7de584d08f0330f01cffaa9463124fe810bca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

