### PR TITLE
fix(sandbox): make publish()'s untracked-dir expansion async

### DIFF
--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -506,12 +506,15 @@ function changedPathsFromStatus(status: { files: GitStatusFile[] }): string[] {
  * itself so .gitignore is honored; walking the dir here would stage ignored
  * files and make `git add` fail.
  */
-function expandUntrackedDirs(repoDir: string, paths: string[]): string[] {
+async function expandUntrackedDirs(
+  repoDir: string,
+  paths: string[],
+): Promise<string[]> {
   const out: string[] = [];
   for (const p of paths) {
     let isDir = false;
     try {
-      isDir = fs.statSync(path.join(repoDir, p)).isDirectory();
+      isDir = (await fs.promises.stat(path.join(repoDir, p))).isDirectory();
     } catch {
       isDir = false;
     }
@@ -703,7 +706,10 @@ export async function publish(
   }
 
   const status = computeWorkingTreeStatus(repoDir);
-  let paths = expandUntrackedDirs(repoDir, changedPathsFromStatus(status));
+  let paths = await expandUntrackedDirs(
+    repoDir,
+    changedPathsFromStatus(status),
+  );
   // Last-resort net: never let a syntactically invalid decofile block reach the
   // branch. The /write and /edit handlers already reject invalid blocks, but a
   // mutation that bypassed them (bash, a git merge, a future write path) would


### PR DESCRIPTION
Continues the daemon's sync-fs → async-fs hardening pass (#5471 discard, #5481 decofile-block validation, #5497 hooks-dir mkdtemp) for the same reason: any blocking `*Sync` fs call on the daemon's single-threaded Bun event loop stalls the `/health` probe Studio polls, which can get a live sandbox marked dead.

**Bug**: `publish()`'s `expandUntrackedDirs()` helper called `fs.statSync` from inside the already-`async` `publish()` handler. `git status --porcelain` collapses an untracked directory into one `?? dir/` entry, so this runs on every publish that touches a fresh untracked directory — e.g. the very common case of a brand-new `.deco/blocks/` dir before its first commit — blocking the event loop for the syscall's duration.

**Fix**: swap `fs.statSync` (node:fs) for `fs.promises.stat`, awaited at the one call site inside `publish()`. Behavior-preserving: same directory-vs-file detection, same fallback to `false` on a stat error (e.g. a raced deletion), same single call site. Net diff: +9/-3.

**Verify**: `cd packages/sandbox && bunx tsc --noEmit` (clean) and `bun test packages/sandbox/daemon/routes/git.test.ts` (51 pass) — several existing publish() tests (e.g. "publish() commits a valid decofile block") write directly into a fresh untracked `.deco/blocks/` dir, exercising this exact code path.

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in `packages/sandbox`, the single test file above, and `bunx oxlint packages/sandbox/daemon/routes/git.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make publish()’s untracked-dir expansion async to avoid blocking the daemon’s event loop and stalling the /health probe. Replaces fs.statSync with fs.promises.stat to prevent stalls when publishing into fresh untracked dirs (e.g. .deco/blocks/).

- **Bug Fixes**
  - Converted expandUntrackedDirs to async and awaited it in publish().
  - Preserved behavior (dir vs file check, fallback on stat errors).
  - Removes event-loop stalls on publishes touching untracked directories.

<sup>Written for commit db9ca1d6025b21ccef8d907fb0ede5e99e39ff9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

