### PR TITLE
fix(dev-assets): stop falling back to a hardcoded signing secret

### DIFF
--- a/apps/api/src/api/routes/dev-assets-mcp.ts
+++ b/apps/api/src/api/routes/dev-assets-mcp.ts
@@ -10,7 +10,7 @@
  * Only mounted when DevObjectStorage is the active backend (no S3 configured)
  */
 
-import { getSettings } from "../../settings";
+import { getDevAssetsSigningSecret } from "../../object-storage/dev-assets-secret";
 import { serveMcpRequest } from "../utils/serve-mcp";
 import {
   type DeleteObjectInput,
@@ -112,7 +112,7 @@ function generateSignature(
   expires: number,
   method: "GET" | "PUT",
 ): string {
-  const secret = getSettings().encryptionKey || "dev-secret";
+  const secret = getDevAssetsSigningSecret();
   const data = `${orgId}:${key}:${expires}:${method}`;
   return createHmac("sha256", secret).update(data).digest("hex");
 }

--- a/apps/api/src/api/routes/dev-assets.test.ts
+++ b/apps/api/src/api/routes/dev-assets.test.ts
@@ -1,6 +1,6 @@
 import { createHmac } from "node:crypto";
 import { describe, expect, test } from "bun:test";
-import { getSettings } from "../../settings";
+import { getDevAssetsSigningSecret } from "../../object-storage/dev-assets-secret";
 import { verifySignature } from "./dev-assets";
 
 function sign(
@@ -9,7 +9,7 @@ function sign(
   expires: number,
   method: "GET" | "PUT",
 ): string {
-  const secret = getSettings().encryptionKey || "dev-secret";
+  const secret = getDevAssetsSigningSecret();
   return createHmac("sha256", secret)
     .update(`${orgId}:${key}:${expires}:${method}`)
     .digest("hex");

--- a/apps/api/src/api/routes/dev-assets.ts
+++ b/apps/api/src/api/routes/dev-assets.ts
@@ -16,7 +16,7 @@ import { createHmac } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { StudioContext } from "../../core/studio-context";
-import { getSettings } from "../../settings";
+import { getDevAssetsSigningSecret } from "../../object-storage/dev-assets-secret";
 import { safeEqual } from "./credential-vault";
 
 // Base directory for dev assets (relative to cwd)
@@ -63,7 +63,7 @@ export function verifySignature(
   method: "GET" | "PUT",
   signature: string,
 ): boolean {
-  const secret = getSettings().encryptionKey || "dev-secret";
+  const secret = getDevAssetsSigningSecret();
   const data = `${orgId}:${key}:${expires}:${method}`;
   const expectedSignature = createHmac("sha256", secret)
     .update(data)

--- a/apps/api/src/object-storage/dev-assets-secret.test.ts
+++ b/apps/api/src/object-storage/dev-assets-secret.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { getDevAssetsSigningSecret } from "./dev-assets-secret";
+
+describe("getDevAssetsSigningSecret", () => {
+  test("never falls back to the old hardcoded literal", () => {
+    expect(getDevAssetsSigningSecret()).not.toBe("dev-secret");
+  });
+
+  test("is memoized across calls (sign and verify must agree)", () => {
+    expect(getDevAssetsSigningSecret()).toBe(getDevAssetsSigningSecret());
+  });
+});

--- a/apps/api/src/object-storage/dev-assets-secret.ts
+++ b/apps/api/src/object-storage/dev-assets-secret.ts
@@ -1,0 +1,30 @@
+/**
+ * Signing secret for dev-assets presigned URLs — the local-filesystem
+ * DevObjectStorage backend used when no S3/R2/MinIO is configured.
+ *
+ * Falls back to ENCRYPTION_KEY when set; otherwise generates a random,
+ * process-lifetime secret (same trade-off as STUDIO_JWT_SECRET in
+ * auth/jwt.ts) instead of a fixed string baked into this open-source repo —
+ * anyone reading the source would otherwise know a deployment's signing
+ * secret whenever ENCRYPTION_KEY is left unset, letting them forge presigned
+ * URLs for any org's dev assets.
+ */
+import { randomBytes } from "crypto";
+import { getSettings } from "../settings";
+
+let devAssetsSecret: string | null = null;
+
+export function getDevAssetsSigningSecret(): string {
+  if (devAssetsSecret) return devAssetsSecret;
+
+  const configured = getSettings().encryptionKey;
+  if (configured) {
+    devAssetsSecret = configured;
+  } else {
+    console.warn(
+      "ENCRYPTION_KEY not set - generating a random dev-assets signing secret (not persistent across restarts)",
+    );
+    devAssetsSecret = randomBytes(32).toString("base64");
+  }
+  return devAssetsSecret;
+}

--- a/apps/api/src/object-storage/dev-object-storage.ts
+++ b/apps/api/src/object-storage/dev-object-storage.ts
@@ -29,7 +29,7 @@ import type {
 } from "./s3-service";
 import type { BoundObjectStorage } from "./bound-object-storage";
 import { detectContentType, isTextContentType, sanitizeKey } from "./key-utils";
-import { getSettings } from "../settings";
+import { getDevAssetsSigningSecret } from "./dev-assets-secret";
 
 const DEV_ASSETS_BASE_DIR = "./data/assets";
 
@@ -220,7 +220,7 @@ export class DevObjectStorage implements BoundObjectStorage {
     }
     const sanitized = sanitizeKey(key);
     const expires = Math.floor(Date.now() / 1000) + expiresIn;
-    const secret = getSettings().encryptionKey || "dev-secret";
+    const secret = getDevAssetsSigningSecret();
     const data = `${this.orgId}:${sanitized}:${expires}:PUT`;
     const signature = createHmac("sha256", secret).update(data).digest("hex");
 


### PR DESCRIPTION
**Source:** a security-hardening bug found while auditing the org-scoped route family (`apps/api/src/api/routes/dev-assets.ts` mounts under `/api/:org/dev-assets/*` via org-scoped.ts). Same bug class as #5278 (Better Auth secret) but a distinct location.

**Why a maintainer wants this:** when `ENCRYPTION_KEY` is unset, three separate call sites (`dev-assets.ts` verify, `dev-assets-mcp.ts` sign, `dev-object-storage.ts` sign) fell back to the literal string `"dev-secret"` to HMAC-sign presigned dev-assets URLs. That string is baked into this open-source repo, so any self-hosted deployment that forgets to set `ENCRYPTION_KEY` (the dev-assets/no-S3 code path is real for self-hosted setups, see CLAUDE.md's self-hosting docs) serves presigned URLs anyone can forge to read/write **any org's** dev-assets files with zero authentication — these routes have no session/API-key check at all, only the HMAC signature gates them.

**Fix:** extracted the three duplicated fallbacks into one memoized `getDevAssetsSigningSecret()` helper (`apps/api/src/object-storage/dev-assets-secret.ts`). It still uses `ENCRYPTION_KEY` when set; otherwise it generates a random, process-lifetime secret (matching the established `STUDIO_JWT_SECRET` fallback pattern in `auth/jwt.ts`, and the same fix shape as #5278's `BETTER_AUTH_SECRET`). Memoizing once per process keeps the independent sign (mcp/dev-object-storage) and verify (dev-assets route) call sites in agreement — this backend is already local-filesystem/single-node only, so a per-process secret is safe.

**Regression test:** `apps/api/src/object-storage/dev-assets-secret.test.ts` asserts the resolved secret is never the old `"dev-secret"` literal and is memoized across calls. Updated `dev-assets.test.ts` to sign through the same shared helper instead of re-deriving the old fallback inline (it would otherwise disagree with the fixed `verifySignature` and fail).

**To confirm:** `bun test apps/api/src/object-storage/dev-assets-secret.test.ts apps/api/src/api/routes/dev-assets.test.ts`

**Locally ran:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above (6/6 pass), and `bunx oxlint` on every changed file (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the hardcoded dev-assets signing fallback with a single helper that uses `ENCRYPTION_KEY` or a random per-process secret to prevent forged presigned URLs when the env var is unset. Unifies sign/verify across routes and adds tests.

- **Bug Fixes**
  - Added `getDevAssetsSigningSecret()` to return `ENCRYPTION_KEY` or a memoized random secret.
  - Swapped old fallbacks in `dev-assets.ts`, `dev-assets-mcp.ts`, and `dev-object-storage.ts`.
  - Added tests to ensure the secret is never `"dev-secret"` and is memoized; updated route tests to use the helper.

- **Migration**
  - Self-hosting: set `ENCRYPTION_KEY` to a stable value. Otherwise, a random per-process secret is used, and existing dev-asset links will break on restart.

<sup>Written for commit be6aaab0d54cdfff24797a7afad0f6386005990f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

