### PR TITLE
fix(web): reload the preview iframe through about:blank on retry

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview-iframe-recovery.test.ts
+++ b/apps/web/src/components/sandbox/preview/preview-iframe-recovery.test.ts
@@ -1,0 +1,82 @@
+import { setupComponentTest } from "../../../../test/setup";
+setupComponentTest();
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { renderHook, act } from "@testing-library/react";
+import type { RefObject } from "react";
+import { useIframeLoadRecovery } from "./preview-iframe-recovery";
+
+// Fakes setTimeout/clearTimeout with a manually-flushed queue so the
+// watchdog/backoff timers in the hook can be advanced synchronously without
+// waiting out real delays (LOAD_TIMEOUT_MS/RETRY_BASE_MS are 10s/1s).
+function installFakeTimers() {
+  const queue: Array<{ id: number; fn: () => void }> = [];
+  let nextId = 1;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  globalThis.setTimeout = ((fn: () => void) => {
+    const id = nextId++;
+    queue.push({ id, fn });
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+  globalThis.clearTimeout = ((id?: unknown) => {
+    const idx = queue.findIndex((t) => t.id === id);
+    if (idx !== -1) queue.splice(idx, 1);
+  }) as typeof clearTimeout;
+  return {
+    flushNext() {
+      const next = queue.shift();
+      if (!next) throw new Error("no pending timer to flush");
+      act(() => next.fn());
+    },
+    restore() {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    },
+  };
+}
+
+function createTrackedIframe() {
+  const srcHistory: string[] = [];
+  let src = "";
+  const iframe = {
+    get src() {
+      return src;
+    },
+    set src(value: string) {
+      src = value;
+      srcHistory.push(value);
+    },
+  } as HTMLIFrameElement;
+  return { iframe, srcHistory };
+}
+
+describe("useIframeLoadRecovery", () => {
+  let timers: ReturnType<typeof installFakeTimers>;
+
+  beforeEach(() => {
+    timers = installFakeTimers();
+  });
+
+  afterEach(() => {
+    timers.restore();
+  });
+
+  it("bounces through about:blank before restoring the stuck src, since reassigning the identical string is a no-op in some browsers", () => {
+    const { iframe, srcHistory } = createTrackedIframe();
+    const src = "https://sandbox.example.dev/";
+    iframe.src = src;
+    const iframeRef = {
+      current: iframe,
+    } as RefObject<HTMLIFrameElement | null>;
+
+    renderHook(() => useIframeLoadRecovery({ iframeRef, src, active: true }));
+
+    // No `load` event ever arrives → the load-timeout watchdog fires and
+    // schedules a backoff reload.
+    timers.flushNext();
+    // The backoff reload fires and must reassign `src`.
+    timers.flushNext();
+
+    expect(srcHistory.slice(-2)).toEqual(["about:blank", src]);
+  });
+});

--- a/apps/web/src/components/sandbox/preview/preview-iframe-recovery.ts
+++ b/apps/web/src/components/sandbox/preview/preview-iframe-recovery.ts
@@ -90,7 +90,11 @@ export function useIframeLoadRecovery({
       const iframe = iframeRef.current;
       const currentSrc = srcRef.current;
       if (!iframe || !currentSrc || !activeRef.current) return;
-      // Reassign `src` to re-trigger the navigation that never completed.
+      // Reassigning `src` to the identical string is a no-op in some browsers
+      // (e.g. Firefox skips the navigation entirely when the URL is unchanged) —
+      // exactly the case here, since the stuck frame never left this URL. Force
+      // a real reload via a blank interstitial before restoring the target.
+      iframe.src = "about:blank";
       iframe.src = currentSrc;
       armWatchdog();
     }, delay);


### PR DESCRIPTION
Follows #5324 (self-heal preview iframe stuck on connection-refused), merged to main just before this run.

## The bug

`useIframeLoadRecovery`'s retry path (`preview-iframe-recovery.ts`) reassigns the iframe's `src` to the exact same URL string it already has to force a reload:

```ts
iframe.src = currentSrc;
```

But in the failure case this watchdog exists to recover from, the iframe never navigated away from that URL in the first place (it's stuck on the browser's connection-refused page while `src` still reads the sandbox URL). Reassigning an unchanged `src` string is a documented no-op in several browsers (Firefox in particular skips the navigation entirely when the value doesn't change; this is the well-known "iframe src reload hack is unreliable" gotcha). So the entire self-heal mechanism silently does nothing in those browsers — it schedules retries forever but the frame never actually reloads.

## The fix

Bounce through `about:blank` before restoring the target URL, so the assignment always differs from the previous value and reliably triggers a real navigation:

```ts
iframe.src = "about:blank";
iframe.src = currentSrc;
```

## Regression test

Added `preview-iframe-recovery.test.ts`, which fakes `setTimeout`/`clearTimeout` with a manually-flushed queue (the real watchdog/backoff delays are 10s/1s) and asserts the iframe's `src` assignment sequence on retry. Confirmed it fails against the pre-fix code (`git stash` + rerun) with the exact same-string no-op it's meant to catch, and passes with the fix.

## To verify

```
bun test apps/web/src/components/sandbox/preview/preview-iframe-recovery.test.ts
```

## Checks run locally

- `bun run fmt`
- `bunx tsc --noEmit` in `apps/web`
- targeted test above (green)

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview iframe self-heal so retries trigger a real reload by bouncing through about:blank. Prevents endless retries on browsers that treat same-URL `src` assignments as no-ops (e.g., Firefox).

- **Bug Fixes**
  - Update `useIframeLoadRecovery` to set `iframe.src = "about:blank"` before restoring the target URL.
  - Add a regression test to assert the `about:blank → target` sequence with fake timers.

<sup>Written for commit a4e7ca1c0aa51b4a76fd856d966b6c2423cf80f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

