### PR TITLE
feat(sandbox-env): opt-in daemon OTLP metrics endpoint

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -24,6 +24,11 @@ type: application
 # orgfs-sidecar is SIGKILLed on teardown and its Sandbox CR is already gone) +
 # grants the housekeeper Role `delete` on pods. Additive; existing reap paths
 # unchanged.
+# 0.9.34: opt-in daemon OTLP metrics (telemetry.otlpEndpoint, default
+# empty) — sets OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_SERVICE_NAME so the
+# daemon registers a MeterProvider and pushes. Additive; no change unless
+# set. The endpoint must clear netinit's blockCIDRs REJECT (which fires
+# before the port ACCEPTs) — see values.yaml before picking one.
 # 0.9.4: default studio-sandbox image tag bumped to 1.12.0 (Node.js 26).
 # 0.9.3: opt-in HPA for the warm pool (warmPool.autoscaling.*, default off) —
 # scales SandboxWarmPool via its native scale subresource. No default metric
@@ -47,7 +52,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.9.33
+version: 0.9.34
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.24.2"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -238,6 +238,7 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `netinit.enabled` | `true` | installs the iptables egress policy before user code starts |
 | `disableFsSidecar` | `false` | debug-only opt-out from the mandatory privileged org-fs sidecar |
 | `depsCache.enabled` / `depsCache.golden` | `false` / `false` | opt-in node-local dependency caches |
+| `telemetry.otlpEndpoint` | `""` | opt-in daemon metrics push; endpoint must be reachable past netinit (see `values.yaml`) |
 | `warmPool.enabled` / `warmPool.size` | `false` / `0` | only after measuring cold-start pain |
 | `warmPool.autoscaling.enabled` | `false` | HPA; requires at least one explicit metric |
 | `previewGateway.enabled` | `false` | wildcard `*.preview.<domain>` Gateway + cert |

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -227,6 +227,17 @@ spec:
               value: "1"
             {{- end }}
             {{- end }}
+            {{- with .Values.telemetry.otlpEndpoint }}
+            # Enables the daemon's MeterProvider (absent → no provider is
+            # registered and every daemon metric stays the API's no-op). The
+            # endpoint MUST be one a sandbox pod can actually reach — netinit
+            # REJECTs the blockCIDRs before the port ACCEPTs, so an in-cluster
+            # ClusterIP is unreachable whatever port is allowed. See values.yaml.
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ . | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ $.Values.telemetry.serviceName | quote }}
+            {{- end }}
             - name: DAEMON_PORT
               value: "9000"
             - name: DAEMON_TOKEN

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -293,6 +293,41 @@ depsCache:
   # same unreaped-growth caveat as above (a golden ≈ a full node_modules).
   golden: false
 
+# ── daemon telemetry ───────────────────────────────────────────────────
+# The daemon pushes metrics over OTLP rather than being scraped: sandbox
+# pods are too ephemeral to be a Prometheus target, and the numbers worth
+# having (dependency-install cost, cache hit rate) are produced at boot —
+# a pod reclaimed between two scrape windows would report nothing. Push
+# also lets the daemon flush on SIGTERM so the last interval still ships.
+#
+# Off by default: with no endpoint the daemon registers no MeterProvider
+# and every `getMeter()` stays the API's no-op, which is the behavior
+# before this existed.
+#
+# CHOOSING AN ENDPOINT — read this first. Sandbox egress is enforced by
+# the netinit iptables init container (see above), which appends:
+#
+#   lo ACCEPT → conntrack ACCEPT → blockCIDRs REJECT
+#     → allowedUDPPorts ACCEPT → allowedTCPPorts ACCEPT → default REJECT
+#
+# The CIDR REJECT fires BEFORE the port ACCEPTs, so a collector on an
+# in-cluster ClusterIP (which lands in RFC1918, i.e. inside blockCIDRs) is
+# unreachable no matter which port you add to allowedTCPPorts. An endpoint
+# here must clear that rule — e.g. the collector's LoadBalancer address on
+# 443, which is already allowed and needs no netinit change. If you must
+# reach a ClusterIP instead, that requires a destination-scoped ACCEPT
+# inserted ahead of the blockCIDRs loop; adding the port alone will
+# silently drop every export.
+#
+# Note this opens a path from pods running untrusted user code to your
+# collector: a compromised sandbox can emit arbitrary series. The daemon
+# only ever sends fixed instrument names with derived attribute values.
+telemetry:
+  # OTLP HTTP endpoint (protobuf). Empty = telemetry off.
+  otlpEndpoint: ""
+  # resource `service.name` for the daemon's metrics.
+  serviceName: studio-sandbox-daemon
+
 # ── sentinel token ─────────────────────────────────────────────────────
 sentinel:
   # Optional: supply an explicit token so CI can pass the same value to


### PR DESCRIPTION
Chart side of #5339. That PR gives the daemon a `MeterProvider` that stays dormant without `OTEL_EXPORTER_OTLP_ENDPOINT`; this one lets an operator set it.

```yaml
telemetry:
  otlpEndpoint: ""              # empty = off (default, today's behavior)
  serviceName: studio-sandbox-daemon
```

Renders nothing when empty; injects both env vars when set. Verified with `helm template` both ways, `helm lint` clean.

**Endpoint-agnostic on purpose** — the actual URL belongs in the per-env values in `deco-apps-cd`, not in the chart. That's also why this isn't blocked on deciding *which* collector address to use: the chart change is identical for every option.

## The constraint that makes this non-obvious

`values.yaml` now documents it, because getting it wrong fails **silently** — every export is dropped and the dashboard just stays empty. Sandbox egress is the netinit iptables init container, not a NetworkPolicy, and it appends:

```
lo ACCEPT → conntrack ACCEPT → blockCIDRs REJECT → UDP ACCEPT → TCP ACCEPT → default REJECT
```

The CIDR REJECT fires **before** the port ACCEPTs. A collector on an in-cluster ClusterIP lands in RFC1918, i.e. inside `blockCIDRs`, so it is unreachable **no matter which port** is added to `allowedTCPPorts` — `gateway-otlp` is `172.20.146.131`, inside `172.16.0.0/12`. Reaching a ClusterIP would need a destination-scoped ACCEPT inserted ahead of the `blockCIDRs` loop, which this PR does not add.

An address that already clears the rule needs no netinit change: `gateway-otlp-ingest` is a LoadBalancer on `443:32184/TCP`, and 443 is already in `allowedTCPPorts`. That's the recommended value, pending confirmation of what auth that listener expects.

Also noted in values: enabling this opens a path from pods running untrusted user code to the collector, so a compromised sandbox can emit arbitrary series. The daemon only ever sends fixed instrument names with derived attribute values.

## Notes

- Chart `0.9.33` → `0.9.34`, changelog entry added (the publish workflow skips existing versions).
- README values table updated.
- Merge after #5339 — setting the endpoint against a daemon without the provider is harmless but pointless.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in OTLP metrics endpoint for the sandbox daemon. Default behavior stays the same until you set `telemetry.otlpEndpoint`.

- **New Features**
  - Injects `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_SERVICE_NAME` when `telemetry.otlpEndpoint` is set (chart v0.9.34; README/values updated).

- **Migration**
  - To enable, set `telemetry.otlpEndpoint` to a collector address reachable past netinit. In-cluster ClusterIP is blocked by RFC1918 REJECT; use the collector’s LoadBalancer on 443 or adjust netinit. Enabling allows sandbox pods to reach your collector.

<sup>Written for commit 909f30c46584aaa52087a2226af15894e06cf0e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

