### PR TITLE
fix(sections-editor): stop custom color swatch reverting text to black

### DIFF
--- a/apps/web/src/components/sections-editor/rich-text-color-control.tsx
+++ b/apps/web/src/components/sections-editor/rich-text-color-control.tsx
@@ -43,7 +43,16 @@ export function RichTextColorControl({
   onOpenChange: (open: boolean) => void;
 }) {
   const t = useT();
-  const [custom, setCustom] = useState("#000000");
+  const [custom, setCustom] = useState(currentColor ?? "#000000");
+  // Resync the custom swatch to the actually-applied color whenever the
+  // popover opens, so canceling the native color dialog without picking a
+  // new value re-applies the same color instead of clobbering it with a
+  // stale "custom" state from a previous session (e.g. a preset pick).
+  const [wasOpen, setWasOpen] = useState(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) setCustom(currentColor ?? "#000000");
+  }
 
   const applyColor = (color: string) => {
     editor.chain().focus().setColor(color).run();


### PR DESCRIPTION
This is a bug fix in the rich-text-color-control added by #5523.

**Failure scenario:** `RichTextColorControl`'s custom `<input type="color">` keeps a local `custom` state that's initialized once to `"#000000"` and only ever updated by that input's own `onChange`. Its `onBlur` unconditionally calls `applyColor(custom)`. Native color inputs fire `blur` when the OS color dialog closes *even if the user cancels without picking a value* (confirmed Chrome/Safari behavior). So: apply a preset swatch (say red), reopen the color popover later to check it, click the custom swatch just to look, then cancel the OS dialog without picking anything — blur still fires, and `applyColor(custom)` reapplies the stale default `"#000000"`, silently turning the text black even though the user never touched the custom picker.

**Fix:** resync the `custom` state to the actually-applied `currentColor` whenever the popover transitions to open (same local-state-with-external-resync pattern already used by `DatePickerInput` in `string-field.tsx`). Canceling the dialog now re-applies the same color that was already there — a no-op — instead of a stale one.

**Net change:** +10/-1 in `apps/web/src/components/sections-editor/rich-text-color-control.tsx`.

**To verify:** apply a preset text color in the rich-text editor's color popover, reopen the popover, click the custom-color swatch, and cancel the native OS color dialog without picking a color — the applied color should be unchanged (previously it would revert to black).

**Locally ran:** `bun run fmt`, `bunx oxlint` on the changed file (0 warnings/errors), `bunx tsc --noEmit` in `apps/web` (clean). This is a browser-interaction bug in a Playwright component test area (`apps/web/ct/`), which this environment can't run (no Playwright) — full CI validates the ct suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where canceling the OS color dialog after clicking the custom swatch reverted rich-text to black. The custom color now syncs to the current color when the popover opens, so canceling keeps the existing color.

<sup>Written for commit 93a0a57649783ccc523776c29176ff41fbc958e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

