### PR TITLE
fix(sandbox): cap the Go daemon's plain-text read path at 10MB

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/fs.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	maxImageBytes    = 5 * 1024 * 1024
+	maxTextBytes     = 10 * 1024 * 1024
 	maxTransferBytes = 500 * 1024 * 1024
 	transferDeadline = 5 * time.Minute
 )
@@ -131,6 +132,11 @@ func Read(deps FsDeps) http.HandlerFunc {
 
 		if bytes.IndexByte(probe, 0) >= 0 {
 			httpx.Error(w, 400, "File appears to be binary and is not a supported image format (jpeg/png/gif/webp).")
+			return
+		}
+
+		if stat.Size() > maxTextBytes {
+			httpx.Error(w, 400, fmt.Sprintf("File too large (%d bytes; cap is %d)", stat.Size(), maxTextBytes))
 			return
 		}
 

--- a/packages/sandbox/daemon-go/internal/routes/fs_read_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs_read_test.go
@@ -1,0 +1,62 @@
+package routes
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newReadRequest(t *testing.T, path string) *http.Request {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{"path": path})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	return httptest.NewRequest(http.MethodPost, "/_sandbox/read", bytes.NewReader(body))
+}
+
+// TestReadRejectsOversizedTextFile guards the untrusted-size boundary on a
+// route the sandbox exposes to any tool call: without a cap, a large text
+// file in the repo (a generated log, a user commit) reads the whole thing
+// into memory multiple times over, which can OOM the daemon and take the
+// sandbox down.
+func TestReadRejectsOversizedTextFile(t *testing.T) {
+	repoDir := t.TempDir()
+	big := strings.Repeat("a", maxTextBytes+1)
+	filePath := filepath.Join(repoDir, "big.txt")
+	if err := os.WriteFile(filePath, []byte(big), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	handler := Read(FsDeps{AppRoot: repoDir, RepoDir: repoDir})
+	rec := httptest.NewRecorder()
+	handler(rec, newReadRequest(t, "big.txt"))
+
+	if rec.Code != 400 {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "too large") {
+		t.Fatalf("body = %s, want a too-large error", rec.Body.String())
+	}
+}
+
+func TestReadAllowsFileUnderCap(t *testing.T) {
+	repoDir := t.TempDir()
+	filePath := filepath.Join(repoDir, "small.txt")
+	if err := os.WriteFile(filePath, []byte("hello\nworld\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	handler := Read(FsDeps{AppRoot: repoDir, RepoDir: repoDir})
+	rec := httptest.NewRecorder()
+	handler(rec, newReadRequest(t, "small.txt"))
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
**Source**: bug found while auditing `packages/sandbox/daemon-go/internal/routes/fs.go` for the sandbox daemon focus area. A prior attempt at this same fix (on the now-deleted TS daemon) was blocked pre-open for an unrelated oversized diff — this is a small, isolated fix on the Go daemon, which is now the only daemon.

**Why a maintainer wants this**: the `/read` route caps images at 5MB (`maxImageBytes`) and file transfers at 500MB (`maxTransferBytes`), but the plain-text branch has no cap at all — `os.ReadFile` loads the whole file, then `strings.Split` and the response `strings.Builder` each hold another full copy. A large text file anywhere in the repo (a generated log, a committed fixture, a build artifact) turns one `/read` tool call into a multi-hundred-MB memory spike. Per the repo's own docs, Studio marks a sandbox **dead on a single missed health probe** and tears the pod down — so an OOM here doesn't just fail one call, it kills the sandbox.

**Failure scenario**: any tool/agent calls `/read` on a text file larger than a few hundred MB sitting in the sandbox's working tree → the daemon reads it into memory 2-3x over → OOM → health probe miss → Studio tears the sandbox down mid-session.

**Fix**: added a `maxTextBytes = 10 * 1024 * 1024` cap (matching the daemon's existing `installLogMaxBytes` convention) checked via `stat.Size()` before the `os.ReadFile` call, returning the same shaped 400 error the image-size cap already uses. Regression test (`fs_read_test.go`) exercises both the oversized-file rejection and that an under-cap file still reads fine.

**Reviewer command**: `cd packages/sandbox/daemon-go && go test ./internal/routes/... -run TestRead -v`

**Locally verified**: `go build ./...`, `go test ./...` (full package, all green), `go vet ./internal/routes/...`, `gofmt -l` (clean) on both changed files. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap the sandbox daemon’s `/read` plain-text path at 10MB to prevent large-file OOMs that can kill the sandbox. Adds a size check before reading and returns a 400 error for oversized files.

- **Bug Fixes**
  - Add `maxTextBytes = 10 * 1024 * 1024` in `packages/sandbox/daemon-go/internal/routes/fs.go`; reject files over cap with 400.
  - Check `stat.Size()` before `os.ReadFile` to avoid large allocations.
  - Add `fs_read_test.go` tests for oversized rejection and an allowed under-cap read.

<sup>Written for commit bb157ba2514d6134b0b7c1a1854da1565ed27072. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

