### PR TITLE
feat(native): enable the clippy panic-family lints across the cargo workspace

### DIFF
--- a/apps/native/Cargo.toml
+++ b/apps/native/Cargo.toml
@@ -19,6 +19,31 @@ unsafe_code = "deny"
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
 
+# --- Panic family: no production path may abort the desktop app. -----------
+# `clippy.toml` next to this file exempts `#[cfg(test)]` blocks, where an
+# unwrap IS the assertion.
+#
+# A site that genuinely cannot be expressed without one of these takes a
+# local `#[expect(clippy::<lint>, reason = "...")]` — never a blanket
+# `allow` and never a widening of this list.
+#
+# (`clippy::pedantic` + `clippy::nursery` are deliberately NOT enabled:
+# 1228 sites, overwhelmingly style — doc_markdown, use_self,
+# must_use_candidate — for no crash-safety gain.)
+todo = "warn"
+unimplemented = "warn"
+panic = "warn"
+panic_in_result_fn = "warn"
+unreachable = "warn"
+exit = "warn"
+unchecked_time_subtraction = "warn"
+string_slice = "warn"
+expect_used = "warn"
+unwrap_used = "warn"
+indexing_slicing = "warn"
+arithmetic_side_effects = "warn"
+as_conversions = "warn"
+
 # --- Dependency versions, pinned once here and inherited via `.workspace = true`
 # in crates/local-api/Cargo.toml. Over-provisioned on purpose (bootstrap
 # directive): every family implementer building on this skeleton pulls from

--- a/apps/native/clippy.toml
+++ b/apps/native/clippy.toml
@@ -1,0 +1,14 @@
+# Clippy configuration for the apps/native cargo workspace.
+# Lint LEVELS live in Cargo.toml's [workspace.lints.clippy]; this file only
+# tunes how individual lints behave.
+#
+# The panic-family lints exist to keep production paths from aborting the
+# desktop app. A test that unwraps is *supposed* to abort — that's the
+# assertion. Without these, the family costs ~2900 annotations inside
+# `#[cfg(test)]` blocks against ~380 in real code; with them, only the ~380
+# that actually matter get reported.
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+allow-indexing-slicing-in-tests = true
+

--- a/apps/native/crates/harness/src/detect.rs
+++ b/apps/native/crates/harness/src/detect.rs
@@ -239,8 +239,8 @@ fn claude_auth_status_indicates_logged_in(text: &str) -> bool {
     if end < start {
         return false;
     }
-    serde_json::from_str::<serde_json::Value>(&text[start..=end])
-        .ok()
+    text.get(start..=end)
+        .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
         .and_then(|v| v.get("loggedIn").and_then(serde_json::Value::as_bool))
         .unwrap_or(false)
 }

