### PR TITLE
refactor(connection): dedupe fetch-tools' tool mapping, fix STDIO output-schema leniency

### DIFF
--- a/apps/api/src/tools/connection/fetch-tools.test.ts
+++ b/apps/api/src/tools/connection/fetch-tools.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { mapListedTools } from "./fetch-tools";
+
+describe("mapListedTools", () => {
+  it("returns null for an empty tool list", () => {
+    expect(mapListedTools([])).toBeNull();
+  });
+
+  it("relaxes outputSchema with additionalProperties: true regardless of transport", () => {
+    // Regression: the STDIO branch used to store outputSchema verbatim while
+    // HTTP/SSE relaxed it — MCP clients re-validate structuredContent with Ajv
+    // (additionalProperties: false by default) and reject any extra field a
+    // closed schema doesn't model.
+    const [mapped] = mapListedTools([
+      {
+        name: "some_tool",
+        inputSchema: { type: "object" },
+        outputSchema: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+        },
+      },
+    ])!;
+
+    expect(mapped!.outputSchema).toEqual({
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+      additionalProperties: true,
+    });
+  });
+
+  it("leaves outputSchema undefined when the tool doesn't declare one", () => {
+    const [mapped] = mapListedTools([
+      { name: "some_tool", inputSchema: { type: "object" } },
+    ])!;
+
+    expect(mapped!.outputSchema).toBeUndefined();
+  });
+});

--- a/apps/api/src/tools/connection/fetch-tools.ts
+++ b/apps/api/src/tools/connection/fetch-tools.ts
@@ -10,6 +10,7 @@ import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Tool as McpTool } from "@modelcontextprotocol/sdk/types.js";
 import { getSettings } from "../../settings";
 import type {
   ConnectionParameters,
@@ -64,6 +65,26 @@ export async function fetchToolsFromMCP(
     default:
       return null;
   }
+}
+
+/**
+ * Maps MCP-listed tools to our stored ToolDefinition shape. `outputSchema` is
+ * relaxed with `additionalProperties: true` for every transport — a closed
+ * schema makes MCP clients (which re-validate structuredContent with Ajv)
+ * reject any tool response carrying a field this schema doesn't model.
+ */
+export function mapListedTools(tools: McpTool[]): ToolDefinition[] | null {
+  if (!tools.length) return null;
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description ?? undefined,
+    inputSchema: tool.inputSchema ?? {},
+    outputSchema: tool.outputSchema
+      ? { ...tool.outputSchema, additionalProperties: true }
+      : undefined,
+    annotations: tool.annotations ?? undefined,
+    _meta: tool._meta ?? undefined,
+  }));
 }
 
 /**
@@ -146,20 +167,7 @@ async function fetchToolsFromHttpMCP(
     await Promise.race([client.connect(transport), timeoutPromise]);
     const result = await Promise.race([client.listTools(), timeoutPromise]);
 
-    const tools =
-      result.tools && result.tools.length > 0
-        ? result.tools.map((tool) => ({
-            name: tool.name,
-            description: tool.description ?? undefined,
-            inputSchema: tool.inputSchema ?? {},
-            outputSchema: tool.outputSchema
-              ? // We strive to have lenient output schemas, so allow additional properties
-                { ...tool.outputSchema, additionalProperties: true }
-              : undefined,
-            annotations: tool.annotations ?? undefined,
-            _meta: tool._meta ?? undefined,
-          }))
-        : null;
+    const tools = mapListedTools(result.tools ?? []);
 
     const scopes = await fetchScopesFromMCP(client);
 
@@ -226,19 +234,7 @@ async function fetchToolsFromSSEMCP(
     await Promise.race([client.connect(transport), timeoutPromise]);
     const result = await Promise.race([client.listTools(), timeoutPromise]);
 
-    const tools =
-      result.tools && result.tools.length > 0
-        ? result.tools.map((tool) => ({
-            name: tool.name,
-            description: tool.description ?? undefined,
-            inputSchema: tool.inputSchema ?? {},
-            outputSchema: tool.outputSchema
-              ? { ...tool.outputSchema, additionalProperties: true }
-              : undefined,
-            annotations: tool.annotations ?? undefined,
-            _meta: tool._meta ?? undefined,
-          }))
-        : null;
+    const tools = mapListedTools(result.tools ?? []);
 
     const scopes = await fetchScopesFromMCP(client);
 
@@ -310,17 +306,7 @@ async function fetchToolsFromStdioMCP(
     await Promise.race([client.connect(transport), timeoutPromise]);
     const result = await Promise.race([client.listTools(), timeoutPromise]);
 
-    const tools =
-      result.tools && result.tools.length > 0
-        ? result.tools.map((tool) => ({
-            name: tool.name,
-            description: tool.description ?? undefined,
-            inputSchema: tool.inputSchema ?? {},
-            outputSchema: tool.outputSchema ?? undefined,
-            annotations: tool.annotations ?? undefined,
-            _meta: tool._meta ?? undefined,
-          }))
-        : null;
+    const tools = mapListedTools(result.tools ?? []);
 
     const scopes = await fetchScopesFromMCP(client);
 


### PR DESCRIPTION
**Source**: reduction + bug found while auditing `apps/api/src/tools/connection/fetch-tools.ts` for hardening issues (SSRF is already covered by open PR #5516 — not duplicated here).

**What/why**: The HTTP, SSE, and STDIO tool-fetch branches each hand-rolled an identical block mapping MCP-listed tools to our stored `ToolDefinition` shape. Collapsed the three into one `mapListedTools()` helper (net -38/+24 in the file). Unifying it surfaced a real inconsistency: HTTP and SSE relaxed `outputSchema` with `additionalProperties: true`, but STDIO stored it verbatim.

**Failure scenario / regression**: `apps/api/src/tools/registry/schema.ts` documents why this matters — MCP clients re-validate a tool's `structuredContent` with Ajv, which enforces `additionalProperties: false` by default and rejects extra fields with `-32602: Structured content does not match the tool's output schema`. A STDIO-backed dev connection (local-mode only) whose tool returns any field not modeled in its declared `outputSchema` would hit that rejection, while the identical HTTP/SSE tool would not — same tool shape, transport-dependent breakage. Now all three transports get the same leniency.

**Verification**: added `apps/api/src/tools/connection/fetch-tools.test.ts`, a unit test for the extracted pure `mapListedTools()` helper covering: empty list → null, outputSchema gets `additionalProperties: true` merged in, and no outputSchema stays undefined. Reviewer can run:
```
bun test apps/api/src/tools/connection/fetch-tools.test.ts
```

**Locally ran**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (3 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped MCP tool-to-ToolDefinition mapping in `fetch-tools` and aligned `outputSchema` leniency across HTTP, SSE, and STDIO. Prevents STDIO-only Ajv revalidation errors when tools return extra fields.

- **Bug Fixes**
  - STDIO now relaxes `outputSchema` with `additionalProperties: true`, matching HTTP/SSE and avoiding `-32602` rejections for extra fields.

- **Refactors**
  - Added `mapListedTools()` and reused it in all transports to remove three near-identical mappings.
  - Added `apps/api/src/tools/connection/fetch-tools.test.ts` to cover empty lists, schema leniency, and absent `outputSchema`.

<sup>Written for commit ee51c3545107c732360bacf00942cbc54756e248. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

