### PR TITLE
feat(sandbox): push daemon dependency-cache metrics over OTLP

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/api": {
       "name": "decocms",
-      "version": "4.137.2",
+      "version": "4.139.13",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -213,7 +213,7 @@
     },
     "packages/bindings": {
       "name": "@decocms/bindings",
-      "version": "1.4.12",
+      "version": "1.5.0",
       "dependencies": {
         "@decocms/mcp-utils": "^1.0.5",
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -230,7 +230,7 @@
     },
     "packages/e2e": {
       "name": "@decocms/e2e",
-      "version": "1.23.0",
+      "version": "1.24.1",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/sandbox": "workspace:*",
@@ -252,7 +252,7 @@
     },
     "packages/harness": {
       "name": "@decocms/harness",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.85",
         "@ai-sdk/google": "^3.0.83",
@@ -274,7 +274,7 @@
     },
     "packages/mcp-utils": {
       "name": "@decocms/mcp-utils",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -290,7 +290,7 @@
     },
     "packages/runtime": {
       "name": "@decocms/runtime",
-      "version": "2.3.5",
+      "version": "2.3.7",
       "dependencies": {
         "@cloudflare/workers-types": "^4.20250617.0",
         "@decocms/bindings": "^1.0.7",
@@ -311,13 +311,16 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "1.23.0",
+      "version": "1.24.2",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/shared": "workspace:*",
         "@kubernetes/client-node": "^1.4.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.211.0",
+        "@opentelemetry/resources": "^2.6.0",
+        "@opentelemetry/sdk-metrics": "^2.2.0",
         "node-pty": "^1.0.0",
         "zod": "^4.0.0",
       },
@@ -330,7 +333,7 @@
     },
     "packages/shared": {
       "name": "@decocms/shared",
-      "version": "0.5.1",
+      "version": "0.7.1",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.1",
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -349,7 +352,7 @@
     },
     "packages/typegen": {
       "name": "@decocms/typegen",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "bin": {
         "typegen": "./dist/cli.js",
       },
@@ -994,9 +997,9 @@
 
     "@opentelemetry/exporter-metrics-otlp-grpc": ["@opentelemetry/exporter-metrics-otlp-grpc@0.207.0", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "2.2.0", "@opentelemetry/exporter-metrics-otlp-http": "0.207.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-grpc-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-6flX89W54gkwmqYShdcTBR1AEF5C1Ob0O8pDgmLPikTKyEv27lByr9yBmO5WrP0+5qJuNPHrLfgFQFYi6npDGA=="],
 
-    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fG8FAJmvXOrKXGIRN8+y41U41IfVXxPRVwyB05LoMqYSjugx/FSBkMZUZXUT/wclTdmBKtS5MKoi0bEKkmRhSw=="],
+    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.211.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/otlp-exporter-base": "0.211.0", "@opentelemetry/otlp-transformer": "0.211.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/sdk-metrics": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lfHXElPAoDSPpPO59DJdN5FLUnwi1wxluLTWQDayqrSPfWRnluzxRhD+g7rF8wbj1qCz0sdqABl//ug1IZyWvA=="],
 
-    "@opentelemetry/exporter-metrics-otlp-proto": ["@opentelemetry/exporter-metrics-otlp-proto@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/exporter-metrics-otlp-http": "0.207.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-kDBxiTeQjaRlUQzS1COT9ic+et174toZH6jxaVuVAvGqmxOkgjpLOjrI5ff8SMMQE69r03L3Ll3nPKekLopLwg=="],
+    "@opentelemetry/exporter-metrics-otlp-proto": ["@opentelemetry/exporter-metrics-otlp-proto@0.211.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/exporter-metrics-otlp-http": "0.211.0", "@opentelemetry/otlp-exporter-base": "0.211.0", "@opentelemetry/otlp-transformer": "0.211.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/sdk-metrics": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-61iNbffEpyZv/abHaz3BQM3zUtA2kVIDBM+0dS9RK68ML0QFLRGYa50xVMn2PYMToyfszEPEgFC3ypGae2z8FA=="],
 
     "@opentelemetry/exporter-prometheus": ["@opentelemetry/exporter-prometheus@0.208.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Rgws8GfIfq2iNWCD3G1dTD9xwYsCof1+tc5S5X0Ahdb5CrAPE+k5P70XCWHqrFFurVCcKaHLJ/6DjIBHWVfLiw=="],
 
@@ -3568,9 +3571,15 @@
 
     "@decocms/e2e/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@decocms/harness/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
     "@decocms/runtime/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@decocms/sandbox/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@decocms/sandbox/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@decocms/shared/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@decocms/studio-web/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -3628,6 +3637,8 @@
 
     "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
 
+    "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fG8FAJmvXOrKXGIRN8+y41U41IfVXxPRVwyB05LoMqYSjugx/FSBkMZUZXUT/wclTdmBKtS5MKoi0bEKkmRhSw=="],
+
     "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw=="],
 
     "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.207.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA=="],
