### PR TITLE
fix(auth): stop resolveCapabilities leaking connection-scoped grants into global capabilities

### DIFF
--- a/packages/shared/src/tools/registry-metadata.test.ts
+++ b/packages/shared/src/tools/registry-metadata.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { resolveCapabilities } from "./registry-metadata";
+
+describe("resolveCapabilities", () => {
+  test("does not grant a management capability from a connection-scoped bucket", () => {
+    // A custom role granting a single connection's own tools happens to reuse
+    // a management tool name in that connection's toolset. This must not
+    // enable the unrelated "members:manage" capability org-wide.
+    const capabilities = resolveCapabilities({
+      conn_abc123: [
+        "ORGANIZATION_MEMBER_LIST",
+        "ORGANIZATION_MEMBER_ADD",
+        "ORGANIZATION_MEMBER_REMOVE",
+        "ORGANIZATION_MEMBER_UPDATE_ROLE",
+        "ORGANIZATION_SEATS_GET",
+        "ORGANIZATION_SEATS_SET",
+        "ORGANIZATION_BILLING_CHECKOUT_START",
+        "ORGANIZATION_SEATS_PREVIEW",
+        "ORGANIZATION_BILLING_PORTAL",
+        "ORGANIZATION_INCLUDED_REPORT_SET",
+        "ORGANIZATION_REPORT_RUN_PAID",
+        "ORGANIZATION_JOIN_REQUEST_LIST",
+        "ORGANIZATION_JOIN_REQUEST_APPROVE",
+        "ORGANIZATION_JOIN_REQUEST_DENY",
+      ],
+    });
+
+    expect(capabilities["members:manage"]).toBe(false);
+  });
+
+  test("grants a management capability when its tools are in the self bucket", () => {
+    const capabilities = resolveCapabilities({
+      self: [
+        "ORGANIZATION_MEMBER_LIST",
+        "ORGANIZATION_MEMBER_ADD",
+        "ORGANIZATION_MEMBER_REMOVE",
+        "ORGANIZATION_MEMBER_UPDATE_ROLE",
+        "ORGANIZATION_SEATS_GET",
+        "ORGANIZATION_SEATS_SET",
+        "ORGANIZATION_BILLING_CHECKOUT_START",
+        "ORGANIZATION_SEATS_PREVIEW",
+        "ORGANIZATION_BILLING_PORTAL",
+        "ORGANIZATION_INCLUDED_REPORT_SET",
+        "ORGANIZATION_REPORT_RUN_PAID",
+        "ORGANIZATION_JOIN_REQUEST_LIST",
+        "ORGANIZATION_JOIN_REQUEST_APPROVE",
+        "ORGANIZATION_JOIN_REQUEST_DENY",
+      ],
+    });
+
+    expect(capabilities["members:manage"]).toBe(true);
+  });
+
+  test("an org-wide `*` grant enables every capability", () => {
+    const capabilities = resolveCapabilities({ self: ["*"] });
+
+    expect(capabilities["members:manage"]).toBe(true);
+    expect(capabilities["connections:manage"]).toBe(true);
+  });
+});

--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -1615,12 +1615,14 @@ export function resolveCapabilities(
   const hasGlobalGrant =
     arrayBucket("*").includes("*") || arrayBucket("self").includes("*");
 
+  // Only "self" and "*" are GLOBAL tool buckets. Any other bucket key is a
+  // resource-scoped grant (e.g. a specific connection id) — its actions must
+  // NOT be counted toward unrelated management capabilities, even when they
+  // happen to share a name with a management tool.
   const grantedActions = new Set<string>();
   if (!hasGlobalGrant) {
-    for (const actions of Object.values(permission)) {
-      if (!Array.isArray(actions)) continue;
-      for (const action of actions) grantedActions.add(action);
-    }
+    for (const action of arrayBucket("self")) grantedActions.add(action);
+    for (const action of arrayBucket("*")) grantedActions.add(action);
   }
 
   const out: Record<string, boolean> = {};


### PR DESCRIPTION
**Source**: bug found while auditing `packages/shared/src/tools/tool-io.ts` and its neighboring `tools/` module for type-safety/correctness issues (that file itself is 100% generated interface declarations with no logic to harden; `registry-metadata.ts` in the same directory has the real runtime helpers).

**The bug**: `resolveCapabilities` (used by `MY_CAPABILITIES`/`apps/api/src/api/routes/auth.ts` to tell the web UI which management capabilities a custom role's stored permission grants) unioned actions from **every** bucket in the permission map — including resource-scoped buckets like a specific connection id from a custom role's per-connection `toolSet` — into a single `grantedActions` set used to decide whether a capability (e.g. `members:manage`) is enabled.

**Failure scenario**: a custom role is granted tools on exactly one connection (`permission = { "conn_abc": ["ORGANIZATION_MEMBER_ADD", ...] }`). If that connection happens to expose a tool whose name collides with a Studio management-tool id (fully attacker/integration-controlled, since MCP connections define their own tool names), `resolveCapabilities` reports the unrelated `members:manage` capability as globally granted. The web UI (`use-capability.ts` / `use-join-requests.ts`) then shows management actions like "approve join request" as available to a member who doesn't actually have them — the real enforcement path (`AccessControl.checkResource`, which checks `hasPermission({ [connectionId]: [resource] })` scoped to `"self"` by default) still correctly denies it, so this is a UI-gating bug, not an auth bypass, but it's a real capability-resolution defect matching the auth org/permission-scoping code path.

**Fix**: only `"self"` and `"*"` are global tool buckets (matching the `hasGlobalGrant` wildcard logic already a few lines above in the same function) — `grantedActions` now sources from those two buckets only, not every key in the permission map.

**Regression test**: added `packages/shared/src/tools/registry-metadata.test.ts` (no test existed for this pure function before) covering: a connection-scoped bucket does NOT grant an unrelated capability, the `self` bucket does grant it, and the org-wide `*`/`self` wildcard still grants everything.

**Reviewer verification**: `bun test packages/shared/src/tools/registry-metadata.test.ts`

**Locally ran**: `bun run fmt`, `bunx tsc --noEmit` in `packages/shared`, the targeted test above, and `bunx oxlint` on both changed files — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes capability resolution so connection-scoped tool grants no longer leak into global management capabilities, preventing the UI from showing org-wide actions a user cannot perform. Global grants are now derived only from `"self"` and `"*"` buckets to align with existing wildcard logic.

- **Bug Fixes**
  - Restrict `resolveCapabilities` in `packages/shared/src/tools/registry-metadata.ts` to use only `"self"` and `"*"` for `grantedActions`; ignore resource-scoped buckets (e.g., connection IDs).
  - Add `packages/shared/src/tools/registry-metadata.test.ts` to verify: connection-scoped grants don’t enable management capabilities; `"self"` grants do; `"*"` wildcard enables all.

<sup>Written for commit 3a8d83158a0394d906ece7611918596f88cc82ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

