### PR TITLE
fix(settings): translate hardcoded strings in org-connect page

### DIFF
--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -619,4 +619,41 @@ export const settings = {
   "settings.aiProviders.customOpenAiDescription":
     "Bring your own model server (advanced)",
   "settings.aiProviders.moreProviders": "{count} more provider{plural}",
+  "settings.orgConnect.pageTitle": "Connect to clients",
+  "settings.orgConnect.copyLabel": "Copy",
+  "settings.orgConnect.unifiedMcpTitle": "Your org's unified MCP",
+  "settings.orgConnect.unifiedMcpDescription":
+    "Plug this URL into any MCP client to give that runtime every connection enabled in this org, governed by your Decopilot rules.",
+  "settings.orgConnect.wiringCustomClient": "Wiring a custom client?",
+  "settings.orgConnect.oauthMetadataAdvertised":
+    "OAuth 2.1 Protected Resource Metadata is advertised on 401:",
+  "settings.orgConnect.clientClaudeCode": "Claude Code",
+  "settings.orgConnect.clientCursor": "Cursor",
+  "settings.orgConnect.clientCodex": "Codex",
+  "settings.orgConnect.clientClaudeDesktop": "Claude Desktop",
+  "settings.orgConnect.clientRawUrl": "Raw URL",
+  "settings.orgConnect.oauthTab": "OAuth",
+  "settings.orgConnect.apiKeyTab": "API key",
+  "settings.orgConnect.oauthTabDescription":
+    "Recommended for your laptop. Browser will open on first use to sign in — no token to manage.",
+  "settings.orgConnect.apiKeyTabDescription":
+    "For CI, Conductor, or headless agents that can't open a browser.",
+  "settings.orgConnect.newKeyWarning":
+    "Copy this snippet now — the key won't be shown again. You can revoke it later from the list below.",
+  "settings.orgConnect.doneHideKey": "Done, hide key",
+  "settings.orgConnect.generating": "Generating…",
+  "settings.orgConnect.generateKeyFor": "Generate key for {client}",
+  "settings.orgConnect.loadingActiveKeys": "Loading active keys…",
+  "settings.orgConnect.failedToLoadKeys": "Failed to load keys: {error}",
+  "settings.orgConnect.noConnectKeys":
+    "No connect keys minted yet. Generate one from a client tab above for headless setups.",
+  "settings.orgConnect.createdOn": "Created {date}",
+  "settings.orgConnect.confirmRevoke":
+    'Revoke "{name}"? Any client still using this key will lose access.',
+  "settings.orgConnect.keyRevoked": "Key revoked",
+  "settings.orgConnect.revoke": "Revoke",
+  "settings.orgConnect.keyCreated": "Key created",
+  "settings.orgConnect.activeKeysTitle": "Active keys",
+  "settings.orgConnect.activeKeysDescription":
+    "Keys you've generated for headless clients. Revoke any time.",
 } as const;

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -658,4 +658,42 @@ export const settings = {
   "settings.aiProviders.customOpenAiDescription":
     "Traga seu pr\u00f3prio servidor de modelos (avan\u00e7ado)",
   "settings.aiProviders.moreProviders": "{count} provedor{plural} adicional",
+  "settings.orgConnect.pageTitle": "Conectar clientes",
+  "settings.orgConnect.copyLabel": "Copiar",
+  "settings.orgConnect.unifiedMcpTitle": "O MCP unificado da sua organização",
+  "settings.orgConnect.unifiedMcpDescription":
+    "Cole esta URL em qualquer cliente MCP para dar a esse runtime acesso a todas as conexões habilitadas nesta organização, governadas pelas regras do seu Decopilot.",
+  "settings.orgConnect.wiringCustomClient":
+    "Configurando um cliente personalizado?",
+  "settings.orgConnect.oauthMetadataAdvertised":
+    "Os metadados do OAuth 2.1 Protected Resource são anunciados no 401:",
+  "settings.orgConnect.clientClaudeCode": "Claude Code",
+  "settings.orgConnect.clientCursor": "Cursor",
+  "settings.orgConnect.clientCodex": "Codex",
+  "settings.orgConnect.clientClaudeDesktop": "Claude Desktop",
+  "settings.orgConnect.clientRawUrl": "URL bruta",
+  "settings.orgConnect.oauthTab": "OAuth",
+  "settings.orgConnect.apiKeyTab": "Chave de API",
+  "settings.orgConnect.oauthTabDescription":
+    "Recomendado para o seu laptop. O navegador abrirá no primeiro uso para você entrar — nenhum token para gerenciar.",
+  "settings.orgConnect.apiKeyTabDescription":
+    "Para CI, Conductor ou agentes headless que não conseguem abrir um navegador.",
+  "settings.orgConnect.newKeyWarning":
+    "Copie este trecho agora — a chave não será exibida novamente. Você pode revogá-la depois na lista abaixo.",
+  "settings.orgConnect.doneHideKey": "Concluído, ocultar chave",
+  "settings.orgConnect.generating": "Gerando…",
+  "settings.orgConnect.generateKeyFor": "Gerar chave para {client}",
+  "settings.orgConnect.loadingActiveKeys": "Carregando chaves ativas…",
+  "settings.orgConnect.failedToLoadKeys": "Falha ao carregar chaves: {error}",
+  "settings.orgConnect.noConnectKeys":
+    "Nenhuma chave de conexão gerada ainda. Gere uma na aba de um cliente acima para configurações headless.",
+  "settings.orgConnect.createdOn": "Criada em {date}",
+  "settings.orgConnect.confirmRevoke":
+    'Revogar "{name}"? Qualquer cliente que ainda use esta chave perderá o acesso.',
+  "settings.orgConnect.keyRevoked": "Chave revogada",
+  "settings.orgConnect.revoke": "Revogar",
+  "settings.orgConnect.keyCreated": "Chave criada",
+  "settings.orgConnect.activeKeysTitle": "Chaves ativas",
+  "settings.orgConnect.activeKeysDescription":
+    "Chaves que você gerou para clientes headless. Revogue a qualquer momento.",
 } satisfies Record<keyof typeof settingsEn, string>;

