### PR TITLE
feat(chat): drag a task board card into the chat composer

### DIFF
--- a/apps/web/src/components/chat/input.tsx
+++ b/apps/web/src/components/chat/input.tsx
@@ -48,6 +48,13 @@ import {
   type UnsupportedFileInfo,
 } from "./tiptap/file";
 import { useCurrentEditor } from "@tiptap/react";
+import { insertMention } from "./tiptap/mention";
+import {
+  CHAT_DROP_TARGET_ATTR,
+  TASK_CHAT_DRAG_OVER_EVENT,
+  TASK_CHAT_DROP_EVENT,
+  type DraggedTaskPayload,
+} from "@/lib/task-drag";
 import {
   TiptapInput,
   TiptapProvider,
@@ -92,7 +99,7 @@ function useWindowFileDrop(
 ) {
   const { editor } = useCurrentEditor();
   const t = useT();
-  const [isDraggingOver, setIsDraggingOver] = useState(false);
+  const [dragKind, setDragKind] = useState<"file" | "task" | null>(null);
   const dragCounterRef = useRef(0);
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect
@@ -101,14 +108,14 @@ function useWindowFileDrop(
       if (e.dataTransfer?.types.includes("Files")) {
         e.preventDefault();
         dragCounterRef.current++;
-        setIsDraggingOver(true);
+        setDragKind("file");
       }
     };
     const onDragLeave = (e: DragEvent) => {
       e.preventDefault();
       dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
       if (dragCounterRef.current === 0) {
-        setIsDraggingOver(false);
+        setDragKind(null);
       }
     };
     const onDragOver = (e: DragEvent) => {
@@ -119,7 +126,7 @@ function useWindowFileDrop(
     const onDrop = (e: DragEvent) => {
       e.preventDefault();
       dragCounterRef.current = 0;
-      setIsDraggingOver(false);
+      setDragKind(null);
 
       if (
         disabled ||
@@ -165,7 +172,37 @@ function useWindowFileDrop(
     };
   }, [editor, selectedModel, onUnsupportedFile, t, disabled]);
 
-  return isDraggingOver;
+  // Task board cards drag via dnd-kit (pointer events, not native DragEvents)
+  // from a sibling panel outside this composer's DOM tree — the board
+  // hit-tests against `data-chat-drop-target` and notifies over these window
+  // events instead (see apps/web/src/lib/task-drag.ts).
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    const onTaskDragOver = (e: Event) => {
+      const over = (e as CustomEvent<boolean>).detail;
+      setDragKind((prev) => (over ? "task" : prev === "task" ? null : prev));
+    };
+    const onTaskDrop = (e: Event) => {
+      setDragKind(null);
+      if (disabled || !editor) return;
+      const task = (e as CustomEvent<DraggedTaskPayload>).detail;
+      insertMention(editor, editor.state.selection, {
+        id: task.id,
+        name: task.title,
+        char: "@",
+        kind: "task",
+        metadata: { title: task.title, description: task.description },
+      });
+    };
+    window.addEventListener(TASK_CHAT_DRAG_OVER_EVENT, onTaskDragOver);
+    window.addEventListener(TASK_CHAT_DROP_EVENT, onTaskDrop);
+    return () => {
+      window.removeEventListener(TASK_CHAT_DRAG_OVER_EVENT, onTaskDragOver);
+      window.removeEventListener(TASK_CHAT_DROP_EVENT, onTaskDrop);
+    };
+  }, [editor, disabled]);
+
+  return dragKind;
 }
 
 // ============================================================================
@@ -203,6 +240,18 @@ function FileDropZoneUnsupported() {
   );
 }
 
+function TaskDropZone() {
+  const t = useT();
+  return (
+    <>
+      <BookOpen01 size={24} />
+      <span className="text-sm font-medium">
+        {t("chat.input.dropTaskHere")}
+      </span>
+    </>
+  );
+}
+
 // ============================================================================
 // FileDropZone - Overlay that catches file drops from anywhere on the window
 // ============================================================================
