### PR TITLE
feat(search): add offset pagination to GLOBAL_SEARCH

### DIFF
--- a/apps/api/src/tools/search/global-search.test.ts
+++ b/apps/api/src/tools/search/global-search.test.ts
@@ -15,4 +15,18 @@ describe("GLOBAL_SEARCH input schema", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it("rejects a negative offset", () => {
+    const result = GLOBAL_SEARCH.inputSchema.safeParse({
+      query: "foo",
+      offset: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults offset to unset (page 1) when omitted", () => {
+    const result = GLOBAL_SEARCH.inputSchema.safeParse({ query: "foo" });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.offset).toBeUndefined();
+  });
 });

--- a/apps/api/src/tools/search/global-search.ts
+++ b/apps/api/src/tools/search/global-search.ts
@@ -51,6 +51,12 @@ const InputSchema = z.object({
     .max(50)
     .optional()
     .describe("Maximum results per resource type (default: 20)."),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Number of results to skip per resource type (default: 0)."),
   types: z
     .array(z.enum(SEARCHABLE_TYPES))
     .optional()
@@ -62,6 +68,7 @@ const InputSchema = z.object({
 const OutputSchema = z.object({
   items: z.array(SearchResultSchema),
   totalCount: z.number(),
+  hasMore: z.boolean(),
 });
 
 function toIso(value: string | Date | null | undefined): string {
@@ -87,20 +94,23 @@ export const GLOBAL_SEARCH = defineTool({
     requireOrganization(ctx);
 
     const limit = input.limit ?? 20;
+    const offset = input.offset ?? 0;
     const requested = input.types?.length ? new Set(input.types) : null;
     const includeThreads = !requested || requested.has("thread");
 
     const items: z.infer<typeof SearchResultSchema>[] = [];
     let totalCount = 0;
+    let hasMore = false;
 
     if (includeThreads) {
       const { threads, total } = await ctx.storage.threads.list(undefined, {
         limit,
-        offset: 0,
+        offset,
         search: input.query,
         includeArchived: false,
       });
       totalCount += total;
+      hasMore = offset + limit < total;
       for (const thread of threads) {
         items.push({
           type: "thread",
@@ -119,6 +129,6 @@ export const GLOBAL_SEARCH = defineTool({
       }
     }
 
-    return { items, totalCount };
+    return { items, totalCount, hasMore };
   },
 });


### PR DESCRIPTION
**Source:** hardening gap in the GLOBAL_SEARCH tool (`apps/api/src/tools/search/global-search.ts`) — the tool hardcoded `offset: 0` on every call, so a caller with more than `limit` (max 50) matching threads in an org could never reach results past the first page.

**Why:** `COLLECTION_THREADS_LIST` already exposes `offset`/`hasMore` for the exact same underlying `threads.list()` storage call — GLOBAL_SEARCH was missing the same pagination contract other list-style tools already follow, so a caller has no way to page through search results for orgs with lots of matching threads.

**What changed:** added an optional `offset` field to the input schema (int, min 0, default 0) that's threaded through to `ctx.storage.threads.list()`, and an `hasMore` boolean to the output schema (`offset + limit < total`), mirroring `COLLECTION_THREADS_LIST`'s existing pagination shape. Both fields are additive/optional, so existing callers (the global-search dialog in the web UI) are unaffected.

**Verification:**
- `bun run fmt`
- `cd apps/api && bunx tsc --noEmit` — clean
- `bun test apps/api/src/tools/search/global-search.test.ts` — 4/4 pass (added two cases: negative offset rejected, offset omitted defaults to undefined)

A reviewer can confirm with the same targeted test command above. Full CI validates the DB-backed integration test (`global-search.integration.test.ts`), which needs Postgres and wasn't runnable locally in this environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add offset-based pagination to `GLOBAL_SEARCH` so callers can page through results and see if more pages exist. Removes the hardcoded `offset: 0` that hid results beyond the first page.

- **New Features**
  - Input: optional `offset` (int ≥ 0, default 0) passed to `ctx.storage.threads.list()`.
  - Output: `hasMore` boolean computed as `offset + limit < total`.
  - Pagination shape matches `COLLECTION_THREADS_LIST`; existing callers continue working with defaults.

<sup>Written for commit 15a6acaa9bcb6ec672b95b16a8653997dfc4cf77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

