### PR TITLE
fix(web): surface a toast when copying the install command fails

### DIFF
--- a/apps/web/src/components/download-app-dialog.tsx
+++ b/apps/web/src/components/download-app-dialog.tsx
@@ -6,6 +6,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
+import { toast } from "@deco/ui/components/sonner.js";
 import { Check, Copy01 } from "@untitledui/icons";
 import { useState } from "react";
 import { useT } from "@/i18n/use-t.ts";
@@ -57,10 +58,13 @@ export function DownloadAppDialog({
             type="button"
             className="w-full gap-2"
             onClick={() => {
-              navigator.clipboard.writeText(command).then(() => {
-                setCopied(true);
-                setTimeout(() => setCopied(false), 2000);
-              });
+              navigator.clipboard.writeText(command).then(
+                () => {
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 2000);
+                },
+                () => toast.error(t("downloadApp.copyFailedLabel")),
+              );
             }}
           >
             {copied ? <Check size={16} /> : <Copy01 size={16} />}

--- a/apps/web/src/components/download-app-dialog.tsx
+++ b/apps/web/src/components/download-app-dialog.tsx
@@ -6,7 +6,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
-import { toast } from "@deco/ui/components/sonner.js";
+import { toast } from "@deco/ui/components/sonner.tsx";
 import { Check, Copy01 } from "@untitledui/icons";
 import { useState } from "react";
 import { useT } from "@/i18n/use-t.ts";

--- a/apps/web/src/i18n/en/download-app.ts
+++ b/apps/web/src/i18n/en/download-app.ts
@@ -4,6 +4,8 @@ export const downloadApp = {
     "The app installs from your Mac's Terminal — copy the command below, paste it there, and press Return.",
   "downloadApp.copyLabel": "Copy install command",
   "downloadApp.copiedLabel": "Copied — now paste it in Terminal",
+  "downloadApp.copyFailedLabel":
+    "Couldn't copy the command — select it manually",
   "downloadApp.terminalHint":
     "Tip: press ⌘ Space and type “Terminal” to open it.",
   "downloadApp.appleSiliconNote":

--- a/apps/web/src/i18n/pt-br/download-app.ts
+++ b/apps/web/src/i18n/pt-br/download-app.ts
@@ -6,6 +6,8 @@ export const downloadApp = {
     "O app é instalado pelo Terminal do seu Mac — copie o comando abaixo, cole lá e pressione Return.",
   "downloadApp.copyLabel": "Copiar comando de instalação",
   "downloadApp.copiedLabel": "Copiado — agora cole no Terminal",
+  "downloadApp.copyFailedLabel":
+    "Não foi possível copiar o comando — selecione-o manualmente",
   "downloadApp.terminalHint":
     "Dica: pressione ⌘ Espaço e digite “Terminal” para abri-lo.",
   "downloadApp.appleSiliconNote":


### PR DESCRIPTION
A bug found while auditing the recently-merged "Install on Mac" account-popover entry (#5492), which reuses `DownloadAppDialog`.

**Why**: `navigator.clipboard.writeText()` returns a Promise that rejects when the page isn't in an active/focused tab, runs in an insecure context, or the browser denies clipboard permission. The dialog's copy button only chained `.then(onSuccess)` with no rejection handler, so a failed copy left the button silently unchanged (never showing "Copied") with an unhandled-promise-rejection in the console and zero user feedback — the user is stuck assuming the paste will work when nothing was actually copied.

**Fix**: pass a rejection handler to `.then()` that shows a `toast.error`, mirroring the existing `copyText()` error-toast pattern already used in `apps/web/src/components/sandbox/preview/file-explorer/file-explorer.tsx`. Added the `downloadApp.copyFailedLabel` string to both `en` and `pt-br` dictionaries.

**Reviewer check**: `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint apps/web/src/components/download-app-dialog.tsx` (0 warnings/errors). No existing test file for this component; the change is a straightforward UI wiring fix with no trust boundary, so no new test was added per repo testing policy.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web workspace), `bunx oxlint` on the touched files. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show an error toast when copying the install command fails in `DownloadAppDialog`. This fixes silent clipboard failures and tells users to select the command manually.

- **Bug Fixes**
  - Handle rejected `navigator.clipboard.writeText()` with `toast.error` (and correct `@deco/ui/components/sonner.tsx` import).
  - Add `downloadApp.copyFailedLabel` to `en` and `pt-br` i18n.

<sup>Written for commit 7c6bf7059539487da8d69b8ffcbce88d1ee6fee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

