### PR TITLE
fix(organization): stop sending raw email to PostHog on member removal

### DIFF
--- a/apps/api/src/tools/organization/member-remove.ts
+++ b/apps/api/src/tools/organization/member-remove.ts
@@ -76,7 +76,8 @@ export const ORGANIZATION_MEMBER_REMOVE = defineTool({
         groups: { organization: organizationId },
         properties: {
           organization_id: organizationId,
-          member_id_or_email: input.memberIdOrEmail,
+          member_id: removed.member.id,
+          target_user_id: removed.member.userId,
         },
       });
     }


### PR DESCRIPTION
**Source:** bug found while auditing org-member removal safety (`apps/api/src/tools/organization/member-remove.ts`).

**Why a maintainer wants this:** `ORGANIZATION_MEMBER_REMOVE`'s `organization_member_removed` analytics event echoed `input.memberIdOrEmail` verbatim into the PostHog `member_id_or_email` property. Since the tool accepts either a member id *or* a raw email, this sends a real user's email address to a third-party analytics service whenever the caller identifies the target by email — an unnecessary PII leak. It's also inconsistent: the sibling `ORGANIZATION_MEMBER_UPDATE_ROLE` tool already tracks `member_id` + `target_user_id` (never the raw caller input) for the equivalent event, so this was the odd one out.

**Fix:** use the already-resolved `removed.member.id` / `removed.member.userId` (returned by Better Auth's `removeMember` call, and already used a few lines above for cache invalidation) instead of the raw `input.memberIdOrEmail`. No behavior change to the actual removal, cache invalidation, or tool output — only the PostHog event payload changes.

**Command a reviewer runs to confirm:**
```
cd apps/api && bunx tsc --noEmit
bun test apps/api/src/tools/organization/member-remove.test.ts
```

**Checks run locally:** `bun run fmt` (no changes needed), `bunx tsc --noEmit` in `apps/api` (clean), and the existing targeted test file `member-remove.test.ts` (3 pass). No new test was added for the PostHog payload itself since `posthog` is a module-level singleton client and asserting on it would require `mock.module`, which this repo's unit-test tier disallows (see TESTING.md) — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending raw emails to PostHog when removing an organization member. The `organization_member_removed` event now uses `removed.member.id` and `removed.member.userId` instead of `input.memberIdOrEmail`, removing PII and matching the role-update event shape.

<sup>Written for commit ded27b794059d1b4b41e0879558bce1490c011fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

