### PR TITLE
refactor(file-storage): remove dead basenameOf helper from org-fs-path

### DIFF
--- a/apps/api/src/file-storage/org-fs-path.test.ts
+++ b/apps/api/src/file-storage/org-fs-path.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   ancestorsOf,
-  basenameOf,
   fsObjectKey,
   fsVolumePrefix,
   isValidVolume,
@@ -34,15 +33,13 @@ describe("normalizeFsPath", () => {
   });
 });
 
-describe("parentOf / basenameOf", () => {
+describe("parentOf", () => {
   test("top-level entries have empty parent", () => {
     expect(parentOf("file.txt")).toBe("");
-    expect(basenameOf("file.txt")).toBe("file.txt");
   });
 
   test("nested entries split on the last slash", () => {
     expect(parentOf("a/b/c.txt")).toBe("a/b");
-    expect(basenameOf("a/b/c.txt")).toBe("c.txt");
   });
 });
 

--- a/apps/api/src/file-storage/org-fs-path.ts
+++ b/apps/api/src/file-storage/org-fs-path.ts
@@ -37,12 +37,6 @@ export function parentOf(path: string): string {
   return i === -1 ? "" : path.slice(0, i);
 }
 
-/** Last path segment ("" for root). */
-export function basenameOf(path: string): string {
-  const i = path.lastIndexOf("/");
-  return i === -1 ? path : path.slice(i + 1);
-}
-
 /**
  * Ancestor directories of a path, top-down, excluding the root ("") and the
  * path itself. `a/b/c.txt` → `["a", "a/b"]`.


### PR DESCRIPTION
Dead-code reduction found while auditing the org-fs path helpers (the filesystem-abstraction area) for this tick's focus.

`basenameOf` in `apps/api/src/file-storage/org-fs-path.ts` had zero callers anywhere in the repo outside its own unit test — `org-fs.ts`, the WebDAV/mount daemon code, and every route/tool use `parentOf`/other helpers instead. Confirmed via `rg -n "basenameOf" .` returning only the definition and its test before this change, and nothing after.

Net line delta: -10 / +1 (removed the function + its two test assertions; folded the now-single-purpose `describe("parentOf / basenameOf")` block into `describe("parentOf")`). Purely subtractive — no behavior change, since nothing called the removed function.

To confirm: `rg -n "basenameOf" .` (no hits), then `bun test apps/api/src/file-storage/org-fs-path.test.ts`.

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in `apps/api` (clean), the targeted test file (10 pass), and `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `basenameOf` helper from `apps/api/src/file-storage/org-fs-path.ts` and cleaned up its test assertions. No functional changes; existing code uses `parentOf` and other helpers.

<sup>Written for commit b6ab1fc4f28c85cace830821152f960dc80552c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

