### PR TITLE
feat(sandbox): auto-save sandbox work to the remote

### DIFF
--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -31,6 +31,10 @@ never becomes another user's execution context.
 - Provision or attach to isolated execution environments.
 - Build and run the authenticated Bun daemon inside each environment.
 - Expose asynchronous filesystem, Git, task, terminal, and preview operations.
+- Auto-save work in progress to the remote every 30 s so an ungraceful exit
+  (SIGKILL on eviction / OOM / node loss) can't lose it. On by default; disable
+  per sandbox with `git.autoCommit: false` in the daemon config. Never pushes to
+  a protected branch.
 - Carry agent dispatch streams between Studio, the daemon, and a harness.
 - Proxy HTTP and WebSocket traffic to development servers inside a sandbox.
 - Support organization filesystem mounts and cleanup.

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -31,10 +31,11 @@ never becomes another user's execution context.
 - Provision or attach to isolated execution environments.
 - Build and run the authenticated Bun daemon inside each environment.
 - Expose asynchronous filesystem, Git, task, terminal, and preview operations.
-- Auto-save work in progress to the remote every 30 s so an ungraceful exit
-  (SIGKILL on eviction / OOM / node loss) can't lose it. On by default; disable
-  per sandbox with `git.autoCommit: false` in the daemon config. Never pushes to
-  a protected branch.
+- Auto-save work in progress to the remote — a few seconds after repo writes
+  settle, and at worst every 30 s — so an ungraceful exit (SIGKILL on eviction /
+  OOM / node loss) can't lose it. On by default; disable per sandbox with
+  `git.autoCommit: false` in the daemon config. Never pushes to a protected
+  branch.
 - Carry agent dispatch streams between Studio, the daemon, and a harness.
 - Proxy HTTP and WebSocket traffic to development servers inside a sandbox.
 - Support organization filesystem mounts and cleanup.

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -335,6 +335,11 @@ let pendingPaths = new Set<string>();
 const FILE_CHANGED_DEBOUNCE_MS = 300;
 
 function emitFileChanged(filePath: string) {
+  // Single funnel for every repo write (fs routes + BranchStatusMonitor's
+  // fs.watch), so it's also where the auto-save loop learns there's work to
+  // push. Cheap when the change is noise: nudge() only schedules, and the tick
+  // it schedules reads already-computed git state.
+  autoCommitter.nudge();
   pendingPaths.add(filePath);
   if (fileChangedDebounce) clearTimeout(fileChangedDebounce);
   fileChangedDebounce = setTimeout(() => {

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -27,6 +27,7 @@ import { startUpstreamProbe } from "./probe";
 import { makeProxyHandler } from "./proxy";
 import { jsonResponse } from "./routes/body-parser";
 import { makeBashHandler } from "./routes/bash";
+import { AutoCommitter } from "./git/auto-commit";
 import {
   makeGitDiffHandler,
   makeGitDiscardHandler,
@@ -390,6 +391,17 @@ const gitDeps = {
   getCloneUrl: () => store.read()?.git?.repository?.cloneUrl ?? null,
   getOperator: () => store.read()?.operator ?? null,
 };
+// Safety net for the ungraceful exits shutdown() never sees (SIGKILL on pod
+// eviction / OOM / node loss): periodically commit + push the work in progress.
+// Default on; tenants opt out with `git.autoCommit: false`.
+const autoCommitter = new AutoCommitter({
+  gitDeps,
+  getBranchMeta: () => branchStatus.getLast(),
+  isEnabled: () => store.read()?.git?.autoCommit !== false,
+  onSynced: () => branchStatus.refresh(),
+});
+autoCommitter.start();
+
 const gitStatusH = makeGitStatusHandler(gitDeps);
 const gitDiffH = makeGitDiffHandler(gitDeps);
 const gitPublishH = makeGitPublishHandler(gitDeps);
@@ -926,6 +938,9 @@ async function shutdown(): Promise<void> {
   shuttingDown = true;
   taskManager.shutdown();
   branchStatus.stop();
+  // Stop the auto-save loop before the shutdown publish so the two can't race
+  // for index.lock; an in-flight tick is already guarded by its own latch.
+  autoCommitter.stop();
   // Publish BEFORE unmount: syncing the user's work is the only irrecoverable
   // step. A stale mount is backstopped (sync `exit` handler + next-boot
   // reclaim), so a hanging unmount must never eat the push's slice of the grace

--- a/packages/sandbox/daemon/git/auto-commit.test.ts
+++ b/packages/sandbox/daemon/git/auto-commit.test.ts
@@ -1,0 +1,120 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import { AutoCommitter, shouldAutoCommit } from "./auto-commit";
+import type { BranchMeta } from "../events/types";
+import { gitSync } from "./git-sync";
+
+const PROTECTED = new Set(["main", "master"]);
+
+function ready(over: Partial<Extract<BranchMeta, { kind: "ready" }>>) {
+  return {
+    kind: "ready",
+    branch: "sandbox-work",
+    base: "main",
+    workingTreeDirty: false,
+    unpushed: 0,
+    aheadOfBase: 0,
+    behindBase: 0,
+    headSha: "abc",
+    ...over,
+  } satisfies BranchMeta;
+}
+
+describe("shouldAutoCommit", () => {
+  it("commits a dirty working tree", () => {
+    expect(shouldAutoCommit(ready({ workingTreeDirty: true }), PROTECTED)).toBe(
+      true,
+    );
+  });
+
+  // Commits the agent made itself via bash are just as lost as uncommitted
+  // work if the remote never sees them.
+  it("pushes a clean tree that still has unpushed commits", () => {
+    expect(shouldAutoCommit(ready({ unpushed: 2 }), PROTECTED)).toBe(true);
+  });
+
+  it("does nothing when the tree is clean and fully pushed", () => {
+    expect(shouldAutoCommit(ready({}), PROTECTED)).toBe(false);
+  });
+
+  // stageAndCommit() refuses these anyway — bailing here keeps a sandbox
+  // sitting on main from logging a warning on every tick.
+  it("skips protected branches", () => {
+    expect(
+      shouldAutoCommit(
+        ready({ branch: "main", workingTreeDirty: true }),
+        PROTECTED,
+      ),
+    ).toBe(false);
+  });
+
+  it("skips until the repo is ready (cloning, detached HEAD, unknown)", () => {
+    expect(shouldAutoCommit({ kind: "unknown" }, PROTECTED)).toBe(false);
+  });
+});
+
+// A feature-branch working repo wired to a real bare `origin`, so tick()'s
+// commit AND push both actually run against git.
+function initRepoWithRemote(): { repoDir: string; bare: string } {
+  const appRoot = mkdtempSync(join(tmpdir(), "auto-commit-"));
+  const bare = join(appRoot, "origin.git");
+  const repoDir = join(appRoot, "app");
+  const g = (args: string[], cwd: string) =>
+    gitSync(args, { cwd, asUser: false });
+
+  g(["-c", "init.defaultBranch=main", "init", "--bare", bare], appRoot);
+  mkdirSync(repoDir, { recursive: true });
+  g(["-c", "init.defaultBranch=main", "init"], repoDir);
+  g(["config", "user.email", "test@example.com"], repoDir);
+  g(["config", "user.name", "Test"], repoDir);
+  g(["config", "commit.gpgsign", "false"], repoDir);
+  writeFileSync(join(repoDir, "README.md"), "hello\n");
+  g(["add", "README.md"], repoDir);
+  g(["commit", "-m", "init"], repoDir);
+  g(["branch", "-M", "main"], repoDir);
+  g(["remote", "add", "origin", bare], repoDir);
+  g(["push", "-u", "origin", "main"], repoDir);
+  g(["checkout", "-b", "sandbox-work"], repoDir);
+  return { repoDir, bare };
+}
+
+function remoteFileList(bare: string, branch: string): string {
+  return gitSync(["ls-tree", "-r", "--name-only", branch], {
+    cwd: bare,
+    asUser: false,
+  });
+}
+
+describe("AutoCommitter.tick", () => {
+  function makeCommitter(
+    repoDir: string,
+    over: { enabled?: boolean; dirty?: boolean } = {},
+  ) {
+    return new AutoCommitter({
+      gitDeps: { appRoot: join(repoDir, ".."), repoDir },
+      getBranchMeta: () =>
+        ready({ branch: "sandbox-work", workingTreeDirty: over.dirty ?? true }),
+      isEnabled: () => over.enabled ?? true,
+    });
+  }
+
+  it("commits and pushes work in progress to origin", async () => {
+    const { repoDir, bare } = initRepoWithRemote();
+    writeFileSync(join(repoDir, "agent-work.ts"), "export const x = 1;\n");
+
+    await makeCommitter(repoDir).tick();
+
+    expect(remoteFileList(bare, "sandbox-work")).toContain("agent-work.ts");
+  });
+
+  it("does nothing when disabled by config", async () => {
+    const { repoDir, bare } = initRepoWithRemote();
+    writeFileSync(join(repoDir, "agent-work.ts"), "export const x = 1;\n");
+
+    await makeCommitter(repoDir, { enabled: false }).tick();
+
+    expect(() => remoteFileList(bare, "sandbox-work")).toThrow();
+  });
+});

--- a/packages/sandbox/daemon/git/auto-commit.test.ts
+++ b/packages/sandbox/daemon/git/auto-commit.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "bun:test";
+import { retry } from "@decocms/shared/std";
 import { AutoCommitter, shouldAutoCommit } from "./auto-commit";
 import type { BranchMeta } from "../events/types";
 import { gitSync } from "./git-sync";
@@ -90,13 +91,14 @@ function remoteFileList(bare: string, branch: string): string {
 describe("AutoCommitter.tick", () => {
   function makeCommitter(
     repoDir: string,
-    over: { enabled?: boolean; dirty?: boolean } = {},
+    over: { enabled?: boolean; dirty?: boolean; debounceMs?: number } = {},
   ) {
     return new AutoCommitter({
       gitDeps: { appRoot: join(repoDir, ".."), repoDir },
       getBranchMeta: () =>
         ready({ branch: "sandbox-work", workingTreeDirty: over.dirty ?? true }),
       isEnabled: () => over.enabled ?? true,
+      debounceMs: over.debounceMs,
     });
   }
 
@@ -107,6 +109,34 @@ describe("AutoCommitter.tick", () => {
     await makeCommitter(repoDir).tick();
 
     expect(remoteFileList(bare, "sandbox-work")).toContain("agent-work.ts");
+  });
+
+  // The primary trigger: a file write nudges, and the save lands once the
+  // writes settle — not on the 30 s interval.
+  it("saves after a nudge's debounce elapses, coalescing a burst", async () => {
+    const { repoDir, bare } = initRepoWithRemote();
+    const committer = makeCommitter(repoDir, { debounceMs: 20 });
+
+    for (const name of ["a.ts", "b.ts", "c.ts"]) {
+      writeFileSync(join(repoDir, name), "export const x = 1;\n");
+      committer.nudge();
+    }
+    // The debounced tick pushes on its own schedule — poll for the result
+    // rather than guessing how long a local git push takes.
+    const remote = await retry(() => remoteFileList(bare, "sandbox-work"), {
+      minTimeout: 20,
+      maxTimeout: 100,
+      maxAttempts: 20,
+    });
+    expect(remote).toContain("a.ts");
+    expect(remote).toContain("c.ts");
+    // One commit for the whole burst, not one per write.
+    expect(
+      gitSync(["rev-list", "--count", "main..sandbox-work"], {
+        cwd: bare,
+        asUser: false,
+      }),
+    ).toBe("1");
   });
 
   it("does nothing when disabled by config", async () => {

--- a/packages/sandbox/daemon/git/auto-commit.ts
+++ b/packages/sandbox/daemon/git/auto-commit.ts
@@ -1,0 +1,112 @@
+import type { BranchMeta } from "../events/types";
+import {
+  ensureOriginPushable,
+  type GitDeps,
+  pushBranchAsync,
+  stageAndCommit,
+} from "../routes/git";
+import { protectedBranches } from "./protect-branch";
+
+/**
+ * How often to check for unsaved work. Also the worst-case window of work lost
+ * to a SIGKILL — the pod's grace period can expire (or the node can vanish)
+ * before shutdown()'s publish runs, and nothing else syncs the tree.
+ *
+ * ponytail: one fixed interval, no adaptive backoff. A clean tree costs zero
+ * git calls (the tick reads BranchStatusMonitor's already-computed meta), so
+ * there is nothing to tune until someone measures a problem.
+ */
+const AUTO_COMMIT_INTERVAL_MS = 30_000;
+
+const COMMIT_MESSAGE = "chore(sandbox): auto-save work in progress";
+
+/** Should this tick do anything? Extracted so the decision is unit-testable. */
+export function shouldAutoCommit(
+  meta: BranchMeta,
+  protectedBranchNames: ReadonlySet<string>,
+): boolean {
+  if (meta.kind !== "ready") return false;
+  // stageAndCommit() refuses a protected branch anyway; bail here so a sandbox
+  // sitting on main doesn't log a warning every tick for the whole session.
+  if (protectedBranchNames.has(meta.branch)) return false;
+  // `unpushed` covers commits the agent made itself via bash — those are just
+  // as lost as uncommitted work if the remote never sees them.
+  return meta.workingTreeDirty || meta.unpushed > 0;
+}
+
+export interface AutoCommitterDeps {
+  gitDeps: GitDeps;
+  /** Current branch metadata, from BranchStatusMonitor (no extra git calls). */
+  getBranchMeta: () => BranchMeta;
+  /**
+   * Read per tick, not at start(): tenant config arrives after boot (PUT
+   * /config) and can change mid-session, so a start-time snapshot would pin
+   * the wrong value.
+   */
+  isEnabled: () => boolean;
+  /** Re-read git state after a commit so the UI's dirty flag settles. */
+  onSynced?: () => void;
+}
+
+/**
+ * Periodically commits and pushes the sandbox's working tree so a SIGKILL
+ * (pod eviction, OOM, node loss) can't take the agent's work with it. Reuses
+ * publish()'s staging rules and its non-reconciling push, so it inherits the
+ * protected-branch refusal, the invalid-decofile-block skip, and credentialed
+ * origin setup.
+ */
+export class AutoCommitter {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+
+  constructor(private readonly deps: AutoCommitterDeps) {}
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => void this.tick(), AUTO_COMMIT_INTERVAL_MS);
+    // Don't hold the process open on this timer alone.
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  /** One pass. Exposed for tests; never throws. */
+  async tick(): Promise<void> {
+    // Overlapping passes would race for index.lock, and a slow push must not
+    // queue up a second commit behind it.
+    if (this.running) return;
+    if (!this.deps.isEnabled()) return;
+    const meta = this.deps.getBranchMeta();
+    if (!shouldAutoCommit(meta, protectedBranches(this.deps.gitDeps.repoDir))) {
+      return;
+    }
+    this.running = true;
+    try {
+      // "skip", not "throw": one invalid decofile block must not stop the rest
+      // of the tree from being saved (same call as the shutdown sync).
+      //
+      // Asymmetry on purpose: the TRIGGER above ignores boot-dirty noise (dev
+      // server rewriting compiled assets — BranchStatusMonitor's baseline),
+      // but the commit stages everything dirty, exactly like the shutdown
+      // sync. Carrying a little noise beats dropping the user's work.
+      const prepared = stageAndCommit(this.deps.gitDeps, COMMIT_MESSAGE, {
+        onInvalidBlock: "skip",
+      });
+      if (!prepared) return;
+      if (prepared.committed) this.deps.onSynced?.();
+      ensureOriginPushable(this.deps.gitDeps);
+      await pushBranchAsync(this.deps.gitDeps.repoDir, prepared.branch);
+    } catch (err) {
+      // Best-effort by design: a protected branch, a diverged origin, or a
+      // missing credential all land here. The next tick retries, and the
+      // shutdown publish is the backstop — never crash the daemon over it.
+      console.warn("[daemon] auto-commit failed", err);
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/packages/sandbox/daemon/git/auto-commit.ts
+++ b/packages/sandbox/daemon/git/auto-commit.ts
@@ -8,13 +8,29 @@ import {
 import { protectedBranches } from "./protect-branch";
 
 /**
- * How often to check for unsaved work. Also the worst-case window of work lost
- * to a SIGKILL — the pod's grace period can expire (or the node can vanish)
- * before shutdown()'s publish runs, and nothing else syncs the tree.
+ * Trailing debounce after a repo file change — the primary trigger, so a save
+ * normally lands a few seconds after the agent stops writing.
  *
- * ponytail: one fixed interval, no adaptive backoff. A clean tree costs zero
- * git calls (the tick reads BranchStatusMonitor's already-computed meta), so
- * there is nothing to tune until someone measures a problem.
+ * Not zero: one commit+push per file write would mean a push every few hundred
+ * ms during a tool loop, and a push to a user's repo can fan out into their CI.
+ * Coalescing a burst into one save costs a few seconds of exposure and cuts the
+ * push count by an order of magnitude.
+ */
+const AUTO_COMMIT_DEBOUNCE_MS = 5_000;
+
+/**
+ * Periodic floor, and the real worst-case window of work lost to a SIGKILL.
+ * Needed because the debounce alone can't be trusted:
+ *  - continuous writing keeps resetting it, so it may never fire during a long
+ *    run — this interval is what bounds the loss window there;
+ *  - the change signal comes from fs.watch, which has real gaps (the same
+ *    reason BranchStatusMonitor keeps its own 3 s poll fallback);
+ *  - commits the agent makes itself via `bash` produce no file-change event at
+ *    all, only `unpushed > 0`.
+ *
+ * ponytail: fixed values, no adaptive backoff. A clean tree costs zero git
+ * calls (the tick reads BranchStatusMonitor's already-computed meta), so there
+ * is nothing to tune until someone measures a problem.
  */
 const AUTO_COMMIT_INTERVAL_MS = 30_000;
 
@@ -46,17 +62,20 @@ export interface AutoCommitterDeps {
   isEnabled: () => boolean;
   /** Re-read git state after a commit so the UI's dirty flag settles. */
   onSynced?: () => void;
+  /** Overridable so tests don't wait out the real debounce. */
+  debounceMs?: number;
 }
 
 /**
- * Periodically commits and pushes the sandbox's working tree so a SIGKILL
- * (pod eviction, OOM, node loss) can't take the agent's work with it. Reuses
- * publish()'s staging rules and its non-reconciling push, so it inherits the
- * protected-branch refusal, the invalid-decofile-block skip, and credentialed
- * origin setup.
+ * Commits and pushes the sandbox's working tree so a SIGKILL (pod eviction,
+ * OOM, node loss) can't take the agent's work with it. Change-driven
+ * (`nudge()`, debounced) with a periodic floor. Reuses publish()'s staging
+ * rules and its non-reconciling push, so it inherits the protected-branch
+ * refusal, the invalid-decofile-block skip, and credentialed origin setup.
  */
 export class AutoCommitter {
   private timer: ReturnType<typeof setInterval> | null = null;
+  private debounce: ReturnType<typeof setTimeout> | null = null;
   private running = false;
 
   constructor(private readonly deps: AutoCommitterDeps) {}
@@ -69,9 +88,27 @@ export class AutoCommitter {
   }
 
   stop(): void {
+    if (this.debounce) {
+      clearTimeout(this.debounce);
+      this.debounce = null;
+    }
     if (!this.timer) return;
     clearInterval(this.timer);
     this.timer = null;
+  }
+
+  /**
+   * A repo file changed — save once the writes settle. Trailing debounce: a
+   * burst (one agent turn writing 20 files) coalesces into a single commit, and
+   * writes that never settle are picked up by the interval instead.
+   */
+  nudge(): void {
+    if (this.debounce) clearTimeout(this.debounce);
+    this.debounce = setTimeout(() => {
+      this.debounce = null;
+      void this.tick();
+    }, this.deps.debounceMs ?? AUTO_COMMIT_DEBOUNCE_MS);
+    this.debounce.unref?.();
   }
 
   /** One pass. Exposed for tests; never throws. */

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -635,17 +635,28 @@ class InvalidDecofileBlockError extends Error {
   }
 }
 
-export function publish(
+/**
+ * Local half of publish(): stage every changed path and commit them. Returns
+ * the checked-out branch, or `null` when there is nothing to publish from (no
+ * repo yet). Split out so the auto-save loop (git/auto-commit.ts) reuses the
+ * exact same staging/commit rules — including the invalid-decofile-block net —
+ * instead of a second blind `git add/commit`.
+ *
+ * Every git call here is local, so it stays synchronous (parity with the
+ * status/diff probes and BranchStatusMonitor's 3 s poll). Only the network push
+ * has an async twin (pushBranchAsync).
+ */
+export function stageAndCommit(
   deps: GitDeps,
   message: string,
-  opts: { onInvalidBlock?: "throw" | "skip"; reconcileRemote?: boolean } = {},
-): { pushed: boolean } {
+  opts: { onInvalidBlock?: "throw" | "skip" } = {},
+): { branch: string; committed: boolean } | null {
   const repoDir = deps.repoDir;
   // The HTTP route guards with isGitRepo(); the shutdown handler calls publish()
   // directly, so a never-cloned/empty dir would throw 128 ("not a git
   // repository") on the rev-parse below. Nothing to publish — skip cleanly.
   if (!isGitRepo(repoDir)) {
-    return { pushed: false };
+    return null;
   }
   const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (!branch || branch === "HEAD") {
@@ -726,7 +737,15 @@ export function publish(
       { env: SKIP_HOOKS_ENV },
     );
   }
+  return { branch, committed: hasStagedChanges };
+}
 
+/**
+ * Point `origin` at the credentialed clone URL and refuse a push that would
+ * fail auth. Local git config only — no network.
+ */
+export function ensureOriginPushable(deps: GitDeps): void {
+  const repoDir = deps.repoDir;
   const cloneUrl = deps.getCloneUrl?.();
   if (typeof cloneUrl === "string" && cloneUrl.length > 0) {
     syncOriginRemote(repoDir, cloneUrl);
@@ -742,11 +761,37 @@ export function publish(
       "GitHub push requires an authenticated clone URL. Connect GitHub for this project and restart the sandbox.",
     );
   }
+}
 
-  pushBranch(repoDir, branch, {
+export function publish(
+  deps: GitDeps,
+  message: string,
+  opts: { onInvalidBlock?: "throw" | "skip"; reconcileRemote?: boolean } = {},
+): { pushed: boolean } {
+  const prepared = stageAndCommit(deps, message, opts);
+  if (!prepared) return { pushed: false };
+  ensureOriginPushable(deps);
+  pushBranch(deps.repoDir, prepared.branch, {
     reconcileRemote: opts.reconcileRemote ?? false,
   });
   return { pushed: true };
+}
+
+/**
+ * Non-blocking `git push` for the background auto-save loop. Deliberately NOT
+ * the reconciling path: an autosave must never force-push over a diverged
+ * origin/<branch> (same reasoning as the shutdown sync). A rejected push is
+ * left for the interactive publish to reconcile.
+ */
+export async function pushBranchAsync(
+  repoDir: string,
+  branch: string,
+): Promise<void> {
+  await runGitAsync(
+    repoDir,
+    [...GIT_PUSH_CONFIG, "push", "--no-verify", "-u", "origin", branch],
+    { env: PUSH_ENV },
+  );
 }
 
 function discard(deps: GitDeps, filepaths: string[]): void {

--- a/packages/sandbox/daemon/types.ts
+++ b/packages/sandbox/daemon/types.ts
@@ -58,6 +58,12 @@ export interface GitRepository {
 export interface GitConfig {
   readonly repository: GitRepository;
   readonly identity?: GitIdentity;
+  /**
+   * Periodically commit + push the working tree so a SIGKILL (pod eviction,
+   * OOM, node loss) can't take the agent's work with it. Default ON — set
+   * `false` to opt out. Never pushes to a protected branch.
+   */
+  readonly autoCommit?: boolean;
 }
 
 export interface PackageManagerConfig {

--- a/packages/sandbox/daemon/validate.ts
+++ b/packages/sandbox/daemon/validate.ts
@@ -89,6 +89,9 @@ function validateGit(git: NonNullable<TenantConfig["git"]>): ValidationResult {
       return { kind: "invalid", reason: `git.repository.branch invalid: ${b}` };
     }
   }
+  if (git.autoCommit !== undefined && typeof git.autoCommit !== "boolean") {
+    return { kind: "invalid", reason: "git.autoCommit must be a boolean" };
+  }
   if (git.identity !== undefined) {
     if (
       typeof git.identity.userName !== "string" ||


### PR DESCRIPTION
## Summary

The daemon only synced the sandbox working tree in `shutdown()`. Any ungraceful exit — SIGKILL on pod eviction, OOM, node loss, grace period elapsing before the push finishes — took the agent's work with it.

This adds `AutoCommitter` (`daemon/git/auto-commit.ts`): every 30s, if the tree is dirty or the branch has unpushed commits, commit and push. **On by default**, opt out with `git.autoCommit: false` in the daemon config (validated, works via `PUT /_sandbox/config` or a tenant-committed `.decocms/daemon.json`).

### Reuse over reinvention

`publish()` is split into its local half and its network half so the loop shares the rules instead of doing a second blind `add`/`commit`/`push`:

- `stageAndCommit()` — staging + commit, incl. the protected-branch refusal, the invalid-decofile-block net (`onInvalidBlock: "skip"`, same as the shutdown sync) and the org-fs `.git/info/exclude` filtering.
- `ensureOriginPushable()` — credentialed origin + the tokenless-GitHub guard.
- `publish()` is now those two plus `pushBranch()`; behavior unchanged.
- `pushBranchAsync()` — new: the loop's push goes through `gitAsync` so it never blocks the daemon's single event loop long enough to miss a health probe (Studio tears a sandbox down on one missed probe). Local git calls stay sync, matching `BranchStatusMonitor`'s existing 3s poll.

### Behavior notes

- Never pushes to a protected branch (checked before the commit, so no stray commit either) and never force-pushes — an autosave must not clobber a diverged `origin/<branch>`, same reasoning as the shutdown sync. A rejected push is left for the interactive publish to reconcile.
- Failures are logged and retried on the next tick; the shutdown publish remains the backstop.
- The trigger reads `BranchStatusMonitor`'s already-computed meta, so a clean tree costs zero git calls, and boot-dirty dev-server noise doesn't *trigger* a tick. The commit itself still stages everything dirty (identical to the shutdown sync) — carrying a little noise beats dropping the user's work.
- `unpushed > 0` is a trigger too, so commits the agent made itself via `bash` also get pushed.
- Overlapping ticks are latched, and `shutdown()` stops the loop before its own publish so the two can't race for `index.lock`.

## Testing

- New `daemon/git/auto-commit.test.ts`: `shouldAutoCommit` decision table, plus two real-git tests against a bare `file://` origin — a dirty tree ends up on the remote branch, and a disabled committer touches nothing.
- `bun test packages/sandbox/` → 878 pass / 0 fail, including the daemon e2e suite booting the rebuilt binary with the loop wired.
- `bun run check`, `bun run lint` (0 errors), `bun run fmt`, `knip` clean.

## Skipped

No Studio-side UI/org-flag to toggle it — the daemon config field is the switch; add a surface when someone asks for one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-save sandbox work to the remote a few seconds after repo writes settle, with a 30s floor, to prevent data loss on ungraceful exits. Enabled by default, never pushes protected branches, and can be disabled with `git.autoCommit: false`.

- **New Features**
  - Added `AutoCommitter` that saves on change (5s trailing debounce) and on a 30s interval; commits and pushes when the tree is dirty or has unpushed commits, using async push to keep the daemon responsive.
  - Config toggle `git.autoCommit` (validated) via `PUT /_sandbox/config` or a tenant `.decocms/daemon.json`.
  - Skips protected branches and never force-pushes; logs failures and retries; shutdown publish remains the backstop.

- **Refactors**
  - Split `publish()` into `stageAndCommit` and `ensureOriginPushable` to reuse staging rules; added `pushBranchAsync` for non-blocking pushes.
  - Integrated start/stop into the daemon lifecycle, wired to the repo write funnel, and latched overlapping ticks; reuses `BranchStatusMonitor` metadata to avoid extra git calls.
  - Updated README and added tests for decision logic, debounce behavior, and real git flow.

<sup>Written for commit f474f81c4e28fe56f86e975c95541f97bf583ad7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

