### PR TITLE
fix(web): don't strand a second account in the previous user's org

### DIFF
--- a/apps/web/src/components/org-access-gate.tsx
+++ b/apps/web/src/components/org-access-gate.tsx
@@ -4,7 +4,11 @@ import { PendingInviteScreen } from "@/components/pending-invite-screen";
 import { RequestPendingScreen } from "@/components/request-pending-screen";
 import { RequestToJoinScreen } from "@/components/request-to-join-screen";
 import { useOrgAccessStatus } from "@/hooks/use-org-access-status";
-import { clearLastLocation, readLastLocation } from "@/lib/last-location";
+import {
+  clearLastLocation,
+  consumeRestoreRedirect,
+  readLastLocation,
+} from "@/lib/last-location";
 import { LOCALSTORAGE_KEYS } from "@/lib/localstorage-keys";
 
 /**
@@ -23,19 +27,17 @@ export function OrgAccessGate({ orgSlug }: { orgSlug: string }) {
   // write for every non-member status so leaving actually leaves.
   if (data.status !== "member") {
     if (readLastLocation()?.org === orgSlug) clearLastLocation();
-
-    const cachedSlugMatches =
-      localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === orgSlug;
-    if (cachedSlugMatches) {
+    if (localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === orgSlug) {
       localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
     }
 
-    // not-found / no-access have nothing actionable here. If the user only
-    // landed here via the stale cached slug, bounce back to "/" so the loader
-    // picks a valid destination instead of dead-ending. A deliberate visit to a
-    // bad org (e.g. a shared link) still shows the screen rather than bouncing.
+    // not-found / no-access have nothing actionable here. If the user never
+    // asked for this org — the home loader restored it from stale state, e.g.
+    // another account's last org on this browser — bounce back to "/" so it
+    // picks their own default org instead of dead-ending. A deliberate visit to
+    // a foreign org (a shared link) still shows the screen.
     if (
-      cachedSlugMatches &&
+      consumeRestoreRedirect(orgSlug) &&
       (data.status === "not-found" || data.status === "no-access")
     ) {
       window.location.href = "/";

--- a/apps/web/src/components/settings/delete-organization-section.tsx
+++ b/apps/web/src/components/settings/delete-organization-section.tsx
@@ -1,5 +1,5 @@
 import { invalidateOrganizationListCache } from "@/lib/auth-client";
-import { LOCALSTORAGE_KEYS } from "@/lib/localstorage-keys";
+import { clearRestoreState } from "@/lib/last-location";
 import { track } from "@/lib/posthog-client";
 import { useStudioTools } from "@/lib/studio-tools";
 import { useT } from "@/i18n/use-t.ts";
@@ -40,10 +40,8 @@ export function DeleteOrganizationSection() {
     onSuccess: () => {
       track("organization_deleted", { organization_id: org.id });
 
-      // Drop the cached slug so homeRoute doesn't try to redirect us back here
-      if (localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === org.slug) {
-        localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
-      }
+      // Drop the restore state so homeRoute doesn't redirect us back here
+      clearRestoreState();
 
       // Drop the TTL-cached org list so the homeRoute loader doesn't redirect
       // back to the just-deleted org.

--- a/apps/web/src/layouts/shell-layout.tsx
+++ b/apps/web/src/layouts/shell-layout.tsx
@@ -9,6 +9,7 @@ import { isModKey } from "@/lib/keyboard-shortcuts";
 import RequiredAuthLayout from "@/layouts/required-auth-layout";
 import { authClient } from "@/lib/auth-client";
 import { AUTOSEND_QUERY_VALUE } from "@/lib/autosend";
+import { claimRestoreStateFor, clearRestoreState } from "@/lib/last-location";
 import { LOCALSTORAGE_KEYS } from "@/lib/localstorage-keys";
 import { readCachedOrg, writeCachedOrg } from "@/lib/query-persist";
 import { PostHogGroupSync } from "@/providers/posthog-group-sync";
@@ -227,6 +228,11 @@ function ShellLayoutContent() {
   const userId = session?.user?.id;
   const cachedOrg = org && userId ? readCachedOrg(userId, org) : null;
 
+  // Drop restore state left behind by a different account on this browser, so
+  // the next cold entry ("/") resolves this user's own default org instead of
+  // redirecting into an org they can't access.
+  if (userId) claimRestoreStateFor(userId);
+
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — subscribes to document keydown for ⌘K / ⌘[ shortcuts; DOM event listener has no React 19 alternative
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent) => {
@@ -340,10 +346,8 @@ function ShellLayoutContent() {
 
   const isArchivedOrg = isOrgArchived(activeOrg);
   if (isArchivedOrg) {
-    // Clear stale slug so /home redirect doesn't bounce the user back here
-    if (localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === org) {
-      localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
-    }
+    // Clear stale restore state so "/" doesn't bounce the user back here
+    clearRestoreState();
     return <ArchivedOrgScreen orgName={activeOrg.name} />;
   }
 

--- a/apps/web/src/lib/last-location.test.ts
+++ b/apps/web/src/lib/last-location.test.ts
@@ -1,0 +1,109 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  claimRestoreStateFor,
+  clearRestoreState,
+  consumeRestoreRedirect,
+  markRestoreRedirect,
+  readLastLocation,
+  saveLastLocation,
+} from "./last-location";
+import { LOCALSTORAGE_KEYS } from "./localstorage-keys";
+
+// Whether the web storages exist depends on whether some other test file
+// registered happy-dom first, so install our own and put the originals back.
+const NAMES = ["localStorage", "sessionStorage"] as const;
+const originals = NAMES.map((n) =>
+  Object.getOwnPropertyDescriptor(globalThis, n),
+);
+
+function stubStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => void store.set(k, v),
+    removeItem: (k) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i) => [...store.keys()][i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+beforeEach(() => {
+  for (const name of NAMES) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value: stubStorage(),
+    });
+  }
+});
+
+afterAll(() => {
+  NAMES.forEach((name, i) => {
+    const original = originals[i];
+    if (original) Object.defineProperty(globalThis, name, original);
+    else delete (globalThis as Partial<typeof globalThis>)[name];
+  });
+});
+
+describe("claimRestoreStateFor", () => {
+  test("drops another principal's restore state", () => {
+    saveLastLocation({ org: "ferragens-floresta" });
+    localStorage.setItem(LOCALSTORAGE_KEYS.lastOrgSlug(), "ferragens-floresta");
+    claimRestoreStateFor("user-a");
+
+    claimRestoreStateFor("user-b");
+
+    expect(readLastLocation()).toBeNull();
+    expect(localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug())).toBeNull();
+  });
+
+  test("keeps the owning principal's restore state", () => {
+    claimRestoreStateFor("user-a");
+    saveLastLocation({ org: "acme", taskId: "t1" });
+
+    claimRestoreStateFor("user-a");
+
+    expect(readLastLocation()).toEqual({
+      org: "acme",
+      taskId: "t1",
+      virtualmcpid: undefined,
+    });
+  });
+});
+
+// The marker's read is memoized for the page load (see consumeRestoreRedirect),
+// so these run unmarked-first — module state is the page load here.
+describe("restore redirect marker", () => {
+  test("unmarked navigation is not a restore", () => {
+    expect(consumeRestoreRedirect("acme")).toBe(false);
+  });
+
+  test("matches the marked org exactly", () => {
+    markRestoreRedirect("acme");
+
+    expect(consumeRestoreRedirect("other")).toBe(false);
+  });
+
+  test("reports a restore-driven arrival, stably across re-reads", () => {
+    markRestoreRedirect("acme");
+
+    expect(consumeRestoreRedirect("acme")).toBe(true);
+    // A re-render must get the same answer, not "you asked for this org".
+    expect(consumeRestoreRedirect("acme")).toBe(true);
+    // ...but the marker itself is gone, so the next page load starts clean.
+    expect(sessionStorage.getItem("studio:restore-redirect")).toBeNull();
+  });
+});
+
+test("clearRestoreState forgets both keys", () => {
+  saveLastLocation({ org: "acme" });
+  localStorage.setItem(LOCALSTORAGE_KEYS.lastOrgSlug(), "acme");
+
+  clearRestoreState();
+
+  expect(readLastLocation()).toBeNull();
+  expect(localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug())).toBeNull();
+});

--- a/apps/web/src/lib/last-location.ts
+++ b/apps/web/src/lib/last-location.ts
@@ -48,3 +48,64 @@ export function clearLastLocation(): void {
     // ignore
   }
 }
+
+/** Forget where the user was — both the location and the cached org slug. */
+export function clearRestoreState(): void {
+  try {
+    localStorage.removeItem(LOCALSTORAGE_KEYS.lastLocation());
+    localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Restore state is browser-global, but it describes ONE principal's history: a
+ * second account signing in on the same browser (or a session that expired and
+ * was replaced) would otherwise be redirected into the previous user's org and
+ * dead-end on the no-access screen. Called from the shell once the session
+ * resolves — the first moment the real principal is known, since cold entry's
+ * redirect happens before any network call.
+ */
+export function claimRestoreStateFor(userId: string): void {
+  try {
+    if (localStorage.getItem(LOCALSTORAGE_KEYS.lastUserId()) === userId) return;
+    localStorage.setItem(LOCALSTORAGE_KEYS.lastUserId(), userId);
+    clearRestoreState();
+  } catch {
+    // ignore
+  }
+}
+
+// Per-tab, one-shot marker: "the home loader sent the user here from restore
+// state", as opposed to the user opening the URL themselves. lastLocation can't
+// answer that — orgLayout.beforeLoad rewrites it to the current org on arrival.
+const RESTORE_REDIRECT_KEY = "studio:restore-redirect";
+
+// `undefined` = not read yet. The answer is memoized because the gate asks
+// during render, and a re-render (StrictMode, a refetch) must get the same
+// answer as the first one — a plain one-shot read would say "not a restore" the
+// second time and render the dead-end screen instead of bouncing.
+let restoredOrg: string | null | undefined;
+
+export function markRestoreRedirect(org: string): void {
+  restoredOrg = undefined;
+  try {
+    sessionStorage.setItem(RESTORE_REDIRECT_KEY, org);
+  } catch {
+    // ignore
+  }
+}
+
+/** Whether `org` was reached via a restore redirect (consumes the marker). */
+export function consumeRestoreRedirect(org: string): boolean {
+  if (restoredOrg === undefined) {
+    try {
+      restoredOrg = sessionStorage.getItem(RESTORE_REDIRECT_KEY);
+      sessionStorage.removeItem(RESTORE_REDIRECT_KEY);
+    } catch {
+      restoredOrg = null;
+    }
+  }
+  return restoredOrg === org;
+}

--- a/apps/web/src/lib/localstorage-keys.ts
+++ b/apps/web/src/lib/localstorage-keys.ts
@@ -25,6 +25,8 @@ export const LOCALSTORAGE_KEYS = {
   preferences: () => `studio:user:preferences`,
   lastOrgSlug: () => `studio:last-org-slug`,
   lastLocation: () => `studio:last-location`,
+  /** Principal that owns the two keys above (see claimRestoreStateFor). */
+  lastUserId: () => `studio:last-user-id`,
   connectionsTab: (org: string) => `studio:connections:tab:${org}`,
   taskLastViewed: (locator: ProjectLocator) =>
     `studio:chat:task-last-viewed:${locator}`,

--- a/apps/web/src/lib/query-persist.test.ts
+++ b/apps/web/src/lib/query-persist.test.ts
@@ -51,8 +51,13 @@ afterAll(() => {
 
 beforeEach(() => {
   localStorageStub = stubLocalStorage();
-  (globalThis.window as { localStorage?: unknown }).localStorage =
-    localStorageStub;
+  // defineProperty, not assignment: when another test file registered happy-dom
+  // first, window.localStorage is a readonly accessor and `=` throws.
+  Object.defineProperty(globalThis.window, "localStorage", {
+    configurable: true,
+    writable: true,
+    value: localStorageStub,
+  });
 });
 
 describe("readCachedOrg/writeCachedOrg", () => {

--- a/apps/web/src/lib/query-persist.ts
+++ b/apps/web/src/lib/query-persist.ts
@@ -14,6 +14,7 @@
 
 import { type QueryClient, dehydrate, hydrate } from "@tanstack/react-query";
 import { clearHtmlResourceCache } from "./html-resource-persist";
+import { clearRestoreState } from "./last-location";
 
 const STORAGE_KEY = "studio:rq-cache";
 const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h
@@ -195,6 +196,9 @@ export function clearPersistedQueryCache(): void {
   // Drop the IndexedDB UI-resource HTML store too (org-scoped UI shells).
   clearHtmlResourceCache();
   if (typeof window === "undefined") return;
+  // Where the user last was is theirs, not the browser's — leaving it behind
+  // redirects the next account into an org it can't access.
+  clearRestoreState();
   try {
     window.localStorage.removeItem(STORAGE_KEY);
     for (let i = window.localStorage.length - 1; i >= 0; i--) {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -15,7 +15,11 @@ import * as z from "zod";
 
 import { listOrganizationsCached } from "@/lib/auth-client";
 import { LOCALSTORAGE_KEYS } from "@/lib/localstorage-keys";
-import { readLastLocation, saveLastLocation } from "@/lib/last-location";
+import {
+  markRestoreRedirect,
+  readLastLocation,
+  saveLastLocation,
+} from "@/lib/last-location";
 
 const rootRoute = createRootRoute({
   // No `<Providers>` here: each entry (`index.web.tsx`, `index.native.tsx`)
@@ -164,6 +168,7 @@ const homeRoute = createRoute({
     // OrgAccessGate clears it and bounces back to "/".
     const lastLocation = readLastLocation();
     if (lastLocation) {
+      markRestoreRedirect(lastLocation.org);
       throw redirect({ to: "/$org", params: { org: lastLocation.org } });
     }
 
@@ -174,6 +179,7 @@ const homeRoute = createRoute({
     // slug self-heals in OrgAccessGate (clears the slug + bounces back to "/").
     const lastOrgSlug = localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug());
     if (lastOrgSlug) {
+      markRestoreRedirect(lastOrgSlug);
       throw redirect({
         to: "/$org",
         params: { org: lastOrgSlug },


### PR DESCRIPTION
## Problem

Signing in with a different account on a browser that already used Studio lands on **No access** instead of that account's own org:

> `studio.decocms.com/ferragens-floresta` → "You don't have access to Ferragens Floresta."

`studio:last-org-slug` and `studio:last-location` are browser-global, but they describe **one principal's** history. A second account (or a session that expired and was replaced) inherits them, and cold entry (`/`) redirects straight into an org it can't access.

The gate's existing self-heal didn't catch it: it bounced back to `/` only when `lastOrgSlug` still matched the org, while the redirect that actually lands users there now comes from `lastLocation` (checked first in `homeRoute`) — and `orgLayout.beforeLoad` overwrites `lastLocation` with the current org on arrival, so it can't answer "did we send them here?" either.

## Changes

- **Principal-scope the restore state.** `studio:last-user-id` records who owns the two keys; the shell calls `claimRestoreStateFor(userId)` as soon as the session resolves and wipes them if it's somebody else. Same pattern as the already user-scoped org cache (`readCachedOrg`). Sign-out clears them too (`clearPersistedQueryCache`, whose contract is already "next user starts clean").
- **Fix the recovery.** `homeRoute` marks its restore-driven redirects (per-tab `sessionStorage`); `OrgAccessGate` reads the marker. A restored org the user can't access → back to `/`, which now resolves their default org. A deliberate visit to a foreign org (shared link) still shows the screen with a working "Go to home".
- **Clear both keys**, not just the slug, when landing on an archived org or deleting the org you're in — `lastLocation` pointing at either bounced the user right back.

## Testing

- `apps/web/src/lib/last-location.test.ts` — principal scoping, marker matching, and that a re-render gets the same marker answer (so StrictMode can't turn a bounce into the dead-end screen).
- `bun test apps/web/src/lib/` green (195 pass); full `bun test apps/web` has fewer failures than `main` in this environment (61 vs 68 — the pre-existing ones are unrelated).
- `bun run fmt`, `bun run lint` (0 errors), `bun run check` pass.

The `query-persist` test's window stub moved to `Object.defineProperty`: happy-dom makes `window.localStorage` a readonly accessor, so the plain assignment threw whenever another test file registered happy-dom first.

## Manual check

Sign in as A, visit an org only A can access, sign out, sign in as B → B lands on B's own org.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes “No access” loops when signing in with a different account by scoping restore state to the current user and tracking restore-driven redirects. Also clears stale state on sign-out, org deletion, and archived orgs to avoid bouncing back.

- **Bug Fixes**
  - Principal-scoped restore state with `studio:last-user-id`; `claimRestoreStateFor(userId)` clears stale `lastLocation`/`lastOrgSlug` as soon as the session resolves. Sign-out also clears it via `clearPersistedQueryCache`.
  - `homeRoute` marks restore redirects per-tab (`markRestoreRedirect`), and `OrgAccessGate` consumes them (`consumeRestoreRedirect`) to send users back to `/` only for restore-driven arrivals without access; direct shared links still show the gate.
  - Replaced ad-hoc slug clearing with `clearRestoreState()` when deleting an org or landing on an archived org.
  - Added tests for principal scoping and the per-tab marker (stable across re-reads); fixed `window.localStorage` stubbing using `Object.defineProperty`.

<sup>Written for commit 82eac493d90fe253f9213fd509bccb01050d8602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