@@ -3636,25 +3647,17 @@
 
     "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw=="],
 
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.5.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ=="],
 
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw=="],
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g=="],
 
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.207.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA=="],
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA=="],
 
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
+    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/core": ["@opentelemetry/core@2.5.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ=="],
 
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw=="],
+    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/resources": ["@opentelemetry/resources@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g=="],
 
-    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
-
-    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw=="],
-
-    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.207.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA=="],
-
-    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
-
-    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw=="],
+    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA=="],
 
     "@opentelemetry/exporter-prometheus/@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
 
@@ -3729,6 +3732,10 @@
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/sdk-logs": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-JpOh7MguEUls8eRfkVVW3yRhClo5b9LqwWTOg8+i4gjr/+8eiCtquJnC7whvpTIGyff06cLZ2NsEj+CVP3Mjeg=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-proto": ["@opentelemetry/exporter-logs-otlp-proto@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.207.0", "@opentelemetry/sdk-trace-base": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-RQJEV/K6KPbQrIUbsrRkEe0ufks1o5OGLHy6jbDD8tRjeCsbFHWfg99lYBRqBV33PYZJXsigqMaAbjWGTFYzLw=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fG8FAJmvXOrKXGIRN8+y41U41IfVXxPRVwyB05LoMqYSjugx/FSBkMZUZXUT/wclTdmBKtS5MKoi0bEKkmRhSw=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/exporter-metrics-otlp-proto": ["@opentelemetry/exporter-metrics-otlp-proto@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/exporter-metrics-otlp-http": "0.207.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-kDBxiTeQjaRlUQzS1COT9ic+et174toZH6jxaVuVAvGqmxOkgjpLOjrI5ff8SMMQE69r03L3Ll3nPKekLopLwg=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/exporter-prometheus": ["@opentelemetry/exporter-prometheus@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Y5p1s39FvIRmU+F1++j7ly8/KSqhMmn6cMfpQqiDCqDjdDHwUtSq0XI0WwL3HYGnZeaR/VV4BNmsYQJ7GAPrhw=="],
 
@@ -4134,22 +4141,6 @@
 
     "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
-
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer/@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-4MEQmn04y+WFe6cyzdrXf58hZxilvY59lzZj2AccuHW/+BxLn/rGVN/Irsi/F0qfBOpMOrrCLKTExoSL2zoQmg=="],
-
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw=="],
-
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
-
-    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-transformer/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
-
-    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-transformer/@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-4MEQmn04y+WFe6cyzdrXf58hZxilvY59lzZj2AccuHW/+BxLn/rGVN/Irsi/F0qfBOpMOrrCLKTExoSL2zoQmg=="],
-
-    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-transformer/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw=="],
-
-    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
-
     "@opentelemetry/exporter-trace-otlp-grpc/@opentelemetry/otlp-transformer/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
 
     "@opentelemetry/exporter-trace-otlp-grpc/@opentelemetry/otlp-transformer/@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-4MEQmn04y+WFe6cyzdrXf58hZxilvY59lzZj2AccuHW/+BxLn/rGVN/Irsi/F0qfBOpMOrrCLKTExoSL2zoQmg=="],
@@ -4193,6 +4184,14 @@
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.207.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.207.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.207.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA=="],
 
     "@opentelemetry/sdk-trace-node/@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 
@@ -4493,6 +4492,10 @@
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-http/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
     "@playwright/experimental-ct-core/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -435,6 +435,7 @@
     "@anthropic-ai/claude-agent-sdk": "0.3.181",
     "@openai/codex": "0.144.3",
     "fast-xml-parser": "5.4.2",
+    "zod": "4.3.6",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -3571,15 +3572,9 @@
 
     "@decocms/e2e/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
-    "@decocms/harness/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
     "@decocms/runtime/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@decocms/sandbox/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
-    "@decocms/sandbox/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
-    "@decocms/shared/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@decocms/studio-web/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -3936,8 +3931,6 @@
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
     "json-schema-to-typescript/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
