### PR TITLE
test(sandbox-proxy): cover branch-name validation trust boundary

### DIFF
--- a/apps/api/src/api/routes/sandbox-proxy.test.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.test.ts
@@ -4,7 +4,11 @@ import {
   readBoundedText,
   UpstreamPayloadTooLargeError,
 } from "../../lib/bounded-text";
-import { redactRepoDir, withClaimGitLock } from "./sandbox-proxy";
+import {
+  assertSandboxBranchParam,
+  redactRepoDir,
+  withClaimGitLock,
+} from "./sandbox-proxy";
 
 describe("redactRepoDir", () => {
   it("nulls a container-internal repoDir while preserving other fields", () => {
@@ -35,6 +39,49 @@ describe("redactRepoDir", () => {
   it("passes through JSON that is not an object", () => {
     expect(redactRepoDir("[1,2,3]")).toBe("[1,2,3]");
     expect(redactRepoDir('"repoDir"')).toBe('"repoDir"');
+  });
+});
+
+describe("assertSandboxBranchParam", () => {
+  it("accepts a plain branch name", () => {
+    expect(() => assertSandboxBranchParam("main")).not.toThrow();
+    expect(() => assertSandboxBranchParam("feature/foo-bar_123")).not.toThrow();
+  });
+
+  it("accepts a thread: synthetic branch id", () => {
+    expect(() => assertSandboxBranchParam("thread:abc123")).not.toThrow();
+  });
+
+  it("rejects an empty branch", () => {
+    expect(() => assertSandboxBranchParam("")).toThrow();
+  });
+
+  it("rejects a thread: branch with no id after the prefix", () => {
+    expect(() => assertSandboxBranchParam("thread:")).toThrow();
+  });
+
+  it("rejects path traversal via ..", () => {
+    expect(() => assertSandboxBranchParam("a/../b")).toThrow();
+    expect(() => assertSandboxBranchParam("thread:../etc")).toThrow();
+  });
+
+  it("rejects a leading or trailing slash", () => {
+    expect(() => assertSandboxBranchParam("/leading")).toThrow();
+    expect(() => assertSandboxBranchParam("trailing/")).toThrow();
+  });
+
+  it("rejects a git lock-file ref", () => {
+    expect(() => assertSandboxBranchParam("refs/heads/main.lock")).toThrow();
+  });
+
+  it("rejects a branch name over 255 chars", () => {
+    expect(() => assertSandboxBranchParam("a".repeat(256))).toThrow();
+  });
+
+  it("rejects characters outside the git-ref charset", () => {
+    expect(() => assertSandboxBranchParam("has space")).toThrow();
+    expect(() => assertSandboxBranchParam("a:b")).toThrow();
+    expect(() => assertSandboxBranchParam("-leading-dash")).toThrow();
   });
 });
 

--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -70,7 +70,7 @@ type VmEnv = Env & { Variables: Env["Variables"] & { vmClaim: VmClaim } };
 
 const SANDBOX_BRANCH_NAME = /^[a-zA-Z0-9][a-zA-Z0-9/._-]*$/;
 
-function assertSandboxBranchParam(branch: string): void {
+export function assertSandboxBranchParam(branch: string): void {
   // "thread:<id>" is a synthetic sandbox-identity branch (bound by `load_repo`
   // for thread-scoped repos) — the daemon accepts it and never checks it out as
   // a git ref, so the ':' is legal here even though the git-ref charset below


### PR DESCRIPTION
Trust-boundary test for `assertSandboxBranchParam` in `apps/api/src/api/routes/sandbox-proxy.ts`.

**Why this is a trust boundary (C4/R4):** `assertSandboxBranchParam` parses the `branch` URL path param — fully client-controlled — before it's used to compose the sandbox claim ref (`composeSandboxRef`) and claim handle (`computeClaimHandle`), which are ultimately forwarded to the sandbox daemon where `branch` is used as a live git ref for checkout/fetch (see `packages/sandbox/daemon/git/ref-name.ts`'s `isValidRemoteBranchName`, which encodes the same git-ref-injection rules: no `..`, no leading/trailing `/`, no `.lock` suffix). This is exactly "a URL used for auth or a network call" / "user-supplied paths feeding a filesystem/proxy op" per the gate. I confirmed via repo-wide grep that no test anywhere (in `apps/api` or `packages/sandbox`) previously exercised this specific function — a regression here (e.g. a loosened regex, or a broken `thread:` prefix strip letting `..` through) would only surface later as an opaque daemon-side git error, not a caught local failure.

**Change:** exported `assertSandboxBranchParam` (previously module-private) and added a `describe("assertSandboxBranchParam", ...)` block in the existing test file covering: valid plain/`thread:`-prefixed branches, empty branch, empty `thread:` id, `..` traversal (both plain and inside a `thread:` id), leading/trailing slash, `.lock` suffix, >255 chars, and disallowed charset (space, `:`, leading `-`). No production logic changed — just an `export` keyword plus the new tests.

**Reviewer check:** `bun test apps/api/src/api/routes/sandbox-proxy.test.ts` (19 tests, all pass).

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), and the targeted test file above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add trust-boundary tests for `assertSandboxBranchParam` in the sandbox proxy to catch unsafe branch inputs before they reach the daemon. Exported the function for testing; covers valid plain and `thread:` branches and rejects empty, `..` traversal, leading/trailing `/`, `.lock` suffix, >255 chars, and invalid charset.

<sup>Written for commit 05386fef77f9b3b93fd4aac0545464dc06a7c113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