--- a/apps/native/crates/harness/src/events/claude.rs
+++ b/apps/native/crates/harness/src/events/claude.rs
@@ -312,7 +312,7 @@ impl ClaudeEventMapper {
 
     fn next_part_id(&mut self) -> String {
         let id = self.next_id;
-        self.next_id += 1;
+        self.next_id = self.next_id.saturating_add(1);
         id.to_string()
     }
 
@@ -775,11 +775,11 @@ mod tests {
 
         let finish = events
             .iter()
-            .find(|e| matches!(e, MappedEvent::Chunk(v) if v["type"] == "finish"))
+            .find_map(|e| match e {
+                MappedEvent::Chunk(v) if v["type"] == "finish" => Some(v),
+                _ => None,
+            })
             .expect("a finish chunk");
-        let MappedEvent::Chunk(finish) = finish else {
-            unreachable!()
-        };
         assert_eq!(finish["finishReason"], "stop");
         assert_eq!(
             finish["messageMetadata"]["codingAgentProvider"],
@@ -809,22 +809,22 @@ mod tests {
 
         let available = events
             .iter()
-            .find(|e| matches!(e, MappedEvent::Chunk(v) if v["type"] == "tool-input-available"))
+            .find_map(|e| match e {
+                MappedEvent::Chunk(v) if v["type"] == "tool-input-available" => Some(v),
+                _ => None,
+            })
             .expect("a tool-input-available chunk");
-        let MappedEvent::Chunk(available) = available else {
-            unreachable!()
-        };
         assert_eq!(available["toolCallId"], "toolu_01ABC");
         assert_eq!(available["toolName"], "Bash");
         assert_eq!(available["input"]["command"], "echo hi");
 
         let output = events
             .iter()
-            .find(|e| matches!(e, MappedEvent::Chunk(v) if v["type"] == "tool-output-available"))
+            .find_map(|e| match e {
+                MappedEvent::Chunk(v) if v["type"] == "tool-output-available" => Some(v),
+                _ => None,
+            })
             .expect("a tool-output-available chunk");
-        let MappedEvent::Chunk(output) = output else {
-            unreachable!()
-        };
         assert_eq!(output["toolCallId"], "toolu_01ABC");
     }
 

--- a/apps/native/crates/harness/src/events/codex.rs
+++ b/apps/native/crates/harness/src/events/codex.rs
@@ -297,11 +297,11 @@ mod tests {
 
         let finish = events
             .iter()
-            .find(|e| matches!(e, MappedEvent::Chunk(v) if v["type"] == "finish"))
+            .find_map(|e| match e {
+                MappedEvent::Chunk(v) if v["type"] == "finish" => Some(v),
+                _ => None,
+            })
             .expect("a finish chunk");
-        let MappedEvent::Chunk(finish) = finish else {
-            unreachable!()
-        };
         assert_eq!(finish["messageMetadata"]["codingAgentProvider"], "codex");
         assert_eq!(finish["messageMetadata"]["usage"]["output_tokens"], 106);
 
@@ -334,11 +334,11 @@ mod tests {
 
         let tool_call = events
             .iter()
-            .find(|e| matches!(e, MappedEvent::Chunk(v) if v["toolCallId"] == "item_1"))
+            .find_map(|e| match e {
+                MappedEvent::Chunk(v) if v["toolCallId"] == "item_1" => Some(v),
+                _ => None,
+            })
             .expect("a generic tool-input-available chunk for command_execution");
-        let MappedEvent::Chunk(tool_call) = tool_call else {
-            unreachable!()
-        };
         assert_eq!(tool_call["type"], "tool-input-available");
         assert_eq!(tool_call["toolName"], "command_execution");
         assert_eq!(tool_call["input"]["command"], "echo hi");

--- a/apps/native/crates/harness/src/parts.rs
+++ b/apps/native/crates/harness/src/parts.rs
@@ -258,17 +258,19 @@ fn part_to_json(id: &str, part: &OpenPart) -> Value {
                 "toolCallId": id,
                 "state": state,
             });
-            if let Some(input) = input {
-                v["input"] = input.clone();
-            }
-            if let Some(raw_input) = raw_input {
-                v["rawInput"] = raw_input.clone();
-            }
-            if let Some(o) = output {
-                v["output"] = o.clone();
-            }
-            if let Some(e) = error_text {
-                v["errorText"] = json!(e);
+            if let Some(fields) = v.as_object_mut() {
+                if let Some(input) = input {
+                    fields.insert("input".to_string(), input.clone());
+                }
+                if let Some(raw_input) = raw_input {
+                    fields.insert("rawInput".to_string(), raw_input.clone());
+                }
+                if let Some(o) = output {
+                    fields.insert("output".to_string(), o.clone());
+                }
+                if let Some(e) = error_text {
+                    fields.insert("errorText".to_string(), json!(e));
+                }
             }
             v
         }

--- a/apps/native/crates/harness/src/resolve.rs
+++ b/apps/native/crates/harness/src/resolve.rs
@@ -148,17 +148,21 @@ pub fn resolve_checked_from(
     override_raw: Option<&str>,
 ) -> Result<Vec<String>, ResolveError> {
     let argv = resolve_argv_from(harness, override_raw)?;
-    let program = Path::new(&argv[0]);
-    if is_executable_path(program) {
+    let Some(program_arg) = argv.first().cloned() else {
+        return Err(ResolveError::NotFound(format!(
+            "{} CLI not found: resolved to an empty argv",
+            harness.wire_id()
+        )));
+    };
+    if is_executable_path(Path::new(&program_arg)) {
         return Ok(argv);
     }
-    if !argv[0].contains(std::path::MAIN_SEPARATOR) && which(&argv[0]).is_some() {
+    if !program_arg.contains(std::path::MAIN_SEPARATOR) && which(&program_arg).is_some() {
         return Ok(argv);
     }
     Err(ResolveError::NotFound(format!(
-        "{} CLI not found: {:?} is neither an executable path nor on PATH",
+        "{} CLI not found: {program_arg:?} is neither an executable path nor on PATH",
         harness.wire_id(),
-        argv[0],
     )))
 }
 

--- a/apps/native/crates/harness/src/run.rs
+++ b/apps/native/crates/harness/src/run.rs
@@ -658,7 +658,7 @@ async fn drive_attempt(
                 tail.push_str(&String::from_utf8_lossy(&chunk));
                 let len = tail.len();
                 if len > STDERR_TAIL_CAP {
-                    let excess = len - STDERR_TAIL_CAP;
+                    let excess = len.saturating_sub(STDERR_TAIL_CAP);
                     tail.drain(0..excess);
                 }
             }
@@ -680,8 +680,10 @@ async fn drive_attempt(
         linebuf.extend_from_slice(&bytes);
         while let Some(pos) = linebuf.iter().position(|&b| b == b'\n') {
             let line_bytes: Vec<u8> = linebuf.drain(..=pos).collect();
-            let line = String::from_utf8_lossy(&line_bytes[..line_bytes.len().saturating_sub(1)])
-                .into_owned();
+            // Drop the trailing '\n' the drain included.
+            let line =
+                String::from_utf8_lossy(line_bytes.split_last().map_or(&[][..], |(_, head)| head))
+                    .into_owned();
             let mut events = mapper.feed_line(&line);
             mapper_reported_fatal |= flush_before_mapped_fatal(&mut *mapper, &mut events);
             trace_first_meaningful_chunk(

--- a/apps/native/crates/harness/src/spawn.rs
+++ b/apps/native/crates/harness/src/spawn.rs
@@ -130,6 +130,11 @@ pub enum SpawnError {
     /// The spawned child never reported a pid (should not happen in
     /// practice; guarded defensively rather than unwrapped).
     NoPid,
+    /// The spawned child exposed no handle for a stream this code configured
+    /// as `Stdio::piped()`. Same defensive posture as [`SpawnError::NoPid`]:
+    /// a harness that cannot read its child's output should fail the spawn,
+    /// not abort the app.
+    NoPipe(&'static str),
 }
 
 impl std::fmt::Display for SpawnError {
@@ -138,6 +143,9 @@ impl std::fmt::Display for SpawnError {
             SpawnError::Io(e) => write!(f, "spawn failed: {e}"),
             SpawnError::Pty(msg) => write!(f, "PTY spawn failed: {msg}"),
             SpawnError::NoPid => write!(f, "spawned child reported no pid"),
+            SpawnError::NoPipe(stream) => {
+                write!(f, "spawned child exposed no {stream} pipe")
+            }
         }
     }
 }
@@ -501,8 +509,8 @@ mod plain {
             }
         };
         let pid = child.id().ok_or(SpawnError::NoPid)?;
-        let stdout = child.stdout.take().expect("stdout was piped");
-        let stderr = child.stderr.take().expect("stderr was piped");
+        let stdout = child.stdout.take().ok_or(SpawnError::NoPipe("stdout"))?;
+        let stderr = child.stderr.take().ok_or(SpawnError::NoPipe("stderr"))?;
 
         let (stdout_tx, stdout_rx) = mpsc::channel(256);
         let (stderr_tx, stderr_rx) = mpsc::channel(256);
@@ -561,7 +569,11 @@ mod plain {
             match reader.read(&mut buf).await {
                 Ok(0) => return,
                 Ok(n) => {
-                    if tx.send(Bytes::copy_from_slice(&buf[..n])).await.is_err() {
+                    if tx
+                        .send(Bytes::copy_from_slice(buf.get(..n).unwrap_or(&buf)))
+                        .await
+                        .is_err()
+                    {
                         return;
                     }
                 }
@@ -581,7 +593,9 @@ mod plain {
     fn shell_exit_code(status: std::process::ExitStatus) -> ExitInfo {
         use std::os::unix::process::ExitStatusExt;
         if let Some(sig) = status.signal() {
-            return ExitInfo { code: 128 + sig };
+            return ExitInfo {
+                code: 128_i32.saturating_add(sig),
+            };
         }
         ExitInfo {
             code: status.code().unwrap_or(1),
@@ -630,7 +644,9 @@ mod pty {
                 Ok(built) => return Ok(built),
                 Err(e) => {
                     last_err = Some(e);
-                    std::thread::sleep(Duration::from_millis(50 * u64::from(attempt + 1)));
+                    std::thread::sleep(Duration::from_millis(
+                        50_u64.saturating_mul(u64::from(attempt).saturating_add(1)),
+                    ));
                 }
             }
         }
@@ -704,7 +720,7 @@ mod pty {
                     Ok(0) => return,
                     Ok(n) => {
                         if stdout_tx
-                            .blocking_send(Bytes::copy_from_slice(&buf[..n]))
+                            .blocking_send(Bytes::copy_from_slice(buf.get(..n).unwrap_or(&buf)))
                             .is_err()
                         {
                             return;
@@ -767,8 +783,8 @@ mod pty {
         match status {
             Ok(s) => ExitInfo {
                 code: signal_number_from_description(s.signal())
-                    .map(|sig| 128 + sig)
-                    .unwrap_or(s.exit_code() as i32),
+                    .map(|sig| 128_i32.saturating_add(sig))
+                    .unwrap_or_else(|| i32::try_from(s.exit_code()).unwrap_or(1)),
             },
             Err(_) => ExitInfo { code: 1 },
         }

--- a/apps/native/crates/harness/src/title.rs
+++ b/apps/native/crates/harness/src/title.rs
@@ -218,7 +218,8 @@ fn extract_title(harness: HarnessId, stdout: &str) -> Option<String> {
         .find('{')
         .zip(text.rfind('}'))
         .filter(|(start, end)| start < end)
-        .and_then(|(start, end)| serde_json::from_str::<Value>(&text[start..=end]).ok())
+        .and_then(|(start, end)| text.get(start..=end))
+        .and_then(|json| serde_json::from_str::<Value>(json).ok())
         .and_then(|value| {
             value
                 .get("title")

--- a/apps/native/crates/local-api/build.rs
+++ b/apps/native/crates/local-api/build.rs
@@ -15,6 +15,11 @@
 
 use std::path::Path;
 
+#[expect(
+    clippy::expect_used,
+    reason = "build script: cargo always sets `CARGO_MANIFEST_DIR`, and a build \
+              script that cannot find its own manifest SHOULD fail the build."
+)]
 fn main() {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
     // apps/native/crates/local-api -> apps/api/package.json
@@ -38,11 +43,11 @@ fn main() {
 /// Pulls the top-level `"version": "…"` string out of a package.json.
 fn parse_version(contents: &str) -> Option<String> {
     let start = contents.find("\"version\"")?;
-    let rest = &contents[start + "\"version\"".len()..];
+    let rest = contents.get(start.checked_add("\"version\"".len())?..)?;
     let colon = rest.find(':')?;
-    let after_colon = &rest[colon + 1..];
+    let after_colon = rest.get(colon.checked_add(1)?..)?;
     let open = after_colon.find('"')?;
-    let value = &after_colon[open + 1..];
+    let value = after_colon.get(open.checked_add(1)?..)?;
     let close = value.find('"')?;
-    Some(value[..close].to_string())
+    Some(value.get(..close)?.to_string())
 }

--- a/apps/native/crates/local-api/src/config/validate.rs
+++ b/apps/native/crates/local-api/src/config/validate.rs
@@ -19,9 +19,27 @@ use serde_json::Value;
 use std::path::{Component, Path};
 use std::sync::LazyLock;
 
+#[expect(
+    clippy::unwrap_used,
+    reason = "the pattern is a literal in this file, so `Regex::new` can only fail \
+              if THIS SOURCE is wrong — a compile-time mistake a test catches, \
+              not a runtime input. `static_regexes_compile` forces every one."
+)]
 static BRANCH_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[A-Za-z0-9._/-]+$").unwrap());
+#[expect(
+    clippy::unwrap_used,
+    reason = "the pattern is a literal in this file, so `Regex::new` can only fail \
+              if THIS SOURCE is wrong — a compile-time mistake a test catches, \
+              not a runtime input. `static_regexes_compile` forces every one."
+)]
 static ENV_KEY_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*$").unwrap());
+#[expect(
+    clippy::unwrap_used,
+    reason = "the pattern is a literal in this file, so `Regex::new` can only fail \
+              if THIS SOURCE is wrong — a compile-time mistake a test catches, \
+              not a runtime input. `static_regexes_compile` forces every one."
+)]
 static EMAIL_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$").unwrap());
 
@@ -225,6 +243,17 @@ fn display_value(v: &Value) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// The three statics above unwrap `Regex::new` on source literals. That
+    /// is only safe because a bad literal is caught here rather than on a
+    /// user's machine: `LazyLock` defers compilation to first use, so this
+    /// forces all three.
+    #[test]
+    fn static_regexes_compile() {
+        assert!(BRANCH_RE.is_match("main"));
+        assert!(ENV_KEY_RE.is_match("PATH"));
+        assert!(EMAIL_RE.is_match("a@b.co"));
+    }
 
     #[test]
     fn empty_config_is_valid() {

--- a/apps/native/crates/local-api/src/http_util.rs
+++ b/apps/native/crates/local-api/src/http_util.rs
@@ -22,7 +22,7 @@
 //!   string, previously duplicated per intercept route.
 
 use axum::body::Body;
-use axum::http::{header, HeaderMap, HeaderName, StatusCode};
+use axum::http::{header, HeaderMap, HeaderName, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use serde::de::DeserializeOwned;
 
@@ -79,11 +79,18 @@ pub(crate) fn strip_hop_by_hop_headers(headers: &mut HeaderMap) {
 /// DELIBERATELY different from [`event_stream_response`]'s events-family set
 /// (`no-store` here, not `no-cache`; no `X-Accel-Buffering`/
 /// `Content-Encoding`, since those aren't pinned for the dispatch routes).
-pub(crate) fn dispatch_sse_headers() -> [(HeaderName, &'static str); 3] {
+pub(crate) fn dispatch_sse_headers() -> [(HeaderName, HeaderValue); 3] {
+    // Pre-parsed rather than `&'static str`: every caller fed these straight
+    // into `HeaderMap::insert`, which meant a `.parse().unwrap()` per call
+    // site for values that are literals right here. `from_static` moves that
+    // to one infallible construction.
     [
-        (header::CONTENT_TYPE, "text/event-stream"),
-        (header::CACHE_CONTROL, "no-store"),
-        (header::CONNECTION, "keep-alive"),
+        (
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/event-stream"),
+        ),
+        (header::CACHE_CONTROL, HeaderValue::from_static("no-store")),
+        (header::CONNECTION, HeaderValue::from_static("keep-alive")),
     ]
 }
 
@@ -224,9 +231,21 @@ mod tests {
     fn dispatch_sse_headers_pin_the_no_store_contract() {
         let headers = dispatch_sse_headers();
         assert_eq!(headers.len(), 3);
-        assert_eq!(headers[0], (header::CONTENT_TYPE, "text/event-stream"));
-        assert_eq!(headers[1], (header::CACHE_CONTROL, "no-store"));
-        assert_eq!(headers[2], (header::CONNECTION, "keep-alive"));
+        assert_eq!(
+            headers[0],
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("text/event-stream")
+            )
+        );
+        assert_eq!(
+            headers[1],
+            (header::CACHE_CONTROL, HeaderValue::from_static("no-store"))
+        );
+        assert_eq!(
+            headers[2],
+            (header::CONNECTION, HeaderValue::from_static("keep-alive"))
+        );
     }
 
     #[test]

--- a/apps/native/crates/local-api/src/lib.rs
+++ b/apps/native/crates/local-api/src/lib.rs
@@ -215,6 +215,8 @@ pub enum StartError {
         #[source]
         source: std::io::Error,
     },
+    #[error("failed to open the native sandbox registry: {message}")]
+    SandboxRegistry { message: String },
     #[error("failed to recover the local chat store: {message}")]
     LocalStore { message: String },
     #[error("invalid embedded client-auth configuration: {message}")]
@@ -383,6 +385,13 @@ impl ServerHandle {
 
     /// Graceful shutdown. Consumes `self` because each listener task and the
     /// app-root lock have one lifecycle owner.
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+                  constant. `checked_add` has no honest fallback here — there \
+                  is no `Instant::MAX` to saturate to, so the call site would \
+                  have to invent a deadline. Overflow is ~584 years out."
+    )]
     pub async fn shutdown(self) {
         let ServerHandle {
             state,
@@ -566,8 +575,12 @@ pub async fn start_with_client_auth(
             let preview_cookie_selftest_origin = embedded
                 .preview_cookie_selftest
                 .then(|| Arc::<str>::from(embedded.control_origin.clone()));
-            let mut bootstrap_secrets =
-                Vec::with_capacity(embedded.additional_bootstrap_secrets.len() + 1);
+            let mut bootstrap_secrets = Vec::with_capacity(
+                embedded
+                    .additional_bootstrap_secrets
+                    .len()
+                    .saturating_add(1),
+            );
             bootstrap_secrets.push(opts.token.clone());
             bootstrap_secrets.extend(embedded.additional_bootstrap_secrets);
             let expected_host = embedded.expected_host.clone();
@@ -591,7 +604,7 @@ pub async fn start_with_client_auth(
                 .unwrap_or_else(|| expected_host.clone());
             let mut expected_hosts = vec![embedded.expected_host];
             if let Some(listener_host) = embedded.listener_host {
-                if listener_host != expected_hosts[0] {
+                if expected_hosts.first() != Some(&listener_host) {
                     expected_hosts.push(listener_host);
                 }
             }
@@ -702,7 +715,8 @@ pub async fn start_with_client_auth(
     // `<app_root>/sandboxes/<handle>/repo` — created lazily per handle by
     // `SandboxManager::ensure`, not eagerly here (unlike `repo_dir` above,
     // which every plain-path request needs immediately).
-    let sandbox_manager = SandboxManager::new(opts.app_root.clone());
+    let sandbox_manager = SandboxManager::new(opts.app_root.clone())
+        .map_err(|message| StartError::SandboxRegistry { message })?;
 
     let state = AppState {
         token: opts.token.into(),
@@ -875,6 +889,13 @@ async fn acquire_child_recovery_fence(path: &Path, budget: Duration) -> std::io:
     acquire_exclusive_with_budget(file, path, budget).await
 }
 
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+              constant. `checked_add` has no honest fallback here — there \
+              is no `Instant::MAX` to saturate to, so the call site would \
+              have to invent a deadline. Overflow is ~584 years out."
+)]
 async fn acquire_exclusive_with_budget(
     file: File,
     path: &Path,
@@ -906,6 +927,13 @@ async fn acquire_exclusive_with_budget(
 /// serves until SIGTERM/Ctrl+C, then runs shutdown hooks. Exits the
 /// process (`std::process::exit(1)`) on any boot failure, matching the old
 /// `main()` body's behavior exactly.
+#[expect(
+    clippy::exit,
+    reason = "this IS the binary's entry point (see the doc comment above): \
+              `main.rs` does nothing but await it, so a boot failure here has \
+              no caller left to return an error to. The other `exit` sites in \
+              this file are its two env resolvers, called only from here."
+)]
 pub async fn boot_from_env() {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -1012,6 +1040,12 @@ fn resolve_boot_id() -> String {
 /// falls back to `"/"`), local-api refuses to boot without an explicit
 /// workdir: a silent `/` clamp on a user's laptop is a much scarier
 /// default than it is inside a disposable sandbox container.
+#[expect(
+    clippy::exit,
+    reason = "boot-only: called exclusively from `boot_from_env`, before the \
+              server exists. A missing required env var is unrecoverable and \
+              there is no request to fail."
+)]
 fn resolve_app_root() -> PathBuf {
     let raw = std::env::var("LOCAL_API_WORKDIR")
         .or_else(|_| std::env::var("APP_ROOT"))
@@ -1027,6 +1061,12 @@ fn resolve_app_root() -> PathBuf {
 /// `LOCAL_API_PORT` / `PROXY_PORT` — required. `0` picks an ephemeral port
 /// (see `resolve_token`'s sibling stdout contract for how a caller
 /// discovers it).
+#[expect(
+    clippy::exit,
+    reason = "boot-only: called exclusively from `boot_from_env`, before the \
+              server exists. A missing required env var is unrecoverable and \
+              there is no request to fail."
+)]
 fn resolve_port() -> u16 {
     let raw = std::env::var("LOCAL_API_PORT")
         .or_else(|_| std::env::var("PROXY_PORT"))
@@ -1060,10 +1100,19 @@ impl InstalledTerminationSignal {
             // `signal(...)` installs Tokio's process-wide handlers
             // synchronously here—before the startup/recovery future is first
             // polled. The spawned task only waits on already-installed streams.
-            let mut terminate =
-                signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
-            let mut interrupt =
-                signal(SignalKind::interrupt()).expect("failed to install SIGINT handler");
+            // A local-api that cannot hear SIGTERM would never run its
+            // shutdown hooks, so failing the boot beats booting deaf. This
+            // whole function already exits(1) on any boot failure.
+            #[expect(
+                clippy::expect_used,
+                reason = "boot-only: `signal()` fails only when the process cannot \
+                          register a handler at all, which leaves no shutdown path \
+                          worth continuing into."
+            )]
+            let (mut terminate, mut interrupt) = (
+                signal(SignalKind::terminate()).expect("failed to install SIGTERM handler"),
+                signal(SignalKind::interrupt()).expect("failed to install SIGINT handler"),
+            );
             tokio::spawn(async move {
                 let first_name = tokio::select! {
                     _ = terminate.recv() => "SIGTERM",

--- a/apps/native/crates/local-api/src/log_store/store.rs
+++ b/apps/native/crates/local-api/src/log_store/store.rs
@@ -54,7 +54,11 @@ fn encode_app_source(source: &str) -> String {
         return source.to_string();
     }
 
-    let mut encoded = String::with_capacity(APP_SOURCE_ESCAPE_PREFIX.len() + source.len() * 2);
+    let mut encoded = String::with_capacity(
+        APP_SOURCE_ESCAPE_PREFIX
+            .len()
+            .saturating_add(source.len().saturating_mul(2)),
+    );
     encoded.push_str(APP_SOURCE_ESCAPE_PREFIX);
     for byte in source.as_bytes() {
         use std::fmt::Write as _;
@@ -167,7 +171,11 @@ impl LogStore {
         }
         let would_exceed = guard
             .get(key)
-            .map(|w| w.written + bytes.len() as u64 > self.cap_bytes)
+            .map(|w| {
+                w.written
+                    .saturating_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX))
+                    > self.cap_bytes
+            })
             .unwrap_or(false);
         if would_exceed {
             self.rotate(&mut guard, key).await;
@@ -224,7 +232,7 @@ impl LogStore {
             return String::new();
         };
         let len = metadata.len();
-        let start = len.saturating_sub(max_bytes as u64);
+        let start = len.saturating_sub(u64::try_from(max_bytes).unwrap_or(u64::MAX));
         if start > 0 && file.seek(std::io::SeekFrom::Start(start)).await.is_err() {
             return String::new();
         }
@@ -387,7 +395,9 @@ impl LogStore {
         if writer.file.flush().await.is_err() {
             return;
         }
-        writer.written += bytes.len() as u64;
+        writer.written = writer
+            .written
+            .saturating_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX));
     }
 }
 

--- a/apps/native/crates/local-api/src/mutation.rs
+++ b/apps/native/crates/local-api/src/mutation.rs
@@ -250,6 +250,13 @@ impl MutationCoordinator {
     /// second `budget`. The commit barrier shares whichever owner phase is
     /// active: registration removal therefore happens before a true terminal
     /// outcome, and a false outcome remains a hard publish gate.
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+                  constant. `checked_add` has no honest fallback here — there \
+                  is no `Instant::MAX` to saturate to, so the call site would \
+                  have to invent a deadline. Overflow is ~584 years out."
+    )]
     pub fn begin_shutdown(
         &self,
         budget: Duration,
@@ -307,7 +314,7 @@ impl MutationCoordinator {
         };
         if removed {
             self.owner_changes
-                .send_modify(|generation| *generation += 1);
+                .send_modify(|generation| *generation = generation.saturating_add(1));
         }
     }
 

--- a/apps/native/crates/local-api/src/process_util.rs
+++ b/apps/native/crates/local-api/src/process_util.rs
@@ -38,7 +38,7 @@ const ESCALATE_AFTER: Duration = Duration::from_secs(3);
 pub(crate) fn exit_status_to_code(status: std::process::ExitStatus) -> i32 {
     use std::os::unix::process::ExitStatusExt;
     match status.signal() {
-        Some(sig) => 128 + sig,
+        Some(sig) => 128_i32.saturating_add(sig),
         None => status.code().unwrap_or(1),
     }
 }
@@ -79,8 +79,8 @@ pub(crate) fn emit_tasks_event(tasks: &TaskRegistry, broadcaster: &Broadcaster) 
         .into_iter()
         .map(|t| {
             let mut obj = json!({"id": t.id, "command": t.command});
-            if let Some(name) = t.log_name {
-                obj["logName"] = json!(name);
+            if let (Some(fields), Some(name)) = (obj.as_object_mut(), t.log_name) {
+                fields.insert("logName".to_string(), json!(name));
             }
             obj
         })
@@ -179,6 +179,13 @@ pub(crate) struct DriveOutcome {
 /// group leader unreaped until every inherited output writer has closed —
 /// its unreaped PID pins the process-group identity, so timeout/controller
 /// signals can never target a recycled PGID.
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+              constant. `checked_add` has no honest fallback here — there \
+              is no `Instant::MAX` to saturate to, so the call site would \
+              have to invent a deadline. Overflow is ~584 years out."
+)]
 pub(crate) async fn drive_group_to_exit<S: OutputSink>(
     child: &mut ProcessGroupChild,
     mut stdout_pipe: ChildStdout,
@@ -218,13 +225,19 @@ pub(crate) async fn drive_group_to_exit<S: OutputSink>(
             res = stdout_pipe.read(&mut so_chunk), if stdout_open => {
                 match res {
                     Ok(0) | Err(_) => stdout_open = false,
-                    Ok(n) => sink.write(OutputStream::Stdout, &so_chunk[..n]).await,
+                    Ok(n) => {
+                        sink.write(OutputStream::Stdout, so_chunk.get(..n).unwrap_or(&so_chunk))
+                            .await
+                    }
                 }
             }
             res = stderr_pipe.read(&mut se_chunk), if stderr_open => {
                 match res {
                     Ok(0) | Err(_) => stderr_open = false,
-                    Ok(n) => sink.write(OutputStream::Stderr, &se_chunk[..n]).await,
+                    Ok(n) => {
+                        sink.write(OutputStream::Stderr, se_chunk.get(..n).unwrap_or(&se_chunk))
+                            .await
+                    }
                 }
             }
             // Do not reap the group leader while descendants may still own an

--- a/apps/native/crates/local-api/src/routes/bash.rs
+++ b/apps/native/crates/local-api/src/routes/bash.rs
@@ -113,7 +113,8 @@ pub async fn bash(State(state): State<AppState>, body: Bytes) -> ApiResult<Json<
 
 fn clamp_timeout(raw: Option<i64>, background: bool) -> u64 {
     let requested = match raw {
-        Some(v) if v > 0 => v as u64,
+        // `try_from` rejects the negatives the old `v > 0` guard did.
+        Some(v) if v > 0 => u64::try_from(v).unwrap_or(DEFAULT_TIMEOUT_MS),
         _ => DEFAULT_TIMEOUT_MS,
     };
     let ceiling = if background {
@@ -185,7 +186,9 @@ impl Utf8ChunkDecoder {
             }
             Err(e) => {
                 let valid_len = e.valid_up_to();
-                let out = String::from_utf8_lossy(&self.pending[..valid_len]).into_owned();
+                let out =
+                    String::from_utf8_lossy(self.pending.get(..valid_len).unwrap_or_default())
+                        .into_owned();
                 self.pending.drain(..valid_len);
                 // A valid UTF-8 sequence is at most 4 bytes; anything larger
                 // still pending can't be "a partial character waiting for
@@ -590,7 +593,8 @@ mod tests {
             update: None,
             token: Arc::from("test-token"),
             boot_id: Arc::from("test-boot"),
-            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),
+            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone())
+                .expect("registry opens in a fresh temp app root"),
             app_root,
             repo_dir,
             mode: crate::state::ApiMode::Strict,

--- a/apps/native/crates/local-api/src/routes/dispatch.rs
+++ b/apps/native/crates/local-api/src/routes/dispatch.rs
@@ -645,7 +645,7 @@ pub async fn dispatch(State(state): State<AppState>, body: Bytes) -> Response {
     let mut response = Response::new(Body::from_stream(body_stream));
     *response.status_mut() = StatusCode::OK;
     for (name, value) in crate::http_util::dispatch_sse_headers() {
-        response.headers_mut().insert(name, value.parse().unwrap());
+        response.headers_mut().insert(name, value);
     }
     response
 }
@@ -773,6 +773,13 @@ fn git_sandbox_config_from_workspace(input: &Value) -> Option<crate::sandbox::Gi
     })
 }
 
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+              constant. `checked_add` has no honest fallback here — there \
+              is no `Instant::MAX` to saturate to, so the call site would \
+              have to invent a deadline. Overflow is ~584 years out."
+)]
 pub async fn cancel_run(State(_state): State<AppState>, Path(run_id): Path<String>) -> StatusCode {
     // Idempotent by construction: unconditionally (re-)writes the
     // tombstone and returns 204 whether or not `run_id` was ever an active

--- a/apps/native/crates/local-api/src/routes/events.rs
+++ b/apps/native/crates/local-api/src/routes/events.rs
@@ -467,7 +467,8 @@ mod tests {
 
         // Opening a fresh manager imports the legacy sidecar into SQLite but
         // deliberately leaves its live object cache empty.
-        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf());
+        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         assert!(manager.get(&handle).is_none());
         let state = state_with_manager(root.path(), manager.clone());
 

--- a/apps/native/crates/local-api/src/routes/fs.rs
+++ b/apps/native/crates/local-api/src/routes/fs.rs
@@ -198,18 +198,19 @@ struct ReadBody {
 /// `None` for everything else — this doesn't try to be clever about
 /// arbitrary binary formats.
 fn sniff_image_media_type(probe: &[u8]) -> Option<&'static str> {
-    if probe.len() >= 3 && probe[0..3] == [0xff, 0xd8, 0xff] {
+    if probe.starts_with(&[0xff, 0xd8, 0xff]) {
         return Some("image/jpeg");
     }
-    if probe.len() >= 8 && probe[0..8] == [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] {
+    if probe.starts_with(&[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]) {
         return Some("image/png");
     }
-    if probe.len() >= 6 && probe[0..4] == [0x47, 0x49, 0x46, 0x38] {
+    // GIF needs 6 bytes present ("GIF87a"/"GIF89a") but only the first 4
+    // identify it — the original length guard is kept deliberately.
+    if probe.len() >= 6 && probe.starts_with(&[0x47, 0x49, 0x46, 0x38]) {
         return Some("image/gif");
     }
-    if probe.len() >= 12
-        && probe[0..4] == [0x52, 0x49, 0x46, 0x46]
-        && probe[8..12] == [0x57, 0x45, 0x42, 0x50]
+    if probe.starts_with(&[0x52, 0x49, 0x46, 0x46])
+        && probe.get(8..12) == Some(&[0x57, 0x45, 0x42, 0x50])
     {
         return Some("image/webp");
     }
@@ -223,21 +224,30 @@ const BASE64_ALPHABET: &[u8; 64] =
 /// dependency table (see `mcp_client.rs`'s doc comment for the "shared
 /// Cargo.toml, don't add deps" constraint); this is a self-contained ~15
 /// line encoder, unit-tested against known vectors below.
+/// One alphabet lookup, masked to six bits so the index cannot leave the
+/// 64-entry table.
+fn base64_char(sextet: u8) -> char {
+    BASE64_ALPHABET
+        .get(usize::from(sextet & 0x3f))
+        .copied()
+        .map_or('=', char::from)
+}
+
 fn base64_encode(data: &[u8]) -> String {
-    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    let mut out = String::with_capacity(data.len().div_ceil(3).saturating_mul(4));
     for chunk in data.chunks(3) {
-        let b0 = chunk[0];
-        let b1 = *chunk.get(1).unwrap_or(&0);
-        let b2 = *chunk.get(2).unwrap_or(&0);
-        out.push(BASE64_ALPHABET[(b0 >> 2) as usize] as char);
-        out.push(BASE64_ALPHABET[(((b0 & 0x03) << 4) | (b1 >> 4)) as usize] as char);
+        let b0 = chunk.first().copied().unwrap_or(0);
+        let b1 = chunk.get(1).copied().unwrap_or(0);
+        let b2 = chunk.get(2).copied().unwrap_or(0);
+        out.push(base64_char(b0 >> 2));
+        out.push(base64_char(((b0 & 0x03) << 4) | (b1 >> 4)));
         out.push(if chunk.len() > 1 {
-            BASE64_ALPHABET[(((b1 & 0x0f) << 2) | (b2 >> 6)) as usize] as char
+            base64_char(((b1 & 0x0f) << 2) | (b2 >> 6))
         } else {
             '='
         });
         out.push(if chunk.len() > 2 {
-            BASE64_ALPHABET[(b2 & 0x3f) as usize] as char
+            base64_char(b2)
         } else {
             '='
         });
@@ -286,7 +296,9 @@ async fn generate_decofile_from_blocks(blocks_dir: &std::path::Path) -> Option<S
 
     let mut parts: Vec<String> = Vec::with_capacity(names.len());
     for name in names {
-        let stem = &name[..name.len() - ".json".len()];
+        let Some(stem) = name.strip_suffix(".json") else {
+            continue;
+        };
         // A stem that is not valid percent-encoding keeps its literal form,
         // mirroring the frontend's own fallback.
         let key = urlencoding::decode(stem)
@@ -356,10 +368,10 @@ pub async fn read(State(state): State<AppState>, body: Bytes) -> Response {
         Ok(d) => d,
         Err(e) => return ApiError::internal(e.to_string()).into_response(),
     };
-    let probe = &data[..data.len().min(8192)];
+    let probe = data.get(..data.len().min(8192)).unwrap_or(&data);
 
     if let Some(media_type) = sniff_image_media_type(probe) {
-        if data.len() as u64 > MAX_IMAGE_BYTES {
+        if u64::try_from(data.len()).unwrap_or(u64::MAX) > MAX_IMAGE_BYTES {
             return ApiError::bad_request(format!(
                 "Image too large ({} bytes; cap is {MAX_IMAGE_BYTES})",
                 data.len()
@@ -388,20 +400,20 @@ pub async fn read(State(state): State<AppState>, body: Bytes) -> Response {
     let offset: usize = if full {
         1
     } else {
-        body.offset.unwrap_or(1).max(1) as usize
+        usize::try_from(body.offset.unwrap_or(1).max(1)).unwrap_or(1)
     };
     let limit: usize = if full {
         lines.len()
     } else {
-        body.limit.unwrap_or(2000).max(0) as usize
+        usize::try_from(body.limit.unwrap_or(2000).max(0)).unwrap_or(2000)
     };
     let start = offset.saturating_sub(1).min(lines.len());
     let end = start.saturating_add(limit).min(lines.len());
-    let slice = &lines[start..end];
+    let slice = lines.get(start..end).unwrap_or_default();
     let numbered = slice
         .iter()
         .enumerate()
-        .map(|(i, l)| format!("{}\t{l}", offset + i))
+        .map(|(i, l)| format!("{}\t{l}", offset.saturating_add(i)))
         .collect::<Vec<_>>()
         .join("\n");
     Json(json!({ "kind": "text", "content": numbered, "lineCount": lines.len() })).into_response()
@@ -499,8 +511,11 @@ pub async fn unlink(State(state): State<AppState>, body: Bytes) -> Response {
                         "Refusing to unlink directory without recursive: true",
                     ));
                 }
-                if recursive {
-                    let trash_path = trash_for_commit.unwrap().join("deleted");
+                // `trash_for_commit` is `Some` exactly when `recursive` — it
+                // was built from that same flag — so match on the value
+                // instead of re-testing the flag and unwrapping.
+                if let Some(trash_root) = trash_for_commit {
+                    let trash_path = trash_root.join("deleted");
                     tokio::fs::rename(&file_path, &trash_path)
                         .await
                         .map_err(|error| ApiError::internal(error.to_string()))?;
@@ -747,13 +762,13 @@ async fn drive_owned_rg(
             read = stdout.read(&mut stdout_chunk), if stdout_open => {
                 match read {
                     Ok(0) | Err(_) => stdout_open = false,
-                    Ok(n) => stdout_bytes.extend_from_slice(&stdout_chunk[..n]),
+                    Ok(n) => stdout_bytes.extend_from_slice(stdout_chunk.get(..n).unwrap_or(&stdout_chunk)),
                 }
             }
             read = stderr.read(&mut stderr_chunk), if stderr_open => {
                 match read {
                     Ok(0) | Err(_) => stderr_open = false,
-                    Ok(n) => stderr_bytes.extend_from_slice(&stderr_chunk[..n]),
+                    Ok(n) => stderr_bytes.extend_from_slice(stderr_chunk.get(..n).unwrap_or(&stderr_chunk)),
                 }
             }
             status = child.wait(), if !exited && !stdout_open && !stderr_open => {
@@ -920,7 +935,7 @@ pub async fn grep(State(state): State<AppState>, body: Bytes) -> Response {
     args.push(pattern);
     args.push(search_path.to_string_lossy().to_string());
 
-    let limit = body.limit.unwrap_or(250).max(0) as usize;
+    let limit = usize::try_from(body.limit.unwrap_or(250).max(0)).unwrap_or(250);
     let output = match run_owned_rg(&state, &args).await {
         Ok(output) => output,
         Err(error) => return error.into_response(),
@@ -977,6 +992,13 @@ pub async fn glob(State(state): State<AppState>, body: Bytes) -> Response {
         None => state.repo_dir.clone(),
     };
     let result_limit = resolve_glob_result_limit(body.limit);
+    // Float-to-integer `as` is a saturating cast (defined behavior since
+    // Rust 1.45) and `max(1.0)` sets the floor, so this clamps rather than
+    // wrapping; there is no `TryFrom<f64> for usize` to express it instead.
+    #[expect(
+        clippy::as_conversions,
+        reason = "saturating float cast, floored above"
+    )]
     let max_depth = body.max_depth.map(|d| (d.max(1.0).floor()) as usize);
 
     let (file_paths, directory_paths, truncated) = if let Some(md) = max_depth {
@@ -1012,7 +1034,9 @@ pub async fn glob(State(state): State<AppState>, body: Bytes) -> Response {
     let empty_dirs = collect_empty_directories(&file_paths, &dirs_vec);
     let mut out = json!({ "files": file_paths, "directories": empty_dirs });
     if truncated {
-        out["truncated"] = json!(true);
+        if let Some(fields) = out.as_object_mut() {
+            fields.insert("truncated".to_string(), json!(true));
+        }
     }
     Json(out).into_response()
 }
@@ -1118,7 +1142,7 @@ async fn write_from_url_owned(
                     )))
                 }
             };
-            written += chunk.len() as u64;
+            written = written.saturating_add(u64::try_from(chunk.len()).unwrap_or(u64::MAX));
             if written > MAX_TRANSFER_BYTES {
                 return Err(ApiError::bad_gateway(format!(
                     "Stream exceeded {MAX_TRANSFER_BYTES} bytes"

--- a/apps/native/crates/local-api/src/routes/fs/glob_logic.rs
+++ b/apps/native/crates/local-api/src/routes/fs/glob_logic.rs
@@ -56,17 +56,25 @@ pub fn register_glob_ancestor_directories(
         .split('/')
         .filter(|s| !s.is_empty())
         .collect();
-    let dir_parts: &[&str] = if is_file && !parts.is_empty() {
-        &parts[..parts.len() - 1]
+    let dir_parts: &[&str] = if is_file {
+        parts.split_last().map_or(&[], |(_, head)| head)
     } else {
         &parts[..]
     };
     let take = dir_parts.len().min(max_depth);
     for i in 1..=take {
-        directory_paths.insert(dir_parts[..i].join("/"));
+        if let Some(prefix) = dir_parts.get(..i) {
+            directory_paths.insert(prefix.join("/"));
+        }
     }
 }
 
+#[expect(
+    clippy::as_conversions,
+    reason = "float-to-integer `as` is a saturating cast (defined behavior \
+              since Rust 1.45), which is precisely the clamp wanted here; \
+              there is no `TryFrom<f64> for usize` to say it another way."
+)]
 pub fn resolve_glob_result_limit(limit: Option<f64>) -> usize {
     match limit {
         None => GLOB_RESULT_LIMIT,
@@ -416,6 +424,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::as_conversions,
+        reason = "test literal: this constant is far below f64's exact-integer range"
+    )]
     fn resolve_glob_result_limit_caps_at_max() {
         assert_eq!(resolve_glob_result_limit(None), GLOB_RESULT_LIMIT);
         assert_eq!(

--- a/apps/native/crates/local-api/src/routes/fs/mcp_client.rs
+++ b/apps/native/crates/local-api/src/routes/fs/mcp_client.rs
@@ -170,7 +170,7 @@ impl Session {
     /// failure.
     async fn request(&mut self, method: &str, params: Value) -> Result<Value, McpFetchError> {
         let id = self.next_id;
-        self.next_id += 1;
+        self.next_id = self.next_id.saturating_add(1);
         let body = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
         let resp = self.post(&body).await?;
         let status = resp.status();

--- a/apps/native/crates/local-api/src/routes/fs/tools_catalog.rs
+++ b/apps/native/crates/local-api/src/routes/fs/tools_catalog.rs
@@ -39,6 +39,12 @@ pub struct CatalogFile {
     pub content: String,
 }
 
+#[expect(
+    clippy::unwrap_used,
+    reason = "the pattern is a literal in this file, so `Regex::new` can only fail \
+              if THIS SOURCE is wrong — a compile-time mistake a test catches, \
+              not a runtime input. `static_regexes_compile` forces every one."
+)]
 fn sanitize_re() -> &'static Regex {
     static RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
     RE.get_or_init(|| Regex::new(r"[^A-Za-z0-9_.\-]").unwrap())
@@ -76,10 +82,10 @@ pub fn tool_catalog_files(tools: &[CatalogTool]) -> Vec<CatalogFile> {
                 sanitized
             };
             let mut filename = format!("{base}.json");
-            let mut i = 2;
+            let mut i = 2_u32;
             while used.contains(&filename) {
                 filename = format!("{base}-{i}.json");
-                i += 1;
+                i = i.saturating_add(1);
             }
             used.insert(filename.clone());
             let content = format!(

--- a/apps/native/crates/local-api/src/routes/git.rs
+++ b/apps/native/crates/local-api/src/routes/git.rs
@@ -390,6 +390,13 @@ async fn run_git_raw<S: AsRef<str>>(
     run_git_raw_with_timeout(repo_dir, args, env, GIT_TIMEOUT).await
 }
 
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+              constant. `checked_add` has no honest fallback here — there \
+              is no `Instant::MAX` to saturate to, so the call site would \
+              have to invent a deadline. Overflow is ~584 years out."
+)]
 async fn run_git_raw_with_timeout<S: AsRef<str>>(
     repo_dir: &Path,
     args: &[S],
@@ -485,11 +492,14 @@ async fn run_git_raw_with_timeout<S: AsRef<str>>(
                     }
                 }
                 signal = async {
-                    controller
-                        .as_ref()
-                        .expect("controller branch is guarded")
-                        .wait_for_change(observed_signal)
-                        .await
+                    match controller.as_ref() {
+                        Some(controller) => controller.wait_for_change(observed_signal).await,
+                        // Unreachable: the `if` precondition below disables
+                        // this branch, and `select!` does not evaluate a
+                        // disabled branch's future. A future that never
+                        // resolves says that without a panic path.
+                        None => std::future::pending().await,
+                    }
                 }, if controller.is_some() => {
                     observed_signal = Some(signal);
                     timeout_active = false;
@@ -769,13 +779,17 @@ fn parse_porcelain_entry(entry: &str) -> Option<(char, char, String)> {
         return None;
     }
     let bytes = entry.as_bytes();
-    let index = bytes[0] as char;
-    let working = bytes[1] as char;
-    let path = if entry.len() >= 4 && bytes[2] == b' ' {
-        &entry[3..]
+    let index = bytes.first().copied().map_or(' ', char::from);
+    let working = bytes.get(1).copied().map_or(' ', char::from);
+    let split_at = if entry.len() >= 4 && bytes.get(2) == Some(&b' ') {
+        3
     } else {
-        &entry[2..]
+        2
     };
+    // `get` rather than `[..]`: the first three bytes are ASCII status
+    // characters, so this always succeeds, but a slice index that is not a
+    // char boundary panics and porcelain output is untrusted git stdout.
+    let path = entry.get(split_at..).unwrap_or_default();
     if path.is_empty() {
         return None;
     }
@@ -789,14 +803,13 @@ fn parse_porcelain_files(out: &str) -> Vec<GitStatusFile> {
     let parts: Vec<&str> = out.split('\0').collect();
     let mut files = Vec::new();
     let mut i = 0;
-    while i < parts.len() {
-        let entry = parts[i];
+    while let Some(entry) = parts.get(i).copied() {
         if !entry.is_empty() {
             if let Some((index, working, path)) = parse_porcelain_entry(entry) {
                 let is_rename_or_copy = index == 'R' || index == 'C';
                 let mut orig_path = None;
                 if is_rename_or_copy {
-                    i += 1;
+                    i = i.saturating_add(1);
                     orig_path = parts
                         .get(i)
                         .filter(|s| !s.is_empty())
@@ -810,7 +823,7 @@ fn parse_porcelain_files(out: &str) -> Vec<GitStatusFile> {
                 });
             }
         }
-        i += 1;
+        i = i.saturating_add(1);
     }
     files
 }
@@ -892,9 +905,9 @@ async fn compute_working_tree_status(repo_dir: &Path) -> Result<WorkingTreeStatu
                 .split_whitespace()
                 .filter_map(|s| s.parse().ok())
                 .collect();
-            if nums.len() == 2 {
-                behind = nums[0];
-                ahead = nums[1];
+            if let [b, a] = nums[..] {
+                behind = b;
+                ahead = a;
             }
         }
     }
@@ -1000,9 +1013,9 @@ async fn compute_branch_divergence(repo_dir: &Path) -> Divergence {
                 .split_whitespace()
                 .filter_map(|s| s.parse().ok())
                 .collect();
-            if nums.len() == 2 {
-                behind_base = nums[0];
-                ahead_of_base = nums[1];
+            if let [behind, ahead] = nums[..] {
+                behind_base = behind;
+                ahead_of_base = ahead;
             }
         }
     }
@@ -1176,7 +1189,10 @@ async fn compute_diff_against_base(
 
     let upstream = format!("origin/{base}");
     let remote_head = format!("origin/{branch}");
-    let has_valid_head_sha = head_sha.map(is_full_sha).unwrap_or(false);
+    // Narrowed once, into an `Option` rather than a bool beside the original:
+    // "usable head sha" means present AND a full 40-char sha, and every use
+    // below wants the value, not the predicate.
+    let valid_head_sha = head_sha.filter(|sha| is_full_sha(sha));
 
     async fn resolve_locally(repo_dir: &Path, env: &[(String, String)], r: &str) -> bool {
         try_git(repo_dir, &["rev-parse", "--verify", r], env)
@@ -1184,19 +1200,22 @@ async fn compute_diff_against_base(
             .is_some()
     }
 
-    let can_skip_fetch = has_valid_head_sha
-        && resolve_locally(repo_dir, &env, &upstream).await
-        && resolve_locally(repo_dir, &env, &format!("{}^{{commit}}", head_sha.unwrap())).await
-        && try_git(
-            repo_dir,
-            &["merge-base", &upstream, head_sha.unwrap()],
-            &env,
-        )
-        .await
-        .is_some();
+    // `Some(sha)` = the sha we can diff against without talking to origin.
+    let mut skip_fetch_sha: Option<&str> = None;
+    if let Some(sha) = valid_head_sha {
+        if resolve_locally(repo_dir, &env, &upstream).await
+            && resolve_locally(repo_dir, &env, &format!("{sha}^{{commit}}")).await
+            && try_git(repo_dir, &["merge-base", &upstream, sha], &env)
+                .await
+                .is_some()
+        {
+            skip_fetch_sha = Some(sha);
+        }
+    }
+    let can_skip_fetch = skip_fetch_sha.is_some();
 
-    let head_ref = if can_skip_fetch {
-        head_sha.unwrap().to_string()
+    let head_ref = if let Some(sha) = skip_fetch_sha {
+        sha.to_string()
     } else {
         let _ = run_git(
             repo_dir,
@@ -1204,27 +1223,24 @@ async fn compute_diff_against_base(
             &env,
         )
         .await;
-        if has_valid_head_sha {
-            let _ = run_git(
-                repo_dir,
-                &["fetch", "--depth", "100", "origin", head_sha.unwrap()],
-                &env,
-            )
-            .await;
+        if let Some(sha) = valid_head_sha {
+            let _ = run_git(repo_dir, &["fetch", "--depth", "100", "origin", sha], &env).await;
         }
         if !resolve_locally(repo_dir, &env, &upstream).await {
             return Err(RouteError::Generic(format!(
                 "Base branch '{base}' not found on origin"
             )));
         }
-        if has_valid_head_sha
-            && resolve_locally(repo_dir, &env, &format!("{}^{{commit}}", head_sha.unwrap())).await
-        {
-            head_sha.unwrap().to_string()
-        } else if resolve_locally(repo_dir, &env, &remote_head).await {
-            remote_head.clone()
-        } else {
-            "HEAD".to_string()
+        let mut fetched_head_sha: Option<String> = None;
+        if let Some(sha) = valid_head_sha {
+            if resolve_locally(repo_dir, &env, &format!("{sha}^{{commit}}")).await {
+                fetched_head_sha = Some(sha.to_string());
+            }
+        }
+        match fetched_head_sha {
+            Some(sha) => sha,
+            None if resolve_locally(repo_dir, &env, &remote_head).await => remote_head.clone(),
+            None => "HEAD".to_string(),
         }
     };
 
@@ -1757,7 +1773,7 @@ async fn resolve_conflicts(repo_dir: &Path, env: &[(String, String)]) -> Result<
                     abort_rebase(repo_dir, env).await;
                     return Err(e);
                 }
-                attempts_left -= 1;
+                attempts_left = attempts_left.saturating_sub(1);
             }
         }
     }
@@ -2334,7 +2350,8 @@ mod tests {
             update: None,
             token: "test-token".into(),
             boot_id: "test-boot".into(),
-            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.to_path_buf()),
+            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.to_path_buf())
+                .expect("registry opens in a fresh temp app root"),
             app_root: app_root.to_path_buf(),
             repo_dir: repo_dir.to_path_buf(),
             mode: crate::state::ApiMode::Strict,

--- a/apps/native/crates/local-api/src/routes/intercept/decopilot.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/decopilot.rs
@@ -54,6 +54,7 @@ use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
+use upstream::poison::MutexExt;
 
 use axum::body::{Body, Bytes};
 use axum::http::{Method, StatusCode};
@@ -441,13 +442,13 @@ impl TurnCancellation {
     }
 
     fn install(&self, handle: harness::run::CancelHandle) -> bool {
-        *self.handle.lock().unwrap() = Some(handle);
+        *self.handle.lock_ok() = Some(handle);
         self.is_requested()
     }
 
     async fn request(&self) {
         self.requested.store(true, Ordering::SeqCst);
-        let handle = self.handle.lock().unwrap().clone();
+        let handle = self.handle.lock_ok().clone();
         if let Some(handle) = handle {
             handle.cancel().await;
         }
@@ -588,7 +589,7 @@ impl ThreadQueue {
     /// returned `first` is an ownership token: exactly its recipient may start
     /// a drain worker, so two concurrent POSTs can never both launch a harness.
     fn enqueue(&self, turn: QueuedTurn) -> EnqueueOutcome {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock_ok();
         if inner
             .items
             .iter()
@@ -614,7 +615,7 @@ impl ThreadQueue {
     /// payload into this RAM mirror: the worker claims and parses one raw FIFO
     /// head at a time, so a malformed tail cannot fail account recovery.
     fn start_worker_if_idle(&self) -> bool {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock_ok();
         if inner.worker_running {
             return false;
         }
@@ -630,7 +631,7 @@ impl ThreadQueue {
     /// then receives a fresh `first` token and starts the next worker.
     #[cfg(test)]
     fn complete_and_next(&self, workflow_id: &str) -> Option<QueuedTurn> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock_ok();
         if inner.items.front().map(|item| item.workflow_id.as_str()) != Some(workflow_id) {
             tracing::error!(
                 workflow_id,
@@ -655,7 +656,7 @@ impl ThreadQueue {
 
     #[cfg(test)]
     fn list(&self) -> Vec<Value> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock_ok();
         inner
             .items
             .iter()
@@ -676,7 +677,7 @@ impl ThreadQueue {
 
     #[cfg(test)]
     fn cancel_workflow(&self, workflow_id: &str) -> QueueCancelOutcome {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock_ok();
         let Some(index) = inner
             .items
             .iter()
@@ -737,7 +738,7 @@ impl ThreadQueue {
         db: &ThreadsDb,
         fence: &RtThreadFence,
     ) -> Option<DurableClaimAdmission> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock_ok();
         if inner.stop_after_current {
             inner.items.clear();
             inner.worker_running = false;
@@ -759,7 +760,7 @@ impl ThreadQueue {
     /// relinquishing ownership merely because the RAM mirror is momentarily
     /// empty would let a concurrent sender start a second worker.
     fn complete_claimed(&self, workflow_id: &str) -> bool {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock_ok();
         if let Some(index) = inner
             .items
             .iter()
@@ -776,7 +777,7 @@ impl ThreadQueue {
     }
 
     fn stop_worker(&self) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock_ok();
         inner.worker_running = false;
         self.changed.notify_waiters();
     }
@@ -786,20 +787,19 @@ impl ThreadQueue {
     /// later in-process enqueue/reap cannot prove the failed transaction was
     /// recovered, while the next process boot owns durable recovery.
     fn stop_worker_after_durable_terminal_failure(&self) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock_ok();
         inner.durable_terminal_failed = true;
         inner.worker_running = false;
         self.changed.notify_waiters();
     }
 
     fn durable_terminal_failed(&self) -> bool {
-        self.inner.lock().unwrap().durable_terminal_failed
+        self.inner.lock_ok().durable_terminal_failed
     }
 
     fn cancellation_for(&self, workflow_id: &str) -> Option<Arc<TurnCancellation>> {
         self.inner
-            .lock()
-            .unwrap()
+            .lock_ok()
             .items
             .iter()
             .find(|turn| turn.workflow_id == workflow_id)
@@ -807,7 +807,7 @@ impl ThreadQueue {
     }
 
     fn remove_mirror(&self, workflow_id: &str) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock_ok();
         if let Some(index) = inner
             .items
             .iter()
@@ -823,7 +823,7 @@ impl ThreadQueue {
     /// handle plus the removed workflow ids. Durable queue rows are mutated by
     /// the caller while holding the same thread lifecycle gate.
     fn stop_and_drain_tail(&self) -> (Option<Arc<TurnCancellation>>, Vec<String>) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock_ok();
         inner.stop_after_current = true;
         let active = inner
             .worker_running
@@ -847,7 +847,7 @@ impl ThreadQueue {
             let changed = self.changed.notified();
             tokio::pin!(changed);
             changed.as_mut().enable();
-            if !self.inner.lock().unwrap().worker_running {
+            if !self.inner.lock_ok().worker_running {
                 return;
             }
             changed.await;
@@ -855,7 +855,7 @@ impl ThreadQueue {
     }
 
     fn is_idle(&self) -> bool {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock_ok();
         !inner.worker_running && inner.items.is_empty() && !inner.durable_terminal_failed
     }
 }
@@ -892,22 +892,19 @@ fn closing_threads() -> &'static Mutex<HashSet<ThreadKey>> {
 
 pub(crate) fn mark_thread_closing(scope: &RtAccountScope, org: &str, thread_id: &str) {
     closing_threads()
-        .lock()
-        .unwrap()
+        .lock_ok()
         .insert(ThreadKey::scoped(scope, org, thread_id));
 }
 
 pub(crate) fn clear_thread_closing(scope: &RtAccountScope, org: &str, thread_id: &str) {
     closing_threads()
-        .lock()
-        .unwrap()
+        .lock_ok()
         .remove(&ThreadKey::scoped(scope, org, thread_id));
 }
 
 pub(crate) fn thread_is_closing(scope: &RtAccountScope, org: &str, thread_id: &str) -> bool {
     closing_threads()
-        .lock()
-        .unwrap()
+        .lock_ok()
         .contains(&ThreadKey::scoped(scope, org, thread_id))
 }
 
@@ -924,8 +921,7 @@ pub(crate) fn thread_lifecycle_gate(
 
 fn thread_lifecycle_gate_for_key(key: &ThreadKey) -> Arc<AsyncMutex<()>> {
     lifecycle_gates()
-        .lock()
-        .unwrap()
+        .lock_ok()
         .entry(key.clone())
         .or_insert_with(|| Arc::new(AsyncMutex::new(())))
         .clone()
@@ -935,7 +931,7 @@ fn enqueue_thread_turn(key: &ThreadKey, turn: QueuedTurn) -> (Arc<ThreadQueue>, 
     // Keep the registry lock through `enqueue`: this pairs with
     // `remove_queue_if_idle` and prevents a sender from retaining an idle queue
     // just as cleanup removes it, then enqueueing onto an orphan Arc.
-    let mut queues = thread_queues().lock().unwrap();
+    let mut queues = thread_queues().lock_ok();
     let queue = queues
         .entry(key.clone())
         .or_insert_with(ThreadQueue::new)
@@ -945,7 +941,7 @@ fn enqueue_thread_turn(key: &ThreadKey, turn: QueuedTurn) -> (Arc<ThreadQueue>, 
 }
 
 fn start_recovered_thread_queue(key: &ThreadKey) -> (Arc<ThreadQueue>, bool) {
-    let mut queues = thread_queues().lock().unwrap();
+    let mut queues = thread_queues().lock_ok();
     let queue = queues
         .entry(key.clone())
         .or_insert_with(ThreadQueue::new)
@@ -955,7 +951,7 @@ fn start_recovered_thread_queue(key: &ThreadKey) -> (Arc<ThreadQueue>, bool) {
 }
 
 fn remove_queue_if_idle(key: &ThreadKey, expected: &Arc<ThreadQueue>) -> bool {
-    let mut queues = thread_queues().lock().unwrap();
+    let mut queues = thread_queues().lock_ok();
     let is_current = queues
         .get(key)
         .is_some_and(|current| Arc::ptr_eq(current, expected));
@@ -969,7 +965,7 @@ fn remove_queue_if_idle(key: &ThreadKey, expected: &Arc<ThreadQueue>) -> bool {
 fn epoch_millis() -> u64 {
     // The registry's canonical clock; clamped because this caller's wire
     // shape is unsigned.
-    crate::tasks::now_ms().max(0) as u64
+    u64::try_from(crate::tasks::now_ms()).unwrap_or(0)
 }
 
 fn queue_text(user_message: &Value) -> String {
@@ -1248,21 +1244,20 @@ pub(crate) async fn ensure_account_recovered(
     scope: &RtAccountScope,
 ) -> Result<(), String> {
     let recovery_key = format!("{}\0{}", state.app_root.display(), scope.storage_key());
-    if recovered_accounts().lock().unwrap().contains(&recovery_key) {
+    if recovered_accounts().lock_ok().contains(&recovery_key) {
         return Ok(());
     }
     let gate = recovery_gates()
-        .lock()
-        .unwrap()
+        .lock_ok()
         .entry(recovery_key.clone())
         .or_insert_with(|| Arc::new(AsyncMutex::new(())))
         .clone();
     let _guard = gate.lock().await;
-    if recovered_accounts().lock().unwrap().contains(&recovery_key) {
+    if recovered_accounts().lock_ok().contains(&recovery_key) {
         return Ok(());
     }
     recover_durable_queue_for_scope(state, scope).await?;
-    recovered_accounts().lock().unwrap().insert(recovery_key);
+    recovered_accounts().lock_ok().insert(recovery_key);
     Ok(())
 }
 
@@ -1371,7 +1366,7 @@ async fn cleanup_stale_run_spools(state: &AppState) -> Result<(), String> {
 /// concurrently and every queue worker is joined before setup/git shutdown
 /// advances. Repeated calls simply observe already-stopped queues.
 pub(crate) async fn shutdown_all(budget: Duration) -> bool {
-    let queues: Vec<Arc<ThreadQueue>> = thread_queues().lock().unwrap().values().cloned().collect();
+    let queues: Vec<Arc<ThreadQueue>> = thread_queues().lock_ok().values().cloned().collect();
     stop_thread_queues(queues, budget).await
 }
 
@@ -1429,7 +1424,7 @@ async fn quiesce_thread_for_delete_with_timeout(
     db.rt_cancel_all_turns_in_org(fence)
         .map_err(|error| ApiError::internal(format!("thread queue database error: {error}")))?;
     let key = ThreadKey::from_fence(fence);
-    let queue = thread_queues().lock().unwrap().get(&key).cloned();
+    let queue = thread_queues().lock_ok().get(&key).cloned();
     if let Some(queue) = &queue {
         let (active, _) = queue.stop_and_drain_tail();
         if let Some(active) = active {
@@ -1440,7 +1435,7 @@ async fn quiesce_thread_for_delete_with_timeout(
             .map_err(|_| ApiError::conflict("thread agent is still stopping"))?;
     }
 
-    let run = registry().lock().unwrap().remove(&key);
+    let run = registry().lock_ok().remove(&key);
     if let Some(run) = run {
         run.finish().await;
         // Deletion has no reconnect grace period: the parent thread and all of
@@ -1453,7 +1448,7 @@ async fn quiesce_thread_for_delete_with_timeout(
             tracing::warn!(%error, "failed to remove deleted thread run spool");
         }
     }
-    thread_queues().lock().unwrap().remove(&key);
+    thread_queues().lock_ok().remove(&key);
     Ok(())
 }
 
@@ -1552,7 +1547,7 @@ async fn queue_cancel(
         Ok(db) => db,
         Err(error) => return error.into_response(),
     };
-    let queue = thread_queues().lock().unwrap().get(&key).cloned();
+    let queue = thread_queues().lock_ok().get(&key).cloned();
     match db.rt_cancel_turn_scoped(scope, org, thread_id, workflow_id) {
         Ok(RtTurnCancelOutcome::QueuedDeleted(_)) => {
             if let Some(queue) = queue {
@@ -1598,8 +1593,7 @@ async fn cancel(state: &AppState, scope: &RtAccountScope, org: &str, thread_id: 
                 .into_response();
         }
         let cancellation = thread_queues()
-            .lock()
-            .unwrap()
+            .lock_ok()
             .get(&key)
             .and_then(|queue| queue.cancellation_for(&active.workflow_id));
         if let Some(cancellation) = cancellation {
@@ -1678,19 +1672,19 @@ async fn stream(state: &AppState, scope: &RtAccountScope, org: &str, thread_id: 
 
     let mut response = Response::new(Body::from_stream(body_stream));
     for (name, value) in crate::http_util::dispatch_sse_headers() {
-        response.headers_mut().insert(name, value.parse().unwrap());
+        response.headers_mut().insert(name, value);
     }
     response
 }
 
 async fn run_for_stream(state: &AppState, key: &ThreadKey) -> Result<Arc<DecopilotRun>, String> {
-    if let Some(existing) = registry().lock().unwrap().get(key).cloned() {
+    if let Some(existing) = registry().lock_ok().get(key).cloned() {
         return Ok(existing);
     }
 
     let candidate = DecopilotRun::open(state, key.clone()).await?;
     let (selected, inserted) = {
-        let mut runs = registry().lock().unwrap();
+        let mut runs = registry().lock_ok();
         match runs.get(key) {
             Some(existing) => (existing.clone(), false),
             None => {
@@ -1712,7 +1706,7 @@ async fn run_for_stream(state: &AppState, key: &ThreadKey) -> Result<Arc<Decopil
 /// the registry slot may clear it; blindly removing by key loses the new run's
 /// replay and was the source of intermittent missing/duplicated turns.
 fn remove_run_if_current(key: &ThreadKey, expected: &Arc<DecopilotRun>) -> bool {
-    let mut runs = registry().lock().unwrap();
+    let mut runs = registry().lock_ok();
     let is_current = runs
         .get(key)
         .is_some_and(|current| Arc::ptr_eq(current, expected));
@@ -2037,7 +2031,21 @@ async fn drain_durable_thread_queue(
                 return;
             }
         };
-        let turn = activated.expect("ready durable claim installs its cancellation mirror");
+        // `claim_durable_head` builds `activated` from the same `Ready` arm
+        // `claimed` came from, so this is dead — but the two travel as
+        // separate tuple fields, so nothing but that convention enforces it.
+        // Stop the worker like the sibling claim-failure arms above rather
+        // than taking the process down: the row stays claimed and is
+        // recovered on the next boot.
+        let Some(turn) = activated else {
+            tracing::error!(
+                org = key.org,
+                thread_id = key.thread_id,
+                "durable claim reported Ready without its cancellation mirror"
+            );
+            queue.stop_worker();
+            return;
+        };
         let begin = db.rt_begin_claimed_turn(&claimed);
         drop(lifecycle_guard);
 
@@ -2117,8 +2125,7 @@ where
 
 async fn run_for_turn(state: &AppState, key: &ThreadKey) -> Result<Arc<DecopilotRun>, String> {
     if let Some(placeholder) = registry()
-        .lock()
-        .unwrap()
+        .lock_ok()
         .get(key)
         .filter(|existing| existing.is_idle_placeholder())
         .cloned()
@@ -2128,7 +2135,7 @@ async fn run_for_turn(state: &AppState, key: &ThreadKey) -> Result<Arc<Decopilot
 
     let candidate = DecopilotRun::open(state, key.clone()).await?;
     let (selected, installed) = {
-        let mut runs = registry().lock().unwrap();
+        let mut runs = registry().lock_ok();
         if let Some(placeholder) = runs
             .get(key)
             .filter(|existing| existing.is_idle_placeholder())
@@ -2369,6 +2376,12 @@ fn terminal_finish_reason(terminal_chunks: &[Value]) -> Option<&str> {
     })
 }
 
+#[expect(
+    clippy::expect_used,
+    reason = "the pattern is a literal in this file, so `Regex::new` can only fail \
+              if THIS SOURCE is wrong — a compile-time mistake a test catches, \
+              not a runtime input. `static_regexes_compile` forces every one."
+)]
 fn response_url_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();
     PATTERN.get_or_init(|| {
@@ -2905,7 +2918,14 @@ fn model_id_for(harness_id: harness::HarnessId, tier: Option<&str>) -> String {
         Some("thinking") => 2,
         _ => 1,
     };
-    harness::tiers::tiers_for(harness_id)[idx].id.to_string()
+    let tiers = harness::tiers::tiers_for(harness_id);
+    // Fall back to the default tier rather than panicking on a harness whose
+    // tier table is shorter than the index — same passthrough-on-unknown
+    // philosophy as `tiers.rs` itself.
+    tiers
+        .get(idx)
+        .or_else(|| tiers.first())
+        .map_or_else(String::new, |tier| tier.id.to_string())
 }
 
 struct HarnessRunRequest {
@@ -3736,7 +3756,7 @@ mod tests {
         // Models the exact production branch after the harness has been reaped
         // but `rt_finalize_claimed_turn` did not commit.
         queue.stop_worker_after_durable_terminal_failure();
-        assert!(!queue.inner.lock().unwrap().worker_running);
+        assert!(!queue.inner.lock_ok().worker_running);
         assert!(queue.durable_terminal_failed());
         assert!(
             !stop_thread_queues(vec![queue], Duration::from_secs(1)).await,
@@ -3811,7 +3831,7 @@ mod tests {
         assert!(active.is_none(), "no durable claim has been mirrored yet");
         assert!(removed.is_empty(), "the recovered RAM mirror starts empty");
         assert!(
-            queue.inner.lock().unwrap().worker_running,
+            queue.inner.lock_ok().worker_running,
             "empty RAM must not falsely mark a recovered worker stopped"
         );
         let waiter = {
@@ -3852,7 +3872,7 @@ mod tests {
         };
 
         assert!(
-            !thread_queues().lock().unwrap().contains_key(&other),
+            !thread_queues().lock_ok().contains_key(&other),
             "another organization must not resolve the same thread id's runtime queue"
         );
         assert_eq!(
@@ -3863,7 +3883,7 @@ mod tests {
 
         drain_thread_queue(queue, *first, |_| async {}).await;
         assert!(
-            !thread_queues().lock().unwrap().contains_key(&acme),
+            !thread_queues().lock_ok().contains_key(&acme),
             "empty per-thread queue entries must be evicted"
         );
     }
@@ -3887,7 +3907,7 @@ mod tests {
         }));
 
         assert!(result.is_err());
-        assert!(!queue.inner.lock().unwrap().worker_running);
+        assert!(!queue.inner.lock_ok().worker_running);
         assert!(queue.durable_terminal_failed());
         assert!(
             !stop_thread_queues(vec![queue], Duration::from_secs(1)).await,
@@ -3914,7 +3934,7 @@ mod tests {
             "text/event-stream"
         );
         drop(res);
-        let run = registry().lock().unwrap().remove(&key).unwrap();
+        let run = registry().lock_ok().remove(&key).unwrap();
         cleanup_run(&run).await;
     }
 
@@ -3926,7 +3946,7 @@ mod tests {
         let state = test_state(dir.path());
         // Simulates the GET .../stream call that arrives before any dispatch.
         let _res = stream(&state, &test_scope(), "acme", thread_id).await;
-        let placeholder = registry().lock().unwrap().get(&key).cloned().unwrap();
+        let placeholder = registry().lock_ok().get(&key).cloned().unwrap();
         assert!(placeholder.is_idle_placeholder());
 
         // Simulates `send_message`'s run-selection logic directly rather
@@ -3939,7 +3959,7 @@ mod tests {
             Arc::ptr_eq(&placeholder, &selected),
             "expected the same Arc so the GET .../stream subscriber sees this turn's frames live"
         );
-        registry().lock().unwrap().remove(&key);
+        registry().lock_ok().remove(&key);
         cleanup_run(&placeholder).await;
     }
 
@@ -3958,7 +3978,7 @@ mod tests {
             finished: AtomicBool::new(false),
             finish_lock: AsyncMutex::new(()),
         });
-        registry().lock().unwrap().insert(key.clone(), run.clone());
+        registry().lock_ok().insert(key.clone(), run.clone());
 
         // `stream` subscribes synchronously before returning its body. Do not
         // poll that body until two frames have crossed a capacity-one channel:
@@ -3972,10 +3992,7 @@ mod tests {
             .await
             .unwrap();
         assert!(lagged_body.is_empty());
-        assert!(Arc::ptr_eq(
-            registry().lock().unwrap().get(&key).unwrap(),
-            &run
-        ));
+        assert!(Arc::ptr_eq(registry().lock_ok().get(&key).unwrap(), &run));
 
         run.finish().await;
         let replayed = stream(&state, &test_scope(), &key.org, &key.thread_id).await;
@@ -3985,7 +4002,7 @@ mod tests {
         let mut expected = first.to_vec();
         expected.extend_from_slice(&second);
         assert_eq!(replayed_body.as_ref(), expected);
-        assert!(!registry().lock().unwrap().contains_key(&key));
+        assert!(!registry().lock_ok().contains_key(&key));
     }
 
     #[tokio::test]
@@ -4007,7 +4024,7 @@ mod tests {
         let other_run = DecopilotRun::open(&state, other.clone()).await.unwrap();
         let old_path = old.spool.path().to_path_buf();
         {
-            let mut runs = registry().lock().unwrap();
+            let mut runs = registry().lock_ok();
             runs.insert(acme.clone(), current.clone());
             runs.insert(other.clone(), other_run.clone());
         }
@@ -4018,12 +4035,12 @@ mod tests {
             std::io::ErrorKind::NotFound
         );
         assert!(Arc::ptr_eq(
-            registry().lock().unwrap().get(&acme).unwrap(),
+            registry().lock_ok().get(&acme).unwrap(),
             &current
         ));
         cleanup_run(&current).await;
         assert!(Arc::ptr_eq(
-            registry().lock().unwrap().get(&other).unwrap(),
+            registry().lock_ok().get(&other).unwrap(),
             &other_run
         ));
         cleanup_run(&other_run).await;
@@ -4343,7 +4360,7 @@ mod tests {
             .unwrap()
             .is_none());
 
-        if let Some(queue) = thread_queues().lock().unwrap().remove(&key) {
+        if let Some(queue) = thread_queues().lock_ok().remove(&key) {
             queue.stop_worker();
         }
         clear_thread_closing(&scope, org, &thread_id);
@@ -4444,11 +4461,10 @@ mod tests {
         let first = ensure_account_recovered(&state, &scope).await.unwrap_err();
         assert!(first.contains("left 1 orphaned turn(s) retryable"));
         let recovery_key = format!("{}\0{}", state.app_root.display(), scope.storage_key());
-        assert!(!recovered_accounts().lock().unwrap().contains(&recovery_key));
+        assert!(!recovered_accounts().lock_ok().contains(&recovery_key));
         assert!(
             !thread_queues()
-                .lock()
-                .unwrap()
+                .lock_ok()
                 .contains_key(&ThreadKey::from_fence(&untouched_fence)),
             "failed recovery must not launch an unrelated queued harness"
         );

--- a/apps/native/crates/local-api/src/routes/intercept/git_assist.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/git_assist.rs
@@ -112,15 +112,13 @@ fn path_change_kind(
 /// Port of `fallbackCommitSuggestion` — mesh's own no-LLM degradation.
 fn fallback_commit_suggestion(status: &GitStatusLike, diff: Option<&GitDiffLike>) -> Response {
     let paths = changed_paths(status, diff);
-    if paths.is_empty() {
+    let Some(first) = paths.first() else {
         return Json(json!({ "title": "No changes", "body": "", "message": "No changes" }))
             .into_response();
-    }
-
-    let first = &paths[0];
+    };
     let label = format!("{} {first}", path_change_kind(first, status, diff));
     let extra = if paths.len() > 1 {
-        format!(" and {} more", paths.len() - 1)
+        format!(" and {} more", paths.len().saturating_sub(1))
     } else {
         String::new()
     };

--- a/apps/native/crates/local-api/src/routes/intercept/mod.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/mod.rs
@@ -186,27 +186,31 @@ pub async fn try_intercept(
             }
             Some(watch::get(&scope, org, query))
         }
-        Some("tools") if rest.len() == 2 && *method == Method::POST => match rest[1] {
-            "LINK_CURRENT_GET" => Some(link_current::get().await),
-            tool_name @ ("COLLECTION_THREADS_LIST"
-            | "COLLECTION_THREADS_GET"
-            | "COLLECTION_THREADS_CREATE"
-            | "COLLECTION_THREADS_UPDATE"
-            | "COLLECTION_THREADS_DELETE"
-            | "COLLECTION_THREAD_MESSAGES_LIST") => {
-                let Some(scope) = thread_tools::current_account_scope().await else {
-                    return Some(ApiError::unauthorized().into_response());
-                };
-                if let Err(error) = decopilot::ensure_account_recovered(state, &scope).await {
-                    return Some(
-                        ApiError::internal(format!("native chat queue recovery failed: {error}"))
+        Some("tools") if *method == Method::POST && rest.len() == 2 => {
+            match rest.get(1).copied().unwrap_or_default() {
+                "LINK_CURRENT_GET" => Some(link_current::get().await),
+                tool_name @ ("COLLECTION_THREADS_LIST"
+                | "COLLECTION_THREADS_GET"
+                | "COLLECTION_THREADS_CREATE"
+                | "COLLECTION_THREADS_UPDATE"
+                | "COLLECTION_THREADS_DELETE"
+                | "COLLECTION_THREAD_MESSAGES_LIST") => {
+                    let Some(scope) = thread_tools::current_account_scope().await else {
+                        return Some(ApiError::unauthorized().into_response());
+                    };
+                    if let Err(error) = decopilot::ensure_account_recovered(state, &scope).await {
+                        return Some(
+                            ApiError::internal(format!(
+                                "native chat queue recovery failed: {error}"
+                            ))
                             .into_response(),
-                    );
+                        );
+                    }
+                    thread_tools::dispatch_scoped(state, &scope, org, tool_name, body).await
                 }
-                thread_tools::dispatch_scoped(state, &scope, org, tool_name, body).await
+                _ => None,
             }
-            _ => None,
-        },
+        }
         Some("decopilot") => {
             let Some(scope) = thread_tools::current_account_scope().await else {
                 return Some(ApiError::unauthorized().into_response());
@@ -217,7 +221,17 @@ pub async fn try_intercept(
                         .into_response(),
                 );
             }
-            Some(decopilot::dispatch(state, &scope, org, method, &rest[1..], body).await)
+            Some(
+                decopilot::dispatch(
+                    state,
+                    &scope,
+                    org,
+                    method,
+                    rest.get(1..).unwrap_or_default(),
+                    body,
+                )
+                .await,
+            )
         }
         _ => None,
     }
@@ -247,7 +261,8 @@ pub(crate) fn test_state(root: &std::path::Path) -> AppState {
     AppState {
         token: Arc::from("test-token"),
         boot_id: Arc::from("boot-1"),
-        sandbox_manager: crate::sandbox::SandboxManager::new(root.to_path_buf()),
+        sandbox_manager: crate::sandbox::SandboxManager::new(root.to_path_buf())
+            .expect("registry opens in a fresh temp app root"),
         app_root: root.to_path_buf(),
         repo_dir,
         mode: ApiMode::Strict,

--- a/apps/native/crates/local-api/src/routes/intercept/run_spool.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/run_spool.rs
@@ -243,7 +243,7 @@ impl RunSpool {
 
         let next_len = inner
             .written
-            .checked_add(frame.len() as u64)
+            .checked_add(u64::try_from(frame.len()).unwrap_or(u64::MAX))
             .filter(|next| *next <= self.cap_bytes)
             .ok_or_else(|| RunSpoolError::CapacityExceeded {
                 path: self.path.clone(),
@@ -252,10 +252,15 @@ impl RunSpool {
                 frame_bytes: frame.len(),
             })?;
 
+        // `writer` is `None` only after `finish()` took it — the same state
+        // the `Finished` guard above reports, so reuse that error instead of
+        // asserting the guard already ran.
         let writer = inner
             .writer
             .as_mut()
-            .expect("an active run spool always owns its writer");
+            .ok_or_else(|| RunSpoolError::Finished {
+                path: self.path.clone(),
+            })?;
         writer
             .write_all(&frame)
             .await
@@ -301,7 +306,7 @@ impl RunSpool {
         }
         let start = inner.written;
         let end = start
-            .checked_add(frame.len() as u64)
+            .checked_add(u64::try_from(frame.len()).unwrap_or(u64::MAX))
             .filter(|next| *next <= self.cap_bytes)
             .ok_or_else(|| RunSpoolError::CapacityExceeded {
                 path: self.path.clone(),
@@ -309,10 +314,15 @@ impl RunSpool {
                 current_bytes: inner.written,
                 frame_bytes: frame.len(),
             })?;
+        // `writer` is `None` only after `finish()` took it — the same state
+        // the `Finished` guard above reports, so reuse that error instead of
+        // asserting the guard already ran.
         let writer = inner
             .writer
             .as_mut()
-            .expect("an active run spool always owns its writer");
+            .ok_or_else(|| RunSpoolError::Finished {
+                path: self.path.clone(),
+            })?;
         writer
             .write_all(&frame)
             .await
@@ -341,7 +351,11 @@ impl RunSpool {
                 path: self.path.clone(),
             });
         }
-        let pending = inner.staged.take().expect("staged frame checked above");
+        let Some(pending) = inner.staged.take() else {
+            return Err(RunSpoolError::StagedFrameMismatch {
+                path: self.path.clone(),
+            });
+        };
         inner.visible = inner.written;
         if let Some(sender) = &inner.sender {
             let _ = sender.send(pending.frame);
@@ -362,10 +376,15 @@ impl RunSpool {
                 path: self.path.clone(),
             });
         }
+        // `writer` is `None` only after `finish()` took it — the same state
+        // the `Finished` guard above reports, so reuse that error instead of
+        // asserting the guard already ran.
         let writer = inner
             .writer
             .as_mut()
-            .expect("an active run spool always owns its writer");
+            .ok_or_else(|| RunSpoolError::Finished {
+                path: self.path.clone(),
+            })?;
         writer
             .flush()
             .await

--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_fs.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_fs.rs
@@ -121,7 +121,11 @@ pub(super) async fn try_dispatch(
         "rename" => crate::routes::fs::rename(State(target_state), body).await,
         "glob" => crate::routes::fs::glob(State(target_state), body).await,
         "grep" => crate::routes::fs::grep(State(target_state), body).await,
-        _ => unreachable!("operation was checked against OPERATIONS"),
+        // The caller already matched `operation` against `OPERATIONS`, so
+        // this arm is dead — but `None` ("not ours, fall through") is
+        // already this function's word for that, and it costs a 404 instead
+        // of killing the request path if the two lists ever drift.
+        _ => return None,
     })
 }
 

--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs
@@ -397,7 +397,7 @@ pub(super) fn local_sandbox_sessions(state: &AppState, virtual_mcp_id: &str) -> 
                 observed_status: &record.observed_status,
                 failure_reason: record.error.as_deref(),
                 updated_at_rfc3339: crate::routes::threads::db::format_rfc3339(
-                    std::time::Duration::from_secs(record.updated_at.max(0) as u64),
+                    std::time::Duration::from_secs(u64::try_from(record.updated_at).unwrap_or(0)),
                 ),
             },
         ));

--- a/apps/native/crates/local-api/src/routes/intercept/thread_tools.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/thread_tools.rs
@@ -200,13 +200,17 @@ fn validate_datetime(value: &str, path: &str) -> Result<(), ApiError> {
     let fraction_ok = match bytes.len() {
         20 => true,
         length if length > 21 => {
-            bytes.get(19) == Some(&b'.') && bytes[20..length - 1].iter().all(u8::is_ascii_digit)
+            bytes.get(19) == Some(&b'.')
+                && bytes
+                    .get(20..length.saturating_sub(1))
+                    .is_some_and(|digits| digits.iter().all(u8::is_ascii_digit))
         }
         _ => false,
     };
     let parse = |range: std::ops::Range<usize>| {
-        std::str::from_utf8(&bytes[range])
-            .ok()
+        bytes
+            .get(range)
+            .and_then(|part| std::str::from_utf8(part).ok())
             .and_then(|part| part.parse::<u32>().ok())
     };
     let year = parse(0..4);
@@ -540,7 +544,7 @@ fn list(state: &AppState, scope: &RtAccountScope, org: &str, body: &Bytes) -> Re
         },
     ) {
         Ok((items, total_count)) => {
-            let has_more = offset + limit < total_count;
+            let has_more = offset.saturating_add(limit) < total_count;
             Json(json!({
                 "items": items,
                 "totalCount": total_count,
@@ -872,7 +876,7 @@ fn messages_list(state: &AppState, scope: &RtAccountScope, org: &str, body: &Byt
     // page, not an error" behavior (see that file's handler).
     match db.rt_list_messages_in_scope(scope, org, &thread_id, limit, offset, desc) {
         Ok((items, total_count)) => {
-            let has_more = offset + limit < total_count;
+            let has_more = offset.saturating_add(limit) < total_count;
             Json(json!({
                 "items": items,
                 "totalCount": total_count,

--- a/apps/native/crates/local-api/src/routes/intercept/watch.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/watch.rs
@@ -378,10 +378,17 @@ pub(crate) fn emit_thread_status(
         "updated_at": thread.updated_at,
     });
     if let Some(metadata) = thread.metadata.as_ref() {
-        data["metadata"] = metadata.clone();
+        if let Some(fields) = data.as_object_mut() {
+            fields.insert("metadata".to_string(), metadata.clone());
+        }
     }
     if let Some(message_id) = message_id {
-        data["message_id"] = serde_json::Value::String(message_id.to_string());
+        if let Some(fields) = data.as_object_mut() {
+            fields.insert(
+                "message_id".to_string(),
+                serde_json::Value::String(message_id.to_string()),
+            );
+        }
     }
     let event = LocalWatchEvent {
         id: Uuid::new_v4().to_string(),

--- a/apps/native/crates/local-api/src/routes/mcp_callback.rs
+++ b/apps/native/crates/local-api/src/routes/mcp_callback.rs
@@ -282,7 +282,9 @@ mod tests {
     fn an_expired_callback_is_not_handed_out() {
         let mut slot = Slot::default();
         slot.park(&params(&[("code", "abc")]));
-        slot.0.as_mut().expect("parked").at = Instant::now() - TTL - Duration::from_secs(1);
+        slot.0.as_mut().expect("parked").at = Instant::now()
+            .checked_sub(TTL + Duration::from_secs(1))
+            .expect("process has been up longer than the TTL");
 
         assert!(slot.take().is_none());
     }

--- a/apps/native/crates/local-api/src/routes/proxy.rs
+++ b/apps/native/crates/local-api/src/routes/proxy.rs
@@ -584,7 +584,7 @@ async fn send_to_loopback(
         match tokio::time::timeout(HEADERS_TIMEOUT, builder.send()).await {
             Ok(Ok(resp)) => return Ok(resp),
             Ok(Err(e)) => {
-                let is_last = idx == hosts.len() - 1;
+                let is_last = idx == hosts.len().saturating_sub(1);
                 if !is_last && e.is_connect() {
                     last_err = Some(e.to_string());
                     continue;
@@ -723,13 +723,19 @@ fn relax_set_cookie(value: &str) -> String {
 
 fn inject_bootstrap_script(html: &str) -> String {
     match html.rfind("</body>") {
-        Some(idx) => {
-            let mut out = String::with_capacity(html.len() + BOOTSTRAP_SCRIPT.len());
-            out.push_str(&html[..idx]);
-            out.push_str(BOOTSTRAP_SCRIPT);
-            out.push_str(&html[idx..]);
-            out
-        }
+        Some(idx) => match (html.get(..idx), html.get(idx..)) {
+            (Some(head), Some(tail)) => {
+                let mut out =
+                    String::with_capacity(html.len().saturating_add(BOOTSTRAP_SCRIPT.len()));
+                out.push_str(head);
+                out.push_str(BOOTSTRAP_SCRIPT);
+                out.push_str(tail);
+                out
+            }
+            // `rfind` returns a char boundary, so this is dead — but
+            // appending still produces a working document.
+            _ => format!("{html}{BOOTSTRAP_SCRIPT}"),
+        },
         None => format!("{html}{BOOTSTRAP_SCRIPT}"),
     }
 }
@@ -1227,7 +1233,8 @@ mod tests {
             update: None,
             token: "test-token".into(),
             boot_id: "test-boot".into(),
-            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),
+            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone())
+                .expect("registry opens in a fresh temp app root"),
             app_root,
             repo_dir,
             mode: crate::state::ApiMode::Strict,

--- a/apps/native/crates/local-api/src/routes/repo_dir.rs
+++ b/apps/native/crates/local-api/src/routes/repo_dir.rs
@@ -152,7 +152,8 @@ mod tests {
     #[test]
     fn headerless_with_no_active_sandbox_is_a_404() {
         let root = tempfile::tempdir().unwrap();
-        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf());
+        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let state = fresh_state(manager);
         // `Arc<Sandbox>` (the `Ok` side) isn't `Debug`, so `expect_err` isn't
         // available here — match explicitly instead.
@@ -165,7 +166,8 @@ mod tests {
     #[test]
     fn an_unknown_explicit_handle_is_a_404() {
         let root = tempfile::tempdir().unwrap();
-        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf());
+        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let state = fresh_state(manager);
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -181,7 +183,8 @@ mod tests {
     #[tokio::test]
     async fn an_explicit_known_handle_resolves_to_that_sandbox() {
         let root = tempfile::tempdir().unwrap();
-        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf());
+        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let sandbox = ensure_one_sandbox(&manager, "repo-dir-known").await;
 
         let mut headers = HeaderMap::new();
@@ -197,7 +200,8 @@ mod tests {
     #[tokio::test]
     async fn headerless_falls_back_to_the_active_sandbox() {
         let root = tempfile::tempdir().unwrap();
-        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf());
+        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let sandbox = ensure_one_sandbox(&manager, "repo-dir-active").await;
 
         let state = fresh_state(manager);
@@ -208,7 +212,8 @@ mod tests {
     #[tokio::test]
     async fn get_returns_404_when_the_resolved_workdir_no_longer_exists_on_disk() {
         let root = tempfile::tempdir().unwrap();
-        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf());
+        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let sandbox = ensure_one_sandbox(&manager, "repo-dir-vanished").await;
         std::fs::remove_dir_all(&sandbox.workdir).unwrap();
 

--- a/apps/native/crates/local-api/src/routes/scripts.rs
+++ b/apps/native/crates/local-api/src/routes/scripts.rs
@@ -747,7 +747,8 @@ mod tests {
             update: None,
             token: Arc::from("test-token"),
             boot_id: Arc::from("test-boot"),
-            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),
+            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone())
+                .expect("registry opens in a fresh temp app root"),
             app_root,
             repo_dir,
             mode: crate::state::ApiMode::Strict,

--- a/apps/native/crates/local-api/src/routes/setup.rs
+++ b/apps/native/crates/local-api/src/routes/setup.rs
@@ -337,7 +337,7 @@ pub async fn stop(State(state): State<AppState>, headers: HeaderMap) -> ApiResul
         if matches!(t.log_name.as_deref(), Some("dev") | Some("start"))
             && target.tasks.kill(&t.id, KillSignal::Term) == Some(true)
         {
-            killed += 1;
+            killed = killed.saturating_add(1);
         }
     }
     if killed == 0 {
@@ -398,7 +398,8 @@ mod tests {
             update: None,
             token: "test-token".into(),
             boot_id: "test-boot".into(),
-            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),
+            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone())
+                .expect("registry opens in a fresh temp app root"),
             app_root,
             repo_dir,
             mode: crate::state::ApiMode::Strict,

--- a/apps/native/crates/local-api/src/routes/tasks.rs
+++ b/apps/native/crates/local-api/src/routes/tasks.rs
@@ -304,7 +304,8 @@ mod tests {
             update: None,
             token: Arc::from("test-token"),
             boot_id: Arc::from("test-boot"),
-            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),
+            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone())
+                .expect("registry opens in a fresh temp app root"),
             app_root,
             repo_dir,
             mode: crate::state::ApiMode::Strict,

--- a/apps/native/crates/local-api/src/routes/threads/db.rs
+++ b/apps/native/crates/local-api/src/routes/threads/db.rs
@@ -842,11 +842,19 @@ pub fn native_assistant_message_id(fence: &RtThreadFence, user_message_id: &str)
         fence.generation.as_str(),
         user_message_id,
     ] {
-        digest.update((component.len() as u64).to_be_bytes());
+        digest.update(
+            u64::try_from(component.len())
+                .unwrap_or(u64::MAX)
+                .to_be_bytes(),
+        );
         digest.update(component.as_bytes());
     }
     let digest = digest.finalize();
-    let mut id = String::with_capacity(NATIVE_ASSISTANT_MESSAGE_ID_V1_PREFIX.len() + 64);
+    let mut id = String::with_capacity(
+        NATIVE_ASSISTANT_MESSAGE_ID_V1_PREFIX
+            .len()
+            .saturating_add(64),
+    );
     id.push_str(NATIVE_ASSISTANT_MESSAGE_ID_V1_PREFIX);
     for byte in digest {
         use std::fmt::Write as _;
@@ -1063,7 +1071,7 @@ pub(crate) fn now_rfc3339() -> String {
 }
 
 pub(crate) fn format_rfc3339(d: Duration) -> String {
-    let secs = d.as_secs() as i64;
+    let secs = i64::try_from(d.as_secs()).unwrap_or(i64::MAX);
     let millis = d.subsec_millis();
     let days = secs.div_euclid(86_400);
     let secs_of_day = secs.rem_euclid(86_400);
@@ -1096,21 +1104,15 @@ fn migrate(conn: &mut Connection) -> DbResult<()> {
     // All pending versions share the same IMMEDIATE transaction: either the
     // full forward upgrade and its final `user_version` land, or the database
     // is byte-for-byte on the old schema.
-    let mut expected = found + 1;
+    // The table's own shape — contiguous, ordered, ending exactly at
+    // `CURRENT_SCHEMA_VERSION` — is a property of THIS SOURCE FILE, not of
+    // the user's database, so `migration_table_is_contiguous` asserts it
+    // once over the whole table instead of re-deriving it here on every
+    // boot against only the `> found` slice.
     for migration in MIGRATIONS.iter().filter(|m| m.version > found) {
-        assert_eq!(
-            migration.version, expected,
-            "native SQLite migrations must be contiguous and ordered"
-        );
         tx.execute_batch(migration.sql)?;
         tx.pragma_update(None, "user_version", migration.version)?;
-        expected += 1;
     }
-    assert_eq!(
-        expected,
-        CURRENT_SCHEMA_VERSION + 1,
-        "CURRENT_SCHEMA_VERSION must match the last native SQLite migration"
-    );
     validate_foreign_keys(&tx)?;
     tx.commit()?;
     Ok(())
@@ -1905,22 +1907,28 @@ impl ThreadsDb {
             clauses.push("hidden = 0".to_string());
             let mut placeholders = Vec::with_capacity(trigger_ids.len());
             for trigger_id in trigger_ids {
-                placeholders.push(format!("?{}", sql_params.len() + 1));
+                placeholders.push(format!("?{}", sql_params.len().saturating_add(1)));
                 sql_params.push(Box::new(trigger_id.clone()));
             }
             clauses.push(format!("trigger_id IN ({})", placeholders.join(", ")));
         } else {
             if let Some(user_id) = options.created_by {
-                clauses.push(format!("created_by = ?{}", sql_params.len() + 1));
+                clauses.push(format!(
+                    "created_by = ?{}",
+                    sql_params.len().saturating_add(1)
+                ));
                 sql_params.push(Box::new(user_id.to_string()));
             }
             if let Some(hidden) = options.hidden {
-                clauses.push(format!("hidden = ?{}", sql_params.len() + 1));
-                sql_params.push(Box::new(hidden as i64));
+                clauses.push(format!("hidden = ?{}", sql_params.len().saturating_add(1)));
+                sql_params.push(Box::new(i64::from(hidden)));
             }
             let virtual_mcp_id = options.virtual_mcp_id.or(options.agent_id);
             if let Some(virtual_mcp_id) = virtual_mcp_id {
-                clauses.push(format!("virtual_mcp_id = ?{}", sql_params.len() + 1));
+                clauses.push(format!(
+                    "virtual_mcp_id = ?{}",
+                    sql_params.len().saturating_add(1)
+                ));
                 sql_params.push(Box::new(virtual_mcp_id.to_string()));
             }
             if let Some(has_trigger) = options.has_trigger {
@@ -1933,23 +1941,26 @@ impl ThreadsDb {
             if let Some(start_date) = options.start_date {
                 clauses.push(format!(
                     "julianday(updated_at) >= julianday(?{})",
-                    sql_params.len() + 1
+                    sql_params.len().saturating_add(1)
                 ));
                 sql_params.push(Box::new(start_date.to_string()));
             }
             if let Some(end_date) = options.end_date {
                 clauses.push(format!(
                     "julianday(updated_at) <= julianday(?{})",
-                    sql_params.len() + 1
+                    sql_params.len().saturating_add(1)
                 ));
                 sql_params.push(Box::new(end_date.to_string()));
             }
             if let Some(s) = options.search.filter(|s| !s.is_empty()) {
-                clauses.push(format!("title LIKE ?{} ESCAPE '\\'", sql_params.len() + 1));
+                clauses.push(format!(
+                    "title LIKE ?{} ESCAPE '\\'",
+                    sql_params.len().saturating_add(1)
+                ));
                 sql_params.push(Box::new(format!("%{}%", like_escape(s))));
             }
             if let Some(status) = options.status {
-                clauses.push(format!("status = ?{}", sql_params.len() + 1));
+                clauses.push(format!("status = ?{}", sql_params.len().saturating_add(1)));
                 sql_params.push(Box::new(status.to_string()));
             }
         }
@@ -1965,8 +1976,8 @@ impl ThreadsDb {
         let list_sql = format!(
             "SELECT {RT_THREAD_COLUMNS} FROM native_scoped_threads WHERE {where_sql} \
              ORDER BY updated_at DESC, rowid DESC LIMIT ?{} OFFSET ?{}",
-            sql_params.len() + 1,
-            sql_params.len() + 2,
+            sql_params.len().saturating_add(1),
+            sql_params.len().saturating_add(2),
         );
         sql_params.push(Box::new(options.limit));
         sql_params.push(Box::new(options.offset));
@@ -2005,38 +2016,47 @@ impl ThreadsDb {
         let mut sql_params: Vec<Box<dyn rusqlite::ToSql>> =
             vec![Box::new(ts), Box::new(updated_by.to_string())];
         if let Some(v) = &patch.title {
-            sets.push(format!("title = ?{}", sql_params.len() + 1));
+            sets.push(format!("title = ?{}", sql_params.len().saturating_add(1)));
             sql_params.push(Box::new(v.clone()));
         }
         if let Some(v) = &patch.description {
-            sets.push(format!("description = ?{}", sql_params.len() + 1));
+            sets.push(format!(
+                "description = ?{}",
+                sql_params.len().saturating_add(1)
+            ));
             sql_params.push(Box::new(v.clone()));
         }
         if let Some(v) = patch.hidden {
-            sets.push(format!("hidden = ?{}", sql_params.len() + 1));
-            sql_params.push(Box::new(v as i64));
+            sets.push(format!("hidden = ?{}", sql_params.len().saturating_add(1)));
+            sql_params.push(Box::new(i64::from(v)));
         }
         if let Some(v) = &patch.status {
-            sets.push(format!("status = ?{}", sql_params.len() + 1));
+            sets.push(format!("status = ?{}", sql_params.len().saturating_add(1)));
             sql_params.push(Box::new(v.clone()));
         }
         if let Some(v) = &patch.metadata {
-            sets.push(format!("metadata = ?{}", sql_params.len() + 1));
+            sets.push(format!(
+                "metadata = ?{}",
+                sql_params.len().saturating_add(1)
+            ));
             sql_params.push(Box::new(v.as_ref().map(|v| v.to_string())));
         }
         if let Some(v) = &patch.branch {
-            sets.push(format!("branch = ?{}", sql_params.len() + 1));
+            sets.push(format!("branch = ?{}", sql_params.len().saturating_add(1)));
             sql_params.push(Box::new(v.clone()));
         }
         if let Some(v) = &patch.virtual_mcp_id {
-            sets.push(format!("virtual_mcp_id = ?{}", sql_params.len() + 1));
+            sets.push(format!(
+                "virtual_mcp_id = ?{}",
+                sql_params.len().saturating_add(1)
+            ));
             sql_params.push(Box::new(v.clone()));
         }
-        let id_placeholder = sql_params.len() + 1;
+        let id_placeholder = sql_params.len().saturating_add(1);
         sql_params.push(Box::new(id.to_string()));
-        let org_placeholder = sql_params.len() + 1;
+        let org_placeholder = sql_params.len().saturating_add(1);
         sql_params.push(Box::new(organization_id.to_string()));
-        let scope_placeholder = sql_params.len() + 1;
+        let scope_placeholder = sql_params.len().saturating_add(1);
         let account_scope = scope.storage_key();
         sql_params.push(Box::new(account_scope.clone()));
         let sql = format!(
@@ -2885,8 +2905,11 @@ impl ThreadsDb {
             ],
         )?;
         if !existing.is_empty() {
-            if existing.len() == 1 {
-                let item = existing.into_iter().next().expect("one existing row");
+            // `len() == 1` then `next().expect(...)` said the same thing
+            // twice; consuming the iterator once says it in the type.
+            let mut rows = existing.into_iter();
+            let only = rows.next().filter(|_| rows.next().is_none());
+            if let Some(item) = only {
                 if item.message_id == input.message_id
                     && item.workflow_id == input.workflow_id
                     && item.task_id == input.task_id
@@ -4800,6 +4823,31 @@ mod tests {
 
     type TableShapeRow = (i64, String, String, i64, Option<String>, i64);
     type ForeignKeyShapeRow = (i64, i64, String, String, String, String, String, String);
+
+    /// `migrate` walks `MIGRATIONS` assuming the table is contiguous, ordered
+    /// from 1, and ends at `CURRENT_SCHEMA_VERSION`. That is a property of
+    /// this source file, so it is asserted here over the WHOLE table — a
+    /// runtime check inside `migrate` could only ever see the `> found`
+    /// slice, so a gap below an existing database's version was invisible to
+    /// it.
+    #[test]
+    fn migration_table_is_contiguous() {
+        for (index, migration) in MIGRATIONS.iter().enumerate() {
+            let position = u32::try_from(index).expect("migration count fits in u32");
+            assert_eq!(
+                migration.version,
+                position + 1,
+                "migrations must be contiguous and ordered from 1; \
+                 entry {index} is version {}",
+                migration.version
+            );
+        }
+        assert_eq!(
+            MIGRATIONS.last().map(|m| m.version),
+            Some(CURRENT_SCHEMA_VERSION),
+            "CURRENT_SCHEMA_VERSION must match the last native SQLite migration"
+        );
+    }
 
     fn local_db_path(app_root: &Path) -> PathBuf {
         app_root.join(crate::STUDIO_DB_FILE_NAME)
@@ -7218,7 +7266,11 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
 
     #[test]
     fn claim_quarantines_wrong_or_reversed_assistant_reservations() {
-        for corruption in ["wrong-id", "reversed-sequence"] {
+        // `assistant_first` doubles as the case selector: the reversed-sequence
+        // case is exactly the one that reuses the reserved id AND writes the
+        // assistant row first. Carrying it in the loop tuple beats re-deriving
+        // it from the label with a match that needs a dead arm.
+        for (corruption, assistant_first) in [("wrong-id", false), ("reversed-sequence", true)] {
             let db = ThreadsDb::open_in_memory().unwrap();
             create_rt_thread(&db, "org", "thread");
             let input = turn_input("m1", corruption, 1);
@@ -7226,11 +7278,10 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
                 RtTurnEnqueueOutcome::Inserted(item) => item,
                 other => panic!("expected insertion, got {other:?}"),
             };
-            let reserved_id = claimed_assistant_id(&queued);
-            let (assistant_id, assistant_first) = match corruption {
-                "wrong-id" => ("foreign-assistant".to_string(), false),
-                "reversed-sequence" => (reserved_id, true),
-                _ => unreachable!(),
+            let assistant_id = if assistant_first {
+                claimed_assistant_id(&queued)
+            } else {
+                "foreign-assistant".to_string()
             };
             if assistant_first {
                 db.rt_append_message_in_org(
@@ -8135,7 +8186,20 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
 
     #[test]
     fn terminal_commit_rolls_back_assistant_when_status_or_delete_fails() {
-        for failure_point in ["status", "delete"] {
+        for (failure_point, trigger) in [
+            (
+                "status",
+                "CREATE TEMP TRIGGER terminal_failure \
+                 BEFORE UPDATE OF status ON native_scoped_threads \
+                 BEGIN SELECT RAISE(ABORT, 'forced status failure'); END",
+            ),
+            (
+                "delete",
+                "CREATE TEMP TRIGGER terminal_failure \
+                 BEFORE DELETE ON native_scoped_turn_queue \
+                 BEGIN SELECT RAISE(ABORT, 'forced delete failure'); END",
+            ),
+        ] {
             let db = ThreadsDb::open_in_memory().unwrap();
             create_rt_thread(&db, "org", "thread");
             db.rt_enqueue_turn_in_org("org", "thread", &turn_input("m1", "first", 1))
@@ -8149,19 +8213,6 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
                 db.rt_begin_claimed_turn(&claimed).unwrap(),
                 RtTurnBeginOutcome::Begun(_)
             ));
-            let trigger = match failure_point {
-                "status" => {
-                    "CREATE TEMP TRIGGER terminal_failure \
-                     BEFORE UPDATE OF status ON native_scoped_threads \
-                     BEGIN SELECT RAISE(ABORT, 'forced status failure'); END"
-                }
-                "delete" => {
-                    "CREATE TEMP TRIGGER terminal_failure \
-                     BEFORE DELETE ON native_scoped_turn_queue \
-                     BEGIN SELECT RAISE(ABORT, 'forced delete failure'); END"
-                }
-                _ => unreachable!(),
-            };
             db.lock().execute_batch(trigger).unwrap();
 
             assert!(matches!(

--- a/apps/native/crates/local-api/src/routes/upstream.rs
+++ b/apps/native/crates/local-api/src/routes/upstream.rs
@@ -454,13 +454,8 @@ async fn proxy_auth_path(
     let url = format!("{}{path_and_query}", session.target());
     let upstream_resp = match send_once_no_bearer(method, &url, &out_headers, body.clone()).await {
         Ok(resp) => resp,
-        Err(ProxyError::Network(msg)) => {
+        Err(msg) => {
             return ApiError::bad_gateway(format!("upstream unreachable: {msg}")).into_response()
-        }
-        // `send_once_no_bearer` never produces `HardUnauthorized` — that
-        // variant only exists for the bearer-retry branch above.
-        Err(ProxyError::HardUnauthorized) => {
-            unreachable!("send_once_no_bearer never returns ProxyError::HardUnauthorized")
         }
     };
 
@@ -680,7 +675,7 @@ fn merge_cookie_headers(base: Option<&str>, overlay: Option<&str>) -> Option<Str
         order
             .iter()
             .map(|name| {
-                let value = &values[name];
+                let value = values.get(name).map_or("", String::as_str);
                 if value.is_empty() {
                     name.clone()
                 } else {
@@ -776,12 +771,7 @@ async fn proxy_public_config(
     let url = format!("{}{path_and_query}", session.target());
     match send_once_no_bearer(method, &url, &out_headers, body.clone()).await {
         Ok(resp) => rewrite_config_version(resp, staged_version.as_deref()).await,
-        Err(ProxyError::Network(msg)) => {
-            ApiError::bad_gateway(format!("upstream unreachable: {msg}")).into_response()
-        }
-        Err(ProxyError::HardUnauthorized) => {
-            unreachable!("send_once_no_bearer never returns ProxyError::HardUnauthorized")
-        }
+        Err(msg) => ApiError::bad_gateway(format!("upstream unreachable: {msg}")).into_response(),
     }
 }
 
@@ -933,6 +923,12 @@ enum ProxyError {
     HardUnauthorized,
 }
 
+#[expect(
+    clippy::expect_used,
+    reason = "the builder is configured entirely from literals here; `build()` fails \
+              only if the rustls backend cannot initialize, in which case no \
+              request this proxy exists to make could succeed anyway."
+)]
 fn proxy_client() -> &'static reqwest::Client {
     static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
     CLIENT.get_or_init(|| {
@@ -1095,7 +1091,9 @@ async fn send_with_retry(
 
     let mut headers = headers.clone();
     if cookie_leads {
-        let first = send_once_no_bearer(method, &url, &headers, body.clone()).await?;
+        let first = send_once_no_bearer(method, &url, &headers, body.clone())
+            .await
+            .map_err(ProxyError::Network)?;
         if first.status() != StatusCode::UNAUTHORIZED {
             return Ok(first);
         }
@@ -1154,20 +1152,26 @@ async fn send_once(
 /// handling, but no `Authorization: Bearer` attached at all (the auth-path
 /// branch authenticates via the `Cookie` header already present in
 /// `headers`, not a bearer token).
+/// `Err` carries the network/timeout message directly rather than a
+/// [`ProxyError`]: this path sends no bearer, so `HardUnauthorized` — which
+/// only the bearer-revalidation branch can produce — is not one of its
+/// outcomes. Encoding that in the type is what keeps the two
+/// response-building callers from having to handle a variant they can never
+/// receive, and makes it a compile error if that ever stops being true.
 async fn send_once_no_bearer(
     method: &Method,
     url: &str,
     headers: &HeaderMap,
     body: axum::body::Bytes,
-) -> Result<reqwest::Response, ProxyError> {
+) -> Result<reqwest::Response, String> {
     let builder = proxy_client()
         .request(method.clone(), url)
         .headers(headers.clone())
         .body(body);
     match tokio::time::timeout(UPSTREAM_HEADERS_TIMEOUT, builder.send()).await {
         Ok(Ok(resp)) => Ok(resp),
-        Ok(Err(err)) => Err(ProxyError::Network(err.to_string())),
-        Err(_elapsed) => Err(ProxyError::Network("upstream headers timeout".to_string())),
+        Ok(Err(err)) => Err(err.to_string()),
+        Err(_elapsed) => Err("upstream headers timeout".to_string()),
     }
 }
 
@@ -1528,7 +1532,9 @@ mod tests {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
-            .as_secs() as i64
+            .as_secs()
+            .try_into()
+            .unwrap_or(i64::MAX)
     }
 
     async fn signed_in_session_with_store(
@@ -1546,7 +1552,7 @@ mod tests {
             },
             access_token: access_token.to_string(),
             refresh_token: Some("refresh_1".to_string()),
-            expires_at: Some(now_unix() + 3600),
+            expires_at: Some(now_unix().saturating_add(3600)),
             created_at: "2026-01-01T00:00:00Z".to_string(),
             cookie: None,
         };
@@ -2601,7 +2607,7 @@ mod tests {
                     },
                     access_token: "tok".to_string(),
                     refresh_token: Some("refresh_1".to_string()),
-                    expires_at: Some(now_unix() + 3600),
+                    expires_at: Some(now_unix().saturating_add(3600)),
                     created_at: "2026-01-01T00:00:00Z".to_string(),
                     cookie: Some("better-auth.session_token=abc".to_string()),
                 },
@@ -2670,7 +2676,7 @@ mod tests {
                     },
                     access_token: "tok".to_string(),
                     refresh_token: Some("refresh_1".to_string()),
-                    expires_at: Some(now_unix() + 3600),
+                    expires_at: Some(now_unix().saturating_add(3600)),
                     created_at: "2026-01-01T00:00:00Z".to_string(),
                     cookie: Some("better-auth.session_token=durable".to_string()),
                 },
@@ -2744,7 +2750,7 @@ mod tests {
                     },
                     access_token: "good-token".to_string(),
                     refresh_token: Some("refresh_1".to_string()),
-                    expires_at: Some(now_unix() + 3600),
+                    expires_at: Some(now_unix().saturating_add(3600)),
                     created_at: "2026-01-01T00:00:00Z".to_string(),
                     cookie: Some("better-auth.session_token=durable".to_string()),
                 },

--- a/apps/native/crates/local-api/src/routes/webdav.rs
+++ b/apps/native/crates/local-api/src/routes/webdav.rs
@@ -263,9 +263,21 @@ async fn serve(fs: &dyn OrgFs, target: &RequestTarget, req: Request) -> Response
                 Ok(bytes) => bytes,
                 Err(err) => return error_response(err),
             };
-            match dav::parse_range(range.as_deref(), bytes.len() as u64) {
+            match dav::parse_range(
+                range.as_deref(),
+                u64::try_from(bytes.len()).unwrap_or(u64::MAX),
+            ) {
                 Some((start, end)) => {
-                    let slice = bytes[start as usize..=end as usize].to_vec();
+                    let range = usize::try_from(start)
+                        .ok()
+                        .zip(usize::try_from(end).ok())
+                        .and_then(|(start, end)| bytes.get(start..=end));
+                    // `parse_range` already validated the bounds against
+                    // `bytes.len()`, so this only fires if that ever drifts —
+                    // in which case 416 is the honest answer, not a panic.
+                    let Some(slice) = range.map(<[u8]>::to_vec) else {
+                        return empty(StatusCode::RANGE_NOT_SATISFIABLE);
+                    };
                     base_headers(Response::builder(), &last_modified)
                         .status(StatusCode::PARTIAL_CONTENT)
                         .header(header::CONTENT_LENGTH, slice.len())
@@ -442,7 +454,7 @@ mod tests {
                 return Some(OrgFsNode {
                     path: path.to_string(),
                     is_dir: false,
-                    size: body.len() as u64,
+                    size: u64::try_from(body.len()).unwrap_or(u64::MAX),
                     updated_at_secs: 1_700_000_000,
                 });
             }

--- a/apps/native/crates/local-api/src/routes/webdav/dav.rs
+++ b/apps/native/crates/local-api/src/routes/webdav/dav.rs
@@ -83,10 +83,9 @@ pub fn parse_target(
     relative_path: &str,
 ) -> Result<RequestTarget, TargetError> {
     let rel: Vec<&str> = relative_path.split('/').filter(|s| !s.is_empty()).collect();
-    if rel.len() < 2 {
+    let Some(([org, volume], rest)) = rel.split_first_chunk::<2>() else {
         return Err(TargetError::NotAVolume);
-    }
-    let rest = &rel[2..];
+    };
     let mut segments = Vec::with_capacity(rest.len());
     for raw in rest {
         let decoded = decode(raw);
@@ -98,11 +97,14 @@ pub fn parse_target(
 
     let original: Vec<&str> = original_path.split('/').filter(|s| !s.is_empty()).collect();
     let prefix_len = original.len().saturating_sub(rest.len());
-    let mount_prefix = format!("/{}", original[..prefix_len].join("/"));
+    let mount_prefix = format!(
+        "/{}",
+        original.get(..prefix_len).unwrap_or_default().join("/")
+    );
 
     Ok(RequestTarget {
-        org: decode(rel[0]),
-        volume: decode(rel[1]),
+        org: decode(org),
+        volume: decode(volume),
         path: segments.join("/"),
         mount_prefix,
     })
@@ -110,7 +112,9 @@ pub fn parse_target(
 
 pub fn basename(path: &str) -> &str {
     match path.rfind('/') {
-        Some(i) => &path[i + 1..],
+        // `/` is one byte, so the boundary always holds; `get` avoids the
+        // panic branch on a path this crate does not control.
+        Some(i) => i.checked_add(1).and_then(|at| path.get(at..)).unwrap_or(""),
         None => path,
     }
 }
@@ -219,12 +223,18 @@ pub fn http_date(epoch_secs: i64) -> String {
     let days = epoch_secs.div_euclid(86_400);
     let secs = epoch_secs.rem_euclid(86_400);
     let (year, month, day) = crate::time_util::civil_from_days(days);
-    // 1970-01-01 was a Thursday (index 4 in WEEKDAYS).
-    let weekday = (days + 4).rem_euclid(7) as usize;
+    // 1970-01-01 was a Thursday (index 4 in WEEKDAYS). `rem_euclid` is
+    // non-negative, and `civil_from_days` returns `month` in 1..=12, so both
+    // lookups resolve — but an out-of-range date should render oddly, never
+    // panic a WebDAV response.
+    let weekday = usize::try_from(days.wrapping_add(4).rem_euclid(7)).unwrap_or(0);
     format!(
         "{wd}, {day:02} {mon} {year:04} {h:02}:{m:02}:{s:02} GMT",
-        wd = WEEKDAYS[weekday],
-        mon = MONTHS[(month - 1) as usize],
+        wd = WEEKDAYS.get(weekday).copied().unwrap_or("Thu"),
+        mon = MONTHS
+            .get(usize::try_from(month.saturating_sub(1)).unwrap_or(0))
+            .copied()
+            .unwrap_or("Jan"),
         h = secs / 3600,
         m = (secs % 3600) / 60,
         s = secs % 60,
@@ -249,21 +259,31 @@ pub fn iso_to_epoch_secs(iso: &str) -> Option<i64> {
     if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
         return None;
     }
-    let mut secs = crate::time_util::days_from_civil(year, month, day) * 86_400
-        + hour * 3600
-        + minute * 60
-        + second;
+    let mut secs = crate::time_util::days_from_civil(year, month, day)
+        .saturating_mul(86_400)
+        .saturating_add(hour.saturating_mul(3600))
+        .saturating_add(minute.saturating_mul(60))
+        .saturating_add(second);
 
-    let tail = &iso[19..];
-    let offset_at = tail.rfind(['+', '-']);
-    if let Some(i) = offset_at {
-        let offset = &tail[i..];
-        let sign = if offset.starts_with('-') { -1 } else { 1 };
-        let digits: String = offset[1..].chars().filter(char::is_ascii_digit).collect();
-        if digits.len() >= 4 {
-            let hours: i64 = digits[0..2].parse().ok()?;
-            let minutes: i64 = digits[2..4].parse().ok()?;
-            secs -= sign * (hours * 3600 + minutes * 60);
+    // `iso` is untrusted request input, so every slice below goes through
+    // `get`: a byte index landing mid-character would otherwise panic the
+    // request instead of rejecting the timestamp.
+    let tail = iso.get(19..)?;
+    if let Some(i) = tail.rfind(['+', '-']) {
+        let offset = tail.get(i..)?;
+        let sign: i64 = if offset.starts_with('-') { -1 } else { 1 };
+        let digits: String = offset
+            .get(1..)?
+            .chars()
+            .filter(char::is_ascii_digit)
+            .collect();
+        if let (Some(hh), Some(mm)) = (digits.get(0..2), digits.get(2..4)) {
+            let hours: i64 = hh.parse().ok()?;
+            let minutes: i64 = mm.parse().ok()?;
+            let offset_secs = hours
+                .saturating_mul(3600)
+                .saturating_add(minutes.saturating_mul(60));
+            secs = secs.saturating_sub(sign.saturating_mul(offset_secs));
         }
     }
     Some(secs)
@@ -285,7 +305,12 @@ pub fn parse_destination(
     {
         Some(rest) => {
             let (authority, path) = match rest.find('/') {
-                Some(i) => (&rest[..i], &rest[i..]),
+                Some(i) => match (rest.get(..i), rest.get(i..)) {
+                    (Some(authority), Some(path)) => (authority, path),
+                    // `find` returns a char boundary; reject rather than
+                    // panic if that ever stops holding.
+                    _ => return Err(400),
+                },
                 None => (rest, "/"),
             };
             if let Some(expected) = host {

--- a/apps/native/crates/local-api/src/routes/webdav/junk.rs
+++ b/apps/native/crates/local-api/src/routes/webdav/junk.rs
@@ -78,7 +78,7 @@ fn key(org: &str, volume: &str, path: &str) -> String {
 pub fn put(org: &str, volume: &str, path: &str, body: Bytes, is_dir: bool) {
     let mut store = lock();
     let seq = store.next_seq;
-    store.next_seq += 1;
+    store.next_seq = store.next_seq.saturating_add(1);
     store.entries.insert(
         key(org, volume, path),
         Entry {
@@ -118,7 +118,7 @@ pub fn stat(org: &str, volume: &str, path: &str) -> Option<OrgFsNode> {
     Some(OrgFsNode {
         path: path.to_string(),
         is_dir: entry.is_dir,
-        size: entry.body.len() as u64,
+        size: u64::try_from(entry.body.len()).unwrap_or(u64::MAX),
         updated_at_secs: entry.updated_at_secs,
     })
 }

--- a/apps/native/crates/local-api/src/sandbox/manager.rs
+++ b/apps/native/crates/local-api/src/sandbox/manager.rs
@@ -143,11 +143,14 @@ pub struct SandboxShutdownResult {
 }
 
 impl SandboxManager {
-    pub fn new(app_root: PathBuf) -> Arc<Self> {
-        let registry = super::registry::SandboxRegistry::open(app_root.clone())
-            .unwrap_or_else(|error| panic!("native sandbox registry failed to open: {error}"));
+    /// Fallible because the registry is a SQLite file on the USER's disk:
+    /// a bad permission or a wedged volume is an operational failure the
+    /// caller can report (`StartError::SandboxRegistry` surfaces it through
+    /// the shell's boot-failure dialog), not a reason to abort the process.
+    pub fn new(app_root: PathBuf) -> Result<Arc<Self>, String> {
+        let registry = super::registry::SandboxRegistry::open(app_root.clone())?;
         let persisted_active = registry.active_handle().ok().flatten();
-        Arc::new(Self {
+        Ok(Arc::new(Self {
             app_root,
             registry,
             closing: AtomicBool::new(false),
@@ -157,7 +160,7 @@ impl SandboxManager {
             active_handle: Mutex::new(persisted_active.clone()),
             active_watch: tokio::sync::watch::channel(persisted_active).0,
             generation_watches: Mutex::new(HashMap::new()),
-        })
+        }))
     }
 
     /// The sandbox the reverse proxy serves for a headerless preview request:
@@ -1333,7 +1336,7 @@ async fn terminate_task_ids_with_timings(
     let mut killed = 0usize;
     for task_id in ids {
         if tasks.kill(task_id, KillSignal::Term) == Some(true) {
-            killed += 1;
+            killed = killed.saturating_add(1);
         }
     }
     if tokio::time::timeout(term_grace, wait_tasks_terminal(tasks, ids))
@@ -1767,7 +1770,8 @@ mod tests {
     #[test]
     fn workdir_for_is_per_handle_and_never_the_shared_repo_dir() {
         let root = tempfile::tempdir().expect("tempdir");
-        let manager = SandboxManager::new(root.path().to_path_buf());
+        let manager = SandboxManager::new(root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let config = |branch: Option<&str>| GitSandboxConfig {
             virtual_mcp_id: "vmcp-1".to_string(),
             clone_url: "https://github.com/acme/site.git".to_string(),
@@ -1819,7 +1823,8 @@ mod tests {
     #[tokio::test]
     async fn generation_watch_is_scoped_to_one_handle_and_survives_replacement() {
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let mut watched = manager.watch_generation("sandbox-a");
 
         let first = {
@@ -1871,7 +1876,8 @@ mod tests {
     async fn ensure_clones_two_branches_into_independent_directories() {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
 
         let sandbox_main = manager
             .ensure(&GitSandboxConfig {
@@ -1918,7 +1924,8 @@ mod tests {
     async fn ensure_is_idempotent_for_the_same_handle() {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
 
         let cfg = GitSandboxConfig {
             virtual_mcp_id: "vmcp-1".to_string(),
@@ -1974,7 +1981,8 @@ mod tests {
     async fn branch_monitor_emits_working_tree_changes_for_an_observed_sandbox() {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let sandbox = manager
             .ensure(&GitSandboxConfig {
                 virtual_mcp_id: "vmcp-live-branch".to_string(),
@@ -2018,7 +2026,8 @@ mod tests {
     async fn ensure_repairs_a_drifted_branch_before_returning() {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let cfg = GitSandboxConfig {
             virtual_mcp_id: "vmcp-drift".to_string(),
             clone_url,
@@ -2048,7 +2057,8 @@ mod tests {
     async fn ensure_rejects_a_failed_drift_repair_instead_of_returning_wrong_branch() {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let cfg = GitSandboxConfig {
             virtual_mcp_id: "vmcp-dirty-drift".to_string(),
             clone_url,
@@ -2094,7 +2104,8 @@ mod tests {
     async fn ensure_coalesces_concurrent_callers_for_a_brand_new_handle() {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
 
         let cfg = GitSandboxConfig {
             virtual_mcp_id: "vmcp-1".to_string(),
@@ -2174,7 +2185,8 @@ mod tests {
     async fn concurrent_provision_calls_coalesce_one_setup_generation() {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let config = GitSandboxConfig {
             virtual_mcp_id: "vmcp-concurrent-provision".to_string(),
             clone_url,
@@ -2213,7 +2225,8 @@ mod tests {
     async fn provision_discards_partial_git_directory_before_clone_retry() {
         let (_origin, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let config = GitSandboxConfig {
             virtual_mcp_id: "vmcp-partial-git".to_string(),
             clone_url,
@@ -2258,7 +2271,8 @@ mod tests {
     async fn stale_generation_lifecycle_cannot_overwrite_resumed_generation() {
         let (_origin, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let config = GitSandboxConfig {
             virtual_mcp_id: "vmcp-stale-monitor".to_string(),
             clone_url,
@@ -2336,7 +2350,8 @@ mod tests {
     #[tokio::test]
     async fn resurrect_returns_none_for_a_handle_with_no_sidecar() {
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let result = manager
             .resurrect("never-ensured-handle")
             .await
@@ -2348,7 +2363,8 @@ mod tests {
     async fn resurrect_returns_the_in_memory_sandbox_without_touching_disk_when_already_known() {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let sandbox = manager
             .ensure(&GitSandboxConfig {
                 virtual_mcp_id: "vmcp-resurrect-known".to_string(),
@@ -2380,7 +2396,8 @@ mod tests {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
 
-        let manager_a = SandboxManager::new(app_root.path().to_path_buf());
+        let manager_a = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let original = manager_a
             .ensure(&GitSandboxConfig {
                 virtual_mcp_id: "vmcp-resurrect-forgotten".to_string(),
@@ -2394,7 +2411,8 @@ mod tests {
         let workdir = original.workdir.clone();
         drop(manager_a);
 
-        let manager_b = SandboxManager::new(app_root.path().to_path_buf());
+        let manager_b = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         assert!(
             manager_b.get(&handle).is_none(),
             "a fresh manager must start with an empty in-memory map"
@@ -2423,7 +2441,8 @@ mod tests {
     async fn adopt_rebuilds_routing_metadata_without_starting_setup() {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager_a = SandboxManager::new(app_root.path().to_path_buf());
+        let manager_a = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let original = manager_a
             .ensure(&GitSandboxConfig {
                 virtual_mcp_id: "vmcp-adopt-only".to_string(),
@@ -2436,7 +2455,8 @@ mod tests {
         let handle = original.handle.clone();
         drop(manager_a);
 
-        let manager_b = SandboxManager::new(app_root.path().to_path_buf());
+        let manager_b = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let adopted = manager_b
             .adopt(&handle)
             .await
@@ -2453,7 +2473,8 @@ mod tests {
     async fn stop_during_install_fences_old_cascade_and_preserves_install_checkpoint() {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let config = GitSandboxConfig {
             virtual_mcp_id: "vmcp-stop-install-fence".to_string(),
             clone_url,
@@ -2558,7 +2579,8 @@ mod tests {
     #[tokio::test]
     async fn resurrect_active_returns_none_when_nothing_was_ever_active() {
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let result = manager
             .resurrect_active()
             .await
@@ -2571,7 +2593,8 @@ mod tests {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
 
-        let manager_a = SandboxManager::new(app_root.path().to_path_buf());
+        let manager_a = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let original = manager_a
             .ensure(&GitSandboxConfig {
                 virtual_mcp_id: "vmcp-resurrect-active".to_string(),
@@ -2586,7 +2609,8 @@ mod tests {
 
         // Fresh manager, same app_root — `active_handle` is `None` in memory,
         // but the persisted `.active-handle` pointer file survives.
-        let manager_b = SandboxManager::new(app_root.path().to_path_buf());
+        let manager_b = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         assert!(manager_b.active().is_none());
 
         let resurrected = manager_b
@@ -2603,7 +2627,8 @@ mod tests {
     async fn resurrect_active_prefers_the_in_memory_active_sandbox_over_disk() {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let sandbox = manager
             .ensure(&GitSandboxConfig {
                 virtual_mcp_id: "vmcp-resurrect-prefers-memory".to_string(),
@@ -2628,7 +2653,8 @@ mod tests {
     #[tokio::test]
     async fn shutdown_all_closes_and_reaps_every_sandbox_concurrently() {
         let app_root = tempfile::tempdir().unwrap();
-        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let manager = SandboxManager::new(app_root.path().to_path_buf())
+            .expect("registry opens in a fresh temp app root");
         let mut sandboxes = Vec::new();
         for handle in ["one", "two"] {
             let lock = manager.handle_lock(handle);

--- a/apps/native/crates/local-api/src/sandbox/mod.rs
+++ b/apps/native/crates/local-api/src/sandbox/mod.rs
@@ -194,11 +194,13 @@ pub fn preview_label(handle: &str) -> String {
     let slug = slug.trim_matches('-');
 
     // `-<hash>` is always kept; the slug yields whatever room is left.
-    let room = MAX_PREVIEW_LABEL - hash.len() - 1;
+    let room = MAX_PREVIEW_LABEL
+        .saturating_sub(hash.len())
+        .saturating_sub(1);
     let kept = if slug.len() > room {
         slug.char_indices()
-            .nth(slug.chars().count() - room)
-            .map(|(index, _)| &slug[index..])
+            .nth(slug.chars().count().saturating_sub(room))
+            .and_then(|(index, _)| slug.get(index..))
             .unwrap_or(slug)
     } else {
         slug

--- a/apps/native/crates/local-api/src/sandbox/org_mount.rs
+++ b/apps/native/crates/local-api/src/sandbox/org_mount.rs
@@ -192,6 +192,13 @@ fn claim(org_slug: &str) -> Option<()> {
     }
 }
 
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+              constant. `checked_add` has no honest fallback here — there \
+              is no `Instant::MAX` to saturate to, so the call site would \
+              have to invent a deadline. Overflow is ~584 years out."
+)]
 fn settle(org_slug: &str, ok: bool) {
     let state = if ok {
         MountState::Ready
@@ -228,6 +235,13 @@ pub fn warm(app_root: &Path, org_slug: &str) {
 /// sandbox can be ensured without any org-scoped request having preceded it
 /// (a resurrect on boot, a test), and such a caller must not wait out the
 /// timeout for something nobody started.
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+              constant. `checked_add` has no honest fallback here — there \
+              is no `Instant::MAX` to saturate to, so the call site would \
+              have to invent a deadline. Overflow is ~584 years out."
+)]
 pub async fn wait_ready(app_root: &Path, org_slug: &str) -> bool {
     warm(app_root, org_slug);
     let deadline = Instant::now() + READY_TIMEOUT;
@@ -737,7 +751,9 @@ mod tests {
         lock_states().insert(
             "cooldown-org".to_string(),
             MountState::Failed {
-                until: Instant::now() - Duration::from_secs(1),
+                until: Instant::now()
+                    .checked_sub(Duration::from_secs(1))
+                    .expect("process has been up at least a second"),
             },
         );
         assert!(

--- a/apps/native/crates/local-api/src/sandbox/org_prompt.rs
+++ b/apps/native/crates/local-api/src/sandbox/org_prompt.rs
@@ -100,7 +100,12 @@ pub fn build(org_dir: &Path, thread_id: &str, user_id: Option<&str>) -> String {
     let tree = rows
         .iter()
         .map(|(path, gloss)| {
-            let pad = " ".repeat(column.unwrap_or_default() - path.chars().count() + 2);
+            let pad = " ".repeat(
+                column
+                    .unwrap_or_default()
+                    .saturating_sub(path.chars().count())
+                    .saturating_add(2),
+            );
             format!("{path}{pad}{gloss}")
         })
         .collect::<Vec<_>>()

--- a/apps/native/crates/local-api/src/sandbox/target.rs
+++ b/apps/native/crates/local-api/src/sandbox/target.rs
@@ -132,7 +132,8 @@ mod tests {
             update: None,
             token: "test-token".into(),
             boot_id: "test-boot".into(),
-            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),
+            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone())
+                .expect("registry opens in a fresh temp app root"),
             app_root,
             repo_dir,
             mode: crate::state::ApiMode::Strict,

--- a/apps/native/crates/local-api/src/setup/clone.rs
+++ b/apps/native/crates/local-api/src/setup/clone.rs
@@ -46,6 +46,7 @@
 
 use std::path::Path;
 use std::sync::Arc;
+use upstream::poison::MutexExt;
 
 use serde_json::{json, Value};
 use tokio::io::AsyncReadExt;
@@ -212,7 +213,9 @@ async fn run_git(
                 match res {
                     Ok(0) | Err(_) => stdout_open = false,
                     Ok(n) => {
-                        let text = String::from_utf8_lossy(&so_chunk[..n]).into_owned();
+                        let text =
+                            String::from_utf8_lossy(so_chunk.get(..n).unwrap_or(&so_chunk))
+                                .into_owned();
                         combined.push_str(&text);
                         emit_chunk(orch, task_id, OutputStream::Stdout, &text).await;
                     }
@@ -222,7 +225,9 @@ async fn run_git(
                 match res {
                     Ok(0) | Err(_) => stderr_open = false,
                     Ok(n) => {
-                        let text = String::from_utf8_lossy(&se_chunk[..n]).into_owned();
+                        let text =
+                            String::from_utf8_lossy(se_chunk.get(..n).unwrap_or(&se_chunk))
+                                .into_owned();
                         combined.push_str(&text);
                         emit_chunk(orch, task_id, OutputStream::Stderr, &text).await;
                     }
@@ -375,13 +380,17 @@ async fn clone_fresh(orch: &Arc<SetupOrchestrator>, clone_url: &str, branch: Opt
         return false;
     }
 
-    match clone_fresh_body(orch, &task_id, clone_url, branch, &controller).await {
-        _ if controller.requested().is_some() => {
-            let signal = controller.requested().expect("checked above");
-            orch.tasks
-                .finalize(&task_id, TaskStatus::Killed, signal.exit_code(), false);
-            false
-        }
+    let outcome = clone_fresh_body(orch, &task_id, clone_url, branch, &controller).await;
+    // A cancellation observed at any point during the body wins over its
+    // result. Read ONCE and bind the signal here: the previous shape asked
+    // `requested()` twice — a match guard and then the arm body — which left
+    // room for the two answers to disagree.
+    if let Some(signal) = controller.requested() {
+        orch.tasks
+            .finalize(&task_id, TaskStatus::Killed, signal.exit_code(), false);
+        return false;
+    }
+    match outcome {
         Ok(()) => {
             orch.tasks.finalize(&task_id, TaskStatus::Exited, 0, false);
             true
@@ -830,8 +839,7 @@ fn mirror_surgery_lock(canonical_str: &str) -> Arc<tokio::sync::Mutex<()>> {
     > = std::sync::OnceLock::new();
     LOCKS
         .get_or_init(Default::default)
-        .lock()
-        .expect("mirror lock map is never poisoned")
+        .lock_ok()
         .entry(canonical_str.to_string())
         .or_default()
         .clone()

--- a/apps/native/crates/local-api/src/setup/detect_runtime.rs
+++ b/apps/native/crates/local-api/src/setup/detect_runtime.rs
@@ -130,7 +130,9 @@ pub(super) async fn ensure_package_manager(orch: &Arc<SetupOrchestrator>, config
         .is_some();
     if !runtime_pinned {
         if let Some(runtime) = runtime_for_package_manager(pm) {
-            application["runtime"] = json!(runtime);
+            if let Some(fields) = application.as_object_mut() {
+                fields.insert("runtime".to_string(), json!(runtime));
+            }
         }
     }
     if let Err(error) = orch.config.patch(json!({ "application": application })) {

--- a/apps/native/crates/local-api/src/setup/dev.rs
+++ b/apps/native/crates/local-api/src/setup/dev.rs
@@ -87,6 +87,12 @@ fn match_group_identity(
     }
 }
 
+#[expect(
+    clippy::expect_used,
+    reason = "the pattern is a literal in this file, so `Regex::new` can only fail \
+              if THIS SOURCE is wrong — a compile-time mistake a test catches, \
+              not a runtime input. `static_regexes_compile` forces every one."
+)]
 fn port_pattern() -> &'static Regex {
     static RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
     RE.get_or_init(|| {
@@ -273,7 +279,7 @@ pub(super) async fn run(orch: &Arc<SetupOrchestrator>, config: &Value) {
         }
         return;
     };
-    let record_started_at = now_ms() as u64;
+    let record_started_at = u64::try_from(now_ms()).unwrap_or(0);
     let identities = match capture_process_group_identity(
         || observe_process_group(pid),
         IDENTITY_CAPTURE_ATTEMPTS,
@@ -432,7 +438,9 @@ async fn drain_and_watch(
                 match res {
                     Ok(0) | Err(_) => stdout_open = false,
                     Ok(n) => {
-                        let text = String::from_utf8_lossy(&so_chunk[..n]).into_owned();
+                        let text =
+                            String::from_utf8_lossy(so_chunk.get(..n).unwrap_or(&so_chunk))
+                                .into_owned();
                         // Both this task's own file AND the stable
                         // `"app/<starter>"` transcript (`routes/events.rs`
                         // replays the latter), then a live `log` SSE frame so
@@ -476,7 +484,9 @@ async fn drain_and_watch(
                 match res {
                     Ok(0) | Err(_) => stderr_open = false,
                     Ok(n) => {
-                        let text = String::from_utf8_lossy(&se_chunk[..n]).into_owned();
+                        let text =
+                            String::from_utf8_lossy(se_chunk.get(..n).unwrap_or(&se_chunk))
+                                .into_owned();
                         orch.tasks
                             .append_log(&id, &starter, OutputStream::Stderr, &text, &orch.broadcaster)
                             .await;
@@ -564,7 +574,11 @@ async fn confirm_running(orch: Arc<SetupOrchestrator>, task_id: String, port: u1
                     .and_then(|v| v.to_str().ok())
                     .map(|s| s.to_ascii_lowercase().contains("text/html"))
                     .unwrap_or(false);
-                let was_down = orch.lifecycle_snapshot()["phase"].as_str() != Some("running");
+                let was_down = orch
+                    .lifecycle_snapshot()
+                    .get("phase")
+                    .and_then(Value::as_str)
+                    != Some("running");
                 if !orch.transition_dev_lifecycle(
                     &task_id,
                     json!({
@@ -590,6 +604,13 @@ async fn confirm_running(orch: Arc<SetupOrchestrator>, task_id: String, port: u1
     }
 }
 
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+              constant. `checked_add` has no honest fallback here — there \
+              is no `Instant::MAX` to saturate to, so the call site would \
+              have to invent a deadline. Overflow is ~584 years out."
+)]
 async fn reap_persisted_dev_group(record: &DevProcessRecord) -> Result<(), String> {
     let current = observe_process_group(record.pgid).await?;
     let authorized = match match_group_identity(&record.identities, current) {
@@ -660,7 +681,7 @@ where
             }
             Err(error) => last_error = error,
         }
-        if attempt + 1 < attempts {
+        if attempt.saturating_add(1) < attempts {
             tokio::time::sleep(interval).await;
         }
     }
@@ -761,13 +782,17 @@ async fn observe_process_identity(
     let output = String::from_utf8(process.stdout)
         .map_err(|error| format!("ps returned non-UTF-8 output for {pid}: {error}"))?;
     let fields: Vec<&str> = output.split_whitespace().collect();
-    if fields.len() < 9 {
-        return Err(format!("cannot parse process identity for {pid}"));
-    }
-    let observed_pid = fields[0]
+    // `ps` emits pid, pgid, state, then a 5-field start time, then the
+    // command — the slice pattern below is that shape, so a short or
+    // reshaped line is rejected instead of indexed into.
+    let ([raw_pid, raw_pgid, state], birth_and_command) = fields
+        .split_first_chunk::<3>()
+        .filter(|(_, rest)| rest.len() >= 6)
+        .ok_or_else(|| format!("cannot parse process identity for {pid}"))?;
+    let observed_pid = raw_pid
         .parse::<u32>()
         .map_err(|error| format!("cannot parse observed pid for {pid}: {error}"))?;
-    let observed_pgid = fields[1]
+    let observed_pgid = raw_pgid
         .parse::<u32>()
         .map_err(|error| format!("cannot parse observed pgid for {pid}: {error}"))?;
     if observed_pid != pid || observed_pgid != expected_pgid {
@@ -775,14 +800,14 @@ async fn observe_process_identity(
             "process {pid} no longer belongs to group {expected_pgid}"
         ));
     }
-    if fields[2].starts_with('Z') {
+    if state.starts_with('Z') {
         return Ok(None);
     }
 
     Ok(Some(DevProcessIdentity {
         pid,
-        birth: fields[3..8].join(" "),
-        executable: fields[8..].join(" "),
+        birth: birth_and_command.get(..5).unwrap_or_default().join(" "),
+        executable: birth_and_command.get(5..).unwrap_or_default().join(" "),
     }))
 }
 

--- a/apps/native/crates/local-api/src/setup/install.rs
+++ b/apps/native/crates/local-api/src/setup/install.rs
@@ -235,7 +235,9 @@ async fn run_install_cmd(
                 match res {
                     Ok(0) | Err(_) => stdout_open = false,
                     Ok(n) => {
-                        let text = String::from_utf8_lossy(&so_chunk[..n]).into_owned();
+                        let text =
+                            String::from_utf8_lossy(so_chunk.get(..n).unwrap_or(&so_chunk))
+                                .into_owned();
                         orch.tasks
                             .append_log(&task_id, "setup", OutputStream::Stdout, &text, &orch.broadcaster)
                             .await;
@@ -246,7 +248,9 @@ async fn run_install_cmd(
                 match res {
                     Ok(0) | Err(_) => stderr_open = false,
                     Ok(n) => {
-                        let text = String::from_utf8_lossy(&se_chunk[..n]).into_owned();
+                        let text =
+                            String::from_utf8_lossy(se_chunk.get(..n).unwrap_or(&se_chunk))
+                                .into_owned();
                         orch.tasks
                             .append_log(&task_id, "setup", OutputStream::Stderr, &text, &orch.broadcaster)
                             .await;

--- a/apps/native/crates/local-api/src/tasks/registry.rs
+++ b/apps/native/crates/local-api/src/tasks/registry.rs
@@ -59,7 +59,7 @@ const STREAM_CHANNEL_CAPACITY: usize = 1024;
 pub(crate) fn now_ms() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
+        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
         .unwrap_or(0)
 }
 
@@ -340,13 +340,13 @@ impl RingBuffer {
         self.buf.push_str(data);
         if self.buf.len() > self.capacity {
             self.truncated = true;
-            let overflow = self.buf.len() - self.capacity;
+            let overflow = self.buf.len().saturating_sub(self.capacity);
             let mut cut = overflow.min(self.buf.len());
             // `overflow` is a byte offset that may land mid-codepoint;
             // walk forward to the next char boundary so we never split a
             // multi-byte UTF-8 sequence.
             while cut < self.buf.len() && !self.buf.is_char_boundary(cut) {
-                cut += 1;
+                cut = cut.saturating_add(1);
             }
             self.buf.drain(..cut);
         }
@@ -450,7 +450,10 @@ impl TaskRegistry {
     /// spawns into this registry. IDs restart at `task1` each process boot;
     /// retained files remain collision-free through [`Self::storage_namespace`].
     pub fn next_id(&self) -> String {
-        let n = self.id_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        let n = self
+            .id_counter
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1);
         format!("task{n}")
     }
 
@@ -542,10 +545,10 @@ impl TaskRegistry {
     /// the live send.
     pub async fn append_output(&self, id: &str, stream: OutputStream, data: &str) -> bool {
         if data.is_empty()
-            || !self
+            || self
                 .lock()
                 .get(id)
-                .is_some_and(|entry| !entry.summary.status.is_terminal())
+                .is_none_or(|entry| entry.summary.status.is_terminal())
         {
             return false;
         }
@@ -714,7 +717,7 @@ impl TaskRegistry {
     /// [`Self::kill_all_and_wait`] during process shutdown.
     pub fn kill_all(&self, signal: KillSignal) -> usize {
         let mut guard = self.lock();
-        let mut count = 0;
+        let mut count = 0_usize;
         for entry in guard.values_mut() {
             if !entry.exposed || entry.summary.status.is_terminal() {
                 continue;
@@ -725,7 +728,7 @@ impl TaskRegistry {
             };
             if signaled {
                 entry.summary.intentional = Some(true);
-                count += 1;
+                count = count.saturating_add(1);
             }
         }
         count
@@ -791,7 +794,7 @@ impl TaskRegistry {
 
     fn kill_ids(&self, ids: &[String], signal: KillSignal) -> usize {
         let mut guard = self.lock();
-        let mut count = 0;
+        let mut count = 0_usize;
         for id in ids {
             let Some(entry) = guard.get_mut(id) else {
                 continue;
@@ -802,7 +805,7 @@ impl TaskRegistry {
             let signaled = entry.kill.as_ref().is_some_and(|kill| kill(signal));
             if signaled {
                 entry.summary.intentional = Some(true);
-                count += 1;
+                count = count.saturating_add(1);
             }
         }
         count

--- a/apps/native/crates/local-api/src/time_util.rs
+++ b/apps/native/crates/local-api/src/time_util.rs
@@ -20,14 +20,24 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub(crate) fn now_unix_secs() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
+        .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
 }
 
 /// Howard Hinnant's `civil_from_days` — days since the Unix epoch to
 /// `(year, month, day)`, proleptic Gregorian, no leap seconds. The same
 /// algorithm libc++'s `<chrono>` uses, valid across the whole `SystemTime`
 /// range.
+#[expect(
+    clippy::arithmetic_side_effects,
+    clippy::as_conversions,
+    reason = "Hinnant's kernel verbatim: every intermediate is proven in \
+              range for any `days` a `SystemTime` can produce (the epoch-second \
+              domain is ~2^38, eight orders below the i64 headroom these \
+              multiplies need), and `doe`/`yoe`/`doy`/`mp` are bounded by \
+              construction. Rewriting the ops as `checked_*` would obscure the \
+              published algorithm without adding a reachable check; \
+              `civil_and_days_invert_each_other` pins the result instead."
+)]
 pub(crate) fn civil_from_days(days: i64) -> (i64, u32, u32) {
     let z = days + 719_468;
     let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
@@ -44,6 +54,11 @@ pub(crate) fn civil_from_days(days: i64) -> (i64, u32, u32) {
 
 /// The inverse of [`civil_from_days`] — `(year, month, day)` to days since
 /// the Unix epoch.
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "inverse of `civil_from_days`; same in-range proof and same \
+              round-trip test."
+)]
 pub(crate) fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
     let y = if month <= 2 { year - 1 } else { year };
     let era = if y >= 0 { y } else { y - 399 } / 400;
@@ -65,7 +80,11 @@ mod tests {
     fn civil_and_days_invert_each_other() {
         for days in [-719_468, -1, 0, 1, 19_000, 20_500, 2_932_896] {
             let (y, m, d) = civil_from_days(days);
-            assert_eq!(days_from_civil(y, m as i64, d as i64), days, "{days}");
+            assert_eq!(
+                days_from_civil(y, i64::from(m), i64::from(d)),
+                days,
+                "{days}"
+            );
         }
         assert_eq!(civil_from_days(0), (1970, 1, 1));
         // 2026-07-29 is day 20663.

--- a/apps/native/crates/upstream/src/bridge.rs
+++ b/apps/native/crates/upstream/src/bridge.rs
@@ -198,7 +198,7 @@ pub async fn complete_via_cookie_jar(
         },
         access_token: token.access_token,
         refresh_token: token.refresh_token,
-        expires_at: token.expires_in.map(|s| now_unix() + s),
+        expires_at: token.expires_in.map(|s| now_unix().saturating_add(s)),
         created_at: now_rfc3339(),
         // Owner course-correction (post-Phase-3): the cookie that
         // authenticated THIS authorize call is no longer a one-shot,

--- a/apps/native/crates/upstream/src/clock.rs
+++ b/apps/native/crates/upstream/src/clock.rs
@@ -11,8 +11,7 @@
 pub fn now_unix() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
+        .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
 }
 
 /// A minimal, dependency-free RFC3339 (UTC, second precision) formatter —
@@ -35,6 +34,16 @@ pub fn now_rfc3339() -> String {
 /// Howard Hinnant's `civil_from_days` algorithm (public domain) — converts
 /// a day count since the Unix epoch into a proleptic-Gregorian
 /// (year, month, day). Small, well-known, dependency-free.
+#[expect(
+    clippy::arithmetic_side_effects,
+    clippy::as_conversions,
+    reason = "Hinnant's kernel verbatim: `z` comes from `now_unix()/86_400`, so \
+              every intermediate is proven in range, and `doe`/`yoe`/`doy`/`mp` \
+              are bounded by construction. Rewriting the ops as `checked_*` \
+              would obscure the published algorithm without adding a reachable \
+              check. Mirrors `local_api::time_util::civil_from_days`, which \
+              carries the round-trip test."
+)]
 fn civil_from_days(z: i64) -> (i64, u32, u32) {
     let z = z + 719_468;
     let era = if z >= 0 { z } else { z - 146_096 } / 146_097;

--- a/apps/native/crates/upstream/src/cookie_jar.rs
+++ b/apps/native/crates/upstream/src/cookie_jar.rs
@@ -46,6 +46,7 @@
 //! engineering for a jar whose entire lifetime is "this process, this
 //! host, until the next bridge attempt or sign-out."
 
+use crate::poison::RwLockExt;
 use std::collections::BTreeMap;
 use std::sync::RwLock;
 
@@ -69,7 +70,7 @@ impl CookieJar {
     /// matching how a real browser jar treats a repeated `Set-Cookie` for
     /// the same name/path/domain.
     pub fn capture<'a>(&self, host: &str, set_cookie_values: impl Iterator<Item = &'a str>) {
-        let mut map = self.entries.write().unwrap();
+        let mut map = self.entries.write_ok();
         let entry = map.entry(host.to_string()).or_default();
         for raw in set_cookie_values {
             if let Some((name, value)) = parse_set_cookie(raw) {
@@ -83,7 +84,7 @@ impl CookieJar {
     /// `None` if nothing has been captured for that host yet — callers
     /// must never send an empty `Cookie:` header.
     pub fn header_value(&self, host: &str) -> Option<String> {
-        let map = self.entries.read().unwrap();
+        let map = self.entries.read_ok();
         let entry = map.get(host)?;
         if entry.is_empty() {
             return None;
@@ -100,7 +101,7 @@ impl CookieJar {
     /// Idempotent — clearing an already-empty host is a no-op, matching
     /// this crate's other idempotent-clear conventions (`TokenStore::clear`).
     pub fn clear(&self, host: &str) {
-        self.entries.write().unwrap().remove(host);
+        self.entries.write_ok().remove(host);
     }
 
     /// `true` when nothing is captured for `host` (including "never
@@ -108,8 +109,7 @@ impl CookieJar {
     /// [`crate::bridge::complete_via_cookie_jar`]'s precondition check.
     pub fn is_empty(&self, host: &str) -> bool {
         self.entries
-            .read()
-            .unwrap()
+            .read_ok()
             .get(host)
             .is_none_or(|m| m.is_empty())
     }

--- a/apps/native/crates/upstream/src/keychain_helper.rs
+++ b/apps/native/crates/upstream/src/keychain_helper.rs
@@ -244,7 +244,7 @@ pub fn serve_stdio() -> std::io::Result<()> {
         .take(MAX_PROTOCOL_BYTES + 1)
         .read_to_end(&mut input)?;
 
-    let response = if input.len() as u64 > MAX_PROTOCOL_BYTES {
+    let response = if u64::try_from(input.len()).unwrap_or(u64::MAX) > MAX_PROTOCOL_BYTES {
         KeychainHelperResponse::error("helper request exceeded the size limit")
     } else {
         match serde_json::from_slice::<KeychainHelperRequest>(&input) {

--- a/apps/native/crates/upstream/src/lib.rs
+++ b/apps/native/crates/upstream/src/lib.rs
@@ -34,6 +34,10 @@
 //!   [`login`] and [`bridge`] (both mint a [`tokens::StoredSession`]).
 //! - [`paths`] — shared app-data-directory resolution for this crate's
 //!   non-secret on-disk caches ([`register`], [`org_cache`]).
+//! - [`poison`] — `lock_ok`/`read_ok`/`write_ok`: the workspace-wide policy
+//!   for a poisoned lock (recover the guard, never cascade the panic).
+//!   Lives here because `crates/local-api` already depends on this crate and
+//!   is its heaviest consumer — same reason [`clock`] does.
 //!
 //! ## Why a process-wide singleton instead of an `AppState` field
 //!
@@ -61,6 +65,7 @@ pub mod cookie_jar;
 pub mod keychain_helper;
 pub mod login;
 pub mod pkce;
+pub mod poison;
 pub mod refresh;
 pub mod register;
 pub mod revalidate;

--- a/apps/native/crates/upstream/src/login.rs
+++ b/apps/native/crates/upstream/src/login.rs
@@ -11,6 +11,7 @@
 //! a specific mesh-hosted failure page existing). Like the CLI, a fresh
 //! client is registered per login — see [`crate::register`]'s module doc.
 
+use crate::poison::MutexExt;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -194,7 +195,7 @@ pub async fn perform_interactive_login(
         },
         access_token: token.access_token,
         refresh_token: token.refresh_token,
-        expires_at: token.expires_in.map(|s| now_unix() + s),
+        expires_at: token.expires_in.map(|s| now_unix().saturating_add(s)),
         created_at: now_rfc3339(),
         // Real-UI course-correction: this used to be unconditionally `None`
         // (the system-browser PKCE flow itself never yields a capturable
@@ -480,7 +481,7 @@ impl LoopbackServer {
     async fn wait_for_callback(self, timeout: Duration) -> Result<String, LoginError> {
         let outcome = tokio::time::timeout(timeout, self.result_rx).await;
         // Always tear down the listener before returning, on every path.
-        if let Some(tx) = self.shutdown_tx.lock().unwrap().take() {
+        if let Some(tx) = self.shutdown_tx.lock_ok().take() {
             let _ = tx.send(());
         }
         match outcome {
@@ -498,7 +499,7 @@ async fn handle_callback(
     state: Arc<CallbackState>,
     Query(query): Query<CallbackQuery>,
 ) -> Response {
-    let Some(tx) = state.result_tx.lock().unwrap().take() else {
+    let Some(tx) = state.result_tx.lock_ok().take() else {
         // A second request after the first already resolved (e.g. a
         // stray browser prefetch/retry) — harmless no-op response.
         return (StatusCode::NO_CONTENT, "").into_response();
@@ -614,7 +615,7 @@ mod tests {
             axum::routing::post(move |headers: HeaderMap| {
                 let seen = seen_for_route.clone();
                 async move {
-                    *seen.lock().unwrap() = headers
+                    *seen.lock_ok() = headers
                         .get(axum::http::header::AUTHORIZATION)
                         .and_then(|v| v.to_str().ok())
                         .map(|s| s.to_string());
@@ -631,7 +632,7 @@ mod tests {
 
         assert_eq!(value, "raw-token.signature");
         assert_eq!(
-            seen_bearer.lock().unwrap().as_deref(),
+            seen_bearer.lock_ok().as_deref(),
             Some("Bearer the-access-token")
         );
     }

--- a/apps/native/crates/upstream/src/poison.rs
+++ b/apps/native/crates/upstream/src/poison.rs
@@ -1,0 +1,95 @@
+//! Lock acquisition that survives a poisoned mutex.
+//!
+//! ## The policy, decided once
+//!
+//! A `std::sync::Mutex` is poisoned when a thread panics while holding it.
+//! `lock().unwrap()` — the shape this module replaces at ~40 call sites —
+//! turns that into a SECOND panic in whichever thread touches the lock next.
+//! In a desktop app that cascade is the worst available outcome: one panicked
+//! background task takes down the request path, the task registry, and the
+//! event stream with it, and unwinding poisons every other lock on the way
+//! out.
+//!
+//! Every lock in this workspace guards plain, self-consistent data — a queue
+//! of turns, an `Option<CancelHandle>`, a cookie map, a cached session. None
+//! of them carry a cross-field invariant that a mid-update panic could leave
+//! half-applied in a way a later reader would misinterpret. So the useful
+//! reading of poison here is "some other task died", which is the panicking
+//! task's problem to report, not a reason to spread the failure.
+//!
+//! `PoisonError::into_inner` is therefore the policy: take the guard and
+//! carry on. This is the same choice `parking_lot` makes by not having
+//! poisoning at all.
+//!
+//! If a future lock DOES guard a multi-field invariant, that lock should not
+//! use these helpers — it should handle `PoisonError` explicitly and decide
+//! what a half-applied update means for it.
+
+use std::sync::{Mutex, MutexGuard, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// [`Mutex::lock`] that ignores poisoning — see the module docs.
+pub trait MutexExt<T: ?Sized> {
+    /// Locks, recovering the guard if a previous holder panicked.
+    fn lock_ok(&self) -> MutexGuard<'_, T>;
+}
+
+impl<T: ?Sized> MutexExt<T> for Mutex<T> {
+    fn lock_ok(&self) -> MutexGuard<'_, T> {
+        self.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// [`RwLock::read`]/[`RwLock::write`] that ignore poisoning — see the module
+/// docs.
+pub trait RwLockExt<T: ?Sized> {
+    /// Read-locks, recovering the guard if a previous writer panicked.
+    fn read_ok(&self) -> RwLockReadGuard<'_, T>;
+    /// Write-locks, recovering the guard if a previous writer panicked.
+    fn write_ok(&self) -> RwLockWriteGuard<'_, T>;
+}
+
+impl<T: ?Sized> RwLockExt<T> for RwLock<T> {
+    fn read_ok(&self) -> RwLockReadGuard<'_, T> {
+        self.read().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn write_ok(&self) -> RwLockWriteGuard<'_, T> {
+        self.write().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    /// The whole point: a panic under the lock must not make the NEXT
+    /// acquisition fail. Without `into_inner` both asserts below panic.
+    #[test]
+    fn recovers_the_guard_after_a_holder_panics() {
+        let m = Arc::new(Mutex::new(vec![1_u8]));
+        let poisoner = Arc::clone(&m);
+        let _ = std::thread::spawn(move || {
+            let mut g = poisoner.lock_ok();
+            g.push(2);
+            panic!("holder dies mid-update");
+        })
+        .join();
+
+        assert!(m.is_poisoned(), "precondition: the lock really is poisoned");
+        assert_eq!(*m.lock_ok(), vec![1, 2]);
+
+        let rw = Arc::new(RwLock::new(0_u8));
+        let poisoner = Arc::clone(&rw);
+        let _ = std::thread::spawn(move || {
+            *poisoner.write_ok() = 7;
+            panic!("writer dies");
+        })
+        .join();
+
+        assert!(rw.is_poisoned());
+        assert_eq!(*rw.read_ok(), 7);
+        *rw.write_ok() = 8;
+        assert_eq!(*rw.read_ok(), 8);
+    }
+}

--- a/apps/native/crates/upstream/src/refresh.rs
+++ b/apps/native/crates/upstream/src/refresh.rs
@@ -90,14 +90,16 @@ struct TokenResponse {
 fn now_unix() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
+        .map(|d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
         .unwrap_or(0)
 }
 
 fn is_expired(session: &StoredSession, skew: Duration) -> bool {
     match session.expires_at {
         None => false,
-        Some(exp) => exp - skew.as_secs() as i64 <= now_unix(),
+        Some(exp) => {
+            exp.saturating_sub(i64::try_from(skew.as_secs()).unwrap_or(i64::MAX)) <= now_unix()
+        }
     }
 }
 
@@ -247,7 +249,7 @@ impl RefreshCoordinator {
             refresh_token: token.refresh_token.or(observed.refresh_token),
             expires_at: token
                 .expires_in
-                .map(|s| now_unix() + s)
+                .map(|s| now_unix().saturating_add(s))
                 .or(observed.expires_at),
             ..observed
         };
@@ -298,7 +300,7 @@ mod tests {
                 "/api/auth/mcp/token",
                 post(
                     move |State(calls): State<Arc<AtomicUsize>>, _body: axum::body::Bytes| {
-                        let n = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                        let n = calls.fetch_add(1, Ordering::SeqCst).saturating_add(1);
                         async move {
                             Json(serde_json::json!({
                                 "access_token": format!("refreshed-{n}"),

--- a/apps/native/crates/upstream/src/session.rs
+++ b/apps/native/crates/upstream/src/session.rs
@@ -40,6 +40,7 @@
 //! problem, not a missing plugin — and why a genuine mesh-side
 //! bearer-to-session bridge was the actual fix).
 
+use crate::poison::RwLockExt;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::{Duration, Instant};
 
@@ -631,18 +632,18 @@ impl UpstreamSession {
     }
 
     async fn load_result(&self) -> Result<Option<StoredSession>, TokenStoreError> {
-        if let Some(cached) = self.0.session_cache.read().unwrap().clone() {
+        if let Some(cached) = self.0.session_cache.read_ok().clone() {
             return Ok(cached);
         }
         // Single-flight the cache miss: concurrent callers wait for ONE
         // Keychain read instead of each spawning their own (and their own
         // potential ACL prompt).
         let _guard = self.0.session_load_lock.lock().await;
-        if let Some(cached) = self.0.session_cache.read().unwrap().clone() {
+        if let Some(cached) = self.0.session_cache.read_ok().clone() {
             return Ok(cached);
         }
         let loaded = self.0.store.load(&self.0.host).await?;
-        *self.0.session_cache.write().unwrap() = Some(loaded.clone());
+        *self.0.session_cache.write_ok() = Some(loaded.clone());
         Ok(loaded)
     }
 
@@ -661,7 +662,7 @@ impl UpstreamSession {
     }
 
     fn cache_session(&self, value: Option<StoredSession>) {
-        *self.0.session_cache.write().unwrap() = Some(value);
+        *self.0.session_cache.write_ok() = Some(value);
     }
 
     fn signed_out(&self) -> StatusResult {
@@ -687,14 +688,13 @@ impl UpstreamSession {
     fn recently_validated(&self) -> bool {
         self.0
             .status_cache
-            .read()
-            .unwrap()
+            .read_ok()
             .as_ref()
             .is_some_and(|c| c.signed_in && c.checked_at.elapsed() < STATUS_CACHE_TTL)
     }
 
     fn mark_validated(&self, signed_in: bool) {
-        *self.0.status_cache.write().unwrap() = Some(StatusCache {
+        *self.0.status_cache.write_ok() = Some(StatusCache {
             checked_at: Instant::now(),
             signed_in,
         });
@@ -1004,7 +1004,7 @@ mod tests {
             },
             access_token: "access-good".to_string(),
             refresh_token: Some("refresh-good".to_string()),
-            expires_at: Some(now_unix() + 3600),
+            expires_at: Some(now_unix().saturating_add(3600)),
             created_at: "2026-01-01T00:00:00Z".to_string(),
             cookie: Some("better-auth.session_token=test".to_string()),
         }
@@ -1014,7 +1014,9 @@ mod tests {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
-            .as_secs() as i64
+            .as_secs()
+            .try_into()
+            .unwrap_or(i64::MAX)
     }
 
     async fn spawn_probe_server(behavior: ProbeBehavior) -> (String, Arc<AtomicUsize>) {
@@ -1819,7 +1821,8 @@ mod tests {
                 post(move |headers: axum::http::HeaderMap| {
                     let calls = calls_for_route.clone();
                     async move {
-                        *calls.lock().unwrap() += 1;
+                        let mut calls = calls.lock().unwrap();
+                        *calls = calls.saturating_add(1);
                         let bearer = headers
                             .get(axum::http::header::AUTHORIZATION)
                             .and_then(|v| v.to_str().ok())

--- a/apps/native/crates/upstream/src/tokens.rs
+++ b/apps/native/crates/upstream/src/tokens.rs
@@ -45,6 +45,7 @@
 //! guidance — this isn't a workaround, it's a verified, documented,
 //! deliberately-accepted default.
 
+use crate::poison::MutexExt;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
@@ -302,7 +303,7 @@ impl StableDevHelperBackend {
             .map_err(|error| helper_backend_error("launch", error))?;
         #[cfg(test)]
         if let Some(spawned_pids) = &self.spawned_pids {
-            spawned_pids.lock().unwrap().push(child.id());
+            spawned_pids.lock_ok().push(child.id());
         }
         let stdin = child
             .stdin
@@ -380,7 +381,7 @@ impl StableDevHelperBackend {
                 status
             )));
         }
-        if output.len() as u64 > MAX_HELPER_RESPONSE_BYTES {
+        if u64::try_from(output.len()).unwrap_or(u64::MAX) > MAX_HELPER_RESPONSE_BYTES {
             return Err(TokenStoreError::Backend(
                 "installed development Keychain helper response exceeded the size limit"
                     .to_string(),
@@ -588,6 +589,13 @@ impl KeychainTokenStore {
         }
     }
 
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+                  constant. `checked_add` has no honest fallback here — there \
+                  is no `Instant::MAX` to saturate to, so the call site would \
+                  have to invent a deadline. Overflow is ~584 years out."
+    )]
     async fn run_blocking<T>(
         &self,
         operation: &'static str,
@@ -744,17 +752,14 @@ pub struct InMemoryTokenStore {
 #[async_trait]
 impl TokenStore for InMemoryTokenStore {
     async fn load(&self, host: &str) -> Result<Option<StoredSession>, TokenStoreError> {
-        Ok(self.entries.lock().unwrap().get(host).cloned())
+        Ok(self.entries.lock_ok().get(host).cloned())
     }
     async fn save(&self, host: &str, session: StoredSession) -> Result<(), TokenStoreError> {
-        self.entries
-            .lock()
-            .unwrap()
-            .insert(host.to_string(), session);
+        self.entries.lock_ok().insert(host.to_string(), session);
         Ok(())
     }
     async fn clear(&self, host: &str) -> Result<(), TokenStoreError> {
-        self.entries.lock().unwrap().remove(host);
+        self.entries.lock_ok().remove(host);
         Ok(())
     }
 }
@@ -843,11 +848,7 @@ pub mod test_support {
 
         pub fn seeded(host: &str, session: StoredSession) -> Self {
             let store = Self::new();
-            store
-                .entries
-                .lock()
-                .unwrap()
-                .insert(host.to_string(), session);
+            store.entries.lock_ok().insert(host.to_string(), session);
             store
         }
     }
@@ -855,19 +856,16 @@ pub mod test_support {
     #[async_trait]
     impl TokenStore for MemoryTokenStore {
         async fn load(&self, host: &str) -> Result<Option<StoredSession>, TokenStoreError> {
-            Ok(self.entries.lock().unwrap().get(host).cloned())
+            Ok(self.entries.lock_ok().get(host).cloned())
         }
 
         async fn save(&self, host: &str, session: StoredSession) -> Result<(), TokenStoreError> {
-            self.entries
-                .lock()
-                .unwrap()
-                .insert(host.to_string(), session);
+            self.entries.lock_ok().insert(host.to_string(), session);
             Ok(())
         }
 
         async fn clear(&self, host: &str) -> Result<(), TokenStoreError> {
-            self.entries.lock().unwrap().remove(host);
+            self.entries.lock_ok().remove(host);
             Ok(())
         }
     }
@@ -934,7 +932,7 @@ mod tests {
         ) -> Result<(), TokenStoreError> {
             self.save_calls.fetch_add(1, Ordering::SeqCst);
             self.save_started.notify_one();
-            if let Some(receiver) = self.save_release.lock().unwrap().take() {
+            if let Some(receiver) = self.save_release.lock_ok().take() {
                 receiver.recv().map_err(|error| {
                     TokenStoreError::Backend(format!("fake save release failed: {error}"))
                 })?;
@@ -946,7 +944,7 @@ mod tests {
         fn clear(&self, _service: &str, _host: &str) -> Result<(), TokenStoreError> {
             self.clear_calls.fetch_add(1, Ordering::SeqCst);
             self.clear_started.notify_one();
-            if let Some(receiver) = self.clear_release.lock().unwrap().take() {
+            if let Some(receiver) = self.clear_release.lock_ok().take() {
                 receiver.recv().map_err(|error| {
                     TokenStoreError::Backend(format!("fake clear release failed: {error}"))
                 })?;
@@ -1193,7 +1191,7 @@ exec /bin/sleep 60
             ),
             "expected a typed {operation} timeout, got {error:?}"
         );
-        let pids = spawned_pids.lock().unwrap();
+        let pids = spawned_pids.lock_ok();
         assert_eq!(pids.len(), 1);
         let pid = pids[0].to_string();
         let still_alive = Command::new("/bin/kill")

--- a/apps/native/src-tauri/build.rs
+++ b/apps/native/src-tauri/build.rs
@@ -1,3 +1,8 @@
+#[expect(
+    clippy::expect_used,
+    reason = "build script: a failed Tauri build-context generation SHOULD fail the \
+              build rather than produce a broken bundle."
+)]
 fn main() {
     const COMMANDS: &[&str] = &[
         "local_api_info",

--- a/apps/native/src-tauri/src/env_path.rs
+++ b/apps/native/src-tauri/src/env_path.rs
@@ -61,6 +61,13 @@ mod unix {
     /// Login (`-l`) but NOT interactive: `-i` can block on prompt frameworks
     /// or tty access, and login config is where PATH exports belong anyway.
     /// Delimiters keep profile chatter on stdout from corrupting the value.
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+                  constant. `checked_add` has no honest fallback here — there \
+                  is no `Instant::MAX` to saturate to, so the call site would \
+                  have to invent a deadline. Overflow is ~584 years out."
+    )]
     fn probe_login_shell_path(timeout: Duration) -> Option<String> {
         let shell = std::env::var("SHELL")
             .ok()
@@ -114,9 +121,10 @@ mod unix {
     /// Pulls the PATH value out from between the probe delimiters, rejecting
     /// anything that doesn't contain at least one absolute directory.
     fn extract_delimited(output: &str) -> Option<&str> {
-        let start = output.find(DELIM_START)? + DELIM_START.len();
-        let end = output[start..].find(DELIM_END)? + start;
-        let path = &output[start..end];
+        let start = output.find(DELIM_START)?.saturating_add(DELIM_START.len());
+        let tail = output.get(start..)?;
+        let end = tail.find(DELIM_END)?;
+        let path = tail.get(..end)?;
         path.split(':')
             .any(|entry| entry.starts_with('/'))
             .then_some(path)

--- a/apps/native/src-tauri/src/lib.rs
+++ b/apps/native/src-tauri/src/lib.rs
@@ -17,6 +17,11 @@ mod ui_assets;
 mod updater;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
+#[expect(
+    clippy::exit,
+    reason = "not ours: the `exit` is inside `tauri::generate_context!`'s \
+              expansion, which we cannot annotate at the call site."
+)]
 pub fn run() {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -51,6 +56,13 @@ pub fn run() {
         builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
     }
 
+    #[expect(
+        clippy::expect_used,
+        reason = "there is no app to show an error in yet: this IS the \
+                  construction of the Tauri application, and it fails only on a \
+                  malformed bundle (bad tauri.conf.json5 / missing context), \
+                  which `tauri-build` already rejects at compile time."
+    )]
     let app = builder
         .invoke_handler(tauri::generate_handler![
             commands::local_api_info,

--- a/apps/native/src-tauri/src/local_tls.rs
+++ b/apps/native/src-tauri/src/local_tls.rs
@@ -154,6 +154,13 @@ pub fn ensure(app_root: &Path) -> Result<LocalTls, TlsError> {
     Ok(paths)
 }
 
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+              constant. `checked_add` has no honest fallback here — there \
+              is no `Instant::MAX` to saturate to, so the call site would \
+              have to invent a deadline. Overflow is ~584 years out."
+)]
 fn ca_params() -> Result<CertificateParams, rcgen::Error> {
     let mut params = CertificateParams::default();
     let mut dn = DistinguishedName::new();
@@ -187,6 +194,13 @@ fn ca_params() -> Result<CertificateParams, rcgen::Error> {
     Ok(params)
 }
 
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+              constant. `checked_add` has no honest fallback here — there \
+              is no `Instant::MAX` to saturate to, so the call site would \
+              have to invent a deadline. Overflow is ~584 years out."
+)]
 fn leaf_params() -> Result<CertificateParams, rcgen::Error> {
     let mut params = CertificateParams::default();
     let mut dn = DistinguishedName::new();

--- a/apps/native/src-tauri/src/setup.rs
+++ b/apps/native/src-tauri/src/setup.rs
@@ -147,6 +147,13 @@ fn install_signal_shutdown(app: tauri::AppHandle) {
                         signal = signal_name,
                         "second native shutdown signal received; forcing exit"
                     );
+                    #[expect(
+                        clippy::exit,
+                        reason = "forcing exit IS this branch — the comment above \
+                                  describes it as the operator's escape hatch from \
+                                  a wedged shutdown hook, which a graceful return \
+                                  cannot provide."
+                    )]
                     std::process::exit(1);
                 }
             }
@@ -259,10 +266,11 @@ pub async fn run(app: &tauri::AppHandle) -> Result<(), SetupError> {
     };
     let browser_origin = control.resolve();
     let bundled_ui = if selftest_mode || !tauri::is_dev() {
-        Some(Arc::new(
+        let assets: Arc<dyn local_api::UiAssetProvider> = Arc::new(
             crate::ui_assets::TauriUiAssets::new(app, selftest_mode)
                 .map_err(SetupError::UiAssets)?,
-        ) as Arc<dyn local_api::UiAssetProvider>)
+        );
+        Some(assets)
     } else {
         None
     };

--- a/apps/native/src-tauri/src/updater.rs
+++ b/apps/native/src-tauri/src/updater.rs
@@ -386,10 +386,11 @@ fn bundle_short_version(targz: &[u8]) -> Result<String, String> {
             .components()
             .map(|c| c.as_os_str().to_string_lossy().into_owned())
             .collect();
-        let is_bundle_plist = components.len() == 3
-            && components[0].ends_with(".app")
-            && components[1] == "Contents"
-            && components[2] == "Info.plist";
+        let is_bundle_plist = matches!(
+            components.as_slice(),
+            [bundle, contents, plist]
+                if bundle.ends_with(".app") && contents == "Contents" && plist == "Info.plist"
+        );
         if !is_bundle_plist {
             continue;
         }
@@ -451,9 +452,16 @@ fn decide(
     Decision::Attempt
 }
 
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "deadline math: `Instant`/`OffsetDateTime` plus a bounded \
+              constant. `checked_add` has no honest fallback here — there \
+              is no `Instant::MAX` to saturate to, so the call site would \
+              have to invent a deadline. Overflow is ~584 years out."
+)]
 fn record_failure(memo: Option<FailureMemo>, version: &str, now: Instant) -> FailureMemo {
     let attempts = match &memo {
-        Some(memo) if memo.version == version => memo.attempts + 1,
+        Some(memo) if memo.version == version => memo.attempts.saturating_add(1),
         _ => 1,
     };
     FailureMemo {
@@ -466,7 +474,7 @@ fn record_failure(memo: Option<FailureMemo>, version: &str, now: Instant) -> Fai
 /// 1h, 2h, 4h, 8h, 16h, 24h cap.
 fn backoff_after(attempts: u32) -> Duration {
     let hours = 1u64 << attempts.saturating_sub(1).min(5);
-    Duration::from_secs(hours.min(24) * 3600)
+    Duration::from_secs(hours.min(24).saturating_mul(3600))
 }
 
 #[cfg(test)]
@@ -551,7 +559,7 @@ mod tests {
         let mut builder = tar::Builder::new(Vec::new());
         let mut add = |path: &str, contents: &str| {
             let mut header = tar::Header::new_gnu();
-            header.set_size(contents.len() as u64);
+            header.set_size(u64::try_from(contents.len()).unwrap_or(u64::MAX));
             header.set_mode(0o644);
             header.set_cksum();
             builder


### PR DESCRIPTION
## Summary

CI already ran `cargo clippy --workspace --all-targets -- -D warnings` for the desktop app ([`native.yml`'s `rust-checks`](https://github.com/decocms/studio/blob/main/.github/workflows/native.yml)), but the only lints configured were `unsafe_code = "deny"` and `clippy::all = "warn"`. Nothing stopped a production path from taking the app down on an unwrap, a slice index, or an integer overflow.

This turns on the whole panic family in `[workspace.lints.clippy]` and **fixes all 384 production sites** it reports.

| lint | sites fixed |
|---|---:|
| `arithmetic_side_effects` | 129 |
| `indexing_slicing` | 72 |
| `unwrap_used` | 68 |
| `as_conversions` | 54 |
| `string_slice` | 21 |
| `expect_used` | 19 |
| `unreachable` | 10 |
| `exit` | 6 |
| `unchecked_time_subtraction` | 2 |
| `panic`, `panic_in_result_fn`, `nonminimal_bool` | 3 |

Levels stay `warn` in the manifest — a `deny` there breaks `cargo build`/`check`, not just clippy — and CI's `-D warnings` promotes them, per that file's existing note.

**`clippy.toml`** exempts `#[cfg(test)]` from the panic lints: an unwrap in a test *is* the assertion. Without it the family reports ~3250 sites, ~2900 of them inside test blocks.

**`clippy::pedantic` + `clippy::nursery` are deliberately not enabled**: 1228 sites, overwhelmingly style (`doc_markdown`, `use_self`, `must_use_candidate`), for no crash-safety gain. Separate PR if wanted.

## Beyond the mechanical fixes

- **New `upstream::poison`** (`lock_ok`/`read_ok`/`write_ok`) replaces 42 production `lock().unwrap()`s. A poisoned lock now recovers the guard rather than cascading one task's panic into the request path, the task registry, and the event stream. The policy is documented once, with a test. Test code keeps `lock().unwrap()`.
- **`SandboxManager::new` is fallible.** It aborted the process when the registry SQLite file would not open — a file on the *user's* disk, so a bad permission or wedged volume killed the app. Its one production caller already returned `Result`; this now surfaces as `StartError::SandboxRegistry` through the boot-failure dialog.
- **`send_once_no_bearer` returns `Result<_, String>`.** Both callers carried `unreachable!("never returns HardUnauthorized")`. The narrower type deletes them and makes future drift a compile error instead of a runtime abort.
- **Migration-table invariant moved to a test.** `migrate()` asserted `MIGRATIONS` contiguity on every boot — a property of the *source file*, not of the user's database — and only over the `> found` slice, so a gap below an existing DB's version was invisible. `migration_table_is_contiguous` now checks the whole table.
- **Latent underflow fixed** in `sandbox::preview_label`: `slug.len() > room` compares BYTES against a char budget, so `chars().count() - room` could panic on a multi-byte slug.
- **`compute_diff_against_base`** narrows `head_sha` into one `Option` instead of an `Option` plus a parallel bool — removes six `unwrap()`s.
- **`clone_fresh`** reads `controller.requested()` once. It was read in a match guard and again in the arm body, where the two answers could disagree.
- **Fixes a `nonminimal_bool`** in `tasks/registry.rs` that `clippy::all` *already* covered — the clippy gate breaks the moment the runner picks up a current stable clippy (local 0.1.96 already flags it).

## Deliberate escapes

52 `#[expect(...)]`, each with a `reason`, concentrated in:

- **Hinnant's calendar kernel** (2 fns) — every intermediate is proven in range for the `SystemTime` domain; rewriting as `checked_*` would obscure the published algorithm. Pinned by the existing round-trip test.
- **`Instant + Duration` deadline math** (17) — there is no `Instant::MAX` for `checked_add` to saturate to, so every call site would have to invent a deadline. (Tried scoping this via `clippy.toml`'s `arithmetic-side-effects-allowed-binary`; it has no effect on this clippy version.)
- **Source-literal regexes** (6) — backed by a new `static_regexes_compile` test that forces each `LazyLock`.
- **Process exits** (5) — the binary's entry point and the two build scripts.
- **Saturating float casts** (2) — float→int `as` is defined saturating behavior and there is no `TryFrom<f64> for usize`.

## Testing

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --workspace` — **971 pass**

One **pre-existing** failure, `setup::clone::tests::case_colliding_remote_branches_survive_on_a_files_backend_mirror`, reproduces unchanged on a clean tree (`git stash`-verified; introduced in #4178). Not touched here — the name suggests APFS case-insensitivity. Worth its own issue.

## Affected areas

`apps/native` only — the `crates/{local-api,harness,upstream}` + `src-tauri` cargo workspace. No wire-contract or behavior changes except the three noted above (`SandboxManager::new`, `send_once_no_bearer`, and 416 instead of a panic on an out-of-range WebDAV byte range).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables clippy’s panic-family lints across the native Rust workspace and fixes 384 sites to prevent crashes from unwraps, indexing, and overflows. Adds safe lock helpers and surfaces operational errors instead of aborting in several paths.

- New Features
  - Enabled panic-family lints in `[workspace.lints.clippy]` and exempted tests via `apps/native/clippy.toml`; CI promotes warnings to errors.
  - Added `upstream::poison` with `lock_ok`/`read_ok`/`write_ok` to recover from poisoned locks (replaces 40+ `lock().unwrap()` call sites).
  - Made `SandboxManager::new` fallible; failures bubble as `StartError::SandboxRegistry` to the boot-failure dialog.
  - Narrowed `send_once_no_bearer` to `Result<_, String>` to remove unreachable auth branches.

- Bug Fixes
  - Removed crash paths across crates: replaced unwraps and unchecked indexes, used saturating/checked math, bounds-checked slicing, and safer JSON/string handling.
  - WebDAV invalid byte ranges now return 416 instead of panicking.
  - Spawn errors are explicit when a configured pipe is missing (no app abort).
  - Added targeted `#[expect(...)]` with reasons for vetted cases (deadline math, known-good regexes, Hinnant calendar kernel).

<sup>Written for commit 51b3f0a54f95700a501627f9b692d15d5892b6b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

