### PR TITLE
feat(sandbox): per-(org, repo) size tiers

### DIFF
--- a/apps/api/src/sandbox/tier.test.ts
+++ b/apps/api/src/sandbox/tier.test.ts
@@ -65,4 +65,19 @@ describe("resolveSandboxTier", () => {
       ),
     ).toBeUndefined();
   });
+
+  it("treats an absent map as no overrides instead of throwing", () => {
+    // This is the whole provisioning path: SANDBOX_START resolves a tier
+    // before calling runner.ensure, so throwing here fails the provision
+    // outright. It did — 16 SANDBOX_START tests died on
+    // "undefined is not an object" because their getSettings() stub has no
+    // sandboxTierMap, and any settings object missing the key would do the
+    // same in production.
+    expect(
+      resolveSandboxTier(undefined, {
+        orgSlug: "acme",
+        repo: { owner: "acme", name: "monorepo" },
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/apps/api/src/sandbox/tier.test.ts
+++ b/apps/api/src/sandbox/tier.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { resolveSandboxTier } from "./tier";
+
+const MAP = {
+  "acme/acme/monorepo": "large",
+  acme: "medium",
+};
+
+describe("resolveSandboxTier", () => {
+  it("prefers the repo-scoped assignment over the org-wide one", () => {
+    expect(
+      resolveSandboxTier(MAP, {
+        orgSlug: "acme",
+        repo: { owner: "acme", name: "monorepo" },
+      }),
+    ).toBe("large");
+  });
+
+  it("falls back to the org-wide assignment for another repo", () => {
+    expect(
+      resolveSandboxTier(MAP, {
+        orgSlug: "acme",
+        repo: { owner: "acme", name: "website" },
+      }),
+    ).toBe("medium");
+  });
+
+  it("applies the org-wide assignment to a repo-less sandbox", () => {
+    expect(resolveSandboxTier(MAP, { orgSlug: "acme", repo: null })).toBe(
+      "medium",
+    );
+  });
+
+  it("returns undefined for an unassigned org so the chart default applies", () => {
+    expect(
+      resolveSandboxTier(MAP, {
+        orgSlug: "other",
+        repo: { owner: "acme", name: "monorepo" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("never applies an assignment without an org scope", () => {
+    // A repo key alone must not match — assignment is per (org, repo), so a
+    // second org cloning the same public repo can't inherit the tier.
+    expect(
+      resolveSandboxTier(MAP, { repo: { owner: "acme", name: "monorepo" } }),
+    ).toBeUndefined();
+  });
+
+  it("matches case-insensitively on owner/repo", () => {
+    expect(
+      resolveSandboxTier(MAP, {
+        orgSlug: "Acme",
+        repo: { owner: "ACME", name: "Monorepo" },
+      }),
+    ).toBe("large");
+  });
+
+  it("returns undefined for an empty map", () => {
+    expect(
+      resolveSandboxTier(
+        {},
+        { orgSlug: "acme", repo: { owner: "acme", name: "monorepo" } },
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/apps/api/src/sandbox/tier.ts
+++ b/apps/api/src/sandbox/tier.ts
@@ -38,11 +38,18 @@ export interface SandboxTierScope {
  * Keys are matched lowercased (GitHub owner/repo are case-insensitive, and org
  * slugs are already lowercase), so a map written with the casing a human reads
  * off the GitHub UI still matches.
+ *
+ * An absent map is "no overrides", not a bug: this is an override-only lookup,
+ * so nothing configured means every sandbox takes the provider's default —
+ * exactly what an empty map means. Typed optional because `getSettings()` is a
+ * partial in unit tests, and a provisioning path must not throw over a setting
+ * whose whole meaning is "may be unset".
  */
 export function resolveSandboxTier(
-  map: Record<string, string>,
+  map: Record<string, string> | undefined,
   scope: SandboxTierScope,
 ): string | undefined {
+  if (!map) return undefined;
   const org = scope.orgSlug?.trim().toLowerCase();
   if (!org) return undefined;
   if (scope.repo) {

--- a/apps/api/src/sandbox/tier.ts
+++ b/apps/api/src/sandbox/tier.ts
@@ -1,0 +1,55 @@
+/**
+ * Sandbox size-tier assignment.
+ *
+ * A tier is an opaque name (small / medium / large / ...) for a size +
+ * placement profile. This module only answers "which tier does this (org,
+ * repo) get", from the `STUDIO_SANDBOX_TIER_MAP` overrides parsed in
+ * `settings/resolve-config.ts`; what a tier *means* belongs to whichever
+ * sandbox provider is active, and nothing here knows how it's implemented (the
+ * hosted provider maps a tier to a per-tier SandboxTemplate; a provider
+ * without tiering ignores it — see `EnsureOptions.tier`).
+ *
+ * Deliberately NOT stored on `virtual_mcps.metadata`: that blob is writable by
+ * any org member through `VIRTUAL_MCP_UPDATE`, so a tenant could assign itself
+ * the largest tier. Assignment has to stay operator-controlled for the tiers
+ * to be priceable at all.
+ *
+ * ponytail: a deploy-time env var, so changing an assignment needs a rollout.
+ * Right for the handful of repos that currently need a bigger pod; when the
+ * list outgrows an env var, move it to a column on `organization_settings`
+ * (non-boolean, so a column and not a `flags` entry) plus an `/api/_admin`
+ * tool — the lookup below is the seam that changes.
+ */
+
+export interface SandboxTierScope {
+  /** Organization slug. Absent (e.g. no org context) → no override applies. */
+  orgSlug?: string;
+  /** Repo the sandbox clones, when the agent has one attached. */
+  repo?: { owner: string; name: string } | null;
+}
+
+/**
+ * Resolve the tier for a scope, most specific key first:
+ *   1. `<orgSlug>/<owner>/<repo>` — one repo of one org
+ *   2. `<orgSlug>` — every repo of one org
+ *   3. undefined — the provider's own default, so Studio never has to know
+ *      which tier that is or what it's called.
+ *
+ * Keys are matched lowercased (GitHub owner/repo are case-insensitive, and org
+ * slugs are already lowercase), so a map written with the casing a human reads
+ * off the GitHub UI still matches.
+ */
+export function resolveSandboxTier(
+  map: Record<string, string>,
+  scope: SandboxTierScope,
+): string | undefined {
+  const org = scope.orgSlug?.trim().toLowerCase();
+  if (!org) return undefined;
+  if (scope.repo) {
+    const owner = scope.repo.owner.trim().toLowerCase();
+    const name = scope.repo.name.trim().toLowerCase();
+    const byRepo = map[`${org}/${owner}/${name}`];
+    if (byRepo) return byRepo;
+  }
+  return map[org];
+}

--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -388,3 +388,43 @@ describe("resolveConfig topup fee percent", () => {
     ).toThrow("STUDIO_TOPUP_FEE_PERCENT must be a positive integer");
   });
 });
+
+describe("resolveConfig sandbox tier map", () => {
+  it("defaults to no assignments", () => {
+    expect(resolveConfig(flags, {}).settings.sandboxTierMap).toEqual({});
+  });
+
+  it("parses org- and repo-scoped assignments, lowercasing the keys", () => {
+    expect(
+      resolveConfig(flags, {
+        STUDIO_SANDBOX_TIER_MAP:
+          '{"acme/Acme/Monorepo":"large","acme":"medium"}',
+      }).settings.sandboxTierMap,
+    ).toEqual({ "acme/acme/monorepo": "large", acme: "medium" });
+  });
+
+  it("ignores malformed JSON instead of failing boot", () => {
+    // This gates sandbox provisioning for the whole deployment — a typo in one
+    // env var must not take every org's sandboxes down with it.
+    expect(
+      resolveConfig(flags, { STUDIO_SANDBOX_TIER_MAP: "{oops" }).settings
+        .sandboxTierMap,
+    ).toEqual({});
+  });
+
+  it("ignores a non-object JSON value", () => {
+    expect(
+      resolveConfig(flags, { STUDIO_SANDBOX_TIER_MAP: '["large"]' }).settings
+        .sandboxTierMap,
+    ).toEqual({});
+  });
+
+  it("drops entries whose tier is not a valid name, keeping the rest", () => {
+    expect(
+      resolveConfig(flags, {
+        STUDIO_SANDBOX_TIER_MAP:
+          '{"acme":"Large","beta":42,"gamma":"","delta":"medium"}',
+      }).settings.sandboxTierMap,
+    ).toEqual({ delta: "medium" });
+  });
+});

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -162,6 +162,66 @@ function resolveSandboxProviderKind(
   return kind as SandboxProviderKind;
 }
 
+// Tier names are opaque to Studio but end up composed into provider-side
+// identifiers, so keep them to a conservative lowercase identifier here rather
+// than passing arbitrary strings through. Matches the shape the sandbox-env
+// chart accepts for a `tiers` key.
+const SANDBOX_TIER_RE = /^[a-z]([a-z0-9-]{0,14}[a-z0-9])?$/;
+
+/**
+ * Parse `STUDIO_SANDBOX_TIER_MAP` — a JSON object of sandbox size-tier
+ * OVERRIDES, keyed by `<orgSlug>/<owner>/<repo>` or `<orgSlug>`:
+ *
+ *   {"acme/acme/monorepo": "large", "acme": "medium"}
+ *
+ * Only overrides; anything unlisted gets the active sandbox provider's own
+ * default, which is why Studio never needs to know the default tier's name.
+ *
+ * Malformed input degrades to "no overrides" rather than throwing: this gates
+ * sandbox provisioning for every org, and a typo in one deploy env var must
+ * not take the whole fleet's sandboxes down. Bad individual entries are
+ * dropped with a warning, so an operator sees which ones didn't take.
+ *
+ * A tier name that passes the shape check but that the provider doesn't offer
+ * fails at provisioning time for that (org, repo) only (on the hosted provider:
+ * "sandboxtemplate not found"). Studio can't enumerate a provider's tiers, so
+ * this map and the provider's tier set have to be changed together.
+ */
+function resolveSandboxTierMap(
+  raw: string | undefined,
+): Record<string, string> {
+  const trimmed = (raw ?? "").trim();
+  if (trimmed === "") return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    console.warn(
+      "[settings] STUDIO_SANDBOX_TIER_MAP is not valid JSON — ignoring it; every sandbox falls back to the provider's default tier.",
+    );
+    return {};
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    console.warn(
+      '[settings] STUDIO_SANDBOX_TIER_MAP must be a JSON object of {"<orgSlug>[/<owner>/<repo>]": "<tier>"} — ignoring it.',
+    );
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    const scope = key.trim().toLowerCase();
+    const tier = typeof value === "string" ? value.trim() : "";
+    if (scope === "" || !SANDBOX_TIER_RE.test(tier)) {
+      console.warn(
+        `[settings] STUDIO_SANDBOX_TIER_MAP entry ${JSON.stringify(key)} dropped: value must be a DNS-label tier name (got ${JSON.stringify(value)}).`,
+      );
+      continue;
+    }
+    out[scope] = tier;
+  }
+  return out;
+}
+
 export interface ResolvedConfig {
   settings: Omit<Settings, "databaseUrl" | "natsUrls">;
   externalDatabaseUrl: string | null;
@@ -303,6 +363,7 @@ export function resolveConfig(
     sandboxProviderKind: resolveSandboxProviderKind(
       envVars.STUDIO_SANDBOX_PROVIDER,
     ),
+    sandboxTierMap: resolveSandboxTierMap(envVars.STUDIO_SANDBOX_TIER_MAP),
 
     // External service credentials
     decoSupabaseUrl: envVars.DECO_SUPABASE_URL,

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -141,6 +141,12 @@ export interface Settings {
   /** Which DBOS run queues this pod dequeues (pod dispatch-role split). */
   dispatchRole: DispatchRole;
   sandboxProviderKind: "agent-sandbox" | "user-desktop";
+  /** Sandbox size-tier assignments, parsed from STUDIO_SANDBOX_TIER_MAP.
+   *  Keys are `<orgSlug>/<owner>/<repo>` or `<orgSlug>`; values are opaque
+   *  tier names the active sandbox provider resolves to a size/placement
+   *  profile of its own. Only overrides live here — an unlisted (org, repo)
+   *  gets the provider's default. See `sandbox/tier.ts` for the lookup. */
+  sandboxTierMap: Record<string, string>;
 
   // External service credentials (optional)
   decoSupabaseUrl: string | undefined;

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -52,6 +52,7 @@ import {
 import { generateBranchName } from "@decocms/shared/branch-name";
 import { PACKAGE_MANAGER_CONFIG } from "@decocms/shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
+import { resolveSandboxTier } from "../../sandbox/tier";
 import {
   getThreadGithubRepo,
   getThreadHeadRef,
@@ -532,25 +533,32 @@ async function provisionSandbox(
     !getSettings().orgFsMountsDisabled;
   // ctx.organization is unset on the decopilot vm-tools dispatch path (the
   // org travels as the `orgId` param there) — resolve the slug from the row
-  // so chat-ephemeral sandboxes get mounts too.
+  // so chat-ephemeral sandboxes get mounts too (and so a tier assignment,
+  // which is keyed by slug, applies on that path as well).
+  const orgSlug =
+    ctx.organization?.slug ??
+    (
+      await ctx.db
+        .selectFrom("organization")
+        .select(["slug"])
+        .where("id", "=", orgId)
+        .executeTakeFirst()
+    )?.slug;
+
+  // Size/placement tier for this (org, repo). Undefined → the provider's
+  // default tier; providers without tiering ignore it entirely.
+  const tier = resolveSandboxTier(getSettings().sandboxTierMap, {
+    orgSlug,
+    repo: githubRepo,
+  });
+
   let orgFsConfigJson: string | undefined;
-  if (wantsOrgFs) {
-    const orgSlug =
-      ctx.organization?.slug ??
-      (
-        await ctx.db
-          .selectFrom("organization")
-          .select(["slug"])
-          .where("id", "=", orgId)
-          .executeTakeFirst()
-      )?.slug;
-    if (orgSlug) {
-      orgFsConfigJson = await mintOrgFsConfigJson(ctx, {
-        orgSlug,
-        orgId,
-        baseUrl: getPublicUrl(),
-      });
-    }
+  if (wantsOrgFs && orgSlug) {
+    orgFsConfigJson = await mintOrgFsConfigJson(ctx, {
+      orgSlug,
+      orgId,
+      baseUrl: getPublicUrl(),
+    });
   }
 
   const sandbox = await runner.ensure(
@@ -564,6 +572,7 @@ async function provisionSandbox(
       branch,
       repo: repoOpts,
       workload,
+      ...(tier ? { tier } : {}),
       tenant: {
         orgId,
         // The sandbox's owner, so the pod's `user_id` label/metric matches the

--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -1,14 +1,25 @@
 apiVersion: v2
 name: sandbox-env
 description: |
-  Studio-side resources that consume the agent-sandbox operator: the
-  shared SandboxTemplate, Studio runner RBAC, sandbox-pod NetworkPolicy,
-  optional SandboxWarmPool, and optional preview Gateway / HTTPRoute /
-  Certificate. Install one release per environment (dev / staging /
+  Studio-side resources that consume the agent-sandbox operator: a
+  SandboxTemplate per size tier, Studio runner RBAC, sandbox-pod
+  NetworkPolicy, optional SandboxWarmPools, and optional preview Gateway /
+  HTTPRoute / Certificate. Install one release per environment (dev / staging /
   prod / ...). Resource names are suffixed with `envName` so multiple
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.10.0: sandbox tiers. One SandboxTemplate + SandboxWarmPool per entry in
+# `values.tiers` (small / medium / large ship by default), each with its own
+# resources, emptyDir size limits, and placement (nodeSelector / tolerations /
+# affinity / spread / podLabels / podAnnotations). `defaultTier` renders at the
+# unsuffixed name, so existing claims and STUDIO_SANDBOX_TEMPLATE_NAME are
+# unaffected and the default tier's rendered pod spec is unchanged apart from a
+# new `studio.decocms.com/tier` label. Minor bump, not patch: the chart now
+# creates additional objects (2 templates + up to 3 warm pools) and the
+# previously-hardcoded emptyDir sizeLimits moved into
+# `values.emptyDirSizeLimits`. Studio assigns a tier per (org, repo) via
+# STUDIO_SANDBOX_TIER_MAP; unassigned sandboxes keep landing on defaultTier.
 # 0.9.20: Studio terminology and compatibility documentation refresh. The
 # legacy `mesh.*` values key remains supported; no runtime behavior changes.
 # 0.9.14: sandbox pod memory request 1Gi -> 2Gi (= measured p95 of per-pod peak
@@ -47,7 +58,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.9.43
+version: 0.10.0
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.26.1"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -7,11 +7,12 @@ is suffixed with `envName` so multiple releases coexist in the shared
 
 Renders:
 
-- `SandboxTemplate` `studio-sandbox-<envName>`
+- One `SandboxTemplate` per size tier: `studio-sandbox-<envName>` for the
+  default tier, `studio-sandbox-<envName>-<tier>` for the rest (see [Tiers](#tiers))
 - `Role` + `RoleBinding` `studio-sandbox-runner-<envName>` (for the Studio
   ServiceAccount of THIS env's studio install)
 - `Secret` `studio-sandbox-sentinel-<envName>` (initial daemon token)
-- `SandboxWarmPool` `studio-sandbox-<envName>` (optional)
+- One `SandboxWarmPool` per tier, named after its template (optional)
 - `HorizontalPodAutoscaler` for the warm pool (optional; requires explicit metrics)
 - `Gateway` + `Certificate` `agent-sandbox-preview-<envName>` (optional;
   per-claim HTTPRoutes are minted by the Studio runner, not by this chart)
@@ -120,6 +121,9 @@ configMap:
     STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
     STUDIO_ENV: "staging"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-staging"
+    # Optional per-(org, repo) size-tier overrides; see Tiers below. Omitted =
+    # every sandbox uses the chart's defaultTier.
+    STUDIO_SANDBOX_TIER_MAP: '{"acme/acme/monorepo":"large"}'
     # The next three values are required only when previewGateway.enabled=true.
     STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.preview.staging.example.com"
     # Per-claim HTTPRoute attaches to this Gateway. Both required whenever
@@ -131,6 +135,59 @@ configMap:
     STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME: "agent-sandbox-preview-staging"
     STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE: "istio-system"
 ```
+
+## Tiers
+
+The chart renders one `SandboxTemplate` per entry in `values.tiers` — the
+size/placement combos a claim can pick from. `defaultTier` renders at the
+**unsuffixed** name (`studio-sandbox-<envName>`) and every other tier at
+`studio-sandbox-<envName>-<tier>`, so adding tiers to a running environment is
+a pure addition: existing claims and an existing
+`STUDIO_SANDBOX_TEMPLATE_NAME` keep resolving untouched.
+
+A tier owns resources **and** placement — `nodeSelector`, `tolerations`,
+`affinity`, `topologySpreadConstraints`, `podLabels`, `podAnnotations`,
+`warmPoolSize` — each wholesale-overriding the top-level value of the same
+name. That's the seam for "this tier runs on on-demand capacity only", or for
+per-tier labels a cost dashboard groups by. `podLabels`/`podAnnotations` may
+not use the `studio.decocms.com/` prefix (the Studio runner owns it; the
+operator rejects claims that redefine a key the template already set) — the
+chart fails at install time rather than at first claim.
+
+Every tier also gets a `SandboxWarmPool`, even at `warmPoolSize: 0`: claims
+always carry `warmpool: "default"`, so the pool has to exist for the reference
+to resolve, and an empty one falls through to a cold render. Warm the tiers you
+want warm and leave the rest at 0 — a warm replica costs its own tier's full
+resource request.
+
+### Assigning a tier
+
+Assignment is Studio-side and operator-controlled, via
+`STUDIO_SANDBOX_TIER_MAP` in the studio release's `configMap.meshConfig`: a
+JSON object of overrides keyed by `<orgSlug>/<owner>/<repo>` (one repo) or
+`<orgSlug>` (every repo of an org), most specific first.
+
+```yaml
+configMap:
+  meshConfig:
+    # Anything unlisted gets the chart's defaultTier.
+    STUDIO_SANDBOX_TIER_MAP: '{"acme/acme/monorepo":"large","acme":"medium"}'
+```
+
+Deliberately not a per-agent setting in the product: agent metadata is writable
+by any org member, so a tenant could assign itself the largest tier. Keep
+`defaultTier` the cheapest option for the same reason.
+
+Two consequences worth knowing:
+
+- **Tier names are not validated against the chart.** Studio can't enumerate a
+  provider's tiers, so a name with no matching `tiers` key fails claim creation
+  with `sandboxtemplate not found` for that (org, repo). Change both sides
+  together.
+- **A tier is frozen for a sandbox's lifetime.** The claim handle can't encode
+  it (the sandbox proxy derives the handle from the URL and has no tier
+  context), so a re-assignment applies on the next cold provision. To resize a
+  running sandbox now, delete it (`SANDBOX_DELETE`) and let it re-provision.
 
 ### Warm-pool token wiring
 
@@ -207,9 +264,9 @@ sandbox-env/
 │   └── values-kind.yaml                 # local dev overrides
 └── templates/
     ├── _helpers.tpl
-    ├── validations.yaml                 # envName + Gateway API + cert-manager preflight
-    ├── sandbox-template.yaml            # SandboxTemplate (per-env)
-    ├── sandbox-warm-pool.yaml           # SandboxWarmPool (optional)
+    ├── validations.yaml                 # envName + tiers + Gateway API + cert-manager preflight
+    ├── sandbox-template.yaml            # SandboxTemplate (one per tier, per env)
+    ├── sandbox-warm-pool.yaml           # SandboxWarmPool (one per tier, optional)
     ├── sandbox-warmpool-hpa.yaml         # Warm-pool HPA (optional)
     ├── sandbox-sentinel-secret.yaml      # Initial daemon token
     ├── sandbox-rbac.yaml                # Role + cross-ns RoleBinding to Studio SA
@@ -231,7 +288,9 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `envName` | _(required)_ | DNS-label suffix on every resource name |
 | `image.repository` | `ghcr.io/decocms/studio/studio-sandbox` | studio-sandbox image |
 | `image.tag` | chart `appVersion` | bump in lockstep with packages/sandbox/package.json |
-| `resources.*` | 0.5/2 CPU, 1/4Gi RAM | per sandbox pod |
+| `resources.*` | 0.5/2 CPU, 2/4Gi RAM | per sandbox pod — the `defaultTier` baseline |
+| `emptyDirSizeLimits.*` | 4Gi / 1Gi / 5Gi | workdir / tmp / home slices of the ephemeral-storage limit |
+| `defaultTier` / `tiers.*` | `small` / small+medium+large | per-tier size + placement; see [Tiers](#tiers) |
 | `nodeSelector` / `tolerations` / `affinity` | `{}` | for sandbox isolation NodePool |
 | `topologySpreadConstraints` | `[]` | spread sandbox pods across AZs; see `values.yaml` for the recommended config |
 | `readOnlyRootFilesystem` | `true` | RO rootfs + emptyDirs on /app, /tmp, /home |

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -38,6 +38,72 @@ keying off `app.kubernetes.io/name` get a single coherent label.
 {{- end }}
 
 {{/*
+Per-tier SandboxTemplate / SandboxWarmPool name. `defaultTier` renders at the
+UNSUFFIXED `sandboxName` so an existing STUDIO_SANDBOX_TEMPLATE_NAME (and every
+claim already referencing it) stays valid — adding tiers is a pure addition.
+Studio therefore never needs to know which tier is the default: it omits the
+suffix when it has no tier assignment. Takes a dict: (dict "root" $ "tier" $t).
+*/}}
+{{- define "sandbox-env.tierTemplateName" -}}
+{{- $base := include "sandbox-env.sandboxName" .root -}}
+{{- if eq .tier .root.Values.defaultTier -}}
+{{- $base -}}
+{{- else -}}
+{{- printf "%s-%s" $base .tier -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Label key carrying the tier on SandboxTemplates, warm pools, and sandbox pods.
+Single definition because it's a join key for cost-attribution dashboards.
+*/}}
+{{- define "sandbox-env.tierLabelKey" -}}
+studio.decocms.com/tier
+{{- end }}
+
+{{/*
+Validate values.tiers before anything renders. Four failure modes, all of
+which would otherwise surface as a broken tier at first claim rather than at
+install time:
+  - defaultTier not a key of tiers: nothing would render at the unsuffixed
+    name, so every existing claim + STUDIO_SANDBOX_TEMPLATE_NAME breaks with
+    "sandboxtemplate not found".
+  - empty tiers map: same, plus no templates at all.
+  - a tier name that isn't a DNS label: the suffixed object name is rejected
+    by the API server.
+  - a podLabels/podAnnotations key under `studio.decocms.com/` — that prefix
+    belongs to the Studio runner's additionalPodMetadata, and the operator
+    rejects a claim whose additionalPodMetadata redefines a key the template
+    already set ("metadata override conflict"). Every claim on that tier
+    would fail. Banning the whole prefix keeps this in sync with the runner's
+    LABEL_KEYS/ANNOTATION_KEYS without duplicating the list here.
+*/}}
+{{- define "sandbox-env.validateTiers" -}}
+{{- if not .Values.tiers -}}
+{{- fail "sandbox-env: values.tiers must define at least one tier (e.g. tiers.small={})." -}}
+{{- end -}}
+{{- $default := .Values.defaultTier | default "" -}}
+{{- if not (hasKey .Values.tiers $default) -}}
+{{- fail (printf "sandbox-env: defaultTier=%q is not a key of values.tiers (%s). The default tier renders at the unsuffixed template name every existing claim references." $default (keys .Values.tiers | sortAlpha | join ",")) -}}
+{{- end -}}
+{{- range $tier, $cfg := .Values.tiers -}}
+{{- if not (regexMatch "^[a-z]([a-z0-9-]{0,14}[a-z0-9])?$" $tier) -}}
+{{- fail (printf "sandbox-env: tier name %q must be a DNS label: lowercase alphanumeric or '-', start with a letter, end alphanumeric, 1-16 chars" $tier) -}}
+{{- end -}}
+{{- range $key, $_ := (default dict (default dict $cfg).podLabels) -}}
+{{- if hasPrefix "studio.decocms.com/" $key -}}
+{{- fail (printf "sandbox-env: tiers.%s.podLabels may not set %q — the studio.decocms.com/ prefix is owned by the Studio runner's additionalPodMetadata, and the operator rejects claims that redefine a key the template already set." $tier $key) -}}
+{{- end -}}
+{{- end -}}
+{{- range $key, $_ := (default dict (default dict $cfg).podAnnotations) -}}
+{{- if hasPrefix "studio.decocms.com/" $key -}}
+{{- fail (printf "sandbox-env: tiers.%s.podAnnotations may not set %q — see the podLabels restriction." $tier $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Studio runner Role / RoleBinding name. Stays under 63 chars even with a
 32-char envName.
 */}}

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -1,18 +1,39 @@
-# Shared SandboxTemplate consumed by every SandboxClaim the Studio runner
-# creates for THIS environment. Resource ceilings come from values.resources.
+# One SandboxTemplate per entry in values.tiers — the size/placement "combos"
+# a SandboxClaim can pick from (small / medium / large / ...). Everything
+# below except the per-tier knobs is shared, so the tiers can't drift in
+# security posture, netinit, or org-fs wiring.
+#
+# `defaultTier` renders at the UNSUFFIXED name (studio-sandbox-<env>), every
+# other tier at studio-sandbox-<env>-<tier>. That keeps an existing
+# STUDIO_SANDBOX_TEMPLATE_NAME (and every live claim referencing it) valid, so
+# adding tiers is a pure addition to a running environment.
 #
 # Hardcoded to the operator's own namespace (agent-sandbox-system) — the CRDs
 # ship with that as the install target, and the operator's RBAC watches it by
 # default. The template *name* is suffixed with envName so multiple
 # environments' SandboxTemplates coexist; Studio in this env must reference
 # the suffixed name via STUDIO_SANDBOX_TEMPLATE_NAME.
+{{- range $tier, $cfg := .Values.tiers }}
+{{- $cfg = default dict $cfg }}
+{{- /* Per-tier overrides. Wholesale (not deep-merged) per key: merging
+       toleration/affinity lists silently produces a placement nobody wrote.
+       An empty value ({} / []) reads as "unset" and inherits, so a tier
+       cannot override *back* to empty — set the top-level default instead. */}}
+{{- $resources := $cfg.resources | default $.Values.resources }}
+{{- $nodeSelector := $cfg.nodeSelector | default $.Values.nodeSelector }}
+{{- $tolerations := $cfg.tolerations | default $.Values.tolerations }}
+{{- $affinity := $cfg.affinity | default $.Values.affinity }}
+{{- $spread := $cfg.topologySpreadConstraints | default $.Values.topologySpreadConstraints }}
+{{- $sizeLimits := $cfg.emptyDirSizeLimits | default dict }}
+---
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxTemplate
 metadata:
-  name: {{ include "sandbox-env.sandboxName" . }}
+  name: {{ include "sandbox-env.tierTemplateName" (dict "root" $ "tier" $tier) }}
   namespace: agent-sandbox-system
   labels:
-    {{- include "sandbox-env.sandboxLabels" . | nindent 4 }}
+    {{- include "sandbox-env.sandboxLabels" $ | nindent 4 }}
+    {{ include "sandbox-env.tierLabelKey" $ }}: {{ $tier | quote }}
 spec:
   # The operator's controller rejects per-claim env outright when
   # `claim.spec.warmpool != "none"`, so warm-pool consumption requires
@@ -29,8 +50,9 @@ spec:
   networkPolicyManagement: Unmanaged
   podTemplate:
     metadata:
-      {{- if .Values.netinit.enabled }}
+      {{- if or $.Values.netinit.enabled $cfg.podAnnotations }}
       annotations:
+        {{- if $.Values.netinit.enabled }}
         # Best-effort AWS VPC CNI opt-out. The real safety net is that no
         # NetworkPolicy selects these pods (networkPolicyManagement:
         # Unmanaged + no chart-rendered NP), so the agent's policy-endpoint
@@ -38,6 +60,10 @@ spec:
         # in aws-network-policy-agent's source — verify it's honored before
         # relying on it if a future NP starts matching these pods.
         vpc.amazonaws.com/v1alpha1.network-policy-enforcement: "disabled"
+        {{- end }}
+        {{- with $cfg.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         # Per-env name so each env's NetworkPolicy podSelector matches only
@@ -45,40 +71,52 @@ spec:
         # SandboxClaim.additionalPodMetadata (driven by
         # STUDIO_SANDBOX_TEMPLATE_NAME pointing at the env-suffixed
         # template) — keep these in lockstep.
-        app.kubernetes.io/name: {{ include "sandbox-env.sandboxName" . }}
+        #
+        # Deliberately NOT tier-suffixed: the housekeeper's podSelector and
+        # any topologySpreadConstraints labelSelector key off this value, so
+        # tiering it would silently drop the other tiers out of idle reaping.
+        # Tier lives in its own label below.
+        app.kubernetes.io/name: {{ include "sandbox-env.sandboxName" $ }}
+        # Cost attribution: joins cAdvisor/kubelet pod metrics to a tier.
+        {{ include "sandbox-env.tierLabelKey" $ }}: {{ $tier | quote }}
+        {{- with $cfg.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         # Do NOT set `studio.decocms.com/role` here. The operator (v0.4.2+)
         # rejects claims whose additionalPodMetadata defines a label key
         # already present in the template — even when the values differ —
         # with "metadata override conflict". The runner sets role=claimed
         # via additionalPodMetadata, so the template must leave that key
         # undefined. Warm-pool pods end up without the role label;
-        # dashboards filter by absence-of-handle instead.
+        # dashboards filter by absence-of-handle instead. Same reason
+        # validateTiers rejects any `studio.decocms.com/*` key in a tier's
+        # podLabels/podAnnotations.
     spec:
       automountServiceAccountToken: false
       # Room for the daemon's SIGTERM git-sync (commit + push, push bounded at
       # 30s) before SIGKILL — the pushed branch is the only durable copy of the
       # user's work. See values.yaml.
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- with .Values.nodeSelector }}
+      terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds }}
+      {{- with $nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with $tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with $affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
+      {{- with $spread }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.dnsPolicy }}
-      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- if $.Values.dnsPolicy }}
+      dnsPolicy: {{ $.Values.dnsPolicy }}
       {{- end }}
-      {{- with .Values.dnsConfig }}
+      {{- with $.Values.dnsConfig }}
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -89,7 +127,7 @@ spec:
       # untrusted agent container is locked down independently either way
       # (drop ALL caps, no privilege escalation, runAsNonRoot, seccomp
       # RuntimeDefault below); only the org-fs sidecar is privileged.
-      hostUsers: {{ not .Values.disableFsSidecar }}
+      hostUsers: {{ not $.Values.disableFsSidecar }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -97,16 +135,16 @@ spec:
         fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
-      {{- if or .Values.netinit.enabled .Values.depsCache.enabled }}
+      {{- if or $.Values.netinit.enabled $.Values.depsCache.enabled }}
       initContainers:
-        {{- if .Values.depsCache.enabled }}
+        {{- if $.Values.depsCache.enabled }}
         # hostPath dirs are created root:root and fsGroup does not apply to
         # hostPath volumes, so hand the cache root to the sandbox uid once
         # per pod (idempotent). Reuses the sandbox image — already on the
         # node, no extra pull.
         - name: deps-cache-init
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
           command: ["sh", "-c", "chown 1000:1000 /deps-cache"]
           resources:
             requests:
@@ -126,10 +164,10 @@ spec:
             - name: deps-cache
               mountPath: /deps-cache
         {{- end }}
-        {{- if .Values.netinit.enabled }}
+        {{- if $.Values.netinit.enabled }}
         - name: setup-netpol
-          image: "{{ .Values.netinit.image }}:{{ .Values.netinit.tag }}"
-          imagePullPolicy: {{ .Values.netinit.pullPolicy }}
+          image: "{{ $.Values.netinit.image }}:{{ $.Values.netinit.tag }}"
+          imagePullPolicy: {{ $.Values.netinit.pullPolicy }}
           command:
             - sh
             - -c
@@ -152,13 +190,13 @@ spec:
               iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT 2>/dev/null \
                 || iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null \
                 || { echo "ERROR: neither -m conntrack nor -m state available; cannot install ESTABLISHED,RELATED rule. Preview ingress would silently break. Failing the init container so the pod does not come up." >&2; exit 1; }
-              {{- range .Values.netinit.blockCIDRs }}
+              {{- range $.Values.netinit.blockCIDRs }}
               iptables -A OUTPUT -d {{ . | quote }} -j REJECT
               {{- end }}
-              {{- range .Values.netinit.allowedUDPPorts }}
+              {{- range $.Values.netinit.allowedUDPPorts }}
               iptables -A OUTPUT -p udp --dport {{ . }} -j ACCEPT
               {{- end }}
-              {{- range .Values.netinit.allowedTCPPorts }}
+              {{- range $.Values.netinit.allowedTCPPorts }}
               iptables -A OUTPUT -p tcp --dport {{ . }} -j ACCEPT
               {{- end }}
               iptables -A OUTPUT -j REJECT
@@ -171,13 +209,13 @@ spec:
                 ip6tables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT 2>/dev/null \
                   || ip6tables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null \
                   || { echo "ERROR: neither -m conntrack nor -m state available (ip6tables); cannot install ESTABLISHED,RELATED rule for IPv6. Failing the init container." >&2; exit 1; }
-                {{- range .Values.netinit.blockCIDRsIPv6 }}
+                {{- range $.Values.netinit.blockCIDRsIPv6 }}
                 ip6tables -A OUTPUT -d {{ . | quote }} -j REJECT
                 {{- end }}
-                {{- range .Values.netinit.allowedUDPPorts }}
+                {{- range $.Values.netinit.allowedUDPPorts }}
                 ip6tables -A OUTPUT -p udp --dport {{ . }} -j ACCEPT
                 {{- end }}
-                {{- range .Values.netinit.allowedTCPPorts }}
+                {{- range $.Values.netinit.allowedTCPPorts }}
                 ip6tables -A OUTPUT -p tcp --dport {{ . }} -j ACCEPT
                 {{- end }}
                 ip6tables -A OUTPUT -j REJECT
@@ -207,18 +245,18 @@ spec:
       {{- end }}
       containers:
         - name: sandbox
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
           workingDir: /app
           env:
             - name: WORKDIR
               value: "/app"
-            {{- if .Values.depsCache.enabled }}
+            {{- if $.Values.depsCache.enabled }}
             # Root of the node-local dependency cache; the daemon derives a
             # per-repo BUN_INSTALL_CACHE_DIR under it (see setup/install.ts).
             - name: DEPS_CACHE_ROOT
               value: "/deps-cache"
-            {{- if .Values.depsCache.golden }}
+            {{- if $.Values.depsCache.golden }}
             # Golden node_modules reflink cache (opt-in, off by default — it
             # touches the boot install path). Requires a reflink-capable
             # filesystem shared between the cache and the workdir; falls back
@@ -232,9 +270,9 @@ spec:
             - name: DAEMON_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "sandbox-env.sentinelSecretName" . }}
+                  name: {{ include "sandbox-env.sentinelSecretName" $ }}
                   key: daemonToken
-            {{- if .Values.readOnlyRootFilesystem }}
+            {{- if $.Values.readOnlyRootFilesystem }}
             # With RO rootfs + emptyDir on /app, the mount root is owned
             # root:1000 (fsGroup). Git 2.35+'s "dubious ownership" check
             # would refuse to operate. Disable the check inside the
@@ -246,7 +284,7 @@ spec:
             - name: GIT_CONFIG_VALUE_0
               value: "*"
             {{- end }}
-            {{- if not .Values.disableFsSidecar }}
+            {{- if not $.Values.disableFsSidecar }}
             # org-fs relay: the daemon writes the mount config here for the
             # sidecar, and gates the per-run output link on its status file.
             - name: ORGFS_SIDECAR_CONFIG_PATH
@@ -262,26 +300,26 @@ spec:
               containerPort: 3000
               protocol: TCP
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml $resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-            readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
+            readOnlyRootFilesystem: {{ $.Values.readOnlyRootFilesystem }}
           volumeMounts:
-            {{- if .Values.readOnlyRootFilesystem }}
+            {{- if $.Values.readOnlyRootFilesystem }}
             - name: workdir
               mountPath: /app
             - name: tmp
               mountPath: /tmp
             {{- end }}
-            {{- if .Values.depsCache.enabled }}
+            {{- if $.Values.depsCache.enabled }}
             - name: deps-cache
               mountPath: /deps-cache
             {{- end }}
             - name: home
               mountPath: /home/sandbox
-            {{- if not .Values.disableFsSidecar }}
+            {{- if not $.Values.disableFsSidecar }}
             # The sidecar's FUSE mounts under /app/org surface here.
             - name: orgfs-org
               mountPath: /app/org
@@ -289,15 +327,15 @@ spec:
             - name: orgfs-ctl
               mountPath: /run/orgfs
             {{- end }}
-        {{- if not .Values.disableFsSidecar }}
+        {{- if not $.Values.disableFsSidecar }}
         # Privileged org-fs mounter: waits for the daemon to relay the mount
         # config onto /run/orgfs (post-bind push), FUSE-mounts the org volumes
         # under the shared /app/org, and Bidirectional propagation surfaces
         # them in the (unprivileged) sandbox container. See
         # packages/sandbox/daemon/org-fs/sidecar.ts.
         - name: orgfs-sidecar
-          image: "{{ .Values.orgFs.image.repository }}:{{ .Values.orgFs.image.tag }}"
-          imagePullPolicy: {{ .Values.orgFs.image.pullPolicy }}
+          image: "{{ $.Values.orgFs.image.repository }}:{{ $.Values.orgFs.image.tag }}"
+          imagePullPolicy: {{ $.Values.orgFs.image.pullPolicy }}
           env:
             - name: APP_ROOT
               value: "/app"
@@ -308,7 +346,7 @@ spec:
             runAsUser: 0
             runAsNonRoot: false
           resources:
-            {{- toYaml .Values.orgFs.resources | nindent 12 }}
+            {{- toYaml $.Values.orgFs.resources | nindent 12 }}
           volumeMounts:
             - name: orgfs-org
               mountPath: /app/org
@@ -317,29 +355,31 @@ spec:
               mountPath: /run/orgfs
         {{- end }}
       volumes:
-        {{- if .Values.readOnlyRootFilesystem }}
-        # Sized to match the per-container ephemeral-storage limit shape;
-        # individual mounts get a slice. Adjust if a workload needs more.
+        {{- if $.Values.readOnlyRootFilesystem }}
+        # Slices of the per-container ephemeral-storage limit. A tier that
+        # raises that limit must raise these too, or the checkout hits the
+        # emptyDir cap long before the tier's ceiling — hence the per-tier
+        # emptyDirSizeLimits override.
         - name: workdir
           emptyDir:
-            sizeLimit: 4Gi
+            sizeLimit: {{ $sizeLimits.workdir | default $.Values.emptyDirSizeLimits.workdir }}
         - name: tmp
           emptyDir:
-            sizeLimit: 1Gi
+            sizeLimit: {{ $sizeLimits.tmp | default $.Values.emptyDirSizeLimits.tmp }}
         {{- end }}
         - name: home
           emptyDir:
-            sizeLimit: 5Gi
-        {{- if .Values.depsCache.enabled }}
+            sizeLimit: {{ $sizeLimits.home | default $.Values.emptyDirSizeLimits.home }}
+        {{- if $.Values.depsCache.enabled }}
         # Node-local package cache shared across sandbox pods (see the
         # depsCache comment in values.yaml for the hardlink + isolation
         # rationale).
         - name: deps-cache
           hostPath:
-            path: {{ .Values.depsCache.hostPath }}
+            path: {{ $.Values.depsCache.hostPath }}
             type: DirectoryOrCreate
         {{- end }}
-        {{- if not .Values.disableFsSidecar }}
+        {{- if not $.Values.disableFsSidecar }}
         # Mount surface (volumes attach under it) + relay control files.
         - name: orgfs-org
           emptyDir:
@@ -348,3 +388,4 @@ spec:
           emptyDir:
             sizeLimit: 1Mi
         {{- end }}
+{{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-warm-pool.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-warm-pool.yaml
@@ -1,19 +1,33 @@
 {{- if .Values.warmPool.enabled }}
-# Pre-warms N sandbox pods against the shared SandboxTemplate so new claims
-# bind instantly rather than waiting on image pull + kubelet start. Disabled
-# by default — enable only after measuring cold-start pain; every pool
-# replica costs the full sandbox resource request.
+# Pre-warms N sandbox pods per tier so new claims bind instantly rather than
+# waiting on image pull + kubelet start. Disabled by default — enable only
+# after measuring cold-start pain; every pool replica costs the full sandbox
+# resource request of ITS tier.
+#
+# A pool is rendered for every tier even at replicas: 0. Claims always carry
+# `warmpool: "default"` (the runner can't inject per-claim env otherwise), so
+# the pool must exist for the reference to resolve; an empty one just falls
+# through to a cold render — the same path a fully-claimed pool already takes
+# in prod. Size the tiers you actually want warm and leave the rest at 0.
 #
 # Schema (v1alpha1): see sandbox-operator/crds/agent-sandbox-crds.yaml.
+{{- range $tier, $cfg := .Values.tiers }}
+{{- $cfg = default dict $cfg }}
+{{- $name := include "sandbox-env.tierTemplateName" (dict "root" $ "tier" $tier) }}
+---
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxWarmPool
 metadata:
-  name: {{ include "sandbox-env.sandboxName" . }}
+  name: {{ $name }}
   namespace: agent-sandbox-system
   labels:
-    {{- include "sandbox-env.sandboxLabels" . | nindent 4 }}
+    {{- include "sandbox-env.sandboxLabels" $ | nindent 4 }}
+    {{ include "sandbox-env.tierLabelKey" $ }}: {{ $tier | quote }}
 spec:
-  replicas: {{ .Values.warmPool.size }}
+  {{- /* hasKey, not `default`: an explicit warmPoolSize: 0 must win over a
+         non-zero global size, and `default` treats 0 as empty. */}}
+  replicas: {{ if hasKey $cfg "warmPoolSize" }}{{ $cfg.warmPoolSize }}{{ else }}{{ $.Values.warmPool.size }}{{ end }}
   sandboxTemplateRef:
-    name: {{ include "sandbox-env.sandboxName" . }}
+    name: {{ $name }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-warmpool-hpa.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-warmpool-hpa.yaml
@@ -9,6 +9,11 @@
 # at whatever signals pool pressure in your cluster (e.g. a Prometheus
 # External/Object metric on claim-creation rate or pending-claim count via
 # the Prometheus adapter). See validations.yaml for the enforced minimum.
+#
+# Scopes to the DEFAULT tier's pool only — the non-default tiers are opt-in
+# overrides for a handful of tenants, so their pools stay at the fixed
+# tiers.<name>.warmPoolSize. Autoscale one of those by adding an HPA of your
+# own against SandboxWarmPool/studio-sandbox-<env>-<tier>.
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/deploy/helm/sandbox-env/templates/validations.yaml
+++ b/deploy/helm/sandbox-env/templates/validations.yaml
@@ -11,6 +11,7 @@ only really matters for Helm's own bookkeeping.
 */ -}}
 {{- include "sandbox-env.validatePreviewGateway" . -}}
 {{- include "sandbox-env.validateWarmPoolAutoscaling" . -}}
+{{- include "sandbox-env.validateTiers" . -}}
 {{- /* Force envName validation to run at template time even when no
 resource references it directly (pure-validation render). Discard the
 return value into a local so it doesn't leak into the rendered YAML. */ -}}

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -65,6 +65,97 @@ resources:
     memory: 4Gi
     ephemeral-storage: 10Gi
 
+# Slices of the ephemeral-storage limit above, as emptyDir sizeLimits. A tier
+# that raises `resources.limits.ephemeral-storage` should raise these too —
+# otherwise a big checkout hits the workdir cap well before the tier's
+# ceiling. `workdir`/`tmp` only apply when readOnlyRootFilesystem is true.
+emptyDirSizeLimits:
+  workdir: 4Gi
+  tmp: 1Gi
+  home: 5Gi
+
+# ── tiers ──────────────────────────────────────────────────────────────
+# One SandboxTemplate per entry: the size/placement combos a claim can pick
+# from. Studio picks a tier per (org, repo) via STUDIO_SANDBOX_TIER_MAP and
+# points `sandboxTemplateRef` at the matching template; unassigned sandboxes
+# land on `defaultTier`. Keep the default the cheapest option — an unassigned
+# tenant should never be able to opt itself into a bigger pod.
+#
+# `defaultTier` renders at the UNSUFFIXED name (studio-sandbox-<envName>) and
+# every other tier at studio-sandbox-<envName>-<tier>, so adding tiers to a
+# running environment is a pure addition: existing claims and an existing
+# STUDIO_SANDBOX_TEMPLATE_NAME keep resolving, and Studio only needs the tier
+# *names* — never which one is the default.
+#
+# Per-tier keys, each WHOLESALE-overriding its top-level counterpart above
+# (not deep-merged — a merged toleration list is a placement nobody wrote):
+#   resources, emptyDirSizeLimits (per sub-key), nodeSelector, tolerations,
+#   affinity, topologySpreadConstraints, podLabels, podAnnotations,
+#   warmPoolSize.
+# An empty value ({} / []) reads as "unset" and inherits the top-level
+# default, so a tier cannot override back to empty.
+#
+# podLabels/podAnnotations may NOT use the `studio.decocms.com/` prefix —
+# that's the Studio runner's additionalPodMetadata namespace and the operator
+# rejects claims that redefine a key the template already set. Every claim on
+# such a tier would fail; the chart fails at install time instead.
+#
+# Tier names must match the values used in STUDIO_SANDBOX_TIER_MAP on the
+# Studio side. A name only Studio knows about resolves to a template that
+# doesn't exist ("sandboxtemplate not found" at claim creation) — the chart
+# can't validate that direction, so change both together.
+defaultTier: small
+
+tiers:
+  # Inherits every top-level default above: 500m/2Gi request, 2/4Gi limit.
+  small: {}
+
+  # 1 CPU / 4Gi steady state for repos that spend their life over the small
+  # request. Both request AND limit move: raising only the limit is what
+  # produced the node memory-pressure evictions described above the
+  # `resources` block.
+  medium:
+    resources:
+      requests:
+        cpu: "1"
+        memory: 4Gi
+      limits:
+        cpu: "2"
+        memory: 8Gi
+        ephemeral-storage: 20Gi
+    emptyDirSizeLimits:
+      workdir: 8Gi
+      home: 8Gi
+    # Not worth holding idle capacity at this size until it has real traffic;
+    # these claims cold-start.
+    warmPoolSize: 0
+
+  # For repos that OOM at the medium limit (large monorepos: a Vite/tsc build
+  # over tens of thousands of modules).
+  #
+  # A tier is also where placement goes — e.g. keeping a 16Gi/20-minute build
+  # off spot capacity so a reclaim can't take it out mid-run. Left commented
+  # because a nodeSelector this chart can't verify makes the tier
+  # unschedulable rather than expensive: the labels have to exist on a
+  # NodePool that actually offers on-demand capacity, which is infra the
+  # chart doesn't provision. Uncomment per environment once it does.
+  large:
+    resources:
+      requests:
+        cpu: "2"
+        memory: 8Gi
+      limits:
+        cpu: "4"
+        memory: 16Gi
+        ephemeral-storage: 40Gi
+    emptyDirSizeLimits:
+      workdir: 16Gi
+      home: 16Gi
+    # nodeSelector:
+    #   workload: sandbox
+    #   karpenter.sh/capacity-type: on-demand
+    warmPoolSize: 0
+
 # ── shutdown grace period ──────────────────────────────────────────────
 # On SIGTERM (rollout, spot reclaim, idle eviction) the daemon commits and
 # pushes the working tree to git — the only durable copy of the user's work

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -85,6 +85,7 @@ import {
   SandboxError,
 } from "./constants";
 import { watchClaimDeletions, watchClaimLifecycle } from "./lifecycle-watcher";
+import { templateNameForTier } from "./template-name";
 import { refreshCredentialsByConnection } from "./credential-refresh";
 import type { ClaimPhase } from "../lifecycle-types";
 
@@ -306,7 +307,11 @@ export interface AgentSandboxProviderOptions {
   kubeConfig?: KubeConfig;
   /** Shared namespace for both SandboxTemplate and SandboxClaims. */
   namespace?: string;
-  /** SandboxTemplate all claims reference. */
+  /**
+   * SandboxTemplate an untiered claim references — also the base name the
+   * per-tier templates are derived from (`<name>-<tier>`, see
+   * `EnsureOptions.tier` and ./template-name.ts).
+   */
   sandboxTemplateName?: string;
   /**
    * Shared sentinel token baked into the SandboxTemplate's pod env (via the
@@ -1170,7 +1175,16 @@ export class AgentSandboxProvider implements SandboxProvider {
         ...(hasAnnotations ? { annotations } : {}),
       },
       spec: {
-        sandboxTemplateRef: { name: this.sandboxTemplateName },
+        sandboxTemplateRef: {
+          name: templateNameForTier(
+            this.sandboxTemplateName,
+            opts.tier,
+            (tier) =>
+              console.warn(
+                `[${LOG_LABEL}] ignoring malformed tier ${JSON.stringify(tier)}; using default template ${this.sandboxTemplateName}`,
+              ),
+          ),
+        },
         // additionalPodMetadata.labels is the operator's pod-label propagation
         // hook (CRD field, not a generic patch). Tenant labels here flow to
         // the pod and become joinable in cAdvisor/kubelet metrics. `role`

--- a/packages/sandbox/server/provider/agent-sandbox/template-name.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/template-name.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { templateNameForTier } from "./template-name";
+
+const BASE = "studio-sandbox-prod";
+
+describe("templateNameForTier", () => {
+  it("uses the base template when no tier is assigned", () => {
+    // The chart renders defaultTier at the unsuffixed name, so an unassigned
+    // sandbox must keep referencing exactly what it referenced before tiers
+    // existed.
+    expect(templateNameForTier(BASE, undefined)).toBe(BASE);
+    expect(templateNameForTier(BASE, "")).toBe(BASE);
+  });
+
+  it("suffixes a well-formed tier", () => {
+    expect(templateNameForTier(BASE, "large")).toBe(
+      "studio-sandbox-prod-large",
+    );
+    expect(templateNameForTier(BASE, "gpu-a10")).toBe(
+      "studio-sandbox-prod-gpu-a10",
+    );
+  });
+
+  it("falls back to base and reports a malformed tier", () => {
+    const seen: string[] = [];
+    for (const bad of [
+      "Large",
+      "large_pool",
+      "-large",
+      "large-",
+      "9large",
+      "a".repeat(17),
+      "../other-template",
+      "large large",
+    ]) {
+      expect(templateNameForTier(BASE, bad, (t) => seen.push(t))).toBe(BASE);
+    }
+    expect(seen).toHaveLength(8);
+  });
+});

--- a/packages/sandbox/server/provider/agent-sandbox/template-name.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/template-name.ts
@@ -1,0 +1,38 @@
+/**
+ * Maps a size/placement tier (`EnsureOptions.tier`) to the SandboxTemplate a
+ * claim references. Provider-local: the tier itself is an opaque name in the
+ * runner-agnostic contract, and this is the hosted provider's interpretation
+ * of it.
+ *
+ * The sandbox-env chart renders its `defaultTier` at the plain template name
+ * and every other tier at `<name>-<tier>`, so an absent tier means "default"
+ * and callers never have to know which tier that is.
+ */
+
+// A tier is appended to a k8s object name, so it has to be a DNS label.
+// Mirrors the sandbox-env chart's validateTiers check.
+const TIER_NAME_RE = /^[a-z]([a-z0-9-]{0,14}[a-z0-9])?$/;
+
+/**
+ * Resolve the SandboxTemplate name for a tier, falling back to `base` (the
+ * default tier) when the tier is absent or malformed.
+ *
+ * A well-formed tier the chart doesn't define still fails at claim creation
+ * with "sandboxtemplate not found" — the runner can't enumerate the chart's
+ * tiers, so Studio's tier assignments and the chart's `tiers` keys have to move
+ * together. Tier names are operator-supplied config, never user input, but the
+ * shape check keeps a stray value from composing a reference to some unrelated
+ * object, and falling back beats failing a provision on a typo.
+ */
+export function templateNameForTier(
+  base: string,
+  tier: string | undefined,
+  onInvalid?: (tier: string) => void,
+): string {
+  if (!tier) return base;
+  if (!TIER_NAME_RE.test(tier)) {
+    onInvalid?.(tier);
+    return base;
+  }
+  return `${base}-${tier}`;
+}

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -90,6 +90,17 @@ export interface EnsureOptions {
   };
   /** Image override. Non-image runners MUST ignore. */
   image?: string;
+  /**
+   * Size/placement tier. Selects one of the per-tier SandboxTemplates the
+   * sandbox-env chart renders; omitted → the chart's default tier (which
+   * renders at the unsuffixed template name), so callers never need to know
+   * the default tier's name. Runners without tiering MUST ignore (not error).
+   *
+   * Frozen for the sandbox's lifetime, like `env`: the claim handle can't
+   * encode the tier (the sandbox proxy derives the handle from the URL and has
+   * no tier context), so re-tiering a *running* sandbox requires deleting it.
+   */
+  tier?: string;
   workload?: Workload;
   /** Frozen for the sandbox's lifetime — changing requires recreate. */
   env?: Record<string, string>;


### PR DESCRIPTION
## Why

Sandbox pods are one fixed size for every tenant — 500m/2Gi request, 2/4Gi limit. A repo that needs more than 4Gi OOMs, and today the only lever is raising the limit for the whole fleet, which we pay for on every pod.

Note the OOM is on the **limit**, not the request. Each tier moves both: `values.yaml` already records that raising only the limit is what produced prod's node memory-pressure evictions.

## What

**Chart** — one `SandboxTemplate` per entry in `values.tiers` (`small` / `medium` / `large` ship by default), rendered from the same template body so tiers can't drift in security posture, netinit, or org-fs wiring. A tier owns resources **and** placement: `nodeSelector`, `tolerations`, `affinity`, `topologySpreadConstraints`, `podLabels`, `podAnnotations`, `warmPoolSize`, each wholesale-overriding the top-level value of the same name. That's the seam for "this tier runs on on-demand capacity only" (snippet included, commented — the labels need a NodePool that offers it) and for per-tier cost labels.

`defaultTier` renders at the **unsuffixed** name, so existing claims and an existing `STUDIO_SANDBOX_TEMPLATE_NAME` keep resolving. Adding tiers to a running environment is a pure addition.

**Studio** — the tier is picked per (org, repo) from `STUDIO_SANDBOX_TIER_MAP`, overrides only, keyed `<orgSlug>/<owner>/<repo>` or `<orgSlug>`, most specific first:

```yaml
STUDIO_SANDBOX_TIER_MAP: '{"acme/acme/monorepo":"large","acme":"medium"}'
```

Deliberately **not** per-agent metadata: that blob is writable by any org member, so a tenant could assign itself the largest tier. Assignment stays operator-controlled and the default stays the cheapest option, which is what makes tiers priceable. No UI — that's the follow-up when the list outgrows an env var (`ponytail:` comment names the upgrade path: a column on `organization_settings` plus an `/api/_admin` tool).

The tier stays provider-agnostic: it rides on `EnsureOptions.tier` in the runner-agnostic contract, resolution lives in `apps/api/src/sandbox/tier.ts`, and only the agent-sandbox runner knows a tier maps to a SandboxTemplate name. Runners without tiering ignore it.

## Decisions worth reviewing

- **`app.kubernetes.io/name` is NOT tier-suffixed.** The housekeeper's `podSelector` and any `topologySpreadConstraints` labelSelector key off it, so tiering it would silently drop the other tiers out of idle reaping. Tier gets its own `studio.decocms.com/tier` label, which also joins cAdvisor pod metrics to a tier for cost attribution.
- **A warm pool is rendered per tier even at `size: 0`.** Claims always carry `warmpool: "default"`, so the pool must exist for the reference to resolve; an empty one falls through to a cold render — the same path a fully-claimed pool already takes in prod. The existing HPA stays scoped to the default tier.
- **emptyDir size limits are now per-tier** (`values.emptyDirSizeLimits`, previously hardcoded 4Gi/1Gi/5Gi). A `large` tier with a 40Gi ephemeral-storage ceiling but a 4Gi workdir cap would just fail on disk instead of memory.
- **A tier is frozen for a sandbox's lifetime.** The claim handle can't encode it — `sandbox-proxy.ts` derives the handle from the URL and has no tier context, so encoding it would 404 every proxy call. A re-assignment applies on the next cold provision; to resize now, `SANDBOX_DELETE`. The tier rides in the persisted `ensureOpts`, so resurrection and autonomous recovery re-ensure at the same tier.
- **Tier names are shape-validated on both sides but membership can't be.** Studio can't enumerate the chart's tiers, so a name with no matching `tiers` key fails claim creation for that (org, repo) only — the two sides have to move together. Called out in the chart README and both code comments.
- **Malformed `STUDIO_SANDBOX_TIER_MAP` degrades to "no overrides"** instead of throwing: it gates provisioning for every org, so a typo in one env var must not take the fleet's sandboxes down. Bad individual entries are dropped with a warning naming them.
- **The chart rejects `studio.decocms.com/*` keys** in a tier's podLabels/podAnnotations. That prefix is the runner's `additionalPodMetadata` namespace and the operator rejects claims redefining a key the template already set — every claim on that tier would fail. Banning the prefix rather than a key list keeps it in sync with the runner without duplicating `LABEL_KEYS`.

## Testing

- **Default tier render is unchanged.** Diffed `helm template` for `studio-sandbox-staging` against `main`: identical apart from the chart-version label and the two new `studio.decocms.com/tier: "small"` labels. Resources, volumes, sizeLimits, netinit, org-fs all byte-identical.
- **Per-tier render verified** for `medium`/`large`: resources, emptyDir sizeLimits, and per-tier podLabels/podAnnotations land where expected.
- **All four chart validations exercised** and fail at template time: `defaultTier` not in `tiers`, empty `tiers`, non-DNS-label tier name, reserved `studio.decocms.com/*` pod label and annotation.
- **Warm pools**: with `warmPool.size=5`, default tier gets 5 and medium/large get an explicit 0 (uses `hasKey`, not `default` — `default` treats 0 as empty and would have leaked the global size).
- **Unit tests**: `tier.test.ts` (precedence, repo-key-without-org must not match, case-insensitivity), `template-name.test.ts` (unsuffixed default, suffixing, 8 malformed inputs fall back), plus 5 new `resolve-config` cases for the env-var parse.
- `helm lint`, `bun run check`, `bun run lint` (0 errors, same 16 pre-existing warnings as main), `bun run fmt:check`, and the sandbox-provider + settings + sandbox test files (232 pass) all clean.

## Rollout

Chart upgrade is additive and prod-inert, but the chart is consumed by a pinned `targetRevision` in deco-apps-cd — that needs a bump to `0.10.0` or nothing ships. Order: chart → `targetRevision` → `STUDIO_SANDBOX_TIER_MAP`. Verify `medium`/`large` end-to-end on staging before assigning a real tenant.

## Follow-ups

- Assignment UI / admin tool + DB column when the override list outgrows an env var.
- An on-demand NodePool if we want the `large` tier's spot opt-out (infra, not this chart).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce per-(org, repo) sandbox size tiers to stop OOMs without raising limits for everyone. The chart renders per-tier SandboxTemplates; Studio assigns tiers via `STUDIO_SANDBOX_TIER_MAP`, and untiered sandboxes keep using the existing default.

- **New Features**
  - Helm: one `SandboxTemplate` per `values.tiers` with per-tier resources, placement, `warmPoolSize`, and `emptyDirSizeLimits`; `defaultTier` renders unsuffixed; adds a `studio.decocms.com/tier` label on templates, warm pools, and pods; tier validations added.
  - Studio/API: parses `STUDIO_SANDBOX_TIER_MAP` (lowercases keys, drops invalid entries, malformed JSON or absent map → no overrides), resolves overrides (`<orgSlug>/<owner>/<repo>` > `<orgSlug>`; repo-less uses org-wide), and passes `EnsureOptions.tier`; the agent-sandbox runner maps tiers to `<template>-<tier>` and falls back on invalid input; runners without tiering ignore it.

- **Migration**
  - Bump the `sandbox-env` chart to `0.10.0` and update the CD `targetRevision`.
  - Optionally set `STUDIO_SANDBOX_TIER_MAP` (JSON) in `configMap.meshConfig`; keys are case-insensitive; unlisted repos use `defaultTier`.
  - Verify non-default tiers on staging; keep `defaultTier` as the cheapest option.

<sup>Written for commit 8033b9fac68900101ad6e9dd377f4b34106bbd96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

