### PR TITLE
fix(sandbox): make publish()'s untracked-dir stat check async

### DIFF
--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { mkdtemp, readFile, unlink } from "node:fs/promises";
+import { mkdtemp, readFile, stat, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { appendCoAuthorTrailer } from "../../git-co-author";
@@ -506,12 +506,15 @@ function changedPathsFromStatus(status: { files: GitStatusFile[] }): string[] {
  * itself so .gitignore is honored; walking the dir here would stage ignored
  * files and make `git add` fail.
  */
-function expandUntrackedDirs(repoDir: string, paths: string[]): string[] {
+async function expandUntrackedDirs(
+  repoDir: string,
+  paths: string[],
+): Promise<string[]> {
   const out: string[] = [];
   for (const p of paths) {
     let isDir = false;
     try {
-      isDir = fs.statSync(path.join(repoDir, p)).isDirectory();
+      isDir = (await stat(path.join(repoDir, p))).isDirectory();
     } catch {
       isDir = false;
     }
@@ -703,7 +706,10 @@ export async function publish(
   }
 
   const status = computeWorkingTreeStatus(repoDir);
-  let paths = expandUntrackedDirs(repoDir, changedPathsFromStatus(status));
+  let paths = await expandUntrackedDirs(
+    repoDir,
+    changedPathsFromStatus(status),
+  );
   // Last-resort net: never let a syntactically invalid decofile block reach the
   // branch. The /write and /edit handlers already reject invalid blocks, but a
   // mutation that bypassed them (bash, a git merge, a future write path) would


### PR DESCRIPTION
Follows #5497 and #5481, which converted this same file's hooks-dir creation and decofile-block validation read from sync fs to async — one more sync-fs spot in `packages/sandbox/daemon/routes/git.ts` remained.

`expandUntrackedDirs()` (called from `publish()`, the daemon's git-publish route) used `fs.statSync` per changed path to detect an untracked directory that `git status --porcelain` collapsed into a single entry. Per CONTRIBUTING.md rule #1, any sync fs call in `packages/sandbox/daemon/**` blocks the daemon's single-threaded Bun event loop for its duration, which can make it miss its health probe — Studio then marks the sandbox dead and tears it down/triggers recovery on a single miss.

Why a maintainer wants this: publish() runs on every interactive publish and on shutdown sync, so this blocking call executes on a routine, frequently-hit path, not an edge case.

Change: `expandUntrackedDirs` is now `async` and uses `stat` from `node:fs/promises` instead of `fs.statSync`; its one call site in `publish()` now awaits it. No behavior change — same directory-detection logic, just non-blocking.

How to confirm: `bun test packages/sandbox/daemon/routes/git.test.ts` (51 tests, all passing, including the publish() coverage for untracked `.deco/` directory expansion).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (packages/sandbox), the targeted test file above, and `bunx oxlint packages/sandbox/daemon/routes/git.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the untracked-dir stat check in the git publish route async to keep the daemon responsive. In `packages/sandbox/daemon/routes/git.ts`, `expandUntrackedDirs` now uses `stat` from `node:fs/promises` and `publish()` awaits it; no behavior change.

- **Bug Fixes**
  - Eliminates a sync FS hotspot on the frequent publish/shutdown path, preventing Bun event loop blocking and reducing sandbox health probe misses.

<sup>Written for commit f5e81b8c6c97d005b7b28864c7658a2a75b0872f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

