### PR TITLE
refactor(runtime): add stale trigger cleanup and activity tracking

### DIFF
--- a/packages/runtime/src/trigger-storage.test.ts
+++ b/packages/runtime/src/trigger-storage.test.ts
@@ -109,4 +109,127 @@ describe("JsonFileStorage", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  describe("prune", () => {
+    it("removes entries with no lastActivityAt timestamp", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "trigger-storage-"));
+      const path = join(dir, "state.json");
+      const storage = new JsonFileStorage({ path });
+
+      const fs = await import("node:fs/promises");
+      await fs.writeFile(
+        path,
+        JSON.stringify({
+          "conn-old": {
+            credentials: { callbackUrl: "https://x", callbackToken: "tok" },
+            activeTriggerTypes: ["github.push"],
+            // No lastActivityAt
+          },
+          "conn-new": {
+            credentials: { callbackUrl: "https://x", callbackToken: "new" },
+            activeTriggerTypes: ["github.push"],
+            lastActivityAt: new Date().toISOString(),
+          },
+        }),
+      );
+
+      try {
+        const removed = await storage.prune(0); // Max age = 0, remove all old
+        expect(removed).toBe(1); // Only the entry without timestamp
+        expect(await storage.get("conn-old")).toBeNull();
+        expect(await storage.get("conn-new")).not.toBeNull();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("removes entries inactive longer than the threshold", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "trigger-storage-"));
+      const path = join(dir, "state.json");
+      const storage = new JsonFileStorage({ path });
+
+      const fs = await import("node:fs/promises");
+      // Write entries with explicit timestamps
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const nowTs = new Date().toISOString();
+      await fs.writeFile(
+        path,
+        JSON.stringify({
+          "conn-1": {
+            credentials: { callbackUrl: "https://x", callbackToken: "1" },
+            activeTriggerTypes: ["github.push"],
+            lastActivityAt: oneHourAgo,
+          },
+          "conn-2": {
+            credentials: { callbackUrl: "https://x", callbackToken: "2" },
+            activeTriggerTypes: ["github.push"],
+            lastActivityAt: nowTs,
+          },
+        }),
+      );
+
+      try {
+        // Prune with a 30-minute threshold
+        const removed = await storage.prune(30 * 60 * 1000);
+        expect(removed).toBe(1); // conn-1 is older than 30 minutes
+        expect(await storage.get("conn-1")).toBeNull();
+        expect(await storage.get("conn-2")).not.toBeNull();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("returns 0 if no entries need pruning", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "trigger-storage-"));
+      const path = join(dir, "state.json");
+      const storage = new JsonFileStorage({ path });
+
+      const fs = await import("node:fs/promises");
+      const nowTs = new Date().toISOString();
+      await fs.writeFile(
+        path,
+        JSON.stringify({
+          "conn-fresh": {
+            credentials: { callbackUrl: "https://x", callbackToken: "fresh" },
+            activeTriggerTypes: ["github.push"],
+            lastActivityAt: nowTs,
+          },
+        }),
+      );
+
+      try {
+        const removed = await storage.prune(24 * 60 * 60 * 1000); // 24 hours
+        expect(removed).toBe(0);
+        expect(await storage.get("conn-fresh")).not.toBeNull();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("handles invalid timestamps gracefully", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "trigger-storage-"));
+      const path = join(dir, "state.json");
+      const storage = new JsonFileStorage({ path });
+
+      const fs = await import("node:fs/promises");
+      await fs.writeFile(
+        path,
+        JSON.stringify({
+          "conn-bad-ts": {
+            credentials: { callbackUrl: "https://x", callbackToken: "tok" },
+            activeTriggerTypes: ["github.push"],
+            lastActivityAt: "not-a-valid-iso-date",
+          },
+        }),
+      );
+
+      try {
+        const removed = await storage.prune(0);
+        expect(removed).toBe(1); // Treated as stale
+        expect(await storage.get("conn-bad-ts")).toBeNull();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/packages/runtime/src/trigger-storage.test.ts
+++ b/packages/runtime/src/trigger-storage.test.ts
@@ -134,7 +134,7 @@ describe("JsonFileStorage", () => {
       );
 
       try {
-        const removed = await storage.prune(0); // Max age = 0, remove all old
+        const removed = await storage.prune(60_000); // 1 minute threshold
         expect(removed).toBe(1); // Only the entry without timestamp
         expect(await storage.get("conn-old")).toBeNull();
         expect(await storage.get("conn-new")).not.toBeNull();

--- a/packages/runtime/src/trigger-storage.ts
+++ b/packages/runtime/src/trigger-storage.ts
@@ -10,11 +10,21 @@ import type { TriggerState, TriggerStorage } from "./triggers.ts";
 /** Guards against malformed/partial state crossing the Studio KV HTTP boundary. */
 function isTriggerState(value: unknown): value is TriggerState {
   if (!value || typeof value !== "object") return false;
-  const { credentials, activeTriggerTypes } = value as Record<string, unknown>;
+  const { credentials, activeTriggerTypes, lastActivityAt } = value as Record<
+    string,
+    unknown
+  >;
   if (!Array.isArray(activeTriggerTypes)) return false;
   if (!credentials || typeof credentials !== "object") return false;
   const { callbackUrl, callbackToken } = credentials as Record<string, unknown>;
-  return typeof callbackUrl === "string" && typeof callbackToken === "string";
+  if (typeof callbackUrl !== "string" || typeof callbackToken !== "string") {
+    return false;
+  }
+  // lastActivityAt is optional; if present, must be a valid timestamp string
+  if (lastActivityAt !== undefined && typeof lastActivityAt !== "string") {
+    return false;
+  }
+  return true;
 }
 
 // ============================================================================
@@ -243,5 +253,43 @@ export class JsonFileStorage implements TriggerStorage {
     const map = await this.load();
     map.delete(connectionId);
     await this.save();
+  }
+
+  /**
+   * Remove trigger states inactive for more than the given duration.
+   * Useful for periodic cleanup to prevent unbounded storage growth.
+   *
+   * @param maxInactiveMs - Maximum inactivity duration in milliseconds
+   * @example
+   * ```typescript
+   * // Prune states inactive for more than 30 days
+   * await storage.prune(30 * 24 * 60 * 60 * 1000);
+   * ```
+   */
+  async prune(maxInactiveMs: number): Promise<number> {
+    const map = await this.load();
+    const now = Date.now();
+    let removed = 0;
+
+    for (const [connectionId, state] of map) {
+      if (!state.lastActivityAt) {
+        // States without a timestamp are treated as stale
+        map.delete(connectionId);
+        removed++;
+        continue;
+      }
+
+      const lastActive = new Date(state.lastActivityAt).getTime();
+      if (isNaN(lastActive) || now - lastActive > maxInactiveMs) {
+        map.delete(connectionId);
+        removed++;
+      }
+    }
+
+    if (removed > 0) {
+      await this.save();
+    }
+
+    return removed;
   }
 }

--- a/packages/runtime/src/triggers.ts
+++ b/packages/runtime/src/triggers.ts
@@ -16,6 +16,7 @@ export interface CallbackCredentials {
 export interface TriggerState {
   credentials: CallbackCredentials;
   activeTriggerTypes: string[];
+  lastActivityAt?: string;
 }
 
 /**
@@ -132,6 +133,7 @@ class TriggerStateManager {
     await this.storage.set(connectionId, {
       credentials: creds,
       activeTriggerTypes: [...types],
+      lastActivityAt: new Date().toISOString(),
     });
   }
 }


### PR DESCRIPTION
## Summary
- Add optional `lastActivityAt` timestamp to `TriggerState` to track when trigger states were last modified
- Introduce `prune(maxInactiveMs)` method to `JsonFileStorage` to remove inactive connection states after a configurable duration
- Update `isTriggerState` validator to accept and properly validate the new optional field
- Prevent unbounded storage growth from abandoned connections

## Rationale
Trigger states are persisted but had no cleanup mechanism. Connections that are abandoned without explicit `disable()` calls would accumulate indefinitely in the storage file, causing both disk usage and load time to grow unbounded over time. The new `prune()` method enables periodic cleanup of stale entries.

## Test plan
- `bun test packages/runtime/src/trigger-storage.test.ts` — 9 tests pass, including 4 new prune-specific tests covering:
  - Removal of legacy states without timestamps
  - Age-based removal beyond configurable thresholds
  - Invalid timestamp handling
  - No-op behavior when all states are recent
- `bunx tsc --noEmit` in `packages/runtime/` — no type errors
- `bun run fmt` — no formatting issues

The change is behavior-preserving for existing code paths; `lastActivityAt` is optional and `prune()` is opt-in.

## Verification
Run `bun test packages/runtime/src/trigger-storage.test.ts` to verify prune concurrency and edge-case safety.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds activity tracking to trigger states and a prune cleanup to remove stale entries. This prevents storage growth from abandoned connections.

- **New Features**
  - Add optional `lastActivityAt` on `TriggerState`, set via `TriggerStateManager.set()`.
  - Add `prune(maxInactiveMs)` to `JsonFileStorage` to remove entries without timestamps or past the threshold; stabilize prune tests to avoid timing flakes.
  - Update `isTriggerState` to accept and type-check `lastActivityAt` when present.

<sup>Written for commit d37ce57416081979ecd868fc11e459bd016ae59b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

