### PR TITLE
fix(decopilot): bind hosted runs to thread authority

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -90,6 +90,7 @@ import { resolveThreadStatus } from "./status";
 import type { StreamBuffer } from "./stream-buffer";
 import type { ChatMessage, ModelsConfig as ClientModelsConfig } from "./types";
 import type { CancelBroadcast } from "./cancel-broadcast";
+import { resolveThreadAuthority } from "@/core/thread-authority";
 import { meter, traced } from "@/observability";
 import { safeMemoryUsage } from "@/observability/profiling/safe-memory";
 import { getPodId } from "@/core/pod-identity";
@@ -511,7 +512,6 @@ function dispatchRunSpanAttrs(
 ): Record<string, string> {
   const clientModels = input.models;
   return {
-    "decopilot.agent.id": input.agent.id,
     "decopilot.model.id": clientModels.thinking.id,
     "decopilot.credential.id": clientModels.credentialId,
     "decopilot.organization.id": input.organizationId,
@@ -765,6 +765,50 @@ async function prepareRun(
   let taskId: string | undefined;
 
   try {
+    if (!input.taskId) {
+      throw new Error("dispatchRunAndWait: taskId is required");
+    }
+    const windowSize = input.windowSize ?? DEFAULT_WINDOW_SIZE;
+
+    // The persisted thread is the authority for both ownership and agent
+    // identity. Resolve it before credentials, model permissions, status
+    // publication, or run-state writes. `input.agent` remains in the durable
+    // shape only so old DBOS payloads deserialize; it never selects execution.
+    const mem = await createMemory(ctx.storage.threads, {
+      organization_id: input.organizationId,
+      thread_id: input.taskId,
+      userId: input.userId,
+      defaultWindowSize: windowSize,
+    });
+    const { agentId } = resolveThreadAuthority(mem.thread, {
+      organizationId: input.organizationId,
+      userId: input.userId,
+    });
+    const authoritativeAgent: AgentConfig = { id: agentId };
+    if (input.agent?.id && input.agent.id !== agentId) {
+      console.warn("decopilot.dispatch: ignored stale payload agent", {
+        threadId: mem.thread.id,
+        requested: input.agent.id,
+        authoritative: agentId,
+      });
+    }
+
+    // Normal rows are scoped by VirtualMCPStorage.findById's SQL predicate;
+    // retain the explicit entity check for synthesized well-known agents and
+    // defense in depth if another storage adapter is introduced.
+    const virtualMcp = await ctx.storage.virtualMcps.findById(
+      agentId,
+      input.organizationId,
+    );
+    if (!virtualMcp || virtualMcp.organization_id !== input.organizationId) {
+      throw new PermanentRunError("agent_not_found", "Agent not found");
+    }
+
+    taskId = mem.thread.id;
+    ctx.metadata.threadId = mem.thread.id;
+    rootSpan.setAttribute("decopilot.thread.id", mem.thread.id);
+    rootSpan.setAttribute("decopilot.agent.id", agentId);
+
     // The HTTP layer still sends the CLIENT models shape (root credentialId,
     // optional client-only extras like `capabilities`). Everything below the
     // normalization call uses the per-slot v2 `models`.
@@ -818,11 +862,6 @@ async function prepareRun(
     // added here when they gain a producer.
     models = filterToolTiersByPermission(allowedModels, models);
 
-    const windowSize = input.windowSize ?? DEFAULT_WINDOW_SIZE;
-
-    if (!input.taskId) {
-      throw new Error("dispatchRunAndWait: taskId is required");
-    }
     if (shouldPublishRunStatus) {
       await publishRunStatusStage(
         streamBuffer,
@@ -845,37 +884,23 @@ async function prepareRun(
           )
         : Promise.resolve(undefined);
     const [
-      virtualMcp,
       thinkingSource,
       fastSource,
       smartSource,
       imageSource,
       webSearchSource,
       deepResearchSource,
-      mem,
       userContext,
     ] = await Promise.all([
-      ctx.storage.virtualMcps.findById(input.agent.id, input.organizationId),
       resolveSlot(models.thinking),
       resolveSlot(models.fast),
       resolveSlot(models.smart),
       resolveSlot(models.image),
       resolveSlot(models.webSearch),
       resolveSlot(models.deepResearch),
-      createMemory(ctx.storage.threads, {
-        organization_id: input.organizationId,
-        thread_id: input.taskId,
-        userId: input.userId,
-        defaultWindowSize: windowSize,
-      }),
       // Pre-resolve threads/interests/sibling-agents agent-side so the portable
       // prompt builder renders them without any `ctx.storage` reach-in.
-      resolveUserContext(
-        ctx,
-        input.organizationId,
-        input.agent.id,
-        input.userId,
-      ),
+      resolveUserContext(ctx, input.organizationId, agentId, input.userId),
     ]);
     if (shouldPublishRunStatus) {
       await publishRunStatusStage(
@@ -899,16 +924,6 @@ async function prepareRun(
     const primaryProvider = thinkingSource
       ? createProviderFromSecret(thinkingSource)
       : null;
-
-    taskId = mem.thread.id;
-    ctx.metadata.threadId = mem.thread.id;
-    rootSpan.setAttribute("decopilot.thread.id", mem.thread.id);
-
-    if (mem.thread.created_by !== input.userId) {
-      throw new Error(
-        "You are not allowed to write to this thread because you are not the owner",
-      );
-    }
 
     // Guard: async-research-only models (e.g. Gemini Deep Research) cannot
     // drive `streamText`. They only work via the AsyncResearchProvider path
@@ -954,12 +969,9 @@ async function prepareRun(
         })
       : null;
 
-    if (!virtualMcp) {
-      throw new PermanentRunError("agent_not_found", "Agent not found");
-    }
     const effectiveVirtualMcp = await resolveEffectiveVirtualMcpForHarness({
       virtualMcp,
-      agentId: input.agent.id,
+      agentId,
       organizationId: input.organizationId,
       ctx,
     });
@@ -984,7 +996,7 @@ async function prepareRun(
         podId: getPodId(),
         runConfig: {
           models: input.models,
-          agent: input.agent,
+          agent: authoritativeAgent,
           temperature: input.temperature,
           toolApprovalLevel: input.toolApprovalLevel,
           mode: input.mode,
@@ -1232,7 +1244,7 @@ async function prepareRun(
       user: { id: input.userId, email: ctx.auth.user?.email ?? "" },
       organizationId: input.organizationId,
       organizationSlug: organization.slug,
-      agent: { id: input.agent.id, instructions: agentInstructions },
+      agent: { id: agentId, instructions: agentInstructions },
       triggerId: input.triggerId,
       currentThreadTitle: mem.thread.title,
       runFenceToken,
@@ -1438,7 +1450,7 @@ async function prepareRun(
                 properties: {
                   organization_id: input.organizationId,
                   thread_id: mem.thread.id,
-                  agent_id: input.agent.id,
+                  agent_id: agentId,
                   model_id: models.thinking.id,
                   mode: input.mode,
                   duration_ms: Date.now() - streamStartAt,

--- a/apps/api/src/api/routes/decopilot/routes.ts
+++ b/apps/api/src/api/routes/decopilot/routes.ts
@@ -61,6 +61,10 @@ import {
   listThreadGateQueue,
 } from "@/dispatch-queue/thread-gate-queue";
 import { type QueuePartRow, foldQueueHydration } from "./queue-text";
+import {
+  ThreadAuthorityError,
+  resolveThreadAuthority,
+} from "@/core/thread-authority";
 
 // Per-connection /stream tail diagnostics. Flip to "1" in an environment where
 // the live stream intermittently delivers no chunks — logs the resolved
@@ -151,6 +155,55 @@ async function validateRequest(
   };
 }
 
+function resolveHttpThreadAuthority(
+  thread: Pick<Thread, "organization_id" | "created_by" | "virtual_mcp_id">,
+  expected: {
+    organizationId: string;
+    userId: string;
+    requestedAgentId?: string;
+  },
+): { agentId: string } {
+  try {
+    return resolveThreadAuthority(thread, expected);
+  } catch (error) {
+    if (!(error instanceof ThreadAuthorityError)) throw error;
+    if (error.reason === "organization_mismatch") {
+      throw new HTTPException(404, { message: "Thread not found" });
+    }
+    if (error.reason === "owner_mismatch") {
+      throw new HTTPException(403, { message: "Not authorized" });
+    }
+    throw new HTTPException(409, { message: error.message });
+  }
+}
+
+/**
+ * Resolve the hosted agent from the thread row and prove that it belongs to
+ * the path-resolved organization. The legacy request `agent.id` is only a
+ * consistency assertion; it never selects the executing Virtual MCP.
+ */
+async function requireHostedThreadAgent(
+  ctx: StudioContext,
+  thread: Pick<Thread, "organization_id" | "created_by" | "virtual_mcp_id">,
+  expected: {
+    organizationId: string;
+    userId: string;
+    requestedAgentId?: string;
+  },
+): Promise<string> {
+  const { agentId } = resolveHttpThreadAuthority(thread, expected);
+  const virtualMcp = await ctx.storage.virtualMcps.findById(
+    agentId,
+    expected.organizationId,
+  );
+  if (!virtualMcp || virtualMcp.organization_id !== expected.organizationId) {
+    throw new HTTPException(409, {
+      message: "Thread agent is unavailable in this organization",
+    });
+  }
+  return agentId;
+}
+
 // ============================================================================
 // Per-Request Model Resolution
 // ============================================================================
@@ -237,9 +290,9 @@ async function resolvePerRequestModels(
  * dispatch, given the values the client supplied and the (possibly
  * locked) thread row.
  *
- * Once a thread row carries a non-null `harness_id`, the thread's
- * runtime is pinned for life: the row's values win and any
- * client-provided override is silently dropped. If the row is unlocked
+ * Once a thread row carries a non-null `harness_id`, persisted runtime state
+ * wins and any client-provided override is silently dropped. Trusted runtime
+ * tools may still evolve server-owned state such as the repository branch. If the row is unlocked
  * (`harness_id == null`) or there's no thread at all (first message of
  * a freshly-created thread, or `taskIdInput === undefined`) we fall
  * back to the client values.
@@ -448,16 +501,34 @@ async function validate(
     throw new HTTPException(401, { message: "User ID is required" });
   }
 
+  // Resolve authority before model selection or any message/runtime write.
+  // The thread row owns both the user and Virtual MCP identities; the legacy
+  // request agent is accepted only when it agrees with that row.
+  if (!taskIdInput) {
+    throw new HTTPException(400, { message: "threadId is required" });
+  }
+  const lockedThread = await ctx.storage.threads.get(taskIdInput);
+  if (!lockedThread) {
+    throw new HTTPException(404, { message: "Thread not found" });
+  }
+  const authoritativeAgentId = await requireHostedThreadAgent(
+    ctx,
+    lockedThread,
+    {
+      organizationId: organization.id,
+      userId,
+      requestedAgentId: agent.id,
+    },
+  );
+
   // Lock guard: once a thread row carries a non-null `harness_id`, the
-  // thread's runtime (harness, sandbox provider, branch) is pinned for
-  // life. Any client-provided override is silently dropped. Native harnesses
+  // thread's persisted runtime (harness, sandbox provider, branch) wins over
+  // client-provided overrides. Trusted runtime tools may still evolve
+  // server-owned state such as the repository branch. Native harnesses
   // are then rejected before model resolution or any message/pin write.
   //
   // See spec:
   // docs/superpowers/specs/2026-06-03-lock-thread-harness-and-branch-design.md
-  const lockedThread = taskIdInput
-    ? await ctx.storage.threads.get(taskIdInput)
-    : null;
   const {
     harnessId: effectiveHarnessId,
     sandboxProviderKind: effectiveSandboxProviderKind,
@@ -502,7 +573,7 @@ async function validate(
   return {
     messages: [...systemMessages, requestMessage],
     models,
-    agent,
+    agent: { id: authoritativeAgentId },
     temperature,
     toolApprovalLevel,
     mode,
@@ -595,11 +666,22 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         throw new HTTPException(400, { message: "threadId is required" });
       }
 
-      // Re-read the canonical row for its pin and message-storage version.
-      // Only a real null uses the legacy create-on-send path. A storage error
-      // must fail closed: treating it as a missing row could race a native pin
-      // and enqueue hosted work against the newly native thread.
+      // Re-read the canonical row for its pin, agent, and message-storage
+      // version. A storage error must fail closed so a disappearing row cannot
+      // enqueue hosted work.
       const existingThread = await ctx.storage.threads.get(taskId);
+      if (!existingThread) {
+        throw new HTTPException(404, { message: "Thread not found" });
+      }
+      let authoritativeAgentId = await requireHostedThreadAgent(
+        ctx,
+        existingThread,
+        {
+          organizationId: input.organizationId,
+          userId: input.userId,
+          requestedAgentId: input.agent.id,
+        },
+      );
 
       // Fall back to the "ephemeral" synthetic branch when neither the
       // thread row nor the request body pins one. Synthetic branches
@@ -608,17 +690,17 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       // out — exactly the right semantics for Decopilot threads on
       // agents with no clonable repo, where the branch is purely an
       // isolation key.
-      let branch = existingThread?.branch ?? input.branch ?? "ephemeral";
+      let branch = existingThread.branch ?? input.branch ?? "ephemeral";
 
       // Determine the pinned (kind, harness). If the thread row has them,
       // use those. Otherwise this is the first message — derive defaults and
       // persist to the thread row.
-      let pinnedKind = (existingThread?.sandbox_provider_kind ??
+      let pinnedKind = (existingThread.sandbox_provider_kind ??
         null) as SandboxProviderKind | null;
 
-      let pinnedHarness = (existingThread?.harness_id ??
+      let pinnedHarness = (existingThread.harness_id ??
         null) as HarnessId | null;
-      let messageStorageVersion = existingThread?.message_storage_version ?? 2;
+      let messageStorageVersion = existingThread.message_storage_version;
 
       // The row may have changed between validate() and this canonical re-read.
       // Re-assert before the initial-pin branch so a persisted non-hosted
@@ -634,42 +716,51 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         pinnedHarness = pinnedHarness ?? input.harnessId ?? "decopilot";
         assertHostedRuntime(pinnedHarness, pinnedKind);
 
-        if (existingThread) {
-          // Stream-of-record v2 is the ONLY write path (Phase C cutover). Pin
-          // every NEW thread (no prior messages, not already v2) to v2 so the
-          // ingest → JetStream → durable-projector pipeline persists its parts.
-          // Pre-existing v1 threads WITH history stay v1: deprecated read-only
-          // legacy — their `thread_messages` rows still render via the v1 read
-          // path; no backfill. The message-count probe only runs for not-yet-v2
-          // threads, so already-v2 threads add no DB read.
-          let pinV2 = false;
-          if (existingThread.message_storage_version !== 2) {
-            try {
-              const { total } = await ctx.storage.threads.listMessages(taskId, {
-                limit: 1,
-              });
-              pinV2 = total === 0;
-            } catch {
-              pinV2 = false;
-            }
+        // Stream-of-record v2 is the ONLY write path (Phase C cutover). Pin
+        // every NEW thread (no prior messages, not already v2) to v2 so the
+        // ingest → JetStream → durable-projector pipeline persists its parts.
+        // Pre-existing v1 threads WITH history stay v1: deprecated read-only
+        // legacy — their `thread_messages` rows still render via the v1 read
+        // path; no backfill. The message-count probe only runs for not-yet-v2
+        // threads, so already-v2 threads add no DB read.
+        let pinV2 = false;
+        if (existingThread.message_storage_version !== 2) {
+          try {
+            const { total } = await ctx.storage.threads.listMessages(taskId, {
+              limit: 1,
+            });
+            pinV2 = total === 0;
+          } catch {
+            pinV2 = false;
           }
-          // Claim all runtime pins in one CAS. A native start can race this
-          // request, so an unconditional update would let the hosted path
-          // overwrite a runtime that became native after our preceding read.
-          const claimed = await ctx.storage.threads.pinRuntimeIfUnset(taskId, {
-            harnessId: pinnedHarness,
-            sandboxProviderKind: pinnedKind,
-            branch,
-            ...(pinV2 ? { messageStorageVersion: 2 } : {}),
-          });
-          if (!claimed.thread) {
-            throw new HTTPException(404, { message: "Thread not found" });
-          }
-          pinnedHarness = claimed.thread.harness_id as HarnessId | null;
-          pinnedKind = claimed.thread
-            .sandbox_provider_kind as SandboxProviderKind | null;
-          branch = claimed.thread.branch ?? "ephemeral";
-          messageStorageVersion = claimed.thread.message_storage_version;
+        }
+        // Claim all runtime pins in one CAS. A native start can race this
+        // request, so an unconditional update would let the hosted path
+        // overwrite a runtime that became native after our preceding read.
+        const claimed = await ctx.storage.threads.pinRuntimeIfUnset(taskId, {
+          harnessId: pinnedHarness,
+          sandboxProviderKind: pinnedKind,
+          branch,
+          ...(pinV2 ? { messageStorageVersion: 2 } : {}),
+        });
+        if (!claimed.thread) {
+          throw new HTTPException(404, { message: "Thread not found" });
+        }
+        pinnedHarness = claimed.thread.harness_id as HarnessId | null;
+        pinnedKind = claimed.thread
+          .sandbox_provider_kind as SandboxProviderKind | null;
+        branch = claimed.thread.branch ?? "ephemeral";
+        messageStorageVersion = claimed.thread.message_storage_version;
+        if (claimed.thread.virtual_mcp_id !== authoritativeAgentId) {
+          authoritativeAgentId = await requireHostedThreadAgent(
+            ctx,
+            claimed.thread,
+            {
+              organizationId: input.organizationId,
+              userId: input.userId,
+              requestedAgentId: input.agent.id,
+            },
+          );
         }
       }
       pinnedKind =
@@ -738,10 +829,13 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         await emitter.emitRequestMessage(persistedRequestMessage);
       }
 
-      const serializableRequest = buildDurableDispatchInput(input, {
-        messageId,
-        branch,
-      });
+      const serializableRequest = buildDurableDispatchInput(
+        { ...input, agent: { id: authoritativeAgentId } },
+        {
+          messageId,
+          branch,
+        },
+      );
       // The workflow body emits `chat_message_started` inside a DBOS step,
       // so idempotent retries that collapse onto an existing workflowID
       // don't double-count in PostHog. Don't add a duplicate emit here.

--- a/apps/api/src/core/thread-authority.test.ts
+++ b/apps/api/src/core/thread-authority.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ThreadAuthorityError,
+  resolveThreadAuthority,
+} from "./thread-authority";
+
+const thread = {
+  organization_id: "org-1",
+  created_by: "user-1",
+  virtual_mcp_id: "agent-canonical",
+};
+
+describe("resolveThreadAuthority", () => {
+  test("derives the executing agent from the persisted thread", () => {
+    expect(
+      resolveThreadAuthority(thread, {
+        organizationId: "org-1",
+        userId: "user-1",
+      }),
+    ).toEqual({ agentId: "agent-canonical" });
+  });
+
+  test("accepts a matching legacy request agent", () => {
+    expect(
+      resolveThreadAuthority(thread, {
+        organizationId: "org-1",
+        userId: "user-1",
+        requestedAgentId: "agent-canonical",
+      }),
+    ).toEqual({ agentId: "agent-canonical" });
+  });
+
+  test("rejects a request that tries to select another agent", () => {
+    expect(() =>
+      resolveThreadAuthority(thread, {
+        organizationId: "org-1",
+        userId: "user-1",
+        requestedAgentId: "agent-from-request",
+      }),
+    ).toThrow("Requested agent does not match this thread");
+  });
+
+  test("checks ownership before considering the request agent", () => {
+    try {
+      resolveThreadAuthority(thread, {
+        organizationId: "org-1",
+        userId: "another-user",
+        requestedAgentId: "agent-from-request",
+      });
+      throw new Error("Expected thread authority to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ThreadAuthorityError);
+      expect((error as ThreadAuthorityError).reason).toBe("owner_mismatch");
+    }
+  });
+
+  test("rejects a thread from another organization", () => {
+    expect(() =>
+      resolveThreadAuthority(thread, {
+        organizationId: "org-2",
+        userId: "user-1",
+      }),
+    ).toThrow("Thread does not belong to this organization");
+  });
+
+  test("rejects empty and whitespace-only persisted agent ids", () => {
+    for (const virtual_mcp_id of ["", "   "]) {
+      expect(() =>
+        resolveThreadAuthority(
+          { ...thread, virtual_mcp_id },
+          { organizationId: "org-1", userId: "user-1" },
+        ),
+      ).toThrow("Thread has no assigned agent");
+    }
+  });
+});

--- a/apps/api/src/core/thread-authority.ts
+++ b/apps/api/src/core/thread-authority.ts
@@ -1,0 +1,67 @@
+import type { Thread } from "@/storage/types";
+
+type ThreadAuthorityFailure =
+  | "organization_mismatch"
+  | "owner_mismatch"
+  | "agent_missing"
+  | "agent_mismatch";
+
+export class ThreadAuthorityError extends Error {
+  constructor(
+    readonly reason: ThreadAuthorityFailure,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ThreadAuthorityError";
+  }
+}
+
+/**
+ * Resolve the identities that authorize a hosted run from the persisted
+ * thread. Request and durable-workflow payloads are snapshots, so neither is
+ * allowed to choose the agent that executes a thread.
+ *
+ * `requestedAgentId` is used only at the HTTP boundary, where a mismatched
+ * legacy field is rejected before any write. Durable callers omit it so an old
+ * DBOS payload can still replay safely after the thread becomes authoritative.
+ */
+export function resolveThreadAuthority(
+  thread: Pick<Thread, "organization_id" | "created_by" | "virtual_mcp_id">,
+  expected: {
+    organizationId: string;
+    userId: string;
+    requestedAgentId?: string;
+  },
+): { agentId: string } {
+  if (thread.organization_id !== expected.organizationId) {
+    throw new ThreadAuthorityError(
+      "organization_mismatch",
+      "Thread does not belong to this organization",
+    );
+  }
+  if (thread.created_by !== expected.userId) {
+    throw new ThreadAuthorityError(
+      "owner_mismatch",
+      "You are not allowed to write to this thread because you are not the owner",
+    );
+  }
+
+  const agentId = thread.virtual_mcp_id.trim();
+  if (!agentId) {
+    throw new ThreadAuthorityError(
+      "agent_missing",
+      "Thread has no assigned agent",
+    );
+  }
+  if (
+    expected.requestedAgentId !== undefined &&
+    expected.requestedAgentId !== agentId
+  ) {
+    throw new ThreadAuthorityError(
+      "agent_mismatch",
+      "Requested agent does not match this thread",
+    );
+  }
+
+  return { agentId };
+}

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -5,6 +5,6 @@
   "dispatch-queue/hosted-harness-workflow.ts": "5a196c0348f238670f2b68297a7fe001128996003567ab87bb6c0c6ba9d38810",
   "dispatch-queue/thread-gate-workflow.ts": "ba06fe1d3b577d0f63fd8156795a94c4ff5c81fd216ae2b5b1e72cf74d694055",
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",
-  "harnesses/decopilot/background-tool-workflow.ts": "c77d5e8820f949280a52309c6eb4653318f8e515513474c11f924a91c62e20ec",
+  "harnesses/decopilot/background-tool-workflow.ts": "06948ef04f10640aec3895f22e938b964bedb2376e73710623381e8242f868d8",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8"
 }

--- a/apps/api/src/harnesses/decopilot/background-tool-workflow.ts
+++ b/apps/api/src/harnesses/decopilot/background-tool-workflow.ts
@@ -33,6 +33,7 @@ import { ingestRun } from "@/api/routes/decopilot/ingest-run";
 import type { StreamBuffer } from "@/api/routes/decopilot/stream-buffer";
 import type { UIMessageChunk } from "ai";
 import { isHostedDecopilotRuntime } from "./hosted-runtime";
+import { resolveThreadAuthority } from "@/core/thread-authority";
 
 // Re-export from the side-effect-free `queue-names` module so `index.ts` can
 // reference the name without importing this module (which registers a workflow).
@@ -198,29 +199,28 @@ export function isHostedDecopilotThread(
 
 async function requireHostedThreadContext(
   ctx: BackgroundToolContext,
-): Promise<StudioContext> {
+): Promise<{ studioCtx: StudioContext; agentId: string }> {
   const studioCtx = await requireStudioContext(ctx);
   const thread = await studioCtx.storage.threads.get(ctx.threadId);
-  if (!isHostedDecopilotThread(thread)) {
+  if (!thread || !isHostedDecopilotThread(thread)) {
     throw new Error(
       `[background-tool] thread ${ctx.threadId} is not hosted Decopilot`,
     );
   }
-  return studioCtx;
-}
-
-/** Resolve a thread row only when it still belongs to hosted Decopilot. */
-function resolveThreadTarget(
-  thread:
-    | {
-        harness_id?: string | null;
-        sandbox_provider_kind?: string | null;
-      }
-    | null
-    | undefined,
-): { harnessId: "decopilot" } | null {
-  if (!isHostedDecopilotThread(thread)) return null;
-  return { harnessId: "decopilot" };
+  const { agentId } = resolveThreadAuthority(thread, {
+    organizationId: ctx.orgId,
+    userId: ctx.userId,
+  });
+  const virtualMcp = await studioCtx.storage.virtualMcps.findById(
+    agentId,
+    ctx.orgId,
+  );
+  if (!virtualMcp || virtualMcp.organization_id !== ctx.orgId) {
+    throw new Error(
+      `[background-tool] thread ${ctx.threadId} agent is unavailable in org ${ctx.orgId}`,
+    );
+  }
+  return { studioCtx, agentId };
 }
 
 /** Build the reaction turn's dispatch request — an internal nudge the model
@@ -244,6 +244,8 @@ function buildReactionRequest(
       // biome-ignore lint/suspicious/noExplicitAny: ChatMessage part union is built from the cluster tool set
     ] as any,
     models: opts.models,
+    // Compatibility snapshot only. Central dispatch resolves the executing
+    // agent from the thread row and ignores this value.
     agent: { id: s.agentId },
     temperature: s.temperature,
     toolApprovalLevel: s.toolApprovalLevel,
@@ -280,7 +282,8 @@ interface BackgroundJob {
 function makeJob(ctx: BackgroundToolContext): BackgroundJob {
   return {
     ctx,
-    studioContext: () => requireStudioContext(ctx),
+    studioContext: async () =>
+      (await requireHostedThreadContext(ctx)).studioCtx,
     emitFinal: (parts) =>
       DBOS.runStep(() => appendPartsStep(ctx, parts), { name: "appendResult" }),
   };
@@ -368,7 +371,7 @@ function extractAssistantText(
 async function runSubtaskStep(
   ctx: BackgroundToolContext,
 ): Promise<{ report: string; finishReason: string; models: ModelsConfig }> {
-  const studioCtx = await requireStudioContext(ctx);
+  const { studioCtx, agentId } = await requireHostedThreadContext(ctx);
   const organization = studioCtx.organization;
   if (!organization) {
     throw new Error(
@@ -376,8 +379,11 @@ async function runSubtaskStep(
     );
   }
   const input = ctx.input as { prompt: string; agent_id?: string };
-  const isSelf = !input.agent_id || input.agent_id === ctx.agentId;
-  const targetId = isSelf ? ctx.agentId : input.agent_id!;
+  const isSelf =
+    !input.agent_id ||
+    input.agent_id === ctx.agentId ||
+    input.agent_id === agentId;
+  const targetId = isSelf ? agentId : input.agent_id!;
   const models = await resolveReactionModels(studioCtx);
   const provider = await studioCtx.aiProviders.activate(
     models.credentialId,
@@ -590,7 +596,7 @@ async function appendPartsStep(
   ctx: BackgroundToolContext,
   parts: AnyMessage["parts"],
 ): Promise<void> {
-  const studioCtx = await requireHostedThreadContext(ctx);
+  const { studioCtx } = await requireHostedThreadContext(ctx);
   const emitter = new PartEmitter({
     storage: studioCtx.storage.threads.messageParts(),
     orgId: ctx.orgId,
@@ -613,7 +619,27 @@ async function resolveReactionTargetStep(
     ctx.userId,
   );
   if (!studioCtx) return null;
-  return resolveThreadTarget(await studioCtx.storage.threads.get(ctx.threadId));
+
+  const thread = await studioCtx.storage.threads.get(ctx.threadId);
+  if (!thread || !isHostedDecopilotThread(thread)) return null;
+
+  // Keep transient storage failures retriable. Only a missing/non-hosted
+  // thread is a deliberate no-op; invalid ownership or agent authority must
+  // fail closed instead of silently dropping the reaction turn.
+  const { agentId } = resolveThreadAuthority(thread, {
+    organizationId: ctx.orgId,
+    userId: ctx.userId,
+  });
+  const virtualMcp = await studioCtx.storage.virtualMcps.findById(
+    agentId,
+    ctx.orgId,
+  );
+  if (!virtualMcp || virtualMcp.organization_id !== ctx.orgId) {
+    throw new Error(
+      `[background-tool] thread ${ctx.threadId} agent is unavailable in org ${ctx.orgId}`,
+    );
+  }
+  return { harnessId: "decopilot" };
 }
 
 /** Re-enter the per-thread gate so the agent reacts to the delivered result.

--- a/apps/api/src/mcp-clients/virtual-mcp/index.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/index.ts
@@ -47,8 +47,14 @@ export async function createVirtualClient(
   const virtualMcpId = connection.id;
 
   // Load virtual MCP entity
-  const virtualMcp = await ctx.storage.virtualMcps.findById(virtualMcpId);
-  if (!virtualMcp) {
+  const virtualMcp = await ctx.storage.virtualMcps.findById(
+    virtualMcpId,
+    connection.organization_id,
+  );
+  if (
+    !virtualMcp ||
+    virtualMcp.organization_id !== connection.organization_id
+  ) {
     throw new Error(`Virtual MCP not found: ${virtualMcpId}`);
   }
 
@@ -96,7 +102,10 @@ export async function createVirtualClientFrom(
       try {
         const result = await Promise.all(
           connectionIds.map((connId) =>
-            ctx.storage.connections.findById(connId),
+            ctx.storage.connections.findById(
+              connId,
+              virtualMcp.organization_id,
+            ),
           ),
         );
         span.setStatus({ code: SpanStatusCode.OK });

--- a/apps/api/src/storage/connection.integration.test.ts
+++ b/apps/api/src/storage/connection.integration.test.ts
@@ -8,6 +8,7 @@ import {
 import type { StudioDatabase } from "../database";
 import { ConnectionStorage } from "./connection";
 import { CredentialVault } from "../encryption/credential-vault";
+import { getDecopilotId } from "@decocms/shared/sdk";
 
 describe("ConnectionStorage", () => {
   let database: StudioDatabase;
@@ -135,6 +136,25 @@ describe("ConnectionStorage", () => {
     it("should return null for non-existent ID", async () => {
       const found = await storage.findById("conn_nonexistent");
       expect(found).toBeNull();
+    });
+
+    it("should reject normal and well-known connections from another organization", async () => {
+      const foreign = await storage.create({
+        organization_id: "org_456",
+        created_by: "user_123",
+        title: "Foreign",
+        connection_type: "HTTP",
+        connection_url: "https://foreign.example.com/mcp",
+      });
+
+      expect(await storage.findById(foreign.id, "org_123")).toBeNull();
+      expect(
+        await storage.findById(getDecopilotId("org_456"), "org_123"),
+      ).toBeNull();
+      expect(await storage.findById(foreign.id, "org_456")).toMatchObject({
+        id: foreign.id,
+        organization_id: "org_456",
+      });
     });
   });
 

--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -275,8 +275,10 @@ export class ConnectionStorage implements ConnectionStoragePort {
     // Handle Decopilot ID - return Decopilot connection entity
     const decopilotOrgId = isDecopilot(id);
     if (decopilotOrgId) {
-      const resolvedOrgId = organizationId ?? decopilotOrgId;
-      return getWellKnownDecopilotConnection(resolvedOrgId);
+      if (organizationId && organizationId !== decopilotOrgId) {
+        return null;
+      }
+      return getWellKnownDecopilotConnection(decopilotOrgId);
     }
 
     let query = this.db

--- a/apps/api/src/storage/ports.ts
+++ b/apps/api/src/storage/ports.ts
@@ -71,6 +71,16 @@ export interface ThreadStoragePort {
     data: ThreadUpdateData,
   ): Promise<Thread>;
   /**
+   * Apply an update only while no runtime has claimed the thread. Used for
+   * agent/branch mutations so a concurrent hosted/native pin cannot race a
+   * preceding read and move a started chat to another execution context.
+   */
+  updateRoutingIfRuntimeUnlocked(
+    id: string,
+    organizationId: string,
+    data: ThreadUpdateData,
+  ): Promise<Thread | null>;
+  /**
    * Atomically pin an unlocked thread's runtime. The `harness_id IS NULL`
    * predicate is the lock: concurrent native and hosted starts cannot
    * overwrite whichever runtime won first.

--- a/apps/api/src/storage/threads.integration.test.ts
+++ b/apps/api/src/storage/threads.integration.test.ts
@@ -245,6 +245,54 @@ describe("SqlThreadStorage", () => {
       expect(result.thread?.branch).toBe("already-selected");
     });
 
+    it("updates routing only while the runtime remains unlocked", async () => {
+      const unlocked = await storage.create({
+        organization_id: "org_1",
+        created_by: "user_1",
+        virtual_mcp_id: "agent-before",
+        branch: "main",
+      });
+      expect(
+        await storage.updateRoutingIfRuntimeUnlocked(unlocked.id, "org_2", {
+          virtual_mcp_id: "cross-tenant",
+        }),
+      ).toBeNull();
+      expect(
+        await storage.updateRoutingIfRuntimeUnlocked("missing", "org_1", {
+          virtual_mcp_id: "missing",
+        }),
+      ).toBeNull();
+
+      const updated = await storage.updateRoutingIfRuntimeUnlocked(
+        unlocked.id,
+        "org_1",
+        { virtual_mcp_id: "agent-after", branch: "feature" },
+      );
+      expect(updated).toMatchObject({
+        virtual_mcp_id: "agent-after",
+        branch: "feature",
+        harness_id: null,
+      });
+
+      await storage.pinRuntimeIfUnset(unlocked.id, "org_1", {
+        harnessId: "decopilot",
+        sandboxProviderKind: "agent-sandbox",
+        branch: "feature",
+      });
+      const lostRace = await storage.updateRoutingIfRuntimeUnlocked(
+        unlocked.id,
+        "org_1",
+        { virtual_mcp_id: "agent-too-late", branch: "other" },
+      );
+
+      expect(lostRace).toBeNull();
+      expect(await storage.get(unlocked.id, "org_1")).toMatchObject({
+        virtual_mcp_id: "agent-after",
+        branch: "feature",
+        harness_id: "decopilot",
+      });
+    });
+
     it("does not overwrite a conflicting partial runtime", async () => {
       const thread = await storage.create({
         organization_id: "org_1",

--- a/apps/api/src/storage/threads.ts
+++ b/apps/api/src/storage/threads.ts
@@ -93,6 +93,17 @@ export class OrgScopedThreadStorage {
     return this.inner.update(id, this.requireOrg(), data);
   }
 
+  updateRoutingIfRuntimeUnlocked(
+    id: string,
+    data: ThreadUpdateData,
+  ): Promise<Thread | null> {
+    return this.inner.updateRoutingIfRuntimeUnlocked(
+      id,
+      this.requireOrg(),
+      data,
+    );
+  }
+
   pinRuntimeIfUnset(
     id: string,
     pin: ThreadRuntimePin,
@@ -360,6 +371,27 @@ export class SqlThreadStorage implements ThreadStoragePort {
     organizationId: string,
     data: ThreadUpdateData,
   ): Promise<Thread> {
+    const thread = await this.executeUpdate(id, organizationId, data, false);
+    if (!thread) {
+      throw new Error("Thread not found after update");
+    }
+    return thread;
+  }
+
+  async updateRoutingIfRuntimeUnlocked(
+    id: string,
+    organizationId: string,
+    data: ThreadUpdateData,
+  ): Promise<Thread | null> {
+    return this.executeUpdate(id, organizationId, data, true);
+  }
+
+  private async executeUpdate(
+    id: string,
+    organizationId: string,
+    data: ThreadUpdateData,
+    requireRuntimeUnlocked: boolean,
+  ): Promise<Thread | null> {
     const now = new Date().toISOString();
 
     const updateData: Record<string, unknown> = {
@@ -422,19 +454,16 @@ export class SqlThreadStorage implements ThreadStoragePort {
     if (data.message_storage_version !== undefined) {
       updateData.message_storage_version = data.message_storage_version;
     }
-    await this.db
+    let query = this.db
       .updateTable("threads")
       .set(updateData)
       .where("id", "=", id)
-      .where("organization_id", "=", organizationId)
-      .execute();
-
-    const thread = await this.get(id, organizationId);
-    if (!thread) {
-      throw new Error("Thread not found after update");
+      .where("organization_id", "=", organizationId);
+    if (requireRuntimeUnlocked) {
+      query = query.where("harness_id", "is", null);
     }
-
-    return thread;
+    const row = await query.returningAll().executeTakeFirst();
+    return row ? this.threadFromDbRow(row) : null;
   }
 
   async pinRuntimeIfUnset(

--- a/apps/api/src/storage/virtual.integration.test.ts
+++ b/apps/api/src/storage/virtual.integration.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../database/test-db-pg";
 import type { StudioDatabase } from "../database";
 import { VirtualMCPStorage } from "./virtual";
-import { getDecopilotId } from "@decocms/shared/sdk";
+import { getBrandContextSetupId, getDecopilotId } from "@decocms/shared/sdk";
 
 describe("VirtualMCPStorage.findById (Decopilot)", () => {
   let database: StudioDatabase;
@@ -77,5 +77,39 @@ describe("VirtualMCPStorage.findById (Decopilot)", () => {
     expect(decopilot).not.toBeNull();
     expect(decopilot?.title).toBe("Super Agent");
     expect(decopilot?.connections).toEqual([]);
+  });
+
+  test("rejects well-known agent ids encoded for another organization", async () => {
+    const foreignOrgId = "org_decopilot_foreign";
+
+    expect(
+      await storage.findById(getDecopilotId(foreignOrgId), orgId),
+    ).toBeNull();
+    expect(
+      await storage.findById(getBrandContextSetupId(foreignOrgId), orgId),
+    ).toBeNull();
+  });
+
+  test("does not return a normal Virtual MCP from another organization", async () => {
+    const foreignOrgId = "org_decopilot_foreign";
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO "organization" (id, name, slug, "createdAt")
+      VALUES (${foreignOrgId}, ${foreignOrgId}, ${foreignOrgId}, ${now})
+      ON CONFLICT (id) DO NOTHING
+    `.execute(database.db);
+
+    const foreign = await storage.create(foreignOrgId, "user_decopilot_test", {
+      title: "Foreign agent",
+      connections: [],
+      status: "active",
+      pinned: false,
+    });
+
+    expect(await storage.findById(foreign.id, orgId)).toBeNull();
+    expect(await storage.findById(foreign.id, foreignOrgId)).toMatchObject({
+      id: foreign.id,
+      organization_id: foreignOrgId,
+    });
   });
 });

--- a/apps/api/src/storage/virtual.ts
+++ b/apps/api/src/storage/virtual.ts
@@ -141,9 +141,11 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
     // The model uses the <available-agents> catalog as its routing table.
     const decopilotOrgId = isDecopilot(id);
     if (decopilotOrgId) {
-      const resolvedOrgId = organizationId ?? decopilotOrgId;
+      if (organizationId && organizationId !== decopilotOrgId) {
+        return null;
+      }
       return {
-        ...getWellKnownDecopilotVirtualMCP(resolvedOrgId),
+        ...getWellKnownDecopilotVirtualMCP(decopilotOrgId),
         pinned: false,
         connections: [],
       };
@@ -154,28 +156,36 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
     // built-in tool is injected by dispatchRun based on this id.
     const bcsOrgId = isBrandContextSetup(id);
     if (bcsOrgId) {
-      const resolvedOrgId = organizationId ?? bcsOrgId;
+      if (organizationId && organizationId !== bcsOrgId) {
+        return null;
+      }
       return {
-        ...getWellKnownBrandContextSetupVirtualMCP(resolvedOrgId),
+        ...getWellKnownBrandContextSetupVirtualMCP(bcsOrgId),
         pinned: false,
         connections: [],
       };
     }
 
-    // Normal database lookup for string IDs
-    return this.findByIdInternal(this.db, id);
+    // Normal database lookup for string IDs. When the caller supplies an
+    // organization, enforce it in SQL rather than relying on every consumer to
+    // remember a second organization_id check after lookup.
+    return this.findByIdInternal(this.db, id, organizationId);
   }
 
   private async findByIdInternal(
     db: Kysely<Database>,
     id: string,
+    organizationId?: string,
   ): Promise<VirtualMCPEntity | null> {
-    const row = await db
+    let query = db
       .selectFrom("connections")
       .selectAll()
       .where("id", "=", id)
-      .where("connection_type", "=", "VIRTUAL")
-      .executeTakeFirst();
+      .where("connection_type", "=", "VIRTUAL");
+    if (organizationId) {
+      query = query.where("organization_id", "=", organizationId);
+    }
+    const row = await query.executeTakeFirst();
 
     if (!row) {
       return null;

--- a/apps/api/src/tools/thread/create.ts
+++ b/apps/api/src/tools/thread/create.ts
@@ -115,10 +115,8 @@ export const COLLECTION_THREADS_CREATE = defineTool({
       data.virtual_mcp_id,
       organization.id,
     );
-    // `findById`'s organizationId param only resolves well-known synthetic
-    // ids (decopilot, brand-context-setup) — for a normal row it does NOT
-    // filter by org, so existence alone doesn't prove the vMCP is ours. Must
-    // check explicitly, same as COLLECTION_VIRTUAL_MCP_UPDATE does.
+    // Keep the explicit entity check as defense in depth for synthesized
+    // well-known agents; normal rows are scoped in SQL by findById.
     if (!vmcp || vmcp.organization_id !== organization.id) {
       throw new Error(`Virtual MCP not found: ${data.virtual_mcp_id}`);
     }

--- a/apps/api/src/tools/thread/delete.ts
+++ b/apps/api/src/tools/thread/delete.ts
@@ -42,20 +42,25 @@ export const COLLECTION_THREADS_DELETE = defineTool({
       throw new Error(`Thread not found: ${input.id}`);
     }
 
+    const userId = getUserId(ctx);
+    if (!userId) {
+      throw new Error("User ID required to delete thread");
+    }
+    if (thread.created_by !== userId) {
+      throw new Error("Only the chat owner can delete this thread");
+    }
+
     await ctx.storage.threads.delete(input.id);
 
-    const userId = getUserId(ctx);
-    if (userId) {
-      posthog.capture({
-        distinctId: userId,
-        event: "chat_deleted",
-        groups: { organization: organization.id },
-        properties: {
-          organization_id: organization.id,
-          thread_id: input.id,
-        },
-      });
-    }
+    posthog.capture({
+      distinctId: userId,
+      event: "chat_deleted",
+      groups: { organization: organization.id },
+      properties: {
+        organization_id: organization.id,
+        thread_id: input.id,
+      },
+    });
 
     return {
       item: normalizeThreadForResponse(thread),

--- a/apps/api/src/tools/thread/runtime-lock.test.ts
+++ b/apps/api/src/tools/thread/runtime-lock.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertThreadRoutingUpdateAllowed,
+  changesThreadRouting,
+} from "./runtime-lock";
+
+describe("assertThreadRoutingUpdateAllowed", () => {
+  test("allows routing changes before a runtime claims the thread", () => {
+    expect(() =>
+      assertThreadRoutingUpdateAllowed(
+        { harness_id: null, virtual_mcp_id: "agent-a", branch: "main" },
+        { virtual_mcp_id: "agent-b", branch: "feature" },
+      ),
+    ).not.toThrow();
+  });
+
+  test("allows idempotent routing values on a claimed thread", () => {
+    expect(() =>
+      assertThreadRoutingUpdateAllowed(
+        {
+          harness_id: "decopilot",
+          virtual_mcp_id: "agent-a",
+          branch: "main",
+        },
+        { virtual_mcp_id: "agent-a", branch: "main" },
+      ),
+    ).not.toThrow();
+  });
+
+  test("rejects changing the agent on a claimed thread", () => {
+    expect(() =>
+      assertThreadRoutingUpdateAllowed(
+        {
+          harness_id: "decopilot",
+          virtual_mcp_id: "agent-a",
+          branch: "main",
+        },
+        { virtual_mcp_id: "agent-b" },
+      ),
+    ).toThrow("Cannot change the agent after this chat has started");
+  });
+
+  test("rejects changing or clearing the branch on a claimed thread", () => {
+    for (const branch of ["feature", null]) {
+      expect(() =>
+        assertThreadRoutingUpdateAllowed(
+          {
+            harness_id: "codex",
+            virtual_mcp_id: "agent-a",
+            branch: "main",
+          },
+          { branch },
+        ),
+      ).toThrow("Cannot change the branch after this chat has started");
+    }
+  });
+
+  test("distinguishes routing changes from omitted or idempotent values", () => {
+    const current = { virtual_mcp_id: "agent-a", branch: "main" };
+    expect(changesThreadRouting(current, {})).toBe(false);
+    expect(
+      changesThreadRouting(current, {
+        virtual_mcp_id: "agent-a",
+        branch: "main",
+      }),
+    ).toBe(false);
+    expect(changesThreadRouting(current, { virtual_mcp_id: "agent-b" })).toBe(
+      true,
+    );
+    expect(changesThreadRouting(current, { branch: null })).toBe(true);
+  });
+});

--- a/apps/api/src/tools/thread/runtime-lock.ts
+++ b/apps/api/src/tools/thread/runtime-lock.ts
@@ -1,0 +1,36 @@
+import type { Thread } from "@/storage/types";
+
+/**
+ * User-authored routing changes are blocked after the first hosted/native
+ * start claims a thread. Display fields may still change, but the thread
+ * update tool cannot move persisted history to another authority context.
+ * Trusted runtime code can still evolve server-owned routing state (for
+ * example, Decopilot's load_repo tool binds a selected repository branch).
+ */
+export function assertThreadRoutingUpdateAllowed(
+  thread: Pick<Thread, "harness_id" | "virtual_mcp_id" | "branch">,
+  update: { virtual_mcp_id?: string; branch?: string | null },
+): void {
+  if (!thread.harness_id) return;
+
+  if (
+    update.virtual_mcp_id !== undefined &&
+    update.virtual_mcp_id !== thread.virtual_mcp_id
+  ) {
+    throw new Error("Cannot change the agent after this chat has started");
+  }
+  if (update.branch !== undefined && update.branch !== thread.branch) {
+    throw new Error("Cannot change the branch after this chat has started");
+  }
+}
+
+export function changesThreadRouting(
+  thread: Pick<Thread, "virtual_mcp_id" | "branch">,
+  update: { virtual_mcp_id?: string; branch?: string | null },
+): boolean {
+  return (
+    (update.virtual_mcp_id !== undefined &&
+      update.virtual_mcp_id !== thread.virtual_mcp_id) ||
+    (update.branch !== undefined && update.branch !== thread.branch)
+  );
+}

--- a/apps/api/src/tools/thread/update.ts
+++ b/apps/api/src/tools/thread/update.ts
@@ -17,6 +17,10 @@ import {
   ThreadEntitySchema,
   ThreadUpdateDataSchema,
 } from "@decocms/shared/thread/schema";
+import {
+  assertThreadRoutingUpdateAllowed,
+  changesThreadRouting,
+} from "./runtime-lock";
 
 /**
  * Input schema for updating threads
@@ -63,16 +67,19 @@ export const COLLECTION_THREADS_UPDATE = defineTool({
     if (!existing) {
       throw new Error("Thread not found in organization");
     }
+    if (existing.created_by !== userId) {
+      throw new Error("Only the chat owner can update this thread");
+    }
+
+    assertThreadRoutingUpdateAllowed(existing, data);
 
     if (data.virtual_mcp_id !== undefined) {
       const targetVmcp = await ctx.storage.virtualMcps.findById(
         data.virtual_mcp_id,
         organization.id,
       );
-      // `findById`'s organizationId param only resolves well-known synthetic
-      // ids — for a normal row it does NOT filter by org, so existence alone
-      // doesn't prove the vMCP is ours. Without this, re-pointing a thread
-      // (data.virtual_mcp_id) could target another organization's agent.
+      // Keep the explicit entity check as defense in depth for synthesized
+      // well-known agents; normal rows are scoped in SQL by findById.
       if (!targetVmcp || targetVmcp.organization_id !== organization.id) {
         throw new Error(`Virtual MCP not found: ${data.virtual_mcp_id}`);
       }
@@ -115,7 +122,15 @@ export const COLLECTION_THREADS_UPDATE = defineTool({
       updateData.virtual_mcp_id = data.virtual_mcp_id;
     }
 
-    const thread = await ctx.storage.threads.update(id, updateData);
+    const routingChanged = changesThreadRouting(existing, data);
+    const thread = routingChanged
+      ? await ctx.storage.threads.updateRoutingIfRuntimeUnlocked(id, updateData)
+      : await ctx.storage.threads.update(id, updateData);
+    if (!thread) {
+      throw new Error(
+        "Cannot change the agent or branch after this chat has started",
+      );
+    }
 
     // Fire chat_archived / chat_unarchived when the hidden flag flips. Only
     // fires on the specific transition, not on title/description edits that

--- a/packages/e2e/tests/hosted-runtime-boundary.spec.ts
+++ b/packages/e2e/tests/hosted-runtime-boundary.spec.ts
@@ -1,7 +1,9 @@
-import { expect, test } from "../fixtures/test";
+import { retry } from "@decocms/shared/std";
+import type { APIRequestContext } from "@playwright/test";
+import { signUpViaApi } from "../fixtures/auth-api";
 import { connectDevDb } from "../fixtures/db";
 import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
-import { retry } from "@decocms/shared/std";
+import { expect, getE2EAppOrigin, newApiContext, test } from "../fixtures/test";
 
 const NON_HOSTED_HARNESSES = ["claude-code", "codex", "opencode", "future"];
 
@@ -27,6 +29,166 @@ const PERSISTED_NON_HOSTED_ROWS = [
     error: "This coding-agent chat can only run in the Studio desktop app",
   },
 ] as const;
+
+type DevDb = Awaited<ReturnType<typeof connectDevDb>>;
+
+async function createAgent(
+  api: APIRequestContext,
+  orgSlug: string,
+  title: string,
+): Promise<string> {
+  const agent = await callSelfMcpTool<{ item: { id: string } }>(
+    api,
+    orgSlug,
+    "COLLECTION_VIRTUAL_MCP_CREATE",
+    {
+      data: {
+        title,
+        connections: [],
+        status: "active",
+        pinned: false,
+      },
+    },
+  );
+  return agent.item.id;
+}
+
+async function createThread(
+  api: APIRequestContext,
+  orgSlug: string,
+  virtualMcpId: string,
+): Promise<string> {
+  const thread = await callSelfMcpTool<{ item: { id: string } }>(
+    api,
+    orgSlug,
+    "COLLECTION_THREADS_CREATE",
+    { data: { virtual_mcp_id: virtualMcpId } },
+  );
+  return thread.item.id;
+}
+
+async function organizationIdForSlug(
+  db: DevDb,
+  orgSlug: string,
+): Promise<string> {
+  const result = await db.query<{ id: string }>(
+    `SELECT id FROM organization WHERE slug = $1`,
+    [orgSlug],
+  );
+  const organizationId = result.rows[0]?.id;
+  if (!organizationId) {
+    throw new Error(`Organization not found for slug ${orgSlug}`);
+  }
+  return organizationId;
+}
+
+async function readThreadAuthorityState(
+  db: DevDb,
+  args: { threadId: string; organizationId: string; userId: string },
+) {
+  const result = await db.query<{
+    title: string;
+    virtual_mcp_id: string;
+    harness_id: string | null;
+    sandbox_provider_kind: string | null;
+    status: string;
+    part_count: number;
+  }>(
+    `SELECT t.title,
+            t.virtual_mcp_id,
+            t.harness_id,
+            t.sandbox_provider_kind,
+            t.status,
+            (SELECT COUNT(*)::int
+               FROM thread_message_parts p
+              WHERE p.org_id = t.organization_id
+                AND p.thread_id = t.id) AS part_count
+       FROM threads t
+      WHERE t.id = $1
+        AND t.organization_id = $2
+        AND t.created_by = $3`,
+    [args.threadId, args.organizationId, args.userId],
+  );
+  const state = result.rows[0];
+  if (!state) {
+    throw new Error(`Thread not found in expected tenant: ${args.threadId}`);
+  }
+  return state;
+}
+
+async function inviteAndAcceptMember(
+  ownerApi: APIRequestContext,
+  memberApi: APIRequestContext,
+  organizationId: string,
+  memberEmail: string,
+): Promise<void> {
+  const invite = await ownerApi.post("/api/auth/organization/invite-member", {
+    data: {
+      organizationId,
+      email: memberEmail,
+      role: "user",
+    },
+    headers: { Origin: getE2EAppOrigin() },
+  });
+  expect(
+    invite.ok(),
+    `invite failed: ${await invite.text().catch(() => "")}`,
+  ).toBe(true);
+  const body = (await invite.json()) as {
+    id?: string;
+    invitation?: { id?: string };
+  };
+  const invitationId = body.id ?? body.invitation?.id;
+  expect(invitationId).toBeTruthy();
+
+  const accept = await memberApi.post(
+    "/api/auth/organization/accept-invitation",
+    { data: { invitationId } },
+  );
+  expect(
+    accept.ok(),
+    `accept failed: ${await accept.text().catch(() => "")}`,
+  ).toBe(true);
+}
+
+async function postMessageAsAgent(
+  api: APIRequestContext,
+  args: {
+    orgSlug: string;
+    threadId: string;
+    agentId: string;
+    messageId: string;
+  },
+) {
+  return api.post(
+    `/api/${args.orgSlug}/decopilot/threads/${args.threadId}/messages`,
+    {
+      data: {
+        messages: [
+          {
+            id: args.messageId,
+            role: "user",
+            parts: [{ type: "text", text: "Do not dispatch this" }],
+          },
+        ],
+        agent: { id: args.agentId },
+        harnessId: "decopilot",
+        sandboxProviderKind: "agent-sandbox",
+      },
+      headers: { "content-type": "application/json" },
+    },
+  );
+}
+
+async function expectNoQueuedRun(
+  api: APIRequestContext,
+  orgSlug: string,
+  threadId: string,
+): Promise<void> {
+  const queue = await api.get(`/api/${orgSlug}/decopilot/queue/${threadId}`);
+  expect(queue.status()).toBe(200);
+  expect(await queue.json()).toEqual({ items: [] });
+}
 
 test.describe("hosted runtime boundary", () => {
   test.describe.configure({ mode: "serial" });
@@ -116,6 +278,185 @@ test.describe("hosted runtime boundary", () => {
       expect(parts.rows[0]?.count).toBe(0);
     } finally {
       await db.end();
+    }
+  });
+
+  test("rejects a body agent that differs from the thread's same-org agent", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug, user } = authedPage;
+    const api = page.context().request;
+    const db = await connectDevDb();
+    try {
+      const organizationId = await organizationIdForSlug(db, orgSlug);
+      const threadAgentId = await createAgent(
+        api,
+        orgSlug,
+        "thread authority canonical agent",
+      );
+      const requestedAgentId = await createAgent(
+        api,
+        orgSlug,
+        "thread authority requested agent",
+      );
+      const threadId = await createThread(api, orgSlug, threadAgentId);
+      const scope = { threadId, organizationId, userId: user.userId };
+      const before = await readThreadAuthorityState(db, scope);
+
+      const response = await postMessageAsAgent(api, {
+        orgSlug,
+        threadId,
+        agentId: requestedAgentId,
+        messageId: "msg-same-org-agent-mismatch",
+      });
+
+      expect(response.status()).toBe(409);
+      expect(await readThreadAuthorityState(db, scope)).toEqual(before);
+      expect(before).toMatchObject({
+        virtual_mcp_id: threadAgentId,
+        harness_id: null,
+        sandbox_provider_kind: null,
+        part_count: 0,
+      });
+      await expectNoQueuedRun(api, orgSlug, threadId);
+    } finally {
+      await db.end();
+    }
+  });
+
+  test("rejects a foreign-org agent before any message or run is persisted", async ({
+    authedPage,
+    playwright,
+  }) => {
+    const { page, orgSlug, user } = authedPage;
+    const api = page.context().request;
+    const foreignApi = await newApiContext(playwright);
+    const db = await connectDevDb();
+    try {
+      const organizationId = await organizationIdForSlug(db, orgSlug);
+      const threadAgentId = await createAgent(
+        api,
+        orgSlug,
+        "foreign authority canonical agent",
+      );
+      const foreignUser = await signUpViaApi(foreignApi);
+      const foreignAgentId = await createAgent(
+        foreignApi,
+        foreignUser.orgSlug,
+        "foreign authority agent",
+      );
+
+      // The usual attack shape: the owned thread still points at its own
+      // tenant's agent, while the request tries to select a foreign one.
+      const threadId = await createThread(api, orgSlug, threadAgentId);
+      const scope = { threadId, organizationId, userId: user.userId };
+      const before = await readThreadAuthorityState(db, scope);
+      const mismatchResponse = await postMessageAsAgent(api, {
+        orgSlug,
+        threadId,
+        agentId: foreignAgentId,
+        messageId: "msg-foreign-agent-mismatch",
+      });
+
+      expect(mismatchResponse.status()).toBe(409);
+      expect(await readThreadAuthorityState(db, scope)).toEqual(before);
+      await expectNoQueuedRun(api, orgSlug, threadId);
+
+      // Defense in depth: even if a malformed legacy row or privileged DB
+      // writer points an owned thread at another tenant's agent, equality with
+      // the body is not authorization. The hosted endpoint must validate the
+      // canonical agent's organization before its first write.
+      const corruptThreadId = await createThread(api, orgSlug, threadAgentId);
+      const corruptUpdate = await db.query(
+        `UPDATE threads
+            SET virtual_mcp_id = $1
+          WHERE id = $2
+            AND organization_id = $3
+            AND created_by = $4`,
+        [foreignAgentId, corruptThreadId, organizationId, user.userId],
+      );
+      expect(corruptUpdate.rowCount).toBe(1);
+
+      const corruptScope = {
+        threadId: corruptThreadId,
+        organizationId,
+        userId: user.userId,
+      };
+      const corruptBefore = await readThreadAuthorityState(db, corruptScope);
+      const corruptResponse = await postMessageAsAgent(api, {
+        orgSlug,
+        threadId: corruptThreadId,
+        agentId: foreignAgentId,
+        messageId: "msg-foreign-agent-canonical-corruption",
+      });
+
+      expect(corruptResponse.status()).toBe(409);
+      expect(await readThreadAuthorityState(db, corruptScope)).toEqual(
+        corruptBefore,
+      );
+      expect(corruptBefore).toMatchObject({
+        virtual_mcp_id: foreignAgentId,
+        harness_id: null,
+        sandbox_provider_kind: null,
+        part_count: 0,
+      });
+      await expectNoQueuedRun(api, orgSlug, corruptThreadId);
+    } finally {
+      await Promise.all([db.end(), foreignApi.dispose()]);
+    }
+  });
+
+  test("keeps an organization teammate from mutating another owner's thread", async ({
+    authedPage,
+    playwright,
+  }) => {
+    const { page, orgSlug, user } = authedPage;
+    const ownerApi = page.context().request;
+    const memberApi = await newApiContext(playwright);
+    const db = await connectDevDb();
+    try {
+      const organizationId = await organizationIdForSlug(db, orgSlug);
+      const agentId = await createAgent(
+        ownerApi,
+        orgSlug,
+        "teammate boundary agent",
+      );
+      const threadId = await createThread(ownerApi, orgSlug, agentId);
+      const scope = { threadId, organizationId, userId: user.userId };
+      const before = await readThreadAuthorityState(db, scope);
+
+      const member = await signUpViaApi(memberApi);
+      await inviteAndAcceptMember(
+        ownerApi,
+        memberApi,
+        organizationId,
+        member.email,
+      );
+
+      const messageResponse = await postMessageAsAgent(memberApi, {
+        orgSlug,
+        threadId,
+        agentId,
+        messageId: "msg-teammate-owner-boundary",
+      });
+      expect(messageResponse.status()).toBe(403);
+
+      await expect(
+        callSelfMcpTool(memberApi, orgSlug, "COLLECTION_THREADS_UPDATE", {
+          id: threadId,
+          data: { title: "teammate changed this" },
+        }),
+      ).rejects.toThrow(/chat owner/i);
+      await expect(
+        callSelfMcpTool(memberApi, orgSlug, "COLLECTION_THREADS_DELETE", {
+          id: threadId,
+        }),
+      ).rejects.toThrow(/chat owner/i);
+
+      expect(await readThreadAuthorityState(db, scope)).toEqual(before);
+      await expectNoQueuedRun(ownerApi, orgSlug, threadId);
+    } finally {
+      await Promise.all([db.end(), memberApi.dispose()]);
     }
   });
 


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## How did you verify your code works?
> Name the tests you ran or added and what you observed. "Verified manually" or "existing tests" without specifics doesn't count.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind hosted Decopilot runs to each thread’s persisted authority. The executing agent now always comes from the thread, with strict org and owner checks that block cross-tenant access and teammate mutations.

- **Bug Fixes**
  - HTTP and background paths resolve the agent from `thread.virtual_mcp_id`; ignore body agents and map errors to 404 (org), 403 (owner), 409 (agent mismatch).
  - Added `requireHostedThreadAgent` to verify the thread’s agent exists in the same org before any write; durable dispatch uses the authoritative agent.
  - Scoped `virtualMcp` and `connection` lookups by organization (including well-known IDs) and enforced org checks at the SQL boundary.
  - Thread tools now require the owner for update/delete and block agent/branch changes after a runtime is pinned.

- **Refactors**
  - Introduced `resolveThreadAuthority` and `ThreadAuthorityError`; integrated into Decopilot routes, dispatch, and background workflows with unit/integration/e2e tests.
  - Added `threads.updateRoutingIfRuntimeUnlocked` and `runtime-lock` helpers to CAS routing updates only while unlocked; idempotent values are allowed.

<sup>Written for commit d0cb3b677a973dd5fb9a21fe746d3d2463448fce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

