### PR TITLE
refactor(web): resolve #5513 TODO by using branchUserLabel in agent-shell-layout

### DIFF
--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -44,7 +44,10 @@ import {
 } from "@/sdk";
 import type { VirtualMCPEntity, SandboxMap } from "@decocms/shared/sdk/types";
 import { agentHasClonableSource } from "@/lib/agent-capabilities";
-import { generateBranchName } from "@decocms/shared/branch-name";
+import {
+  generateBranchName,
+  branchUserLabel,
+} from "@decocms/shared/branch-name";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useIsSandboxStartPending } from "@/components/sandbox/hooks/use-sandbox-start";
 import { useStatusSounds } from "../../hooks/use-status-sounds";
@@ -190,13 +193,7 @@ function VmEventsBridge({
     if (!adoptBranchEligible || !activeTask) return;
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- record the thread so a re-render can't mint twice
     adoptedBranchForThreadRef.current = activeTask.id;
-    setCurrentTaskBranch(
-      generateBranchName(
-        // TODO: swap for `branchUserLabel` once decocms/studio#5513 lands — `??`
-        // would let Better Auth's empty display name through and slug to "user".
-        session?.user?.name || session?.user?.email?.split("@")[0],
-      ),
-    );
+    setCurrentTaskBranch(generateBranchName(branchUserLabel(session?.user)));
   }, [adoptBranchEligible, activeTask, session, setCurrentTaskBranch]);
 
   // Open the events stream only when a sandbox actually exists or a start is


### PR DESCRIPTION
## Summary

Resolves a TODO in agent-shell-layout that was waiting for #5513 to land. That PR added the `branchUserLabel` helper to handle Better Auth's quirk of storing an unset display name as `""` (not null), which made the previous `??`-based fallback skip the email local-part and always slug to `"user"`.

Replaces the manual fallback expression with a call to `branchUserLabel`, reducing code duplication and moving the logic to its single authorized home in the shared branch-name module.

## Change

- Added `branchUserLabel` to the import from `@decocms/shared/branch-name`
- Replaced the inline `session?.user?.name || session?.user?.email?.split("@")[0]` expression with `branchUserLabel(session?.user)`
- Removed the TODO comment

Net: **-3 lines**, behavior unchanged (the `branchUserLabel` implementation uses `||` instead of `??`, which is the fix #5513 made)

## Testing

No existing test file for this component. Verified with:
- `bun run fmt` — passing
- `cd apps/web && bunx tsc --noEmit` — no type errors
- `bunx oxlint apps/web/src/layouts/agent-shell-layout/index.tsx` — no lint errors

CI runs full type check and test suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `branchUserLabel` from `@decocms/shared/branch-name` in `agent-shell-layout` to centralize user label fallback and keep branch names correct when Better Auth sets an empty display name.

- **Refactors**
  - Replaced inline `name || email local-part` with `branchUserLabel(session?.user)`.
  - Updated import and removed the TODO.

<sup>Written for commit 49914a3fc1ca06ffdb046373ab576ee9755e72f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

