### PR TITLE
fix(auth): fail startup when Google/GitHub OAuth client secret is missing

### DIFF
--- a/apps/api/src/auth/auth-env.test.ts
+++ b/apps/api/src/auth/auth-env.test.ts
@@ -48,6 +48,40 @@ describe("authEnvSchema", () => {
     });
   });
 
+  it("rejects Google OAuth configured without a client secret", () => {
+    expect(() =>
+      authEnvSchema.parse({ AUTH_GOOGLE_CLIENT_ID: "client-id" }),
+    ).toThrow(/AUTH_GOOGLE_CLIENT_SECRET/);
+  });
+
+  it("accepts Google OAuth when fully configured", () => {
+    const config = authEnvSchema.parse({
+      AUTH_GOOGLE_CLIENT_ID: "client-id",
+      AUTH_GOOGLE_CLIENT_SECRET: "secret",
+    });
+    expect(config.socialProviders?.google).toEqual({
+      clientId: "client-id",
+      clientSecret: "secret",
+    });
+  });
+
+  it("rejects GitHub OAuth configured without a client secret", () => {
+    expect(() =>
+      authEnvSchema.parse({ AUTH_GITHUB_CLIENT_ID: "client-id" }),
+    ).toThrow(/AUTH_GITHUB_CLIENT_SECRET/);
+  });
+
+  it("accepts GitHub OAuth when fully configured", () => {
+    const config = authEnvSchema.parse({
+      AUTH_GITHUB_CLIENT_ID: "client-id",
+      AUTH_GITHUB_CLIENT_SECRET: "secret",
+    });
+    expect(config.socialProviders?.github).toEqual({
+      clientId: "client-id",
+      clientSecret: "secret",
+    });
+  });
+
   it("rejects Microsoft SSO configured without a client secret", () => {
     expect(() =>
       authEnvSchema.parse({

--- a/apps/api/src/auth/auth-env.ts
+++ b/apps/api/src/auth/auth-env.ts
@@ -94,6 +94,24 @@ export const authEnvSchema = z
       }
     }
 
+    if (env.AUTH_GOOGLE_CLIENT_ID && !env.AUTH_GOOGLE_CLIENT_SECRET) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["AUTH_GOOGLE_CLIENT_SECRET"],
+        message:
+          "AUTH_GOOGLE_CLIENT_ID is set but AUTH_GOOGLE_CLIENT_SECRET is not",
+      });
+    }
+
+    if (env.AUTH_GITHUB_CLIENT_ID && !env.AUTH_GITHUB_CLIENT_SECRET) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["AUTH_GITHUB_CLIENT_SECRET"],
+        message:
+          "AUTH_GITHUB_CLIENT_ID is set but AUTH_GITHUB_CLIENT_SECRET is not",
+      });
+    }
+
     if (env.AUTH_MAGIC_LINK_ENABLED && configured.size === 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,


### PR DESCRIPTION
**Source:** hardening gap in `apps/api/src/auth/auth-env.ts` (this session's "auth scopes validation" focus area) — the wildcard-scope gap in the same directory is already covered by open PR #5021, so this targets a distinct, un-covered validation hole in the same file.

**Why a maintainer wants this:** `authEnvSchema` already fails startup when Microsoft SSO, Google SSO, or an email-provider reference is half-configured (client ID set, secret missing) — but the plain social-login providers (`AUTH_GOOGLE_CLIENT_ID`/`AUTH_GITHUB_CLIENT_ID`) had no matching check. Setting just the client ID (a typo'd or partially-copied `.env`) silently produced a `socialProviders.google/github` config with `clientSecret: ""` instead of failing fast — the exact inconsistency the SSO checks already exist to prevent for the other providers.

**Failure scenario:** deploy with `AUTH_GOOGLE_CLIENT_ID` set but `AUTH_GOOGLE_CLIENT_SECRET` unset (e.g. an incomplete secret-manager sync) → server boots fine, Better Auth registers the Google provider with an empty secret, and Google OAuth login fails confusingly at request time instead of at startup where it's obvious. Same for GitHub.

**Fix:** two `superRefine` checks mirroring the existing SSO pattern — reject at config-parse time (which runs at server boot via `getConfig()` → `loadAuthConfig()`) when a client ID is set without its secret. Added a regression test per provider (accept-when-complete + reject-when-incomplete), inverting-style tests matching the existing SSO test shape in the same file.

**Reviewer check:** `bun test apps/api/src/auth/auth-env.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/auth/auth-env.test.ts` (14 pass), `bunx oxlint apps/api/src/auth/auth-env.ts apps/api/src/auth/auth-env.test.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail startup when Google/GitHub OAuth client secrets are missing to surface misconfigurations early and prevent runtime login failures. Aligns social-login validation with existing SSO checks.

- **Bug Fixes**
  - Added `superRefine` checks in `apps/api/src/auth/auth-env.ts` to require `AUTH_GOOGLE_CLIENT_SECRET` and `AUTH_GITHUB_CLIENT_SECRET` when their client IDs are set.
  - Added tests in `apps/api/src/auth/auth-env.test.ts` for accept/reject cases on Google and GitHub OAuth.

<sup>Written for commit b75e2de9ee1eaaa0fa68e4c442b368bd17a576ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

