### PR TITLE
refactor(web): resolve stale TODO by using branchUserLabel in agent-shell-layout

### DIFF
--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -44,7 +44,10 @@ import {
 } from "@/sdk";
 import type { VirtualMCPEntity, SandboxMap } from "@decocms/shared/sdk/types";
 import { agentHasClonableSource } from "@/lib/agent-capabilities";
-import { generateBranchName } from "@decocms/shared/branch-name";
+import {
+  branchUserLabel,
+  generateBranchName,
+} from "@decocms/shared/branch-name";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useIsSandboxStartPending } from "@/components/sandbox/hooks/use-sandbox-start";
 import { useStatusSounds } from "../../hooks/use-status-sounds";
@@ -190,13 +193,7 @@ function VmEventsBridge({
     if (!adoptBranchEligible || !activeTask) return;
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- record the thread so a re-render can't mint twice
     adoptedBranchForThreadRef.current = activeTask.id;
-    setCurrentTaskBranch(
-      generateBranchName(
-        // TODO: swap for `branchUserLabel` once decocms/studio#5513 lands — `??`
-        // would let Better Auth's empty display name through and slug to "user".
-        session?.user?.name || session?.user?.email?.split("@")[0],
-      ),
-    );
+    setCurrentTaskBranch(generateBranchName(branchUserLabel(session?.user)));
   }, [adoptBranchEligible, activeTask, session, setCurrentTaskBranch]);
 
   // Open the events stream only when a sandbox actually exists or a start is


### PR DESCRIPTION
Follows #5513 (which added `branchUserLabel` to `packages/shared/src/branch-name.ts` to fix empty-display-name branches falling back to the literal "user"). This call site in `agent-shell-layout/index.tsx` had its own `TODO: swap for branchUserLabel once decocms/studio#5513 lands` comment, sitting on hand-rolled `session?.user?.name || session?.user?.email?.split("@")[0]` logic — a duplicate of exactly what `branchUserLabel` does. #5513 merged a while ago; this closes the loop so the fallback logic lives in one place (branch-name.ts) instead of being copy-pasted at each `generateBranchName` call site (as `header-actions.tsx` and `apps/api/src/tools/thread/create.ts` already do).

No behavior change: `||` in the old code and `branchUserLabel`'s `||` chain are equivalent (both skip empty-string `name` and fall through to the email local-part), so this is a pure duplication removal, not a bug fix.

Reviewer check: `cd apps/web && bunx tsc --noEmit` (green), `bunx oxlint apps/web/src/layouts/agent-shell-layout/index.tsx` (0 warnings/errors).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in apps/web, `bunx oxlint` on the touched file. No test file covers this specific effect, and the change is behavior-preserving, so no new test was added; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the hand-rolled name/email fallback in `agent-shell-layout` with `branchUserLabel` from `@decocms/shared/branch-name` to centralize and keep branch naming consistent. No behavior change; this removes duplication and clears the old TODO.

<sup>Written for commit e5bec820b575ffe3dac1f8bb4c6fab74ebf96d91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

