### PR TITLE
fix(settings): validate DUCKDB_THREADS instead of silently producing NaN

### DIFF
--- a/apps/mesh/src/settings/resolve-config.test.ts
+++ b/apps/mesh/src/settings/resolve-config.test.ts
@@ -103,6 +103,29 @@ describe("resolveConfig database pool max", () => {
   );
 });
 
+describe("resolveConfig duckdb threads", () => {
+  it("defaults to undefined when unset", () => {
+    const result = resolveConfig(flags, {});
+
+    expect(result.settings.duckdbThreads).toBeUndefined();
+  });
+
+  it("uses DUCKDB_THREADS when set", () => {
+    const result = resolveConfig(flags, { DUCKDB_THREADS: "4" });
+
+    expect(result.settings.duckdbThreads).toBe(4);
+  });
+
+  it.each(["abc", "0", "-1", "1.5", "Infinity"])(
+    "throws for invalid thread count %p",
+    (value) => {
+      expect(() => resolveConfig(flags, { DUCKDB_THREADS: value })).toThrow(
+        "DUCKDB_THREADS must be a positive integer",
+      );
+    },
+  );
+});
+
 describe("resolveConfig deployment admin emails", () => {
   it("defaults to an empty list when unset", () => {
     const result = resolveConfig(flags, {});

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -57,6 +57,19 @@ function toPositiveIntegerOrDefault(
   return numberValue;
 }
 
+function toPositiveIntegerOrUndefined(
+  name: string,
+  value: string | undefined,
+): number | undefined {
+  if (value === undefined || value === "") return undefined;
+
+  const numberValue = Number(value);
+  if (!Number.isSafeInteger(numberValue) || numberValue <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return numberValue;
+}
+
 /** Tri-state flag: unset/empty → `fallback`, otherwise parse as boolean. */
 function toBoolWithDefault(
   value: string | undefined,
@@ -219,9 +232,10 @@ export function resolveConfig(
     duckdbExtensionDirectory:
       envVars.DUCKDB_EXTENSION_DIRECTORY || "/opt/duckdb/extensions",
     duckdbMemoryLimit: envVars.DUCKDB_MEMORY_LIMIT || undefined,
-    duckdbThreads: envVars.DUCKDB_THREADS
-      ? Number(envVars.DUCKDB_THREADS)
-      : undefined,
+    duckdbThreads: toPositiveIntegerOrUndefined(
+      "DUCKDB_THREADS",
+      envVars.DUCKDB_THREADS,
+    ),
 
     // Runtime flags
     isCli: true,


### PR DESCRIPTION
Bug (same class as PORT/DATABASE_POOL_MAX, this tick's other session): `resolveConfig` parsed `DUCKDB_THREADS` as `envVars.DUCKDB_THREADS ? Number(envVars.DUCKDB_THREADS) : undefined` — unlike `CLICKHOUSE_MAX_MEMORY_USAGE` (which falls back to `undefined` via `|| undefined`), an invalid value here (e.g. `DUCKDB_THREADS=abc`) produces `NaN`, which is then threaded into `DuckDBTuning.threads` and stringified into the DuckDB instance `threads` config (`apps/mesh/src/monitoring/query-engine.ts`), causing a cryptic runtime failure when the embedded monitoring DuckDB engine spins up instead of a clear startup error.

A maintainer wants this because it turns a silent/cryptic monitoring-engine failure into a clear fail-fast error at config-resolution time, matching the validation already applied to `PORT` and `DATABASE_POOL_MAX`.

Fix: added `toPositiveIntegerOrUndefined` (same shape as the existing `toPositiveIntegerOrDefault` but with no default, since DuckDB threads legitimately has no numeric default — unset means "use all CPUs") and used it for `DUCKDB_THREADS`. Throws `"DUCKDB_THREADS must be a positive integer"` for non-integer/non-positive values, same as the sibling validators.

Regression test: added a `describe("resolveConfig duckdb threads")` block to `resolve-config.test.ts` covering the unset-default, valid-value, and invalid-value-throws cases (mirroring the existing `DATABASE_POOL_MAX`/`NATS_TUNNEL_SESSION_TTL_SECONDS` test blocks).

Reviewer check: `bun test apps/mesh/src/settings/resolve-config.test.ts`

Locally ran: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, and the targeted test file above (all green). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate DUCKDB_THREADS during config resolution to fail fast on invalid values, preventing NaN from reaching DuckDB and causing a cryptic startup crash in the monitoring engine.

- **Bug Fixes**
  - Added toPositiveIntegerOrUndefined and used it for DUCKDB_THREADS; invalid values throw "DUCKDB_THREADS must be a positive integer", unset stays undefined (use all CPUs).
  - Added tests for unset, valid, and invalid cases in apps/mesh/src/settings/resolve-config.test.ts.

<sup>Written for commit 9bd1d79f3c91f0c461d431461404d68e3fa27a26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

