### PR TITLE
fix(task-board): reject a review token replayed from a stale review cycle

### DIFF
--- a/apps/api/src/tools/task-board/review-decision.test.ts
+++ b/apps/api/src/tools/task-board/review-decision.test.ts
@@ -1,0 +1,40 @@
+/**
+ * A reviewToken must verify only within the review cycle it was minted for.
+ * Without the cycle check, a token saved from a PRIOR cycle (e.g. a reviewer's
+ * own earlier approval) could be replayed after a `request_changes` bounce
+ * reopened review, faking a fresh sign-off for a PR the reviewer never
+ * actually looked at again.
+ */
+import { describe, expect, it } from "bun:test";
+import { isTokenVerified } from "./review-decision";
+
+const CYCLE_1 = new Date("2026-01-01T10:00:00Z").getTime();
+const CYCLE_2 = new Date("2026-01-01T14:00:00Z").getTime();
+
+describe("isTokenVerified", () => {
+  it("verifies a claim minted for the current cycle by the matching reviewer", () => {
+    expect(
+      isTokenVerified({ reviewer: "qa", cycleAt: CYCLE_2 }, "qa", CYCLE_2),
+    ).toBe(true);
+  });
+
+  it("rejects a claim minted for a PRIOR cycle, even with a matching reviewer", () => {
+    expect(
+      isTokenVerified({ reviewer: "qa", cycleAt: CYCLE_1 }, "qa", CYCLE_2),
+    ).toBe(false);
+  });
+
+  it("rejects a claim whose reviewer doesn't match the caller's claimed kind", () => {
+    expect(
+      isTokenVerified(
+        { reviewer: "code_review", cycleAt: CYCLE_2 },
+        "qa",
+        CYCLE_2,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a missing claim (no token, or a token that resolved to nothing)", () => {
+    expect(isTokenVerified(null, "qa", CYCLE_2)).toBe(false);
+  });
+});

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -7,6 +7,8 @@ import {
   REVIEWER_FLAG,
   REVIEWER_KINDS,
   REVIEWER_LABEL,
+  type ReviewerKind,
+  reviewCycleStart,
 } from "@decocms/shared/task-board";
 import { TaskBoardItemStatusSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
@@ -15,13 +17,31 @@ import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
 import { mergeLinkedPr } from "./merge-pr";
 
 /**
- * True when EVERY enabled reviewer has a token-VERIFIED `approve` as its latest
- * decision in the current review cycle. `verifiedOnly` is the point: a
- * self-asserted approval (missing/wrong reviewToken) must never trigger an
- * automatic merge, otherwise one agent could forge the two-reviewer gate. Reads
- * the activity log through the shared cycle reducer (same logic the ship button
- * uses, minus the verification requirement).
+ * True when a reviewToken's claim genuinely proves `reviewer` signed off within
+ * the review cycle this decision is being recorded for — both the identity
+ * (`claim.reviewer` matches) AND the cycle (`claim.cycleAt` matches the task's
+ * CURRENT cycle start). The cycle check matters: without it, a token from a
+ * PRIOR cycle (e.g. a reviewer's own earlier approval, replayed after a
+ * `request_changes` bounce reopened review for a fixed PR) would still verify
+ * an approval it was never minted for — the reviewer never actually looked at
+ * the new code, but the auto-merge gate would count it anyway. Pure —
+ * unit-tested.
  */
+export function isTokenVerified(
+  claim: { reviewer: string; cycleAt: number } | null,
+  reviewer: ReviewerKind,
+  currentCycleAt: number,
+): boolean {
+  return (
+    claim !== null &&
+    claim.reviewer === reviewer &&
+    claim.cycleAt === currentCycleAt
+  );
+}
+
+/** True when EVERY enabled reviewer has a token-VERIFIED `approve` as its latest
+ *  decision in the current review cycle — reads the activity log through the
+ *  shared cycle reducer (same logic the ship button uses, minus verification). */
 async function allEnabledReviewersVerifiedApproved(
   ctx: StudioContext,
   orgId: string,
@@ -110,17 +130,29 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
       throw new Error(`Task board item not found: ${taskBoardItemId}`);
     }
 
-    // Verify the caller is the reviewer it claims to be: the reviewToken must
-    // resolve to a claim for THIS task whose reviewer matches. An unverified
-    // decision is still recorded (so a dropped token never stalls the flow) but
-    // won't count toward an automatic merge (see the verified gate below).
-    const claim = reviewToken
+    // Verify the caller is the reviewer it claims to be, FOR THIS REVIEW CYCLE:
+    // the reviewToken must resolve to a claim for THIS task whose reviewer
+    // matches AND whose cycle matches the task's current one — otherwise a
+    // token saved from a prior cycle could verify a fresh approval the reviewer
+    // never actually gave. An unverified decision is still recorded (so a
+    // dropped token never stalls the flow) but won't count toward an automatic
+    // merge (see the verified gate below).
+    const cycleAt = reviewCycleStart(
+      await ctx.storage.taskBoard.listActivity(taskBoardItemId, organizationId),
+    );
+    const rawClaim = reviewToken
       ? await ctx.storage.taskBoard.resolveReviewClaimByToken(
           taskBoardItemId,
           reviewToken,
         )
       : null;
-    const verified = claim?.reviewer === reviewer;
+    const verified = isTokenVerified(
+      rawClaim
+        ? { reviewer: rawClaim.reviewer, cycleAt: rawClaim.cycleAt.getTime() }
+        : null,
+      reviewer,
+      cycleAt,
+    );
 
     if (decision === "request_changes") {
       // Any reviewer requesting changes bounces the task straight back to the

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -34,6 +34,8 @@ export function isTokenVerified(
 ): boolean {
   return (
     claim !== null &&
+    claim.cycleAt > 0 &&
+    currentCycleAt > 0 &&
     claim.reviewer === reviewer &&
     claim.cycleAt === currentCycleAt
   );


### PR DESCRIPTION
**Source:** hardening follow-up to #5520 (QA Agent + Code Reviewer review flow), which introduced per-cycle review-claim tokens specifically to stop "one agent forging the two-reviewer sign-off." This closes a gap the same commit left open.

**Why a maintainer wants it:** `TASK_BOARD_REVIEW_DECISION` verified a `reviewToken` by reviewer identity only (`claim.reviewer === reviewer`) and never checked which review cycle the underlying claim was minted for. A token stays resolvable in the DB forever (`resolveReviewClaimByToken` looks it up by task+token only), so a token a reviewer saw in cycle 1 still verifies in cycle 2 — after a `request_changes` bounce sent the task back to the Super Agent, a fix was pushed, and the task re-entered In Review. Replaying the old token would mark a *new* approval as `verified: true` even though that reviewer never re-reviewed the updated PR, letting a stale sign-off count toward auto-merge.

**The fix:** `verified` now also requires `claim.cycleAt` to equal the task's current review-cycle start (`reviewCycleStart` over the activity log — the same reducer the claim-minting side already keys off). Extracted the check into a pure `isTokenVerified(claim, reviewer, currentCycleAt)` and added `review-decision.test.ts` covering: same-cycle match → verified; matching reviewer but stale cycle → NOT verified; wrong reviewer → NOT verified; no claim → NOT verified.

**Reviewer command:** `bun test apps/api/src/tools/task-board/review-decision.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above (4/4 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects review tokens from prior review cycles so stale approvals can't verify in a new cycle. Ensures `TASK_BOARD_REVIEW_DECISION` only verifies approvals for the current cycle, protecting the auto-merge gate.

- **Bug Fixes**
  - Verify tokens by reviewer AND cycle: compare claim `cycleAt` to the current cycle start from `reviewCycleStart(listActivity(...))`; reject stale claims.
  - Added `isTokenVerified(claim, reviewer, currentCycleAt)` and used it in `TASK_BOARD_REVIEW_DECISION`.
  - Tests cover: same-cycle pass; stale cycle reject; wrong reviewer; missing claim.

<sup>Written for commit 93b7007a32563e1f3ec187d3f99760de4d671230. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

