### PR TITLE
refactor(harness): use @decocms/shared/std's sleep in gemini-interactions poll loop

### DIFF
--- a/packages/harness/src/decopilot/gemini-interactions.test.ts
+++ b/packages/harness/src/decopilot/gemini-interactions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { pollInteraction } from "./gemini-interactions";
+
+describe("pollInteraction", () => {
+  test("rejects with an Error named AbortError when aborted mid-poll", async () => {
+    const originalFetch = globalThis.fetch;
+    const controller = new AbortController();
+    globalThis.fetch = (async () => {
+      // Abort right after the first poll response comes back, so the loop's
+      // next `sleep` is what has to reject.
+      controller.abort();
+      return new Response(
+        JSON.stringify({ status: "in_progress", steps: [] }),
+        {
+          status: 200,
+        },
+      );
+    }) as never;
+
+    try {
+      let caught: unknown;
+      try {
+        await pollInteraction({
+          apiKey: "k",
+          interactionId: "i1",
+          abortSignal: controller.signal,
+          pollIntervalMs: 10,
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).name).toBe("AbortError");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/packages/harness/src/decopilot/gemini-interactions.ts
+++ b/packages/harness/src/decopilot/gemini-interactions.ts
@@ -14,6 +14,7 @@
  * `Error` for transient HTTP/network problems (the job may still be running,
  * keep the handle for a future reconnect).
  */
+import { sleep as stdSleep } from "@decocms/shared/std";
 import { AsyncResearchTerminalError } from "./async-research-terminal-error";
 
 /**
@@ -365,18 +366,13 @@ function parseUsage(payload: Record<string, unknown>): {
   return { inputTokens, outputTokens };
 }
 
+// `@decocms/shared/std`'s `sleep` may reject with a raw AbortSignal `reason`
+// (e.g. a DOMException, which is NOT `instanceof Error`) — normalize through
+// `makeAbortError` so callers (and `classifyStreamError`'s `instanceof Error`
+// check) keep seeing the same shape as before this used the shared primitive.
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (signal?.aborted) return reject(makeAbortError(signal));
-    const t = setTimeout(() => {
-      signal?.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    const onAbort = () => {
-      clearTimeout(t);
-      reject(makeAbortError(signal));
-    };
-    signal?.addEventListener("abort", onAbort, { once: true });
+  return stdSleep(ms, { signal }).catch(() => {
+    throw makeAbortError(signal);
   });
 }
 


### PR DESCRIPTION
**Source:** C1 reduction — reinvented stdlib. `pollInteraction`'s poll loop (Gemini Deep Research usage/cost tracking path, `packages/harness/src/decopilot/gemini-interactions.ts`) hand-rolled a `new Promise` + `setTimeout` + `AbortController` sleep instead of using `@decocms/shared/std`'s canonical `sleep(ms, { signal })`, which is already the established pattern elsewhere in this same package (see `liveness-heartbeat.ts`, which explicitly calls out this rule from CLAUDE.md/AGENTS.md).

**Why a maintainer wants it:** one fewer hand-rolled setTimeout/AbortController wait to maintain, consistent with the repo's consolidated async-primitives rule; net line reduction (-11/+7 in the source file).

**Behavior preserved:** `@decocms/shared/std`'s `sleep` may reject with a raw `AbortSignal.reason` (which can be a `DOMException`, NOT `instanceof Error`), whereas callers here (and `classifyStreamError`'s `error instanceof Error && error.name === "AbortError"` check) expect a real `Error`. The replacement keeps the existing `makeAbortError` normalization by wrapping the shared `sleep` call in a `.catch()` that re-throws through it — so the rejection shape is byte-identical to before in both the pre-aborted and abort-mid-sleep cases.

**Regression test:** added `gemini-interactions.test.ts`, which mocks `fetch` to abort mid-poll and asserts `pollInteraction` rejects with an `Error` named `"AbortError"` — this is the case the manual wrapper exists to guarantee, and it would have caught a naive swap-in of the shared `sleep` without the normalization.

**Reviewer check:** `bun test packages/harness/src/decopilot/gemini-interactions.test.ts`

**Locally verified:** `bun run fmt`, `cd packages/harness && bunx tsc --noEmit` (clean), and the targeted test above (1 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the custom sleep in the Gemini interactions poll loop with the shared `sleep` from `@decocms/shared/std`, keeping abort behavior identical. Added a regression test to ensure aborts still throw an Error named "AbortError".

- **Refactors**
  - Use `@decocms/shared/std`'s `sleep(ms, { signal })` in `pollInteraction` instead of a manual Promise/timeout.
  - Catch `sleep` rejections and rethrow via `makeAbortError` to preserve the exact `Error` shape for pre-abort and mid-sleep aborts.

<sup>Written for commit 4093c058ed5ffc7b66fd0084711c4b43f86a7bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