-
-    "knip/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "linebreak/base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "overrides": {
     "@openai/codex": "0.144.3",
     "fast-xml-parser": "5.4.2",
-    "@anthropic-ai/claude-agent-sdk": "0.3.181"
+    "@anthropic-ai/claude-agent-sdk": "0.3.181",
+    "zod": "4.3.6"
   }
 }

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -932,11 +932,6 @@ async function shutdown(): Promise<void> {
   shuttingDown = true;
   taskManager.shutdown();
   branchStatus.stop();
-  // Start the metric export NOW so it runs concurrently with the git sync
-  // below, and await it only at the very end. Awaiting here would put
-  // telemetry ahead of the user's work in a 30s grace period; not awaiting at
-  // all would let the process.exit() below cut the export mid-flight.
-  const flushed = flushTelemetry();
   // Publish BEFORE unmount: syncing the user's work is the only irrecoverable
   // step. A stale mount is backstopped (sync `exit` handler + next-boot
   // reclaim), so a hanging unmount must never eat the push's slice of the grace
@@ -966,7 +961,12 @@ async function shutdown(): Promise<void> {
   if (mountManager) {
     await mountManager.stop().catch(() => {});
   }
-  await flushed;
+  // Last, after the user's work is safely pushed — telemetry never competes
+  // with it for the grace period. Can't usefully start earlier either: the
+  // publish above is synchronous (spawnSync), so it blocks the loop and the
+  // exporter's request couldn't make progress alongside it. Self-bounded, so
+  // a dead collector can't hold the process open.
+  await flushTelemetry();
   process.exit(0);
 }
 

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -85,11 +85,17 @@ import { makeScriptsHandler } from "./routes/scripts";
 import { discoverScripts } from "./process/script-discovery";
 import { SetupOrchestrator } from "./setup/orchestrator";
 import type { Config, TenantConfig } from "./types";
+import { flushTelemetry, initTelemetry } from "./telemetry";
 import { makeWsUpgrader, type WsProxyData } from "./ws-proxy";
 
 if (!process.env.DAEMON_BOOT_ID) {
   process.env.DAEMON_BOOT_ID = randomUUID();
 }
+
+// Before ANY getMeter() call in this module body (dispatchMeter below). The
+// metrics API resolves the global provider at call time and does not proxy a
+// later registration, so a meter taken before this line stays no-op forever.
+initTelemetry();
 
 // Corepack walks UP from cwd to find the closest `packageManager` field and
 // rejects mismatched invocations. On host runners the daemon's workdir lives
@@ -926,6 +932,11 @@ async function shutdown(): Promise<void> {
   shuttingDown = true;
   taskManager.shutdown();
   branchStatus.stop();
+  // Start the metric export NOW so it runs concurrently with the git sync
+  // below, and await it only at the very end. Awaiting here would put
+  // telemetry ahead of the user's work in a 30s grace period; not awaiting at
+  // all would let the process.exit() below cut the export mid-flight.
+  const flushed = flushTelemetry();
   // Publish BEFORE unmount: syncing the user's work is the only irrecoverable
   // step. A stale mount is backstopped (sync `exit` handler + next-boot
   // reclaim), so a hanging unmount must never eat the push's slice of the grace
@@ -955,6 +966,7 @@ async function shutdown(): Promise<void> {
   if (mountManager) {
     await mountManager.stop().catch(() => {});
   }
+  await flushed;
   process.exit(0);
 }
 

--- a/packages/sandbox/daemon/setup/golden-cache.ts
+++ b/packages/sandbox/daemon/setup/golden-cache.ts
@@ -67,7 +67,7 @@ const LOCKFILES: Record<string, readonly string[]> = {
 };
 
 /** 16 hex chars of sha256, credential-stripped — matches depsCacheEnv's key. */
-function repoHash(cloneUrl: string): string {
+export function repoHash(cloneUrl: string): string {
   let key = cloneUrl;
   try {
     const u = new URL(cloneUrl);

--- a/packages/sandbox/daemon/setup/install-metrics.test.ts
+++ b/packages/sandbox/daemon/setup/install-metrics.test.ts
@@ -31,54 +31,67 @@ describe("recordDepsRestore", () => {
     });
     metrics.setGlobalMeterProvider(provider);
 
-    recordDepsRestore({
-      source: "l1",
-      cloneUrl: "https://user:token@github.com/acme/site.git",
-      durationMs: 900,
-    });
-    recordDepsRestore({
-      source: "miss",
-      cloneUrl: "https://user:token@github.com/acme/site.git",
-      durationMs: 42_000,
-    });
+    try {
+      recordDepsRestore({
+        source: "l1",
+        cloneUrl: "https://user:token@github.com/acme/site.git",
+        durationMs: 900,
+      });
+      recordDepsRestore({
+        source: "miss",
+        cloneUrl: "https://user:token@github.com/acme/site.git",
+        durationMs: 42_000,
+      });
 
-    await provider.forceFlush();
+      await provider.forceFlush();
 
-    const byName = new Map(
-      exporter
-        .getMetrics()
-        .flatMap((r) => r.scopeMetrics)
-        .flatMap((s) => s.metrics)
-        .map((m) => [m.descriptor.name, m]),
-    );
+      const byName = new Map(
+        exporter
+          .getMetrics()
+          .flatMap((r) => r.scopeMetrics)
+          .flatMap((s) => s.metrics)
+          .map((m) => [m.descriptor.name, m]),
+      );
 
-    // Both outcomes counted, split by source.
-    const restore = byName.get("studio.sandbox.deps.restore");
-    expect(
-      restore?.dataPoints.map((p) => [p.attributes.source, p.value]),
-    ).toEqual([
-      ["l1", 1],
-      ["miss", 1],
-    ]);
+      // Both outcomes counted, split by source.
+      const restore = byName.get("studio.sandbox.deps.restore");
+      expect(
+        restore?.dataPoints.map((p) => [p.attributes.source, p.value]),
+      ).toEqual([
+        ["l1", 1],
+        ["miss", 1],
+      ]);
 
-    // A miss times the install; a hit times the restore. Crossing these would
-    // make L1 look as expensive as a cold install.
-    expect(
-      byName.get("studio.sandbox.deps.install_ms")?.dataPoints[0]?.attributes
-        .source,
-    ).toBe("miss");
-    expect(
-      byName.get("studio.sandbox.deps.restore_ms")?.dataPoints[0]?.attributes
-        .source,
-    ).toBe("l1");
+      // A miss times the install; a hit times the restore. Crossing these
+      // would make L1 look as expensive as a cold install.
+      const install = byName.get("studio.sandbox.deps.install_ms");
+      const restoreMs = byName.get("studio.sandbox.deps.restore_ms");
+      expect(install?.dataPoints[0]?.attributes.source).toBe("miss");
+      expect(restoreMs?.dataPoints[0]?.attributes.source).toBe("l1");
 
-    // Credentials in the clone URL must never reach the collector — the label
-    // is the cache's own credential-stripped hash.
-    const repoHashes = restore?.dataPoints.map((p) => p.attributes.repo_hash);
-    expect(repoHashes?.every((h) => /^[0-9a-f]{16}$/.test(String(h)))).toBe(
-      true,
-    );
+      // Buckets must actually bracket the value. The SDK's defaults top out
+      // at 10s, so a 42s install would land in +Inf and make every quantile
+      // identical — the exact number this instrument exists to produce.
+      const installPoint = install?.dataPoints[0]?.value as
+        | { buckets: { boundaries: number[]; counts: number[] } }
+        | undefined;
+      const boundaries = installPoint?.buckets.boundaries ?? [];
+      const overflow = installPoint?.buckets.counts.at(-1) ?? 0;
+      expect(boundaries.at(-1)).toBeGreaterThan(42_000);
+      expect(overflow).toBe(0);
 
-    await provider.shutdown();
+      // Credentials in the clone URL must never reach the collector — the
+      // label is the cache's own credential-stripped hash.
+      const repoHashes = restore?.dataPoints.map((p) => p.attributes.repo_hash);
+      expect(repoHashes?.every((h) => /^[0-9a-f]{16}$/.test(String(h)))).toBe(
+        true,
+      );
+    } finally {
+      // Bun shares one process across test files, so a provider left
+      // registered here — worse, a shut-down one — would silently swallow
+      // every metric recorded by any file that runs after this one.
+      await provider.shutdown();
+      metrics.disable();
+    }
   });
 });

--- a/packages/sandbox/daemon/setup/install-metrics.test.ts
+++ b/packages/sandbox/daemon/setup/install-metrics.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { metrics } from "@opentelemetry/api";
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from "@opentelemetry/sdk-metrics";
+import { recordDepsRestore } from "./install-metrics";
+
+/**
+ * The failure this guards is silent: a dependency-install path that records
+ * nothing, or records into the wrong instrument, looks identical to a healthy
+ * one — nothing throws, the dashboard is just empty or wrong. Registering a
+ * real SDK provider (no mocks) and reading the points back is the only way to
+ * see the difference.
+ */
+describe("recordDepsRestore", () => {
+  test("routes each source to its own instrument", async () => {
+    const exporter = new InMemoryMetricExporter(
+      AggregationTemporality.CUMULATIVE,
+    );
+    const provider = new MeterProvider({
+      readers: [
+        new PeriodicExportingMetricReader({
+          exporter,
+          // Long enough that only the explicit forceFlush below exports.
+          exportIntervalMillis: 60_000,
+        }),
+      ],
+    });
+    metrics.setGlobalMeterProvider(provider);
+
+    recordDepsRestore({
+      source: "l1",
+      cloneUrl: "https://user:token@github.com/acme/site.git",
+      durationMs: 900,
+    });
+    recordDepsRestore({
+      source: "miss",
+      cloneUrl: "https://user:token@github.com/acme/site.git",
+      durationMs: 42_000,
+    });
+
+    await provider.forceFlush();
+
+    const byName = new Map(
+      exporter
+        .getMetrics()
+        .flatMap((r) => r.scopeMetrics)
+        .flatMap((s) => s.metrics)
+        .map((m) => [m.descriptor.name, m]),
+    );
+
+    // Both outcomes counted, split by source.
+    const restore = byName.get("studio.sandbox.deps.restore");
+    expect(
+      restore?.dataPoints.map((p) => [p.attributes.source, p.value]),
+    ).toEqual([
+      ["l1", 1],
+      ["miss", 1],
+    ]);
+
+    // A miss times the install; a hit times the restore. Crossing these would
+    // make L1 look as expensive as a cold install.
+    expect(
+      byName.get("studio.sandbox.deps.install_ms")?.dataPoints[0]?.attributes
+        .source,
+    ).toBe("miss");
+    expect(
+      byName.get("studio.sandbox.deps.restore_ms")?.dataPoints[0]?.attributes
+        .source,
+    ).toBe("l1");
+
+    // Credentials in the clone URL must never reach the collector — the label
+    // is the cache's own credential-stripped hash.
+    const repoHashes = restore?.dataPoints.map((p) => p.attributes.repo_hash);
+    expect(repoHashes?.every((h) => /^[0-9a-f]{16}$/.test(String(h)))).toBe(
+      true,
+    );
+
+    await provider.shutdown();
+  });
+});

--- a/packages/sandbox/daemon/setup/install-metrics.ts
+++ b/packages/sandbox/daemon/setup/install-metrics.ts
@@ -1,0 +1,84 @@
+/**
+ * Dependency-install cache metrics.
+ *
+ * Answers the one question the golden cache can't answer about itself: how
+ * often does a fresh pod actually hit it? The golden is node-local, so a hit
+ * requires landing on a node already warm for that repo — and whether that
+ * happens is a property of the fleet (pod churn, AZ spread), not of the cache
+ * code. `source` splits the outcomes and `repo_hash` shows how concentrated
+ * repos are per node, which together size the cross-node (EFS L2) work.
+ *
+ * Only recorded for install paths that COMPLETED — an `l1` restore or a
+ * successful install. Failed installs are excluded deliberately: the ratio we
+ * want is "did the cache save a boot", and a failure saved nothing either way.
+ */
+
+import { metrics } from "@opentelemetry/api";
+import type { Counter, Histogram } from "@opentelemetry/api";
+import { repoHash } from "./golden-cache";
+
+/**
+ * `l1` — reflinked the node-local golden, install skipped.
+ * `miss` — no golden for this (repo, lockfile) on this node; ran a full install.
+ * `l2` joins this union when the EFS archive tier lands.
+ */
+export type RestoreSource = "l1" | "miss";
+
+interface Instruments {
+  restore: Counter;
+  installMs: Histogram;
+  restoreMs: Histogram;
+}
+
+// Resolved per call, deliberately uncached. The metrics API reads the global
+// provider at call time and never proxies a later registration, so a cached
+// instrument taken before `initTelemetry()` would record into the void forever
+// — silently, since nothing throws. This runs about once per pod boot, so
+// there is nothing to optimize away and no ordering trap to document.
+function getInstruments(): Instruments {
+  const meter = metrics.getMeter("link-daemon");
+  return {
+    restore: meter.createCounter("studio.sandbox.deps.restore", {
+      description:
+        "Dependency install outcomes, split by which cache tier served them",
+    }),
+    installMs: meter.createHistogram("studio.sandbox.deps.install_ms", {
+      description: "Wall-clock cost of a full dependency install (cache miss)",
+      unit: "ms",
+    }),
+    restoreMs: meter.createHistogram("studio.sandbox.deps.restore_ms", {
+      description: "Wall-clock cost of restoring dependencies from a cache",
+      unit: "ms",
+    }),
+  };
+}
+
+/**
+ * Record one completed dependency-install path. Best-effort: telemetry must
+ * never fail a boot, so everything here is swallowed.
+ */
+export function recordDepsRestore(input: {
+  source: RestoreSource;
+  cloneUrl: string | undefined;
+  durationMs: number;
+}): void {
+  try {
+    const { restore, installMs, restoreMs } = getInstruments();
+    // Attributes are fixed keys with derived values only — nothing
+    // tenant-authored reaches the collector from a pod running user code.
+    // `repoHash` is the cache's own key (16 hex chars), so a series lines up
+    // with the golden dir on disk and the attribute is inherently bounded.
+    const attrs = {
+      source: input.source,
+      repo_hash: input.cloneUrl ? repoHash(input.cloneUrl) : "unknown",
+    };
+    restore.add(1, attrs);
+    if (input.source === "miss") {
+      installMs.record(input.durationMs, attrs);
+    } else {
+      restoreMs.record(input.durationMs, attrs);
+    }
+  } catch {
+    // never let a metric break the install path
+  }
+}

--- a/packages/sandbox/daemon/setup/install-metrics.ts
+++ b/packages/sandbox/daemon/setup/install-metrics.ts
@@ -45,10 +45,29 @@ function getInstruments(): Instruments {
     installMs: meter.createHistogram("studio.sandbox.deps.install_ms", {
       description: "Wall-clock cost of a full dependency install (cache miss)",
       unit: "ms",
+      // Without this advice the SDK applies its default millisecond
+      // boundaries, which top out at 10s — and installs run for tens of
+      // seconds, so every real point would land in the +Inf overflow bucket
+      // and p50 would equal p95. That number is the whole reason this
+      // instrument exists, so the range has to cover 1s–5min.
+      advice: {
+        explicitBucketBoundaries: [
+          1_000, 2_500, 5_000, 10_000, 20_000, 30_000, 45_000, 60_000, 90_000,
+          120_000, 180_000, 300_000,
+        ],
+      },
     }),
     restoreMs: meter.createHistogram("studio.sandbox.deps.restore_ms", {
       description: "Wall-clock cost of restoring dependencies from a cache",
       unit: "ms",
+      // Sub-second at the fast end (a reflink is ~1s) but an L2 archive
+      // extract is seconds. The defaults would collapse a healthy 200ms
+      // restore and a degraded 2s one into neighbouring buckets.
+      advice: {
+        explicitBucketBoundaries: [
+          50, 100, 250, 500, 750, 1_000, 2_000, 4_000, 8_000, 15_000, 30_000,
+        ],
+      },
     }),
   };
 }

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -33,7 +33,8 @@ import { emitInstalledDeps } from "./dep-metrics";
 import { publishGolden, pruneGoldens, tryRestoreGolden } from "./golden-cache";
 import { gitBaseArgv, gitStepEnv } from "./git-command";
 import { configureGitIdentity } from "./identity";