@@ -216,7 +265,7 @@ function FileDropZone({
   onUnsupportedFile?: (info: UnsupportedFileInfo) => void;
   disabled?: boolean;
 }) {
-  const isDraggingOver = useWindowFileDrop(
+  const dragKind = useWindowFileDrop(
     selectedModel,
     onUnsupportedFile,
     disabled,
@@ -227,13 +276,15 @@ function FileDropZone({
     <div
       className={cn(
         "absolute inset-0 z-20 rounded-xl flex flex-col items-center justify-center gap-2 bg-muted border-2 border-dashed transition-opacity",
-        isDraggingOver ? "opacity-100" : "opacity-0 pointer-events-none",
-        supportsFiles
-          ? "border-primary/40 text-primary/70"
-          : "border-destructive/30 text-destructive/70",
+        dragKind ? "opacity-100" : "opacity-0 pointer-events-none",
+        dragKind === "file" && !supportsFiles
+          ? "border-destructive/30 text-destructive/70"
+          : "border-primary/40 text-primary/70",
       )}
     >
-      {supportsFiles ? (
+      {dragKind === "task" ? (
+        <TaskDropZone />
+      ) : supportsFiles ? (
         <FileDropZoneSupported selectedModel={selectedModel} />
       ) : (
         <FileDropZoneUnsupported />
@@ -568,7 +619,10 @@ export function ChatInput({
   return (
     <>
       <div className="flex flex-col w-full justify-end">
-        <div className="relative rounded-2xl w-full flex flex-col">
+        <div
+          {...{ [CHAT_DROP_TARGET_ATTR]: true }}
+          className="relative rounded-2xl w-full flex flex-col"
+        >
           {/* Muted background for connections banner - peeks through form's bottom radius */}
           {showConnectionsBanner && (
             <div className="absolute inset-0 rounded-2xl pointer-events-none bg-muted/50" />

--- a/apps/web/src/components/chat/tiptap/mention-at.tsx
+++ b/apps/web/src/components/chat/tiptap/mention-at.tsx
@@ -4,6 +4,7 @@
  */
 
 import { KEYS } from "@/lib/query-keys";
+import { useTaskBoardItems } from "@/hooks/use-task-board-items";
 import {
   isDecopilot,
   listResources,
@@ -29,15 +30,17 @@ interface AtMentionProps {
   suggestionOpenRef?: { current: boolean };
 }
 
-type AtMode = "categories" | "agents" | "resources";
+type AtMode = "categories" | "agents" | "resources" | "tasks";
 
 interface AtItem extends BaseItem {
   /** Discriminator for item type */
-  kind: "category" | "agent" | "resource";
+  kind: "category" | "agent" | "resource" | "task";
   /** Agent ID (for agents) */
   agentId?: string;
   /** Resource URI (for resources) */
   uri?: string;
+  /** Task board item (for tasks) */
+  taskId?: string;
 }
 
 export const AtMention = ({
@@ -49,6 +52,7 @@ export const AtMention = ({
   const queryClient = useQueryClient();
   const { org } = useProjectContext();
   const agents = useVirtualMCPs();
+  const { items: tasks } = useTaskBoardItems();
   // Dev agents are reached via the Develop/Live toggle, not @-mentioned.
   const devAgentIds = getDevAgentIds(agents);
   const client = useMCPClient({
@@ -86,6 +90,13 @@ export const AtMention = ({
       kind: "category" as const,
       drillable: true,
     },
+    {
+      name: "tasks",
+      title: t("chat.mentionAt.tasksTitle"),
+      description: t("chat.mentionAt.tasksDescription"),
+      kind: "category" as const,
+      drillable: true,
+    },
   ];
 
   const handleItemSelect = async ({
@@ -104,7 +115,13 @@ export const AtMention = ({
 
     if (item.kind === "category") {
       // Drill into category — keep menu open
-      setMode(item.name === "agents" ? "agents" : "resources");
+      setMode(
+        item.name === "agents"
+          ? "agents"
+          : item.name === "tasks"
+            ? "tasks"
+            : "resources",
+      );
       return false;
     }
 
@@ -114,6 +131,22 @@ export const AtMention = ({
         name: item.name,
         metadata: { agentId: item.agentId, title: item.name },
         char: "@",
+      });
+      setMode("categories");
+      return;
+    }
+
+    if (item.kind === "task" && item.taskId) {
+      const task = tasks.find((t) => t.id === item.taskId);
+      insertMention(editor, range, {
+        id: item.taskId,
+        name: item.title ?? item.name,
+        char: "@",
+        kind: "task",
+        metadata: {
+          title: item.title ?? item.name,
+          description: task?.description,
+        },
       });
       setMode("categories");
       return;
@@ -193,7 +226,21 @@ export const AtMention = ({
           }));
       })();
 
-      return [...matchedAgents, ...matchedResources];
+      const matchedTasks: AtItem[] = tasks
+        .filter(
+          (task) =>
+            task.title.toLowerCase().includes(lq) ||
+            task.description?.toLowerCase().includes(lq),
+        )
+        .map((task) => ({
+          name: task.title,
+          title: task.title,
+          description: task.description ?? undefined,
+          kind: "task" as const,
+          taskId: task.id,
+        }));
+
+      return [...matchedAgents, ...matchedResources, ...matchedTasks];
     }
 
     if (currentMode === "agents") {
@@ -219,6 +266,25 @@ export const AtMention = ({
         icon: agent.icon ?? null,
         kind: "agent" as const,
         agentId: agent.id,
+      }));
+    }
+
+    if (currentMode === "tasks") {
+      let filtered = tasks;
+      if (query.trim()) {
+        const lq = query.toLowerCase();
+        filtered = filtered.filter(
+          (task) =>
+            task.title.toLowerCase().includes(lq) ||
+            task.description?.toLowerCase().includes(lq),
+        );
+      }
+      return filtered.map((task) => ({
+        name: task.title,
+        title: task.title,
+        description: task.description ?? undefined,
+        kind: "task" as const,
+        taskId: task.id,
       }));
     }
 

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -254,6 +254,7 @@ export const chat = {
   "chat.input.createImage": "Create image",
   "chat.input.deepResearch": "Deep research",
   "chat.input.dropFilesHere": "Drop {fileTypes} here",
+  "chat.input.dropTaskHere": "Drop to reference this task",
   "chat.input.microphoneAccessDenied":
     "Microphone access denied — click to try again",
   "chat.input.modelCannotReadAttachments":
@@ -270,7 +271,7 @@ export const chat = {
   "chat.input.voiceInput": "Voice input",
   "chat.input.webSearch": "Web search",
   "chat.input.placeholder":
-    "Ask anything, / for prompts & skills, @ for agents & resources...",
+    "Ask anything, / for prompts & skills, @ for agents, resources & tasks...",
   "chat.markdown.copyAsCSV": "Copy as CSV",
   "chat.markdown.copyCode": "Copy code",
   "chat.markdown.image": "Image",
@@ -281,6 +282,8 @@ export const chat = {
     "Failed to load resource. Please try again.",
   "chat.mentionAt.resourcesDescription": "Attach a resource as context",
   "chat.mentionAt.resourcesTitle": "Resources",
+  "chat.mentionAt.tasksDescription": "Reference a task as context",
+  "chat.mentionAt.tasksTitle": "Tasks",
   "chat.mentionSlash.failedLoadPrompt":
     "Failed to load prompt. Please try again.",
   "chat.mentionSlash.failedLoadResource":

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -261,6 +261,7 @@ export const chat = {
   "chat.input.createImage": "Criar imagem",
   "chat.input.deepResearch": "Pesquisa profunda",
   "chat.input.dropFilesHere": "Solte {fileTypes} aqui",
+  "chat.input.dropTaskHere": "Solte para referenciar esta tarefa",
   "chat.input.microphoneAccessDenied":
     "Acesso ao microfone negado — clique para tentar novamente",
   "chat.input.modelCannotReadAttachments":
@@ -277,7 +278,7 @@ export const chat = {
   "chat.input.voiceInput": "Entrada de voz",
   "chat.input.webSearch": "Busca na web",
   "chat.input.placeholder":
-    "Pergunte qualquer coisa, / para prompts & habilidades, @ para agentes & recursos...",
+    "Pergunte qualquer coisa, / para prompts & habilidades, @ para agentes, recursos & tarefas...",
   "chat.markdown.copyAsCSV": "Copiar como CSV",
   "chat.markdown.copyCode": "Copiar código",
   "chat.markdown.image": "Imagem",
@@ -289,6 +290,8 @@ export const chat = {
     "Falha ao carregar recurso. Tente novamente.",
   "chat.mentionAt.resourcesDescription": "Anexar um recurso como contexto",
   "chat.mentionAt.resourcesTitle": "Recursos",
+  "chat.mentionAt.tasksDescription": "Referenciar uma tarefa como contexto",
+  "chat.mentionAt.tasksTitle": "Tarefas",
   "chat.mentionSlash.failedLoadPrompt":
     "Falha ao carregar prompt. Tente novamente.",
   "chat.mentionSlash.failedLoadResource":

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -122,6 +122,12 @@ import { usePanelActions } from "@/layouts/shell-layout";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useThreadActions } from "@/components/chat/store/hooks";
 import { writeChatDraft } from "@/lib/chat-draft";
+import {
+  isRectOverChatDropTarget,
+  TASK_CHAT_DRAG_OVER_EVENT,
+  TASK_CHAT_DROP_EVENT,
+  type DraggedTaskPayload,
+} from "@/lib/task-drag";
 import { createMentionDoc } from "@/components/chat/tiptap/mention";
 import type { TiptapDoc } from "@/components/chat/types";
 import { useReportsOnly } from "@/hooks/use-organization-settings";
@@ -1180,8 +1186,38 @@ function Lanes({
     );
   };
 
+  // Tracks whether the dragged card is currently hovering the chat composer
+  // (a sibling panel outside this DndContext) — only dispatched on
+  // enter/leave transitions so the composer isn't re-rendered every frame.
+  const wasOverChatRef = useRef(false);
+  const notifyChatDragOver = (over: boolean) => {
+    if (wasOverChatRef.current === over) return;
+    wasOverChatRef.current = over;
+    window.dispatchEvent(
+      new CustomEvent(TASK_CHAT_DRAG_OVER_EVENT, { detail: over }),
+    );
+  };
+
   const handleDragEnd = (event: DragEndEvent) => {
     const id = String(event.active.id);
+    const draggedRect = event.active.rect.current.translated;
+    notifyChatDragOver(false);
+    if (draggedRect && isRectOverChatDropTarget(draggedRect)) {
+      const item = placed.find((candidate) => candidate.id === id);
+      setActiveId(null);
+      setOverrides(new Map());
+      if (item) {
+        const payload: DraggedTaskPayload = {
+          id: item.id,
+          title: item.title,
+          description: item.description,
+        };
+        window.dispatchEvent(
+          new CustomEvent(TASK_CHAT_DROP_EVENT, { detail: payload }),
+        );
+      }
+      return;
+    }
     setActiveId(null);
     const lane =
       laneOf(event.over?.id) ?? placed.find((item) => item.id === id)?.status;
@@ -1243,9 +1279,14 @@ function Lanes({
         setActiveId(String(event.active.id));
         setLandedIds([]);
       }}
+      onDragMove={(event) => {
+        const rect = event.active.rect.current.translated;
+        notifyChatDragOver(Boolean(rect && isRectOverChatDropTarget(rect)));
+      }}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
       onDragCancel={() => {
+        notifyChatDragOver(false);
         setActiveId(null);
         setOverrides(new Map());
       }}

--- a/apps/web/src/lib/task-drag.ts
+++ b/apps/web/src/lib/task-drag.ts
@@ -1,0 +1,40 @@
+/**
+ * Bridges dragging a task board card (dnd-kit, pointer-based, confined to the
+ * board's own DndContext) into the chat composer, which lives in a sibling
+ * panel outside that context. dnd-kit's drag never fires native DragEvents,
+ * so the board hit-tests the dragged card's rect against the element carrying
+ * `CHAT_DROP_TARGET_ATTR` and notifies the composer over these window events
+ * instead of relying on the browser's own dragenter/dragover/drop.
+ */
+export const TASK_CHAT_DRAG_OVER_EVENT = "studio:task-chat-drag-over";
+export const TASK_CHAT_DROP_EVENT = "studio:task-chat-drop";
+
+/** Marks the chat composer's drop target for the board's hit-testing. */
+export const CHAT_DROP_TARGET_ATTR = "data-chat-drop-target";
+
+export interface DraggedTaskPayload {
+  id: string;
+  title: string;
+  description?: string | null;
+}
+
+export type TaskChatDragOverEvent = CustomEvent<boolean>;
+export type TaskChatDropEvent = CustomEvent<DraggedTaskPayload>;
+
+/** Whether `rect` overlaps the chat composer's drop target, if any is mounted. */
+export function isRectOverChatDropTarget(rect: {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}): boolean {
+  const target = document.querySelector(`[${CHAT_DROP_TARGET_ATTR}]`);
+  if (!target) return false;
+  const targetRect = target.getBoundingClientRect();
+  return (
+    rect.left < targetRect.right &&
+    rect.right > targetRect.left &&
+    rect.top < targetRect.bottom &&
+    rect.bottom > targetRect.top
+  );
+}


### PR DESCRIPTION
## What is this contribution about?
Lets you drag a task board card into the chat composer to insert it as an @-mention, so you can reference a task as context in a chat. Also adds a "Tasks" category to the existing @-mention menu so tasks can be searched and inserted without dragging. Since dnd-kit's drag doesn't fire native DragEvents, the board hit-tests the dragged card's rect against the composer's drop target and communicates over custom window events (`apps/web/src/lib/task-drag.ts`).

## Screenshots/Demonstration
N/A (see How to Test below).

## How to Test
1. Open a project with a task board and at least one task.
2. Drag a task card from the board over the chat composer — it should show a "Drop to reference this task" overlay, and dropping inserts an @-mention for that task.
3. In the chat composer, type `@` and select the new "Tasks" category — search and select a task to insert the same mention.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add task references to chat by dragging a task board card into the composer or by selecting tasks from a new “Tasks” category in the @-mention menu. This makes it easy to include task context in messages.

- New Features
  - Drag a task card over the chat composer to see “Drop to reference this task.” Dropping inserts a task @-mention.
  - Added a “Tasks” category to the @ menu; search by title/description and insert the same mention.
  - Implemented a small bridge for `dnd-kit` drags using a chat drop target and custom window events to detect drag-over/drop across panels.
  - Updated EN/PT-BR strings for the new UI text.

<sup>Written for commit 75b749318f92aa41eaff46c0e261ca0b9c6eea45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

