### PR TITLE
fix(web): add API Keys menu item to settings navigation

### DIFF
--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -4,6 +4,7 @@ export const settings = {
   "settings.nav.general": "General",
   "settings.nav.brandContext": "Brand Context",
   "settings.nav.aiProviders": "AI Providers",
+  "settings.nav.apiKeys": "API Keys",
   "settings.nav.secrets": "Secrets",
   "settings.nav.buckets": "Buckets",
   "settings.nav.build": "Build",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -6,6 +6,7 @@ export const settings = {
   "settings.nav.general": "Geral",
   "settings.nav.brandContext": "Contexto da marca",
   "settings.nav.aiProviders": "Provedores de IA",
+  "settings.nav.apiKeys": "Chaves de API",
   "settings.nav.secrets": "Segredos",
   "settings.nav.buckets": "Buckets",
   "settings.nav.build": "Criação",

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -501,6 +501,14 @@ const settingsAiProvidersRoute = createRoute({
   ),
 });
 
+const settingsApiKeysRoute = createRoute({
+  getParentRoute: () => settingsLayout,
+  path: "/api-keys",
+  component: lazyRouteComponent(
+    () => import("./routes/orgs/settings/api-keys.tsx"),
+  ),
+});
+
 const settingsSecretsRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/secrets",
@@ -611,6 +619,7 @@ const settingsWithChildren = settingsLayout.addChildren([
   settingsConnectRoute,
   settingsBrandContextRoute,
   settingsAiProvidersRoute,
+  settingsApiKeysRoute,
   settingsSecretsRoute,
   settingsBucketsRoute,
   settingsMembersRoute,

--- a/apps/web/src/layouts/settings-layout.tsx
+++ b/apps/web/src/layouts/settings-layout.tsx
@@ -124,6 +124,13 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
           requires: "ai-providers:manage",
         },
         {
+          key: "api-keys",
+          label: t("settings.nav.apiKeys"),
+          icon: <Key01 size={14} />,
+          to: "/$org/settings/api-keys",
+          requires: "api-keys:manage",
+        },
+        {
           key: "secrets",
           label: t("settings.nav.secrets"),
           icon: <Key01 size={14} />,

--- a/apps/web/src/routes/orgs/settings/api-keys.tsx
+++ b/apps/web/src/routes/orgs/settings/api-keys.tsx
@@ -1,0 +1,5 @@
+import { OrgApiKeysPage } from "@/views/settings/api-keys";
+
+export default function Page() {
+  return <OrgApiKeysPage />;
+}

--- a/apps/web/src/views/settings/api-keys.tsx
+++ b/apps/web/src/views/settings/api-keys.tsx
@@ -1,0 +1,101 @@
+import { Suspense } from "react";
+import { AlertCircle, Key01 } from "@untitledui/icons";
+import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import { ErrorBoundary } from "@/components/error-boundary";
+import { Page } from "@/components/page";
+import { SettingsPage } from "@/components/settings/settings-section";
+import { useT } from "@/i18n/use-t.ts";
+import type { ApiKey } from "@/hooks/use-api-keys";
+import { useApiKeysList } from "@/hooks/use-api-keys";
+
+function ErrorFallback({ error }: { error: Error }) {
+  return (
+    <div className="p-4 rounded-md bg-destructive/10 text-destructive flex items-center gap-2">
+      <AlertCircle size={16} />
+      <span className="text-sm font-medium">
+        Failed to load API keys: {error.message}
+      </span>
+    </div>
+  );
+}
+
+function ApiKeyRow({ apiKey }: { apiKey: ApiKey }) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-3 border-b border-border/60 last:border-b-0">
+      <div className="flex items-start gap-3 min-w-0">
+        <div className="size-9 rounded-md bg-muted flex items-center justify-center shrink-0">
+          <Key01 size={16} className="text-muted-foreground" />
+        </div>
+        <div className="min-w-0">
+          <span className="font-medium text-sm truncate">{apiKey.name}</span>
+        </div>
+      </div>
+      <div className="text-xs text-muted-foreground shrink-0">
+        {new Date(apiKey.createdAt).toLocaleDateString()}
+      </div>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-2xl border border-dashed border-border/60 p-10 flex flex-col items-center justify-center text-center gap-3">
+      <div className="size-12 rounded-full bg-muted flex items-center justify-center">
+        <Key01 size={20} className="text-muted-foreground" />
+      </div>
+      <div>
+        <p className="font-medium text-sm">No API keys yet</p>
+        <p className="text-xs text-muted-foreground mt-1 max-w-sm">
+          Create API keys to access Studio programmatically from scripts and
+          automation tools.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ApiKeysContent() {
+  const { data: keys, isLoading } = useApiKeysList();
+
+  if (isLoading) {
+    return <Skeleton className="h-64 w-full" />;
+  }
+
+  if (!keys || keys.length === 0) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className="space-y-3">
+      {keys.map((apiKey) => (
+        <ApiKeyRow key={apiKey.id} apiKey={apiKey} />
+      ))}
+    </div>
+  );
+}
+
+export function OrgApiKeysPage() {
+  const t = useT();
+  return (
+    <Page>
+      <Page.Content>
+        <Page.Body>
+          <SettingsPage>
+            <Page.Title>{t("settings.nav.apiKeys")}</Page.Title>
+            <ErrorBoundary
+              fallback={({ error }) => (
+                <ErrorFallback
+                  error={error ?? new Error("Failed to load API keys")}
+                />
+              )}
+            >
+              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                <ApiKeysContent />
+              </Suspense>
+            </ErrorBoundary>
+          </SettingsPage>
+        </Page.Body>
+      </Page.Content>
+    </Page>
+  );
+}


### PR DESCRIPTION
## Summary

Add the missing API Keys entry to the settings menu for users with the `api-keys:manage` capability. The API Keys feature was documented and functional via the API Key Manager agent, but had no entry in the settings sidebar, making it invisible to users who expected it there.

Includes a settings page view that lists existing API keys with creation dates, plus full i18n translations (English and Portuguese).

## Test Plan

- [ ] Verify the "API Keys" menu item appears in settings for users with the `api-keys:manage` capability
- [ ] Verify the menu item is hidden for users without the capability
- [ ] Verify clicking "API Keys" navigates to `/$org/settings/api-keys`
- [ ] Verify the API Keys page displays existing keys from `useApiKeysList()`
- [ ] Verify empty state renders when no keys exist
- [ ] Verify Portuguese translation displays correctly when language is set to pt-BR

## Implementation Details

- Added `api-keys` menu item to `useSettingsSidebarGroups()` in `settings-layout.tsx`, gated by `requires: "api-keys:manage"`
- Added translation keys to both `i18n/en/settings.ts` and `i18n/pt-br/settings.ts`
- Created route file at `routes/orgs/settings/api-keys.tsx` that renders `OrgApiKeysPage`
- Created view component at `views/settings/api-keys.tsx` that displays API keys using the existing `useApiKeysList()` hook
- Used existing `Key01` icon to match other credential-related menu items (secrets)
- Menu placement: below "AI Providers" in the Organization section, above "Secrets"

Behavior is preserved: no existing tests affected, no API changes. Type checking passes with no errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing “API Keys” item to Settings for users with `api-keys:manage`, plus a page to view existing keys. Wires the route into the router so API key management is now discoverable and navigable, with EN/pt-BR translations.

- **New Features**
  - Adds “API Keys” under “AI Providers,” above “Secrets,” gated by `api-keys:manage`.
  - Adds `/$org/settings/api-keys` and lazy-loads the page in the router.
  - New page lists keys from `useApiKeysList()` with creation dates, plus empty state, loading skeleton, and error handling.

<sup>Written for commit 5f172be4b842d21f89b29190d527b7681bcb177d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