-import { denoCacheEnv, spawnInstall } from "./install";
+import { denoCacheEnv, resolveCloneUrl, spawnInstall } from "./install";
+import { recordDepsRestore } from "./install-metrics";
 import { spawnSetupStep } from "./spawn-step";
 import { installProtectedBranchHook } from "../git/protect-branch";
 
@@ -368,6 +369,7 @@ export class SetupOrchestrator {
       config.repoDir,
       config.application?.packageManager?.path,
     );
+    const restoreStartedAt = Date.now();
     if (
       await tryRestoreGolden({
         config,
@@ -378,11 +380,17 @@ export class SetupOrchestrator {
     ) {
       // Restored from an existing golden — nothing to publish.
       this.pendingGolden = null;
+      recordDepsRestore({
+        source: "l1",
+        cloneUrl: resolveCloneUrl(config),
+        durationMs: Date.now() - restoreStartedAt,
+      });
       this.markInstallSucceeded(config);
       return true;
     }
 
     this.chunk(`[orchestrator] installing dependencies\r\n`);
+    const installStartedAt = Date.now();
 
     const installLogPath = appLogPath(this.deps.logsDir, "install");
     try {
@@ -419,6 +427,11 @@ export class SetupOrchestrator {
       this.deps.lifecycle.transition({ phase: "install-failed", error });
       return false;
     }
+    recordDepsRestore({
+      source: "miss",
+      cloneUrl: resolveCloneUrl(config),
+      durationMs: Date.now() - installStartedAt,
+    });
     this.markInstallSucceeded(config);
     // Install scripts (postinstall/prepare — lefthook, husky, etc.) can
     // overwrite .git/hooks/pre-push; reinstall so branch protection survives.

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -369,7 +369,10 @@ export class SetupOrchestrator {
       config.repoDir,
       config.application?.packageManager?.path,
     );
-    const restoreStartedAt = Date.now();
+    // Times the WHOLE dependency step, not just the install: a failed golden
+    // probe (stat, partial reflink, cleanup) is real boot latency, and on a
+    // miss the cost L2 would replace is probe + install, not install alone.
+    const depsStartedAt = Date.now();
     if (
       await tryRestoreGolden({
         config,
@@ -383,14 +386,13 @@ export class SetupOrchestrator {
       recordDepsRestore({
         source: "l1",
         cloneUrl: resolveCloneUrl(config),
-        durationMs: Date.now() - restoreStartedAt,
+        durationMs: Date.now() - depsStartedAt,
       });
       this.markInstallSucceeded(config);
       return true;
     }
 
     this.chunk(`[orchestrator] installing dependencies\r\n`);
-    const installStartedAt = Date.now();
 
     const installLogPath = appLogPath(this.deps.logsDir, "install");
     try {
@@ -430,7 +432,7 @@ export class SetupOrchestrator {
     recordDepsRestore({
       source: "miss",
       cloneUrl: resolveCloneUrl(config),
-      durationMs: Date.now() - installStartedAt,
+      durationMs: Date.now() - depsStartedAt,
     });
     this.markInstallSucceeded(config);
     // Install scripts (postinstall/prepare — lefthook, husky, etc.) can

--- a/packages/sandbox/daemon/telemetry.ts
+++ b/packages/sandbox/daemon/telemetry.ts
@@ -1,0 +1,77 @@
+/**
+ * Daemon metrics export.
+ *
+ * PUSH, not scrape. Sandbox pods are too ephemeral to be a Prometheus target —
+ * a pod that boots, installs and is reclaimed between two scrape windows
+ * reports nothing, and boot-time numbers are exactly what we want. So the
+ * daemon owns a MeterProvider and pushes over OTLP, with a flush on shutdown
+ * (see `flushTelemetry`) so the last interval's points still ship.
+ *
+ * Dormant by default: with no OTEL_EXPORTER_OTLP_ENDPOINT no provider is
+ * registered, `metrics.getMeter()` stays the API's no-op, and this module costs
+ * one env read. That is today's behavior — enabling is a chart change.
+ *
+ * Egress caveat for whoever wires the endpoint: sandbox pods enforce egress via
+ * the netinit iptables init container, which REJECTs the RFC1918 blockCIDRs
+ * *before* the port ACCEPTs. An in-cluster ClusterIP collector is therefore
+ * unreachable no matter which port is added to `allowedTCPPorts`. Point this at
+ * an endpoint that clears that rule (e.g. the collector's LoadBalancer on 443).
+ */
+
+import { metrics } from "@opentelemetry/api";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
+import {
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from "@opentelemetry/sdk-metrics";
+import { sleep } from "@decocms/shared/std";
+
+const EXPORT_INTERVAL_MS = 60_000;
+
+// Tail budget for the shutdown flush. `shutdown()` starts the flush before the
+// git sync and awaits it after, so this is only the slice left over once the
+// user's work is safely pushed — it must not eat into the 30s grace period the
+// push depends on. OTLP acks 202 without waiting on downstream ingestion, so a
+// healthy collector answers in well under a second.
+const FLUSH_TIMEOUT_MS = 3_000;
+
+let provider: MeterProvider | null = null;
+
+/**
+ * Register the global MeterProvider. No-op without an OTLP endpoint, and
+ * idempotent. Must run before the first `getMeter()` call that matters: the
+ * metrics API resolves the provider at call time and does NOT proxy a later
+ * registration, so instruments created before this are permanently no-op.
+ * Callers create instruments lazily to respect that (see setup/install-metrics).
+ */
+export function initTelemetry(): void {
+  if (provider || !process.env.OTEL_EXPORTER_OTLP_ENDPOINT) return;
+  provider = new MeterProvider({
+    resource: resourceFromAttributes({
+      "service.name": process.env.OTEL_SERVICE_NAME ?? "studio-sandbox-daemon",
+    }),
+    readers: [
+      new PeriodicExportingMetricReader({
+        exporter: new OTLPMetricExporter(),
+        exportIntervalMillis: EXPORT_INTERVAL_MS,
+      }),
+    ],
+  });
+  metrics.setGlobalMeterProvider(provider);
+}
+
+/**
+ * Start exporting whatever is buffered. Returns a promise that always resolves
+ * — a dead or slow collector must never delay shutdown past the timeout, and
+ * must never surface as an error on a path whose real job is saving the user's
+ * work. Resolves immediately when telemetry is off.
+ */
+export function flushTelemetry(): Promise<void> {
+  const p = provider;
+  if (!p) return Promise.resolve();
+  return Promise.race([p.forceFlush(), sleep(FLUSH_TIMEOUT_MS)]).then(
+    () => {},
+    () => {},
+  );
+}

--- a/packages/sandbox/daemon/telemetry.ts
+++ b/packages/sandbox/daemon/telemetry.ts
@@ -29,11 +29,10 @@ import { sleep } from "@decocms/shared/std";
 
 const EXPORT_INTERVAL_MS = 60_000;
 
-// Tail budget for the shutdown flush. `shutdown()` starts the flush before the
-// git sync and awaits it after, so this is only the slice left over once the
-// user's work is safely pushed — it must not eat into the 30s grace period the
-// push depends on. OTLP acks 202 without waiting on downstream ingestion, so a
-// healthy collector answers in well under a second.
+// Tail budget for the shutdown flush, which runs only after the user's work is
+// pushed — it must never eat into the grace period that push depends on. OTLP
+// acks 202 without waiting on downstream ingestion, so a healthy collector
+// answers in well under a second; this cap is for an unreachable one.
 const FLUSH_TIMEOUT_MS = 3_000;
 
 let provider: MeterProvider | null = null;

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -33,6 +33,9 @@
     "@kubernetes/client-node": "^1.4.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.211.0",
+    "@opentelemetry/resources": "^2.6.0",
+    "@opentelemetry/sdk-metrics": "^2.2.0",
     "node-pty": "^1.0.0",
     "zod": "^4.0.0"
   },


### PR DESCRIPTION
## Why

The golden `node_modules` cache runs in prod (`GOLDEN_CACHE_ENABLED=1`) but **nothing measures it**. A hit requires the pod to land on a node already warm for its repo — whether that happens is a property of fleet churn (~170 nodes/day across 3 AZs, ~80% fresh pods), not of the cache code. Without a hit rate we can't size the cross-node EFS L2 tier that would remove the same-node dependency.

The daemon couldn't tell us even if it wanted to: `packages/sandbox` depends on `@opentelemetry/api` **alone** — there is no `MeterProvider` anywhere in the package, so `metrics.getMeter("link-daemon")` (`entry.ts`) has always returned the API's no-op. Daemon metrics were never merely unscraped; they were never collected.

## What

Push, not scrape. Sandbox pods are too ephemeral to be a Prometheus target — one reclaimed between two scrape windows reports nothing about the boot we care about. The daemon now owns a `MeterProvider` with an OTLP exporter and flushes on shutdown.

| Instrument | Type | Labels |
|---|---|---|
| `studio.sandbox.deps.restore` | Counter | `source`, `repo_hash` |
| `studio.sandbox.deps.install_ms` | Histogram (ms) | `source`, `repo_hash` |
| `studio.sandbox.deps.restore_ms` | Histogram (ms) | `source`, `repo_hash` |

`source` is `l1` (reflinked the golden, install skipped) or `miss` (ran a full install); it grows an `l2` arm when the EFS tier lands. Recorded only on **completed** paths — failed installs are excluded on purpose, since the ratio we want is "did the cache save a boot".

`repo_hash` is the cache's own credential-stripped key (16 hex chars), so a series lines up with the golden dir on disk, and the label is bounded by construction. Every attribute is a fixed key with a derived value — nothing tenant-authored leaves a pod running user code.

## Ships dark

Without `OTEL_EXPORTER_OTLP_ENDPOINT` no provider is registered and behavior is byte-for-byte what it is today. Rollback is unsetting the env.

## ⚠️ Enabling this needs an egress decision — not in this PR

Sandbox egress is the **netinit iptables init container**, not a NetworkPolicy, and it appends:

```
lo ACCEPT → conntrack ACCEPT → blockCIDRs REJECT → UDP ACCEPT → TCP ACCEPT → default REJECT
```

`gateway-otlp` is ClusterIP `172.20.146.131`, inside `blockCIDRs`' `172.16.0.0/12` — **rejected at step 3, before any port ACCEPT at step 5**. So adding `4317` to `netinit.allowedTCPPorts`, however high the port, changes nothing. Options, in preference order:

1. **Point at `gateway-otlp-ingest`** (LoadBalancer, `443:32184/TCP`). Public ELB address clears the CIDR REJECT and lands on the already-allowed 443. Zero netinit change, zero new hole into the cluster, TLS by default. Needs confirmation of what auth that listener expects (the sibling `8443` suggests a separate authed path).
2. A destination-scoped ACCEPT inserted *before* the block rules — new `netinit.allowedDestinations` knob. Needs the ClusterIP pinned in values (Helm can't resolve DNS), so it's cluster-specific and breaks if the Service is recreated.
3. Widening `blockCIDRs` by port — rejected, that would let user code reach any in-cluster service on that port.

## Shutdown ordering is load-bearing

`shutdown()` already commits and pushes the user's work, bounded at 30s inside a 30s grace period — that push is the only durable copy of their work. So the flush is **dispatched before** the git sync (runs concurrently with it) and **awaited only after**, bounded at 3s. Awaiting it up front would put telemetry ahead of user data; not awaiting at all would let the trailing `process.exit(0)` cut the export mid-flight. OTLP acks 202 without waiting on ingestion, so a healthy collector answers in well under a second.

## Notes

- Exporter is HTTP/**protobuf** — binary and compressed as asked, without pulling `@grpc/grpc-js` into the bundle. Swapping to gRPC is a one-line change; both are already in the lockfile. Daemon bundle grows 3.13 MB → 4.09 MB (protobufjs), read once per pod boot from a local image layer.
- Instruments are resolved per call rather than cached. The metrics API reads the global provider at call time and never proxies a later registration, so a cached instrument built before `initTelemetry()` would record into the void forever, silently. This runs about once per pod boot — nothing to optimize, and the trap disappears instead of needing a comment.
- `repoHash` is now exported from `golden-cache.ts` (was module-private).

## Testing

- New `install-metrics.test.ts`: registers a real SDK `MeterProvider` + `InMemoryMetricExporter` (no mocks) and reads the points back — asserts both outcomes are counted, that a miss times the install while a hit times the restore (crossing these would make L1 look as expensive as a cold install), and that clone-URL credentials never reach the collector.
- `bun test packages/sandbox/daemon/setup/` → 87 pass; `daemon.e2e.test.ts` → 103 pass.
- `bun run fmt`, `bun run lint` (0 errors), `knip` clean.
- `bun run --cwd=packages/sandbox check` reports one **pre-existing** error in `packages/shared/src/sdk/types/connection.ts` (zod `_zod.version.minor` 3 vs 4) — reproduced on the branch base, unrelated to this change.

**Not yet validated on a real pod** — that needs the chart PR and the egress decision above. Follows the repo norm of confirming a live increment before calling it done.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OTLP push metrics to the sandbox daemon to measure the golden `node_modules` cache hit rate and the time cost of installs vs. restores. Ships dark; behavior is unchanged unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set.

- New Features
  - In-process `MeterProvider` with an OTLP proto exporter, initialized at startup; instruments are created lazily to avoid no-op meters.
  - Metrics: `studio.sandbox.deps.restore` (Counter), `studio.sandbox.deps.install_ms` and `studio.sandbox.deps.restore_ms` (Histograms), labeled by `source` (`l1`|`miss`) and `repo_hash` (credential-stripped, 16 hex). Histograms use explicit buckets (install: 1s–5min; restore: 50ms–30s). Durations time the whole dependency step.
  - Flush on shutdown after the user’s push, capped at 3s.

- Dependencies
  - Pin `zod` to `4.3.6` across the workspace to ensure a single copy.

<sup>Written for commit 80d5a9753ad4af1b92649e1079f10dc536cc2939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