--- a/apps/web/src/views/settings/org-connect.tsx
+++ b/apps/web/src/views/settings/org-connect.tsx
@@ -31,19 +31,21 @@ import {
   useCreateApiKey,
   useDeleteApiKey,
 } from "@/hooks/use-api-keys";
+import { useT, type TFunction, type TranslationKey } from "@/i18n/use-t";
 
 const KEY_NAME_PREFIX = "Connect: ";
 
-const CLIENTS: { id: ConnectClient; label: string }[] = [
-  { id: "claude-code", label: "Claude Code" },
-  { id: "cursor", label: "Cursor" },
-  { id: "codex", label: "Codex" },
-  { id: "claude-desktop", label: "Claude Desktop" },
-  { id: "raw", label: "Raw URL" },
+const CLIENTS: { id: ConnectClient; labelKey: TranslationKey }[] = [
+  { id: "claude-code", labelKey: "settings.orgConnect.clientClaudeCode" },
+  { id: "cursor", labelKey: "settings.orgConnect.clientCursor" },
+  { id: "codex", labelKey: "settings.orgConnect.clientCodex" },
+  { id: "claude-desktop", labelKey: "settings.orgConnect.clientClaudeDesktop" },
+  { id: "raw", labelKey: "settings.orgConnect.clientRawUrl" },
 ];
 
-function clientLabel(id: ConnectClient): string {
-  return CLIENTS.find((c) => c.id === id)?.label ?? id;
+function clientLabel(t: TFunction, id: ConnectClient): string {
+  const key = CLIENTS.find((c) => c.id === id)?.labelKey;
+  return key ? t(key) : id;
 }
 
 function hostnameLabel(): string {
@@ -52,6 +54,7 @@ function hostnameLabel(): string {
 }
 
 function CopyInline({ text }: { text: string }) {
+  const t = useT();
   const { handleCopy, copied } = useCopy();
   return (
     <Button
@@ -59,7 +62,7 @@ function CopyInline({ text }: { text: string }) {
       size="icon"
       className="size-7 shrink-0"
       onClick={() => handleCopy(text)}
-      aria-label="Copy"
+      aria-label={t("settings.orgConnect.copyLabel")}
     >
       {copied ? <Check size={14} /> : <Copy01 size={14} />}
     </Button>
@@ -81,32 +84,35 @@ function ClientPanel({
   isGenerating: boolean;
   onClearNewKey: () => void;
 }) {
+  const t = useT();
   return (
     <Tabs defaultValue="oauth" className="mt-4">
       <TabsList>
-        <TabsTrigger value="oauth">OAuth</TabsTrigger>
-        <TabsTrigger value="api-key">API key</TabsTrigger>
+        <TabsTrigger value="oauth">
+          {t("settings.orgConnect.oauthTab")}
+        </TabsTrigger>
+        <TabsTrigger value="api-key">
+          {t("settings.orgConnect.apiKeyTab")}
+        </TabsTrigger>
       </TabsList>
 
       <TabsContent value="oauth" className="mt-3 space-y-3">
         <p className="text-xs text-muted-foreground">
-          Recommended for your laptop. Browser will open on first use to sign in
-          — no token to manage.
+          {t("settings.orgConnect.oauthTabDescription")}
         </p>
         <InstallSnippet client={client} mode="oauth" url={url} />
       </TabsContent>
 
       <TabsContent value="api-key" className="mt-3 space-y-3">
         <p className="text-xs text-muted-foreground">
-          For CI, Conductor, or headless agents that can't open a browser.
+          {t("settings.orgConnect.apiKeyTabDescription")}
         </p>
         {newKey ? (
           <>
             <Alert variant="warning" className="text-xs">
               <AlertTriangle />
               <AlertDescription>
-                Copy this snippet now — the key won't be shown again. You can
-                revoke it later from the list below.
+                {t("settings.orgConnect.newKeyWarning")}
               </AlertDescription>
             </Alert>
             <InstallSnippet
@@ -121,7 +127,7 @@ function ClientPanel({
               onClick={onClearNewKey}
               className="text-xs"
             >
-              Done, hide key
+              {t("settings.orgConnect.doneHideKey")}
             </Button>
           </>
         ) : (
@@ -135,8 +141,10 @@ function ClientPanel({
             >
               <Key01 size={14} />
               {isGenerating
-                ? "Generating…"
-                : `Generate key for ${clientLabel(client)}`}
+                ? t("settings.orgConnect.generating")
+                : t("settings.orgConnect.generateKeyFor", {
+                    client: clientLabel(t, client),
+                  })}
             </Button>
           </>
         )}
@@ -146,6 +154,7 @@ function ClientPanel({
 }
 
 function ConnectKeysList() {
+  const t = useT();
   const { data, isLoading, error } = useApiKeysList();
   const deleteKey = useDeleteApiKey();
 
@@ -154,14 +163,16 @@ function ConnectKeysList() {
 
   if (isLoading) {
     return (
-      <p className="text-xs text-muted-foreground">Loading active keys…</p>
+      <p className="text-xs text-muted-foreground">
+        {t("settings.orgConnect.loadingActiveKeys")}
+      </p>
     );
   }
 
   if (error) {
     return (
       <p className="text-xs text-destructive">
-        Failed to load keys: {error.message}
+        {t("settings.orgConnect.failedToLoadKeys", { error: error.message })}
       </p>
     );
   }
@@ -169,8 +180,7 @@ function ConnectKeysList() {
   if (connectKeys.length === 0) {
     return (
       <p className="text-xs text-muted-foreground">
-        No connect keys minted yet. Generate one from a client tab above for
-        headless setups.
+        {t("settings.orgConnect.noConnectKeys")}
       </p>
     );
   }
@@ -187,7 +197,9 @@ function ConnectKeysList() {
               {key.name.replace(KEY_NAME_PREFIX, "")}
             </div>
             <div className="text-muted-foreground">
-              Created {new Date(key.createdAt).toLocaleDateString()}
+              {t("settings.orgConnect.createdOn", {
+                date: new Date(key.createdAt).toLocaleDateString(),
+              })}
             </div>
           </div>
           <Button
@@ -196,11 +208,12 @@ function ConnectKeysList() {
             onClick={() => {
               if (
                 confirm(
-                  `Revoke "${key.name}"? Any client still using this key will lose access.`,
+                  t("settings.orgConnect.confirmRevoke", { name: key.name }),
                 )
               ) {
                 deleteKey.mutate(key.id, {
-                  onSuccess: () => toast.success("Key revoked"),
+                  onSuccess: () =>
+                    toast.success(t("settings.orgConnect.keyRevoked")),
                   onError: (e) => toast.error(e.message),
                 });
               }
@@ -209,7 +222,7 @@ function ConnectKeysList() {
             className="gap-1 text-destructive hover:text-destructive"
           >
             <Trash01 size={14} />
-            Revoke
+            {t("settings.orgConnect.revoke")}
           </Button>
         </li>
       ))}
@@ -218,6 +231,7 @@ function ConnectKeysList() {
 }
 
 export function OrgConnectPage() {
+  const t = useT();
   const { org } = useProjectContext();
   const url = mcpUrl(org.slug);
   const createKey = useCreateApiKey();
@@ -226,13 +240,13 @@ export function OrgConnectPage() {
   >({});
 
   const handleGenerate = (client: ConnectClient) => {
-    const name = `${KEY_NAME_PREFIX}${clientLabel(client)} on ${hostnameLabel()}`;
+    const name = `${KEY_NAME_PREFIX}${clientLabel(t, client)} on ${hostnameLabel()}`;
     createKey.mutate(
       { name, permissions: { "*": ["*"] } },
       {
         onSuccess: (key) => {
           setNewKeys((prev) => ({ ...prev, [client]: key.key }));
-          toast.success("Key created");
+          toast.success(t("settings.orgConnect.keyCreated"));
         },
         onError: (err) => toast.error(err.message),
       },
@@ -249,7 +263,7 @@ export function OrgConnectPage() {
       <Page.Content>
         <Page.Body>
           <SettingsPage>
-            <Page.Title>Connect to clients</Page.Title>
+            <Page.Title>{t("settings.orgConnect.pageTitle")}</Page.Title>
 
             <Card className="p-5 gap-3">
               <div className="flex items-start gap-3">
@@ -258,12 +272,10 @@ export function OrgConnectPage() {
                 </div>
                 <div className="min-w-0 flex-1">
                   <h2 className="text-[15px] font-medium leading-tight">
-                    Your org's unified MCP
+                    {t("settings.orgConnect.unifiedMcpTitle")}
                   </h2>
                   <p className="text-sm text-muted-foreground mt-1 leading-snug">
-                    Plug this URL into any MCP client to give that runtime every
-                    connection enabled in this org, governed by your Decopilot
-                    rules.
+                    {t("settings.orgConnect.unifiedMcpDescription")}
                   </p>
                 </div>
               </div>
@@ -273,12 +285,10 @@ export function OrgConnectPage() {
               </div>
               <details className="text-xs text-muted-foreground">
                 <summary className="cursor-pointer hover:text-foreground">
-                  Wiring a custom client?
+                  {t("settings.orgConnect.wiringCustomClient")}
                 </summary>
                 <div className="mt-2 space-y-1">
-                  <p>
-                    OAuth 2.1 Protected Resource Metadata is advertised on 401:
-                  </p>
+                  <p>{t("settings.orgConnect.oauthMetadataAdvertised")}</p>
                   <div className="flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1">
                     <code className="text-[11px] flex-1 truncate">
                       {oauthMetadataUrl}
@@ -293,7 +303,7 @@ export function OrgConnectPage() {
               <TabsList variant="underline">
                 {CLIENTS.map((c) => (
                   <TabsTrigger key={c.id} value={c.id} variant="underline">
-                    {c.label}
+                    {t(c.labelKey)}
                   </TabsTrigger>
                 ))}
               </TabsList>
@@ -308,7 +318,7 @@ export function OrgConnectPage() {
                     isGenerating={
                       createKey.isPending &&
                       createKey.variables?.name?.startsWith(
-                        `${KEY_NAME_PREFIX}${c.label}`,
+                        `${KEY_NAME_PREFIX}${t(c.labelKey)}`,
                       ) === true
                     }
                     onClearNewKey={() =>
@@ -326,10 +336,10 @@ export function OrgConnectPage() {
             <section className="flex flex-col gap-3">
               <div className="px-4">
                 <h2 className="text-[15px] font-medium leading-tight">
-                  Active keys
+                  {t("settings.orgConnect.activeKeysTitle")}
                 </h2>
                 <p className="text-sm text-muted-foreground leading-snug mt-1">
-                  Keys you've generated for headless clients. Revoke any time.
+                  {t("settings.orgConnect.activeKeysDescription")}
                 </p>
               </div>
               <ConnectKeysList />


### PR DESCRIPTION
**Source:** i18n-coverage-audit focus area — the `apps/web/src/views/settings/org-connect.tsx` view (Settings > Connections, the "connect to clients" page reached via `apps/web/src/routes/orgs/settings/connect.tsx`) had zero i18n coverage: every JSX label, tab, button, toast, and confirm-dialog string was hardcoded English, so pt-BR users saw untranslated UI across the entire page.

**Payoff:** this is a real, visible i18n gap for a page every org visits to connect Claude Code/Cursor/Codex/Claude Desktop clients — pt-BR users currently see raw English strings mixed in with the rest of a translated Settings section.

**What changed:**
- Added a new `settings.orgConnect.*` key group (28 keys) to `apps/web/src/i18n/en/settings.ts` and its pt-BR mirror in `apps/web/src/i18n/pt-br/settings.ts` (the `satisfies Record<keyof typeof settingsEn, string>` check keeps them in sync at compile time).
- Replaced every hardcoded string in `org-connect.tsx` (tab labels, descriptions, button text, toasts, the revoke confirm dialog, and the client-name list) with `t(...)` calls via `useT()`. The `CLIENTS` array now carries a `labelKey: TranslationKey` instead of a raw `label: string`.
- No behavior change: same strings, same interpolation values (`{client}`, `{error}`, `{date}`, `{name}`), just routed through the i18n dictionary.

**How to verify:** open Settings > Connections with the language preference set to Portuguese (`usePreferences()` / browser language) and confirm the whole page — tabs, descriptions, buttons, toasts — renders in Portuguese instead of a mix of English and Portuguese.

**Checks run locally:** `bun run fmt` (clean), `cd apps/web && bunx tsc --noEmit` (clean, confirms the `satisfies Record<...>` mirror check passes and no consumer still references the old `label` field on `CLIENTS`). No existing test covers this file. Full CI (lint, full test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translated all hardcoded strings on Settings > Connections (org-connect) to the i18n system. pt-BR users now see a fully localized page; no behavior changes.

- **Bug Fixes**
  - Added `settings.orgConnect.*` keys to the `en` and `pt-br` dictionaries, kept in sync via a compile-time mirror check.
  - Replaced all hardcoded UI strings in `apps/web/src/views/settings/org-connect.tsx` with `t(...)` via `useT()`. `CLIENTS` now uses `labelKey` for localized labels.

<sup>Written for commit 67e27af3a896fe5c4c4966e8053f2e597e34a893. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

