### PR TITLE
refactor(native): harden sandbox workspace authority

### DIFF
--- a/apps/native/crates/local-api/src/auth_fence.rs
+++ b/apps/native/crates/local-api/src/auth_fence.rs
@@ -1,11 +1,9 @@
 //! Ordering between process-global upstream credentials and account-scoped
 //! interactive agent processes.
 
-use std::sync::Arc;
-
 use upstream::{PreparedSession, SessionIdentityEvent, StatusResult, UpstreamSession};
 
-use crate::{AgentSessionRegistry, AppState};
+use crate::AppState;
 
 #[derive(Debug, thiserror::Error)]
 pub enum AccountInstallError {
@@ -29,7 +27,7 @@ pub async fn install_upstream_session(
     let transition = session.begin_transition().await;
     let current_user_sub = transition.current_user_sub_result().await?;
     if should_reap_for_install(current_user_sub.as_deref(), prepared.user_sub()) {
-        reap_all(&state.agent_sessions).await?;
+        reap_all(state).await?;
     }
     Ok(transition.install(prepared).await?)
 }
@@ -42,33 +40,95 @@ pub async fn logout_upstream_session(state: &AppState) -> StatusResult {
     let transition = session.begin_transition().await;
     let status = transition.logout().await;
     if !status.signed_in {
-        log_reap_failure(reap_all(&state.agent_sessions).await, "logout");
+        log_reap_failure(reap_all(state).await, "logout");
     }
     status
 }
 
-/// Hard sign-out counterpart for request paths that directly observe a
-/// rejected refresh token. Other hard sign-outs (including background
-/// revalidation) are covered by [`spawn_identity_reaper`].
-pub(crate) async fn hard_sign_out_upstream_session(state: &AppState, reason: &str) -> StatusResult {
-    let session = upstream::global();
+/// Hard-sign-out a directly rejected refresh token only if the request that
+/// observed it still names the current account. A delayed account-A failure
+/// must never clear credentials installed for account B.
+pub(crate) async fn hard_sign_out_upstream_session_if_current(
+    state: &AppState,
+    session: &UpstreamSession,
+    expected_generation: u64,
+    expected_epoch: crate::sandbox::manager::AccountEpoch,
+    reason: &str,
+) -> bool {
     let transition = session.begin_transition().await;
-    let status = transition.hard_sign_out(reason).await;
-    log_reap_failure(reap_all(&state.agent_sessions).await, "hard sign-out");
-    status
+    if transition.generation() != expected_generation
+        || state
+            .sandbox_manager
+            .validate_account_epoch(expected_epoch)
+            .is_err()
+    {
+        return false;
+    }
+    transition.hard_sign_out(reason).await;
+    log_reap_failure(reap_all(state).await, "hard sign-out");
+    true
 }
 
-pub(crate) async fn reap_all(registry: &AgentSessionRegistry) -> Result<(), AccountInstallError> {
-    let failures = registry.terminate_all().await;
-    let remaining = registry.active_count();
+pub(crate) async fn reap_all(state: &AppState) -> Result<(), AccountInstallError> {
+    let sandbox_transition = state
+        .sandbox_manager
+        .begin_account_transition()
+        .await
+        .map_err(AccountInstallError::AgentReap)?;
+    let preparation = state.agent_sessions.cancel_all_preparations();
+    let preparation_fences = preparation.fences();
+    let mut failures = Vec::new();
+    let first_preparation_error = preparation.wait().await.err();
+    let first_sandbox_error = sandbox_transition.drain_and_stop_live().await.err();
+    let preparation_quiesced = match first_preparation_error {
+        None => true,
+        Some(first_error) => match preparation.wait().await {
+            Ok(()) => true,
+            Err(error) => {
+                failures.push(format!(
+                    "managed coding agent artifacts were not removed because preparation remained active after sandbox shutdown and was unsafe to clean: {first_error}; retry: {error}"
+                ));
+                false
+            }
+        },
+    };
+    if preparation_quiesced {
+        // The first sandbox drain can time out before taking a snapshot while
+        // a canceled preparation still owns a materialization admission. The
+        // successful preparation retry proves that admission is now gone, so
+        // one idempotent drain retry is required before the transition gate
+        // may reopen. A successful retry fully recovers the first timeout.
+        if let Some(first_error) = first_sandbox_error {
+            if let Err(error) = sandbox_transition.drain_and_stop_live().await {
+                failures.push(format!(
+                    "could not stop sandbox processes before changing accounts: {first_error}; retry: {error}"
+                ));
+            }
+        }
+        for fence in &preparation_fences {
+            if let Err(error) =
+                crate::terminal::launch_context::cleanup_managed_state(&state.app_root, fence).await
+            {
+                failures.push(format!(
+                    "could not clean canceled coding agent preparation for {}: {error}",
+                    fence.thread_id
+                ));
+            }
+        }
+    } else if let Some(error) = first_sandbox_error {
+        failures.push(format!(
+            "could not stop sandbox processes before changing accounts: {error}"
+        ));
+    }
+    failures.extend(state.agent_sessions.terminate_active_sessions().await);
+    let remaining = state.agent_sessions.active_count();
     if failures.is_empty() && remaining == 0 {
         return Ok(());
     }
-    let mut details = failures;
     if remaining != 0 {
-        details.push(format!("{remaining} terminal session(s) remain active"));
+        failures.push(format!("{remaining} terminal session(s) remain active"));
     }
-    Err(AccountInstallError::AgentReap(details.join("; ")))
+    Err(AccountInstallError::AgentReap(failures.join("; ")))
 }
 
 fn log_reap_failure(result: Result<(), AccountInstallError>, transition: &str) {
@@ -88,18 +148,18 @@ fn should_reap_for_install(current_user_sub: Option<&str>, next_user_sub: &str) 
 /// pre-commit reap.
 pub(crate) fn spawn_identity_reaper(
     session: UpstreamSession,
-    registry: Arc<AgentSessionRegistry>,
+    state: AppState,
 ) -> tokio::task::JoinHandle<()> {
     let mut events = session.subscribe_identity();
     tokio::spawn(async move {
         loop {
             match events.recv().await {
-                Ok(event) => reap_identity_event(&session, &registry, event).await,
+                Ok(event) => reap_identity_event(&session, &state, event).await,
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
                     let transition = session.begin_transition().await;
                     match transition.current_user_sub_result().await {
                         Ok(None) => {
-                            log_reap_failure(reap_all(&registry).await, "lagged hard sign-out");
+                            log_reap_failure(reap_all(&state).await, "lagged hard sign-out");
                         }
                         Ok(Some(_)) => {}
                         Err(error) => {
@@ -115,7 +175,7 @@ pub(crate) fn spawn_identity_reaper(
 
 async fn reap_identity_event(
     session: &UpstreamSession,
-    registry: &AgentSessionRegistry,
+    state: &AppState,
     event: SessionIdentityEvent,
 ) {
     if event.user_sub.is_some() {
@@ -125,7 +185,7 @@ async fn reap_identity_event(
     if !should_reap_identity_event(transition.generation(), &event) {
         return;
     }
-    log_reap_failure(reap_all(registry).await, "hard sign-out event");
+    log_reap_failure(reap_all(state).await, "hard sign-out event");
 }
 
 fn should_reap_identity_event(current_generation: u64, event: &SessionIdentityEvent) -> bool {
@@ -135,6 +195,10 @@ fn should_reap_identity_event(current_generation: u64, event: &SessionIdentityEv
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use upstream::tokens::{
+        host_key, test_support::MemoryTokenStore, StoredSession, TokenStore, UserInfo,
+    };
 
     #[test]
     fn account_replacement_and_post_signout_login_require_reap() {
@@ -164,5 +228,115 @@ mod tests {
             user_sub: Some("account-b".to_string()),
         };
         assert!(!should_reap_identity_event(5, &signed_in));
+    }
+
+    #[tokio::test]
+    async fn delayed_hard_sign_out_cannot_clear_replacement_credentials() {
+        let root = tempfile::tempdir().unwrap();
+        let state = crate::routes::intercept::test_state(root.path());
+        let expected_epoch = state.sandbox_manager.account_epoch();
+        let target = "http://replacement.invalid";
+        let host = host_key(target);
+        let store = Arc::new(MemoryTokenStore::new());
+        let account_a = StoredSession {
+            target: target.to_string(),
+            client_id: "client-a".to_string(),
+            user: UserInfo {
+                sub: "account-a".to_string(),
+                email: None,
+                name: None,
+            },
+            access_token: "token-a".to_string(),
+            refresh_token: Some("refresh-a".to_string()),
+            expires_at: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            cookie: None,
+        };
+        store.save(&host, account_a).await.unwrap();
+        let session = UpstreamSession::new(target.to_string(), store.clone());
+        let expected_generation = session.begin_transition().await.generation();
+
+        session
+            .begin_transition()
+            .await
+            .hard_sign_out("test replacement")
+            .await;
+        let account_b = StoredSession {
+            target: target.to_string(),
+            client_id: "client-b".to_string(),
+            user: UserInfo {
+                sub: "account-b".to_string(),
+                email: None,
+                name: None,
+            },
+            access_token: "token-b".to_string(),
+            refresh_token: Some("refresh-b".to_string()),
+            expires_at: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            cookie: None,
+        };
+        store.save(&host, account_b).await.unwrap();
+
+        assert!(
+            !hard_sign_out_upstream_session_if_current(
+                &state,
+                &session,
+                expected_generation,
+                expected_epoch,
+                "delayed account-a rejection",
+            )
+            .await
+        );
+        let stored = store.load(&host).await.unwrap().unwrap();
+        assert_eq!(stored.user.sub, "account-b");
+        assert_eq!(stored.access_token, "token-b");
+    }
+
+    #[tokio::test]
+    async fn account_reap_stops_real_and_synthetic_sandbox_generations() {
+        let root = tempfile::tempdir().unwrap();
+        let state = crate::routes::intercept::test_state(root.path());
+        let real_handle = state
+            .sandbox_manager
+            .register_for_test("https://github.com/acme/auth-real.git", "feature/account-a");
+        let synthetic_handle = state.sandbox_manager.register_for_test(
+            "https://github.com/acme/auth-synthetic.git",
+            "thread:account-a-thread",
+        );
+        let account_epoch = state.sandbox_manager.account_epoch();
+        let real = state
+            .sandbox_manager
+            .adopt_for_account(account_epoch, &real_handle)
+            .await
+            .unwrap()
+            .unwrap();
+        let synthetic = state
+            .sandbox_manager
+            .adopt_for_account(account_epoch, &synthetic_handle)
+            .await
+            .unwrap()
+            .unwrap();
+
+        reap_all(&state).await.unwrap();
+        let current_epoch = state.sandbox_manager.account_epoch();
+
+        for (handle, generation) in [(&real_handle, real), (&synthetic_handle, synthetic)] {
+            assert!(state
+                .sandbox_manager
+                .get_for_account(current_epoch, handle)
+                .unwrap()
+                .is_none());
+            assert!(generation.tasks.is_admission_closed());
+            assert!(generation.tasks.list(None).is_empty());
+            assert_eq!(
+                state
+                    .sandbox_manager
+                    .registry_record_for_account(current_epoch, handle)
+                    .unwrap()
+                    .unwrap()
+                    .desired_status,
+                "stopped"
+            );
+        }
     }
 }

--- a/apps/native/crates/local-api/src/lib.rs
+++ b/apps/native/crates/local-api/src/lib.rs
@@ -841,8 +841,7 @@ pub async fn start_with_client_auth(
 
     // Subscribe before listener admission starts so even an immediate
     // background hard sign-out has a process-owner waiting to reap terminals.
-    let auth_reaper_task =
-        auth_fence::spawn_identity_reaper(upstream::global(), state.agent_sessions.clone());
+    let auth_reaper_task = auth_fence::spawn_identity_reaper(upstream::global(), state.clone());
 
     let shutdown_notify = Arc::new(Notify::new());
     let notify_for_task = shutdown_notify.clone();

--- a/apps/native/crates/local-api/src/process_util.rs
+++ b/apps/native/crates/local-api/src/process_util.rs
@@ -95,7 +95,7 @@ pub(crate) fn emit_tasks_event(tasks: &TaskRegistry, broadcaster: &Broadcaster) 
 /// signal)`. For anchored groups prefer [`ProcessGroupChild::signal`], which
 /// spares the anchor; this raw variant backs the setup family's
 /// persisted-orphan reaping, where no live owner exists.
-#[cfg(unix)]
+#[cfg(all(test, unix))]
 pub(crate) async fn kill_group(pid: u32, signal: KillSignal) {
     let _ = tokio::process::Command::new("kill")
         .arg(signal.flag())
@@ -108,7 +108,7 @@ pub(crate) async fn kill_group(pid: u32, signal: KillSignal) {
         .await;
 }
 
-#[cfg(not(unix))]
+#[cfg(all(test, not(unix)))]
 pub(crate) async fn kill_group(pid: u32, _signal: KillSignal) {
     let _ = tokio::process::Command::new("taskkill")
         .args(["/PID", &pid.to_string(), "/T", "/F"])

--- a/apps/native/crates/local-api/src/router.rs
+++ b/apps/native/crates/local-api/src/router.rs
@@ -147,7 +147,8 @@ pub fn build(
         .route("/setup/ensure", post(routes::setup::ensure))
         .route("/setup/start", post(routes::setup::start))
         // NEW — no daemon precedent (see routes::setup::stop's own doc
-        // comment): kills the resolved target's running dev/start task
+        // comment): quiesces a registered sandbox generation; the legacy
+        // headerless non-git fallback stops its running dev/start task
         // WITHOUT respawning, giving the sandbox drawer's Stop button a
         // real desktop-local action to call.
         .route("/setup/stop", post(routes::setup::stop))
@@ -405,18 +406,28 @@ async fn preview_fence(
     next: Next,
 ) -> Response {
     crate::client_auth::remove_local_session_cookie(req.headers_mut());
+    let authorization = match routes::sandbox_account::authorize(&fence.state).await {
+        Ok(authorization) => authorization,
+        Err(error) => return error.into_response(),
+    };
     if let Some(base) = fence.base.as_deref() {
-        if !names_a_known_sandbox(&fence.state, req.headers(), base) {
+        if !names_a_known_sandbox(&fence.state, authorization.epoch(), req.headers(), base) {
             return ApiError::not_found("Not found").into_response();
         }
     }
+    drop(authorization);
     next.run(req).await
 }
 
 /// Whether `Host` is `<label>.<base>` for a `label` the sandbox manager
 /// currently maps to a handle. Deliberately strict: exactly one label, and the
 /// bare `base` itself is NOT accepted.
-fn names_a_known_sandbox(state: &AppState, headers: &axum::http::HeaderMap, base: &str) -> bool {
+fn names_a_known_sandbox(
+    state: &AppState,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    headers: &axum::http::HeaderMap,
+    base: &str,
+) -> bool {
     let Some(host) = headers.get(header::HOST).and_then(|v| v.to_str().ok()) else {
         return false;
     };
@@ -435,8 +446,8 @@ fn names_a_known_sandbox(state: &AppState, headers: &axum::http::HeaderMap, base
         && !label.contains('.')
         && state
             .sandbox_manager
-            .handle_for_preview_label(label)
-            .is_some()
+            .handle_for_preview_label_for_account(account_epoch, label)
+            .is_ok_and(|handle| handle.is_some())
 }
 
 /// `{"error":"Not found: <full request path>"}` — byte-parity in spirit

--- a/apps/native/crates/local-api/src/routes/bash.rs
+++ b/apps/native/crates/local-api/src/routes/bash.rs
@@ -228,11 +228,14 @@ async fn run_await(
     env: Option<&HashMap<String, String>>,
     timeout_ms: u64,
 ) -> ApiResult<RunResult> {
-    let Some(admission) = state.shutdown.admit_work().await else {
+    let Some(shutdown_admission) = state.shutdown.admit_work().await else {
         return Err(ApiError::new(
             StatusCode::SERVICE_UNAVAILABLE,
             "application is shutting down",
         ));
+    };
+    let Some(generation_admission) = state.tasks.admit() else {
+        return Err(ApiError::conflict("sandbox generation is stopped"));
     };
 
     let mut cmd = build_command(command, cwd, env);
@@ -255,7 +258,7 @@ async fn run_await(
     let id = format!("internal-bash-{}", uuid::Uuid::new_v4());
     let controller = ProcessController::new();
     let kill_handle = controller.kill_handle();
-    state.tasks.insert(TaskEntry::new_internal(
+    generation_admission.register(TaskEntry::new_internal(
         TaskSummary {
             id: id.clone(),
             command: command.to_string(),
@@ -276,7 +279,7 @@ async fn run_await(
     // the owner; there is no spawn -> registry cancellation window.
     let (Some(stdout_pipe), Some(stderr_pipe)) = (child.take_stdout(), child.take_stderr()) else {
         spawn_missing_stdio_cleanup(state.clone(), id, child, false);
-        drop(admission);
+        drop(shutdown_admission);
         return Ok(RunResult {
             stdout: String::new(),
             stderr: "spawn error: missing stdio pipe\n".to_string(),
@@ -298,7 +301,7 @@ async fn run_await(
         Some(result_tx),
         false,
     );
-    drop(admission);
+    drop(shutdown_admission);
 
     let mut cancel_on_drop = CancelOnDrop::new(kill_handle, KillSignal::Term);
     let result = result_rx
@@ -315,11 +318,14 @@ async fn spawn_background(
     env: Option<HashMap<String, String>>,
     timeout_ms: u64,
 ) -> ApiResult<Json<Value>> {
-    let Some(admission) = state.shutdown.admit_work().await else {
+    let Some(shutdown_admission) = state.shutdown.admit_work().await else {
         return Err(ApiError::new(
             StatusCode::SERVICE_UNAVAILABLE,
             "application is shutting down",
         ));
+    };
+    let Some(generation_admission) = state.tasks.admit() else {
+        return Err(ApiError::conflict("sandbox generation is stopped"));
     };
     let mut cmd = build_command(&command, &cwd, env.as_ref());
     let id = state.tasks.next_id();
@@ -343,7 +349,7 @@ async fn spawn_background(
                     log_name: None,
                     intentional: None,
                 };
-                state.tasks.insert(TaskEntry::new(summary, None));
+                generation_admission.register(TaskEntry::new(summary, None));
                 emit_tasks_event(&state.tasks, &state.broadcaster);
                 return Ok(Json(json!({"taskId": id, "status": "failed"})));
             }
@@ -361,14 +367,12 @@ async fn spawn_background(
         log_name: None,
         intentional: None,
     };
-    state
-        .tasks
-        .insert(TaskEntry::new(summary, Some(kill_handle)));
+    generation_admission.register(TaskEntry::new(summary, Some(kill_handle)));
     emit_tasks_event(&state.tasks, &state.broadcaster);
 
     let (Some(stdout_pipe), Some(stderr_pipe)) = (child.take_stdout(), child.take_stderr()) else {
         spawn_missing_stdio_cleanup(state.clone(), id.clone(), child, true);
-        drop(admission);
+        drop(shutdown_admission);
         return Ok(Json(json!({"taskId": id, "status": "failed"})));
     };
 
@@ -383,7 +387,7 @@ async fn spawn_background(
         None,
         true,
     );
-    drop(admission);
+    drop(shutdown_admission);
 
     Ok(Json(json!({"taskId": id, "status": "running"})))
 }

--- a/apps/native/crates/local-api/src/routes/config.rs
+++ b/apps/native/crates/local-api/src/routes/config.rs
@@ -38,6 +38,9 @@ pub async fn read(State(state): State<AppState>) -> Json<Value> {
 }
 
 pub async fn update(State(state): State<AppState>, body: Bytes) -> Response {
+    let Some(_generation_admission) = state.tasks.admit() else {
+        return ApiError::conflict("sandbox generation is stopped").into_response();
+    };
     let raw: Value = match serde_json::from_slice(&body) {
         Ok(v) => v,
         Err(e) => return ApiError::bad_request(format!("bad body: {e}")).into_response(),
@@ -111,6 +114,22 @@ fn reject_auth_patch(auth: &Value) -> Option<ApiError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn stopped_generation_rejects_config_patch_without_mutating_state() {
+        let root = tempfile::tempdir().unwrap();
+        let state = crate::routes::intercept::test_state(root.path());
+        state.tasks.close_admission().await;
+
+        let response = update(
+            State(state.clone()),
+            Bytes::from_static(br#"{"application":{"runtime":"node"}}"#),
+        )
+        .await;
+        assert_eq!(response.status(), axum::http::StatusCode::CONFLICT);
+        assert!(state.config.snapshot().config.is_none());
+        assert_eq!(state.setup.pending_count(), 0);
+    }
 
     #[test]
     fn reject_auth_patch_allows_object_without_rotate_token() {

--- a/apps/native/crates/local-api/src/routes/events.rs
+++ b/apps/native/crates/local-api/src/routes/events.rs
@@ -43,7 +43,7 @@ use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
-use futures::stream;
+use futures::{stream, StreamExt};
 use serde::Deserialize;
 use tokio::sync::{broadcast, mpsc};
 use tokio::time::interval;
@@ -94,7 +94,10 @@ async fn initial_frames(target: &crate::sandbox::SandboxTarget) -> Vec<Bytes> {
         snapshot::frame("tasks", &snapshot::active_tasks(&running)),
         snapshot::frame("status", &snapshot::status()),
     ];
-    if let Some(meta) = crate::routes::git::branch_snapshot(&target.repo_dir).await {
+    if let Some(meta) =
+        crate::routes::git::owned_branch_snapshot(target.tasks.clone(), target.repo_dir.clone())
+            .await
+    {
         initial.push(snapshot::frame(
             "branch",
             &serde_json::json!({ "meta": meta }),
@@ -139,6 +142,20 @@ async fn initial_frames(target: &crate::sandbox::SandboxTarget) -> Vec<Bytes> {
 }
 
 pub async fn events(State(state): State<AppState>, Query(q): Query<EventsQuery>) -> Response {
+    let authorization = match super::sandbox_account::authorize(&state).await {
+        Ok(authorization) => authorization,
+        Err(error) => return error.into_response(),
+    };
+    let account_epoch = authorization.epoch();
+    drop(authorization);
+    events_for_account(state, q, account_epoch).await
+}
+
+pub(crate) async fn events_for_account(
+    state: AppState,
+    q: EventsQuery,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+) -> Response {
     // Resolve WHICH orchestrator quadruple this stream observes: a strict,
     // metadata-only-adopted per-handle sandbox (`?handle=`), the active sandbox
     // (headerless), or the process-global one. Every per-target read below
@@ -146,7 +163,11 @@ pub async fn events(State(state): State<AppState>, Query(q): Query<EventsQuery>)
     // connect-time branch snapshot.
     let explicit_handle = q.handle.filter(|handle| !handle.is_empty());
     let target = match explicit_handle.as_deref() {
-        Some(handle) => match state.sandbox_manager.adopt(handle).await {
+        Some(handle) => match state
+            .sandbox_manager
+            .adopt_for_account(account_epoch, handle)
+            .await
+        {
             Ok(Some(sandbox)) => crate::sandbox::SandboxTarget::from_sandbox(&sandbox),
             Ok(None) => {
                 return (
@@ -164,7 +185,12 @@ pub async fn events(State(state): State<AppState>, Query(q): Query<EventsQuery>)
                     .into_response();
             }
         },
-        None => state.resolve_sandbox_target(None),
+        None => match state.resolve_sandbox_target_for_account(account_epoch, None) {
+            Ok(target) => target,
+            Err(error) => {
+                return crate::error::ApiError::conflict(error).into_response();
+            }
+        },
     };
 
     if target.broadcaster.subscriber_count() >= MAX_SSE_CLIENTS {
@@ -183,11 +209,29 @@ pub async fn events(State(state): State<AppState>, Query(q): Query<EventsQuery>)
     // observable even if another chat becomes active in between.
     let mut active_rx = state.sandbox_manager.watch_active();
     let mut generation_rx = match explicit_handle.as_deref() {
-        Some(handle) => state.sandbox_manager.watch_generation(handle),
+        Some(handle) => match state
+            .sandbox_manager
+            .watch_generation_for_account(account_epoch, handle)
+        {
+            Ok(receiver) => receiver,
+            Err(error) => return crate::error::ApiError::conflict(error).into_response(),
+        },
         None => tokio::sync::watch::channel(None).1,
     };
+    let mut account_epoch_rx = match state.sandbox_manager.watch_account_epoch(account_epoch) {
+        Ok(receiver) => receiver,
+        Err(error) => return crate::error::ApiError::conflict(error).into_response(),
+    };
+    // The producer stops enqueueing on epoch change, while this second
+    // receiver fences consumption of frames already buffered in `out_rx`.
+    // Without both halves, a slow client could drain account A's replay from
+    // the channel after account B had been installed.
+    let mut body_account_epoch_rx = account_epoch_rx.clone();
 
     let initial = initial_frames(&target).await;
+    if let Err(error) = state.sandbox_manager.validate_account_epoch(account_epoch) {
+        return crate::error::ApiError::conflict(error).into_response();
+    }
 
     let (tx, out_rx) = mpsc::channel::<Bytes>(OUT_CHANNEL_CAPACITY);
 
@@ -198,8 +242,27 @@ pub async fn events(State(state): State<AppState>, Query(q): Query<EventsQuery>)
     let task_state = state.clone();
     tokio::spawn(async move {
         for frame in initial {
-            if tx.send(frame).await.is_err() {
+            // `borrow()` deliberately does not mark a notification seen. A
+            // saturated epoch may publish the same numeric value; consuming
+            // that notification here would hide it from `changed()` below.
+            if *account_epoch_rx.borrow() != account_epoch {
                 return;
+            }
+            tokio::select! {
+                biased;
+                changed = account_epoch_rx.changed() => {
+                    // Any notification is terminal, even if a saturated
+                    // epoch has to publish the same numeric value again.
+                    // Treating only a value mismatch as stale would reopen
+                    // the stream in that fail-closed state.
+                    let _ = changed;
+                    return;
+                }
+                sent = tx.send(frame) => {
+                    if sent.is_err() {
+                        return;
+                    }
+                }
             }
         }
 
@@ -208,6 +271,14 @@ pub async fn events(State(state): State<AppState>, Query(q): Query<EventsQuery>)
 
         loop {
             tokio::select! {
+                biased;
+                changed = account_epoch_rx.changed() => {
+                    // A successful same-value notification is possible when
+                    // epoch advance saturates. Every notification closes the
+                    // account-A producer; channel closure does too.
+                    let _ = changed;
+                    return;
+                }
                 event = rx.recv() => {
                     match event {
                         Ok(ev) => {
@@ -240,7 +311,13 @@ pub async fn events(State(state): State<AppState>, Query(q): Query<EventsQuery>)
                         continue;
                     }
                     let now_active = active_rx.borrow_and_update().clone();
-                    let new_target = task_state.resolve_sandbox_target(now_active.as_deref());
+                    let new_target = match task_state.resolve_sandbox_target_for_account(
+                        account_epoch,
+                        now_active.as_deref(),
+                    ) {
+                        Ok(target) => target,
+                        Err(_) => return,
+                    };
                     if std::sync::Arc::ptr_eq(&new_target.broadcaster, &current_broadcaster) {
                         continue;
                     }
@@ -285,6 +362,16 @@ pub async fn events(State(state): State<AppState>, Query(q): Query<EventsQuery>)
             .await
             .map(|frame| (Ok::<_, Infallible>(frame), rx))
     });
+    let account_changed = async move {
+        if *body_account_epoch_rx.borrow() != account_epoch {
+            return;
+        }
+        // Terminate on any notification, not just a changed numeric value:
+        // saturation deliberately publishes the same maximum epoch while
+        // leaving account materialization permanently closed.
+        let _ = body_account_epoch_rx.changed().await;
+    };
+    let body_stream = body_stream.take_until(account_changed);
 
     crate::http_util::event_stream_response(Body::from_stream(body_stream), "SSE response")
 }
@@ -469,7 +556,11 @@ mod tests {
         // Opening a fresh manager imports the legacy sidecar into SQLite but
         // deliberately leaves its live object cache empty.
         let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf());
-        assert!(manager.get(&handle).is_none());
+        let account_epoch = manager.account_epoch();
+        assert!(manager
+            .get_for_account(account_epoch, &handle)
+            .unwrap()
+            .is_none());
         let state = state_with_manager(root.path(), manager.clone());
 
         let response = events(
@@ -480,7 +571,10 @@ mod tests {
         )
         .await;
         assert_eq!(response.status(), StatusCode::OK);
-        let adopted = manager.get(&handle).expect("metadata was adopted");
+        let adopted = manager
+            .get_for_account(account_epoch, &handle)
+            .unwrap()
+            .expect("metadata was adopted");
         assert!(
             adopted.tasks.list(None).is_empty(),
             "observing retained logs must not spawn setup/dev tasks"
@@ -531,5 +625,28 @@ mod tests {
         assert!(!main_frame.contains(r#""branch":"feature/two""#));
         assert!(feature_frame.contains(r#""branch":"feature/two""#));
         assert!(!feature_frame.contains(r#""branch":"main""#));
+    }
+
+    #[tokio::test]
+    async fn account_transition_discards_initial_frames_already_queued_for_the_body() {
+        let root = tempfile::tempdir().unwrap();
+        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf());
+        let state = state_with_manager(root.path(), manager.clone());
+        let epoch = manager.account_epoch();
+
+        let response = events_for_account(state, EventsQuery { handle: None }, epoch).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // `events_for_account` has already spawned its producer, which may
+        // have filled `out_rx` with the connect-time replay. Advancing before
+        // the HTTP body is first polled proves the consumer fence drops that
+        // backlog instead of leaking it into the next account.
+        let transition = manager.begin_account_transition().await.unwrap();
+        let mut body = response.into_body().into_data_stream();
+        assert!(tokio::time::timeout(Duration::from_secs(1), body.next())
+            .await
+            .expect("stale event stream must finish promptly")
+            .is_none());
+        drop(transition);
     }
 }

--- a/apps/native/crates/local-api/src/routes/fs.rs
+++ b/apps/native/crates/local-api/src/routes/fs.rs
@@ -68,6 +68,14 @@ const TRANSFER_DEADLINE: Duration = Duration::from_secs(5 * 60);
 
 static TOOLS_CATALOG_COMMIT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+fn require_open_generation(state: &AppState) -> Result<(), ApiError> {
+    if state.tasks.is_admission_closed() {
+        Err(ApiError::conflict("sandbox generation is stopped"))
+    } else {
+        Ok(())
+    }
+}
+
 fn shutting_down() -> ApiError {
     ApiError::new(
         StatusCode::SERVICE_UNAVAILABLE,
@@ -82,7 +90,20 @@ where
     Fut: Future<Output = Result<T, ApiError>> + Send + 'static,
 {
     let mutations = state.shutdown.mutations();
-    match mutations.run_commit(operation).await {
+    let tasks = state.tasks.clone();
+    match mutations
+        .run_commit(move || async move {
+            // Preparation may happen before this helper, but the actual
+            // managed-worktree commit is generation-owned. Stop closes this
+            // gate, drains an already-running bounded commit, then snapshots
+            // tasks; a queued or late mutation cannot commit behind it.
+            let Some(_generation_admission) = tasks.admit() else {
+                return Err(ApiError::conflict("sandbox generation is stopped"));
+            };
+            operation().await
+        })
+        .await
+    {
         Ok(result) => result,
         Err(error) => Err(map_owner_error(error)),
     }
@@ -416,6 +437,9 @@ struct WriteBody {
 }
 
 pub async fn write(State(state): State<AppState>, body: Bytes) -> Response {
+    if let Err(error) = require_open_generation(&state) {
+        return error.into_response();
+    }
     let body: WriteBody = match parse_body(&body) {
         Ok(b) => b,
         Err(e) => return e.into_response(),
@@ -466,6 +490,9 @@ fn assert_unlink_allowed(normalized: &str, recursive: bool) -> Option<&'static s
 }
 
 pub async fn unlink(State(state): State<AppState>, body: Bytes) -> Response {
+    if let Err(error) = require_open_generation(&state) {
+        return error.into_response();
+    }
     let body: UnlinkBody = match parse_body(&body) {
         Ok(b) => b,
         Err(e) => return e.into_response(),
@@ -548,6 +575,9 @@ struct MkdirBody {
 }
 
 pub async fn mkdir(State(state): State<AppState>, body: Bytes) -> Response {
+    if let Err(error) = require_open_generation(&state) {
+        return error.into_response();
+    }
     let body: MkdirBody = match parse_body(&body) {
         Ok(b) => b,
         Err(e) => return e.into_response(),
@@ -587,6 +617,9 @@ struct RenameBody {
 }
 
 pub async fn rename(State(state): State<AppState>, body: Bytes) -> Response {
+    if let Err(error) = require_open_generation(&state) {
+        return error.into_response();
+    }
     let body: RenameBody = match parse_body(&body) {
         Ok(b) => b,
         Err(e) => return e.into_response(),
@@ -657,6 +690,9 @@ struct EditBody {
 }
 
 pub async fn edit(State(state): State<AppState>, body: Bytes) -> Response {
+    if let Err(error) = require_open_generation(&state) {
+        return error.into_response();
+    }
     let body: EditBody = match parse_body(&body) {
         Ok(b) => b,
         Err(e) => return e.into_response(),
@@ -775,11 +811,14 @@ async fn drive_owned_rg(
 }
 
 async fn run_owned_rg(state: &AppState, args: &[String]) -> Result<std::process::Output, ApiError> {
-    let Some(admission) = state.shutdown.admit_work().await else {
+    let Some(shutdown_admission) = state.shutdown.admit_work().await else {
         return Err(ApiError::new(
             StatusCode::SERVICE_UNAVAILABLE,
             "application is shutting down",
         ));
+    };
+    let Some(generation_admission) = state.tasks.admit() else {
+        return Err(ApiError::conflict("sandbox generation is stopped"));
     };
 
     let mut command = Command::new("rg");
@@ -806,7 +845,7 @@ async fn run_owned_rg(state: &AppState, args: &[String]) -> Result<std::process:
     let id = format!("internal-grep-{}", uuid::Uuid::new_v4());
     let controller = ProcessController::new();
     let kill_handle = controller.kill_handle();
-    state.tasks.insert(TaskEntry::new_internal(
+    generation_admission.register(TaskEntry::new_internal(
         TaskSummary {
             id: id.clone(),
             command: format!("rg {}", args.join(" ")),
@@ -854,7 +893,7 @@ async fn run_owned_rg(state: &AppState, args: &[String]) -> Result<std::process:
         let _ = tasks.remove(&owner_id).await;
         let _ = result_tx.send(output);
     });
-    drop(admission);
+    drop(shutdown_admission);
 
     // `rg` has no graceful-shutdown protocol. Use KILL on request
     // cancellation so an aborted HTTP future cannot leave an internal
@@ -1033,6 +1072,9 @@ fn http_client() -> reqwest::Client {
 }
 
 pub async fn write_from_url(State(state): State<AppState>, body: Bytes) -> Response {
+    if let Err(error) = require_open_generation(&state) {
+        return error.into_response();
+    }
     let body: WriteFromUrlBody = match parse_body(&body) {
         Ok(b) => b,
         Err(e) => return e.into_response(),
@@ -1282,7 +1324,8 @@ async fn commit_endpoint_file(state: &AppState, content: String) -> Result<(), A
         return Err(ApiError::internal("tools catalog path escapes app root"));
     };
     let endpoint = catalog_dir.join(tools_catalog::ENDPOINT_FILENAME);
-    let repo_dir = state.repo_dir.clone();
+    let exclude_path = git_exclude::resolve_git_exclude(state.tasks.clone(), &state.repo_dir).await;
+    let exclude_line = format!("/{}/", tools_catalog::CATALOG_DIR);
     let mutation_root = state.app_root.join(".decocms").join("mutations");
     run_commit_owned(state, move || async move {
         let commit_lock = TOOLS_CATALOG_COMMIT_LOCK.get_or_init(|| Mutex::new(()));
@@ -1290,8 +1333,9 @@ async fn commit_endpoint_file(state: &AppState, content: String) -> Result<(), A
         tokio::fs::create_dir_all(&catalog_dir)
             .await
             .map_err(|error| ApiError::internal(error.to_string()))?;
-        git_exclude::ensure_git_exclude(&repo_dir, &format!("/{}/", tools_catalog::CATALOG_DIR))
-            .await;
+        if let Some(exclude_path) = exclude_path.as_deref() {
+            git_exclude::ensure_git_exclude_path(exclude_path, &exclude_line).await;
+        }
         // Finish any prior catalog directory transaction before mutating a
         // file inside its target. Unrelated long mutation stages are retained.
         let endpoint_stage_sentinel = mutation_root.join(".endpoint-update");
@@ -1357,7 +1401,8 @@ async fn commit_catalog_dir(
     };
     let stage_dir = stage_dir.to_path_buf();
     let staged_catalog = staged_catalog.to_path_buf();
-    let repo_dir = state.repo_dir.clone();
+    let exclude_path = git_exclude::resolve_git_exclude(state.tasks.clone(), &state.repo_dir).await;
+    let exclude_line = format!("/{}/", tools_catalog::CATALOG_DIR);
     let mutation_root = state.app_root.join(".decocms").join("mutations");
     run_commit_owned(state, move || async move {
         let commit_lock = TOOLS_CATALOG_COMMIT_LOCK.get_or_init(|| Mutex::new(()));
@@ -1367,8 +1412,9 @@ async fn commit_catalog_dir(
                 .await
                 .map_err(|error| ApiError::internal(error.to_string()))?;
         }
-        git_exclude::ensure_git_exclude(&repo_dir, &format!("/{}/", tools_catalog::CATALOG_DIR))
-            .await;
+        if let Some(exclude_path) = exclude_path.as_deref() {
+            git_exclude::ensure_git_exclude_path(exclude_path, &exclude_line).await;
+        }
         tools_transaction::recover_catalog_transactions(&mutation_root, &target, &stage_dir)
             .await
             .map_err(|error| ApiError::internal(error.to_string()))?;
@@ -1386,6 +1432,9 @@ async fn commit_catalog_dir(
 /// The catalog lives under `<repo>/.deco/tools/` — distinct from local-api's
 /// own `<workdir>/.decocms/` (see the threads store doc).
 pub async fn tools_sync(State(state): State<AppState>, body: Bytes) -> Response {
+    if let Err(error) = require_open_generation(&state) {
+        return error.into_response();
+    }
     let body: ToolsSyncBody = match parse_body(&body) {
         Ok(b) => b,
         Err(e) => return e.into_response(),
@@ -1462,6 +1511,73 @@ pub async fn tools_sync(State(state): State<AppState>, body: Bytes) -> Response 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn generation_close_waits_for_a_commit_and_rejects_the_delayed_next_commit() {
+        let root = tempfile::tempdir().unwrap();
+        let state = crate::routes::intercept::test_state(root.path());
+        tokio::fs::create_dir_all(&state.repo_dir).await.unwrap();
+        let staged = root.path().join("staged");
+        tokio::fs::write(&staged, b"prepared").await.unwrap();
+        let target = state.repo_dir.join("committed.txt");
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let commit_state = state.clone();
+        let commit = tokio::spawn(async move {
+            run_commit_owned(&commit_state, move || async move {
+                entered_tx.send(()).unwrap();
+                release_rx.await.unwrap();
+                tokio::fs::rename(staged, target)
+                    .await
+                    .map_err(|error| ApiError::internal(error.to_string()))
+            })
+            .await
+        });
+        entered_rx
+            .await
+            .expect("commit owns generation admission before pausing");
+
+        let closing_tasks = state.tasks.clone();
+        let close = tokio::spawn(async move {
+            closing_tasks
+                .close_and_kill_all_and_wait(Duration::ZERO, Duration::ZERO)
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !state.tasks.is_admission_closed() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("close begins");
+        assert!(
+            !close.is_finished(),
+            "generation close must drain the bounded commit"
+        );
+        release_tx.send(()).unwrap();
+        commit.await.unwrap().unwrap();
+        close.await.unwrap();
+        assert_eq!(
+            tokio::fs::read(state.repo_dir.join("committed.txt"))
+                .await
+                .unwrap(),
+            b"prepared"
+        );
+
+        let late = state.repo_dir.join("late.txt");
+        let late_result = run_commit_owned(&state, move || async move {
+            tokio::fs::write(late, b"late")
+                .await
+                .map_err(|error| ApiError::internal(error.to_string()))
+        })
+        .await;
+        assert_eq!(
+            late_result.unwrap_err().status,
+            StatusCode::CONFLICT,
+            "a staged mutation reaching commit after Stop must be rejected"
+        );
+        assert!(!state.repo_dir.join("late.txt").exists());
+    }
 
     /// A fresh worktree has `.deco/blocks/*.json` but not the merged
     /// `blocks.gen.json` (repos gitignore it), and without this rebuild the

--- a/apps/native/crates/local-api/src/routes/fs/git_exclude.rs
+++ b/apps/native/crates/local-api/src/routes/fs/git_exclude.rs
@@ -4,23 +4,40 @@
 //! paths (the tool catalog, its endpoint credential file) onto the user's
 //! branch. Best-effort: an unwritable `.git` never blocks the caller.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use tokio::fs;
 
-pub async fn ensure_git_exclude(repo_dir: &Path, line: &str) {
+use crate::tasks::TaskRegistry;
+
+/// Resolve the worktree-aware exclude path through a hidden generation-owned
+/// Git probe. Callers do this before acquiring the filesystem commit lease:
+/// Stop can preempt and reap the child, and if Stop wins between resolution
+/// and commit the later commit admission rejects the mutation.
+pub async fn resolve_git_exclude(tasks: Arc<TaskRegistry>, repo_dir: &Path) -> Option<PathBuf> {
+    let repo_dir = repo_dir.to_path_buf();
+    crate::routes::git::run_owned_git_probe(tasks, "git exclude-path probe", async move {
+        crate::routes::git::git_path(&repo_dir, "info/exclude").await
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+/// Best-effort filesystem half of exclude registration. The Git child that
+/// produced `exclude_path` has already joined; callers run this mutation under
+/// `fs::run_commit_owned` so Stop drains or rejects it atomically.
+pub async fn ensure_git_exclude_path(exclude_path: &Path, line: &str) {
     // Resolved through git, not by joining `.git`: every sandbox workdir is a
     // linked worktree, where `.git` is a FILE pointing elsewhere. The old
     // `is_dir()` guard therefore returned early for every real sandbox, so
     // this never ran and `git add -A` at publish staged the tool catalog and
     // its endpoint CREDENTIAL file onto the user's branch.
-    let Some(exclude_path) = crate::routes::git::git_path(repo_dir, "info/exclude").await else {
-        return;
-    };
     let Some(info_dir) = exclude_path.parent().map(std::path::Path::to_path_buf) else {
         return;
     };
-    match fs::read_to_string(&exclude_path).await {
+    match fs::read_to_string(exclude_path).await {
         Ok(existing) => {
             if !existing.lines().any(|l| l == line) {
                 let appended = if existing.ends_with('\n') || existing.is_empty() {
@@ -28,14 +45,14 @@ pub async fn ensure_git_exclude(repo_dir: &Path, line: &str) {
                 } else {
                     format!("{existing}\n{line}\n")
                 };
-                let _ = fs::write(&exclude_path, appended).await;
+                let _ = fs::write(exclude_path, appended).await;
             }
         }
         Err(_) => {
             // Template-less clones (libgit2/JGit, bare templates) lack
             // info/exclude.
             if fs::create_dir_all(&info_dir).await.is_ok() {
-                let _ = fs::write(&exclude_path, format!("{line}\n")).await;
+                let _ = fs::write(exclude_path, format!("{line}\n")).await;
             }
         }
     }
@@ -46,6 +63,19 @@ mod tests {
     use super::*;
     use std::process::Command;
     use tempfile::tempdir;
+
+    async fn ensure_git_exclude(repo_dir: &Path, line: &str) {
+        let logs_root = repo_dir
+            .parent()
+            .unwrap_or(repo_dir)
+            .join("git-exclude-test-logs");
+        let tasks = Arc::new(TaskRegistry::new(Arc::new(
+            crate::log_store::LogStore::new(logs_root),
+        )));
+        if let Some(path) = resolve_git_exclude(tasks, repo_dir).await {
+            ensure_git_exclude_path(&path, line).await;
+        }
+    }
 
     fn git(cwd: &Path, args: &[&str]) {
         let status = Command::new("git")

--- a/apps/native/crates/local-api/src/routes/git.rs
+++ b/apps/native/crates/local-api/src/routes/git.rs
@@ -76,7 +76,8 @@ use crate::process_group::ProcessGroupChild;
 use crate::process_util::CancelOnDrop;
 use crate::state::AppState;
 use crate::tasks::{
-    registry::now_ms, KillHandle, KillSignal, ProcessController, TaskEntry, TaskStatus, TaskSummary,
+    registry::now_ms, GenerationAdmission, KillHandle, KillSignal, ProcessController, TaskEntry,
+    TaskRegistry, TaskStatus, TaskSummary,
 };
 
 const GIT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -168,7 +169,7 @@ async fn publish_inner(state: AppState, body: Bytes) -> ApiResult<Json<Value>> {
     match publish_internal(&state.repo_dir, &message).await {
         Ok(pushed) => {
             if pushed {
-                emit_branch_event(&state.repo_dir, &state.broadcaster).await;
+                emit_branch_event(state.tasks.clone(), &state.repo_dir, &state.broadcaster).await;
             }
             Ok(Json(json!({ "pushed": pushed })))
         }
@@ -193,7 +194,7 @@ async fn discard_inner(state: AppState, body: Bytes) -> ApiResult<Json<Value>> {
 
     match discard_files(&state.app_root, &state.repo_dir, &filepaths).await {
         Ok(()) => {
-            emit_branch_event(&state.repo_dir, &state.broadcaster).await;
+            emit_branch_event(state.tasks.clone(), &state.repo_dir, &state.broadcaster).await;
             Ok(Json(json!({ "success": true })))
         }
         // Byte-parity with `makeGitDiscardHandler`'s catch-all 500 (including
@@ -224,7 +225,7 @@ async fn rebase_inner(state: AppState, body: Bytes) -> ApiResult<Json<Value>> {
 
     match rebase_onto_base(&state.repo_dir, base).await {
         Ok(()) => {
-            emit_branch_event(&state.repo_dir, &state.broadcaster).await;
+            emit_branch_event(state.tasks.clone(), &state.repo_dir, &state.broadcaster).await;
             Ok(Json(json!({ "rebased": true })))
         }
         Err(e) => Err(route_error_response(e, true)),
@@ -237,9 +238,10 @@ async fn rebase_inner(state: AppState, body: Bytes) -> ApiResult<Json<Value>> {
 /// immediately afterward: every accepted operation is then enumerable through
 /// `TaskRegistry`, without holding a read-admission guard for its full runtime.
 fn spawn_git_operation_owner<T, F>(
-    state: AppState,
+    tasks: std::sync::Arc<TaskRegistry>,
     command: &str,
     operation: F,
+    generation_admission: GenerationAdmission,
 ) -> (KillHandle, oneshot::Receiver<Result<T, &'static str>>)
 where
     T: Send + 'static,
@@ -248,7 +250,7 @@ where
     let id = format!("internal-git-{}", uuid::Uuid::new_v4());
     let controller = ProcessController::new();
     let kill_handle = controller.kill_handle();
-    state.tasks.insert(TaskEntry::new_internal(
+    generation_admission.register(TaskEntry::new_internal(
         TaskSummary {
             id: id.clone(),
             command: command.to_string(),
@@ -264,8 +266,7 @@ where
         Some(kill_handle.clone()),
     ));
 
-    let tasks = state.tasks.clone();
-    let child_lifetime_lock_path = state.tasks.child_lifetime_lock_path().to_path_buf();
+    let child_lifetime_lock_path = tasks.child_lifetime_lock_path().to_path_buf();
     let owner_id = id.clone();
     let (result_tx, result_rx) = oneshot::channel();
     tokio::spawn(async move {
@@ -296,6 +297,78 @@ where
     (kill_handle, result_rx)
 }
 
+async fn await_git_operation<T>(
+    kill_handle: KillHandle,
+    result_rx: oneshot::Receiver<Result<T, &'static str>>,
+) -> ApiResult<T> {
+    await_git_operation_result(kill_handle, result_rx)
+        .await
+        .map_err(ApiError::internal)
+}
+
+async fn await_git_operation_result<T>(
+    kill_handle: KillHandle,
+    result_rx: oneshot::Receiver<Result<T, &'static str>>,
+) -> Result<T, String> {
+    let mut cancel_on_drop = CancelOnDrop::new(kill_handle, KillSignal::Term);
+    let result = result_rx
+        .await
+        .map_err(|_| "git operation owner stopped unexpectedly".to_string())?
+        .map_err(str::to_string)?;
+    cancel_on_drop.disarm();
+    Ok(result)
+}
+
+/// Own a non-route Git observation in this exact sandbox generation. The
+/// hidden registry entry is installed synchronously before the detached owner
+/// can spawn any Git child; Stop can therefore signal and join probes from
+/// manager, bridge, and filesystem helper paths just like ordinary Git routes.
+pub(crate) async fn run_owned_git_probe<T, F>(
+    tasks: std::sync::Arc<TaskRegistry>,
+    command: &str,
+    operation: F,
+) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: Future<Output = T> + Send + 'static,
+{
+    let generation = tasks.clone();
+    let generation_admission = tasks
+        .admit()
+        .ok_or_else(|| "sandbox generation is stopped".to_string())?;
+    let (kill_handle, result_rx) =
+        spawn_git_operation_owner(tasks, command, operation, generation_admission);
+    let result = await_git_operation_result(kill_handle, result_rx).await?;
+    if generation.is_admission_closed() {
+        return Err("sandbox generation stopped during Git probe".to_string());
+    }
+    Ok(result)
+}
+
+pub(crate) async fn owned_is_git_repo(
+    tasks: std::sync::Arc<TaskRegistry>,
+    repo_dir: PathBuf,
+) -> Result<bool, String> {
+    run_owned_git_probe(tasks, "git repository probe", async move {
+        is_git_repo(&repo_dir).await
+    })
+    .await
+}
+
+pub(crate) async fn prune_worktree_registrations(canonical_repo: &Path) -> Result<(), String> {
+    if GIT_PROCESS_CONTROLLER.try_with(|_| ()).is_err() {
+        return Err("worktree prune requires a generation-owned Git controller".to_string());
+    }
+    run_git_raw(
+        canonical_repo,
+        &["worktree", "prune"],
+        &route_env(canonical_repo),
+    )
+    .await
+    .map(|_| ())
+    .map_err(|error| error.message)
+}
+
 /// Admits only the spawn + hidden-owner registration critical section. The
 /// detached owner remains visible to coordinated shutdown until all of its Git
 /// process groups have been joined and the operation has finalized.
@@ -311,16 +384,18 @@ where
             "application is shutting down",
         ));
     };
-    let (kill_handle, result_rx) = spawn_git_operation_owner(state, command, operation);
+    let Some(generation_admission) = state.tasks.admit() else {
+        return Err(ApiError::conflict("sandbox generation is stopped"));
+    };
+    let (kill_handle, result_rx) = spawn_git_operation_owner(
+        state.tasks.clone(),
+        command,
+        operation,
+        generation_admission,
+    );
     drop(admission);
 
-    let mut cancel_on_drop = CancelOnDrop::new(kill_handle, KillSignal::Term);
-    let result = result_rx
-        .await
-        .map_err(|_| ApiError::internal("git operation owner stopped unexpectedly"))?
-        .map_err(ApiError::internal)?;
-    cancel_on_drop.disarm();
-    result
+    await_git_operation(kill_handle, result_rx).await?
 }
 
 async fn require_git_repo(repo_dir: &Path) -> ApiResult<()> {
@@ -1928,11 +2003,36 @@ async fn rebase_onto_base(repo_dir: &Path, base: &str) -> Result<(), RouteError>
 /// `branchStatus.refresh()` call) — hence taking `repo_dir`/`broadcaster`
 /// directly rather than a full `&AppState` (the setup module constructs its
 /// own view of these, not a route-extracted `AppState`).
-pub(crate) async fn emit_branch_event(repo_dir: &Path, broadcaster: &crate::events::Broadcaster) {
-    let Some(meta) = branch_snapshot(repo_dir).await else {
+pub(crate) async fn emit_branch_event(
+    tasks: std::sync::Arc<TaskRegistry>,
+    repo_dir: &Path,
+    broadcaster: &crate::events::Broadcaster,
+) {
+    let Some(meta) = owned_branch_snapshot(tasks, repo_dir.to_path_buf()).await else {
         return;
     };
     broadcaster.emit("branch", json!({ "meta": meta }));
+}
+
+/// Run an observational branch snapshot under the same hidden generation
+/// owner as mutating Git routes. SSE handshakes and background pollers are
+/// process-spawning paths too: a stopped metadata generation rejects them,
+/// while Stop can signal and await any snapshot admitted before close.
+pub(crate) async fn owned_branch_snapshot(
+    tasks: std::sync::Arc<TaskRegistry>,
+    repo_dir: PathBuf,
+) -> Option<Value> {
+    let generation_admission = tasks.admit()?;
+    let (kill_handle, result_rx) = spawn_git_operation_owner(
+        tasks,
+        "git branch snapshot",
+        async move { branch_snapshot(&repo_dir).await },
+        generation_admission,
+    );
+    await_git_operation(kill_handle, result_rx)
+        .await
+        .ok()
+        .flatten()
 }
 
 /// Compute the current reconnect/live branch payload for exactly `repo_dir`.
@@ -2120,6 +2220,47 @@ mod tests {
         })
         .await
         .expect("detached owner finalized after its operation completed");
+    }
+
+    #[tokio::test]
+    async fn generation_close_reaps_owned_non_route_git_probe_and_rejects_late_probe() {
+        let root = TempDir::new().unwrap();
+        let state = test_app_state(root.path());
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let probe_tasks = state.tasks.clone();
+        let probe = tokio::spawn(async move {
+            run_owned_git_probe(probe_tasks, "git lifecycle probe", async move {
+                let controller = GIT_PROCESS_CONTROLLER
+                    .try_with(Clone::clone)
+                    .expect("owned probe installs its process controller");
+                started_tx.send(()).unwrap();
+                controller.wait_for_change(None).await
+            })
+            .await
+        });
+        started_rx.await.expect("probe owner is registered");
+
+        let result = state
+            .tasks
+            .close_and_kill_all_and_wait(Duration::from_secs(1), Duration::from_secs(1))
+            .await;
+        assert_eq!(result.initially_running, 1);
+        assert_eq!(result.term_signaled, 1);
+        assert!(result.remaining.is_empty());
+        assert!(
+            probe.await.unwrap().is_err(),
+            "a probe signaled by generation close cannot publish an observation"
+        );
+
+        let ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let late_ran = ran.clone();
+        let error = run_owned_git_probe(state.tasks.clone(), "late probe", async move {
+            late_ran.store(true, std::sync::atomic::Ordering::SeqCst);
+        })
+        .await
+        .expect_err("closed generation rejects a new raw Git probe");
+        assert!(error.contains("stopped"));
+        assert!(!ran.load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[tokio::test]
@@ -2318,7 +2459,10 @@ mod tests {
     /// point at the same directory) for tests that do not materialize a
     /// per-handle sandbox.
     fn test_app_state(dir: &Path) -> AppState {
-        let (app_root, repo_dir) = (dir, dir);
+        test_app_state_at(dir, dir)
+    }
+
+    fn test_app_state_at(app_root: &Path, repo_dir: &Path) -> AppState {
         let config = std::sync::Arc::new(crate::config::ConfigStore::new());
         let logs = std::sync::Arc::new(crate::log_store::LogStore::new(app_root.join("logs")));
         let tasks = std::sync::Arc::new(crate::tasks::TaskRegistry::new(logs));
@@ -2569,16 +2713,20 @@ mod tests {
     #[tokio::test]
     async fn branch_event_emitted_after_publish() {
         let repo = setup_repo();
+        let app_root = TempDir::new().unwrap();
         std::fs::write(repo.work_dir.join("evented.txt"), "x\n").unwrap();
 
-        let state = test_app_state(&repo.work_dir);
+        // Production task logs live under the native app root, never in the
+        // checkout. Keep that boundary in the fixture: the hidden owner for
+        // the branch probe must not make the repository appear dirty.
+        let state = test_app_state_at(app_root.path(), &repo.work_dir);
         let mut rx = state.broadcaster.subscribe();
 
         let pushed = publish_internal(&state.repo_dir, "evented publish")
             .await
             .unwrap();
         assert!(pushed);
-        emit_branch_event(&state.repo_dir, &state.broadcaster).await;
+        emit_branch_event(state.tasks.clone(), &state.repo_dir, &state.broadcaster).await;
 
         let evt = rx.recv().await.expect("branch event delivered");
         assert_eq!(evt.name, "branch");

--- a/apps/native/crates/local-api/src/routes/intercept/agent_sessions.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/agent_sessions.rs
@@ -14,12 +14,14 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde_json::{json, Map, Value};
 
+use super::sandbox_authority::{authorize, manager_error, require_account, Access};
 use super::sandbox_lifecycle::local_sandbox_sessions;
 use crate::state::AppState;
 
 pub(super) async fn try_dispatch(
     state: &AppState,
     method: &Method,
+    org: &str,
     rest: &[&str],
     query: Option<&str>,
 ) -> Option<Response> {
@@ -29,27 +31,52 @@ pub(super) async fn try_dispatch(
     if *method != Method::GET {
         return None;
     }
-    let virtual_mcp_id = urlencoding::decode(encoded_virtual_mcp_id)
-        .map(|decoded| decoded.into_owned())
-        .unwrap_or_else(|_| (*encoded_virtual_mcp_id).to_string());
+    let virtual_mcp_id =
+        match super::sandbox_fs::decode_identity_segment("virtualMcpId", encoded_virtual_mcp_id) {
+            Ok(value) => value,
+            Err(error) => return Some(error.into_response()),
+        };
 
     let branch_filter = query.and_then(|query| crate::http_util::query_param(query, "branch"));
-    Some(local_sessions(
-        state,
-        &virtual_mcp_id,
-        branch_filter.as_deref(),
-    ))
+    let authorization = match branch_filter.as_deref() {
+        Some(branch) => {
+            match authorize(state, org, &virtual_mcp_id, branch, Access::Viewer).await {
+                Ok(authorization) => authorization,
+                Err(error) => return Some(error.into_response()),
+            }
+        }
+        None => match require_account(state).await {
+            Ok(authorization) => authorization,
+            Err(error) => return Some(error.into_response()),
+        },
+    };
+    Some(
+        match local_sessions(
+            state,
+            &virtual_mcp_id,
+            branch_filter.as_deref(),
+            authorization.account_epoch(),
+        ) {
+            Ok(response) => response,
+            Err(error) => manager_error(error).into_response(),
+        },
+    )
 }
 
-fn local_sessions(state: &AppState, virtual_mcp_id: &str, branch_filter: Option<&str>) -> Response {
-    let items: Vec<Value> = local_sandbox_sessions(state, virtual_mcp_id)
+fn local_sessions(
+    state: &AppState,
+    virtual_mcp_id: &str,
+    branch_filter: Option<&str>,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+) -> Result<Response, String> {
+    let items: Vec<Value> = local_sandbox_sessions(state, virtual_mcp_id, account_epoch)?
         .into_iter()
         .filter(|local| {
             let branch = local.get("branch").and_then(Value::as_str).unwrap_or("");
             branch_filter.is_none_or(|wanted| wanted == branch)
         })
         .collect();
-    Json(json!({ "items": items })).into_response()
+    Ok(Json(json!({ "items": items })).into_response())
 }
 
 /// One local sandbox, as the session wire shape needs it.

--- a/apps/native/crates/local-api/src/routes/intercept/mod.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/mod.rs
@@ -11,11 +11,12 @@
 //!
 //! [`try_intercept`] is [`crate::routes::upstream::proxy`]'s FIRST decision,
 //! before the `/api/auth/*` cookie-relay branch or the ordinary
-//! bearer-forwarding branch ever run: intercepted routes need neither — they
-//! never talk to upstream at all. Anything this module doesn't recognize
-//! returns `None`, and the caller falls through to the unmodified proxy
-//! behavior (bearer + persisted-cookie forwarding). See each submodule's own
-//! doc comment for its slice of the table:
+//! bearer-forwarding branch ever runs. Intercepted routes enforce their own
+//! current-account authority; the sandbox start path also performs one
+//! explicit upstream virtual-MCP lookup. Anything this module doesn't
+//! recognize returns `None`, and the caller falls through to the unmodified
+//! proxy behavior (bearer + persisted-cookie forwarding). See each
+//! submodule's own doc comment for its slice of the table:
 //!
 //! | Route(s) | Map section | Submodule |
 //! | --- | --- | --- |
@@ -50,16 +51,18 @@
 //!
 //! ## `:org` is opaque
 //!
-//! Neither this module nor its submodules validate the `:org` path segment
-//! against a real organization — it is stamped verbatim as
-//! `organization_id` on locally-created rows. Map §3.1 makes the same
-//! point about `virtual_mcp_id`: these are opaque strings scoping purely
-//! local data, never round-tripped against upstream.
+//! Local thread storage treats `:org` as an account-scoped opaque identifier;
+//! it does not perform a separate upstream membership lookup. Thread-backed
+//! sandbox routes verify that their virtual-MCP id matches the local thread.
+//! `SANDBOX_START` is the deliberate exception for remote data: it resolves
+//! that virtual MCP upstream to obtain repository metadata before provisioning
+//! the local worktree.
 
 mod agent_sessions;
 mod dev_server;
 mod git_assist;
 mod preview_invoke;
+mod sandbox_authority;
 mod sandbox_events;
 mod sandbox_fs;
 mod sandbox_lifecycle;
@@ -127,23 +130,24 @@ pub async fn try_intercept(
         crate::sandbox::org_mount::warm(&state.app_root, org);
     }
 
-    if let Some(response) = sandbox_fs::try_dispatch(state, method, &rest, body).await {
+    if let Some(response) = sandbox_fs::try_dispatch(state, method, org, &rest, body).await {
         return Some(response);
     }
 
-    if let Some(response) = sandbox_events::try_dispatch(state, method, &rest).await {
+    if let Some(response) = sandbox_events::try_dispatch(state, method, org, &rest).await {
         return Some(response);
     }
 
-    if let Some(response) = preview_invoke::try_dispatch(state, method, &rest, body).await {
+    if let Some(response) = preview_invoke::try_dispatch(state, method, org, &rest, body).await {
         return Some(response);
     }
 
-    if let Some(response) = sandbox_ops::try_dispatch(state, method, &rest, query, body).await {
+    if let Some(response) = sandbox_ops::try_dispatch(state, method, org, &rest, query, body).await
+    {
         return Some(response);
     }
 
-    if let Some(response) = agent_sessions::try_dispatch(state, method, &rest, query).await {
+    if let Some(response) = agent_sessions::try_dispatch(state, method, org, &rest, query).await {
         return Some(response);
     }
 
@@ -158,17 +162,40 @@ pub async fn try_intercept(
             // `EventSource` reconnect with 401/500/503 closes that stream for
             // the life of the page, and a native rebuild restarts the listener
             // under a webview that keeps running.
-            let scope = match thread_tools::current_account_scope_result().await {
-                Ok(Some(scope)) => scope,
-                Ok(None) => return Some(watch::retryable_refusal("no signed-in account yet")),
+            let scope =
+                match crate::routes::threads::authority::current_account_scope_result().await {
+                    Ok(Some(scope)) => scope,
+                    Ok(None) => return Some(watch::retryable_refusal("no signed-in account yet")),
+                    Err(error) => {
+                        tracing::warn!(%error, "native watch account scope storage unavailable");
+                        return Some(watch::retryable_refusal(
+                            "session storage temporarily unavailable",
+                        ));
+                    }
+                };
+            let account_guard =
+                match crate::routes::threads::authority::lock_account_scope(&scope).await {
+                    Ok(guard) => guard,
+                    Err(error) => {
+                        tracing::debug!(?error, "native watch account changed during admission");
+                        return Some(watch::retryable_refusal(
+                            "account changed while opening native watch",
+                        ));
+                    }
+                };
+            let account_epoch = state.sandbox_manager.account_epoch();
+            let account_epoch_rx = match state.sandbox_manager.watch_account_epoch(account_epoch) {
+                Ok(receiver) => receiver,
                 Err(error) => {
-                    tracing::warn!(%error, "native watch account scope storage unavailable");
+                    drop(account_guard);
+                    tracing::debug!(%error, "native watch sandbox account fence unavailable");
                     return Some(watch::retryable_refusal(
-                        "session storage temporarily unavailable",
+                        "account transition in progress while opening native watch",
                     ));
                 }
             };
-            Some(watch::get(&scope, org, query))
+            drop(account_guard);
+            Some(watch::get_for_account(&scope, org, query, account_epoch_rx))
         }
         Some("tools") if rest.len() == 2 && *method == Method::POST => match rest[1] {
             tool_name @ ("COLLECTION_THREADS_LIST"
@@ -177,8 +204,9 @@ pub async fn try_intercept(
             | "COLLECTION_THREADS_UPDATE"
             | "COLLECTION_THREADS_DELETE"
             | "COLLECTION_THREAD_MESSAGES_LIST") => {
-                let Some(scope) = thread_tools::current_account_scope().await else {
-                    return Some(ApiError::unauthorized().into_response());
+                let scope = match crate::routes::threads::authority::current_account_scope().await {
+                    Ok(scope) => scope,
+                    Err(error) => return Some(error.into_response()),
                 };
                 thread_tools::dispatch_scoped(state, &scope, org, tool_name, body).await
             }

--- a/apps/native/crates/local-api/src/routes/intercept/preview_invoke.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/preview_invoke.rs
@@ -26,18 +26,34 @@ use super::sandbox_fs::decode_identity_segment;
 use crate::error::ApiError;
 use crate::state::AppState;
 
+use super::sandbox_authority::{authorize, manager_error, Access};
+
 /// Cap on the invoke body, mirroring `PREVIEW_INVOKE_MAX_BODY_BYTES`.
 const MAX_BODY_BYTES: usize = 1024 * 1024;
 
 pub(super) async fn try_dispatch(
     state: &AppState,
     method: &Method,
+    org: &str,
     rest: &[&str],
     body: &Bytes,
 ) -> Option<Response> {
     let ["sandbox", encoded_virtual_mcp_id, encoded_branch, "preview-invoke"] = rest else {
         return None;
     };
+    let virtual_mcp_id = match decode_identity_segment("virtualMcpId", encoded_virtual_mcp_id) {
+        Ok(value) => value,
+        Err(error) => return Some(error.into_response()),
+    };
+    let branch = match decode_identity_segment("branch", encoded_branch) {
+        Ok(value) => value,
+        Err(error) => return Some(error.into_response()),
+    };
+    let authorization =
+        match authorize(state, org, &virtual_mcp_id, &branch, Access::ActiveOwner).await {
+            Ok(authorization) => authorization,
+            Err(error) => return Some(error.into_response()),
+        };
     if *method != Method::POST {
         return Some(
             ApiError::new(
@@ -52,19 +68,25 @@ pub(super) async fn try_dispatch(
             ApiError::new(StatusCode::PAYLOAD_TOO_LARGE, "Payload too large").into_response(),
         );
     }
-
-    let virtual_mcp_id = match decode_identity_segment("virtualMcpId", encoded_virtual_mcp_id) {
-        Ok(value) => value,
-        Err(error) => return Some(error.into_response()),
-    };
-    let branch = match decode_identity_segment("branch", encoded_branch) {
-        Ok(value) => value,
-        Err(error) => return Some(error.into_response()),
-    };
-    Some(invoke(state, &virtual_mcp_id, &branch, body).await)
+    Some(
+        invoke(
+            state,
+            &virtual_mcp_id,
+            &branch,
+            body,
+            authorization.account_epoch(),
+        )
+        .await,
+    )
 }
 
-async fn invoke(state: &AppState, virtual_mcp_id: &str, branch: &str, body: &Bytes) -> Response {
+async fn invoke(
+    state: &AppState,
+    virtual_mcp_id: &str,
+    branch: &str,
+    body: &Bytes,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+) -> Response {
     let Some(parsed) = serde_json::from_slice::<Value>(body)
         .ok()
         .and_then(|value| parse_invoke(&value))
@@ -77,17 +99,28 @@ async fn invoke(state: &AppState, virtual_mcp_id: &str, branch: &str, body: &Byt
 
     // Keyed by (virtualMcpId, branch); the worktree handle is derived from the
     // repository, so the registry is what bridges them.
-    let Ok(Some(handle)) = state
-        .sandbox_manager
-        .handle_for_agent(virtual_mcp_id, branch)
-    else {
-        return ApiError::new(StatusCode::BAD_GATEWAY, "Preview not available").into_response();
+    let handle = match state.sandbox_manager.handle_for_virtual_mcp_for_account(
+        account_epoch,
+        virtual_mcp_id,
+        branch,
+    ) {
+        Ok(Some(handle)) => handle,
+        Ok(None) => {
+            return ApiError::new(StatusCode::BAD_GATEWAY, "Preview not available").into_response()
+        }
+        Err(error) => return manager_error(error).into_response(),
     };
-    let Some(port) = state
+    let sandbox = match state
         .sandbox_manager
-        .get(&handle)
-        .and_then(|sandbox| crate::routes::proxy::sandbox_dev_port(&sandbox))
-    else {
+        .get_for_account(account_epoch, &handle)
+    {
+        Ok(Some(sandbox)) => sandbox,
+        Ok(None) => {
+            return ApiError::new(StatusCode::BAD_GATEWAY, "Preview not available").into_response()
+        }
+        Err(error) => return manager_error(error).into_response(),
+    };
+    let Some(port) = crate::routes::proxy::sandbox_dev_port(&sandbox) else {
         return ApiError::new(StatusCode::BAD_GATEWAY, "Preview not available").into_response();
     };
 
@@ -110,8 +143,15 @@ async fn invoke(state: &AppState, virtual_mcp_id: &str, branch: &str, body: &Byt
         .post(&url)
         .header(header::CONTENT_TYPE, "application/json")
         .body(payload);
-    super::dev_server::send_and_mirror(request, Some(HeaderValue::from_static("application/json")))
-        .await
+    let response = super::dev_server::send_and_mirror(
+        request,
+        Some(HeaderValue::from_static("application/json")),
+    )
+    .await;
+    match state.sandbox_manager.validate_account_epoch(account_epoch) {
+        Ok(()) => response,
+        Err(error) => manager_error(error).into_response(),
+    }
 }
 
 struct Invoke {

--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_authority.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_authority.rs
@@ -1,0 +1,228 @@
+//! Account and thread authority for native sandbox interceptions.
+//!
+//! Every local sandbox route is behind two independent fences: the loopback
+//! bearer proves the caller is the embedded app, while this module proves the
+//! app still has a signed-in Studio account. A `thread:<id>` branch carries
+//! enough information to apply the canonical local thread authority as well.
+//! Ordinary git branches do not, so they remain account-authenticated without
+//! claiming cross-account ownership isolation the URL cannot prove. The
+//! account-transition gate fences admission only; it is released before any
+//! potentially long workspace I/O so account switching cannot be starved.
+
+use crate::error::{ApiError, ApiResult};
+use crate::routes::threads::authority::{self, ThreadAccess};
+use crate::sandbox::manager::AccountEpoch;
+use crate::state::AppState;
+use tokio::sync::OwnedMutexGuard;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Access {
+    Viewer,
+    ActiveOwner,
+    Recovery,
+    WorkspaceMutation,
+}
+
+/// Keeps an ordinary thread-backed workspace mutation inside the same
+/// lifecycle critical section as terminal start, archive, and delete.
+/// Recovery controls intentionally carry no lifecycle guard so they can stop
+/// the operation holding it.
+#[must_use = "dropping sandbox authority releases its thread lifecycle lock"]
+pub(super) struct Authorization {
+    account_epoch: AccountEpoch,
+    identity_generation: u64,
+    _owner_guard: Option<OwnedMutexGuard<()>>,
+}
+
+impl Authorization {
+    pub(super) fn account_epoch(&self) -> AccountEpoch {
+        self.account_epoch
+    }
+
+    pub(super) fn identity_generation(&self) -> u64 {
+        self.identity_generation
+    }
+}
+
+/// Require a current account and, for a thread-backed sandbox, resolve the
+/// named thread under that same account/org scope and verify its virtual MCP.
+pub(super) async fn authorize(
+    state: &AppState,
+    org: &str,
+    virtual_mcp_id: &str,
+    branch: &str,
+    access: Access,
+) -> ApiResult<Authorization> {
+    let scope = authority::current_account_scope().await?;
+    let Some(thread_id) = thread_id(branch)? else {
+        // Ordinary branches have no thread row from which to derive a
+        // lifecycle owner, but their admission still has to linearize with
+        // logout/account replacement. Release the transition gate before the
+        // potentially long workspace operation; this is point-in-time account
+        // authentication, not tenant ownership for the machine-wide registry.
+        let account_guard = authority::lock_account_scope(&scope).await?;
+        let account_epoch = state.sandbox_manager.account_epoch();
+        crate::routes::sandbox_account::validate_expected_epoch(account_epoch)?;
+        let identity_generation = account_guard.generation();
+        drop(account_guard);
+        return Ok(Authorization {
+            account_epoch,
+            identity_generation,
+            _owner_guard: None,
+        });
+    };
+
+    if access == Access::Viewer {
+        let account_guard = authority::lock_account_scope(&scope).await?;
+        let resolved =
+            authority::resolve_scoped_thread(state, scope, org, thread_id, ThreadAccess::Viewer)?;
+        verify_virtual_mcp(&resolved.thread.virtual_mcp_id, virtual_mcp_id)?;
+        let account_epoch = state.sandbox_manager.account_epoch();
+        crate::routes::sandbox_account::validate_expected_epoch(account_epoch)?;
+        let identity_generation = account_guard.generation();
+        drop(account_guard);
+        return Ok(Authorization {
+            account_epoch,
+            identity_generation,
+            _owner_guard: None,
+        });
+    }
+
+    if matches!(access, Access::ActiveOwner | Access::Recovery) {
+        // Controls and potentially long viewer-adjacent I/O must be admitted
+        // under a stable account identity, but must never queue behind a
+        // workspace operation. Recovery deliberately accepts an archived or
+        // delete-pending owned thread so stop/kill/delete can finish cleanup;
+        // preview invocation still requires ActiveOwner.
+        let account_guard = authority::lock_account_scope(&scope).await?;
+        let thread_access = if access == Access::Recovery {
+            ThreadAccess::Owner
+        } else {
+            ThreadAccess::ActiveOwner
+        };
+        let resolved =
+            authority::resolve_scoped_thread(state, scope, org, thread_id, thread_access)?;
+        verify_virtual_mcp(&resolved.thread.virtual_mcp_id, virtual_mcp_id)?;
+        let account_epoch = state.sandbox_manager.account_epoch();
+        crate::routes::sandbox_account::validate_expected_epoch(account_epoch)?;
+        let identity_generation = account_guard.generation();
+        drop(account_guard);
+        return Ok(Authorization {
+            account_epoch,
+            identity_generation,
+            _owner_guard: None,
+        });
+    }
+
+    // Resolve once to select the canonical per-generation lock, then resolve
+    // again after winning it. Archive/delete/terminal transitions use this
+    // same lock, so whichever operation wins is visible to the loser before
+    // it can touch the workspace.
+    let initial = authority::resolve_scoped_thread(
+        state,
+        scope.clone(),
+        org,
+        thread_id,
+        ThreadAccess::ActiveOwner,
+    )?;
+    verify_virtual_mcp(&initial.thread.virtual_mcp_id, virtual_mcp_id)?;
+    let initial_fence = initial.fence;
+    let owner_guard = state
+        .agent_sessions
+        .start_lock(&initial_fence)
+        .lock_owned()
+        .await;
+    let account_guard = authority::lock_account_scope(&scope).await?;
+
+    // Re-read the row while both admission fences are held. The account gate
+    // is released immediately after this decision; keeping it through setup,
+    // exec, preview, or filesystem I/O would indefinitely block logout and
+    // account switching. The thread lifecycle gate remains held through the
+    // workspace side effect.
+    let resolved =
+        authority::resolve_scoped_thread(state, scope, org, thread_id, ThreadAccess::ActiveOwner)?;
+    if resolved.fence != initial_fence {
+        return Err(ApiError::not_found("sandbox not found"));
+    }
+    verify_virtual_mcp(&resolved.thread.virtual_mcp_id, virtual_mcp_id)?;
+    let account_epoch = state.sandbox_manager.account_epoch();
+    crate::routes::sandbox_account::validate_expected_epoch(account_epoch)?;
+    let identity_generation = account_guard.generation();
+    drop(account_guard);
+    Ok(Authorization {
+        account_epoch,
+        identity_generation,
+        _owner_guard: Some(owner_guard),
+    })
+}
+
+/// Authentication for intercepted sandbox reads that do not identify one
+/// thread (for example a virtual-MCP list or an unfiltered session list).
+pub(super) async fn require_account(state: &AppState) -> ApiResult<Authorization> {
+    let scope = authority::current_account_scope().await?;
+    let account_guard = authority::lock_account_scope(&scope).await?;
+    let account_epoch = state.sandbox_manager.account_epoch();
+    crate::routes::sandbox_account::validate_expected_epoch(account_epoch)?;
+    let identity_generation = account_guard.generation();
+    drop(account_guard);
+    Ok(Authorization {
+        account_epoch,
+        identity_generation,
+        _owner_guard: None,
+    })
+}
+
+fn thread_id(branch: &str) -> ApiResult<Option<&str>> {
+    crate::sandbox::synthetic_thread_id_from_input(branch).map_err(ApiError::bad_request)
+}
+
+fn verify_virtual_mcp(actual: &str, requested: &str) -> ApiResult<()> {
+    if actual != requested {
+        return Err(ApiError::not_found("sandbox not found"));
+    }
+    Ok(())
+}
+
+pub(super) fn manager_error(error: String) -> ApiError {
+    if error.contains("stale account epoch") || error.contains("account transition") {
+        ApiError::conflict("Your Studio account changed while this request was running. Try again.")
+    } else {
+        ApiError::internal(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_only_complete_thread_backed_branches() {
+        assert_eq!(thread_id("thread:chat-1").unwrap(), Some("chat-1"));
+        assert_eq!(
+            thread_id("thread:chat-1/connection-2").unwrap(),
+            Some("chat-1")
+        );
+        assert_eq!(thread_id("feature/thread:chat-1").unwrap(), None);
+        assert_eq!(thread_id("ephemeral").unwrap(), None);
+        assert!(thread_id(" thread:chat-1 ").is_err());
+        assert!(thread_id("thread:").is_err());
+        assert!(thread_id("thread:/connection-2").is_err());
+        assert!(thread_id("thread:chat-1/").is_err());
+    }
+
+    #[tokio::test]
+    async fn authorization_holds_the_lifecycle_lock_until_dropped() {
+        let root = tempfile::tempdir().unwrap();
+        let state = super::super::test_state(root.path());
+        let lock = std::sync::Arc::new(tokio::sync::Mutex::new(()));
+        let authorization = Authorization {
+            account_epoch: state.sandbox_manager.account_epoch(),
+            identity_generation: 0,
+            _owner_guard: Some(lock.clone().lock_owned().await),
+        };
+        assert!(lock.try_lock().is_err());
+
+        drop(authorization);
+        assert!(lock.try_lock().is_ok());
+    }
+}

--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_events.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_events.rs
@@ -31,14 +31,14 @@
 //! registry first and answers with the frame the shell is waiting for.
 
 use axum::body::Body;
-use axum::extract::{Query, State};
 use axum::http::{Method, StatusCode};
 use axum::response::{IntoResponse, Response};
 
 use crate::error::ApiError;
-use crate::routes::events::{events, EventsQuery};
+use crate::routes::events::{events_for_account, EventsQuery};
 use crate::state::AppState;
 
+use super::sandbox_authority::{authorize, manager_error, Access};
 use super::sandbox_fs::decode_identity_segment;
 
 /// One `event: gone` frame on a well-formed SSE response.
@@ -52,11 +52,26 @@ fn gone_stream() -> Response {
 pub(super) async fn try_dispatch(
     state: &AppState,
     method: &Method,
+    org: &str,
     rest: &[&str],
 ) -> Option<Response> {
     let ["sandbox", encoded_virtual_mcp_id, encoded_branch, "events"] = rest else {
         return None;
     };
+    let virtual_mcp_id = match decode_identity_segment("virtualMcpId", encoded_virtual_mcp_id) {
+        Ok(value) => value,
+        Err(error) => return Some(error.into_response()),
+    };
+    let branch = match decode_identity_segment("branch", encoded_branch) {
+        Ok(value) => value,
+        Err(error) => return Some(error.into_response()),
+    };
+    let authorization = match authorize(state, org, &virtual_mcp_id, &branch, Access::Viewer).await
+    {
+        Ok(authorization) => authorization,
+        Err(error) => return Some(error.into_response()),
+    };
+    let account_epoch = authorization.account_epoch();
     if *method != Method::GET {
         return Some(
             ApiError::new(
@@ -67,37 +82,35 @@ pub(super) async fn try_dispatch(
         );
     }
 
-    let virtual_mcp_id = match decode_identity_segment("virtualMcpId", encoded_virtual_mcp_id) {
-        Ok(value) => value,
-        Err(error) => return Some(error.into_response()),
-    };
-    let branch = match decode_identity_segment("branch", encoded_branch) {
-        Ok(value) => value,
-        Err(error) => return Some(error.into_response()),
-    };
-
     // Keyed by (virtualMcpId, branch); the handle comes from the repository,
     // so the registry bridges them. No row means never provisioned — the same
     // thing `is_registered(false)` means below.
-    let Ok(Some(handle)) = state
-        .sandbox_manager
-        .handle_for_agent(&virtual_mcp_id, &branch)
-    else {
-        return Some(gone_stream());
+    let handle = match state.sandbox_manager.handle_for_virtual_mcp_for_account(
+        account_epoch,
+        &virtual_mcp_id,
+        &branch,
+    ) {
+        Ok(Some(handle)) => handle,
+        Ok(None) => return Some(gone_stream()),
+        Err(error) => return Some(manager_error(error).into_response()),
     };
-    match state.sandbox_manager.is_registered(&handle) {
+    match state
+        .sandbox_manager
+        .is_registered_for_account(account_epoch, &handle)
+    {
         Ok(true) => {}
         // Never provisioned, or reaped: tell the shell so it can re-start it.
         Ok(false) => return Some(gone_stream()),
-        Err(error) => return Some(ApiError::internal(error).into_response()),
+        Err(error) => return Some(manager_error(error).into_response()),
     }
 
     Some(
-        events(
-            State(state.clone()),
-            Query(EventsQuery {
+        events_for_account(
+            state.clone(),
+            EventsQuery {
                 handle: Some(handle),
-            }),
+            },
+            account_epoch,
         )
         .await,
     )
@@ -119,14 +132,16 @@ mod tests {
 
         // Filesystem operations belong to `sandbox_fs`, not here.
         assert!(
-            try_dispatch(&state, &get(), &["sandbox", "vm", "main", "read"])
+            try_dispatch(&state, &get(), "acme", &["sandbox", "vm", "main", "read"])
                 .await
                 .is_none()
         );
         // A different family entirely.
-        assert!(try_dispatch(&state, &get(), &["tools", "SANDBOX_START"])
-            .await
-            .is_none());
+        assert!(
+            try_dispatch(&state, &get(), "acme", &["tools", "SANDBOX_START"])
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -134,7 +149,7 @@ mod tests {
         let root = tempfile::tempdir().expect("tempdir");
         let state = super::super::test_state(root.path());
 
-        let response = try_dispatch(&state, &get(), &["sandbox", "vm", "main", "events"])
+        let response = try_dispatch(&state, &get(), "acme", &["sandbox", "vm", "main", "events"])
             .await
             .expect("the events path is intercepted");
 
@@ -159,9 +174,14 @@ mod tests {
         let root = tempfile::tempdir().expect("tempdir");
         let state = super::super::test_state(root.path());
 
-        let response = try_dispatch(&state, &Method::POST, &["sandbox", "vm", "main", "events"])
-            .await
-            .expect("still intercepted, so it cannot silently proxy upstream");
+        let response = try_dispatch(
+            &state,
+            &Method::POST,
+            "acme",
+            &["sandbox", "vm", "main", "events"],
+        )
+        .await
+        .expect("still intercepted, so it cannot silently proxy upstream");
         assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
     }
 }

--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_fs.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_fs.rs
@@ -26,11 +26,14 @@ use crate::error::ApiError;
 use crate::sandbox::manager::Sandbox;
 use crate::state::AppState;
 
+use super::sandbox_authority::{authorize, manager_error, Access};
+
 const OPERATIONS: &[&str] = &["read", "write", "unlink", "mkdir", "rename", "glob", "grep"];
 
 pub(super) async fn try_dispatch(
     state: &AppState,
     method: &Method,
+    org: &str,
     rest: &[&str],
     body: &Bytes,
 ) -> Option<Response> {
@@ -40,6 +43,21 @@ pub(super) async fn try_dispatch(
     if !OPERATIONS.contains(operation) {
         return None;
     }
+    let virtual_mcp_id = match decode_identity_segment("virtualMcpId", encoded_virtual_mcp_id) {
+        Ok(value) => value,
+        Err(error) => return Some(error.into_response()),
+    };
+    let branch = match decode_identity_segment("branch", encoded_branch) {
+        Ok(value) => value,
+        Err(error) => return Some(error.into_response()),
+    };
+    let access = access_for(method, operation);
+    let read_only = matches!(*operation, "read" | "glob" | "grep");
+    let authorization = match authorize(state, org, &virtual_mcp_id, &branch, access).await {
+        Ok(authorization) => authorization,
+        Err(error) => return Some(error.into_response()),
+    };
+    let account_epoch = authorization.account_epoch();
     if *method != Method::POST {
         return Some(
             ApiError::new(
@@ -49,15 +67,6 @@ pub(super) async fn try_dispatch(
             .into_response(),
         );
     }
-
-    let virtual_mcp_id = match decode_identity_segment("virtualMcpId", encoded_virtual_mcp_id) {
-        Ok(value) => value,
-        Err(error) => return Some(error.into_response()),
-    };
-    let branch = match decode_identity_segment("branch", encoded_branch) {
-        Ok(value) => value,
-        Err(error) => return Some(error.into_response()),
-    };
     if *operation == "read" {
         if let Some(error) = reject_absolute_read(body) {
             return Some(error.into_response());
@@ -65,10 +74,11 @@ pub(super) async fn try_dispatch(
     }
     // Keyed by (virtualMcpId, branch) in the URL, but the worktree handle is
     // derived from the REPOSITORY — the registry is what bridges them.
-    let handle = match state
-        .sandbox_manager
-        .handle_for_agent(&virtual_mcp_id, &branch)
-    {
+    let handle = match state.sandbox_manager.handle_for_virtual_mcp_for_account(
+        account_epoch,
+        &virtual_mcp_id,
+        &branch,
+    ) {
         Ok(Some(handle)) => handle,
         Ok(None) => {
             return Some(
@@ -76,44 +86,77 @@ pub(super) async fn try_dispatch(
                     .into_response(),
             )
         }
-        Err(error) => return Some(ApiError::internal(error).into_response()),
+        Err(error) => return Some(manager_error(error).into_response()),
     };
 
-    let record = match state.sandbox_manager.registry_record(&handle) {
+    let record = match state
+        .sandbox_manager
+        .registry_record_for_account(account_epoch, &handle)
+    {
         Ok(Some(record)) => record,
         Ok(None) => {
             return Some(
                 ApiError::not_found(format!("sandbox not found: {handle}")).into_response(),
             )
         }
-        Err(error) => return Some(ApiError::internal(error).into_response()),
+        Err(error) => return Some(manager_error(error).into_response()),
     };
-    if record.observed_status == "absent"
-        || !crate::routes::git::is_git_repo(&record.workdir_path).await
-    {
+    if record.observed_status == "absent" {
         return Some(
             ApiError::not_found(format!("sandbox worktree not found: {handle}")).into_response(),
         );
     }
 
-    let sandbox = match state.sandbox_manager.adopt(&handle).await {
+    let sandbox = match state
+        .sandbox_manager
+        .adopt_for_account(account_epoch, &handle)
+        .await
+    {
         Ok(Some(sandbox)) => sandbox,
         Ok(None) => {
             return Some(
                 ApiError::not_found(format!("sandbox not found: {handle}")).into_response(),
             )
         }
-        Err(error) => {
+        Err(error) => return Some(manager_error(error).into_response()),
+    };
+    let repo_probe = if read_only && sandbox.tasks.is_admission_closed() {
+        // Archive/stop closes generation task admission, but the durable
+        // worktree deliberately remains available for read-only inspection.
+        // Do not reopen the generation merely to spawn a Git probe; the fs
+        // handlers below still clamp every path to this exact worktree.
+        Ok(true)
+    } else {
+        crate::routes::git::owned_is_git_repo(sandbox.tasks.clone(), record.workdir_path.clone())
+            .await
+    };
+    match repo_probe {
+        Ok(true) => {}
+        Ok(false) if sandbox.tasks.is_admission_closed() => {
+            return Some(ApiError::conflict("sandbox generation is stopped").into_response())
+        }
+        Ok(false) => {
             return Some(
-                ApiError::internal(format!("failed to adopt sandbox {handle}: {error}"))
+                ApiError::not_found(format!("sandbox worktree not found: {handle}"))
                     .into_response(),
             )
         }
-    };
+        Err(_) if sandbox.tasks.is_admission_closed() => {
+            return Some(ApiError::conflict("sandbox generation is stopped").into_response())
+        }
+        Err(error) => {
+            return Some(
+                ApiError::internal(format!(
+                    "could not inspect sandbox worktree {handle}: {error}"
+                ))
+                .into_response(),
+            )
+        }
+    }
     let target_state = state_for_sandbox(state, &sandbox);
     let body = body.clone();
 
-    Some(match *operation {
+    let response = match *operation {
         "read" => crate::routes::fs::read(State(target_state), body).await,
         "write" => crate::routes::fs::write(State(target_state), body).await,
         "unlink" => crate::routes::fs::unlink(State(target_state), body).await,
@@ -122,7 +165,24 @@ pub(super) async fn try_dispatch(
         "glob" => crate::routes::fs::glob(State(target_state), body).await,
         "grep" => crate::routes::fs::grep(State(target_state), body).await,
         _ => unreachable!("operation was checked against OPERATIONS"),
-    })
+    };
+    if read_only {
+        if let Err(error) = state.sandbox_manager.validate_account_epoch(account_epoch) {
+            return Some(manager_error(error).into_response());
+        }
+    }
+    Some(response)
+}
+
+fn access_for(method: &Method, operation: &str) -> Access {
+    if *method != Method::POST {
+        return Access::Viewer;
+    }
+    match operation {
+        "write" | "unlink" | "mkdir" | "rename" => Access::WorkspaceMutation,
+        "read" | "glob" | "grep" => Access::Viewer,
+        _ => Access::Viewer,
+    }
 }
 
 pub(super) fn decode_identity_segment(label: &str, encoded: &str) -> Result<String, ApiError> {
@@ -172,6 +232,25 @@ mod tests {
     use super::*;
     use crate::sandbox::GitSandboxConfig;
 
+    #[test]
+    fn filesystem_access_distinguishes_reads_from_mutations() {
+        for operation in ["write", "unlink", "mkdir", "rename"] {
+            assert_eq!(
+                access_for(&Method::POST, operation),
+                Access::WorkspaceMutation,
+                "{operation} mutates the workspace"
+            );
+        }
+        for operation in ["read", "glob", "grep"] {
+            assert_eq!(
+                access_for(&Method::POST, operation),
+                Access::Viewer,
+                "{operation} is read-only"
+            );
+        }
+        assert_eq!(access_for(&Method::GET, "write"), Access::Viewer);
+    }
+
     fn git(dir: &Path, args: &[&str]) {
         let output = std::process::Command::new("git")
             .args(args)
@@ -212,14 +291,20 @@ mod tests {
             git(&bare, &["symbolic-ref", "HEAD", "refs/heads/main"]);
         }
 
+        let (_cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
         state
             .sandbox_manager
-            .ensure(&GitSandboxConfig {
-                virtual_mcp_id: virtual_mcp_id.to_string(),
-                clone_url: bare_string,
-                branch: Some(branch.to_string()),
-                ..Default::default()
-            })
+            .ensure_for_terminal(
+                state.sandbox_manager.account_epoch(),
+                &GitSandboxConfig {
+                    virtual_mcp_id: virtual_mcp_id.to_string(),
+                    clone_url: bare_string,
+                    branch: Some(branch.to_string()),
+                    ..Default::default()
+                },
+                cancel_rx,
+                false,
+            )
             .await
             .expect("sandbox ensure")
     }
@@ -242,6 +327,7 @@ mod tests {
         let response = try_dispatch(
             &state,
             &Method::POST,
+            "acme",
             &["sandbox", "vir_blocks", "feature%2Fblocks", "write"],
             &Bytes::from(
                 serde_json::to_vec(&json!({
@@ -263,7 +349,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn persisted_sandbox_is_metadata_adopted_for_writes_after_restart() {
+    async fn stopped_metadata_adoption_rejects_writes_until_explicit_provision() {
         let root = tempfile::tempdir().unwrap();
         let first_state = super::super::test_state(root.path());
         let sandbox = ensure_sandbox(&first_state, "vir_restart", "main").await;
@@ -271,20 +357,26 @@ mod tests {
         let handle = sandbox.handle.clone();
         first_state
             .sandbox_manager
-            .stop_registered(&handle)
+            .stop_registered_for_account(first_state.sandbox_manager.account_epoch(), &handle)
             .await
             .expect("stop registered sandbox");
         drop(sandbox);
         drop(first_state);
 
         let restarted_state = super::super::test_state(root.path());
+        let restarted_epoch = restarted_state.sandbox_manager.account_epoch();
         assert!(
-            restarted_state.sandbox_manager.get(&handle).is_none(),
+            restarted_state
+                .sandbox_manager
+                .get_for_account(restarted_epoch, &handle)
+                .unwrap()
+                .is_none(),
             "fresh manager starts with an empty live-object cache"
         );
-        let response = try_dispatch(
+        let stopped_response = try_dispatch(
             &restarted_state,
             &Method::POST,
+            "acme",
             &["sandbox", "vir_restart", "main", "write"],
             &Bytes::from(
                 serde_json::to_vec(&json!({
@@ -297,11 +389,48 @@ mod tests {
         .await
         .expect("filesystem route is intercepted");
 
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(stopped_response.status(), StatusCode::CONFLICT);
         assert!(
-            restarted_state.sandbox_manager.get(&handle).is_some(),
+            restarted_state
+                .sandbox_manager
+                .get_for_account(restarted_epoch, &handle)
+                .unwrap()
+                .is_some(),
             "the durable sandbox was metadata-adopted"
         );
+        assert!(
+            !workdir.join(".deco/blocks/restarted.json").exists(),
+            "metadata adoption must not silently reopen write admission"
+        );
+
+        let config = restarted_state
+            .sandbox_manager
+            .registry_record_for_account(restarted_epoch, &handle)
+            .unwrap()
+            .unwrap()
+            .config;
+        let resumed = restarted_state
+            .sandbox_manager
+            .provision_for_account(restarted_epoch, &config)
+            .await
+            .expect("explicit provision installs a fresh open generation");
+        assert!(!resumed.tasks.is_admission_closed());
+        let resumed_response = try_dispatch(
+            &restarted_state,
+            &Method::POST,
+            "acme",
+            &["sandbox", "vir_restart", "main", "write"],
+            &Bytes::from(
+                serde_json::to_vec(&json!({
+                    "path": ".deco/blocks/restarted.json",
+                    "content": "{\"survived\":true}"
+                }))
+                .unwrap(),
+            ),
+        )
+        .await
+        .expect("filesystem route is intercepted after resume");
+        assert_eq!(resumed_response.status(), StatusCode::OK);
         assert_eq!(
             std::fs::read_to_string(workdir.join(".deco/blocks/restarted.json")).unwrap(),
             "{\"survived\":true}"
@@ -318,6 +447,7 @@ mod tests {
         let response = try_dispatch(
             &state,
             &Method::POST,
+            "acme",
             &["sandbox", "never_seen", "main", "write"],
             &Bytes::from(
                 serde_json::to_vec(&json!({
@@ -350,6 +480,7 @@ mod tests {
         let response = try_dispatch(
             &state,
             &Method::POST,
+            "acme",
             &["sandbox", "vir_first", "main", "write"],
             &Bytes::from(
                 serde_json::to_vec(&json!({
@@ -387,6 +518,7 @@ mod tests {
         let bridged = try_dispatch(
             &state,
             &Method::POST,
+            "acme",
             &["sandbox", "vir_read", "main", "read"],
             &body,
         )
@@ -414,6 +546,7 @@ mod tests {
         let response = try_dispatch(
             &state,
             &Method::GET,
+            "acme",
             &["sandbox", "vir_blocks", "main", "write"],
             &Bytes::new(),
         )

--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs
@@ -13,11 +13,12 @@
 //!
 //! ## Where the git config comes from
 //!
-//! [`SandboxManager::ensure`] needs a [`GitSandboxConfig`] — clone URL, branch,
-//! runtime. That used to ride along on the chat dispatch payload (the web
+//! [`SandboxManager::provision`] needs a [`GitSandboxConfig`] — clone URL,
+//! branch, runtime. That used to ride along on the chat dispatch payload (the web
 //! bundle's `build-sandbox-block.ts`), which meant the frontend carried desktop
 //! -specific plumbing. It no longer does, so we resolve it here from the
-//! cluster-side virtual-MCP registry via [`upstream::call_org_tool`] — the one
+//! cluster-side virtual-MCP registry via
+//! [`upstream::call_org_tool_for_identity`] — the one
 //! deliberate upstream read in an otherwise strictly-local table (see that
 //! function's doc comment). Field mapping mirrors what the dispatch block used
 //! to send, so the resulting sandbox is byte-identical to the one the old path
@@ -34,9 +35,12 @@ use serde_json::{json, Value};
 
 use crate::error::ApiError;
 use crate::routes::upstream;
+use crate::sandbox::manager::AccountEpoch;
 use crate::sandbox::GitSandboxConfig;
 use crate::setup::detect_runtime::runtime_for_package_manager;
 use crate::state::AppState;
+
+use super::sandbox_authority::{authorize, manager_error, Access};
 
 /// The preview listener's port, published by [`crate::start`] once it binds.
 ///
@@ -136,9 +140,13 @@ pub(crate) const EPHEMERAL_BRANCH: &str = "ephemeral";
 ///
 /// Returns [`EPHEMERAL_BRANCH`] when this agent has no sandbox — not-yet
 /// provisioned, or not git-backed at all.
-pub(crate) fn branch_for_virtual_mcp(state: &AppState, virtual_mcp_id: &str) -> String {
+pub(crate) fn branch_for_virtual_mcp(
+    state: &AppState,
+    virtual_mcp_id: &str,
+    account_epoch: AccountEpoch,
+) -> Result<String, String> {
     if virtual_mcp_id.is_empty() {
-        return EPHEMERAL_BRANCH.to_string();
+        return Ok(EPHEMERAL_BRANCH.to_string());
     }
     // Prefer whichever sandbox this agent has LIVE in this process; any
     // durable row is the fallback. Read from the registry — walking
@@ -147,21 +155,23 @@ pub(crate) fn branch_for_virtual_mcp(state: &AppState, virtual_mcp_id: &str) -> 
     let mut fallback = None;
     for record in state
         .sandbox_manager
-        .records_for_agent(virtual_mcp_id)
-        .unwrap_or_default()
+        .records_for_virtual_mcp_for_account(account_epoch, virtual_mcp_id)?
     {
         let Some(branch) = record.config.branch.clone().filter(|b| !b.is_empty()) else {
             continue;
         };
-        if matches!(
-            state.sandbox_manager.is_registered(&record.handle),
-            Ok(true)
-        ) {
-            return branch;
+        if state
+            .sandbox_manager
+            .is_registered_for_account(account_epoch, &record.handle)?
+        {
+            return Ok(branch);
         }
         fallback.get_or_insert(branch);
     }
-    fallback.unwrap_or_else(|| EPHEMERAL_BRANCH.to_string())
+    state
+        .sandbox_manager
+        .validate_account_epoch(account_epoch)?;
+    Ok(fallback.unwrap_or_else(|| EPHEMERAL_BRANCH.to_string()))
 }
 
 /// Build the sandbox config from a virtual MCP's `metadata`, or `None` when it
@@ -224,7 +234,7 @@ pub(crate) async fn try_dispatch(
     }
     match *tool_name {
         "SANDBOX_START" => Some(start(state, org, body).await),
-        "SANDBOX_DELETE" => Some(delete(state, body).await),
+        "SANDBOX_DELETE" => Some(delete(state, org, body).await),
         "COLLECTION_VIRTUAL_MCP_GET" | "COLLECTION_VIRTUAL_MCP_LIST" => {
             Some(virtual_mcp_read(state, org, tool_name, body).await)
         }
@@ -252,26 +262,69 @@ pub(crate) async fn try_dispatch(
 /// GET: the collection hooks seed the per-item cache from it, so an un-enriched
 /// list entry is what the shell would read for the active agent.
 async fn virtual_mcp_read(state: &AppState, org: &str, tool_name: &str, body: &Bytes) -> Response {
+    let scope = match crate::routes::threads::authority::current_account_scope().await {
+        Ok(scope) => scope,
+        Err(error) => return error.into_response(),
+    };
     let input: Value = match crate::http_util::json_body(body) {
         Ok(value) => value,
         Err(error) => return error.into_response(),
     };
 
-    let mut answer = match upstream::call_org_tool(org, tool_name, &input).await {
+    let initial_account_guard =
+        match crate::routes::threads::authority::lock_account_scope(&scope).await {
+            Ok(guard) => guard,
+            Err(error) => return error.into_response(),
+        };
+    let initial_account_epoch = state.sandbox_manager.account_epoch();
+    if let Err(error) =
+        crate::routes::sandbox_account::validate_expected_epoch(initial_account_epoch)
+    {
+        return error.into_response();
+    }
+    let initial_identity_generation = initial_account_guard.generation();
+    drop(initial_account_guard);
+
+    let mut answer = match upstream::call_org_tool_for_identity(
+        state,
+        initial_account_epoch,
+        initial_identity_generation,
+        org,
+        tool_name,
+        &input,
+    )
+    .await
+    {
         Ok(value) => value,
+        Err(upstream::OrgToolCallError::StaleIdentity) => {
+            return ApiError::conflict(
+                "Your Studio account changed while this request was running. Try again.",
+            )
+            .into_response();
+        }
         Err(error) => {
-            return ApiError::new(StatusCode::BAD_GATEWAY, error).into_response();
+            return ApiError::new(StatusCode::BAD_GATEWAY, error.to_string()).into_response();
         }
     };
 
-    let Some(user_id) = super::thread_tools::current_account_scope()
-        .await
-        .map(|scope| scope.user_id)
-    else {
-        // Not signed in: nothing to attribute sandboxes to, and the shell has
-        // nothing to render anyway. Pass upstream's answer through untouched.
-        return Json(answer).into_response();
+    // The upstream call can outlive a logout/account replacement. Recheck the
+    // captured scope before merging machine-local state into its response and
+    // retain the short transition fence through the synchronous merge, so an
+    // account-B response can never be enriched under account A's user key.
+    let _account_guard = match crate::routes::threads::authority::lock_account_scope(&scope).await {
+        Ok(guard) => guard,
+        Err(error) => return error.into_response(),
     };
+    let account_epoch = state.sandbox_manager.account_epoch();
+    if _account_guard.generation() != initial_identity_generation
+        || account_epoch != initial_account_epoch
+    {
+        return ApiError::conflict(
+            "Your Studio account changed while this request was running. Try again.",
+        )
+        .into_response();
+    }
+    let user_id = scope.user_id;
 
     // `{ items: [ … ] }`, `{ item: … }`, or a bare entity. Resolve which
     // BEFORE borrowing mutably, so there is only ever one live borrow.
@@ -283,28 +336,42 @@ async fn virtual_mcp_read(state: &AppState, org: &str, tool_name: &str, body: &B
         ""
     };
 
-    match envelope {
-        "items" => {
-            if let Some(items) = answer.get_mut("items").and_then(Value::as_array_mut) {
-                for entity in items.iter_mut() {
-                    enrich_entity(state, entity, &user_id);
+    let enrich_result = (|| -> Result<(), String> {
+        match envelope {
+            "items" => {
+                if let Some(items) = answer.get_mut("items").and_then(Value::as_array_mut) {
+                    for entity in items.iter_mut() {
+                        enrich_entity(state, entity, &user_id, account_epoch)?;
+                    }
                 }
             }
-        }
-        "item" => {
-            if let Some(item) = answer.get_mut("item") {
-                enrich_entity(state, item, &user_id);
+            "item" => {
+                if let Some(item) = answer.get_mut("item") {
+                    enrich_entity(state, item, &user_id, account_epoch)?;
+                }
             }
+            _ => enrich_entity(state, &mut answer, &user_id, account_epoch)?,
         }
-        _ => enrich_entity(state, &mut answer, &user_id),
+        Ok(())
+    })();
+    if let Err(error) = enrich_result {
+        return manager_error(error).into_response();
+    }
+    if let Err(error) = state.sandbox_manager.validate_account_epoch(account_epoch) {
+        return manager_error(error).into_response();
     }
     Json(answer).into_response()
 }
 
 /// Publish this machine's sandboxes for one virtual-MCP entity, in place.
-fn enrich_entity(state: &AppState, entity: &mut Value, user_id: &str) {
+fn enrich_entity(
+    state: &AppState,
+    entity: &mut Value,
+    user_id: &str,
+    account_epoch: AccountEpoch,
+) -> Result<(), String> {
     let Some(id) = entity.get("id").and_then(Value::as_str).map(str::to_string) else {
-        return;
+        return Ok(());
     };
     // Cloud sandboxes are INVISIBLE on desktop, by design: every sandbox
     // route here resolves against local worktrees only, so a cloud entry in
@@ -313,10 +380,11 @@ fn enrich_entity(state: &AppState, entity: &mut Value, user_id: &str) {
     // this machine's own. `user-desktop` entries from OTHER users survive —
     // they are what tells the shell a teammate's desktop owns a branch.
     strip_hosted_sandbox_entries(entity);
-    let local = local_sandbox_entries(state, &id);
+    let local = local_sandbox_entries(state, &id, account_epoch)?;
     if !local.is_empty() {
         merge_sandbox_map(entity, user_id, local);
     }
+    Ok(())
 }
 
 /// Remove every non-`user-desktop` kind from `metadata.sandboxMap`, dropping
@@ -358,15 +426,18 @@ fn strip_hosted_sandbox_entries(entity: &mut Value) {
 /// session is a durable record: a stopped or failed sandbox is exactly what
 /// the shell needs to show, so this reads the registry rather than the live
 /// map.
-pub(super) fn local_sandbox_sessions(state: &AppState, virtual_mcp_id: &str) -> Vec<Value> {
+pub(super) fn local_sandbox_sessions(
+    state: &AppState,
+    virtual_mcp_id: &str,
+    account_epoch: AccountEpoch,
+) -> Result<Vec<Value>, String> {
     if virtual_mcp_id.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
     let mut sessions = Vec::new();
     for record in state
         .sandbox_manager
-        .records_for_agent(virtual_mcp_id)
-        .unwrap_or_default()
+        .records_for_virtual_mcp_for_account(account_epoch, virtual_mcp_id)?
     {
         let handle = record.handle.clone();
         let stored = record.config.branch.as_deref();
@@ -398,18 +469,24 @@ pub(super) fn local_sandbox_sessions(state: &AppState, virtual_mcp_id: &str) -> 
             },
         ));
     }
-    sessions
+    state
+        .sandbox_manager
+        .validate_account_epoch(account_epoch)?;
+    Ok(sessions)
 }
 
-fn local_sandbox_entries(state: &AppState, virtual_mcp_id: &str) -> Vec<(String, Value)> {
+fn local_sandbox_entries(
+    state: &AppState,
+    virtual_mcp_id: &str,
+    account_epoch: AccountEpoch,
+) -> Result<Vec<(String, Value)>, String> {
     if virtual_mcp_id.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
     let mut entries = Vec::new();
     for record in state
         .sandbox_manager
-        .records_for_agent(virtual_mcp_id)
-        .unwrap_or_default()
+        .records_for_virtual_mcp_for_account(account_epoch, virtual_mcp_id)?
     {
         let handle = record.handle;
         let config = record.config;
@@ -421,8 +498,11 @@ fn local_sandbox_entries(state: &AppState, virtual_mcp_id: &str) -> Vec<(String,
                 continue;
             }
         }
-        // Publish ONLY a sandbox that is live in this process — not merely one
-        // the registry still has a row for.
+        // Publish ONLY an open sandbox generation that is live in this
+        // process — not merely one the registry still has a row for. A
+        // metadata-only adoption of a durable stopped sandbox deliberately
+        // stays cached for retained reads, but its task gate is permanently
+        // closed and it must not suppress the shell's explicit Start.
         //
         // An entry in `sandboxMap` means "a VM is serving this branch": the
         // shell reads it as the preview origin, and its auto-start gate fires
@@ -431,12 +511,18 @@ fn local_sandbox_entries(state: &AppState, virtual_mcp_id: &str) -> Vec<(String,
         // restart) therefore told the shell someone was already serving, which
         // suppressed the very auto-start that would have revived it — the
         // sandbox stayed dead and the UI sat on its provisioning label until a
-        // later sandbox ensure happened to revive it.
+        // later sandbox provision happened to revive it.
         //
         // Omitting a dead sandbox is self-correcting: the shell auto-starts,
-        // `SANDBOX_START` ensures/adopts it here, and the next read publishes
+        // `SANDBOX_START` provisions it here, and the next read publishes
         // it with a preview origin that is actually listening.
-        if state.sandbox_manager.get(&handle).is_none() {
+        let Some(sandbox) = state
+            .sandbox_manager
+            .get_for_account(account_epoch, &handle)?
+        else {
+            continue;
+        };
+        if sandbox.tasks.is_admission_closed() {
             continue;
         }
         let branch = config
@@ -456,7 +542,10 @@ fn local_sandbox_entries(state: &AppState, virtual_mcp_id: &str) -> Vec<(String,
             }),
         ));
     }
-    entries
+    state
+        .sandbox_manager
+        .validate_account_epoch(account_epoch)?;
+    Ok(entries)
 }
 
 /// Merge `entries` into `entity.metadata.sandboxMap[user_id][branch]` under the
@@ -508,7 +597,7 @@ fn merge_sandbox_map(entity: &mut Value, user_id: &str, entries: Vec<(String, Va
 /// `removeWorktree` defaults to `false`, and absent means false: the shell's
 /// Restart is `await stop(); start()`, so a flipped default would delete the
 /// repository — and any uncommitted work in it — on every restart.
-async fn delete(state: &AppState, body: &Bytes) -> Response {
+async fn delete(state: &AppState, org: &str, body: &Bytes) -> Response {
     let input: Value = match crate::http_util::json_body(body) {
         Ok(value) => value,
         Err(error) => return error.into_response(),
@@ -527,29 +616,39 @@ async fn delete(state: &AppState, body: &Bytes) -> Response {
         .get("removeWorktree")
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    let authorization = match authorize(state, org, virtual_mcp_id, branch, Access::Recovery).await
+    {
+        Ok(authorization) => authorization,
+        Err(error) => return error.into_response(),
+    };
 
-    let Ok(Some(handle)) = state
-        .sandbox_manager
-        .handle_for_agent(virtual_mcp_id, branch)
-    else {
-        // Nothing registered for this agent+branch: deleting it is a no-op,
-        // not an error, so a repeated delete stays idempotent.
-        return Json(json!({ "success": true })).into_response();
+    let handle = match state.sandbox_manager.handle_for_virtual_mcp_for_account(
+        authorization.account_epoch(),
+        virtual_mcp_id,
+        branch,
+    ) {
+        Ok(Some(handle)) => handle,
+        Ok(None) => {
+            // Nothing registered for this agent+branch: deleting it is a
+            // no-op, so a repeated delete stays idempotent.
+            return Json(json!({ "success": true })).into_response();
+        }
+        Err(error) => return manager_error(error).into_response(),
     };
     let outcome = if remove_worktree {
-        state.sandbox_manager.remove_registered(&handle).await
+        state
+            .sandbox_manager
+            .remove_registered_for_account(authorization.account_epoch(), &handle)
+            .await
     } else {
-        state.sandbox_manager.stop_registered(&handle).await
+        state
+            .sandbox_manager
+            .delete_registered_for_account(authorization.account_epoch(), &handle)
+            .await
     };
     match outcome {
         Ok(_) => Json(json!({ "success": true })).into_response(),
-        Err(error) if remove_worktree => {
-            ApiError::internal(format!("could not reclaim the local sandbox: {error}"))
-                .into_response()
-        }
-        Err(error) => {
-            ApiError::internal(format!("could not stop the local sandbox: {error}")).into_response()
-        }
+        Err(error) => manager_error(error).into_response(),
     }
 }
 
@@ -562,15 +661,53 @@ async fn start(state: &AppState, org: &str, body: &Bytes) -> Response {
         return ApiError::bad_request("virtualMcpId is required").into_response();
     };
     let branch = input.get("branch").and_then(Value::as_str);
+    // Prove this request names an active owned thread before consulting the
+    // upstream virtual-MCP registry, but do not hold the thread lifecycle
+    // lock across that network call. Admission is rechecked under the lock
+    // immediately before the local provisioning side effect below.
+    let initial_authorization = match authorize(
+        state,
+        org,
+        virtual_mcp_id,
+        branch.unwrap_or(DEFAULT_BRANCH),
+        Access::ActiveOwner,
+    )
+    .await
+    {
+        Ok(authorization) => authorization,
+        Err(error) => return error.into_response(),
+    };
+    let initial_account_epoch = initial_authorization.account_epoch();
+    let initial_identity_generation = initial_authorization.identity_generation();
+    drop(initial_authorization);
 
-    let virtual_mcp = match upstream::call_org_tool(
+    let virtual_mcp_result = upstream::call_org_tool_for_identity(
+        state,
+        initial_account_epoch,
+        initial_identity_generation,
         org,
         "COLLECTION_VIRTUAL_MCP_GET",
         &json!({ "id": virtual_mcp_id }),
     )
-    .await
+    .await;
+    // The lookup can outlive account replacement. Never reinterpret an
+    // account-A request under whichever identity happens to be current when
+    // the network call returns, even when B has the same org/thread/agent
+    // identifiers. The response is discarded before any field is inspected.
+    if let Err(error) = state
+        .sandbox_manager
+        .validate_account_epoch(initial_account_epoch)
     {
+        return manager_error(error).into_response();
+    }
+    let virtual_mcp = match virtual_mcp_result {
         Ok(value) => value,
+        Err(upstream::OrgToolCallError::StaleIdentity) => {
+            return ApiError::conflict(
+                "Your Studio account changed while this request was running. Try again.",
+            )
+            .into_response();
+        }
         Err(error) => {
             return ApiError::new(
                 StatusCode::BAD_GATEWAY,
@@ -592,29 +729,74 @@ async fn start(state: &AppState, org: &str, body: &Bytes) -> Response {
         .into_response();
     };
     let resolved_branch = crate::sandbox::normalize_branch(config.branch.as_deref()).to_string();
-    let Some(handle) =
-        crate::sandbox::SandboxManager::compute_handle(&config.clone_url, &resolved_branch)
-    else {
+    if crate::sandbox::SandboxManager::compute_handle(&config.clone_url, &resolved_branch).is_none()
+    {
         return ApiError::bad_request(format!(
             "this agent's repository URL cannot be scoped: {}",
             config.clone_url
         ))
         .into_response();
     };
-    let existed = state
-        .sandbox_manager
-        .is_registered(&handle)
-        .unwrap_or(false);
-
-    if let Err(error) = state.sandbox_manager.ensure(&config).await {
-        return ApiError::internal(format!("could not start the local sandbox: {error}"))
+    let authorization = match authorize(
+        state,
+        org,
+        virtual_mcp_id,
+        branch.unwrap_or(DEFAULT_BRANCH),
+        Access::WorkspaceMutation,
+    )
+    .await
+    {
+        Ok(authorization) => authorization,
+        Err(error) => return error.into_response(),
+    };
+    if authorization.account_epoch() != initial_account_epoch
+        || authorization.identity_generation() != initial_identity_generation
+    {
+        return manager_error("sandbox request belongs to a stale account epoch".to_string())
             .into_response();
     }
+    if let Err(error) = state
+        .sandbox_manager
+        .validate_account_epoch(initial_account_epoch)
+    {
+        return manager_error(error).into_response();
+    }
+    let existed = match state.sandbox_manager.handle_for_virtual_mcp_for_account(
+        authorization.account_epoch(),
+        virtual_mcp_id,
+        &resolved_branch,
+    ) {
+        Ok(handle) => handle.is_some(),
+        Err(error) => return manager_error(error).into_response(),
+    };
+    let sandbox = match state
+        .sandbox_manager
+        .try_provision_for_account(authorization.account_epoch(), &config)
+        .await
+    {
+        Ok(Some(sandbox)) => sandbox,
+        Ok(None) => {
+            return ApiError::conflict(
+                "sandbox provisioning is already in progress; retry after it completes",
+            )
+            .into_response()
+        }
+        Err(error) => return manager_error(error).into_response(),
+    };
+    // Provision may deliberately reuse a pre-hash durable handle from an
+    // older app version. Always report the manager's resolved identity, never
+    // the new-algorithm candidate computed only for URL validation above.
+    let handle = sandbox.handle.clone();
 
-    // Derived from the manager AFTER `ensure`, so the value reported is the
-    // one actually registered rather than the one this request happened to
-    // ask for.
-    let reported_branch = branch_for_virtual_mcp(state, virtual_mcp_id);
+    // Derived from the manager AFTER `provision`, so the value reported is
+    // the one durably registered rather than the one this request happened
+    // to ask for. Clone/install/start continue on the serialized setup worker
+    // where Stop can cancel them.
+    let reported_branch =
+        match branch_for_virtual_mcp(state, virtual_mcp_id, authorization.account_epoch()) {
+            Ok(branch) => branch,
+            Err(error) => return manager_error(error).into_response(),
+        };
 
     Json(json!({
         "previewUrl": preview_url(&handle),
@@ -822,7 +1004,7 @@ mod tests {
     }
 
     async fn delete_body(state: &AppState, body: Value) -> (StatusCode, Value) {
-        let response = delete(state, &Bytes::from(body.to_string())).await;
+        let response = delete(state, "acme", &Bytes::from(body.to_string())).await;
         let status = response.status();
         let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
@@ -848,7 +1030,10 @@ mod tests {
             assert_eq!(status, StatusCode::OK, "{body}");
             assert_eq!(answer, json!({ "success": true }), "{body}");
             assert!(worktree.is_dir(), "stop must never remove the worktree");
-            assert!(state.sandbox_manager.is_registered(&handle).unwrap());
+            assert!(state
+                .sandbox_manager
+                .is_registered_for_account(state.sandbox_manager.account_epoch(), &handle)
+                .unwrap());
         }
     }
 
@@ -866,7 +1051,10 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(answer, json!({ "success": true }));
         assert!(!worktree.exists());
-        assert!(!state.sandbox_manager.is_registered(&handle).unwrap());
+        assert!(!state
+            .sandbox_manager
+            .is_registered_for_account(state.sandbox_manager.account_epoch(), &handle)
+            .unwrap());
 
         // And it stays idempotent: the second call finds nothing to do.
         let (status, answer) = delete_body(

--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_ops.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_ops.rs
@@ -27,6 +27,7 @@ use axum::extract::{Path as AxumPath, State};
 use axum::http::{HeaderMap, Method, StatusCode};
 use axum::response::{IntoResponse, Response};
 
+use super::sandbox_authority::{authorize, manager_error, Access, Authorization};
 use super::sandbox_fs::{decode_identity_segment, state_for_sandbox};
 use crate::error::ApiError;
 use crate::state::AppState;
@@ -34,6 +35,7 @@ use crate::state::AppState;
 pub(super) async fn try_dispatch(
     state: &AppState,
     method: &Method,
+    org: &str,
     rest: &[&str],
     query: Option<&str>,
     body: &Bytes,
@@ -54,13 +56,27 @@ pub(super) async fn try_dispatch(
         Ok(value) => value,
         Err(error) => return Some(error.into_response()),
     };
+    let authorization = match authorize(
+        state,
+        org,
+        &virtual_mcp_id,
+        &branch,
+        access_for(method, tail),
+    )
+    .await
+    {
+        Ok(authorization) => authorization,
+        Err(error) => return Some(error.into_response()),
+    };
+    let account_epoch = authorization.account_epoch();
 
     // Keyed by (virtualMcpId, branch) in the URL, but the worktree handle is
     // derived from the REPOSITORY — the registry is what bridges them.
-    let handle = match state
-        .sandbox_manager
-        .handle_for_agent(&virtual_mcp_id, &branch)
-    {
+    let handle = match state.sandbox_manager.handle_for_virtual_mcp_for_account(
+        account_epoch,
+        &virtual_mcp_id,
+        &branch,
+    ) {
         Ok(Some(handle)) => handle,
         Ok(None) => {
             return Some(
@@ -68,24 +84,34 @@ pub(super) async fn try_dispatch(
                     .into_response(),
             )
         }
-        Err(error) => return Some(ApiError::internal(error).into_response()),
+        Err(error) => return Some(manager_error(error).into_response()),
     };
-    let sandbox = match state.sandbox_manager.adopt(&handle).await {
+    let sandbox = match state
+        .sandbox_manager
+        .adopt_for_account(account_epoch, &handle)
+        .await
+    {
         Ok(Some(sandbox)) => sandbox,
         Ok(None) => {
             return Some(
                 ApiError::not_found(format!("sandbox not found: {handle}")).into_response(),
             )
         }
-        Err(error) => {
-            return Some(
-                ApiError::internal(format!("failed to adopt sandbox {handle}: {error}"))
-                    .into_response(),
-            )
-        }
+        Err(error) => return Some(manager_error(error).into_response()),
     };
     let target = state_for_sandbox(state, &sandbox);
-    Some(route(&target, method, tail, query, body.clone(), &handle).await)
+    Some(
+        route(
+            &target,
+            method,
+            tail,
+            query,
+            body.clone(),
+            &handle,
+            authorization,
+        )
+        .await,
+    )
 }
 
 /// Whether this module owns `tail`. Checked BEFORE the sandbox is adopted, so
@@ -103,6 +129,31 @@ fn is_handled(tail: &[&str]) -> bool {
     )
 }
 
+fn access_for(method: &Method, tail: &[&str]) -> Access {
+    if matches!(
+        (method, tail),
+        (&Method::POST, ["setup", "stop"]) | (&Method::POST, ["exec", _, "kill"])
+    ) {
+        Access::Recovery
+    } else if matches!(
+        (method, tail),
+        (&Method::PUT, ["config"])
+            | (
+                &Method::POST,
+                [
+                    "git",
+                    "publish" | "discard" | "rebase" | "suggest-commit" | "judge-review"
+                ]
+            )
+            | (&Method::POST, ["setup", "clone" | "install" | "start"])
+            | (&Method::POST, ["exec", _])
+    ) {
+        Access::WorkspaceMutation
+    } else {
+        Access::Viewer
+    }
+}
+
 async fn route(
     target: &AppState,
     method: &Method,
@@ -110,8 +161,10 @@ async fn route(
     query: Option<&str>,
     body: Bytes,
     handle: &str,
+    authorization: Authorization,
 ) -> Response {
     let state = State(target.clone());
+    let account_epoch = authorization.account_epoch();
     // The handle MUST be carried in the header, not left to `state_for_sandbox`.
     //
     // That helper retargets `repo_dir`/`config`/`setup`/`tasks`, which is
@@ -128,7 +181,25 @@ async fn route(
         headers.insert(crate::sandbox::SANDBOX_HANDLE_HEADER, value);
     }
 
-    match (method, tail) {
+    if let (&Method::POST, ["exec", name]) = (method, tail) {
+        return match crate::routes::scripts::exec_with_admission(
+            state,
+            headers,
+            AxumPath((*name).to_string()),
+            body,
+            account_epoch,
+            authorization,
+        )
+        .await
+        {
+            Ok(response) => response,
+            Err(error) => error.into_response(),
+        };
+    }
+    let _authorization = authorization;
+    let revalidate_response = access_for(method, tail) == Access::Viewer;
+
+    let response = match (method, tail) {
         (&Method::GET, ["config"]) => crate::routes::config::read(state).await.into_response(),
         (&Method::PUT, ["config"]) => crate::routes::config::update(state, body).await,
 
@@ -177,32 +248,35 @@ async fn route(
         (&Method::POST, ["git", "suggest-commit"]) => super::git_assist::suggest_commit(&body),
         (&Method::POST, ["git", "judge-review"]) => super::git_assist::judge_review(),
 
-        (&Method::POST, ["setup", "clone"]) => crate::routes::setup::clone(state, headers)
-            .await
-            .into_response(),
-        (&Method::POST, ["setup", "install"]) => crate::routes::setup::install(state, headers)
-            .await
-            .into_response(),
-        (&Method::POST, ["setup", "start"]) => crate::routes::setup::start(state, headers)
-            .await
-            .into_response(),
-        (&Method::POST, ["setup", "stop"]) => crate::routes::setup::stop(state, headers)
-            .await
-            .into_response(),
-
-        (&Method::POST, ["exec", name]) => {
-            match crate::routes::scripts::exec(state, headers, AxumPath((*name).to_string()), body)
-                .await
-            {
-                Ok(response) => response,
-                Err(error) => error.into_response(),
-            }
-        }
-        (&Method::POST, ["exec", name, "kill"]) => {
-            crate::routes::scripts::exec_kill(state, headers, AxumPath((*name).to_string()))
+        (&Method::POST, ["setup", "clone"]) => {
+            crate::routes::setup::clone_for_account(target.clone(), headers, account_epoch)
                 .await
                 .into_response()
         }
+        (&Method::POST, ["setup", "install"]) => {
+            crate::routes::setup::install_for_account(target.clone(), headers, account_epoch)
+                .await
+                .into_response()
+        }
+        (&Method::POST, ["setup", "start"]) => {
+            crate::routes::setup::start_for_account(target.clone(), headers, account_epoch)
+                .await
+                .into_response()
+        }
+        (&Method::POST, ["setup", "stop"]) => {
+            crate::routes::setup::stop_for_account(target.clone(), headers, account_epoch)
+                .await
+                .into_response()
+        }
+
+        (&Method::POST, ["exec", name, "kill"]) => crate::routes::scripts::exec_kill_for_account(
+            target.clone(),
+            headers,
+            (*name).to_string(),
+            _authorization.account_epoch(),
+        )
+        .await
+        .into_response(),
 
         // `is_handled` admitted the path but not this method.
         _ => ApiError::new(
@@ -210,7 +284,13 @@ async fn route(
             format!("method not allowed for this sandbox route: {method}"),
         )
         .into_response(),
+    };
+    if revalidate_response {
+        if let Err(error) = target.sandbox_manager.validate_account_epoch(account_epoch) {
+            return manager_error(error).into_response();
+        }
     }
+    response
 }
 
 /// `GET …/preview-fetch?path=…` — read one path off the sandbox's dev server.
@@ -260,5 +340,40 @@ mod tests {
         ] {
             assert!(!is_handled(&foreign), "should NOT own {foreign:?}");
         }
+    }
+
+    #[test]
+    fn distinguishes_viewer_reads_workspace_mutations_and_controls() {
+        for read in [
+            vec!["preview-fetch"],
+            vec!["git", "status"],
+            vec!["git", "diff"],
+        ] {
+            assert_eq!(access_for(&Method::GET, &read), Access::Viewer);
+            if read.first() == Some(&"git") {
+                assert_eq!(access_for(&Method::POST, &read), Access::Viewer);
+            }
+        }
+        for mutation in [
+            vec!["git", "publish"],
+            vec!["git", "discard"],
+            vec!["git", "suggest-commit"],
+            vec!["git", "judge-review"],
+            vec!["setup", "start"],
+            vec!["exec", "dev"],
+        ] {
+            assert_eq!(
+                access_for(&Method::POST, &mutation),
+                Access::WorkspaceMutation
+            );
+        }
+        for control in [vec!["setup", "stop"], vec!["exec", "dev", "kill"]] {
+            assert_eq!(access_for(&Method::POST, &control), Access::Recovery);
+        }
+        assert_eq!(
+            access_for(&Method::PUT, &["config"]),
+            Access::WorkspaceMutation
+        );
+        assert_eq!(access_for(&Method::GET, &["config"]), Access::Viewer);
     }
 }

--- a/apps/native/crates/local-api/src/routes/intercept/thread_tools.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/thread_tools.rs
@@ -21,11 +21,14 @@ use axum::Json;
 use serde_json::{json, Map, Value};
 
 use crate::error::ApiError;
+use crate::routes::threads::authority::{lock_account_scope, resolve_scoped_thread, ThreadAccess};
 use crate::routes::threads::db::{
     DbError, RtAccountScope, RtThreadListOptions, RtThreadPatch, ThreadsDb,
 };
 use crate::routes::threads::shared_db;
 use crate::state::AppState;
+
+use super::sandbox_authority::manager_error;
 
 #[cfg(test)]
 pub async fn dispatch(
@@ -34,7 +37,9 @@ pub async fn dispatch(
     tool_name: &str,
     body: &Bytes,
 ) -> Option<Response> {
-    let scope = current_account_scope().await?;
+    let scope = crate::routes::threads::authority::current_account_scope()
+        .await
+        .ok()?;
     dispatch_scoped(state, &scope, org, tool_name, body).await
 }
 
@@ -46,12 +51,12 @@ pub async fn dispatch_scoped(
     body: &Bytes,
 ) -> Option<Response> {
     match tool_name {
-        "COLLECTION_THREADS_LIST" => Some(list(state, scope, org, body)),
-        "COLLECTION_THREADS_GET" => Some(get(state, scope, org, body)),
+        "COLLECTION_THREADS_LIST" => Some(list(state, scope, org, body).await),
+        "COLLECTION_THREADS_GET" => Some(get(state, scope, org, body).await),
         "COLLECTION_THREADS_CREATE" => Some(create(state, scope, org, body).await),
         "COLLECTION_THREADS_UPDATE" => Some(update(state, scope, org, body).await),
         "COLLECTION_THREADS_DELETE" => Some(delete(state, scope, org, body).await),
-        "COLLECTION_THREAD_MESSAGES_LIST" => Some(messages_list(state, scope, org, body)),
+        "COLLECTION_THREAD_MESSAGES_LIST" => Some(messages_list(state, scope, org, body).await),
         _ => None,
     }
 }
@@ -342,67 +347,9 @@ fn db(state: &AppState) -> Result<&'static ThreadsDb, ApiError> {
     shared_db(state)
 }
 
-/// The user id local-api stamps on `created_by`/`updated_by`.
-///
-/// MUST match the real signed-in user's id: the production shell's own
-/// chat input (`components/chat/input.tsx`) renders read-only whenever
-/// `task.created_by !== userId`, so any value other than the actual
-/// signed-in user permanently locks every locally-created thread as
-/// "viewing someone else's chat" — verified live against the real UI
-/// (Gate C drive), which is what an earlier, always-opaque placeholder
-/// value did. Resolved via `upstream::global()`'s signed-in session (the
-/// SAME identity the real mesh backend's own `COLLECTION_THREADS_CREATE`
-/// stamps `created_by` with server-side, per `apps/api/src/tools/thread/
-/// create.ts`). Signed-out requests are rejected before dispatch; they never
-/// create placeholder-owned rows.
-///
-/// `#[cfg(not(test))]`/`#[cfg(test)]` split, not a richer runtime branch:
-/// `upstream::global()`'s `TokenStore` is the REAL macOS Keychain in every
-/// COMPILED build of this crate (there is no test-only override reachable
-/// from inside `routes/intercept/*` — unlike `routes/upstream.rs`'s own
-/// tests, which construct a throwaway `UpstreamSession` over a
-/// `MemoryTokenStore` instead of touching `upstream::global()` at all).
-/// Querying it from a plain `cargo test` unit test measurably hung this
-/// crate's test binary (a `keyring::Entry::new(..).get_password()` call
-/// against a real, possibly-unlocked/no-session Keychain took far longer
-/// than `KeychainTokenStore`'s own 4s async-level timeout bounds, because
-/// that timeout only abandons the FUTURE — the underlying `spawn_blocking`
-/// OS thread can still be stuck) — found empirically while writing this
-/// module's own tests, and the reason this file's tests must never take
-/// the `cfg(not(test))` branch below. `#[cfg(test)]` is a compile-time
-/// swap (this crate's own `cargo test` binary never links the
-/// Keychain-touching branch at all), not a runtime "are we testing"
-/// check, so it carries none of this repo's usual "workaround with a
-/// comment" smell.
-#[cfg(not(test))]
-pub(crate) async fn current_account_scope() -> Option<RtAccountScope> {
-    current_account_scope_result().await.ok().flatten()
-}
-
-#[cfg(not(test))]
-pub(crate) async fn current_account_scope_result(
-) -> Result<Option<RtAccountScope>, upstream::tokens::TokenStoreError> {
-    let session = upstream::global();
-    let Some(user_id) = session.current_user_sub_result().await? else {
-        return Ok(None);
-    };
-    Ok(RtAccountScope::new(session.host(), user_id))
-}
-
-#[cfg(test)]
-pub(crate) async fn current_account_scope() -> Option<RtAccountScope> {
-    RtAccountScope::new("test.invalid", "local-desktop-user")
-}
-
-#[cfg(test)]
-pub(crate) async fn current_account_scope_result(
-) -> Result<Option<RtAccountScope>, upstream::tokens::TokenStoreError> {
-    Ok(current_account_scope().await)
-}
-
 // --- COLLECTION_THREADS_LIST -------------------------------------------------
 
-fn list(state: &AppState, scope: &RtAccountScope, org: &str, body: &Bytes) -> Response {
+async fn list(state: &AppState, scope: &RtAccountScope, org: &str, body: &Bytes) -> Response {
     let input = match parse_json(body) {
         Ok(v) => v,
         Err(r) => return r.into_response(),
@@ -535,22 +482,29 @@ fn list(state: &AppState, scope: &RtAccountScope, org: &str, body: &Bytes) -> Re
         Err(r) => return r.into_response(),
     };
 
-    match db.rt_list_threads_scoped(
-        scope,
-        org,
-        RtThreadListOptions {
-            created_by,
-            hidden: Some(hidden),
-            search,
-            trigger_ids: trigger_ids.as_deref(),
-            virtual_mcp_id,
-            has_trigger,
-            start_date,
-            end_date,
-            status,
-            agent_id,
-        },
-    ) {
+    let result = {
+        let _account_guard = match lock_account_scope(scope).await {
+            Ok(guard) => guard,
+            Err(error) => return error.into_response(),
+        };
+        db.rt_list_threads_scoped(
+            scope,
+            org,
+            RtThreadListOptions {
+                created_by,
+                hidden: Some(hidden),
+                search,
+                trigger_ids: trigger_ids.as_deref(),
+                virtual_mcp_id,
+                has_trigger,
+                start_date,
+                end_date,
+                status,
+                agent_id,
+            },
+        )
+    };
+    match result {
         Ok((items, total_count)) => Json(json!({
             "items": items,
             "totalCount": total_count,
@@ -563,7 +517,7 @@ fn list(state: &AppState, scope: &RtAccountScope, org: &str, body: &Bytes) -> Re
 
 // --- COLLECTION_THREADS_GET --------------------------------------------------
 
-fn get(state: &AppState, scope: &RtAccountScope, org: &str, body: &Bytes) -> Response {
+async fn get(state: &AppState, scope: &RtAccountScope, org: &str, body: &Bytes) -> Response {
     let input = match parse_json(body) {
         Ok(v) => v,
         Err(r) => return r.into_response(),
@@ -575,7 +529,14 @@ fn get(state: &AppState, scope: &RtAccountScope, org: &str, body: &Bytes) -> Res
     let Some(id) = input.get("id").and_then(Value::as_str) else {
         return ApiError::bad_request("id is required").into_response();
     };
-    match db.rt_get_thread_in_scope(scope, org, id) {
+    let result = {
+        let _account_guard = match lock_account_scope(scope).await {
+            Ok(guard) => guard,
+            Err(error) => return error.into_response(),
+        };
+        db.rt_get_thread_in_scope(scope, org, id)
+    };
+    match result {
         Ok(item) => Json(json!({ "item": item })).into_response(),
         Err(e) => ApiError::internal(format!("thread database error: {e}")).into_response(),
     }
@@ -625,22 +586,34 @@ async fn create(state: &AppState, scope: &RtAccountScope, org: &str, body: &Byte
         Ok(value) => value,
         Err(error) => return error.into_response(),
     };
+    if let Some(branch) = branch {
+        if let Err(error) = validate_thread_branch_identity(branch, id, "data.id") {
+            return error.into_response();
+        }
+    }
     let db = match db(state) {
         Ok(d) => d,
         Err(r) => return r.into_response(),
     };
     let user = &scope.user_id;
 
-    match db.rt_create_thread_scoped(
-        scope,
-        id,
-        org,
-        title,
-        description,
-        virtual_mcp_id,
-        branch,
-        user,
-    ) {
+    let result = {
+        let _account_guard = match lock_account_scope(scope).await {
+            Ok(guard) => guard,
+            Err(error) => return error.into_response(),
+        };
+        db.rt_create_thread_scoped(
+            scope,
+            id,
+            org,
+            title,
+            description,
+            virtual_mcp_id,
+            branch,
+            user,
+        )
+    };
+    match result {
         Ok(item) => Json(json!({ "item": item })).into_response(),
         // An explicit id already owned by another account or organization is
         // neither returned nor described: expose only that this caller cannot
@@ -713,13 +686,14 @@ async fn update(state: &AppState, scope: &RtAccountScope, org: &str, body: &Byte
         Ok(value) => value.map(|value| value.map(String::from)),
         Err(error) => return error.into_response(),
     };
+    if let Some(Some(branch)) = branch.as_ref() {
+        if let Err(error) = validate_thread_branch_identity(branch, Some(id), "id") {
+            return error.into_response();
+        }
+    }
     let virtual_mcp_id = match optional_string(data, "virtual_mcp_id", "data") {
         Ok(value) => value.map(String::from),
         Err(error) => return error.into_response(),
-    };
-    let db = match db(state) {
-        Ok(d) => d,
-        Err(r) => return r.into_response(),
     };
     let patch = RtThreadPatch {
         title,
@@ -730,41 +704,235 @@ async fn update(state: &AppState, scope: &RtAccountScope, org: &str, body: &Byte
         branch,
         virtual_mcp_id,
     };
-    let archive_fence = if patch.hidden == Some(true) {
-        match db.rt_thread_fence_in_scope(scope, org, id) {
-            Ok(Some(fence)) => Some(fence),
-            Ok(None) => return ApiError::not_found("thread not found").into_response(),
+    let result = if patch_requires_workspace_lock(&patch) {
+        // This first read is only a lock-key hint. Authority is resolved again
+        // after taking the lifecycle lock and account-transition fence, before
+        // any side effect or durable mutation can use the captured scope.
+        let lock_hint = {
+            let _account_guard = match lock_account_scope(scope).await {
+                Ok(guard) => guard,
+                Err(error) => return error.into_response(),
+            };
+            match resolve_scoped_thread(state, scope.clone(), org, id, ThreadAccess::Owner) {
+                Ok(resolved) => resolved.fence,
+                Err(error) => return error.into_response(),
+            }
+        };
+        let workspace_lock = state.agent_sessions.start_lock(&lock_hint);
+        let _workspace_guard = workspace_lock.lock().await;
+        let account_guard = match lock_account_scope(scope).await {
+            Ok(guard) => guard,
+            Err(error) => return error.into_response(),
+        };
+        let resolved =
+            match resolve_scoped_thread(state, scope.clone(), org, id, ThreadAccess::Owner) {
+                Ok(resolved) if resolved.fence == lock_hint => resolved,
+                Ok(_) => return ApiError::not_found("thread not found").into_response(),
+                Err(error) => return error.into_response(),
+            };
+        let db = resolved.db;
+        let fence = resolved.fence;
+        let thread = resolved.thread;
+        match db.rt_validate_workspace_identity_patch_fenced(&fence, &patch) {
+            Ok(()) => {}
+            Err(DbError::ThreadWorkspaceLocked { .. }) => {
+                return ApiError::conflict(
+                    "The chat workspace cannot be changed after its coding agent starts.",
+                )
+                .into_response()
+            }
+            Err(DbError::ThreadDeletePending { .. }) => {
+                return ApiError::conflict("thread is being deleted").into_response()
+            }
+            Err(DbError::StaleThreadGeneration { .. }) => {
+                return ApiError::not_found("thread not found").into_response()
+            }
             Err(error) => {
                 return ApiError::internal(format!("thread database error: {error}"))
                     .into_response()
             }
         }
-    } else {
-        None
-    };
-    let archive_lock = archive_fence
-        .as_ref()
-        .map(|fence| state.agent_sessions.start_lock(fence));
-    let _archive_guard = match archive_lock.as_ref() {
-        Some(lock) => Some(lock.lock().await),
-        None => None,
-    };
-    if let Some(fence) = archive_fence.as_ref() {
-        if let Err(error) = state.agent_sessions.terminate_fence(fence).await {
-            return ApiError::internal(format!(
-                "chat was not archived because its coding agent could not be stopped: {error}"
-            ))
-            .into_response();
+        let changes_workspace_identity = workspace_identity_changes(&patch, &thread);
+        if patch.hidden == Some(true) || changes_workspace_identity {
+            let account_epoch = state.sandbox_manager.account_epoch();
+            // The per-thread lifecycle lock keeps this generation stable.
+            // Release the process-wide account transition gate before any
+            // bounded preparation or child-process drain.
+            drop(account_guard);
+            if let Err(error) = cancel_preparing_terminal(state, db, &fence).await {
+                return error.into_response();
+            }
+            if patch.hidden == Some(true) {
+                if let Err(error) = state.agent_sessions.terminate_fence(&fence).await {
+                    return ApiError::internal(format!(
+                        "chat was not archived because its coding agent could not be stopped: {error}"
+                    ))
+                    .into_response();
+                }
+            }
+            if let Err(error) =
+                quiesce_thread_sandbox(state, account_epoch, &thread.id, &thread.virtual_mcp_id)
+                    .await
+            {
+                return error.into_response();
+            }
+            let _account_guard = match lock_account_scope(scope).await {
+                Ok(guard) => guard,
+                Err(error) => return error.into_response(),
+            };
+            let resolved =
+                match resolve_scoped_thread(state, scope.clone(), org, id, ThreadAccess::Owner) {
+                    Ok(resolved) if resolved.fence == fence => resolved,
+                    Ok(_) => return ApiError::not_found("thread not found").into_response(),
+                    Err(error) => return error.into_response(),
+                };
+            if let Err(error) = resolved
+                .db
+                .rt_validate_workspace_identity_patch_fenced(&fence, &patch)
+            {
+                return workspace_patch_error(error).into_response();
+            }
+            resolved
+                .db
+                .rt_update_thread_in_scope(scope, org, id, &scope.user_id, &patch)
+        } else {
+            db.rt_update_thread_in_scope(scope, org, id, &scope.user_id, &patch)
         }
-    }
-    match db.rt_update_thread_in_scope(scope, org, id, &scope.user_id, &patch) {
+    } else {
+        let _account_guard = match lock_account_scope(scope).await {
+            Ok(guard) => guard,
+            Err(error) => return error.into_response(),
+        };
+        let db = match resolve_scoped_thread(state, scope.clone(), org, id, ThreadAccess::Owner) {
+            Ok(resolved) => resolved.db,
+            Err(error) => return error.into_response(),
+        };
+        db.rt_update_thread_in_scope(scope, org, id, &scope.user_id, &patch)
+    };
+    match result {
         Ok(Some(item)) => Json(json!({ "item": item })).into_response(),
         Ok(None) => ApiError::not_found("thread not found").into_response(),
         Err(DbError::ThreadDeletePending { .. }) => {
             ApiError::conflict("thread is being deleted").into_response()
         }
+        Err(DbError::ThreadWorkspaceLocked { .. }) => ApiError::conflict(
+            "The chat workspace cannot be changed after its coding agent starts.",
+        )
+        .into_response(),
         Err(e) => ApiError::internal(format!("thread database error: {e}")).into_response(),
     }
+}
+
+fn patch_requires_workspace_lock(patch: &RtThreadPatch) -> bool {
+    patch.hidden == Some(true) || patch.branch.is_some() || patch.virtual_mcp_id.is_some()
+}
+
+fn workspace_identity_changes(
+    patch: &RtThreadPatch,
+    thread: &crate::routes::threads::db::RtThread,
+) -> bool {
+    patch
+        .branch
+        .as_ref()
+        .is_some_and(|branch| branch != &thread.branch)
+        || patch
+            .virtual_mcp_id
+            .as_ref()
+            .is_some_and(|virtual_mcp_id| virtual_mcp_id != &thread.virtual_mcp_id)
+}
+
+fn validate_thread_branch_identity(
+    branch: &str,
+    expected_thread_id: Option<&str>,
+    expected_id_path: &str,
+) -> Result<(), ApiError> {
+    let Some(branch_thread_id) = crate::sandbox::synthetic_thread_id_from_input(branch)
+        .map_err(|error| ApiError::bad_request(format!("data.branch is invalid: {error}")))?
+    else {
+        return Ok(());
+    };
+    let expected_thread_id = expected_thread_id.ok_or_else(|| {
+        ApiError::bad_request(format!(
+            "{expected_id_path} is required when data.branch is thread-backed"
+        ))
+    })?;
+    if branch_thread_id != expected_thread_id {
+        return Err(ApiError::bad_request(format!(
+            "data.branch must belong to {expected_id_path}"
+        )));
+    }
+    Ok(())
+}
+
+fn workspace_patch_error(error: DbError) -> ApiError {
+    match error {
+        DbError::ThreadWorkspaceLocked { .. } => ApiError::conflict(
+            "The chat workspace cannot be changed after its coding agent starts.",
+        ),
+        DbError::ThreadDeletePending { .. } => ApiError::conflict("thread is being deleted"),
+        DbError::StaleThreadGeneration { .. } => ApiError::not_found("thread not found"),
+        error => ApiError::internal(format!("thread database error: {error}")),
+    }
+}
+
+async fn cancel_preparing_terminal(
+    state: &AppState,
+    db: &'static ThreadsDb,
+    fence: &crate::routes::threads::db::RtThreadFence,
+) -> Result<(), ApiError> {
+    let preparation = state.agent_sessions.cancel_preparation(fence);
+    let had_preparation = preparation.had_preparations();
+    preparation.wait().await.map_err(|error| {
+        ApiError::internal(format!(
+            "could not stop coding agent preparation before cleanup: {error}"
+        ))
+    })?;
+    if had_preparation {
+        crate::terminal::launch_context::cleanup_managed_state(&state.app_root, fence)
+            .await
+            .map_err(|error| {
+                ApiError::internal(format!(
+                    "could not clean canceled coding agent preparation: {error}"
+                ))
+            })?;
+    }
+    let live = db
+        .rt_get_live_terminal_session_fenced(fence)
+        .map_err(|error| {
+            ApiError::internal(format!(
+                "could not inspect coding agent before cleanup: {error}"
+            ))
+        })?;
+    if let Some(session) = live {
+        crate::routes::terminal::mark_starting_session_exited_if_present(
+            db,
+            fence,
+            &session.id,
+            "coding agent start was canceled before process creation",
+            true,
+        );
+    }
+    Ok(())
+}
+
+/// Every live synthetic `thread:<id>[/...]` sandbox belongs only to that thread
+/// and is safe to quiesce with its lifecycle. The manager rechecks both the
+/// pre-patch virtual-MCP id and exact synthetic thread identity under each
+/// handle lock before closing the generation. Real git branches are shared by
+/// every native chat on that repository branch and must never be stopped when
+/// one chat is archived, deleted, or changes workspace identity.
+async fn quiesce_thread_sandbox(
+    state: &AppState,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    thread_id: &str,
+    virtual_mcp_id: &str,
+) -> Result<(), ApiError> {
+    state
+        .sandbox_manager
+        .delete_live_thread_sandboxes_for_account(account_epoch, virtual_mcp_id, thread_id)
+        .await
+        .map(|_| ())
+        .map_err(manager_error)
 }
 
 // --- COLLECTION_THREADS_DELETE -----------------------------------------------
@@ -774,29 +942,35 @@ async fn delete(state: &AppState, scope: &RtAccountScope, org: &str, body: &Byte
         Ok(v) => v,
         Err(r) => return r.into_response(),
     };
-    let db = match db(state) {
-        Ok(d) => d,
-        Err(r) => return r.into_response(),
-    };
     let Some(id) = input.get("id").and_then(Value::as_str) else {
         return ApiError::bad_request("id is required").into_response();
     };
 
-    // Read through the same organization predicate used by the delete. The
-    // collection binding returns the deleted entity, while an id owned by a
-    // different organization must be indistinguishable from an unknown id.
-    let item = match db.rt_get_thread_in_scope(scope, org, id) {
-        Ok(Some(item)) => item,
-        Ok(None) => return ApiError::not_found("thread not found").into_response(),
-        Err(e) => return ApiError::internal(format!("thread database error: {e}")).into_response(),
+    let resolved = {
+        let _account_guard = match lock_account_scope(scope).await {
+            Ok(guard) => guard,
+            Err(error) => return error.into_response(),
+        };
+        match resolve_scoped_thread(state, scope.clone(), org, id, ThreadAccess::Owner) {
+            Ok(resolved) => resolved,
+            Err(error) => return error.into_response(),
+        }
     };
-    let fence = match db.rt_thread_fence_in_scope(scope, org, id) {
-        Ok(Some(fence)) => fence,
-        Ok(None) => return ApiError::not_found("thread not found").into_response(),
-        Err(e) => return ApiError::internal(format!("thread database error: {e}")).into_response(),
-    };
+    let fence = resolved.fence;
     let start_lock = state.agent_sessions.start_lock(&fence);
     let _start_guard = start_lock.lock().await;
+    let account_guard = match lock_account_scope(scope).await {
+        Ok(guard) => guard,
+        Err(error) => return error.into_response(),
+    };
+    let resolved = match resolve_scoped_thread(state, scope.clone(), org, id, ThreadAccess::Owner) {
+        Ok(resolved) if resolved.fence == fence => resolved,
+        Ok(_) => return ApiError::not_found("thread not found").into_response(),
+        Err(error) => return error.into_response(),
+    };
+    let db = resolved.db;
+    let item = resolved.thread;
+    let account_epoch = state.sandbox_manager.account_epoch();
     match db.rt_mark_thread_delete_pending(&fence) {
         Ok(true) => {}
         Ok(false) => return ApiError::not_found("thread not found").into_response(),
@@ -804,15 +978,37 @@ async fn delete(state: &AppState, scope: &RtAccountScope, org: &str, body: &Byte
             return ApiError::internal(format!("thread database error: {e}")).into_response();
         }
     }
+    // `delete_pending` durably closes new starts and the lifecycle lock keeps
+    // this generation stable, so process cleanup must not hold the global
+    // account transition gate.
+    drop(account_guard);
+    if let Err(error) = cancel_preparing_terminal(state, db, &fence).await {
+        return error.into_response();
+    }
     if let Err(error) = state.agent_sessions.terminate_fence(&fence).await {
         // `delete_pending` deliberately survives failed reaping. A retry can
         // complete the same generation-fenced cascade, while new terminal
         // starts remain closed by the durable marker.
         return ApiError::internal(format!("could not stop coding agent: {error}")).into_response();
     }
+    if let Err(error) =
+        quiesce_thread_sandbox(state, account_epoch, &item.id, &item.virtual_mcp_id).await
+    {
+        return error.into_response();
+    }
+    let account_guard = match lock_account_scope(scope).await {
+        Ok(guard) => guard,
+        Err(error) => return error.into_response(),
+    };
+    match resolve_scoped_thread(state, scope.clone(), org, id, ThreadAccess::Owner) {
+        Ok(resolved) if resolved.fence == fence => {}
+        Ok(_) => return ApiError::not_found("thread not found").into_response(),
+        Err(error) => return error.into_response(),
+    }
 
-    match db.rt_delete_thread_in_org_if_generation(&fence) {
+    match db.rt_delete_owned_thread_if_generation(&fence, &scope.user_id) {
         Ok(true) => {
+            drop(account_guard);
             state.agent_sessions.forget_fence(&fence);
             if let Err(error) =
                 crate::terminal::launch_context::cleanup_managed_state(&state.app_root, &fence)
@@ -836,7 +1032,12 @@ async fn delete(state: &AppState, scope: &RtAccountScope, org: &str, body: &Byte
 
 // --- COLLECTION_THREAD_MESSAGES_LIST -----------------------------------------
 
-fn messages_list(state: &AppState, scope: &RtAccountScope, org: &str, body: &Bytes) -> Response {
+async fn messages_list(
+    state: &AppState,
+    scope: &RtAccountScope,
+    org: &str,
+    body: &Bytes,
+) -> Response {
     let input = match parse_json(body) {
         Ok(v) => v,
         Err(r) => return r.into_response(),
@@ -884,7 +1085,14 @@ fn messages_list(state: &AppState, scope: &RtAccountScope, org: &str, body: &Byt
 
     // Byte-parity with `list-messages.ts`'s own "unknown thread -> empty
     // page, not an error" behavior (see that file's handler).
-    match db.rt_list_messages_in_scope(scope, org, &thread_id, limit, offset, desc) {
+    let result = {
+        let _account_guard = match lock_account_scope(scope).await {
+            Ok(guard) => guard,
+            Err(error) => return error.into_response(),
+        };
+        db.rt_list_messages_in_scope(scope, org, &thread_id, limit, offset, desc)
+    };
+    match result {
         Ok((items, total_count)) => {
             let has_more = offset + limit < total_count;
             Json(json!({
@@ -906,12 +1114,16 @@ mod tests {
     use axum::http::StatusCode;
     use std::sync::OnceLock;
 
-    /// `shared_db` is process-wide, so its backing directory must live for the
-    /// whole test binary too. A per-test `TempDir` let the first completed test
-    /// unlink the database underneath every later test's still-open handle.
+    /// `shared_db` and the native sandbox registry are process-wide test
+    /// resources. Cache the whole state so parallel tests neither unlink the
+    /// shared database nor race separate registry connections while enabling
+    /// SQLite WAL mode.
     fn persistent_test_state() -> AppState {
         static ROOT: OnceLock<tempfile::TempDir> = OnceLock::new();
-        test_state(ROOT.get_or_init(|| tempfile::tempdir().unwrap()).path())
+        static STATE: OnceLock<AppState> = OnceLock::new();
+        STATE
+            .get_or_init(|| test_state(ROOT.get_or_init(|| tempfile::tempdir().unwrap()).path()))
+            .clone()
     }
 
     async fn body_json(res: Response) -> Value {
@@ -961,6 +1173,90 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn reserved_thread_branches_require_the_matching_explicit_thread_id() {
+        let state = persistent_test_state();
+        let org = "thread-tools-reserved-branch";
+        for input in [
+            json!({"data": {
+                "virtual_mcp_id": "vmcp-reserved",
+                "branch": "thread:generated-id-is-not-authority"
+            }}),
+            json!({"data": {
+                "id": "reserved-whitespace",
+                "virtual_mcp_id": "vmcp-reserved",
+                "branch": " thread:reserved-whitespace "
+            }}),
+            json!({"data": {
+                "id": "reserved-mismatch",
+                "virtual_mcp_id": "vmcp-reserved",
+                "branch": "thread:another-thread"
+            }}),
+            json!({"data": {
+                "id": "reserved-malformed",
+                "virtual_mcp_id": "vmcp-reserved",
+                "branch": "thread:"
+            }}),
+        ] {
+            let response = dispatch(
+                &state,
+                org,
+                "COLLECTION_THREADS_CREATE",
+                &Bytes::from(input.to_string()),
+            )
+            .await
+            .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        let thread_id = "reserved-exact";
+        let create = dispatch(
+            &state,
+            org,
+            "COLLECTION_THREADS_CREATE",
+            &Bytes::from(
+                json!({"data": {
+                    "id": thread_id,
+                    "virtual_mcp_id": "vmcp-reserved",
+                    "branch": format!("thread:{thread_id}/connection-1")
+                }})
+                .to_string(),
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(create.status(), StatusCode::OK);
+
+        for branch in [
+            "thread:another-thread",
+            "thread:reserved-exact/",
+            " thread:reserved-exact ",
+        ] {
+            let update = dispatch(
+                &state,
+                org,
+                "COLLECTION_THREADS_UPDATE",
+                &Bytes::from(json!({"id": thread_id, "data": {"branch": branch}}).to_string()),
+            )
+            .await
+            .unwrap();
+            assert_eq!(update.status(), StatusCode::BAD_REQUEST);
+        }
+
+        let get = dispatch(
+            &state,
+            org,
+            "COLLECTION_THREADS_GET",
+            &Bytes::from(json!({"id": thread_id}).to_string()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            body_json(get).await["item"]["branch"],
+            format!("thread:{thread_id}/connection-1")
+        );
     }
 
     #[tokio::test]
@@ -1476,50 +1772,59 @@ mod tests {
     async fn routes_isolate_same_org_slug_by_upstream_and_authenticated_user() {
         let state = persistent_test_state();
         let org = "route-account-scope-shared-org";
-        let id = "route-account-scope-thread";
+        let id = "route-account-scope-local-thread";
+        let local = RtAccountScope::new("test.invalid", "local-desktop-user").unwrap();
         let prod_alice = RtAccountScope::new("studio.decocms.com", "alice").unwrap();
-        let prod_bob = RtAccountScope::new("studio.decocms.com", "bob").unwrap();
         let dev_alice = RtAccountScope::new("localhost:4000", "alice").unwrap();
         let body = Bytes::from(json!({"data": {"id": id, "virtual_mcp_id": "vmcp"}}).to_string());
-        let created = dispatch_scoped(&state, &prod_alice, org, "COLLECTION_THREADS_CREATE", &body)
+        let created = dispatch_scoped(&state, &local, org, "COLLECTION_THREADS_CREATE", &body)
             .await
             .unwrap();
         assert_eq!(created.status(), axum::http::StatusCode::OK);
         let created = body_json(created).await;
         assert_eq!(created["item"]["organization_id"], org);
-        assert_eq!(created["item"]["created_by"], "alice");
+        assert_eq!(created["item"]["created_by"], "local-desktop-user");
         assert_eq!(created["item"]["title"], "New chat");
 
+        let database = shared_db(&state).unwrap();
+        for (scope, foreign_id) in [
+            (&prod_alice, "route-account-scope-prod-alice"),
+            (&dev_alice, "route-account-scope-dev-alice"),
+        ] {
+            database
+                .rt_create_thread_scoped(
+                    scope,
+                    Some(foreign_id),
+                    org,
+                    "foreign",
+                    None,
+                    "vmcp",
+                    None,
+                    &scope.user_id,
+                )
+                .unwrap();
+        }
+
         let list_body = Bytes::from(json!({"where": {"created_by": "me"}}).to_string());
-        let alice_list = body_json(
-            dispatch_scoped(
-                &state,
-                &prod_alice,
-                org,
-                "COLLECTION_THREADS_LIST",
-                &list_body,
-            )
-            .await
-            .unwrap(),
+        let local_list = body_json(
+            dispatch_scoped(&state, &local, org, "COLLECTION_THREADS_LIST", &list_body)
+                .await
+                .unwrap(),
         )
         .await;
-        assert_eq!(alice_list["totalCount"], 1);
+        assert_eq!(local_list["totalCount"], 1);
 
-        for foreign in [&prod_bob, &dev_alice] {
-            let list = body_json(
-                dispatch_scoped(&state, foreign, org, "COLLECTION_THREADS_LIST", &list_body)
-                    .await
-                    .unwrap(),
-            )
-            .await;
-            assert_eq!(list["totalCount"], 0);
+        for foreign_id in [
+            "route-account-scope-prod-alice",
+            "route-account-scope-dev-alice",
+        ] {
             let get = body_json(
                 dispatch_scoped(
                     &state,
-                    foreign,
+                    &local,
                     org,
                     "COLLECTION_THREADS_GET",
-                    &Bytes::from(json!({"id": id}).to_string()),
+                    &Bytes::from(json!({"id": foreign_id}).to_string()),
                 )
                 .await
                 .unwrap(),
@@ -1527,6 +1832,17 @@ mod tests {
             .await;
             assert_eq!(get, json!({"item": null}));
         }
+
+        let stale_scope = dispatch_scoped(
+            &state,
+            &prod_alice,
+            org,
+            "COLLECTION_THREADS_LIST",
+            &list_body,
+        )
+        .await
+        .unwrap();
+        assert_eq!(stale_scope.status(), StatusCode::CONFLICT);
     }
 
     #[tokio::test]
@@ -1558,6 +1874,220 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), axum::http::StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn teammate_thread_update_and_delete_are_forbidden() {
+        let state = persistent_test_state();
+        let scope = RtAccountScope::new("test.invalid", "local-desktop-user").unwrap();
+        let org = "thread-tools-teammate-authority";
+        let id = "thread-tools-teammate-thread";
+        shared_db(&state)
+            .unwrap()
+            .rt_create_thread_scoped(
+                &scope,
+                Some(id),
+                org,
+                "Teammate chat",
+                None,
+                "vmcp",
+                None,
+                "teammate-user",
+            )
+            .unwrap();
+
+        let update = dispatch(
+            &state,
+            org,
+            "COLLECTION_THREADS_UPDATE",
+            &Bytes::from(json!({"id": id, "data": {"title": "hijacked"}}).to_string()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(update.status(), StatusCode::FORBIDDEN);
+
+        let delete = dispatch(
+            &state,
+            org,
+            "COLLECTION_THREADS_DELETE",
+            &Bytes::from(json!({"id": id}).to_string()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(delete.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            shared_db(&state)
+                .unwrap()
+                .rt_get_thread_in_scope(&scope, org, id)
+                .unwrap()
+                .unwrap()
+                .title,
+            "Teammate chat"
+        );
+    }
+
+    #[tokio::test]
+    async fn changing_a_reserved_terminal_workspace_returns_conflict() {
+        let state = persistent_test_state();
+        let org = "thread-tools-workspace-lock";
+        let created = dispatch(
+            &state,
+            org,
+            "COLLECTION_THREADS_CREATE",
+            &Bytes::from(json!({"data": {"virtual_mcp_id": "vmcp", "branch": "main"}}).to_string()),
+        )
+        .await
+        .unwrap();
+        let id = body_json(created).await["item"]["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let database = shared_db(&state).unwrap();
+        let fence = database.rt_thread_fence_in_org(org, &id).unwrap().unwrap();
+        database
+            .rt_create_terminal_session_fenced(&fence, "workspace-lock-terminal", "codex")
+            .unwrap();
+
+        let response = dispatch(
+            &state,
+            org,
+            "COLLECTION_THREADS_UPDATE",
+            &Bytes::from(
+                json!({"id": id, "data": {"branch": "feature", "hidden": true}}).to_string(),
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            body_json(response).await,
+            json!({"error": "The chat workspace cannot be changed after its coding agent starts."})
+        );
+        assert!(database
+            .rt_get_live_terminal_session_fenced(&fence)
+            .unwrap()
+            .is_some());
+        assert!(
+            !database
+                .rt_get_thread_in_org(org, &id)
+                .unwrap()
+                .unwrap()
+                .hidden
+        );
+    }
+
+    #[tokio::test]
+    async fn routing_update_waits_for_the_workspace_lifecycle_lock() {
+        let state = persistent_test_state();
+        let org = "thread-tools-routing-linearization";
+        let id = "thread-tools-routing-linearization-thread";
+        let database = shared_db(&state).unwrap();
+        database
+            .rt_create_thread(
+                Some(id),
+                org,
+                "Routing chat",
+                None,
+                "vmcp-a",
+                Some("main"),
+                "local-desktop-user",
+            )
+            .unwrap();
+        let fence = database.rt_thread_fence_in_org(org, id).unwrap().unwrap();
+        let lifecycle_lock = state.agent_sessions.start_lock(&fence);
+        let lifecycle_guard = lifecycle_lock.lock().await;
+
+        let update_state = state.clone();
+        let update = tokio::spawn(async move {
+            dispatch(
+                &update_state,
+                org,
+                "COLLECTION_THREADS_UPDATE",
+                &Bytes::from(
+                    json!({"id": id, "data": {"branch": "feature", "virtual_mcp_id": "vmcp-b"}})
+                        .to_string(),
+                ),
+            )
+            .await
+            .unwrap()
+        });
+        tokio::task::yield_now().await;
+        assert!(!update.is_finished());
+        let before = database.rt_get_thread_in_org(org, id).unwrap().unwrap();
+        assert_eq!(before.branch.as_deref(), Some("main"));
+        assert_eq!(before.virtual_mcp_id, "vmcp-a");
+
+        drop(lifecycle_guard);
+        let response = tokio::time::timeout(std::time::Duration::from_secs(1), update)
+            .await
+            .expect("routing update should resume after the lifecycle lock")
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let after = body_json(response).await["item"].clone();
+        assert_eq!(after["branch"], "feature");
+        assert_eq!(after["virtual_mcp_id"], "vmcp-b");
+    }
+
+    #[tokio::test]
+    async fn routing_update_quiesces_the_pre_patch_synthetic_sandbox() {
+        let state = persistent_test_state();
+        let org = "thread-tools-routing-old-sandbox";
+        let id = "thread-tools-routing-old-sandbox-thread";
+        let branch = format!("thread:{id}");
+        let database = shared_db(&state).unwrap();
+        database
+            .rt_create_thread(
+                Some(id),
+                org,
+                "Routing chat",
+                None,
+                "test-agent",
+                Some(&branch),
+                "local-desktop-user",
+            )
+            .unwrap();
+        let handle = state
+            .sandbox_manager
+            .register_for_test("https://github.com/acme/routing-old-sandbox.git", &branch);
+        let account_epoch = state.sandbox_manager.account_epoch();
+        let old_generation = state
+            .sandbox_manager
+            .adopt_for_account(account_epoch, &handle)
+            .await
+            .unwrap()
+            .expect("synthetic sandbox is live before the identity patch");
+        assert!(!old_generation.tasks.is_admission_closed());
+
+        let response = dispatch(
+            &state,
+            org,
+            "COLLECTION_THREADS_UPDATE",
+            &Bytes::from(json!({"id": id, "data": {"virtual_mcp_id": "vmcp-b"}}).to_string()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            body_json(response).await["item"]["virtual_mcp_id"],
+            "vmcp-b"
+        );
+        assert!(state
+            .sandbox_manager
+            .get_for_account(account_epoch, &handle)
+            .unwrap()
+            .is_none());
+        assert!(old_generation.tasks.is_admission_closed());
+        assert!(old_generation.tasks.list(None).is_empty());
+        assert_eq!(
+            state
+                .sandbox_manager
+                .registry_record_for_account(account_epoch, &handle)
+                .unwrap()
+                .unwrap()
+                .desired_status,
+            "stopped"
+        );
     }
 
     #[tokio::test]
@@ -1616,8 +2146,16 @@ mod tests {
         let owner_org = "thread-tools-scope-owner";
         let other_org = "thread-tools-scope-other";
         let id = "thread-tools-scoped-delete";
-        db.rt_create_thread(Some(id), owner_org, "original", None, "v", None, "u")
-            .unwrap();
+        db.rt_create_thread(
+            Some(id),
+            owner_org,
+            "original",
+            None,
+            "v",
+            None,
+            "local-desktop-user",
+        )
+        .unwrap();
         db.rt_append_message("scoped-u", id, "user", &json!([]), None)
             .unwrap();
         db.rt_append_message("scoped-a", id, "assistant", &json!([]), None)

--- a/apps/native/crates/local-api/src/routes/intercept/watch.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/watch.rs
@@ -198,6 +198,9 @@ impl Drop for Subscription {
 struct WatchStream {
     initial: Option<Bytes>,
     subscription: Subscription,
+    account_epoch_rx: tokio::sync::watch::Receiver<crate::sandbox::manager::AccountEpoch>,
+    _account_epoch_keepalive:
+        Option<tokio::sync::watch::Sender<crate::sandbox::manager::AccountEpoch>>,
 }
 
 fn hub() -> &'static LocalWatchHub {
@@ -313,7 +316,24 @@ fn event_frame(event: &LocalWatchEvent) -> Result<Bytes, serde_json::Error> {
     )))
 }
 
-pub(crate) fn get(scope: &RtAccountScope, organization_id: &str, query: Option<&str>) -> Response {
+pub(crate) fn get_for_account(
+    scope: &RtAccountScope,
+    organization_id: &str,
+    query: Option<&str>,
+    account_epoch_rx: tokio::sync::watch::Receiver<crate::sandbox::manager::AccountEpoch>,
+) -> Response {
+    get_inner(scope, organization_id, query, account_epoch_rx, None)
+}
+
+fn get_inner(
+    scope: &RtAccountScope,
+    organization_id: &str,
+    query: Option<&str>,
+    account_epoch_rx: tokio::sync::watch::Receiver<crate::sandbox::manager::AccountEpoch>,
+    account_epoch_keepalive: Option<
+        tokio::sync::watch::Sender<crate::sandbox::manager::AccountEpoch>,
+    >,
+) -> Response {
     if organization_id.is_empty() {
         return ApiError::bad_request("organization id missing").into_response();
     }
@@ -339,22 +359,41 @@ pub(crate) fn get(scope: &RtAccountScope, organization_id: &str, query: Option<&
     let stream_state = WatchStream {
         initial: Some(initial),
         subscription,
+        account_epoch_rx,
+        _account_epoch_keepalive: account_epoch_keepalive,
     };
     let body_stream = stream::unfold(stream_state, |mut state| async move {
         if let Some(initial) = state.initial.take() {
+            if state.account_epoch_rx.has_changed().unwrap_or(true) {
+                return None;
+            }
             return Some((Ok::<_, Infallible>(initial), state));
         }
-        match tokio::time::timeout(KEEPALIVE_INTERVAL, state.subscription.receiver.recv()).await {
-            Ok(Some(frame)) => Some((Ok(frame), state)),
-            Ok(None) => None,
-            Err(_) => Some((
-                Ok(Bytes::from_static(b"event: keepalive\ndata: \n\n")),
-                state,
-            )),
+        tokio::select! {
+            biased;
+            _ = state.account_epoch_rx.changed() => None,
+            event = tokio::time::timeout(
+                KEEPALIVE_INTERVAL,
+                state.subscription.receiver.recv(),
+            ) => match event {
+                Ok(Some(frame)) => Some((Ok(frame), state)),
+                Ok(None) => None,
+                Err(_) => Some((
+                    Ok(Bytes::from_static(b"event: keepalive\ndata: \n\n")),
+                    state,
+                )),
+            },
         }
     });
 
     sse_response(Body::from_stream(body_stream))
+}
+
+#[cfg(test)]
+fn get(scope: &RtAccountScope, organization_id: &str, query: Option<&str>) -> Response {
+    let (sender, receiver) =
+        tokio::sync::watch::channel(crate::sandbox::manager::AccountEpoch::for_test());
+    get_inner(scope, organization_id, query, receiver, Some(sender))
 }
 
 /// Publishes the exact production-shaped status event after its SQLite
@@ -630,6 +669,37 @@ mod tests {
             .await
             .expect("a refusal must end rather than hang")
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn account_epoch_change_closes_before_connected_and_during_stream() {
+        let root = tempfile::tempdir().unwrap();
+        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf());
+        let account = scope("epoch-alice");
+        let org = format!("org-{}", Uuid::new_v4());
+
+        let epoch = manager.account_epoch();
+        let epoch_rx = manager.watch_account_epoch(epoch).unwrap();
+        let response = get_for_account(&account, &org, None, epoch_rx);
+        let transition = manager.begin_account_transition().await.unwrap();
+        let mut stream = response.into_body().into_data_stream();
+        assert!(tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("stale pre-connected watch must finish promptly")
+            .is_none());
+        drop(transition);
+
+        let epoch = manager.account_epoch();
+        let epoch_rx = manager.watch_account_epoch(epoch).unwrap();
+        let response = get_for_account(&account, &org, None, epoch_rx);
+        let mut stream = response.into_body().into_data_stream();
+        assert!(next_frame(&mut stream).await.contains("event: connected"));
+        let transition = manager.begin_account_transition().await.unwrap();
+        assert!(tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("open watch must finish promptly on account transition")
+            .is_none());
+        drop(transition);
     }
 
     #[test]

--- a/apps/native/crates/local-api/src/routes/mod.rs
+++ b/apps/native/crates/local-api/src/routes/mod.rs
@@ -17,6 +17,7 @@ pub mod mcp_callback;
 pub mod orgfs;
 pub mod proxy;
 pub mod repo_dir;
+pub(crate) mod sandbox_account;
 pub mod scripts;
 pub mod setup;
 pub mod tasks;

--- a/apps/native/crates/local-api/src/routes/proxy.rs
+++ b/apps/native/crates/local-api/src/routes/proxy.rs
@@ -77,6 +77,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use futures_util::StreamExt;
 use serde_json::{json, Value};
 
 use super::ws_proxy;
@@ -121,13 +122,58 @@ pub(crate) struct PreviewCookieSelftest {
     pub cookie_value: Arc<str>,
 }
 
-pub async fn fallback(State(state): State<AppState>, req: Request) -> Response {
-    if is_websocket_upgrade(req.headers()) {
-        return handle_ws_upgrade(state, req).await;
+struct ResponseEpochFence {
+    expected: crate::sandbox::manager::AccountEpoch,
+    receiver: tokio::sync::watch::Receiver<crate::sandbox::manager::AccountEpoch>,
+}
+
+impl ResponseEpochFence {
+    fn is_stale(&self) -> bool {
+        *self.receiver.borrow() != self.expected
     }
 
-    match resolve_preview(&state, req.headers()) {
-        PreviewResolution::Port(port) => proxy_to_port(port, req).await,
+    async fn changed(&mut self) {
+        if self.is_stale() {
+            return;
+        }
+        // Any version change closes the response, even if epoch saturation
+        // publishes the same numeric value to fail permanently closed.
+        let _ = self.receiver.changed().await;
+    }
+}
+
+pub async fn fallback(State(state): State<AppState>, req: Request) -> Response {
+    let authorization = match super::sandbox_account::authorize(&state).await {
+        Ok(authorization) => authorization,
+        Err(error) => return error.into_response(),
+    };
+    let account_epoch = authorization.epoch();
+    if is_websocket_upgrade(req.headers()) {
+        drop(authorization);
+        return handle_ws_upgrade(state, account_epoch, req).await;
+    }
+
+    let resolution = match resolve_preview(&state, account_epoch, req.headers()) {
+        Ok(resolution) => resolution,
+        Err(error) => return crate::error::ApiError::conflict(error).into_response(),
+    };
+    drop(authorization);
+    match resolution {
+        PreviewResolution::Port(port) => {
+            let receiver = match state.sandbox_manager.watch_account_epoch(account_epoch) {
+                Ok(receiver) => receiver,
+                Err(error) => return crate::error::ApiError::conflict(error).into_response(),
+            };
+            proxy_to_port_inner(
+                port,
+                req,
+                Some(ResponseEpochFence {
+                    expected: account_epoch,
+                    receiver,
+                }),
+            )
+            .await
+        }
         PreviewResolution::Starting => starting_response(),
         PreviewResolution::NoServer => no_upstream_response(),
     }
@@ -265,17 +311,23 @@ pub async fn set_preview_handle(
     State(state): State<AppState>,
     axum::Json(body): axum::Json<serde_json::Value>,
 ) -> Response {
+    let authorization = match super::sandbox_account::authorize(&state).await {
+        Ok(authorization) => authorization,
+        Err(error) => return error.into_response(),
+    };
+    let account_epoch = authorization.epoch();
     match body.get("handle").and_then(Value::as_str) {
-        Some(handle) if !handle.is_empty() => match state.sandbox_manager.set_active(handle) {
+        Some(handle) if !handle.is_empty() => match state
+            .sandbox_manager
+            .set_active_for_account(account_epoch, handle)
+        {
             Ok(()) => (StatusCode::OK, axum::Json(json!({ "ok": true }))).into_response(),
             Err(error) if error.starts_with("unknown sandbox handle:") => {
                 (StatusCode::NOT_FOUND, axum::Json(json!({ "error": error }))).into_response()
             }
-            Err(error) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                axum::Json(json!({ "error": error })),
-            )
-                .into_response(),
+            Err(error) => {
+                (StatusCode::CONFLICT, axum::Json(json!({ "error": error }))).into_response()
+            }
         },
         _ => (
             StatusCode::BAD_REQUEST,
@@ -317,38 +369,67 @@ pub async fn set_preview_handle(
 /// is tiny (one entry per worktree on this machine) and the alternative — a
 /// second persisted label->handle index — is a thing that can disagree with
 /// `preview_label`.
-fn handle_from_host(state: &AppState, headers: &HeaderMap) -> Option<String> {
-    let host = headers.get(header::HOST)?.to_str().ok()?;
-    let host = host.split(':').next()?;
-    let (label, rest) = host.split_once('.')?;
+fn handle_from_host(
+    state: &AppState,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    headers: &HeaderMap,
+) -> Result<Option<String>, String> {
+    let Some(host) = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return Ok(None);
+    };
+    let Some(host) = host.split(':').next() else {
+        return Ok(None);
+    };
+    let Some((label, rest)) = host.split_once('.') else {
+        return Ok(None);
+    };
     if label.is_empty() || rest.is_empty() {
-        return None;
+        return Ok(None);
     }
     // A cached in-memory lookup: this runs on EVERY preview asset request,
     // and the walk-the-worktrees version it replaces enumerated directories
     // and hashed every handle each time.
-    state.sandbox_manager.handle_for_preview_label(label)
+    state
+        .sandbox_manager
+        .handle_for_preview_label_for_account(account_epoch, label)
 }
 
-fn dev_port(state: &AppState, headers: &HeaderMap) -> Option<u16> {
+fn dev_port(
+    state: &AppState,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    headers: &HeaderMap,
+) -> Result<Option<u16>, String> {
     if let Some(handle) = crate::sandbox::handle_from_headers(headers) {
-        let sandbox = state.sandbox_manager.get(handle)?;
-        return dev_port_for(&sandbox.setup, &sandbox.config);
+        let Some(sandbox) = state
+            .sandbox_manager
+            .get_for_account(account_epoch, handle)?
+        else {
+            return Ok(None);
+        };
+        return Ok(dev_port_for(&sandbox.setup, &sandbox.config));
     }
     // A preview iframe cannot set the handle header, but its Host names the
     // sandbox — this is the per-handle preview origin resolving itself.
-    if let Some(sandbox) =
-        handle_from_host(state, headers).and_then(|handle| state.sandbox_manager.get(&handle))
-    {
-        return dev_port_for(&sandbox.setup, &sandbox.config);
+    if let Some(handle) = handle_from_host(state, account_epoch, headers)? {
+        if let Some(sandbox) = state
+            .sandbox_manager
+            .get_for_account(account_epoch, &handle)?
+        {
+            return Ok(dev_port_for(&sandbox.setup, &sandbox.config));
+        }
     }
     // Neither: serve the ACTIVE sandbox's dev server if a git-backed thread has
     // selected one, else the global (non-git) orchestrator — unchanged
     // behavior for the plain path.
-    match state.sandbox_manager.active() {
-        Some(sandbox) => dev_port_for(&sandbox.setup, &sandbox.config),
-        None => dev_port_for(&state.setup, &state.config),
-    }
+    Ok(
+        match state.sandbox_manager.active_for_account(account_epoch)? {
+            Some(sandbox) => dev_port_for(&sandbox.setup, &sandbox.config),
+            None => dev_port_for(&state.setup, &state.config),
+        },
+    )
 }
 
 /// `portSniffer.current() ?? application.port ?? null` for one
@@ -415,25 +496,39 @@ enum PreviewResolution {
 /// no-dev-port result to `Starting` vs `NoServer` by the resolved
 /// orchestrator's lifecycle phase. NOT shared with `dev_port` on purpose — see
 /// [`dev_port`]'s doc and plan D1/D4.
-fn resolve_preview(state: &AppState, headers: &HeaderMap) -> PreviewResolution {
+fn resolve_preview(
+    state: &AppState,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    headers: &HeaderMap,
+) -> Result<PreviewResolution, String> {
     if let Some(handle) = crate::sandbox::handle_from_headers(headers) {
-        return match state.sandbox_manager.get(handle) {
-            Some(sandbox) => preview_from(&sandbox.setup, &sandbox.config),
-            // Unknown explicit handle: never fall back to the wrong branch.
-            None => PreviewResolution::NoServer,
-        };
+        return Ok(
+            match state
+                .sandbox_manager
+                .get_for_account(account_epoch, handle)?
+            {
+                Some(sandbox) => preview_from(&sandbox.setup, &sandbox.config),
+                // Unknown explicit handle: never fall back to the wrong branch.
+                None => PreviewResolution::NoServer,
+            },
+        );
     }
     // Per-handle preview origin (`<handle>.<preview-host>`): the iframe's Host
     // names the sandbox even though it cannot set the handle header.
-    if let Some(sandbox) =
-        handle_from_host(state, headers).and_then(|handle| state.sandbox_manager.get(&handle))
-    {
-        return preview_from(&sandbox.setup, &sandbox.config);
+    if let Some(handle) = handle_from_host(state, account_epoch, headers)? {
+        if let Some(sandbox) = state
+            .sandbox_manager
+            .get_for_account(account_epoch, &handle)?
+        {
+            return Ok(preview_from(&sandbox.setup, &sandbox.config));
+        }
     }
-    match state.sandbox_manager.active() {
-        Some(sandbox) => preview_from(&sandbox.setup, &sandbox.config),
-        None => preview_from(&state.setup, &state.config),
-    }
+    Ok(
+        match state.sandbox_manager.active_for_account(account_epoch)? {
+            Some(sandbox) => preview_from(&sandbox.setup, &sandbox.config),
+            None => preview_from(&state.setup, &state.config),
+        },
+    )
 }
 
 /// Maps one orchestrator/config pair to a [`PreviewResolution`]: a resolvable
@@ -466,8 +561,19 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
         .is_some_and(|v| v.eq_ignore_ascii_case("websocket"))
 }
 
-async fn handle_ws_upgrade(state: AppState, req: Request) -> Response {
-    let port = dev_port(&state, req.headers());
+async fn handle_ws_upgrade(
+    state: AppState,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    req: Request,
+) -> Response {
+    let port = match dev_port(&state, account_epoch, req.headers()) {
+        Ok(port) => port,
+        Err(error) => return crate::error::ApiError::conflict(error).into_response(),
+    };
+    let account_epoch_rx = match state.sandbox_manager.watch_account_epoch(account_epoch) {
+        Ok(receiver) => receiver,
+        Err(error) => return crate::error::ApiError::conflict(error).into_response(),
+    };
     let (mut parts, _body) = req.into_parts();
     let path_and_query = parts
         .uri
@@ -484,12 +590,14 @@ async fn handle_ws_upgrade(state: AppState, req: Request) -> Response {
 
     match WebSocketUpgrade::from_request_parts(&mut parts, &state).await {
         Ok(upgrade) => {
-            ws_proxy::upgrade(
+            ws_proxy::upgrade_for_account(
                 upgrade,
                 port,
                 path_and_query,
                 requested_protocols,
                 request_headers,
+                account_epoch,
+                account_epoch_rx,
             )
             .await
         }
@@ -501,7 +609,16 @@ async fn handle_ws_upgrade(state: AppState, req: Request) -> Response {
 /// Split out from `fallback` so unit tests can drive it directly against a
 /// real loopback listener without needing `AppState`/`ConfigStore` — see
 /// this file's module doc.
+#[cfg(test)]
 async fn proxy_to_port(port: u16, req: Request) -> Response {
+    proxy_to_port_inner(port, req, None).await
+}
+
+async fn proxy_to_port_inner(
+    port: u16,
+    req: Request,
+    mut account_epoch: Option<ResponseEpochFence>,
+) -> Response {
     let (parts, body) = req.into_parts();
     let is_root = parts.uri.path() == "/";
     let path_and_query = parts
@@ -534,8 +651,16 @@ async fn proxy_to_port(port: u16, req: Request) -> Response {
     )
     .await
     {
-        Ok(upstream) => build_success_response(upstream, is_root).await,
+        Ok(upstream) => {
+            if account_epoch.as_mut().is_some_and(|fence| fence.is_stale()) {
+                return crate::error::ApiError::conflict("Studio account changed").into_response();
+            }
+            build_success_response(upstream, is_root, account_epoch).await
+        }
         Err(msg) => {
+            if account_epoch.as_mut().is_some_and(|fence| fence.is_stale()) {
+                return crate::error::ApiError::conflict("Studio account changed").into_response();
+            }
             tracing::warn!(port, path = %path_and_query, error = %msg, "proxy error");
             if is_root {
                 starting_response()
@@ -597,7 +722,11 @@ async fn send_to_loopback(
     Err(last_err.unwrap_or_else(|| "upstream unreachable".to_string()))
 }
 
-async fn build_success_response(upstream: reqwest::Response, is_root: bool) -> Response {
+async fn build_success_response(
+    upstream: reqwest::Response,
+    is_root: bool,
+    mut account_epoch: Option<ResponseEpochFence>,
+) -> Response {
     let status = upstream.status();
     if status.as_u16() >= 500 {
         tracing::warn!(status = status.as_u16(), "proxy upstream error");
@@ -626,6 +755,9 @@ async fn build_success_response(upstream: reqwest::Response, is_root: bool) -> R
                 return proxy_error_response(&format!("failed reading upstream body: {err}"))
             }
         };
+        if account_epoch.as_mut().is_some_and(|fence| fence.is_stale()) {
+            return crate::error::ApiError::conflict("Studio account changed").into_response();
+        }
         let injected = inject_bootstrap_script(&text);
         return build_response(status, resp_headers, Body::from(injected));
     }
@@ -637,10 +769,20 @@ async fn build_success_response(upstream: reqwest::Response, is_root: bool) -> R
         // Drain the body so the connection can be reused/closed cleanly —
         // mirrors `upstream.body?.cancel()`.
         let _ = upstream.bytes().await;
+        if account_epoch.as_mut().is_some_and(|fence| fence.is_stale()) {
+            return crate::error::ApiError::conflict("Studio account changed").into_response();
+        }
         return no_web_page_response(resp_headers);
     }
 
-    let body = Body::from_stream(upstream.bytes_stream());
+    let body = match account_epoch {
+        Some(mut account_epoch) => Body::from_stream(
+            upstream
+                .bytes_stream()
+                .take_until(async move { account_epoch.changed().await }),
+        ),
+        None => Body::from_stream(upstream.bytes_stream()),
+    };
     build_response(status, resp_headers, body)
 }
 
@@ -831,6 +973,21 @@ mod tests {
             .uri(uri)
             .body(Body::empty())
             .unwrap()
+    }
+
+    #[tokio::test]
+    async fn response_epoch_fence_closes_on_same_value_fail_closed_notification() {
+        let epoch = crate::sandbox::manager::AccountEpoch::for_test();
+        let (sender, receiver) = tokio::sync::watch::channel(epoch);
+        let mut fence = ResponseEpochFence {
+            expected: epoch,
+            receiver,
+        };
+
+        sender.send_replace(epoch);
+        tokio::time::timeout(Duration::from_secs(1), fence.changed())
+            .await
+            .expect("same-value epoch closure must terminate the response");
     }
 
     #[tokio::test]
@@ -1390,7 +1547,14 @@ mod tests {
     fn dev_port_none_when_config_unset() {
         // Exercises `dev_port()` against a real (freshly booted) `AppState`.
         let state = fresh_state();
-        assert!(dev_port(&state, &HeaderMap::new()).is_none());
+        assert_eq!(
+            dev_port(
+                &state,
+                state.sandbox_manager.account_epoch(),
+                &HeaderMap::new(),
+            ),
+            Ok(None)
+        );
     }
 
     #[test]
@@ -1401,7 +1565,8 @@ mod tests {
             .patch(json!({"application": {"port": 4321}}))
             .expect("patch ok");
         // Static config alone: falls back to `application.port`.
-        assert_eq!(dev_port(&state, &HeaderMap::new()), Some(4321));
+        let epoch = state.sandbox_manager.account_epoch();
+        assert_eq!(dev_port(&state, epoch, &HeaderMap::new()), Ok(Some(4321)));
 
         // Orchestrator reaches `running` with a DIFFERENT (sniffed) port —
         // that must win, matching `getDevPort()`'s `portSniffer.current() ??
@@ -1409,7 +1574,7 @@ mod tests {
         state
             .setup
             .transition_lifecycle(json!({"phase": "running", "port": 9999, "htmlSupport": false}));
-        assert_eq!(dev_port(&state, &HeaderMap::new()), Some(9999));
+        assert_eq!(dev_port(&state, epoch, &HeaderMap::new()), Ok(Some(9999)));
     }
 
     #[test]
@@ -1427,15 +1592,22 @@ mod tests {
             crate::sandbox::SANDBOX_HANDLE_HEADER,
             HeaderValue::from_static("unknown-handle"),
         );
-        assert_eq!(dev_port(&state, &headers), None);
+        assert_eq!(
+            dev_port(&state, state.sandbox_manager.account_epoch(), &headers),
+            Ok(None)
+        );
     }
 
     #[test]
     fn resolve_preview_is_no_server_when_idle_and_unconfigured() {
         let state = fresh_state();
         assert!(matches!(
-            resolve_preview(&state, &HeaderMap::new()),
-            PreviewResolution::NoServer
+            resolve_preview(
+                &state,
+                state.sandbox_manager.account_epoch(),
+                &HeaderMap::new(),
+            ),
+            Ok(PreviewResolution::NoServer)
         ));
     }
 
@@ -1446,8 +1618,12 @@ mod tests {
             state.setup.transition_lifecycle(json!({ "phase": phase }));
             assert!(
                 matches!(
-                    resolve_preview(&state, &HeaderMap::new()),
-                    PreviewResolution::Starting
+                    resolve_preview(
+                        &state,
+                        state.sandbox_manager.account_epoch(),
+                        &HeaderMap::new(),
+                    ),
+                    Ok(PreviewResolution::Starting)
                 ),
                 "phase {phase} should map to Starting"
             );
@@ -1461,8 +1637,12 @@ mod tests {
             .setup
             .transition_lifecycle(json!({"phase": "running", "port": 8321, "htmlSupport": false}));
         assert!(matches!(
-            resolve_preview(&state, &HeaderMap::new()),
-            PreviewResolution::Port(8321)
+            resolve_preview(
+                &state,
+                state.sandbox_manager.account_epoch(),
+                &HeaderMap::new(),
+            ),
+            Ok(PreviewResolution::Port(8321))
         ));
     }
 
@@ -1475,8 +1655,12 @@ mod tests {
             .setup
             .transition_lifecycle(json!({"phase": "running", "htmlSupport": false}));
         assert!(matches!(
-            resolve_preview(&state, &HeaderMap::new()),
-            PreviewResolution::Starting
+            resolve_preview(
+                &state,
+                state.sandbox_manager.account_epoch(),
+                &HeaderMap::new(),
+            ),
+            Ok(PreviewResolution::Starting)
         ));
     }
 
@@ -1494,8 +1678,8 @@ mod tests {
             HeaderValue::from_static("unknown-handle"),
         );
         assert!(matches!(
-            resolve_preview(&state, &headers),
-            PreviewResolution::NoServer
+            resolve_preview(&state, state.sandbox_manager.account_epoch(), &headers,),
+            Ok(PreviewResolution::NoServer)
         ));
     }
 
@@ -1539,12 +1723,15 @@ mod tests {
 
         let sandbox = state
             .sandbox_manager
-            .ensure(&crate::sandbox::GitSandboxConfig {
-                virtual_mcp_id: "vmcp-proxy-test".to_string(),
-                clone_url: bare_str.to_string(),
-                branch: Some("main".to_string()),
-                ..Default::default()
-            })
+            .ensure_for_account(
+                state.sandbox_manager.account_epoch(),
+                &crate::sandbox::GitSandboxConfig {
+                    virtual_mcp_id: "vmcp-proxy-test".to_string(),
+                    clone_url: bare_str.to_string(),
+                    branch: Some("main".to_string()),
+                    ..Default::default()
+                },
+            )
             .await
             .expect("ensure succeeds against a real one-commit bare repo");
         sandbox
@@ -1556,12 +1743,13 @@ mod tests {
             crate::sandbox::SANDBOX_HANDLE_HEADER,
             HeaderValue::from_str(&sandbox.handle).unwrap(),
         );
-        assert_eq!(dev_port(&state, &headers), Some(8123));
+        let epoch = state.sandbox_manager.account_epoch();
+        assert_eq!(dev_port(&state, epoch, &headers), Ok(Some(8123)));
         // Headerless (the preview iframe) now follows the ACTIVE handle, which
         // `ensure()` set to this sandbox — so it serves the branch just run
         // (8123), NOT the process-global config port. An explicit re-focus
         // still works and is honored the same way.
-        assert_eq!(dev_port(&state, &HeaderMap::new()), Some(8123));
+        assert_eq!(dev_port(&state, epoch, &HeaderMap::new()), Ok(Some(8123)));
         // A frontend-computed phantom cannot replace the durable active
         // sandbox. The known target remains selected after the rejection.
         assert_eq!(
@@ -1571,6 +1759,6 @@ mod tests {
                 .unwrap_err(),
             "unknown sandbox handle: never-ensured-handle"
         );
-        assert_eq!(dev_port(&state, &HeaderMap::new()), Some(8123));
+        assert_eq!(dev_port(&state, epoch, &HeaderMap::new()), Ok(Some(8123)));
     }
 }

--- a/apps/native/crates/local-api/src/routes/repo_dir.rs
+++ b/apps/native/crates/local-api/src/routes/repo_dir.rs
@@ -38,13 +38,19 @@ use crate::state::AppState;
 use std::sync::Arc;
 
 pub async fn get(State(state): State<AppState>, headers: HeaderMap) -> ApiResult<Json<Value>> {
-    let sandbox = resolve(&state, &headers)?;
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    let account_epoch = authorization.epoch();
+    let sandbox = resolve(&state, account_epoch, &headers)?;
     if tokio::fs::metadata(&sandbox.workdir).await.is_err() {
         return Err(ApiError::not_found(format!(
             "repo dir does not exist: {}",
             sandbox.workdir.display()
         )));
     }
+    state
+        .sandbox_manager
+        .validate_account_epoch(account_epoch)
+        .map_err(ApiError::conflict)?;
     Ok(Json(
         json!({ "repoDir": sandbox.workdir.to_string_lossy() }),
     ))
@@ -52,15 +58,21 @@ pub async fn get(State(state): State<AppState>, headers: HeaderMap) -> ApiResult
 
 /// `handle -> get(handle)` else `active()` — see this file's module doc for
 /// why this does NOT fall further to the process-global path.
-fn resolve(state: &AppState, headers: &HeaderMap) -> Result<Arc<Sandbox>, ApiError> {
+fn resolve(
+    state: &AppState,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    headers: &HeaderMap,
+) -> Result<Arc<Sandbox>, ApiError> {
     match crate::sandbox::handle_from_headers(headers) {
         Some(handle) => state
             .sandbox_manager
-            .get(handle)
+            .get_for_account(account_epoch, handle)
+            .map_err(ApiError::conflict)?
             .ok_or_else(|| ApiError::not_found(format!("unknown sandbox handle: {handle}"))),
         None => state
             .sandbox_manager
-            .active()
+            .active_for_account(account_epoch)
+            .map_err(ApiError::conflict)?
             .ok_or_else(|| ApiError::not_found("no active sandbox")),
     }
 }
@@ -140,12 +152,15 @@ mod tests {
         git(&bare_dir, &["symbolic-ref", "HEAD", "refs/heads/main"]);
 
         manager
-            .ensure(&crate::sandbox::GitSandboxConfig {
-                virtual_mcp_id: vmcp.to_string(),
-                clone_url: bare_str.to_string(),
-                branch: Some("main".to_string()),
-                ..Default::default()
-            })
+            .ensure_for_account(
+                manager.account_epoch(),
+                &crate::sandbox::GitSandboxConfig {
+                    virtual_mcp_id: vmcp.to_string(),
+                    clone_url: bare_str.to_string(),
+                    branch: Some("main".to_string()),
+                    ..Default::default()
+                },
+            )
             .await
             .expect("ensure succeeds against a real one-commit bare repo")
     }
@@ -157,7 +172,11 @@ mod tests {
         let state = fresh_state(manager);
         // `Arc<Sandbox>` (the `Ok` side) isn't `Debug`, so `expect_err` isn't
         // available here — match explicitly instead.
-        match resolve(&state, &HeaderMap::new()) {
+        match resolve(
+            &state,
+            state.sandbox_manager.account_epoch(),
+            &HeaderMap::new(),
+        ) {
             Err(e) => assert_eq!(e.status, axum::http::StatusCode::NOT_FOUND),
             Ok(_) => panic!("no active sandbox -> 404"),
         }
@@ -173,7 +192,7 @@ mod tests {
             "x-decocms-sandbox-handle",
             HeaderValue::from_static("never-ensured"),
         );
-        match resolve(&state, &headers) {
+        match resolve(&state, state.sandbox_manager.account_epoch(), &headers) {
             Err(e) => assert_eq!(e.status, axum::http::StatusCode::NOT_FOUND),
             Ok(_) => panic!("unknown handle -> 404"),
         }
@@ -191,7 +210,8 @@ mod tests {
             HeaderValue::from_str(&sandbox.handle).unwrap(),
         );
         let state = fresh_state(manager);
-        let resolved = resolve(&state, &headers).expect("known handle resolves");
+        let resolved = resolve(&state, state.sandbox_manager.account_epoch(), &headers)
+            .expect("known handle resolves");
         assert_eq!(resolved.workdir, sandbox.workdir);
     }
 
@@ -202,7 +222,12 @@ mod tests {
         let sandbox = ensure_one_sandbox(&manager, "repo-dir-active").await;
 
         let state = fresh_state(manager);
-        let resolved = resolve(&state, &HeaderMap::new()).expect("active sandbox resolves");
+        let resolved = resolve(
+            &state,
+            state.sandbox_manager.account_epoch(),
+            &HeaderMap::new(),
+        )
+        .expect("active sandbox resolves");
         assert_eq!(resolved.workdir, sandbox.workdir);
     }
 

--- a/apps/native/crates/local-api/src/routes/sandbox_account.rs
+++ b/apps/native/crates/local-api/src/routes/sandbox_account.rs
@@ -1,0 +1,99 @@
+//! Admission helper for direct local-daemon routes that operate on sandbox
+//! state without first passing through an intercepted Studio thread tool.
+
+use crate::error::ApiResult;
+use crate::sandbox::manager::AccountEpoch;
+use crate::state::AppState;
+
+#[derive(Clone, Copy)]
+pub(crate) struct ExpectedIdentity {
+    epoch: AccountEpoch,
+    generation: u64,
+}
+
+impl ExpectedIdentity {
+    pub(crate) fn new(epoch: AccountEpoch, generation: u64) -> Self {
+        Self { epoch, generation }
+    }
+}
+
+tokio::task_local! {
+    /// Ingress identity for one intercepted app-API request. Interceptors
+    /// acquire their own short account guards immediately before mutations;
+    /// this inherited expectation makes those guards prove they still belong
+    /// to the identity captured before request-body buffering.
+    static EXPECTED_IDENTITY: ExpectedIdentity;
+}
+
+pub(crate) struct Authorization {
+    epoch: AccountEpoch,
+    _account: upstream::SessionTransitionGuard,
+}
+
+impl Authorization {
+    pub(crate) fn epoch(&self) -> AccountEpoch {
+        self.epoch
+    }
+
+    /// The upstream identity generation captured by the same transition
+    /// guard that proved the account scope. Long-lived proxy requests pair
+    /// this with subscriptions created before the guard is released, so an
+    /// account replacement cannot hide in a validate/subscribe gap.
+    pub(crate) fn identity_generation(&self) -> u64 {
+        self._account.generation()
+    }
+}
+
+/// Capture an opaque sandbox account ticket while the upstream account scope
+/// is locked and revalidated. Callers pass the ticket through every manager
+/// lookup or mutation; long work may release the upstream lock because the
+/// manager rejects the ticket after an account transition.
+pub(crate) async fn authorize(state: &AppState) -> ApiResult<Authorization> {
+    let scope = super::threads::authority::current_account_scope().await?;
+    let account = super::threads::authority::lock_account_scope(&scope).await?;
+    Ok(Authorization {
+        epoch: state.sandbox_manager.account_epoch(),
+        _account: account,
+    })
+}
+
+pub(crate) async fn with_expected_identity<F>(expected: ExpectedIdentity, future: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    EXPECTED_IDENTITY.scope(expected, future).await
+}
+
+/// Called by the canonical account-scope lock. Outside an intercepted proxy
+/// request there is no task-local expectation and the ordinary authorization
+/// behavior is unchanged.
+pub(crate) fn validate_expected_generation(generation: u64) -> ApiResult<()> {
+    EXPECTED_IDENTITY
+        .try_with(|expected| {
+            if expected.generation == generation {
+                Ok(())
+            } else {
+                Err(crate::error::ApiError::conflict(
+                    "Your Studio account changed while this request was running. Try again.",
+                ))
+            }
+        })
+        .unwrap_or(Ok(()))
+}
+
+/// Sandbox admission additionally proves the native materialization epoch is
+/// the one captured at ingress. Comparing the opaque ticket, rather than only
+/// its account subject, also rejects logout/re-login of the same user.
+pub(crate) fn validate_expected_epoch(epoch: AccountEpoch) -> ApiResult<()> {
+    EXPECTED_IDENTITY
+        .try_with(|expected| {
+            if expected.epoch == epoch {
+                Ok(())
+            } else {
+                Err(crate::error::ApiError::conflict(
+                    "Your Studio account changed while this request was running. Try again.",
+                ))
+            }
+        })
+        .unwrap_or(Ok(()))
+}

--- a/apps/native/crates/local-api/src/routes/scripts.rs
+++ b/apps/native/crates/local-api/src/routes/scripts.rs
@@ -86,24 +86,51 @@ use crate::tasks::{
     TaskSummary,
 };
 
-/// Resolve the per-handle [`SandboxTarget`] from the request's
-/// `x-decocms-sandbox-handle` header (absent/unknown -> active/global) so a
-/// script runs in — and its logs/tasks are observed on — the RIGHT sandbox's
-/// workdir + orchestrator quadruple. See [`AppState::resolve_sandbox_target`].
-fn resolve(state: &AppState, headers: &HeaderMap) -> SandboxTarget {
-    state.resolve_sandbox_target(crate::sandbox::handle_from_headers(headers))
+/// Resolve an explicit sandbox identity without ever falling through to the
+/// process-global registry. A stopped durable sandbox is metadata-adopted with
+/// permanently closed task admission, so exec truthfully returns 409 until an
+/// explicit Start installs a fresh generation.
+async fn resolve(
+    state: &AppState,
+    epoch: crate::sandbox::manager::AccountEpoch,
+    headers: &HeaderMap,
+) -> Result<SandboxTarget, ApiError> {
+    let Some(handle) = crate::sandbox::handle_from_headers(headers) else {
+        return state
+            .resolve_sandbox_target_for_account(epoch, None)
+            .map_err(ApiError::conflict);
+    };
+    match state.sandbox_manager.adopt_for_account(epoch, handle).await {
+        Ok(Some(sandbox)) => Ok(SandboxTarget::from_sandbox(&sandbox)),
+        Ok(None) => Err(ApiError::not_found(format!(
+            "unknown sandbox handle: {handle}"
+        ))),
+        Err(error) => Err(ApiError::internal(format!(
+            "failed to resolve sandbox handle {handle}: {error}"
+        ))),
+    }
 }
 
 // --- GET /_sandbox/scripts ---------------------------------------------------
 
-pub async fn list(State(state): State<AppState>, headers: HeaderMap) -> Json<Value> {
-    let target = resolve(&state, &headers);
+pub async fn list(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, ApiError> {
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    let epoch = authorization.epoch();
+    let target = resolve(&state, epoch, &headers).await?;
     let snapshot = target.config.snapshot();
     let pm = pm_name(&snapshot.config);
     let cwd = pm_path(&snapshot.config).unwrap_or_else(|| target.repo_dir.clone());
     let scripts = discover_scripts(&cwd, pm.as_deref());
-    emit_if_changed(&target.broadcaster, &cwd, &scripts);
-    Json(json!({ "scripts": scripts }))
+    state
+        .sandbox_manager
+        .with_account_epoch(epoch, || {
+            emit_if_changed(&target.broadcaster, &cwd, &scripts)
+        })
+        .map_err(ApiError::conflict)?;
+    Ok(Json(json!({ "scripts": scripts })))
 }
 
 /// Compares against the last-discovered set for THIS cwd and emits `"scripts"`
@@ -149,7 +176,36 @@ pub async fn exec(
     AxumPath(name): AxumPath<String>,
     body: Bytes,
 ) -> Result<Response, ApiError> {
-    let target = resolve(&state, &headers);
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    exec_with_admission(
+        State(state),
+        headers,
+        AxumPath(name),
+        body,
+        authorization.epoch(),
+        (),
+    )
+    .await
+}
+
+/// Execute a script while retaining an upstream admission fence only until
+/// the spawned child has a durable [`TaskRegistry`] owner.
+///
+/// Intercepted thread-backed routes pass their workspace-lifecycle guard here
+/// by value. Every error before registration returns from this function and
+/// therefore drops the guard through RAII. Once registration succeeds, the
+/// explicit `drop` below releases it before any response path or process wait.
+/// The generic stays deliberately opaque: this module neither knows nor
+/// couples itself to the authority layer that produced the fence.
+pub(crate) async fn exec_with_admission<Admission>(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    AxumPath(name): AxumPath<String>,
+    body: Bytes,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    admission_guard: Admission,
+) -> Result<Response, ApiError> {
+    let target = resolve(&state, account_epoch, &headers).await?;
     let snapshot = target.config.snapshot();
     let Some(pm) = pm_name(&snapshot.config) else {
         return Err(ApiError::conflict(
@@ -192,11 +248,14 @@ pub async fn exec(
     );
     let env = build_env(&snapshot.config, exec_body.env.as_ref(), default_port);
 
-    let Some(admission) = state.shutdown.admit_work().await else {
+    let Some(shutdown_admission) = state.shutdown.admit_work().await else {
         return Err(ApiError::new(
             StatusCode::SERVICE_UNAVAILABLE,
             "application is shutting down",
         ));
+    };
+    let Some(generation_admission) = target.tasks.admit() else {
+        return Err(ApiError::conflict("sandbox generation is stopped"));
     };
 
     let mut cmd = build_command(&command, &cwd, &env);
@@ -225,7 +284,15 @@ pub async fn exec(
         log_name: Some(name.clone()),
         intentional: None,
     };
-    tasks.insert(TaskEntry::new(summary, Some(kill_handle.clone())));
+    generation_admission.register(TaskEntry::new(summary, Some(kill_handle.clone())));
+
+    // The process is now owned by TaskRegistry and can be controlled even if
+    // archive/delete wins the workspace lifecycle lock next. Release both
+    // admission fences before event delivery, stdio plumbing, the background
+    // response, or an `await`-mode process wait.
+    drop(admission_guard);
+    drop(shutdown_admission);
+
     emit_tasks_event(&tasks, &broadcaster);
 
     // Registration deliberately precedes these takes. Once spawn succeeds,
@@ -233,7 +300,6 @@ pub async fn exec(
     // cancellation point between process creation and TaskRegistry ownership.
     let (Some(stdout_pipe), Some(stderr_pipe)) = (child.take_stdout(), child.take_stderr()) else {
         spawn_missing_stdio_cleanup(tasks, broadcaster, id, child);
-        drop(admission);
         return Err(ApiError::internal("spawn error: missing stdio pipe"));
     };
 
@@ -250,7 +316,6 @@ pub async fn exec(
         controller,
         completion_tx,
     );
-    drop(admission);
 
     if background {
         return Ok(Json(json!({ "taskId": id, "status": "running" })).into_response());
@@ -266,6 +331,10 @@ pub async fn exec(
     let (exit_code, timed_out) = final_summary
         .map(|s| (s.exit_code, s.timed_out))
         .unwrap_or((None, false));
+    state
+        .sandbox_manager
+        .validate_account_epoch(account_epoch)
+        .map_err(ApiError::conflict)?;
     Ok(Json(json!({
         "taskId": id,
         "stdout": stdout,
@@ -283,8 +352,18 @@ pub async fn exec_kill(
     State(state): State<AppState>,
     headers: HeaderMap,
     AxumPath(name): AxumPath<String>,
-) -> Json<Value> {
-    let target = resolve(&state, &headers);
+) -> Result<Json<Value>, ApiError> {
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    exec_kill_for_account(state, headers, name, authorization.epoch()).await
+}
+
+pub(crate) async fn exec_kill_for_account(
+    state: AppState,
+    headers: HeaderMap,
+    name: String,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+) -> Result<Json<Value>, ApiError> {
+    let target = resolve(&state, account_epoch, &headers).await?;
     let matching: Vec<String> = target
         .tasks
         .list(Some(&[TaskStatus::Running]))
@@ -293,12 +372,17 @@ pub async fn exec_kill(
         .map(|s| s.id)
         .collect();
 
-    let killed = matching
-        .iter()
-        .filter(|id| matches!(target.tasks.kill(id, KillSignal::Term), Some(true)))
-        .count();
+    let killed = state
+        .sandbox_manager
+        .with_account_epoch(account_epoch, || {
+            matching
+                .iter()
+                .filter(|id| matches!(target.tasks.kill(id, KillSignal::Term), Some(true)))
+                .count()
+        })
+        .map_err(ApiError::conflict)?;
 
-    Json(json!({ "killed": killed }))
+    Ok(Json(json!({ "killed": killed })))
 }
 
 // --- process spawn / drain / kill ---------------------------------------------
@@ -562,6 +646,16 @@ fn build_env(
 mod tests {
     use super::*;
 
+    struct DropProbe(Option<oneshot::Sender<()>>);
+
+    impl Drop for DropProbe {
+        fn drop(&mut self) {
+            if let Some(dropped) = self.0.take() {
+                let _ = dropped.send(());
+            }
+        }
+    }
+
     fn write(dir: &tempfile::TempDir, name: &str, contents: &str) {
         std::fs::write(dir.path().join(name), contents).expect("write fixture");
     }
@@ -758,6 +852,50 @@ mod tests {
             shutdown: Arc::new(crate::shutdown::ShutdownCoordinator::new()),
             setup,
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn exec_releases_admission_before_await_mode_completes() {
+        let state = test_state(Arc::new(crate::events::Broadcaster::new()));
+        std::fs::write(
+            state.repo_dir.join("package.json"),
+            r#"{"scripts":{"slow":"sleep 5"}}"#,
+        )
+        .expect("write package fixture");
+        state
+            .config
+            .patch(json!({
+                "application": { "packageManager": { "name": "bun" } }
+            }))
+            .expect("configure package manager");
+
+        let (dropped_tx, dropped_rx) = oneshot::channel();
+        let account_epoch = state.sandbox_manager.account_epoch();
+        let response_task = tokio::spawn(exec_with_admission(
+            State(state),
+            HeaderMap::new(),
+            AxumPath("slow".to_string()),
+            Bytes::from_static(br#"{"mode":"await","timeoutMs":1000}"#),
+            account_epoch,
+            DropProbe(Some(dropped_tx)),
+        ));
+
+        tokio::time::timeout(Duration::from_secs(1), dropped_rx)
+            .await
+            .expect("admission guard stayed held after process registration")
+            .expect("drop probe sender disappeared");
+        assert!(
+            !response_task.is_finished(),
+            "await-mode response completed before the child process"
+        );
+
+        let response = tokio::time::timeout(Duration::from_secs(5), response_task)
+            .await
+            .expect("await-mode exec did not time out and reap")
+            .expect("exec task panicked")
+            .expect("exec request failed");
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[allow(clippy::type_complexity)]

--- a/apps/native/crates/local-api/src/routes/setup.rs
+++ b/apps/native/crates/local-api/src/routes/setup.rs
@@ -115,6 +115,15 @@ pub async fn ensure(
     State(state): State<AppState>,
     Json(body): Json<EnsureSandboxRequest>,
 ) -> ApiResult<Json<Value>> {
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    ensure_for_account(state, body, authorization.epoch()).await
+}
+
+pub(crate) async fn ensure_for_account(
+    state: AppState,
+    body: EnsureSandboxRequest,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+) -> ApiResult<Json<Value>> {
     let workload = body.workload.unwrap_or_default();
     let config = crate::sandbox::GitSandboxConfig {
         // Daemon-parity route: its body carries no org. A sandbox that has
@@ -137,12 +146,12 @@ pub async fn ensure(
     }
     let sandbox = state
         .sandbox_manager
-        .provision(&config)
+        .provision_for_account(account_epoch, &config)
         .await
         .map_err(ApiError::conflict)?;
     let record = state
         .sandbox_manager
-        .registry_record(&sandbox.handle)
+        .registry_record_for_account(account_epoch, &sandbox.handle)
         .map_err(ApiError::internal)?
         .ok_or_else(|| ApiError::internal("ensured sandbox was not persisted"))?;
     Ok(Json(json!({
@@ -159,14 +168,21 @@ pub async fn ensure(
 /// by `clone`/`install`/[`stop`] — never resurrects (see [`stop`]'s doc
 /// comment for why; `clone`/`install` simply haven't needed it, unlike
 /// `start`, which uses [`resolve_for_start`] instead).
-fn resolve(state: &AppState, headers: &HeaderMap) -> Result<SandboxTarget, ApiError> {
+fn resolve(
+    state: &AppState,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    headers: &HeaderMap,
+) -> Result<SandboxTarget, ApiError> {
     match crate::sandbox::handle_from_headers(headers) {
         Some(handle) => state
             .sandbox_manager
-            .get(handle)
+            .get_for_account(account_epoch, handle)
+            .map_err(ApiError::conflict)?
             .map(|sb| SandboxTarget::from_sandbox(&sb))
             .ok_or_else(|| ApiError::not_found(format!("unknown sandbox handle: {handle}"))),
-        None => Ok(state.resolve_sandbox_target(None)),
+        None => state
+            .resolve_sandbox_target_for_account(account_epoch, None)
+            .map_err(ApiError::conflict),
     }
 }
 
@@ -177,12 +193,21 @@ fn resolve(state: &AppState, headers: &HeaderMap) -> Result<SandboxTarget, ApiEr
 /// `ensure()` cascade already covers it, see `start`'s body).
 async fn resolve_for_start(
     state: &AppState,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
     headers: &HeaderMap,
 ) -> Result<(SandboxTarget, bool), ApiError> {
     match crate::sandbox::handle_from_headers(headers) {
         Some(handle) => {
-            let already_known = state.sandbox_manager.get(handle).is_some();
-            match state.sandbox_manager.resurrect(handle).await {
+            let already_known = state
+                .sandbox_manager
+                .get_for_account(account_epoch, handle)
+                .map_err(ApiError::conflict)?
+                .is_some();
+            match state
+                .sandbox_manager
+                .resurrect_for_account(account_epoch, handle)
+                .await
+            {
                 Ok(Some(sb)) => Ok((SandboxTarget::from_sandbox(&sb), !already_known)),
                 Ok(None) => Err(ApiError::not_found(format!(
                     "unknown sandbox handle: {handle}"
@@ -193,11 +218,28 @@ async fn resolve_for_start(
             }
         }
         None => {
-            let already_active = state.sandbox_manager.active().is_some();
-            match state.sandbox_manager.resurrect_active().await {
+            let already_active = state
+                .sandbox_manager
+                .active_for_account(account_epoch)
+                .map_err(ApiError::conflict)?
+                .is_some();
+            match state
+                .sandbox_manager
+                .resurrect_active_for_account(account_epoch)
+                .await
+            {
                 Ok(Some(sb)) => Ok((SandboxTarget::from_sandbox(&sb), !already_active)),
-                Ok(None) => Ok((state.resolve_sandbox_target(None), false)),
+                Ok(None) => Ok((
+                    state
+                        .resolve_sandbox_target_for_account(account_epoch, None)
+                        .map_err(ApiError::conflict)?,
+                    false,
+                )),
                 Err(err) => {
+                    state
+                        .sandbox_manager
+                        .validate_account_epoch(account_epoch)
+                        .map_err(ApiError::conflict)?;
                     // Byte-parity floor: a headerless request must still 200
                     // even when self-heal itself fails — fall back to the
                     // existing (global) resolution rather than hard-erroring
@@ -207,7 +249,12 @@ async fn resolve_for_start(
                         error = %err,
                         "headerless sandbox resurrection failed; falling back to the process-global target"
                     );
-                    Ok((state.resolve_sandbox_target(None), false))
+                    Ok((
+                        state
+                            .resolve_sandbox_target_for_account(account_epoch, None)
+                            .map_err(ApiError::conflict)?,
+                        false,
+                    ))
                 }
             }
         }
@@ -215,7 +262,21 @@ async fn resolve_for_start(
 }
 
 pub async fn clone(State(state): State<AppState>, headers: HeaderMap) -> ApiResult<Json<Value>> {
-    if !resolve(&state, &headers)?.setup.resume_from(Step::Clone) {
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    clone_for_account(state, headers, authorization.epoch()).await
+}
+
+pub(crate) async fn clone_for_account(
+    state: AppState,
+    headers: HeaderMap,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+) -> ApiResult<Json<Value>> {
+    let target = resolve(&state, account_epoch, &headers)?;
+    let accepted = state
+        .sandbox_manager
+        .with_account_epoch(account_epoch, || target.setup.resume_from(Step::Clone))
+        .map_err(ApiError::conflict)?;
+    if !accepted {
         return Err(ApiError::new(
             axum::http::StatusCode::SERVICE_UNAVAILABLE,
             "setup worker is unavailable",
@@ -225,7 +286,21 @@ pub async fn clone(State(state): State<AppState>, headers: HeaderMap) -> ApiResu
 }
 
 pub async fn install(State(state): State<AppState>, headers: HeaderMap) -> ApiResult<Json<Value>> {
-    if !resolve(&state, &headers)?.setup.resume_from(Step::Install) {
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    install_for_account(state, headers, authorization.epoch()).await
+}
+
+pub(crate) async fn install_for_account(
+    state: AppState,
+    headers: HeaderMap,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+) -> ApiResult<Json<Value>> {
+    let target = resolve(&state, account_epoch, &headers)?;
+    let accepted = state
+        .sandbox_manager
+        .with_account_epoch(account_epoch, || target.setup.resume_from(Step::Install))
+        .map_err(ApiError::conflict)?;
+    if !accepted {
         return Err(ApiError::new(
             axum::http::StatusCode::SERVICE_UNAVAILABLE,
             "setup worker is unavailable",
@@ -235,8 +310,17 @@ pub async fn install(State(state): State<AppState>, headers: HeaderMap) -> ApiRe
 }
 
 pub async fn start(State(state): State<AppState>, headers: HeaderMap) -> ApiResult<Json<Value>> {
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    start_for_account(state, headers, authorization.epoch()).await
+}
+
+pub(crate) async fn start_for_account(
+    state: AppState,
+    headers: HeaderMap,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+) -> ApiResult<Json<Value>> {
     let explicit_handle = crate::sandbox::handle_from_headers(&headers).map(str::to_owned);
-    let (target, resurrected) = resolve_for_start(&state, &headers).await?;
+    let (target, resurrected) = resolve_for_start(&state, account_epoch, &headers).await?;
     if resurrected {
         // `SandboxManager::ensure` (invoked by `resolve_for_start`'s
         // resurrection above) already ran its own clone/checkout -> install
@@ -255,16 +339,18 @@ pub async fn start(State(state): State<AppState>, headers: HeaderMap) -> ApiResu
             "setup/start: target was just resurrected — its own ensure() cascade already covers this restart"
         );
     } else {
-        let durable_handle = explicit_handle.or_else(|| {
-            state
+        let durable_handle = match explicit_handle {
+            Some(handle) => Some(handle),
+            None => state
                 .sandbox_manager
-                .active()
-                .map(|sandbox| sandbox.handle.clone())
-        });
+                .active_for_account(account_epoch)
+                .map_err(ApiError::conflict)?
+                .map(|sandbox| sandbox.handle.clone()),
+        };
         if let Some(handle) = durable_handle {
             state
                 .sandbox_manager
-                .restart_registered(&handle)
+                .restart_registered_for_account(account_epoch, &handle)
                 .await
                 .map_err(ApiError::conflict)?
                 .ok_or_else(|| ApiError::not_found(format!("unknown sandbox handle: {handle}")))?;
@@ -274,7 +360,11 @@ pub async fn start(State(state): State<AppState>, headers: HeaderMap) -> ApiResu
             crate::sandbox::manager::terminate_tasks_by_log_name(&target.tasks, &["dev", "start"])
                 .await
                 .map_err(ApiError::conflict)?;
-            if !target.setup.resume_from(Step::Start) {
+            let accepted = state
+                .sandbox_manager
+                .with_account_epoch(account_epoch, || target.setup.resume_from(Step::Start))
+                .map_err(ApiError::conflict)?;
+            if !accepted {
                 return Err(ApiError::new(
                     axum::http::StatusCode::SERVICE_UNAVAILABLE,
                     "setup worker is unavailable",
@@ -285,35 +375,47 @@ pub async fn start(State(state): State<AppState>, headers: HeaderMap) -> ApiResu
     Ok(Json(json!({ "enqueued": Step::Start.as_str() })))
 }
 
-/// `POST /_sandbox/setup/stop` kills the resolved target's running `dev`/`start`
-/// task(s) WITHOUT re-spawning (unlike `start` above, which
-/// kills-then-resumes). It gives native callers a local stop action while the
-/// selectorless `SANDBOX_DELETE` interception owns full sandbox teardown.
+/// `POST /_sandbox/setup/stop` stops the resolved target WITHOUT re-spawning
+/// it (unlike `start` above, which kills-then-resumes). A registered git
+/// sandbox is one process generation, so Stop closes its admission and reaps
+/// every setup, dev, exec, grep, and other registered child before eviction;
+/// no inaccessible task may survive a successful response.
 ///
 /// A registered handle forgotten by this process is already stopped: its old
 /// child lifetime ended with that process. We persist `desired=stopped` and
 /// return an idempotent success without materializing the sandbox (which
 /// would risk starting it). A truly unknown explicit handle remains a loud
-/// 404. Headerless non-git daemon compatibility retains the legacy 400 when
-/// there is no dev/start task to stop.
+/// 404. The headerless process-global fallback is not a registered sandbox
+/// generation and retains daemon compatibility: it stops only `dev`/`start`
+/// and returns the legacy 400 when neither is running.
 pub async fn stop(State(state): State<AppState>, headers: HeaderMap) -> ApiResult<Json<Value>> {
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    stop_for_account(state, headers, authorization.epoch()).await
+}
+
+pub(crate) async fn stop_for_account(
+    state: AppState,
+    headers: HeaderMap,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+) -> ApiResult<Json<Value>> {
     let explicit_handle = crate::sandbox::handle_from_headers(&headers).map(str::to_owned);
     let durable_handle = match explicit_handle {
         Some(handle) => Some(handle),
         None => state
             .sandbox_manager
-            .active()
+            .active_for_account(account_epoch)
+            .map_err(ApiError::conflict)?
             .map(|sandbox| sandbox.handle.clone())
             .or(state
                 .sandbox_manager
-                .registered_active_handle()
-                .map_err(ApiError::internal)?),
+                .registered_active_handle_for_account(account_epoch)
+                .map_err(ApiError::conflict)?),
     };
 
     if let Some(handle) = durable_handle {
         let killed = state
             .sandbox_manager
-            .stop_registered(&handle)
+            .stop_registered_for_account(account_epoch, &handle)
             .await
             .map_err(ApiError::internal)?
             .ok_or_else(|| ApiError::not_found(format!("unknown sandbox handle: {handle}")))?;
@@ -326,16 +428,24 @@ pub async fn stop(State(state): State<AppState>, headers: HeaderMap) -> ApiResul
     }
 
     // Daemon-compatible plain-path fallback for a non-git workspace.
-    let target = state.resolve_sandbox_target(None);
+    let target = state
+        .resolve_sandbox_target_for_account(account_epoch, None)
+        .map_err(ApiError::conflict)?;
 
-    let mut killed = 0usize;
-    for t in target.tasks.list(Some(&[TaskStatus::Running])) {
-        if matches!(t.log_name.as_deref(), Some("dev") | Some("start"))
-            && target.tasks.kill(&t.id, KillSignal::Term) == Some(true)
-        {
-            killed += 1;
-        }
-    }
+    let killed = state
+        .sandbox_manager
+        .with_account_epoch(account_epoch, || {
+            let mut killed = 0usize;
+            for t in target.tasks.list(Some(&[TaskStatus::Running])) {
+                if matches!(t.log_name.as_deref(), Some("dev") | Some("start"))
+                    && target.tasks.kill(&t.id, KillSignal::Term) == Some(true)
+                {
+                    killed += 1;
+                }
+            }
+            killed
+        })
+        .map_err(ApiError::conflict)?;
     if killed == 0 {
         return Err(ApiError::bad_request(
             "nothing to stop: no running dev/start task for this sandbox",
@@ -345,9 +455,14 @@ pub async fn stop(State(state): State<AppState>, headers: HeaderMap) -> ApiResul
     // default (see `crate::setup`'s `LifecycleState` union), so the drawer's
     // SSE-driven status naturally reflects "stopped" without a wire-shape
     // change.
-    target
-        .setup
-        .transition_lifecycle(json!({ "phase": "idle" }));
+    state
+        .sandbox_manager
+        .with_account_epoch(account_epoch, || {
+            target
+                .setup
+                .transition_lifecycle(json!({ "phase": "idle" }));
+        })
+        .map_err(ApiError::conflict)?;
     Ok(Json(json!({
         "stopped": true,
         "killed": killed,
@@ -410,7 +525,12 @@ mod tests {
     #[test]
     fn headerless_resolve_falls_back_to_the_global_target_when_nothing_is_active() {
         let state = fresh_state();
-        let target = resolve(&state, &HeaderMap::new()).expect("headerless never errors");
+        let target = resolve(
+            &state,
+            state.sandbox_manager.account_epoch(),
+            &HeaderMap::new(),
+        )
+        .expect("headerless never errors");
         assert!(Arc::ptr_eq(&target.setup, &state.setup));
     }
 
@@ -424,7 +544,7 @@ mod tests {
         );
         // `SandboxTarget` (the `Ok` side) isn't `Debug`, so `expect_err`
         // isn't available here — match explicitly instead.
-        match resolve(&state, &headers) {
+        match resolve(&state, state.sandbox_manager.account_epoch(), &headers) {
             Err(e) => {
                 assert_eq!(e.status, axum::http::StatusCode::NOT_FOUND);
                 assert_eq!(
@@ -441,7 +561,8 @@ mod tests {
         let state = fresh_state();
         let mut headers = HeaderMap::new();
         headers.insert("x-decocms-sandbox-handle", HeaderValue::from_static(""));
-        let target = resolve(&state, &headers).expect("empty handle is treated as absent");
+        let target = resolve(&state, state.sandbox_manager.account_epoch(), &headers)
+            .expect("empty handle is treated as absent");
         assert!(Arc::ptr_eq(&target.setup, &state.setup));
     }
 
@@ -502,12 +623,15 @@ mod tests {
 
         state
             .sandbox_manager
-            .ensure(&crate::sandbox::GitSandboxConfig {
-                virtual_mcp_id: vmcp.to_string(),
-                clone_url: bare_str.to_string(),
-                branch: Some("work".to_string()),
-                ..Default::default()
-            })
+            .ensure_for_account(
+                state.sandbox_manager.account_epoch(),
+                &crate::sandbox::GitSandboxConfig {
+                    virtual_mcp_id: vmcp.to_string(),
+                    clone_url: bare_str.to_string(),
+                    branch: Some("work".to_string()),
+                    ..Default::default()
+                },
+            )
             .await
             .expect("ensure succeeds against a real one-commit bare repo")
     }
@@ -561,18 +685,23 @@ mod tests {
             crate::sandbox::SandboxManager::compute_handle(&bare_dir.to_string_lossy(), "work")
                 .expect("scopeable clone url")
         );
-        assert!(state.sandbox_manager.get(handle).is_some());
+        let account_epoch = state.sandbox_manager.account_epoch();
+        assert!(state
+            .sandbox_manager
+            .get_for_account(account_epoch, handle)
+            .unwrap()
+            .is_some());
         assert_eq!(
             state
                 .sandbox_manager
-                .registered_active_handle()
+                .registered_active_handle_for_account(account_epoch)
                 .unwrap()
                 .as_deref(),
             Some(handle)
         );
         let record = state
             .sandbox_manager
-            .registry_record(handle)
+            .registry_record_for_account(account_epoch, handle)
             .unwrap()
             .unwrap();
         assert_eq!(record.config.package_manager.as_deref(), Some("bun"));
@@ -612,7 +741,7 @@ mod tests {
             loop {
                 let record = state
                     .sandbox_manager
-                    .registry_record(&handle)
+                    .registry_record_for_account(state.sandbox_manager.account_epoch(), &handle)
                     .unwrap()
                     .unwrap();
                 if record.observed_status == "failed" {
@@ -638,7 +767,8 @@ mod tests {
             "x-decocms-sandbox-handle",
             HeaderValue::from_str(&sandbox.handle).unwrap(),
         );
-        let target = resolve(&state, &headers).expect("known handle resolves");
+        let target = resolve(&state, state.sandbox_manager.account_epoch(), &headers)
+            .expect("known handle resolves");
         assert!(Arc::ptr_eq(&target.setup, &sandbox.setup));
         assert_eq!(target.repo_dir, sandbox.workdir);
     }
@@ -653,7 +783,12 @@ mod tests {
         // stricter `resolve()` wrapper).
         let sandbox = ensure_one_sandbox(&state, "setup-resolve-active").await;
 
-        let target = resolve(&state, &HeaderMap::new()).expect("headerless never errors");
+        let target = resolve(
+            &state,
+            state.sandbox_manager.account_epoch(),
+            &HeaderMap::new(),
+        )
+        .expect("headerless never errors");
         assert!(Arc::ptr_eq(&target.setup, &sandbox.setup));
         assert!(!Arc::ptr_eq(&target.setup, &state.setup));
     }
@@ -681,7 +816,12 @@ mod tests {
         // A FRESH state over the SAME app_root — simulates the restarted
         // process: `state.sandbox_manager` has never heard of `handle`.
         let state = fresh_state_at(app_root.path().to_path_buf());
-        assert!(state.sandbox_manager.get(&handle).is_none());
+        let account_epoch = state.sandbox_manager.account_epoch();
+        assert!(state
+            .sandbox_manager
+            .get_for_account(account_epoch, &handle)
+            .unwrap()
+            .is_none());
 
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -693,7 +833,11 @@ mod tests {
             .expect("start resurrects the forgotten handle instead of 404ing");
         assert_eq!(res.0["enqueued"], "start");
         assert!(
-            state.sandbox_manager.get(&handle).is_some(),
+            state
+                .sandbox_manager
+                .get_for_account(account_epoch, &handle)
+                .unwrap()
+                .is_some(),
             "a successful resurrection must leave the handle known in memory afterward"
         );
     }
@@ -704,14 +848,23 @@ mod tests {
         let handle = ensure_then_forget(app_root.path(), "start-resurrect-headerless").await;
 
         let state = fresh_state_at(app_root.path().to_path_buf());
-        assert!(state.sandbox_manager.active().is_none());
+        let account_epoch = state.sandbox_manager.account_epoch();
+        assert!(state
+            .sandbox_manager
+            .active_for_account(account_epoch)
+            .unwrap()
+            .is_none());
 
         let res = start(State(state.clone()), HeaderMap::new())
             .await
             .expect("headerless start resurrects the persisted active handle");
         assert_eq!(res.0["enqueued"], "start");
         assert!(
-            state.sandbox_manager.get(&handle).is_some(),
+            state
+                .sandbox_manager
+                .get_for_account(account_epoch, &handle)
+                .unwrap()
+                .is_some(),
             "the persisted active handle must be the one resurrected"
         );
     }
@@ -774,7 +927,11 @@ mod tests {
             .expect("start on an already-known handle succeeds");
         assert_eq!(res.0["enqueued"], "start");
         assert!(Arc::ptr_eq(
-            &state.sandbox_manager.get(&sandbox.handle).unwrap(),
+            &state
+                .sandbox_manager
+                .get_for_account(state.sandbox_manager.account_epoch(), &sandbox.handle)
+                .unwrap()
+                .unwrap(),
             &sandbox
         ));
     }
@@ -963,12 +1120,16 @@ mod tests {
         assert_eq!(response.0["alreadyStopped"], true);
         assert_eq!(response.0["killed"], 0);
         assert!(
-            state.sandbox_manager.get(&handle).is_none(),
+            state
+                .sandbox_manager
+                .get_for_account(state.sandbox_manager.account_epoch(), &handle)
+                .unwrap()
+                .is_none(),
             "stop must not materialize or start the persisted sandbox"
         );
         let record = state
             .sandbox_manager
-            .registry_record(&handle)
+            .registry_record_for_account(state.sandbox_manager.account_epoch(), &handle)
             .unwrap()
             .unwrap();
         assert_eq!(record.desired_status, "stopped");

--- a/apps/native/crates/local-api/src/routes/tasks.rs
+++ b/apps/native/crates/local-api/src/routes/tasks.rs
@@ -30,11 +30,17 @@ use crate::tasks::{KillSignal, OutputStream, StreamEvent, TaskStatus};
 /// to the process-global registry. After a backend restart a known durable
 /// handle is metadata-adopted (no process spawn); a genuinely unknown handle
 /// is a truthful 404. Only an absent handle uses active/global compatibility.
-async fn resolve(state: &AppState, handle: Option<&str>) -> ApiResult<SandboxTarget> {
+async fn resolve(
+    state: &AppState,
+    epoch: crate::sandbox::manager::AccountEpoch,
+    handle: Option<&str>,
+) -> ApiResult<SandboxTarget> {
     let Some(handle) = handle.filter(|handle| !handle.is_empty()) else {
-        return Ok(state.resolve_sandbox_target(None));
+        return state
+            .resolve_sandbox_target_for_account(epoch, None)
+            .map_err(ApiError::conflict);
     };
-    match state.sandbox_manager.adopt(handle).await {
+    match state.sandbox_manager.adopt_for_account(epoch, handle).await {
         Ok(Some(sandbox)) => Ok(SandboxTarget::from_sandbox(&sandbox)),
         Ok(None) => Err(ApiError::not_found(format!(
             "unknown sandbox handle: {handle}"
@@ -45,8 +51,12 @@ async fn resolve(state: &AppState, handle: Option<&str>) -> ApiResult<SandboxTar
     }
 }
 
-async fn resolve_headers(state: &AppState, headers: &HeaderMap) -> ApiResult<SandboxTarget> {
-    resolve(state, crate::sandbox::handle_from_headers(headers)).await
+async fn resolve_headers(
+    state: &AppState,
+    epoch: crate::sandbox::manager::AccountEpoch,
+    headers: &HeaderMap,
+) -> ApiResult<SandboxTarget> {
+    resolve(state, epoch, crate::sandbox::handle_from_headers(headers)).await
 }
 
 #[derive(Deserialize)]
@@ -70,6 +80,8 @@ pub async fn list(
     headers: HeaderMap,
     Query(q): Query<StatusQuery>,
 ) -> ApiResult<Json<Value>> {
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    let epoch = authorization.epoch();
     let parsed: Option<Vec<TaskStatus>> = q
         .status
         .as_deref()
@@ -78,7 +90,14 @@ pub async fn list(
         Some(v) if !v.is_empty() => Some(v.as_slice()),
         _ => None,
     };
-    let tasks = resolve_headers(&state, &headers).await?.tasks.list(filter);
+    let tasks = resolve_headers(&state, epoch, &headers)
+        .await?
+        .tasks
+        .list(filter);
+    state
+        .sandbox_manager
+        .validate_account_epoch(epoch)
+        .map_err(ApiError::conflict)?;
     Ok(Json(json!({ "tasks": tasks })))
 }
 
@@ -88,12 +107,18 @@ pub async fn get(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> ApiResult<Json<Value>> {
-    let target = resolve_headers(&state, &headers).await?;
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    let epoch = authorization.epoch();
+    let target = resolve_headers(&state, epoch, &headers).await?;
     let summary = target
         .tasks
         .get_exposed(&id)
         .ok_or_else(|| ApiError::not_found("task not found"))?;
     let (stdout, stderr, truncated) = target.tasks.output_exposed(&id).await.unwrap_or_default();
+    state
+        .sandbox_manager
+        .validate_account_epoch(epoch)
+        .map_err(ApiError::conflict)?;
     let mut value = serde_json::to_value(&summary).unwrap_or_else(|_| json!({}));
     if let Value::Object(map) = &mut value {
         map.insert("stdout".to_string(), json!(stdout));
@@ -117,15 +142,18 @@ pub async fn kill(
     Path(id): Path<String>,
     Query(q): Query<SignalQuery>,
 ) -> ApiResult<Json<Value>> {
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    let epoch = authorization.epoch();
     let signal = match q.signal.as_deref() {
         Some("SIGKILL") => KillSignal::Kill,
         _ => KillSignal::Term,
     };
-    match resolve_headers(&state, &headers)
-        .await?
-        .tasks
-        .kill_exposed(&id, signal)
-    {
+    let target = resolve_headers(&state, epoch, &headers).await?;
+    let killed = state
+        .sandbox_manager
+        .with_account_epoch(epoch, || target.tasks.kill_exposed(&id, signal))
+        .map_err(ApiError::conflict)?;
+    match killed {
         Some(true) => Ok(Json(json!({"ok": true}))),
         _ => Err(ApiError::bad_request("task not running")),
     }
@@ -133,10 +161,13 @@ pub async fn kill(
 
 /// `POST /_sandbox/tasks/kill-all`.
 pub async fn kill_all(State(state): State<AppState>, headers: HeaderMap) -> ApiResult<Json<Value>> {
-    let killed = resolve_headers(&state, &headers)
-        .await?
-        .tasks
-        .kill_all(KillSignal::Term);
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    let epoch = authorization.epoch();
+    let target = resolve_headers(&state, epoch, &headers).await?;
+    let killed = state
+        .sandbox_manager
+        .with_account_epoch(epoch, || target.tasks.kill_all(KillSignal::Term))
+        .map_err(ApiError::conflict)?;
     Ok(Json(json!({"ok": true, "killed": killed})))
 }
 
@@ -148,12 +179,18 @@ pub async fn delete(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> ApiResult<Json<Value>> {
-    match resolve_headers(&state, &headers)
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    let epoch = authorization.epoch();
+    let removed = resolve_headers(&state, epoch, &headers)
         .await?
         .tasks
         .remove_exposed(&id)
-        .await
-    {
+        .await;
+    state
+        .sandbox_manager
+        .validate_account_epoch(epoch)
+        .map_err(ApiError::conflict)?;
+    match removed {
         Some(true) => Ok(Json(json!({"ok": true}))),
         _ => Err(ApiError::bad_request("task not found or still running")),
     }
@@ -169,13 +206,19 @@ pub async fn stream(
     Path(id): Path<String>,
     Query(q): Query<HandleQuery>,
 ) -> Result<Response, ApiError> {
+    let authorization = super::sandbox_account::authorize(&state).await?;
+    let account_epoch = authorization.epoch();
     // Handle from the header (fetch/`FetchEventSource`) OR `?handle=` (native
     // `EventSource`), header winning. An explicit unknown handle is never
     // allowed to fall through to active/global.
     let handle = crate::sandbox::handle_from_headers(&headers)
         .map(str::to_string)
         .or(q.handle);
-    let target = resolve(&state, handle.as_deref()).await?;
+    let target = resolve(&state, account_epoch, handle.as_deref()).await?;
+    let mut account_epoch_rx = state
+        .sandbox_manager
+        .watch_account_epoch(account_epoch)
+        .map_err(ApiError::conflict)?;
 
     // Subscribe BEFORE reading the summary/output snapshot: if the task is
     // still running at that snapshot, this subscription is guaranteed to
@@ -189,6 +232,10 @@ pub async fn stream(
         return Err(ApiError::not_found("task not found"));
     };
     let (stdout, stderr, _truncated) = target.tasks.output_exposed(&id).await.unwrap_or_default();
+    state
+        .sandbox_manager
+        .validate_account_epoch(account_epoch)
+        .map_err(ApiError::conflict)?;
 
     let mut frames: Vec<BodyBytes> = Vec::new();
     if !stdout.is_empty() {
@@ -218,6 +265,16 @@ pub async fn stream(
         let live = stream::unfold(LiveState::Recv(rx), live_step);
         Box::pin(stream::iter(frames.into_iter().map(Ok)).chain(live))
     };
+    let account_changed = async move {
+        if *account_epoch_rx.borrow() != account_epoch {
+            return;
+        }
+        // A same-value notification is the epoch-exhaustion fail-closed
+        // signal, so every observed version change terminates the stream.
+        let _ = account_epoch_rx.changed().await;
+    };
+    let body_stream = body_stream.take_until(account_changed);
+    drop(authorization);
 
     let mut response = Response::new(axum::body::Body::from_stream(body_stream));
     let headers = response.headers_mut();

--- a/apps/native/crates/local-api/src/routes/terminal.rs
+++ b/apps/native/crates/local-api/src/routes/terminal.rs
@@ -20,17 +20,16 @@ use terminal_session::{
 use uuid::Uuid;
 
 use crate::error::{ApiError, ApiResult};
-use crate::routes::intercept::thread_tools;
+use crate::routes::threads::authority::{self, ThreadAccess};
 use crate::routes::threads::db::{
-    RtAccountScope, RtTerminalLogicalState, RtTerminalPhysicalState, RtTerminalResumeDecision,
-    RtTerminalSession, RtTerminalSessionCasOutcome, RtTerminalSessionCreateOutcome, RtThreadFence,
-    ThreadsDb,
+    RtTerminalLogicalState, RtTerminalPhysicalState, RtTerminalResumeDecision, RtTerminalSession,
+    RtTerminalSessionCasOutcome, RtTerminalSessionCreateOutcome, RtThreadFence, ThreadsDb,
 };
-use crate::routes::threads::shared_db;
 use crate::state::AppState;
 use crate::terminal::launch_context::{self, LaunchRequest, PreparedLaunch};
 use crate::terminal::registry::{
-    generate_hook_token, generate_mcp_token, ManagedTerminal, PromptRequestStatus, WriterLeaseGuard,
+    generate_hook_token, generate_mcp_token, ManagedTerminal, PreparationReservation,
+    PromptRequestStatus, WriterLeaseGuard,
 };
 
 const MAX_CONTROL_FRAME_BYTES: usize = 256 * 1024;
@@ -47,7 +46,7 @@ const CLAUDE_RESUME_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const CLAUDE_RESUME_DIAGNOSTIC_MAX_BYTES: u64 = 64 * 1024;
 
 #[derive(Debug, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct StartTerminalBody {
     pub harness_id: Option<String>,
     #[serde(default = "default_approval_mode")]
@@ -66,11 +65,11 @@ fn default_approval_mode() -> String {
 #[serde(
     tag = "type",
     rename_all = "snake_case",
-    rename_all_fields = "camelCase"
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
 )]
 enum ClientFrame {
     Start {
-        #[serde(alias = "harness_id")]
         harness_id: String,
         #[serde(default = "default_approval_mode")]
         approval_mode: String,
@@ -130,6 +129,11 @@ struct SpawnFences {
     _claude_state: Option<tokio::sync::OwnedMutexGuard<()>>,
 }
 
+struct SpawnAdmissionFences {
+    account: upstream::SessionTransitionGuard,
+    claude_state: Option<tokio::sync::OwnedMutexGuard<()>>,
+}
+
 enum SpawnFenceError {
     Account(String),
     WorkspaceTrust(String),
@@ -144,11 +148,11 @@ struct SessionSpawnOwner {
     provider_session_id: Option<String>,
     hook_token: String,
     mcp_token: String,
-    launch: PreparedLaunch,
-    command: CommandSpec,
     key: SessionKey,
-    start_guard: tokio::sync::OwnedMutexGuard<()>,
+    preparation: PreparationReservation,
     upstream_session: upstream::UpstreamSession,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    identity_generation: u64,
 }
 
 impl SpawnFenceError {
@@ -171,6 +175,18 @@ struct Handshake {
 enum ClientFrameError {
     Invalid(String),
     StaleAttachment { request_id: Option<String> },
+}
+
+#[derive(Debug)]
+enum HandshakeError {
+    AccountChanged,
+    Invalid(String),
+}
+
+impl From<String> for HandshakeError {
+    fn from(error: String) -> Self {
+        Self::Invalid(error)
+    }
 }
 
 #[derive(Debug)]
@@ -260,7 +276,9 @@ pub async fn get(
     State(state): State<AppState>,
     Path((org, thread_id)): Path<(String, String)>,
 ) -> ApiResult<Json<Value>> {
-    let (db, _scope, fence) = scoped_owned_thread(&state, &org, &thread_id).await?;
+    let upstream_session = upstream::global();
+    let _account_transition = upstream_session.begin_transition().await;
+    let (db, fence) = scoped_owned_thread(&state, &org, &thread_id).await?;
     let session = db
         .rt_get_live_terminal_session_fenced(&fence)
         .map_err(|error| terminal_storage_error("load live coding agent session", error))?
@@ -295,7 +313,7 @@ pub async fn start(
     })?)?;
     let size = terminal_size(parsed.rows.unwrap_or(30), parsed.cols.unwrap_or(100))?;
     validate_approval_mode(&parsed.approval_mode)?;
-    let (db, _scope, fence) = scoped_owned_thread(&state, &org, &thread_id).await?;
+    let (db, fence) = scoped_owned_thread(&state, &org, &thread_id).await?;
     let managed = ensure_session(
         &state,
         db,
@@ -319,9 +337,56 @@ pub async fn delete(
     State(state): State<AppState>,
     Path((org, thread_id)): Path<(String, String)>,
 ) -> ApiResult<StatusCode> {
-    let (_db, _scope, fence) = scoped_owned_thread(&state, &org, &thread_id).await?;
+    // Resolve once to choose the lifecycle lock, then resolve the exact same
+    // incarnation again after winning it under the account-transition fence.
+    // An account switch can therefore never terminate the prior account's PTY.
+    let initial =
+        authority::resolve_current_thread(&state, &org, &thread_id, ThreadAccess::Owner).await?;
+    let db = initial.db;
+    let fence = initial.fence;
     let start_lock = state.agent_sessions.start_lock(&fence);
-    let _guard = start_lock.lock().await;
+    let _start_guard = start_lock.lock().await;
+    let upstream_session = upstream::global();
+    let _account_transition = upstream_session.begin_transition().await;
+    let current =
+        authority::resolve_current_thread(&state, &org, &thread_id, ThreadAccess::Owner).await?;
+    if current.fence != fence {
+        return Err(ApiError::conflict(
+            "This chat changed while the coding agent was closing. Try again.",
+        ));
+    }
+
+    let preparation = state.agent_sessions.cancel_preparation(&fence);
+    let had_preparation = preparation.had_preparations();
+    preparation.wait().await.map_err(|error| {
+        tracing::warn!(%error, thread_id = %fence.thread_id, "coding agent preparation did not stop before close");
+        ApiError::internal(
+            "We couldn't close the coding agent preparation. Restart Studio and try again.",
+        )
+    })?;
+    if had_preparation {
+        launch_context::cleanup_managed_state(&state.app_root, &fence)
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, thread_id = %fence.thread_id, "could not clean canceled coding agent preparation");
+                ApiError::internal(
+                    "We couldn't clean up the canceled coding agent preparation. Restart Studio and try again.",
+                )
+            })?;
+    }
+    if let Some(session) = db
+        .rt_get_live_terminal_session_fenced(&fence)
+        .map_err(|error| terminal_storage_error("load closing coding agent session", error))?
+        .filter(|session| session.physical_state == RtTerminalPhysicalState::Starting)
+    {
+        mark_starting_session_exited_if_present(
+            db,
+            &fence,
+            &session.id,
+            "coding agent start was canceled before process creation",
+            true,
+        );
+    }
     state
         .agent_sessions
         .terminate_fence(&fence)
@@ -338,10 +403,26 @@ pub async fn websocket(
     State(state): State<AppState>,
     Path((org, thread_id)): Path<(String, String)>,
 ) -> ApiResult<Response> {
-    let (db, _scope, fence) = scoped_owned_thread(&state, &org, &thread_id).await?;
+    let scope = authority::current_account_scope().await?;
+    let account_guard = authority::lock_account_scope(&scope).await?;
+    let resolved = authority::resolve_scoped_thread(
+        &state,
+        scope,
+        &org,
+        &thread_id,
+        ThreadAccess::ActiveOwner,
+    )?;
+    let account_epoch = state.sandbox_manager.account_epoch();
+    let account_epoch_rx = state
+        .sandbox_manager
+        .watch_account_epoch(account_epoch)
+        .map_err(ApiError::conflict)?;
+    drop(account_guard);
+    let db = resolved.db;
+    let fence = resolved.fence;
     Ok(ws
         .max_message_size(MAX_CONTROL_FRAME_BYTES)
-        .on_upgrade(move |socket| serve_socket(socket, state, db, fence))
+        .on_upgrade(move |socket| serve_socket(socket, state, db, fence, account_epoch_rx))
         .into_response())
 }
 
@@ -350,23 +431,36 @@ async fn serve_socket(
     state: AppState,
     db: &'static ThreadsDb,
     fence: RtThreadFence,
+    mut account_epoch_rx: tokio::sync::watch::Receiver<crate::sandbox::manager::AccountEpoch>,
 ) {
-    let handshake = match receive_handshake(&mut socket, db, &fence).await {
+    let handshake = match receive_handshake(&mut socket, db, &fence, &mut account_epoch_rx).await {
         Ok(handshake) => handshake,
-        Err(error) => {
+        Err(HandshakeError::AccountChanged) => return,
+        Err(HandshakeError::Invalid(error)) => {
             tracing::warn!(%error, "coding agent terminal handshake failed");
-            let _ = send_error_socket(
-                &mut socket,
-                "invalid_start",
-                "We couldn't open this coding agent. Refresh the chat and try again.",
-                false,
+            let _ = until_account_change(
+                &mut account_epoch_rx,
+                send_error_socket(
+                    &mut socket,
+                    "invalid_start",
+                    "We couldn't open this coding agent. Refresh the chat and try again.",
+                    false,
+                ),
             )
             .await;
             return;
         }
     };
     let requested_size = handshake.options.size;
-    let managed = match ensure_session(&state, db, &fence, handshake.options).await {
+    let Some(managed_result) = until_account_change(
+        &mut account_epoch_rx,
+        ensure_session(&state, db, &fence, handshake.options),
+    )
+    .await
+    else {
+        return;
+    };
+    let managed = match managed_result {
         Ok(managed) => managed,
         Err(error) => {
             let retryable = error
@@ -379,45 +473,69 @@ async fn serve_socket(
                 .get("error")
                 .and_then(Value::as_str)
                 .unwrap_or("We couldn't start the coding agent. Restart Studio and try again.");
-            let _ = send_error_socket(&mut socket, "start_failed", message, retryable).await;
+            let _ = until_account_change(
+                &mut account_epoch_rx,
+                send_error_socket(&mut socket, "start_failed", message, retryable),
+            )
+            .await;
             return;
         }
     };
+    if account_epoch_changed(&account_epoch_rx) {
+        return;
+    }
 
     let mut lifecycle = state.agent_sessions.subscribe_lifecycle();
     let row = match db.rt_get_terminal_session_fenced(&fence, managed.session.id()) {
         Ok(Some(row)) => row,
         Ok(None) => {
-            let _ = send_error_socket(
-                &mut socket,
-                "stale_session",
-                "This coding agent is no longer available. Reopen the chat and try again.",
-                false,
+            let _ = until_account_change(
+                &mut account_epoch_rx,
+                send_error_socket(
+                    &mut socket,
+                    "stale_session",
+                    "This coding agent is no longer available. Reopen the chat and try again.",
+                    false,
+                ),
             )
             .await;
             return;
         }
         Err(error) => {
             tracing::warn!(%error, "could not load coding agent terminal state");
-            let _ = send_error_socket(
-                &mut socket,
-                "storage_error",
-                "We couldn't load this chat right now. Try again.",
-                true,
+            let _ = until_account_change(
+                &mut account_epoch_rx,
+                send_error_socket(
+                    &mut socket,
+                    "storage_error",
+                    "We couldn't load this chat right now. Try again.",
+                    true,
+                ),
             )
             .await;
             return;
         }
     };
-    let writer = match managed.claim_writer_lease().await {
+    if account_epoch_changed(&account_epoch_rx) {
+        return;
+    }
+    let Some(writer_result) =
+        until_account_change(&mut account_epoch_rx, managed.claim_writer_lease()).await
+    else {
+        return;
+    };
+    let writer = match writer_result {
         Ok(writer) => writer,
         Err(error) => {
             tracing::warn!(%error, "could not claim coding agent terminal input ownership");
-            let _ = send_error_socket(
-                &mut socket,
-                "writer_unavailable",
-                "We couldn't open the coding agent terminal. Restart Studio and try again.",
-                false,
+            let _ = until_account_change(
+                &mut account_epoch_rx,
+                send_error_socket(
+                    &mut socket,
+                    "writer_unavailable",
+                    "We couldn't open the coding agent terminal. Restart Studio and try again.",
+                    false,
+                ),
             )
             .await;
             return;
@@ -425,18 +543,37 @@ async fn serve_socket(
     };
     // Handshake dimensions belong to the new writer. Claim before resizing so
     // an older attachment cannot interleave input after this mutation.
-    if let Some(_permit) = writer.mutation_permit().await {
-        if let Err(error) = managed.session.resize(requested_size).await {
+    let Some(mutation_permit) =
+        until_account_change(&mut account_epoch_rx, writer.mutation_permit()).await
+    else {
+        return;
+    };
+    if let Some(_permit) = mutation_permit {
+        let Some(resize_result) = until_account_change(
+            &mut account_epoch_rx,
+            managed.session.resize(requested_size),
+        )
+        .await
+        else {
+            return;
+        };
+        if let Err(error) = resize_result {
             tracing::warn!(%error, "could not set coding agent terminal size");
-            let _ = send_error_socket(
-                &mut socket,
-                "resize_failed",
-                "We couldn't open the coding agent terminal. Reopen the chat and try again.",
-                true,
+            let _ = until_account_change(
+                &mut account_epoch_rx,
+                send_error_socket(
+                    &mut socket,
+                    "resize_failed",
+                    "We couldn't open the coding agent terminal. Reopen the chat and try again.",
+                    true,
+                ),
             )
             .await;
             return;
         }
+    }
+    if account_epoch_changed(&account_epoch_rx) {
+        return;
     }
     let initial_snapshot = managed.session.snapshot();
     let replay_until = initial_snapshot.next_offset;
@@ -450,21 +587,21 @@ async fn serve_socket(
         last_seq: replay_until,
         provider_session_available: row.provider_session_id.is_some(),
     });
-    if send_json(
-        &mut socket,
-        &json!({
-            "type": "ready",
-            "sessionId": ready.session_id,
-            "generation": ready.generation,
-            "harnessId": ready.harness_id,
-            "physicalState": ready.physical_state,
-            "logicalState": ready.logical_state,
-            "lastSeq": ready.last_seq,
-        }),
-    )
-    .await
-    .is_err()
-    {
+    let ready_frame = json!({
+        "type": "ready",
+        "sessionId": ready.session_id,
+        "generation": ready.generation,
+        "harnessId": ready.harness_id,
+        "physicalState": ready.physical_state,
+        "logicalState": ready.logical_state,
+        "lastSeq": ready.last_seq,
+    });
+    let Some(ready_result) =
+        until_account_change(&mut account_epoch_rx, send_json(&mut socket, &ready_frame)).await
+    else {
+        return;
+    };
+    if ready_result.is_err() {
         return;
     }
 
@@ -472,26 +609,58 @@ async fn serve_socket(
         let request_id = handshake
             .request_id
             .unwrap_or_else(|| Uuid::new_v4().to_string());
-        match writer.mutation_permit().await {
+        let Some(mutation_permit) =
+            until_account_change(&mut account_epoch_rx, writer.mutation_permit()).await
+        else {
+            return;
+        };
+        match mutation_permit {
             Some(permit) => {
-                let result =
-                    submit_prompt(&state, db, &fence, &managed, &prompt, &request_id).await;
+                let Some(result) = until_account_change(
+                    &mut account_epoch_rx,
+                    submit_prompt(&state, db, &fence, &managed, &prompt, &request_id),
+                )
+                .await
+                else {
+                    return;
+                };
                 drop(permit);
                 match result {
                     Ok(()) => {
-                        let _ = send_json(
-                            &mut socket,
-                            &json!({ "type": "prompt_accepted", "requestId": request_id }),
+                        let frame = json!({ "type": "prompt_accepted", "requestId": request_id });
+                        if until_account_change(
+                            &mut account_epoch_rx,
+                            send_json(&mut socket, &frame),
                         )
-                        .await;
+                        .await
+                        .is_none()
+                        {
+                            return;
+                        }
                     }
                     Err(error) => {
-                        let _ = send_prompt_error_socket(&mut socket, &request_id, &error).await;
+                        if until_account_change(
+                            &mut account_epoch_rx,
+                            send_prompt_error_socket(&mut socket, &request_id, &error),
+                        )
+                        .await
+                        .is_none()
+                        {
+                            return;
+                        }
                     }
                 }
             }
             None => {
-                let _ = send_stale_attachment_socket(&mut socket, Some(&request_id)).await;
+                if until_account_change(
+                    &mut account_epoch_rx,
+                    send_stale_attachment_socket(&mut socket, Some(&request_id)),
+                )
+                .await
+                .is_none()
+                {
+                    return;
+                }
             }
         }
     }
@@ -499,79 +668,118 @@ async fn serve_socket(
     let mut subscription = managed.session.subscribe(handshake.after_seq);
     loop {
         tokio::select! {
+            biased;
+            _ = account_epoch_rx.changed() => break,
             inbound = socket.recv() => {
                 let Some(inbound) = inbound else { break; };
                 match inbound {
                     Ok(Message::Text(text)) => {
-                        if let Err(error) = handle_client_frame(
-                            &state,
-                            db,
-                            &fence,
-                            &managed,
-                            &writer,
-                            &mut socket,
-                            &text,
-                        ).await {
+                        let Some(frame_result) = until_account_change(
+                            &mut account_epoch_rx,
+                            handle_client_frame(
+                                &state,
+                                db,
+                                &fence,
+                                &managed,
+                                &writer,
+                                &mut socket,
+                                &text,
+                            ),
+                        ).await else { break; };
+                        if let Err(error) = frame_result {
                             match error {
                                 ClientFrameError::Invalid(error) => {
                                     tracing::warn!(%error, "coding agent terminal command failed");
-                                    let _ = send_error_socket(
-                                        &mut socket,
-                                        "invalid_control",
-                                        "We couldn't complete that terminal action. Reopen the chat and try again.",
-                                        false,
-                                    ).await;
+                                    if until_account_change(
+                                        &mut account_epoch_rx,
+                                        send_error_socket(
+                                            &mut socket,
+                                            "invalid_control",
+                                            "We couldn't complete that terminal action. Reopen the chat and try again.",
+                                            false,
+                                        ),
+                                    ).await.is_none() { break; }
                                 }
                                 ClientFrameError::StaleAttachment { request_id } => {
-                                    let _ = send_stale_attachment_socket(&mut socket, request_id.as_deref()).await;
+                                    if until_account_change(
+                                        &mut account_epoch_rx,
+                                        send_stale_attachment_socket(&mut socket, request_id.as_deref()),
+                                    ).await.is_none() { break; }
                                 }
                             }
                         }
                     }
                     Ok(Message::Binary(data)) => {
-                        match writer.mutation_permit().await {
+                        let Some(mutation_permit) = until_account_change(
+                            &mut account_epoch_rx,
+                            writer.mutation_permit(),
+                        ).await else { break; };
+                        match mutation_permit {
                             Some(_permit) => {
-                                if let Err(error) = managed.session.write(data).await {
+                                let Some(write_result) = until_account_change(
+                                    &mut account_epoch_rx,
+                                    managed.session.write(data),
+                                ).await else { break; };
+                                if let Err(error) = write_result {
                                     tracing::warn!(%error, "could not write coding agent terminal input");
-                                    let _ = send_error_socket(
-                                        &mut socket,
-                                        "input_failed",
-                                        "We couldn't send input to the coding agent. Reopen the chat and try again.",
-                                        true,
-                                    ).await;
+                                    if until_account_change(
+                                        &mut account_epoch_rx,
+                                        send_error_socket(
+                                            &mut socket,
+                                            "input_failed",
+                                            "We couldn't send input to the coding agent. Reopen the chat and try again.",
+                                            true,
+                                        ),
+                                    ).await.is_none() { break; }
                                 }
                             }
                             None => {
-                                let _ = send_stale_attachment_socket(&mut socket, None).await;
+                                if until_account_change(
+                                    &mut account_epoch_rx,
+                                    send_stale_attachment_socket(&mut socket, None),
+                                ).await.is_none() { break; }
                             }
                         }
                     }
                     Ok(Message::Close(_)) | Err(_) => break,
                     Ok(Message::Ping(data)) => {
-                        if socket.send(Message::Pong(data)).await.is_err() { break; }
+                        let Some(result) = until_account_change(
+                            &mut account_epoch_rx,
+                            socket.send(Message::Pong(data)),
+                        ).await else { break; };
+                        if result.is_err() { break; }
                     }
                     Ok(Message::Pong(_)) => {}
                 }
             }
             event = subscription.recv() => {
                 let Ok(event) = event else { break; };
-                if forward_terminal_event(&mut socket, event, replay_until)
-                    .await
-                    .is_err()
-                {
+                let Some(result) = until_account_change(
+                    &mut account_epoch_rx,
+                    forward_terminal_event(&mut socket, event, replay_until),
+                ).await else { break; };
+                if result.is_err() {
                     break;
                 }
             }
             lifecycle_event = lifecycle.recv() => {
                 match lifecycle_event {
                     Ok(changed) if changed == fence => {
-                        if send_state(&mut socket, db, &fence, managed.session.id()).await.is_err() {
+                        let Some(result) = until_account_change(
+                            &mut account_epoch_rx,
+                            send_state(&mut socket, db, &fence, managed.session.id()),
+                        ).await else { break; };
+                        if result.is_err() {
                             break;
                         }
                     }
                     Ok(_) => {}
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                        if send_state(&mut socket, db, &fence, managed.session.id()).await.is_err() {
+                        let Some(result) = until_account_change(
+                            &mut account_epoch_rx,
+                            send_state(&mut socket, db, &fence, managed.session.id()),
+                        ).await else { break; };
+                        if result.is_err() {
                             break;
                         }
                     }
@@ -582,17 +790,41 @@ async fn serve_socket(
     }
 }
 
+fn account_epoch_changed(
+    account_epoch_rx: &tokio::sync::watch::Receiver<crate::sandbox::manager::AccountEpoch>,
+) -> bool {
+    account_epoch_rx.has_changed().unwrap_or(true)
+}
+
+/// Await one potentially-stalled socket or terminal operation, but let an
+/// account transition win whenever both outcomes are ready. This is the
+/// common fence for pre-handshake waits, replay/live output, and control
+/// replies; a retained account-A socket can never resume sending under B.
+async fn until_account_change<T>(
+    account_epoch_rx: &mut tokio::sync::watch::Receiver<crate::sandbox::manager::AccountEpoch>,
+    future: impl Future<Output = T>,
+) -> Option<T> {
+    tokio::select! {
+        biased;
+        _ = account_epoch_rx.changed() => None,
+        output = future => Some(output),
+    }
+}
+
 async fn receive_handshake(
     socket: &mut WebSocket,
     db: &'static ThreadsDb,
     fence: &RtThreadFence,
-) -> Result<Handshake, String> {
+    account_epoch_rx: &mut tokio::sync::watch::Receiver<crate::sandbox::manager::AccountEpoch>,
+) -> Result<Handshake, HandshakeError> {
     loop {
-        let message = socket
-            .recv()
-            .await
-            .ok_or_else(|| "terminal connection closed before start".to_string())?
-            .map_err(|error| error.to_string())?;
+        let message = tokio::select! {
+            biased;
+            _ = account_epoch_rx.changed() => return Err(HandshakeError::AccountChanged),
+            message = socket.recv() => message
+                .ok_or_else(|| "terminal connection closed before start".to_string())?
+                .map_err(|error| error.to_string())?,
+        };
         match message {
             Message::Text(text) => {
                 let frame = parse_client_frame(&text)?;
@@ -652,22 +884,36 @@ async fn receive_handshake(
                         });
                     }
                     _ => {
-                        send_error_socket(
-                            socket,
-                            "start_required",
-                            "Choose a coding agent before using the terminal.",
-                            false,
+                        let Some(result) = until_account_change(
+                            account_epoch_rx,
+                            send_error_socket(
+                                socket,
+                                "start_required",
+                                "Choose a coding agent before using the terminal.",
+                                false,
+                            ),
                         )
                         .await
-                        .map_err(|error| error.to_string())?;
+                        else {
+                            return Err(HandshakeError::AccountChanged);
+                        };
+                        result.map_err(|error| error.to_string())?;
                     }
                 }
             }
-            Message::Close(_) => return Err("terminal connection closed before start".to_string()),
-            Message::Ping(data) => socket
-                .send(Message::Pong(data))
-                .await
-                .map_err(|error| error.to_string())?,
+            Message::Close(_) => {
+                return Err(HandshakeError::Invalid(
+                    "terminal connection closed before start".to_string(),
+                ))
+            }
+            Message::Ping(data) => {
+                let Some(result) =
+                    until_account_change(account_epoch_rx, socket.send(Message::Pong(data))).await
+                else {
+                    return Err(HandshakeError::AccountChanged);
+                };
+                result.map_err(|error| error.to_string())?;
+            }
             Message::Binary(_) | Message::Pong(_) => {}
         }
     }
@@ -680,40 +926,31 @@ async fn ensure_session(
     options: StartOptions,
 ) -> ApiResult<ManagedTerminal> {
     let start_lock = state.agent_sessions.start_lock(fence);
-    let start_guard = start_lock.lock_owned().await;
     let upstream_session = upstream::global();
+    {
+        let _start_guard = start_lock.clone().lock_owned().await;
+        let _account_transition = upstream_session.begin_transition().await;
+        validate_initial_start_admission(db, fence, options.harness).await?;
+        if let Some(managed) = reusable_managed_session(state, fence, options.harness) {
+            reconcile_registered_session(db, fence, managed.session.id(), options.harness)?;
+            state.agent_sessions.notify_lifecycle(fence);
+            return Ok(managed);
+        }
+    }
+
+    // CLI readiness may invoke a bounded subprocess, so it runs without the
+    // per-thread lifecycle lock. Admission is repeated afterward before any
+    // durable row is reserved.
+    require_supported_harness(options.harness).await?;
+
+    let start_guard = start_lock.lock_owned().await;
     let initial_account_transition = upstream_session.begin_transition().await;
-    require_current_account(fence)
-        .await
-        .map_err(|error| account_start_error(options.harness, error))?;
-    let current_thread = db
-        .rt_get_thread_for_fence(fence)
-        .map_err(|error| {
-            agent_start_internal_error(options.harness, "load chat before start", error)
-        })?
-        .ok_or_else(|| {
-            ApiError::not_found("This chat is no longer available. Refresh Studio and try again.")
-        })?;
-    if current_thread.hidden {
-        return Err(ApiError::conflict(
-            "This chat is archived. Restore it before starting a coding agent.",
-        ));
-    }
-    if db.rt_thread_delete_pending(fence).map_err(|error| {
-        agent_start_internal_error(options.harness, "check chat deletion state", error)
-    })? {
-        return Err(ApiError::conflict(
-            "This chat is being deleted and can't start a coding agent.",
-        ));
-    }
-    if let Some(managed) = state.agent_sessions.get(fence).filter(|managed| {
-        !managed.session.snapshot().state.is_terminal() && managed.hook.harness == options.harness
-    }) {
+    validate_initial_start_admission(db, fence, options.harness).await?;
+    if let Some(managed) = reusable_managed_session(state, fence, options.harness) {
         reconcile_registered_session(db, fence, managed.session.id(), options.harness)?;
         state.agent_sessions.notify_lifecycle(fence);
         return Ok(managed);
     }
-    drop(initial_account_transition);
 
     let pinned = db
         .rt_harness_id_fenced(fence)
@@ -735,12 +972,6 @@ async fn ensure_session(
         )));
     }
 
-    // Fail before the durable session transaction pins this harness. The
-    // launch-context check repeats at the process boundary to close the
-    // executable/version TOCTOU window, but this preflight is what keeps a
-    // missing or unsupported selection on the fresh-chat picker.
-    require_supported_harness(options.harness).await?;
-
     let provider_session_id = match db
         .rt_terminal_resume_decision_fenced(fence, options.harness.wire_id())
         .map_err(|error| {
@@ -749,131 +980,269 @@ async fn ensure_session(
         RtTerminalResumeDecision::Fresh => None,
         RtTerminalResumeDecision::Resume(provider_session_id) => Some(provider_session_id),
     };
-    let terminal_session_id = Uuid::new_v4().to_string();
-    let commit = match db
-        .rt_create_terminal_session_fenced(fence, &terminal_session_id, options.harness.wire_id())
-        .map_err(|error| {
-            agent_start_internal_error(options.harness, "create coding agent session", error)
-        })? {
-        RtTerminalSessionCreateOutcome::Created(commit) => commit,
-        RtTerminalSessionCreateOutcome::ExistingLive(commit) => {
-            // A live durable row without an in-process PTY can only be an
-            // interrupted/failed start. Close it before admitting a retry.
-            if let Some(managed) = state.agent_sessions.get(fence) {
-                if managed.session.id() == commit.session.id
-                    && !managed.session.snapshot().state.is_terminal()
-                {
-                    reconcile_registered_session(db, fence, managed.session.id(), options.harness)?;
-                    state.agent_sessions.notify_lifecycle(fence);
-                    return Ok(managed);
-                }
-                if !managed.session.snapshot().state.is_terminal() {
-                    return Err(ApiError::conflict(format!(
-                        "We couldn't safely reopen {}. Restart Studio and try again.",
-                        agent_display_name(options.harness)
-                    )));
-                }
-            }
-            crate::terminal::lifecycle::mark_exited(
-                db,
-                fence,
-                &commit.session.id,
-                None,
-                false,
-                Some("terminal process was not present in the current app instance"),
-            )
-            .map_err(|error| {
-                agent_start_internal_error(
-                    options.harness,
-                    "close interrupted coding agent session",
-                    error,
-                )
-            })?;
-            let replacement_id = Uuid::new_v4().to_string();
-            match db
-                .rt_create_terminal_session_fenced(
-                    fence,
-                    &replacement_id,
-                    options.harness.wire_id(),
-                )
-                .map_err(|error| {
-                    agent_start_internal_error(
-                        options.harness,
-                        "replace interrupted coding agent session",
-                        error,
-                    )
-                })? {
-                RtTerminalSessionCreateOutcome::Created(commit) => commit,
-                RtTerminalSessionCreateOutcome::ExistingLive(_) => {
-                    return Err(retryable_start_error(ApiError::conflict(format!(
-                        "{} is already starting. Try again in a moment.",
-                        agent_display_name(options.harness)
-                    ))));
-                }
-            }
-        }
-    };
-    crate::terminal::lifecycle::emit_thread(fence, &commit.thread);
-
-    let hook_token = generate_hook_token();
-    let mcp_token = generate_mcp_token();
-    let launch = launch_context::prepare(
-        state,
-        db,
-        LaunchRequest {
-            fence,
-            terminal_session_id: &commit.session.id,
-            harness: options.harness,
-            approval_mode: &options.approval_mode,
-            plan_mode: options.plan_mode,
-            hook_token: &hook_token,
-            mcp_token: &mcp_token,
-            provider_session_id: provider_session_id.as_deref(),
-        },
-    )
-    .await;
-    let launch = match launch {
-        Ok(launch) => launch,
-        Err(error) => {
-            let diagnostic = error.to_string();
-            tracing::warn!(
-                harness = options.harness.wire_id(),
-                error = %diagnostic,
-                "coding agent launch preparation failed"
-            );
-            let _ = crate::terminal::lifecycle::mark_exited(
-                db,
-                fence,
-                &commit.session.id,
-                None,
-                false,
-                Some(&diagnostic),
-            );
-            return Err(launch_preparation_api_error(options.harness, &error));
-        }
-    };
-    let command = command_spec(state, &launch);
     let key = crate::terminal::AgentSessionRegistry::session_key(fence)
         .map_err(|error| terminal_start_error(options.harness, error))?;
+    let (terminal_session_id, preparation) =
+        reserve_durable_start(&state.agent_sessions, db, fence, options.harness)?;
+    let account_epoch = state.sandbox_manager.account_epoch();
+    let identity_generation = initial_account_transition.generation();
+    drop(initial_account_transition);
+    drop(start_guard);
+
+    // Once the durable reservation exists, a detached owner performs every
+    // preparation and finalizes or exits that exact row even if its HTTP or
+    // WebSocket waiter disconnects.
     run_spawn_owner(
         SessionSpawnOwner {
             state: state.clone(),
             db,
             fence: fence.clone(),
             options,
-            terminal_session_id: commit.session.id,
+            terminal_session_id,
             provider_session_id,
-            hook_token,
-            mcp_token,
-            launch,
-            command,
+            hook_token: generate_hook_token(),
+            mcp_token: generate_mcp_token(),
             key,
-            start_guard,
+            preparation,
             upstream_session,
+            account_epoch,
+            identity_generation,
         }
         .run(),
     )
     .await
+}
+
+async fn validate_initial_start_admission(
+    db: &'static ThreadsDb,
+    fence: &RtThreadFence,
+    harness: HarnessId,
+) -> ApiResult<()> {
+    require_current_account(fence)
+        .await
+        .map_err(|error| account_start_error(harness, error))?;
+    let current_thread = db
+        .rt_get_thread_for_fence(fence)
+        .map_err(|error| agent_start_internal_error(harness, "load chat before start", error))?
+        .ok_or_else(|| {
+            ApiError::not_found("This chat is no longer available. Refresh Studio and try again.")
+        })?;
+    if current_thread.hidden {
+        return Err(ApiError::conflict(
+            "This chat is archived. Restore it before starting a coding agent.",
+        ));
+    }
+    if db
+        .rt_thread_delete_pending(fence)
+        .map_err(|error| agent_start_internal_error(harness, "check chat deletion state", error))?
+    {
+        return Err(ApiError::conflict(
+            "This chat is being deleted and can't start a coding agent.",
+        ));
+    }
+    Ok(())
+}
+
+fn reusable_managed_session(
+    state: &AppState,
+    fence: &RtThreadFence,
+    harness: HarnessId,
+) -> Option<ManagedTerminal> {
+    state.agent_sessions.get(fence).filter(|managed| {
+        !managed.session.snapshot().state.is_terminal() && managed.hook.harness == harness
+    })
+}
+
+fn reserve_durable_start(
+    registry: &std::sync::Arc<crate::terminal::AgentSessionRegistry>,
+    db: &'static ThreadsDb,
+    fence: &RtThreadFence,
+    harness: HarnessId,
+) -> ApiResult<(String, PreparationReservation)> {
+    if let Some(existing) = db
+        .rt_get_live_terminal_session_fenced(fence)
+        .map_err(|error| agent_start_internal_error(harness, "load live coding agent", error))?
+    {
+        if registry.is_preparing(fence, &existing.id) {
+            return Err(retryable_start_error(ApiError::conflict(format!(
+                "{} is already starting. Try again in a moment.",
+                agent_display_name(harness)
+            ))));
+        }
+        if registry
+            .get(fence)
+            .is_some_and(|managed| !managed.session.snapshot().state.is_terminal())
+        {
+            return Err(ApiError::conflict(format!(
+                "We couldn't safely reopen {}. Restart Studio and try again.",
+                agent_display_name(harness)
+            )));
+        }
+
+        // No process-local preparation or PTY owns this live durable row, so
+        // it is stale state left by a previous app process. Inspecting before
+        // create also heals an interrupted attempt for a different harness.
+        crate::terminal::lifecycle::mark_exited(
+            db,
+            fence,
+            &existing.id,
+            None,
+            false,
+            Some("terminal process was not present in the current app instance"),
+        )
+        .map_err(|error| {
+            agent_start_internal_error(harness, "close interrupted coding agent session", error)
+        })?;
+    }
+
+    let terminal_session_id = Uuid::new_v4().to_string();
+    let commit = match db
+        .rt_create_terminal_session_fenced(fence, &terminal_session_id, harness.wire_id())
+        .map_err(|error| {
+            agent_start_internal_error(harness, "create coding agent session", error)
+        })? {
+        RtTerminalSessionCreateOutcome::Created(commit) => commit,
+        RtTerminalSessionCreateOutcome::ExistingLive(_) => {
+            return Err(retryable_start_error(ApiError::conflict(format!(
+                "{} is already starting. Try again in a moment.",
+                agent_display_name(harness)
+            ))));
+        }
+    };
+    let terminal_session_id = commit.session.id.clone();
+    let preparation = registry
+        .reserve_preparation(fence.clone(), terminal_session_id.clone())
+        .ok_or_else(|| {
+            retryable_start_error(ApiError::conflict(format!(
+                "{} is already starting. Try again in a moment.",
+                agent_display_name(harness)
+            )))
+        })?;
+    crate::terminal::lifecycle::emit_thread(fence, &commit.thread);
+    Ok((terminal_session_id, preparation))
+}
+
+fn fail_launch_preparation(
+    db: &'static ThreadsDb,
+    fence: &RtThreadFence,
+    terminal_session_id: &str,
+    harness: HarnessId,
+    error: &launch_context::LaunchContextError,
+    context: &'static str,
+) {
+    let diagnostic = error.to_string();
+    tracing::warn!(
+        harness = harness.wire_id(),
+        error = %diagnostic,
+        "{context}"
+    );
+    mark_starting_session_exited_if_present(
+        db,
+        fence,
+        terminal_session_id,
+        &diagnostic,
+        matches!(error, launch_context::LaunchContextError::Canceled),
+    );
+}
+
+async fn validate_final_start_admission(
+    state: &AppState,
+    db: &'static ThreadsDb,
+    fence: &RtThreadFence,
+    terminal_session_id: &str,
+    preparation: &PreparationReservation,
+) -> ApiResult<()> {
+    if !preparation.is_active() {
+        return Err(ApiError::conflict(
+            "This coding agent start was canceled. Reopen the chat and try again.",
+        ));
+    }
+    let resolved = authority::resolve_current_thread(
+        state,
+        &fence.organization_id,
+        &fence.thread_id,
+        ThreadAccess::ActiveOwner,
+    )
+    .await?;
+    if resolved.fence != *fence {
+        return Err(ApiError::conflict(
+            "This chat changed while the coding agent was preparing. Try again.",
+        ));
+    }
+    validate_exact_durable_start(db, fence, terminal_session_id, preparation)
+}
+
+fn validate_exact_durable_start(
+    db: &'static ThreadsDb,
+    fence: &RtThreadFence,
+    terminal_session_id: &str,
+    preparation: &PreparationReservation,
+) -> ApiResult<()> {
+    if !preparation.is_active() {
+        return Err(ApiError::conflict(
+            "This coding agent start was canceled. Reopen the chat and try again.",
+        ));
+    }
+    let thread = db
+        .rt_get_thread_for_fence(fence)
+        .map_err(|error| terminal_storage_error("recheck coding agent chat", error))?
+        .ok_or_else(|| {
+            ApiError::not_found("This chat is no longer available. Refresh Studio and try again.")
+        })?;
+    if thread.hidden {
+        return Err(ApiError::conflict(
+            "This chat is archived. Restore it before starting a coding agent.",
+        ));
+    }
+    if db
+        .rt_thread_delete_pending(fence)
+        .map_err(|error| terminal_storage_error("recheck coding agent deletion state", error))?
+    {
+        return Err(ApiError::conflict(
+            "This chat is being deleted and can't start a coding agent.",
+        ));
+    }
+    let live = db
+        .rt_get_live_terminal_session_fenced(fence)
+        .map_err(|error| terminal_storage_error("recheck coding agent start", error))?;
+    if !live.is_some_and(|session| {
+        session.id == terminal_session_id
+            && session.physical_state == RtTerminalPhysicalState::Starting
+    }) {
+        return Err(ApiError::conflict(
+            "This coding agent start is no longer current. Reopen the chat and try again.",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn mark_starting_session_exited_if_present(
+    db: &'static ThreadsDb,
+    fence: &RtThreadFence,
+    terminal_session_id: &str,
+    diagnostic: &str,
+    requested: bool,
+) {
+    let row = match db.rt_get_terminal_session_fenced(fence, terminal_session_id) {
+        Ok(row) => row,
+        Err(error) => {
+            tracing::warn!(%error, terminal_session_id, "could not inspect canceled coding agent start");
+            return;
+        }
+    };
+    if !row.is_some_and(|row| row.physical_state == RtTerminalPhysicalState::Starting) {
+        return;
+    }
+    if let Err(error) = crate::terminal::lifecycle::mark_exited(
+        db,
+        fence,
+        terminal_session_id,
+        None,
+        requested,
+        Some(diagnostic),
+    ) {
+        tracing::warn!(%error, terminal_session_id, "could not close canceled coding agent start");
+    }
 }
 
 impl SessionSpawnOwner {
@@ -887,44 +1256,143 @@ impl SessionSpawnOwner {
             mut provider_session_id,
             mut hook_token,
             mut mcp_token,
-            mut launch,
-            mut command,
             key,
-            start_guard: _start_guard,
+            preparation,
             upstream_session,
+            account_epoch,
+            identity_generation,
         } = self;
         let mut may_recover_missing_claude_resume =
             options.harness == HarnessId::ClaudeCode && provider_session_id.is_some();
+        let Some(preparation_phase) = preparation.begin_phase() else {
+            mark_starting_session_exited_if_present(
+                db,
+                &fence,
+                &terminal_session_id,
+                "coding agent preparation was canceled before it began",
+                true,
+            );
+            return Err(ApiError::conflict(
+                "This coding agent start was canceled. Reopen the chat and try again.",
+            ));
+        };
+        let cancellation = preparation_phase.cancellation();
+        let launch_result = launch_context::prepare(
+            &state,
+            db,
+            LaunchRequest {
+                fence: &fence,
+                terminal_session_id: &terminal_session_id,
+                harness: options.harness,
+                approval_mode: &options.approval_mode,
+                plan_mode: options.plan_mode,
+                hook_token: &hook_token,
+                mcp_token: &mcp_token,
+                provider_session_id: provider_session_id.as_deref(),
+                cancellation: &cancellation,
+                account_epoch,
+                identity_generation,
+            },
+        )
+        .await;
+        drop(preparation_phase);
+        let mut launch = match launch_result {
+            Ok(launch) => launch,
+            Err(error) => {
+                fail_launch_preparation(
+                    db,
+                    &fence,
+                    &terminal_session_id,
+                    options.harness,
+                    &error,
+                    "coding agent launch preparation failed",
+                );
+                return Err(launch_preparation_api_error(options.harness, &error));
+            }
+        };
 
         loop {
+            let start_guard = state.agent_sessions.start_lock(&fence).lock_owned().await;
             // Linearize process creation with every sign-out/account replacement.
-            // Preparation above may perform network I/O and therefore stays outside
-            // this short gate; the account is rechecked before trust or a child can
-            // exist. Claude's path lock is acquired first so a concurrent config
-            // writer never makes logout wait while this request is merely queued.
+            // Both initial and Claude recovery preparation stay outside this
+            // short gate. The exact durable reservation and owner are rechecked
+            // before a hook or child process can exist.
+            let admission_fences = match acquire_spawn_admission_fences(
+                &state,
+                &upstream_session,
+                &fence,
+                &launch,
+                account_epoch,
+                identity_generation,
+            )
+            .await
+            {
+                Ok(fences) => fences,
+                Err(error) => {
+                    let diagnostic = error.message().to_string();
+                    tracing::warn!(
+                        harness = options.harness.wire_id(),
+                        error = %diagnostic,
+                        "coding agent account or workspace preparation failed"
+                    );
+                    let message = spawn_fence_message(options.harness, &error);
+                    let _ = crate::terminal::lifecycle::mark_exited(
+                        db,
+                        &fence,
+                        &terminal_session_id,
+                        None,
+                        false,
+                        Some(&diagnostic),
+                    );
+                    return Err(match error {
+                        SpawnFenceError::Account(_) => ApiError::conflict(message),
+                        SpawnFenceError::WorkspaceTrust(_) => ApiError::bad_gateway(message),
+                    });
+                }
+            };
+            if let Err(error) = validate_final_start_admission(
+                &state,
+                db,
+                &fence,
+                &terminal_session_id,
+                &preparation,
+            )
+            .await
+            {
+                let requested = !preparation.is_active();
+                tracing::warn!(
+                    harness = options.harness.wire_id(),
+                    terminal_session_id,
+                    "coding agent start admission changed during preparation"
+                );
+                mark_starting_session_exited_if_present(
+                    db,
+                    &fence,
+                    &terminal_session_id,
+                    "coding agent start admission changed during preparation",
+                    requested,
+                );
+                return Err(error);
+            }
             let spawn_fences =
-                match acquire_spawn_fences(&state, &upstream_session, &fence, &launch).await {
+                match establish_spawn_trust(&state, &fence, &launch, admission_fences).await {
                     Ok(fences) => fences,
                     Err(error) => {
                         let diagnostic = error.message().to_string();
                         tracing::warn!(
                             harness = options.harness.wire_id(),
                             error = %diagnostic,
-                            "coding agent account or workspace preparation failed"
+                            "coding agent workspace preparation failed"
                         );
                         let message = spawn_fence_message(options.harness, &error);
-                        let _ = crate::terminal::lifecycle::mark_exited(
+                        mark_starting_session_exited_if_present(
                             db,
                             &fence,
                             &terminal_session_id,
-                            None,
+                            &diagnostic,
                             false,
-                            Some(&diagnostic),
                         );
-                        return Err(match error {
-                            SpawnFenceError::Account(_) => ApiError::conflict(message),
-                            SpawnFenceError::WorkspaceTrust(_) => ApiError::bad_gateway(message),
-                        });
+                        return Err(ApiError::bad_gateway(message));
                     }
                 };
             let mut lifecycle = state.agent_sessions.subscribe_lifecycle();
@@ -948,7 +1416,7 @@ impl SessionSpawnOwner {
                 .start_or_attach_with_id(
                     key.clone(),
                     terminal_session_id.clone(),
-                    command,
+                    command_spec(&state, &launch),
                     options.size,
                 )
                 .await;
@@ -985,6 +1453,7 @@ impl SessionSpawnOwner {
                 state.agent_sessions.unregister_hook(&terminal_session_id);
                 drop(hook);
                 drop(spawn_fences);
+                drop(start_guard);
                 tracing::info!(
                     terminal_session_id,
                     "Claude resume target was missing; restarting the terminal fresh"
@@ -994,7 +1463,20 @@ impl SessionSpawnOwner {
                 provider_session_id = None;
                 hook_token = generate_hook_token();
                 mcp_token = generate_mcp_token();
-                launch = match launch_context::prepare(
+                let Some(preparation_phase) = preparation.begin_phase() else {
+                    mark_starting_session_exited_if_present(
+                        db,
+                        &fence,
+                        &terminal_session_id,
+                        "coding agent recovery preparation was canceled before it began",
+                        true,
+                    );
+                    return Err(ApiError::conflict(
+                        "This coding agent start was canceled. Reopen the chat and try again.",
+                    ));
+                };
+                let cancellation = preparation_phase.cancellation();
+                let launch_result = launch_context::prepare(
                     &state,
                     db,
                     LaunchRequest {
@@ -1006,30 +1488,27 @@ impl SessionSpawnOwner {
                         hook_token: &hook_token,
                         mcp_token: &mcp_token,
                         provider_session_id: None,
+                        cancellation: &cancellation,
+                        account_epoch,
+                        identity_generation,
                     },
                 )
-                .await
-                {
+                .await;
+                drop(preparation_phase);
+                launch = match launch_result {
                     Ok(launch) => launch,
                     Err(error) => {
-                        let diagnostic = error.to_string();
-                        tracing::warn!(
-                            harness = options.harness.wire_id(),
-                            error = %diagnostic,
-                            "coding agent fresh-session recovery preparation failed"
-                        );
-                        let _ = crate::terminal::lifecycle::mark_exited(
+                        fail_launch_preparation(
                             db,
                             &fence,
                             &terminal_session_id,
-                            None,
-                            false,
-                            Some(&diagnostic),
+                            options.harness,
+                            &error,
+                            "coding agent fresh-session recovery preparation failed",
                         );
                         return Err(launch_preparation_api_error(options.harness, &error));
                     }
                 };
-                command = command_spec(&state, &launch);
                 continue;
             }
 
@@ -1044,66 +1523,52 @@ impl SessionSpawnOwner {
                 started.session.clone(),
                 hook,
             );
-            let account_error = require_current_account(&fence)
-                .await
-                .err()
-                .map(|diagnostic| {
+            let pin_error = match db
+                .rt_pin_harness_if_unset_fenced(
+                    &fence,
+                    options.harness.wire_id(),
+                    Some(DESKTOP_SANDBOX_PROVIDER),
+                    None,
+                )
+                .and_then(|updated| {
+                    if updated {
+                        db.rt_harness_id_fenced(&fence)
+                    } else {
+                        Ok(None)
+                    }
+                }) {
+                Ok(Some(Some(ref pinned))) if pinned == options.harness.wire_id() => None,
+                Ok(Some(Some(pinned))) => {
+                    let pinned_agent = HarnessId::from_wire_id(&pinned)
+                        .map(agent_display_name)
+                        .unwrap_or("another coding agent");
+                    Some((
+                        format!("chat is already using {pinned}"),
+                        format!("This chat is already using {pinned_agent}."),
+                        false,
+                    ))
+                }
+                Ok(_) => Some((
+                    "thread is no longer available".to_string(),
+                    "This chat is no longer available. Refresh Studio and try again.".to_string(),
+                    false,
+                )),
+                Err(error) => {
                     tracing::warn!(
                         harness = options.harness.wire_id(),
-                        error = %diagnostic,
-                        "coding agent account changed before harness pin"
+                        %error,
+                        "could not pin coding agent to chat"
                     );
-                    (diagnostic, account_start_message(options.harness), false)
-                });
-            let pin_error = account_error.or_else(|| {
-                match db
-                    .rt_pin_harness_if_unset_fenced(
-                        &fence,
-                        options.harness.wire_id(),
-                        Some(DESKTOP_SANDBOX_PROVIDER),
-                        None,
-                    )
-                    .and_then(|updated| {
-                        if updated {
-                            db.rt_harness_id_fenced(&fence)
-                        } else {
-                            Ok(None)
-                        }
-                    }) {
-                    Ok(Some(Some(ref pinned))) if pinned == options.harness.wire_id() => None,
-                    Ok(Some(Some(pinned))) => {
-                        let pinned_agent = HarnessId::from_wire_id(&pinned)
-                            .map(agent_display_name)
-                            .unwrap_or("another coding agent");
-                        Some((
-                            format!("chat is already using {pinned}"),
-                            format!("This chat is already using {pinned_agent}."),
-                            false,
-                        ))
-                    }
-                    Ok(_) => Some((
-                        "thread is no longer available".to_string(),
-                        "This chat is no longer available. Refresh Studio and try again."
-                            .to_string(),
-                        false,
-                    )),
-                    Err(error) => {
-                        tracing::warn!(
-                            harness = options.harness.wire_id(),
-                            %error,
-                            "could not pin coding agent to chat"
-                        );
-                        Some((
-                            error.to_string(),
-                            format!(
-                                "We couldn't finish starting {}. Try again.",
-                                agent_display_name(options.harness)
-                            ),
-                            true,
-                        ))
-                    }
+                    Some((
+                        error.to_string(),
+                        format!(
+                            "We couldn't finish starting {}. Try again.",
+                            agent_display_name(options.harness)
+                        ),
+                        true,
+                    ))
                 }
-            });
+            };
             if let Some((diagnostic, message, retryable)) = pin_error {
                 let exit = started
                     .session
@@ -1338,12 +1803,14 @@ where
     })?
 }
 
-async fn acquire_spawn_fences(
+async fn acquire_spawn_admission_fences(
     state: &AppState,
     upstream_session: &upstream::UpstreamSession,
     fence: &RtThreadFence,
     launch: &PreparedLaunch,
-) -> Result<SpawnFences, SpawnFenceError> {
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    identity_generation: u64,
+) -> Result<SpawnAdmissionFences, SpawnFenceError> {
     let claude_state = match launch.claude_state_path() {
         Some(path) => Some(
             state
@@ -1355,9 +1822,34 @@ async fn acquire_spawn_fences(
         None => None,
     };
     let account = upstream_session.begin_transition().await;
+    if account.generation() != identity_generation {
+        return Err(SpawnFenceError::Account(
+            "the upstream account changed while starting the coding agent".to_string(),
+        ));
+    }
     require_current_account(fence)
         .await
         .map_err(SpawnFenceError::Account)?;
+    state
+        .sandbox_manager
+        .validate_account_epoch(account_epoch)
+        .map_err(SpawnFenceError::Account)?;
+    Ok(SpawnAdmissionFences {
+        account,
+        claude_state,
+    })
+}
+
+async fn establish_spawn_trust(
+    state: &AppState,
+    fence: &RtThreadFence,
+    launch: &PreparedLaunch,
+    admission: SpawnAdmissionFences,
+) -> Result<SpawnFences, SpawnFenceError> {
+    let SpawnAdmissionFences {
+        account,
+        claude_state,
+    } = admission;
     let account = launch
         .establish_managed_codex_hook_trust(state, &fence.account_scope, account)
         .await
@@ -1390,7 +1882,7 @@ async fn acquire_spawn_fences(
 }
 
 async fn require_current_account(fence: &RtThreadFence) -> Result<(), String> {
-    let current = thread_tools::current_account_scope_result()
+    let current = authority::current_account_scope_result()
         .await
         .map_err(|error| format!("session storage unavailable: {error}"))?
         .ok_or_else(|| {
@@ -1458,6 +1950,9 @@ fn launch_preparation_message(
 ) -> String {
     let agent = agent_display_name(harness_id);
     match error {
+        launch_context::LaunchContextError::Canceled => {
+            "This coding agent start was canceled. Reopen the chat and try again.".to_string()
+        }
         launch_context::LaunchContextError::StaleThread => {
             "This chat is no longer available. Refresh Studio and try again.".to_string()
         }
@@ -1503,6 +1998,7 @@ fn launch_preparation_api_error(
 ) -> ApiError {
     let message = launch_preparation_message(harness_id, error);
     let api_error = match error {
+        launch_context::LaunchContextError::Canceled => ApiError::conflict(message),
         launch_context::LaunchContextError::StaleThread => ApiError::not_found(message),
         launch_context::LaunchContextError::Storage(_)
         | launch_context::LaunchContextError::Workspace(_)
@@ -1891,48 +2387,10 @@ async fn scoped_owned_thread(
     state: &AppState,
     org: &str,
     thread_id: &str,
-) -> ApiResult<(&'static ThreadsDb, RtAccountScope, RtThreadFence)> {
-    let scope = thread_tools::current_account_scope_result()
-        .await
-        .map_err(|error| {
-            tracing::warn!(%error, "could not load the Studio account for a coding agent request");
-            ApiError::internal(
-                "We couldn't confirm your Studio account. Restart Studio and try again; if needed, sign in again.",
-            )
-        })?
-        .ok_or_else(|| {
-            ApiError::new(
-                StatusCode::UNAUTHORIZED,
-                "Your Studio session expired. Sign in again.",
-            )
-        })?;
-    let db = shared_db(state).map_err(|error| {
-        terminal_storage_error("open coding agent storage", api_error_message(error))
-    })?;
-    let thread = db
-        .rt_get_thread_in_scope(&scope, org, thread_id)
-        .map_err(|error| terminal_storage_error("load chat for coding agent request", error))?
-        .ok_or_else(|| {
-            ApiError::not_found("This chat is no longer available. Refresh Studio and try again.")
-        })?;
-    if thread.created_by != scope.user_id {
-        return Err(ApiError::new(
-            StatusCode::FORBIDDEN,
-            "Only the chat owner can control this coding agent.",
-        ));
-    }
-    if thread.hidden {
-        return Err(ApiError::conflict(
-            "This chat is archived. Restore it before opening the coding agent.",
-        ));
-    }
-    let fence = db
-        .rt_thread_fence_in_scope(&scope, org, thread_id)
-        .map_err(|error| terminal_storage_error("load chat ownership state", error))?
-        .ok_or_else(|| {
-            ApiError::not_found("This chat is no longer available. Refresh Studio and try again.")
-        })?;
-    Ok((db, scope, fence))
+) -> ApiResult<(&'static ThreadsDb, RtThreadFence)> {
+    let resolved =
+        authority::resolve_current_thread(state, org, thread_id, ThreadAccess::ActiveOwner).await?;
+    Ok((resolved.db, resolved.fence))
 }
 
 fn metadata_for(
@@ -1987,7 +2445,7 @@ fn terminal_storage_error(context: &'static str, error: impl std::fmt::Display) 
 
 fn parse_harness(value: &str) -> ApiResult<HarnessId> {
     match value {
-        "claude" | "claude-code" => Ok(HarnessId::ClaudeCode),
+        "claude-code" => Ok(HarnessId::ClaudeCode),
         "codex" => Ok(HarnessId::Codex),
         "opencode" => Ok(HarnessId::OpenCode),
         _ => Err(ApiError::bad_request(
@@ -2114,14 +2572,71 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use crate::routes::threads::db::RtThreadPatch;
+
     use super::*;
 
+    fn terminal_preparation_fixture(
+        thread_id: &str,
+    ) -> (
+        &'static ThreadsDb,
+        RtThreadFence,
+        Arc<crate::terminal::AgentSessionRegistry>,
+    ) {
+        let db = Box::leak(Box::new(ThreadsDb::open_in_memory().unwrap()));
+        db.rt_create_thread(
+            Some(thread_id),
+            "org",
+            "",
+            None,
+            "vmcp",
+            None,
+            "local-desktop-user",
+        )
+        .unwrap();
+        let fence = db
+            .rt_thread_fence_in_org("org", thread_id)
+            .unwrap()
+            .unwrap();
+        (db, fence, crate::terminal::AgentSessionRegistry::new())
+    }
+
+    #[tokio::test]
+    async fn account_epoch_preempts_stalled_and_ready_terminal_delivery() {
+        let root = tempfile::tempdir().unwrap();
+        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf());
+
+        let epoch = manager.account_epoch();
+        let mut stalled_rx = manager.watch_account_epoch(epoch).unwrap();
+        let stalled = tokio::spawn(async move {
+            until_account_change(&mut stalled_rx, std::future::pending::<()>()).await
+        });
+        tokio::task::yield_now().await;
+        let transition = manager.begin_account_transition().await.unwrap();
+        assert!(tokio::time::timeout(Duration::from_secs(1), stalled)
+            .await
+            .expect("stalled terminal wait must be canceled promptly")
+            .unwrap()
+            .is_none());
+        drop(transition);
+
+        let epoch = manager.account_epoch();
+        let mut ready_rx = manager.watch_account_epoch(epoch).unwrap();
+        let transition = manager.begin_account_transition().await.unwrap();
+        assert_eq!(
+            until_account_change(&mut ready_rx, std::future::ready("account-a-bytes")).await,
+            None,
+            "an epoch change must win over an already-ready sensitive frame"
+        );
+        drop(transition);
+    }
+
     #[test]
-    fn protocol_accepts_canonical_and_legacy_claude_ids() {
+    fn protocol_accepts_only_canonical_harness_ids() {
         assert_eq!(parse_harness("claude-code").unwrap(), HarnessId::ClaudeCode);
-        assert_eq!(parse_harness("claude").unwrap(), HarnessId::ClaudeCode);
         assert_eq!(parse_harness("codex").unwrap(), HarnessId::Codex);
         assert_eq!(parse_harness("opencode").unwrap(), HarnessId::OpenCode);
+        assert!(parse_harness("claude").is_err());
         assert!(parse_harness("decopilot").is_err());
     }
 
@@ -2306,6 +2821,11 @@ mod tests {
         let stale_error = launch_preparation_api_error(HarnessId::Codex, &stale);
         assert_eq!(stale_error.status, StatusCode::NOT_FOUND);
         assert_eq!(stale_error.body.get("retryable"), None);
+
+        let canceled = launch_context::LaunchContextError::Canceled;
+        let canceled_error = launch_preparation_api_error(HarnessId::Codex, &canceled);
+        assert_eq!(canceled_error.status, StatusCode::CONFLICT);
+        assert_eq!(canceled_error.body.get("retryable"), None);
     }
 
     #[test]
@@ -2339,6 +2859,215 @@ mod tests {
 
         // Reusing an already-running session remains idempotent.
         reconcile_registered_session(db, &fence, session_id, HarnessId::Codex).unwrap();
+    }
+
+    #[tokio::test]
+    async fn archive_can_win_while_terminal_preparation_is_blocked() {
+        let (db, fence, registry) = terminal_preparation_fixture("preparing-archive");
+        let start_lock = registry.start_lock(&fence);
+        let admission = start_lock.clone().lock_owned().await;
+        let (session_id, preparation) =
+            reserve_durable_start(&registry, db, &fence, HarnessId::Codex).unwrap();
+        drop(admission);
+
+        let (blocked_tx, blocked_rx) = tokio::sync::oneshot::channel();
+        let task_fence = fence.clone();
+        let task_session_id = session_id.clone();
+        let task_lock = start_lock.clone();
+        let prepared = tokio::spawn(async move {
+            let phase = preparation.begin_phase().unwrap();
+            let cancellation = phase.cancellation();
+            blocked_tx.send(()).unwrap();
+            cancellation.cancelled().await;
+            drop(phase);
+            let _spawn_guard = task_lock.lock_owned().await;
+            let result =
+                validate_exact_durable_start(db, &task_fence, &task_session_id, &preparation);
+            if result.is_err() {
+                mark_starting_session_exited_if_present(
+                    db,
+                    &task_fence,
+                    &task_session_id,
+                    "archive won terminal preparation",
+                    false,
+                );
+            }
+            result
+        });
+        blocked_rx.await.unwrap();
+
+        let archive_guard = tokio::time::timeout(Duration::from_secs(1), start_lock.lock_owned())
+            .await
+            .expect("preparation must not retain the thread lifecycle lock");
+        db.rt_update_thread_in_org(
+            "org",
+            "preparing-archive",
+            "local-desktop-user",
+            &RtThreadPatch {
+                hidden: Some(true),
+                ..RtThreadPatch::default()
+            },
+        )
+        .unwrap()
+        .unwrap();
+        registry.cancel_preparation(&fence).wait().await.unwrap();
+        drop(archive_guard);
+
+        assert_eq!(
+            prepared.await.unwrap().unwrap_err().status,
+            StatusCode::CONFLICT
+        );
+        let row = db
+            .rt_get_terminal_session_fenced(&fence, &session_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.physical_state, RtTerminalPhysicalState::Exited);
+        assert!(db.rt_get_thread_for_fence(&fence).unwrap().unwrap().hidden);
+    }
+
+    #[tokio::test]
+    async fn delete_can_win_while_terminal_preparation_is_blocked() {
+        let (db, fence, registry) = terminal_preparation_fixture("preparing-delete");
+        let start_lock = registry.start_lock(&fence);
+        let admission = start_lock.clone().lock_owned().await;
+        let (session_id, preparation) =
+            reserve_durable_start(&registry, db, &fence, HarnessId::Codex).unwrap();
+        drop(admission);
+
+        let (blocked_tx, blocked_rx) = tokio::sync::oneshot::channel();
+        let task_fence = fence.clone();
+        let task_session_id = session_id.clone();
+        let task_lock = start_lock.clone();
+        let prepared = tokio::spawn(async move {
+            let phase = preparation.begin_phase().unwrap();
+            let cancellation = phase.cancellation();
+            blocked_tx.send(()).unwrap();
+            cancellation.cancelled().await;
+            drop(phase);
+            let _spawn_guard = task_lock.lock_owned().await;
+            let result =
+                validate_exact_durable_start(db, &task_fence, &task_session_id, &preparation);
+            if result.is_err() {
+                mark_starting_session_exited_if_present(
+                    db,
+                    &task_fence,
+                    &task_session_id,
+                    "delete won terminal preparation",
+                    true,
+                );
+            }
+            result
+        });
+        blocked_rx.await.unwrap();
+
+        let delete_guard = tokio::time::timeout(Duration::from_secs(1), start_lock.lock_owned())
+            .await
+            .expect("preparation must not retain the thread lifecycle lock");
+        registry.cancel_preparation(&fence).wait().await.unwrap();
+        assert!(db.rt_delete_thread_in_org_if_generation(&fence).unwrap());
+        drop(delete_guard);
+
+        assert!(prepared.await.unwrap().is_err());
+        assert!(db
+            .rt_get_terminal_session_fenced(&fence, &session_id)
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn account_replacement_cancels_a_blocked_terminal_preparation() {
+        let (db, fence, registry) = terminal_preparation_fixture("preparing-account-switch");
+        let start_lock = registry.start_lock(&fence);
+        let admission = start_lock.clone().lock_owned().await;
+        let (session_id, preparation) =
+            reserve_durable_start(&registry, db, &fence, HarnessId::Codex).unwrap();
+        drop(admission);
+
+        let (blocked_tx, blocked_rx) = tokio::sync::oneshot::channel();
+        let task_fence = fence.clone();
+        let task_session_id = session_id.clone();
+        let task_lock = start_lock.clone();
+        let prepared = tokio::spawn(async move {
+            let phase = preparation.begin_phase().unwrap();
+            let cancellation = phase.cancellation();
+            blocked_tx.send(()).unwrap();
+            cancellation.cancelled().await;
+            drop(phase);
+            let _spawn_guard = task_lock.lock_owned().await;
+            let result =
+                validate_exact_durable_start(db, &task_fence, &task_session_id, &preparation);
+            if result.is_err() {
+                mark_starting_session_exited_if_present(
+                    db,
+                    &task_fence,
+                    &task_session_id,
+                    "account changed during terminal preparation",
+                    false,
+                );
+            }
+            result
+        });
+        blocked_rx.await.unwrap();
+
+        assert!(registry.terminate_all().await.is_empty());
+
+        assert_eq!(
+            prepared.await.unwrap().unwrap_err().status,
+            StatusCode::CONFLICT
+        );
+        assert_eq!(
+            db.rt_get_terminal_session_fenced(&fence, &session_id)
+                .unwrap()
+                .unwrap()
+                .physical_state,
+            RtTerminalPhysicalState::Exited
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_start_keeps_the_exact_in_process_preparation() {
+        let (db, fence, registry) = terminal_preparation_fixture("preparing-concurrent");
+        let _admission = registry.start_lock(&fence).lock_owned().await;
+        let (session_id, _preparation) =
+            reserve_durable_start(&registry, db, &fence, HarnessId::Codex).unwrap();
+
+        let error = match reserve_durable_start(&registry, db, &fence, HarnessId::Codex) {
+            Ok(_) => panic!("a concurrent start replaced an active preparation"),
+            Err(error) => error,
+        };
+        assert_eq!(error.status, StatusCode::CONFLICT);
+        let live = db
+            .rt_get_live_terminal_session_fenced(&fence)
+            .unwrap()
+            .unwrap();
+        assert_eq!(live.id, session_id);
+        assert_eq!(live.physical_state, RtTerminalPhysicalState::Starting);
+    }
+
+    #[test]
+    fn stale_starting_row_without_a_process_reservation_self_heals() {
+        let (db, fence, registry) = terminal_preparation_fixture("preparing-stale-restart");
+        db.rt_create_terminal_session_fenced(&fence, "stale-session", "claude-code")
+            .unwrap();
+
+        let (replacement_id, _preparation) =
+            reserve_durable_start(&registry, db, &fence, HarnessId::Codex).unwrap();
+
+        assert_ne!(replacement_id, "stale-session");
+        assert_eq!(
+            db.rt_get_terminal_session_fenced(&fence, "stale-session")
+                .unwrap()
+                .unwrap()
+                .physical_state,
+            RtTerminalPhysicalState::Exited
+        );
+        assert_eq!(
+            db.rt_get_terminal_session_fenced(&fence, &replacement_id)
+                .unwrap()
+                .unwrap()
+                .physical_state,
+            RtTerminalPhysicalState::Starting
+        );
     }
 
     #[test]
@@ -2450,6 +3179,27 @@ mod tests {
                 ..
             } if harness_id == "codex" && prompt == "hello"
         ));
+        assert!(parse_client_frame(
+            r#"{"type":"start","harness_id":"codex","rows":30,"cols":100}"#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn terminal_protocol_rejects_mixed_canonical_and_retired_fields() {
+        assert!(serde_json::from_value::<StartTerminalBody>(json!({
+            "harnessId": "codex",
+            "harness_id": "claude-code",
+        }))
+        .is_err());
+        assert!(parse_client_frame(
+            r#"{"type":"start","harnessId":"codex","harness_id":"claude-code","rows":30,"cols":100}"#,
+        )
+        .is_err());
+        assert!(parse_client_frame(
+            r#"{"type":"attach","afterSeq":7,"after_seq":0,"rows":30,"cols":100}"#,
+        )
+        .is_err());
     }
 
     #[test]

--- a/apps/native/crates/local-api/src/routes/threads.rs
+++ b/apps/native/crates/local-api/src/routes/threads.rs
@@ -6,6 +6,7 @@
 //! intentionally absent. The SQLite schema remains compatible with existing
 //! installations while its `rt_*` methods own the terminal-specific state.
 
+pub(crate) mod authority;
 pub(crate) mod db;
 
 use std::sync::OnceLock;

--- a/apps/native/crates/local-api/src/routes/threads/authority.rs
+++ b/apps/native/crates/local-api/src/routes/threads/authority.rs
@@ -1,0 +1,213 @@
+//! Canonical native account and thread authority resolution.
+
+use axum::http::StatusCode;
+
+use super::db::{RtAccountScope, RtThread, RtThreadFence, ThreadsDb};
+use super::shared_db;
+use crate::error::{ApiError, ApiResult};
+use crate::state::AppState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ThreadAccess {
+    Viewer,
+    Owner,
+    ActiveOwner,
+}
+
+pub(crate) struct ResolvedThread {
+    pub db: &'static ThreadsDb,
+    pub thread: RtThread,
+    pub fence: RtThreadFence,
+}
+
+#[cfg(not(test))]
+pub(crate) async fn current_account_scope_result(
+) -> Result<Option<RtAccountScope>, upstream::tokens::TokenStoreError> {
+    let session = upstream::global();
+    let Some(user_id) = session.current_user_sub_result().await? else {
+        return Ok(None);
+    };
+    Ok(RtAccountScope::new(session.host(), user_id))
+}
+
+#[cfg(test)]
+pub(crate) async fn current_account_scope_result(
+) -> Result<Option<RtAccountScope>, upstream::tokens::TokenStoreError> {
+    Ok(RtAccountScope::new("test.invalid", "local-desktop-user"))
+}
+
+pub(crate) async fn current_account_scope() -> ApiResult<RtAccountScope> {
+    current_account_scope_result()
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "could not load the current Studio account");
+            ApiError::internal(
+                "We couldn't confirm your Studio account. Restart Studio and try again; if needed, sign in again.",
+            )
+        })?
+        .ok_or_else(|| {
+            ApiError::new(
+                StatusCode::UNAUTHORIZED,
+                "Your Studio session expired. Sign in again.",
+            )
+        })
+}
+
+/// Acquires the process-wide account-transition fence and proves it still
+/// names the account that authorized this request. When a thread lifecycle
+/// lock is also required, callers acquire that lock first. Short durable
+/// operations retain both guards through commit; long workspace I/O may drop
+/// the account guard after its admission decision while retaining the
+/// lifecycle guard.
+#[cfg(not(test))]
+pub(crate) async fn lock_account_scope(
+    expected: &RtAccountScope,
+) -> ApiResult<upstream::SessionTransitionGuard> {
+    let session = upstream::global();
+    let transition = session.begin_transition().await;
+    let current_user_id = transition.current_user_sub_result().await.map_err(|error| {
+        tracing::warn!(%error, "could not verify Studio account under transition fence");
+        ApiError::internal(
+            "We couldn't confirm your Studio account. Restart Studio and try again; if needed, sign in again.",
+        )
+    })?;
+    if !account_scope_matches(expected, session.host(), current_user_id.as_deref()) {
+        return Err(ApiError::conflict(
+            "Your Studio account changed while this request was waiting. Try again.",
+        ));
+    }
+    crate::routes::sandbox_account::validate_expected_generation(transition.generation())?;
+    Ok(transition)
+}
+
+#[cfg(test)]
+pub(crate) async fn lock_account_scope(
+    expected: &RtAccountScope,
+) -> ApiResult<upstream::SessionTransitionGuard> {
+    let session = upstream::global();
+    let transition = session.begin_transition().await;
+    if !account_scope_matches(expected, "test.invalid", Some("local-desktop-user")) {
+        return Err(ApiError::conflict(
+            "Your Studio account changed while this request was waiting. Try again.",
+        ));
+    }
+    crate::routes::sandbox_account::validate_expected_generation(transition.generation())?;
+    Ok(transition)
+}
+
+fn account_scope_matches(
+    expected: &RtAccountScope,
+    current_host: &str,
+    current_user_id: Option<&str>,
+) -> bool {
+    current_user_id
+        .and_then(|user_id| RtAccountScope::new(current_host, user_id))
+        .is_some_and(|current| current == *expected)
+}
+
+pub(crate) async fn resolve_current_thread(
+    state: &AppState,
+    organization_id: &str,
+    thread_id: &str,
+    access: ThreadAccess,
+) -> ApiResult<ResolvedThread> {
+    let scope = current_account_scope().await?;
+    resolve_scoped_thread(state, scope, organization_id, thread_id, access)
+}
+
+pub(crate) fn resolve_scoped_thread(
+    state: &AppState,
+    scope: RtAccountScope,
+    organization_id: &str,
+    thread_id: &str,
+    access: ThreadAccess,
+) -> ApiResult<ResolvedThread> {
+    let db = shared_db(state).map_err(|error| {
+        tracing::warn!(
+            ?error,
+            "could not open native thread storage for authority check"
+        );
+        ApiError::internal("We couldn't load this chat right now. Try again.")
+    })?;
+    let (thread, fence, delete_pending) = db
+        .rt_get_thread_and_fence_in_scope(&scope, organization_id, thread_id)
+        .map_err(|error| {
+            tracing::warn!(%error, "could not resolve native thread authority");
+            ApiError::internal("We couldn't load this chat right now. Try again.")
+        })?
+        .ok_or_else(|| ApiError::not_found("thread not found"))?;
+
+    enforce_thread_access(
+        access,
+        &thread.created_by,
+        &scope.user_id,
+        thread.hidden,
+        delete_pending,
+    )?;
+
+    Ok(ResolvedThread { db, thread, fence })
+}
+
+fn enforce_thread_access(
+    access: ThreadAccess,
+    created_by: &str,
+    current_user_id: &str,
+    hidden: bool,
+    delete_pending: bool,
+) -> ApiResult<()> {
+    if matches!(access, ThreadAccess::Owner | ThreadAccess::ActiveOwner)
+        && created_by != current_user_id
+    {
+        return Err(ApiError::new(
+            StatusCode::FORBIDDEN,
+            "Only the chat owner can change this chat.",
+        ));
+    }
+    if access == ThreadAccess::ActiveOwner && delete_pending {
+        return Err(ApiError::conflict("This chat is being deleted."));
+    }
+    if access == ThreadAccess::ActiveOwner && hidden {
+        return Err(ApiError::conflict(
+            "This chat is archived. Restore it before opening the coding agent.",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_owner_rejects_delete_pending_while_owner_retry_remains_allowed() {
+        assert!(enforce_thread_access(ThreadAccess::Owner, "user", "user", false, true).is_ok());
+        let error = enforce_thread_access(ThreadAccess::ActiveOwner, "user", "user", false, true)
+            .unwrap_err();
+        assert_eq!(error.status, StatusCode::CONFLICT);
+        assert_eq!(
+            error.body,
+            serde_json::json!({"error": "This chat is being deleted."})
+        );
+    }
+
+    #[test]
+    fn transition_scope_requires_the_same_host_and_subject() {
+        let expected = RtAccountScope::new("studio.example", "user-a").unwrap();
+        assert!(account_scope_matches(
+            &expected,
+            "STUDIO.EXAMPLE",
+            Some("user-a")
+        ));
+        assert!(!account_scope_matches(
+            &expected,
+            "studio.example",
+            Some("user-b")
+        ));
+        assert!(!account_scope_matches(
+            &expected,
+            "other.example",
+            Some("user-a")
+        ));
+        assert!(!account_scope_matches(&expected, "studio.example", None));
+    }
+}

--- a/apps/native/crates/local-api/src/routes/threads/db.rs
+++ b/apps/native/crates/local-api/src/routes/threads/db.rs
@@ -713,6 +713,10 @@ pub enum DbError {
         organization_id: String,
         thread_id: String,
     },
+    ThreadWorkspaceLocked {
+        organization_id: String,
+        thread_id: String,
+    },
     InvalidTerminalSessionData(String),
 }
 
@@ -755,6 +759,13 @@ impl std::fmt::Display for DbError {
             } => write!(
                 f,
                 "thread deletion is pending: {organization_id}/{thread_id}"
+            ),
+            DbError::ThreadWorkspaceLocked {
+                organization_id,
+                thread_id,
+            } => write!(
+                f,
+                "thread workspace identity is locked: {organization_id}/{thread_id}"
             ),
             DbError::InvalidTerminalSessionData(message) => {
                 write!(f, "invalid terminal session data: {message}")
@@ -1475,6 +1486,45 @@ impl ThreadsDb {
         rt_thread_by_id_in_scope(&conn, &scope.storage_key(), organization_id, id)
     }
 
+    /// Reads a thread, its generation fence, and durable deletion gate from
+    /// the same SQLite snapshot. Authority checks use this tuple so a later
+    /// side effect never combines state from two lifecycle moments.
+    pub fn rt_get_thread_and_fence_in_scope(
+        &self,
+        scope: &RtAccountScope,
+        organization_id: &str,
+        id: &str,
+    ) -> DbResult<Option<(RtThread, RtThreadFence, bool)>> {
+        self.adopt_legacy_account_rows(scope, organization_id)?;
+        let account_scope = scope.storage_key();
+        let conn = self.lock();
+        conn.query_row(
+            &format!(
+                "SELECT {RT_THREAD_COLUMNS}, generation, delete_pending \
+                 FROM native_scoped_threads \
+                 WHERE account_scope = ?1 AND organization_id = ?2 AND id = ?3"
+            ),
+            params![account_scope, organization_id, id],
+            |row| {
+                let thread = row_to_rt_thread(row)?;
+                let generation = row.get(18)?;
+                let delete_pending = row.get(19)?;
+                Ok((
+                    thread,
+                    RtThreadFence {
+                        account_scope: account_scope.clone(),
+                        organization_id: organization_id.to_string(),
+                        thread_id: id.to_string(),
+                        generation,
+                    },
+                    delete_pending,
+                ))
+            },
+        )
+        .optional()
+        .map_err(DbError::from)
+    }
+
     #[cfg(test)]
     pub fn rt_get_thread_in_org(
         &self,
@@ -1658,6 +1708,68 @@ impl ThreadsDb {
         Ok((out, total))
     }
 
+    /// Preflights a workspace-identity patch while a caller holds the
+    /// process-local terminal start lock. Archiving must stop a live terminal
+    /// before it writes `hidden`; this check prevents that stop from erasing
+    /// the very `starting`/`running` evidence that should reject a combined
+    /// branch or virtual-MCP change. The update transaction repeats the gate
+    /// as the storage-level authority fence.
+    pub fn rt_validate_workspace_identity_patch_fenced(
+        &self,
+        fence: &RtThreadFence,
+        patch: &RtThreadPatch,
+    ) -> DbResult<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let gate: Option<(bool, Option<String>, String, bool)> = tx
+            .query_row(
+                "SELECT delete_pending, branch, virtual_mcp_id, \
+                     harness_id IS NOT NULL OR EXISTS(\
+                         SELECT 1 FROM native_terminal_sessions \
+                         WHERE account_scope = ?1 AND organization_id = ?2 AND thread_id = ?3 \
+                           AND thread_generation = ?4 \
+                           AND physical_state IN ('starting', 'running')\
+                     ) \
+                 FROM native_scoped_threads \
+                 WHERE account_scope = ?1 AND organization_id = ?2 AND id = ?3 \
+                   AND generation = ?4",
+                params![
+                    fence.account_scope,
+                    fence.organization_id,
+                    fence.thread_id,
+                    fence.generation,
+                ],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()?;
+        let Some((delete_pending, branch, virtual_mcp_id, workspace_locked)) = gate else {
+            return Err(DbError::StaleThreadGeneration {
+                organization_id: fence.organization_id.clone(),
+                thread_id: fence.thread_id.clone(),
+                generation: fence.generation.clone(),
+            });
+        };
+        if delete_pending {
+            return Err(DbError::ThreadDeletePending {
+                organization_id: fence.organization_id.clone(),
+                thread_id: fence.thread_id.clone(),
+            });
+        }
+        let changes_workspace_identity = patch.branch.as_ref().is_some_and(|next| next != &branch)
+            || patch
+                .virtual_mcp_id
+                .as_ref()
+                .is_some_and(|next| next != &virtual_mcp_id);
+        if changes_workspace_identity && workspace_locked {
+            return Err(DbError::ThreadWorkspaceLocked {
+                organization_id: fence.organization_id.clone(),
+                thread_id: fence.thread_id.clone(),
+            });
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Applies `patch`'s present fields, bumps `updated_at`, and returns the
     /// resulting row — `None` if `id` doesn't exist. A patch with every
     /// field `None` still bumps `updated_at` (matches
@@ -1672,6 +1784,9 @@ impl ThreadsDb {
         patch: &RtThreadPatch,
     ) -> DbResult<Option<RtThread>> {
         self.adopt_legacy_account_rows(scope, organization_id)?;
+        if updated_by != scope.user_id {
+            return Ok(None);
+        }
         let ts = now_rfc3339();
         let mut sets = vec![
             "updated_at = ?1".to_string(),
@@ -1715,31 +1830,66 @@ impl ThreadsDb {
         let scope_placeholder = sql_params.len() + 1;
         let account_scope = scope.storage_key();
         sql_params.push(Box::new(account_scope.clone()));
+        let owner_placeholder = sql_params.len() + 1;
+        sql_params.push(Box::new(scope.user_id.clone()));
         let sql = format!(
             "UPDATE native_scoped_threads SET {} \
              WHERE id = ?{id_placeholder} AND organization_id = ?{org_placeholder} \
-               AND account_scope = ?{scope_placeholder}",
+               AND account_scope = ?{scope_placeholder} AND created_by = ?{owner_placeholder}",
             sets.join(", "),
         );
         let mut conn = self.lock();
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let delete_pending: Option<bool> = tx
+        let gate: Option<(bool, String, Option<String>, String)> = tx
             .query_row(
-                "SELECT delete_pending FROM native_scoped_threads \
+                "SELECT delete_pending, created_by, branch, virtual_mcp_id \
+                 FROM native_scoped_threads \
                  WHERE id = ?1 AND organization_id = ?2 AND account_scope = ?3",
                 params![id, organization_id, account_scope],
-                |row| row.get(0),
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
             )
             .optional()?;
-        let Some(delete_pending) = delete_pending else {
+        let Some((delete_pending, created_by, current_branch, current_virtual_mcp_id)) = gate
+        else {
             tx.commit()?;
             return Ok(None);
         };
+        if created_by != scope.user_id {
+            tx.commit()?;
+            return Ok(None);
+        }
         if delete_pending {
             return Err(DbError::ThreadDeletePending {
                 organization_id: organization_id.to_string(),
                 thread_id: id.to_string(),
             });
+        }
+        let changes_workspace_identity = patch
+            .branch
+            .as_ref()
+            .is_some_and(|branch| branch != &current_branch)
+            || patch
+                .virtual_mcp_id
+                .as_ref()
+                .is_some_and(|virtual_mcp_id| virtual_mcp_id != &current_virtual_mcp_id);
+        if changes_workspace_identity {
+            let workspace_locked: bool = tx.query_row(
+                "SELECT harness_id IS NOT NULL OR EXISTS(\
+                     SELECT 1 FROM native_terminal_sessions \
+                     WHERE account_scope = ?1 AND organization_id = ?2 AND thread_id = ?3 \
+                       AND thread_generation = native_scoped_threads.generation \
+                       AND physical_state IN ('starting', 'running')\
+                 ) FROM native_scoped_threads \
+                 WHERE account_scope = ?1 AND organization_id = ?2 AND id = ?3",
+                params![account_scope, organization_id, id],
+                |row| row.get(0),
+            )?;
+            if workspace_locked {
+                return Err(DbError::ThreadWorkspaceLocked {
+                    organization_id: organization_id.to_string(),
+                    thread_id: id.to_string(),
+                });
+            }
         }
         let changed = tx.execute(
             &sql,
@@ -1785,28 +1935,51 @@ impl ThreadsDb {
         self.rt_delete_thread_in_org_if_generation(&fence)
     }
 
-    /// Generation-fenced delete for lifecycle shutdown. The durable tombstone,
-    /// thread deletion, and child-row cascades commit atomically: after a
-    /// successful return, neither a delayed request nor a process restart can
-    /// recreate this public id inside the same account + organization scope.
+    /// Test-only bypass for exercising generation/tombstone invariants without
+    /// a request authority layer.
+    #[cfg(test)]
     pub fn rt_delete_thread_in_org_if_generation(&self, fence: &RtThreadFence) -> DbResult<bool> {
+        self.rt_delete_thread_if_generation(fence, None)
+    }
+
+    /// User-facing generation-fenced delete. The owner predicate is checked
+    /// inside the same transaction that writes the tombstone and cascades the
+    /// thread, so a viewer can never advance the deletion lifecycle.
+    pub fn rt_delete_owned_thread_if_generation(
+        &self,
+        fence: &RtThreadFence,
+        owner_id: &str,
+    ) -> DbResult<bool> {
+        self.rt_delete_thread_if_generation(fence, Some(owner_id))
+    }
+
+    fn rt_delete_thread_if_generation(
+        &self,
+        fence: &RtThreadFence,
+        owner_id: Option<&str>,
+    ) -> DbResult<bool> {
         let mut conn = self.lock();
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let owns_generation: bool = tx.query_row(
-            "SELECT EXISTS(\
-                 SELECT 1 FROM native_scoped_threads \
+        let created_by: Option<String> = tx
+            .query_row(
+                "SELECT created_by FROM native_scoped_threads \
                  WHERE id = ?1 AND organization_id = ?2 AND generation = ?3 \
-                   AND account_scope = ?4\
-             )",
-            params![
-                fence.thread_id,
-                fence.organization_id,
-                fence.generation,
-                fence.account_scope,
-            ],
-            |row| row.get(0),
-        )?;
-        if !owns_generation {
+                   AND account_scope = ?4",
+                params![
+                    fence.thread_id,
+                    fence.organization_id,
+                    fence.generation,
+                    fence.account_scope,
+                ],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let authorized = match (created_by.as_deref(), owner_id) {
+            (Some(_), None) => true,
+            (Some(created_by), Some(owner_id)) => created_by == owner_id,
+            (None, _) => false,
+        };
+        if !authorized {
             tx.commit()?;
             return Ok(false);
         }
@@ -4967,6 +5140,158 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
         assert_eq!(unchanged.harness_id, None);
         assert_eq!(unchanged.branch, None);
         assert!(db.rt_get_message("cross-org-message").unwrap().is_none());
+    }
+
+    #[test]
+    fn user_facing_thread_mutations_require_the_current_owner() {
+        let db = ThreadsDb::open_in_memory().unwrap();
+        let scope = RtAccountScope::test_default();
+        db.rt_create_thread_scoped(
+            &scope,
+            Some("teammate-thread"),
+            "org",
+            "Teammate chat",
+            None,
+            "vmcp",
+            None,
+            "teammate-user",
+        )
+        .unwrap();
+        let (_, fence, _) = db
+            .rt_get_thread_and_fence_in_scope(&scope, "org", "teammate-thread")
+            .unwrap()
+            .unwrap();
+
+        assert!(db
+            .rt_update_thread_in_scope(
+                &scope,
+                "org",
+                "teammate-thread",
+                &scope.user_id,
+                &RtThreadPatch {
+                    title: Some("hijacked".to_string()),
+                    ..RtThreadPatch::default()
+                },
+            )
+            .unwrap()
+            .is_none());
+        assert!(!db
+            .rt_delete_owned_thread_if_generation(&fence, &scope.user_id)
+            .unwrap());
+        assert_eq!(
+            db.rt_get_thread_in_scope(&scope, "org", "teammate-thread")
+                .unwrap()
+                .unwrap()
+                .title,
+            "Teammate chat"
+        );
+    }
+
+    #[test]
+    fn workspace_identity_locks_at_terminal_reservation_or_harness_pin() {
+        let db = ThreadsDb::open_in_memory().unwrap();
+        let scope = RtAccountScope::test_default();
+        let owner = scope.user_id.clone();
+        db.rt_create_thread_scoped(
+            &scope,
+            Some("starting-thread"),
+            "org",
+            "Starting chat",
+            None,
+            "vmcp-a",
+            Some("main"),
+            &owner,
+        )
+        .unwrap();
+        let (_, starting_fence, _) = db
+            .rt_get_thread_and_fence_in_scope(&scope, "org", "starting-thread")
+            .unwrap()
+            .unwrap();
+
+        let mutable = db
+            .rt_update_thread_in_scope(
+                &scope,
+                "org",
+                "starting-thread",
+                &owner,
+                &RtThreadPatch {
+                    branch: Some(Some("feature".to_string())),
+                    virtual_mcp_id: Some("vmcp-b".to_string()),
+                    ..RtThreadPatch::default()
+                },
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(mutable.branch.as_deref(), Some("feature"));
+        assert_eq!(mutable.virtual_mcp_id, "vmcp-b");
+
+        created_terminal(
+            db.rt_create_terminal_session_fenced(&starting_fence, "terminal-starting", "codex")
+                .unwrap(),
+        );
+        let metadata_only = db
+            .rt_update_thread_in_scope(
+                &scope,
+                "org",
+                "starting-thread",
+                &owner,
+                &RtThreadPatch {
+                    title: Some("Still mutable metadata".to_string()),
+                    branch: Some(Some("feature".to_string())),
+                    virtual_mcp_id: Some("vmcp-b".to_string()),
+                    ..RtThreadPatch::default()
+                },
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(metadata_only.title, "Still mutable metadata");
+        for patch in [
+            RtThreadPatch {
+                branch: Some(Some("other".to_string())),
+                ..RtThreadPatch::default()
+            },
+            RtThreadPatch {
+                virtual_mcp_id: Some("vmcp-c".to_string()),
+                ..RtThreadPatch::default()
+            },
+        ] {
+            assert!(matches!(
+                db.rt_update_thread_in_scope(&scope, "org", "starting-thread", &owner, &patch,),
+                Err(DbError::ThreadWorkspaceLocked { .. })
+            ));
+        }
+
+        db.rt_create_thread_scoped(
+            &scope,
+            Some("pinned-thread"),
+            "org",
+            "Pinned chat",
+            None,
+            "vmcp-a",
+            Some("main"),
+            &owner,
+        )
+        .unwrap();
+        let (_, pinned_fence, _) = db
+            .rt_get_thread_and_fence_in_scope(&scope, "org", "pinned-thread")
+            .unwrap()
+            .unwrap();
+        assert!(db
+            .rt_pin_harness_if_unset_fenced(&pinned_fence, "opencode", None, None)
+            .unwrap());
+        assert!(matches!(
+            db.rt_update_thread_in_scope(
+                &scope,
+                "org",
+                "pinned-thread",
+                &owner,
+                &RtThreadPatch {
+                    branch: Some(None),
+                    ..RtThreadPatch::default()
+                },
+            ),
+            Err(DbError::ThreadWorkspaceLocked { .. })
+        ));
     }
 
     #[test]

--- a/apps/native/crates/local-api/src/routes/upstream.rs
+++ b/apps/native/crates/local-api/src/routes/upstream.rs
@@ -98,6 +98,7 @@
 //! never reaches the webview" invariant uniform across every branch of this
 //! proxy even though this particular route would never trigger it.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use axum::{
@@ -107,6 +108,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use futures::StreamExt;
 use serde_json::json;
 
 use crate::error::ApiError;
@@ -146,6 +148,219 @@ const UPSTREAM_HEADERS_TIMEOUT: Duration = Duration::from_secs(30);
 /// dev-server-sized responses).
 const MAX_UPSTREAM_BODY_BYTES: usize = 25 * 1024 * 1024;
 
+const STALE_UPSTREAM_IDENTITY: &str =
+    "Your Studio account changed while this request was running. Try again.";
+
+/// One generic upstream request's authenticated-account ticket.
+///
+/// Admission captures both independently-moving native boundaries while the
+/// upstream subject-transition gate is held: the upstream identity generation
+/// and the sandbox/materialization account epoch. Two subscriptions for each
+/// boundary avoid a validate/subscribe gap: one pair rejects stale credential
+/// selection and retries, while the untouched pair terminates the eventual
+/// response body even when bytes are already queued in reqwest.
+struct UpstreamRequestTicket {
+    identity_generation: u64,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    sandbox_manager: Arc<crate::sandbox::SandboxManager>,
+    validation_identity_rx: tokio::sync::broadcast::Receiver<upstream::SessionIdentityEvent>,
+    body_identity_rx: tokio::sync::broadcast::Receiver<upstream::SessionIdentityEvent>,
+    validation_account_rx: tokio::sync::watch::Receiver<crate::sandbox::manager::AccountEpoch>,
+    body_account_rx: tokio::sync::watch::Receiver<crate::sandbox::manager::AccountEpoch>,
+}
+
+impl UpstreamRequestTicket {
+    async fn capture(
+        state: &AppState,
+        session: &upstream::UpstreamSession,
+    ) -> Result<Self, ApiError> {
+        let authorization = super::sandbox_account::authorize(state).await?;
+        let account_epoch = authorization.epoch();
+        let identity_generation = authorization.identity_generation();
+
+        // Subscribe before releasing `authorization`'s subject-transition
+        // guard. Account replacement therefore either happened before this
+        // ticket was admitted or is observable by every receiver below.
+        let validation_identity_rx = session.subscribe_identity();
+        let body_identity_rx = session.subscribe_identity();
+        let validation_account_rx = state
+            .sandbox_manager
+            .watch_account_epoch(account_epoch)
+            .map_err(ApiError::conflict)?;
+        let body_account_rx = validation_account_rx.clone();
+
+        Ok(Self {
+            identity_generation,
+            account_epoch,
+            sandbox_manager: state.sandbox_manager.clone(),
+            validation_identity_rx,
+            body_identity_rx,
+            validation_account_rx,
+            body_account_rx,
+        })
+    }
+
+    /// Recreate subscriptions for a previously captured admission ticket.
+    /// Internal launch/sandbox flows carry the original generation+epoch
+    /// through long preparation phases; this rejects them before selecting a
+    /// credential if the account moved in the meantime.
+    async fn capture_expected(
+        state: &AppState,
+        session: &upstream::UpstreamSession,
+        account_epoch: crate::sandbox::manager::AccountEpoch,
+        identity_generation: u64,
+    ) -> Result<Self, ProxyError> {
+        let transition = session.begin_transition().await;
+        if transition.generation() != identity_generation
+            || state
+                .sandbox_manager
+                .validate_account_epoch(account_epoch)
+                .is_err()
+        {
+            return Err(ProxyError::StaleIdentity);
+        }
+
+        let validation_identity_rx = session.subscribe_identity();
+        let body_identity_rx = session.subscribe_identity();
+        let validation_account_rx = state
+            .sandbox_manager
+            .watch_account_epoch(account_epoch)
+            .map_err(|_| ProxyError::StaleIdentity)?;
+        let body_account_rx = validation_account_rx.clone();
+        drop(transition);
+
+        Ok(Self {
+            identity_generation,
+            account_epoch,
+            sandbox_manager: state.sandbox_manager.clone(),
+            validation_identity_rx,
+            body_identity_rx,
+            validation_account_rx,
+            body_account_rx,
+        })
+    }
+
+    fn expected_identity(&self) -> super::sandbox_account::ExpectedIdentity {
+        super::sandbox_account::ExpectedIdentity::new(self.account_epoch, self.identity_generation)
+    }
+
+    /// Reject token/cookie selection and every retry once either account
+    /// boundary has moved. `has_changed()` is deliberately checked without
+    /// comparing values: epoch saturation publishes the same maximum value
+    /// while leaving materialization closed, and must still fail closed.
+    fn validate(&mut self) -> Result<(), ProxyError> {
+        if self
+            .sandbox_manager
+            .validate_account_epoch(self.account_epoch)
+            .is_err()
+            || !matches!(self.validation_account_rx.has_changed(), Ok(false))
+        {
+            return Err(ProxyError::StaleIdentity);
+        }
+
+        match self.validation_identity_rx.try_recv() {
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty) => Ok(()),
+            Ok(event) => {
+                tracing::debug!(
+                    expected_generation = self.identity_generation,
+                    observed_generation = event.generation,
+                    "discarding an upstream request after account replacement"
+                );
+                Err(ProxyError::StaleIdentity)
+            }
+            Err(
+                tokio::sync::broadcast::error::TryRecvError::Lagged(_)
+                | tokio::sync::broadcast::error::TryRecvError::Closed,
+            ) => Err(ProxyError::StaleIdentity),
+        }
+    }
+
+    /// Async counterpart used while buffering a small response that must be
+    /// rewritten before it reaches the caller. A transition cancels the read;
+    /// if the read wins, the caller synchronously validates once more before
+    /// constructing its separately fenced response body.
+    async fn validation_changed(&mut self) {
+        if self.validate().is_err() {
+            return;
+        }
+        tokio::select! {
+            biased;
+            _ = self.validation_account_rx.changed() => {}
+            _ = self.validation_identity_rx.recv() => {}
+        }
+    }
+
+    /// Resolves on the first account notification or identity event. Channel
+    /// closure is terminal too. The caller uses this as a `take_until` fence,
+    /// whose stop future is polled before another upstream body item can be
+    /// yielded to the webview.
+    async fn changed(mut self) {
+        if self
+            .sandbox_manager
+            .validate_account_epoch(self.account_epoch)
+            .is_err()
+            || !matches!(self.body_account_rx.has_changed(), Ok(false))
+        {
+            return;
+        }
+        match self.body_identity_rx.try_recv() {
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty) => {}
+            Ok(_)
+            | Err(
+                tokio::sync::broadcast::error::TryRecvError::Lagged(_)
+                | tokio::sync::broadcast::error::TryRecvError::Closed,
+            ) => return,
+        }
+
+        tokio::select! {
+            biased;
+            // Any account notification is terminal, including a successful
+            // same-value notification at epoch saturation.
+            _ = self.body_account_rx.changed() => {}
+            _ = self.body_identity_rx.recv() => {}
+        }
+    }
+}
+
+/// Clear an invalid credential only if the request that observed the failure
+/// still owns the current subject. Reacquiring the transition guard and
+/// comparing the captured generation closes the otherwise-dangerous gap where
+/// account B could be installed between account A's refresh error and cleanup.
+async fn hard_sign_out_if_ticket_current(
+    state: &AppState,
+    session: &upstream::UpstreamSession,
+    ticket: &mut UpstreamRequestTicket,
+    reason: &str,
+) -> bool {
+    if ticket.validate().is_err() {
+        return false;
+    }
+    // The helper reacquires the subject-transition guard and compares both
+    // captured boundaries before clearing anything.
+    crate::auth_fence::hard_sign_out_upstream_session_if_current(
+        state,
+        session,
+        ticket.identity_generation,
+        ticket.account_epoch,
+        reason,
+    )
+    .await
+}
+
+/// Apply the ingress fence to locally intercepted responses as well. Most
+/// interceptors return small JSON bodies, but wrapping the body stream matters
+/// for watch/SSE and closes the final gap where an account transition lands
+/// after a handler's last authorization check but before axum polls its body.
+fn fence_response_for_identity(response: Response, mut ticket: UpstreamRequestTicket) -> Response {
+    if ticket.validate().is_err() {
+        return ApiError::conflict(STALE_UPSTREAM_IDENTITY).into_response();
+    }
+    let (mut parts, body) = response.into_parts();
+    parts.headers.remove(header::CONTENT_LENGTH);
+    let body = Body::from_stream(body.into_data_stream().take_until(ticket.changed()));
+    Response::from_parts(parts, body)
+}
+
 pub async fn proxy(State(state): State<AppState>, req: Request) -> Response {
     let (parts, body) = req.into_parts();
     let path = parts.uri.path().to_string();
@@ -157,36 +372,105 @@ pub async fn proxy(State(state): State<AppState>, req: Request) -> Response {
 
     tracing::debug!(method = %parts.method, path = %path, "app-api proxy: incoming request");
 
-    let body_bytes = match axum::body::to_bytes(body, MAX_UPSTREAM_BODY_BYTES).await {
+    let session = upstream::global();
+    let auth_path = path_and_query.split('?').next().unwrap_or(&path_and_query);
+    let is_auth_path = path.starts_with(AUTH_PATH_PREFIX);
+    let is_sign_out = parts.method == Method::POST && auth_path == AUTH_SIGN_OUT_PATH;
+    // Login/auth bootstrap and public config are deliberately sessionless.
+    // Sign-out is different: it mutates the current identity, so it must be
+    // admitted for the account that sent it before body buffering too.
+    let needs_identity_ticket = is_sign_out || (!is_auth_path && path != PUBLIC_NO_AUTH_PATH);
+    let mut identity_ticket = if needs_identity_ticket {
+        match UpstreamRequestTicket::capture(&state, &session).await {
+            Ok(ticket) => Some(ticket),
+            Err(error) => return error.into_response(),
+        }
+    } else {
+        None
+    };
+
+    let body_result = if let Some(ticket) = identity_ticket.as_mut() {
+        tokio::select! {
+            biased;
+            _ = ticket.validation_changed() => {
+                return ApiError::conflict(STALE_UPSTREAM_IDENTITY).into_response();
+            }
+            result = axum::body::to_bytes(body, MAX_UPSTREAM_BODY_BYTES) => result,
+        }
+    } else {
+        axum::body::to_bytes(body, MAX_UPSTREAM_BODY_BYTES).await
+    };
+    let body_bytes = match body_result {
         Ok(b) => b,
         Err(err) => {
             return ApiError::payload_too_large(format!("failed to read request body: {err}"))
                 .into_response()
         }
     };
-
-    // The interception table (`routes/intercept/`) is checked FIRST, before
-    // either the cookie-relay or bearer-forwarding branches below — an
-    // intercepted route never talks to upstream at all (not even to decide
-    // whether there's a valid session), so it must never wait on, or be
-    // gated by, this proxy's auth machinery. See that module's doc comment
-    // for the full route table and the map citations behind each entry.
-    if let Some(response) =
-        intercept::try_intercept(&state, &parts.method, &path, parts.uri.query(), &body_bytes).await
+    if identity_ticket
+        .as_mut()
+        .is_some_and(|ticket| ticket.validate().is_err())
     {
-        return response;
+        return ApiError::conflict(STALE_UPSTREAM_IDENTITY).into_response();
     }
 
-    let session = upstream::global();
+    // The interception table (`routes/intercept/`) is checked FIRST, before
+    // either proxy-auth branch below. Interceptors apply their own local
+    // account/thread authority and may make an explicit upstream data lookup;
+    // they never fall through into the generic cookie-relay or bearer-forward
+    // machinery after claiming a route. See that module's doc comment for the
+    // full route table and the map citations behind each entry.
+    if let Some(ticket) = identity_ticket.as_ref() {
+        let expected = ticket.expected_identity();
+        let intercepted = super::sandbox_account::with_expected_identity(
+            expected,
+            intercept::try_intercept(&state, &parts.method, &path, parts.uri.query(), &body_bytes),
+        )
+        .await;
+        if let Some(response) = intercepted {
+            let ticket = identity_ticket
+                .take()
+                .expect("intercepted identity-bound request has an ingress ticket");
+            return fence_response_for_identity(response, ticket);
+        }
+    }
 
-    if path.starts_with(AUTH_PATH_PREFIX) {
-        let auth_path = path_and_query.split('?').next().unwrap_or(&path_and_query);
-        let is_sign_out = parts.method == Method::POST && auth_path == AUTH_SIGN_OUT_PATH;
-        let sign_out_transition = if is_sign_out {
-            Some(session.begin_transition().await)
-        } else {
-            None
-        };
+    if is_auth_path {
+        if is_sign_out {
+            let mut ticket = identity_ticket
+                .take()
+                .expect("sign-out is admitted with an identity ticket");
+            if ticket.validate().is_err() {
+                return ApiError::conflict(STALE_UPSTREAM_IDENTITY).into_response();
+            }
+            let transition = session.begin_transition().await;
+            if transition.generation() != ticket.identity_generation
+                || ticket
+                    .sandbox_manager
+                    .validate_account_epoch(ticket.account_epoch)
+                    .is_err()
+            {
+                return ApiError::conflict(STALE_UPSTREAM_IDENTITY).into_response();
+            }
+            let response = proxy_auth_path(
+                &session,
+                &parts.method,
+                &path_and_query,
+                &parts.headers,
+                &body_bytes,
+            )
+            .await;
+            if response.status().is_success() {
+                transition.logout().await;
+                if let Err(error) = crate::auth_fence::reap_all(&state).await {
+                    tracing::error!(%error, "proxied logout did not reap every coding agent");
+                }
+                return response;
+            }
+            drop(transition);
+            return fence_response_for_identity(response, ticket);
+        }
+
         let response = proxy_auth_path(
             &session,
             &parts.method,
@@ -195,14 +479,6 @@ pub async fn proxy(State(state): State<AppState>, req: Request) -> Response {
             &body_bytes,
         )
         .await;
-        if response.status().is_success() {
-            if let Some(transition) = sign_out_transition {
-                transition.logout().await;
-                if let Err(error) = crate::auth_fence::reap_all(&state.agent_sessions).await {
-                    tracing::error!(%error, "proxied logout did not reap every coding agent");
-                }
-            }
-        }
         return response;
     }
 
@@ -225,7 +501,15 @@ pub async fn proxy(State(state): State<AppState>, req: Request) -> Response {
         .await;
     }
 
-    let access_token = match session.access_token().await {
+    let mut identity_ticket = identity_ticket
+        .take()
+        .expect("generic upstream request has an ingress identity ticket");
+
+    let access_token_result = session.access_token().await;
+    if identity_ticket.validate().is_err() {
+        return ApiError::conflict(STALE_UPSTREAM_IDENTITY).into_response();
+    }
+    let access_token = match access_token_result {
         Ok(token) => token,
         Err(err) if err.kind == upstream::refresh::RefreshErrorKind::Transient => {
             return ApiError::bad_gateway(format!("upstream unreachable: {}", err.message))
@@ -238,19 +522,27 @@ pub async fn proxy(State(state): State<AppState>, req: Request) -> Response {
         // stale local credentials so the NEXT call doesn't repeat a
         // doomed refresh attempt.
         Err(err) => {
-            if err.kind == upstream::refresh::RefreshErrorKind::InvalidGrant {
-                crate::auth_fence::hard_sign_out_upstream_session(
+            if err.kind == upstream::refresh::RefreshErrorKind::InvalidGrant
+                && !hard_sign_out_if_ticket_current(
                     &state,
+                    &session,
+                    &mut identity_ticket,
                     "refresh token rejected while resolving an app-API request",
                 )
-                .await;
+                .await
+            {
+                return ApiError::conflict(STALE_UPSTREAM_IDENTITY).into_response();
             }
             return unauthorized_upstream();
         }
     };
 
     let mut out_headers = build_forward_headers(&parts.headers);
-    let cookie_attached = attach_persisted_cookie(&mut out_headers, &session).await;
+    let selected_cookie = session.cookie_header().await;
+    if identity_ticket.validate().is_err() {
+        return ApiError::conflict(STALE_UPSTREAM_IDENTITY).into_response();
+    }
+    let cookie_attached = attach_cookie_header(&mut out_headers, selected_cookie);
     // A payload we intend to rewrite must arrive uncompressed — reqwest is
     // built without `gzip`, so a compressed body would fail to parse and the
     // rewrite would silently fail open.
@@ -261,25 +553,37 @@ pub async fn proxy(State(state): State<AppState>, req: Request) -> Response {
         );
     }
 
-    match send_with_retry(
+    match send_with_retry_for_identity(
         &session,
-        &parts.method,
-        &path_and_query,
-        &out_headers,
-        &body_bytes,
-        access_token,
-        cookie_attached,
+        RetriableUpstreamRequest {
+            method: parts.method.clone(),
+            path_and_query: &path_and_query,
+            headers: &out_headers,
+            body: &body_bytes,
+            token: access_token,
+            cookie_leads: cookie_attached,
+        },
+        &mut identity_ticket,
     )
     .await
     {
         Ok(upstream_resp) if is_protected_resource_metadata(&path) => {
-            localized_resource_metadata(upstream_resp, session.target(), &parts.headers).await
+            localized_resource_metadata_for_identity(
+                upstream_resp,
+                session.target(),
+                &parts.headers,
+                identity_ticket,
+            )
+            .await
         }
-        Ok(upstream_resp) => build_response(upstream_resp).await,
+        Ok(upstream_resp) => build_response_for_identity(upstream_resp, identity_ticket).await,
         Err(ProxyError::Network(msg)) => {
             ApiError::bad_gateway(format!("upstream unreachable: {msg}")).into_response()
         }
         Err(ProxyError::HardUnauthorized) => unauthorized_upstream(),
+        Err(ProxyError::StaleIdentity) => {
+            ApiError::conflict(STALE_UPSTREAM_IDENTITY).into_response()
+        }
     }
 }
 
@@ -305,16 +609,21 @@ fn is_protected_resource_metadata(path: &str) -> bool {
 /// `authorization_servers` is deliberately left pointing upstream: that IS
 /// where the authorization endpoints live, and this proxy has no OAuth
 /// endpoints of its own to offer instead.
-async fn localized_resource_metadata(
+/// Identity-fenced metadata localization for the generic catchall. Metadata
+/// has to be buffered for rewriting, so account
+/// replacement races both the read itself and the final one-item response
+/// body; both phases are fenced.
+async fn localized_resource_metadata_for_identity(
     upstream: reqwest::Response,
     target: &str,
     request_headers: &HeaderMap,
+    mut ticket: UpstreamRequestTicket,
 ) -> Response {
     if !upstream.status().is_success() {
-        return build_response(upstream).await;
+        return build_response_for_identity(upstream, ticket).await;
     }
     let Some(local_origin) = caller_origin(request_headers) else {
-        return build_response(upstream).await;
+        return build_response_for_identity(upstream, ticket).await;
     };
 
     let status = upstream.status();
@@ -322,19 +631,28 @@ async fn localized_resource_metadata(
     strip_hop_by_hop_headers(&mut headers);
     headers.remove(header::CONTENT_ENCODING);
 
-    let Ok(bytes) = upstream.bytes().await else {
+    let bytes_result = tokio::select! {
+        biased;
+        _ = ticket.validation_changed() => {
+            return ApiError::conflict(STALE_UPSTREAM_IDENTITY).into_response();
+        }
+        result = upstream.bytes() => result,
+    };
+    if ticket.validate().is_err() {
+        return ApiError::conflict(STALE_UPSTREAM_IDENTITY).into_response();
+    }
+    let Ok(bytes) = bytes_result else {
         return ApiError::bad_gateway("upstream metadata body was unreadable").into_response();
     };
-    // Fail OPEN: an unparseable or unchanged body is forwarded verbatim, so a
-    // shape this does not recognize can never break OAuth outright.
+
     let body = rewrite_resource_field(&bytes, target.trim_end_matches('/'), &local_origin)
         .map(axum::body::Bytes::from)
         .unwrap_or(bytes);
     headers.remove(header::CONTENT_LENGTH);
-    let mut res = Response::new(Body::from(body));
-    *res.status_mut() = status;
-    *res.headers_mut() = headers;
-    res
+    let mut response = Response::new(Body::from(body));
+    *response.status_mut() = status;
+    *response.headers_mut() = headers;
+    fence_response_for_identity(response, ticket)
 }
 
 /// The origin the webview used to reach us — `Origin` when it sent one, else
@@ -479,6 +797,9 @@ async fn proxy_auth_path(
         // variant only exists for the bearer-retry branch above.
         Err(ProxyError::HardUnauthorized) => {
             unreachable!("send_once_no_bearer never returns ProxyError::HardUnauthorized")
+        }
+        Err(ProxyError::StaleIdentity) => {
+            unreachable!("send_once_no_bearer is not identity-fenced")
         }
     };
 
@@ -745,7 +1066,15 @@ async fn attach_persisted_cookie(
     headers: &mut HeaderMap,
     session: &upstream::UpstreamSession,
 ) -> bool {
-    let Some(cookie) = session.cookie_header().await else {
+    attach_cookie_header(headers, session.cookie_header().await)
+}
+
+/// Synchronous half of [`attach_persisted_cookie`], used by the generic
+/// proxy after it has selected a cookie and revalidated its account ticket.
+/// Keeping selection separate from attachment makes it impossible to send a
+/// cookie loaded from account B on a request admitted for account A.
+fn attach_cookie_header(headers: &mut HeaderMap, cookie: Option<String>) -> bool {
+    let Some(cookie) = cookie else {
         return false;
     };
     match HeaderValue::from_str(&cookie) {
@@ -798,6 +1127,9 @@ async fn proxy_public_config(
         }
         Err(ProxyError::HardUnauthorized) => {
             unreachable!("send_once_no_bearer never returns ProxyError::HardUnauthorized")
+        }
+        Err(ProxyError::StaleIdentity) => {
+            unreachable!("send_once_no_bearer is not identity-fenced")
         }
     }
 }
@@ -948,6 +1280,9 @@ enum ProxyError {
     /// The independent OAuth probe rejected the credential even after its
     /// normal refresh path. A resource-specific `401` never produces this.
     HardUnauthorized,
+    /// The request was admitted for an account that was replaced before its
+    /// credentials, retry, or response body could be safely consumed.
+    StaleIdentity,
 }
 
 fn proxy_client() -> &'static reqwest::Client {
@@ -978,16 +1313,39 @@ fn proxy_client() -> &'static reqwest::Client {
 /// before it can provision a local sandbox. It fails closed — a signed-out or
 /// unreachable upstream surfaces an error rather than provisioning a sandbox
 /// against a guessed repo.
-pub(crate) async fn call_org_tool(
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum OrgToolCallError {
+    #[error("{STALE_UPSTREAM_IDENTITY}")]
+    StaleIdentity,
+    #[error("{0}")]
+    Failed(String),
+}
+
+pub(crate) async fn call_org_tool_for_identity(
+    state: &AppState,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    identity_generation: u64,
     org: &str,
     tool_name: &str,
     input: &serde_json::Value,
-) -> Result<serde_json::Value, String> {
+) -> Result<serde_json::Value, OrgToolCallError> {
     let session = upstream::global();
-    let token = session
-        .access_token()
-        .await
-        .map_err(|_| "not signed in to the upstream deployment".to_string())?;
+    let mut ticket = UpstreamRequestTicket::capture_expected(
+        state,
+        &session,
+        account_epoch,
+        identity_generation,
+    )
+    .await
+    .map_err(|_| OrgToolCallError::StaleIdentity)?;
+
+    let token_result = session.access_token().await;
+    ticket
+        .validate()
+        .map_err(|_| OrgToolCallError::StaleIdentity)?;
+    let token = token_result.map_err(|_| {
+        OrgToolCallError::Failed("not signed in to the upstream deployment".to_string())
+    })?;
 
     let path = format!(
         "/api/{}/tools/{}",
@@ -1001,41 +1359,66 @@ pub(crate) async fn call_org_tool(
     );
     headers.insert(header::ACCEPT, HeaderValue::from_static("application/json"));
 
-    let body = axum::body::Bytes::from(serde_json::to_vec(input).map_err(|e| e.to_string())?);
+    let body = axum::body::Bytes::from(
+        serde_json::to_vec(input).map_err(|error| OrgToolCallError::Failed(error.to_string()))?,
+    );
     // Same browser-shaped credential rule as the proxy branch: cookie leads,
     // bearer in reserve — tool handlers upstream can make nested Better Auth
     // calls with these headers, and a bearer poisons those (api-key probe).
-    let cookie_attached = attach_persisted_cookie(&mut headers, &session).await;
-    let response = send_with_retry(
+    let selected_cookie = session.cookie_header().await;
+    ticket
+        .validate()
+        .map_err(|_| OrgToolCallError::StaleIdentity)?;
+    let cookie_attached = attach_cookie_header(&mut headers, selected_cookie);
+    let response = send_with_retry_for_identity(
         &session,
-        &Method::POST,
-        &path,
-        &headers,
-        &body,
-        token,
-        cookie_attached,
+        RetriableUpstreamRequest {
+            method: Method::POST,
+            path_and_query: &path,
+            headers: &headers,
+            body: &body,
+            token,
+            cookie_leads: cookie_attached,
+        },
+        &mut ticket,
     )
     .await
     .map_err(|error| match error {
-        ProxyError::Network(msg) => format!("upstream unreachable: {msg}"),
-        ProxyError::HardUnauthorized => "not signed in to the upstream deployment".to_string(),
+        ProxyError::Network(msg) => {
+            OrgToolCallError::Failed(format!("upstream unreachable: {msg}"))
+        }
+        ProxyError::HardUnauthorized => {
+            OrgToolCallError::Failed("not signed in to the upstream deployment".to_string())
+        }
+        ProxyError::StaleIdentity => OrgToolCallError::StaleIdentity,
     })?;
 
     let status = response.status();
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| format!("could not read {tool_name} response: {e}"))?;
+    let bytes_result = tokio::select! {
+        biased;
+        _ = ticket.validation_changed() => {
+            return Err(OrgToolCallError::StaleIdentity);
+        }
+        result = response.bytes() => result,
+    };
+    ticket
+        .validate()
+        .map_err(|_| OrgToolCallError::StaleIdentity)?;
+    let bytes = bytes_result.map_err(|error| {
+        OrgToolCallError::Failed(format!("could not read {tool_name} response: {error}"))
+    })?;
     if !status.is_success() {
-        return Err(format!(
+        return Err(OrgToolCallError::Failed(format!(
             "{tool_name} failed upstream ({status}): {}",
             String::from_utf8_lossy(&bytes)
                 .chars()
                 .take(300)
                 .collect::<String>()
-        ));
+        )));
     }
-    serde_json::from_slice(&bytes).map_err(|e| format!("{tool_name} returned invalid JSON: {e}"))
+    serde_json::from_slice(&bytes).map_err(|error| {
+        OrgToolCallError::Failed(format!("{tool_name} returned invalid JSON: {error}"))
+    })
 }
 
 /// Why an authenticated upstream call never produced a response at all. A
@@ -1053,7 +1436,7 @@ pub(crate) enum UpstreamCallError {
 /// raw response back — status, headers and an unconsumed body, so a caller
 /// serving a large object can stream it rather than buffering.
 ///
-/// [`call_org_tool`] above is the JSON-tool-shaped convenience over the same
+/// [`call_org_tool_for_identity`] above is the JSON-tool-shaped convenience over the same
 /// machinery; this is the general form, used by `routes/webdav.rs` for the
 /// org filesystem's REST contract (`/api/:org/fs/:volume/*`), which is not a
 /// tool call. Both share [`send_with_retry`], so both get the same
@@ -1088,6 +1471,7 @@ pub(crate) async fn send_org_request(
     .map_err(|error| match error {
         ProxyError::Network(msg) => UpstreamCallError::Unreachable(msg),
         ProxyError::HardUnauthorized => UpstreamCallError::NotSignedIn,
+        ProxyError::StaleIdentity => UpstreamCallError::NotSignedIn,
     })
 }
 
@@ -1146,6 +1530,82 @@ async fn send_with_retry(
     }
 
     send_once(method, &url, headers, body.clone(), &current).await
+}
+
+/// Identity-pinned form of [`send_with_retry`] for the generic app-API
+/// catchall. The ordinary helper remains for narrowly-scoped internal reads;
+/// this variant validates after every async credential operation and network
+/// attempt, so a response obtained while account replacement was in flight is
+/// discarded before its headers or body reach the webview.
+struct RetriableUpstreamRequest<'a> {
+    method: Method,
+    path_and_query: &'a str,
+    headers: &'a HeaderMap,
+    body: &'a axum::body::Bytes,
+    token: String,
+    cookie_leads: bool,
+}
+
+async fn send_with_retry_for_identity(
+    session: &upstream::UpstreamSession,
+    request: RetriableUpstreamRequest<'_>,
+    ticket: &mut UpstreamRequestTicket,
+) -> Result<reqwest::Response, ProxyError> {
+    let RetriableUpstreamRequest {
+        method,
+        path_and_query,
+        headers,
+        body,
+        token,
+        cookie_leads,
+    } = request;
+    let url = format!("{}{path_and_query}", session.target());
+    let mut headers = headers.clone();
+
+    if cookie_leads {
+        ticket.validate()?;
+        let first_result = send_once_no_bearer(&method, &url, &headers, body.clone()).await;
+        ticket.validate()?;
+        let first = first_result?;
+        if first.status() != StatusCode::UNAUTHORIZED {
+            return Ok(first);
+        }
+        headers.remove(header::COOKIE);
+    }
+
+    ticket.validate()?;
+    let first_result = send_once(&method, &url, &headers, body.clone(), &token).await;
+    ticket.validate()?;
+    let first = first_result?;
+    if first.status() != StatusCode::UNAUTHORIZED {
+        return Ok(first);
+    }
+
+    // Revalidation may itself refresh or hard-sign-out. The ticket check
+    // immediately afterward prevents a concurrent replacement's status or
+    // token from being reused for this request.
+    ticket.validate()?;
+    let status = session.force_revalidate().await;
+    ticket.validate()?;
+    if !status.signed_in {
+        return Err(ProxyError::HardUnauthorized);
+    }
+
+    let current_result = session.access_token().await;
+    ticket.validate()?;
+    let current = match current_result {
+        Ok(current) => current,
+        Err(_) => return Err(ProxyError::HardUnauthorized),
+    };
+    if current == token {
+        return Ok(first);
+    }
+
+    ticket.validate()?;
+    let retry_result = send_once(&method, &url, &headers, body.clone(), &current).await;
+    ticket.validate()?;
+    let retry = retry_result?;
+    Ok(retry)
 }
 
 async fn send_once(
@@ -1211,6 +1671,28 @@ async fn build_response(upstream: reqwest::Response) -> Response {
     strip_hop_by_hop_headers(&mut headers);
     headers.remove(header::SET_COOKIE);
     let body = Body::from_stream(upstream.bytes_stream());
+    let mut res = Response::new(body);
+    *res.status_mut() = status;
+    *res.headers_mut() = headers;
+    res
+}
+
+/// Generic bearer-branch response builder. In addition to the ordinary
+/// header hygiene, the body stops at the first identity/epoch notification.
+/// `take_until` fences bytes already queued by reqwest as well as future
+/// chunks, which is essential for SSE and other long-lived responses.
+async fn build_response_for_identity(
+    upstream: reqwest::Response,
+    mut ticket: UpstreamRequestTicket,
+) -> Response {
+    if ticket.validate().is_err() {
+        return ApiError::conflict(STALE_UPSTREAM_IDENTITY).into_response();
+    }
+    let status = upstream.status();
+    let mut headers = upstream.headers().clone();
+    strip_hop_by_hop_headers(&mut headers);
+    headers.remove(header::SET_COOKIE);
+    let body = Body::from_stream(upstream.bytes_stream().take_until(ticket.changed()));
     let mut res = Response::new(body);
     *res.status_mut() = status;
     *res.headers_mut() = headers;
@@ -1588,6 +2070,215 @@ mod tests {
         signed_in_session_with_store(target, access_token).await.0
     }
 
+    fn identity_ticket_for_test(
+        manager: Arc<crate::sandbox::SandboxManager>,
+        identity_generation: u64,
+    ) -> (
+        UpstreamRequestTicket,
+        tokio::sync::broadcast::Sender<upstream::SessionIdentityEvent>,
+    ) {
+        let account_epoch = manager.account_epoch();
+        let validation_account_rx = manager.watch_account_epoch(account_epoch).unwrap();
+        let body_account_rx = validation_account_rx.clone();
+        let (identity_tx, _) = tokio::sync::broadcast::channel(8);
+        let validation_identity_rx = identity_tx.subscribe();
+        let body_identity_rx = identity_tx.subscribe();
+        (
+            UpstreamRequestTicket {
+                identity_generation,
+                account_epoch,
+                sandbox_manager: manager,
+                validation_identity_rx,
+                body_identity_rx,
+                validation_account_rx,
+                body_account_rx,
+            },
+            identity_tx,
+        )
+    }
+
+    #[tokio::test]
+    async fn account_change_while_request_body_is_stalled_never_reaches_interception() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = crate::routes::intercept::test_state(dir.path());
+        let manager = state.sandbox_manager.clone();
+        let body_started = Arc::new(tokio::sync::Notify::new());
+        let release_body = Arc::new(tokio::sync::Notify::new());
+        let started_for_body = body_started.clone();
+        let release_for_body = release_body.clone();
+        let body = Body::from_stream(futures::stream::once(async move {
+            started_for_body.notify_one();
+            release_for_body.notified().await;
+            Ok::<_, std::convert::Infallible>(axum::body::Bytes::from_static(b"{}"))
+        }));
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("/api/acme/decopilot/retired")
+            .body(body)
+            .unwrap();
+
+        let request_task = tokio::spawn(proxy(State(state), request));
+        tokio::time::timeout(Duration::from_secs(1), body_started.notified())
+            .await
+            .expect("proxy never began reading the stalled body");
+        let transition = manager.begin_account_transition().await.unwrap();
+        release_body.notify_waiters();
+
+        let response = tokio::time::timeout(Duration::from_secs(1), request_task)
+            .await
+            .expect("stale request did not terminate")
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_ne!(
+            response.status(),
+            StatusCode::GONE,
+            "the retired-route interceptor must never run under the replacement account"
+        );
+        drop(transition);
+    }
+
+    #[tokio::test]
+    async fn queued_upstream_body_is_discarded_after_identity_change() {
+        let app = Router::new().route("/stream", get(|| async { "account-a-secret" }));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        let upstream = reqwest::Client::new()
+            .get(format!("http://{addr}/stream"))
+            .send()
+            .await
+            .unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf());
+        let (ticket, identity_tx) = identity_ticket_for_test(manager, 7);
+        let response = build_response_for_identity(upstream, ticket).await;
+
+        identity_tx
+            .send(upstream::SessionIdentityEvent {
+                generation: 8,
+                user_sub: Some("account-b".to_string()),
+            })
+            .unwrap();
+        let mut body = response.into_body().into_data_stream();
+        assert!(tokio::time::timeout(Duration::from_secs(1), body.next())
+            .await
+            .expect("identity-fenced body did not terminate")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn identity_change_during_first_401_prevents_retry_with_replacement_token() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let seen_auth = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let first_arrived = Arc::new(tokio::sync::Notify::new());
+        let release_first = Arc::new(tokio::sync::Notify::new());
+        let app = Router::new()
+            .route(
+                "/resource",
+                get({
+                    let calls = calls.clone();
+                    let seen_auth = seen_auth.clone();
+                    let first_arrived = first_arrived.clone();
+                    let release_first = release_first.clone();
+                    move |headers: HeaderMap| {
+                        let calls = calls.clone();
+                        let seen_auth = seen_auth.clone();
+                        let first_arrived = first_arrived.clone();
+                        let release_first = release_first.clone();
+                        async move {
+                            seen_auth.lock().unwrap().push(
+                                headers
+                                    .get(header::AUTHORIZATION)
+                                    .and_then(|value| value.to_str().ok())
+                                    .unwrap_or_default()
+                                    .to_string(),
+                            );
+                            let attempt = calls.fetch_add(1, Ordering::SeqCst);
+                            if attempt == 0 {
+                                first_arrived.notify_one();
+                                release_first.notified().await;
+                                StatusCode::UNAUTHORIZED
+                            } else {
+                                StatusCode::OK
+                            }
+                        }
+                    }
+                }),
+            )
+            .route("/api/links/me", get(|| async { StatusCode::OK }))
+            .route(
+                "/api/auth/get-session",
+                get(|| async { Json(json!({ "user": { "id": "account-b" } })) }),
+            );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        let target = format!("http://{addr}");
+        let (session, store) = signed_in_session_with_store(&target, "token-a").await;
+        let root = tempfile::tempdir().unwrap();
+        let manager = crate::sandbox::SandboxManager::new(root.path().to_path_buf());
+        let (mut ticket, identity_tx) = identity_ticket_for_test(manager, 11);
+
+        let send_task = tokio::spawn(async move {
+            send_with_retry_for_identity(
+                &session,
+                RetriableUpstreamRequest {
+                    method: Method::GET,
+                    path_and_query: "/resource",
+                    headers: &HeaderMap::new(),
+                    body: &axum::body::Bytes::new(),
+                    token: "token-a".to_string(),
+                    cookie_leads: false,
+                },
+                &mut ticket,
+            )
+            .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), first_arrived.notified())
+            .await
+            .expect("first request never reached upstream");
+        store
+            .save(
+                &host_key(&target),
+                StoredSession {
+                    target: target.clone(),
+                    client_id: "client-b".to_string(),
+                    user: UserInfo {
+                        sub: "account-b".to_string(),
+                        email: None,
+                        name: None,
+                    },
+                    access_token: "token-b".to_string(),
+                    refresh_token: Some("refresh-b".to_string()),
+                    expires_at: Some(now_unix() + 3600),
+                    created_at: "2026-01-01T00:00:00Z".to_string(),
+                    cookie: Some("better-auth.session_token=b".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+        identity_tx
+            .send(upstream::SessionIdentityEvent {
+                generation: 12,
+                user_sub: Some("account-b".to_string()),
+            })
+            .unwrap();
+        release_first.notify_waiters();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), send_task)
+            .await
+            .expect("identity-fenced retry did not terminate")
+            .unwrap();
+        assert!(matches!(result, Err(ProxyError::StaleIdentity)));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(seen_auth.lock().unwrap().as_slice(), ["Bearer token-a"]);
+    }
+
     #[tokio::test]
     async fn native_watch_is_intercepted_without_contacting_upstream() {
         let dir = tempfile::tempdir().unwrap();
@@ -1601,9 +2292,15 @@ mod tests {
         // The process-global upstream session is deliberately not configured
         // in this test. A fallthrough would return 401 (or block on credential
         // resolution); the local watch must answer immediately instead.
-        let response = tokio::time::timeout(Duration::from_secs(1), proxy(State(state), request))
-            .await
-            .expect("local watch attempted an upstream operation");
+        // Keep the router state alive while polling the returned streaming
+        // body, just as the real Axum router does. Dropping the last manager
+        // here must close the epoch channel and terminate the watch; retaining
+        // a clone in the response would weaken that production fail-closed
+        // behavior.
+        let response =
+            tokio::time::timeout(Duration::from_secs(1), proxy(State(state.clone()), request))
+                .await
+                .expect("local watch attempted an upstream operation");
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.headers().get(header::CONTENT_TYPE).unwrap(),

--- a/apps/native/crates/local-api/src/routes/ws_proxy.rs
+++ b/apps/native/crates/local-api/src/routes/ws_proxy.rs
@@ -66,6 +66,7 @@ struct UpstreamHandshake {
 /// `Set-Cookie`, and other end-to-end response headers exist only on the
 /// upstream `101`, and browsers need them on their own `101`. Accepting the
 /// downstream first makes those headers impossible to propagate.
+#[cfg(test)]
 pub async fn upgrade(
     downstream: WebSocketUpgrade,
     port: Option<u16>,
@@ -73,11 +74,78 @@ pub async fn upgrade(
     requested_protocols: Vec<String>,
     request_headers: HeaderMap,
 ) -> Response {
+    upgrade_inner(
+        downstream,
+        port,
+        path_and_query,
+        requested_protocols,
+        request_headers,
+        None,
+    )
+    .await
+}
+
+pub(crate) async fn upgrade_for_account(
+    downstream: WebSocketUpgrade,
+    port: Option<u16>,
+    path_and_query: String,
+    requested_protocols: Vec<String>,
+    request_headers: HeaderMap,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    account_epoch_rx: tokio::sync::watch::Receiver<crate::sandbox::manager::AccountEpoch>,
+) -> Response {
+    upgrade_inner(
+        downstream,
+        port,
+        path_and_query,
+        requested_protocols,
+        request_headers,
+        Some(AccountEpochFence {
+            expected: account_epoch,
+            receiver: account_epoch_rx,
+        }),
+    )
+    .await
+}
+
+struct AccountEpochFence {
+    expected: crate::sandbox::manager::AccountEpoch,
+    receiver: tokio::sync::watch::Receiver<crate::sandbox::manager::AccountEpoch>,
+}
+
+impl AccountEpochFence {
+    fn is_stale(&mut self) -> bool {
+        *self.receiver.borrow_and_update() != self.expected
+    }
+
+    async fn changed(&mut self) {
+        loop {
+            if self.is_stale() || self.receiver.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+}
+
+async fn upgrade_inner(
+    downstream: WebSocketUpgrade,
+    port: Option<u16>,
+    path_and_query: String,
+    requested_protocols: Vec<String>,
+    request_headers: HeaderMap,
+    mut account_epoch: Option<AccountEpochFence>,
+) -> Response {
+    if account_epoch
+        .as_mut()
+        .is_some_and(AccountEpochFence::is_stale)
+    {
+        return failed_upgrade_response(downstream, requested_protocols, "Studio account changed");
+    }
     let Some(port) = port else {
         return failed_upgrade_response(downstream, requested_protocols, REASON_NO_UPSTREAM);
     };
 
-    let Some(upstream) = connect_upstream(
+    let Some(mut upstream) = connect_upstream(
         port,
         &path_and_query,
         &requested_protocols,
@@ -87,6 +155,13 @@ pub async fn upgrade(
     else {
         return failed_upgrade_response(downstream, requested_protocols, REASON_UNREACHABLE);
     };
+    if account_epoch
+        .as_mut()
+        .is_some_and(AccountEpochFence::is_stale)
+    {
+        let _ = upstream.socket.close(None).await;
+        return failed_upgrade_response(downstream, requested_protocols, "Studio account changed");
+    }
 
     let UpstreamHandshake {
         socket,
@@ -97,7 +172,7 @@ pub async fn upgrade(
         Some(protocol) => downstream.protocols([protocol]),
         None => downstream,
     };
-    let mut response = downstream.on_upgrade(move |client| bridge(client, socket));
+    let mut response = downstream.on_upgrade(move |client| bridge(client, socket, account_epoch));
     copy_upstream_response_headers(&headers, response.headers_mut());
     response
 }
@@ -121,11 +196,26 @@ fn failed_upgrade_response(
     })
 }
 
-async fn bridge(mut client: WebSocket, upstream: UpstreamSocket) {
+async fn bridge(
+    mut client: WebSocket,
+    upstream: UpstreamSocket,
+    mut account_epoch: Option<AccountEpochFence>,
+) {
     let (mut up_write, mut up_read) = upstream.split();
 
     loop {
         tokio::select! {
+            biased;
+            _ = async {
+                match account_epoch.as_mut() {
+                    Some(fence) => fence.changed().await,
+                    None => std::future::pending::<()>().await,
+                }
+            } => {
+                let _ = up_write.close().await;
+                close_client(&mut client, 1008, "Studio account changed").await;
+                break;
+            }
             client_msg = client.recv() => {
                 match client_msg {
                     Some(Ok(AxumMessage::Close(frame))) => {

--- a/apps/native/crates/local-api/src/sandbox/manager.rs
+++ b/apps/native/crates/local-api/src/sandbox/manager.rs
@@ -19,6 +19,22 @@ use crate::setup::{SetupOrchestrator, SetupShutdownResult, Step};
 use crate::tasks::{KillSignal, TaskRegistry, TaskStatus};
 
 const BRANCH_STATUS_POLL_INTERVAL: Duration = Duration::from_secs(3);
+const ACCOUNT_TRANSITION_MATERIALIZATION_DRAIN_TIMEOUT: Duration = Duration::from_secs(15);
+const STALE_ACCOUNT_EPOCH: &str = "sandbox request belongs to a stale account epoch";
+
+/// Opaque proof that an account-scoped request was admitted while the
+/// upstream account-transition lock was held. The counter is deliberately
+/// private: callers can carry and compare tickets, but cannot manufacture an
+/// account selector from a wire value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct AccountEpoch(u64);
+
+impl AccountEpoch {
+    #[cfg(test)]
+    pub(crate) const fn for_test() -> Self {
+        Self(0)
+    }
+}
 
 /// True if this sandbox has a `dev`/`start` task currently Running. `ensure()`
 /// uses it to decide whether a no-op-clone dispatch still needs to (re)start
@@ -82,6 +98,7 @@ pub struct Sandbox {
     pub tasks: Arc<TaskRegistry>,
     pub broadcaster: Arc<Broadcaster>,
     pub setup: Arc<SetupOrchestrator>,
+    account_epoch: AccountEpoch,
     registry_monitor_started: AtomicBool,
     branch_monitor_started: AtomicBool,
     /// Last `[org-fs]` outcome announced for this sandbox, so `ensure` — which
@@ -132,13 +149,290 @@ pub struct SandboxManager {
     /// Per-handle process-generation feeds. An explicit xterm/SSE stream must
     /// follow a stopped sandbox when Resume replaces its in-memory `Sandbox`
     /// Arc, independently of whichever other chat is currently active.
-    generation_watches: Mutex<HashMap<String, tokio::sync::watch::Sender<Option<Arc<Sandbox>>>>>,
+    generation_watches: Mutex<GenerationWatchMap>,
+    materialization_gate: Arc<MaterializationGate>,
+    account_transition_lock: Arc<tokio::sync::Mutex<()>>,
 }
+
+type GenerationWatchMap =
+    HashMap<(AccountEpoch, String), tokio::sync::watch::Sender<Option<Arc<Sandbox>>>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SandboxShutdownResult {
     pub handle: String,
     pub result: SetupShutdownResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TerminalEnsureError {
+    Canceled,
+    Failed(String),
+}
+
+const TERMINAL_ENSURE_CANCELED: &str = "terminal sandbox preparation canceled";
+
+struct TerminalEnsureControl {
+    canceled: Arc<AtomicBool>,
+    cancel: tokio::sync::watch::Receiver<bool>,
+    materialized: tokio::sync::oneshot::Sender<TerminalEnsureMaterialized>,
+}
+
+struct TerminalEnsureMaterialized {
+    sandbox: Arc<Sandbox>,
+    resume: tokio::sync::oneshot::Sender<()>,
+}
+
+#[derive(Default)]
+struct MaterializationState {
+    closed: bool,
+    active: usize,
+    epoch: u64,
+}
+
+struct MaterializationGate {
+    state: Mutex<MaterializationState>,
+    changed: tokio::sync::Notify,
+    epoch_watch: tokio::sync::watch::Sender<AccountEpoch>,
+}
+
+struct MaterializationAdmission {
+    gate: Arc<MaterializationGate>,
+}
+
+struct MaterializationClosure {
+    gate: Arc<MaterializationGate>,
+}
+
+/// Owns the native half of an account transition. Acquisition advances the
+/// account epoch and closes sandbox publication atomically. The caller keeps
+/// this guard through terminal cancellation and artifact cleanup; dropping it
+/// is the only operation that reopens publication for the next account.
+#[must_use = "dropping the account transition guard reopens sandbox materialization"]
+pub(crate) struct SandboxAccountTransitionGuard {
+    manager: Arc<SandboxManager>,
+    _transition: tokio::sync::OwnedMutexGuard<()>,
+    closure: MaterializationClosure,
+}
+
+impl MaterializationGate {
+    fn account_epoch(&self) -> AccountEpoch {
+        AccountEpoch(
+            self.state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .epoch,
+        )
+    }
+
+    fn validate(&self, epoch: AccountEpoch) -> Result<(), String> {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.closed {
+            return Err("sandbox account transition is in progress".to_string());
+        }
+        if state.epoch != epoch.0 {
+            return Err(STALE_ACCOUNT_EPOCH.to_string());
+        }
+        Ok(())
+    }
+
+    fn watch_account_epoch(
+        &self,
+        epoch: AccountEpoch,
+    ) -> Result<tokio::sync::watch::Receiver<AccountEpoch>, String> {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.closed {
+            return Err("sandbox account transition is in progress".to_string());
+        }
+        if state.epoch != epoch.0 {
+            return Err(STALE_ACCOUNT_EPOCH.to_string());
+        }
+        // Subscribe while holding the same state lock that advances the
+        // epoch. A transition therefore cannot land between validation and
+        // receiver creation.
+        Ok(self.epoch_watch.subscribe())
+    }
+
+    fn admit(self: &Arc<Self>, epoch: AccountEpoch) -> Result<MaterializationAdmission, String> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.closed {
+            return Err("sandbox account transition is in progress".to_string());
+        }
+        if state.epoch != epoch.0 {
+            return Err(STALE_ACCOUNT_EPOCH.to_string());
+        }
+        state.active += 1;
+        Ok(MaterializationAdmission { gate: self.clone() })
+    }
+
+    fn advance_and_close(self: &Arc<Self>) -> Result<MaterializationClosure, String> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some(next_epoch) = state.epoch.checked_add(1) else {
+            // No ticket can safely describe a later account. Permanently
+            // closing publication is safer than wrapping and accepting an
+            // ancient request as current.
+            state.closed = true;
+            // `send_replace` advances the watch version even though the
+            // value cannot advance, terminating long-lived account-scoped
+            // streams as part of the fail-closed path.
+            self.epoch_watch.send_replace(AccountEpoch(state.epoch));
+            return Err("sandbox account epoch exhausted".to_string());
+        };
+        state.epoch = next_epoch;
+        state.closed = true;
+        self.epoch_watch.send_replace(AccountEpoch(next_epoch));
+        Ok(MaterializationClosure { gate: self.clone() })
+    }
+}
+
+impl Default for MaterializationGate {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(MaterializationState::default()),
+            changed: tokio::sync::Notify::new(),
+            epoch_watch: tokio::sync::watch::channel(AccountEpoch(0)).0,
+        }
+    }
+}
+
+impl Drop for MaterializationAdmission {
+    fn drop(&mut self) {
+        let quiescent = {
+            let mut state = self
+                .gate
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            debug_assert!(state.active > 0, "materialization admission underflow");
+            state.active = state.active.saturating_sub(1);
+            state.active == 0
+        };
+        if quiescent {
+            self.gate.changed.notify_waiters();
+        }
+    }
+}
+
+impl MaterializationClosure {
+    async fn drain(&self) {
+        loop {
+            let changed = self.gate.changed.notified();
+            tokio::pin!(changed);
+            changed.as_mut().enable();
+            if self
+                .gate
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .active
+                == 0
+            {
+                return;
+            }
+            changed.await;
+        }
+    }
+}
+
+impl Drop for MaterializationClosure {
+    fn drop(&mut self) {
+        self.gate
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .closed = false;
+        self.gate.changed.notify_waiters();
+    }
+}
+
+impl SandboxAccountTransitionGuard {
+    /// Wait only for the short in-memory insertion + durable registration
+    /// commit section, then stop every generation visible in the snapshot.
+    /// A timeout returns before the snapshot, so callers never receive a
+    /// misleading partial stop result.
+    pub(crate) async fn drain_and_stop_live(&self) -> Result<usize, String> {
+        self.drain_and_stop_live_with_timeout(ACCOUNT_TRANSITION_MATERIALIZATION_DRAIN_TIMEOUT)
+            .await
+    }
+
+    async fn drain_and_stop_live_with_timeout(&self, timeout: Duration) -> Result<usize, String> {
+        tokio::time::timeout(timeout, self.closure.drain())
+            .await
+            .map_err(|_| {
+                format!(
+                    "timed out after {}ms waiting for sandbox materialization to drain",
+                    timeout.as_millis()
+                )
+            })?;
+
+        let handles = self
+            .manager
+            .lock_sandboxes()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut stopped = 0;
+        let mut failures = Vec::new();
+        for handle in handles {
+            match self.manager.stop_registered_generation(&handle).await {
+                Ok(Some(_)) => stopped += 1,
+                Ok(None) => {}
+                Err(error) => failures.push(format!("{handle}: {error}")),
+            }
+        }
+        let current_epoch = self.manager.account_epoch();
+        self.manager
+            .generation_watches
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .retain(|(epoch, _), _| *epoch == current_epoch);
+        if failures.is_empty() {
+            Ok(stopped)
+        } else {
+            Err(format!(
+                "could not stop sandbox(es) for account transition: {}",
+                failures.join("; ")
+            ))
+        }
+    }
+}
+
+async fn wait_terminal_cancellation(cancel: &mut tokio::sync::watch::Receiver<bool>) {
+    loop {
+        if *cancel.borrow() {
+            return;
+        }
+        if cancel.changed().await.is_err() {
+            // Dropping the preparation owner is cancellation too. Treating a
+            // closed false-valued watch as "keep waiting" would strand this
+            // manager-owned coordinator if its caller unwound unexpectedly.
+            return;
+        }
+    }
+}
+
+fn map_terminal_ensure_result(
+    result: Result<Result<Arc<Sandbox>, String>, tokio::task::JoinError>,
+) -> Result<Arc<Sandbox>, TerminalEnsureError> {
+    match result {
+        Ok(Ok(sandbox)) => Ok(sandbox),
+        Ok(Err(error)) if error == TERMINAL_ENSURE_CANCELED => Err(TerminalEnsureError::Canceled),
+        Ok(Err(error)) => Err(TerminalEnsureError::Failed(error)),
+        Err(error) => Err(TerminalEnsureError::Failed(format!(
+            "terminal sandbox preparation owner failed: {error}"
+        ))),
+    }
 }
 
 impl SandboxManager {
@@ -156,6 +450,8 @@ impl SandboxManager {
             active_handle: Mutex::new(persisted_active.clone()),
             active_watch: tokio::sync::watch::channel(persisted_active).0,
             generation_watches: Mutex::new(HashMap::new()),
+            materialization_gate: Arc::new(MaterializationGate::default()),
+            account_transition_lock: Arc::new(tokio::sync::Mutex::new(())),
         })
     }
 
@@ -163,9 +459,28 @@ impl SandboxManager {
     /// the last handle `ensure()`-d, or one explicitly focused by the webview.
     /// `None` until the first git-backed dispatch — the proxy then falls back
     /// to the global (non-git) orchestrator, exactly as before.
-    pub fn active(&self) -> Option<Arc<Sandbox>> {
+    #[cfg(test)]
+    fn active(&self) -> Option<Arc<Sandbox>> {
         let handle = self.active_handle.lock().ok()?.clone()?;
         self.get(&handle)
+    }
+
+    pub(crate) fn active_for_account(
+        &self,
+        epoch: AccountEpoch,
+    ) -> Result<Option<Arc<Sandbox>>, String> {
+        self.validate_account_epoch(epoch)?;
+        let handle = self
+            .active_handle
+            .lock()
+            .map_err(|_| "sandbox active handle lock poisoned".to_string())?
+            .clone();
+        let resolved = match handle {
+            Some(handle) => self.get_for_account(epoch, &handle)?,
+            None => None,
+        };
+        self.validate_account_epoch(epoch)?;
+        Ok(resolved)
     }
 
     /// Point the headerless preview at a registered `handle` (idempotent).
@@ -174,7 +489,7 @@ impl SandboxManager {
     ///
     /// Also best-effort persists `handle` to disk (see the `persist` module
     /// doc) so a HEADERLESS resolve after a process restart can find its way
-    /// back to the last-focused sandbox via [`Self::resurrect_active`] —
+    /// back to the last-focused sandbox via [`Self::resurrect_active_for_account`] —
     /// `active_handle` above is in-memory only and starts `None` every boot.
     /// Subscribe to active-handle changes (see `active_watch`).
     pub fn watch_active(&self) -> tokio::sync::watch::Receiver<Option<String>> {
@@ -185,38 +500,68 @@ impl SandboxManager {
     /// generation. Unlike `watch_active`, this is identity-scoped: focusing a
     /// different chat cannot hide a Stop -> Resume replacement from an xterm
     /// that is still following this handle.
-    pub fn watch_generation(
+    fn watch_generation(
         &self,
+        epoch: AccountEpoch,
         handle: &str,
     ) -> tokio::sync::watch::Receiver<Option<Arc<Sandbox>>> {
-        let current = self.get(handle);
+        let current = self
+            .get(handle)
+            .filter(|sandbox| sandbox.account_epoch == epoch);
         let mut watches = self
             .generation_watches
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let sender = watches.entry(handle.to_string()).or_insert_with(|| {
-            let (sender, _receiver) = tokio::sync::watch::channel(current.clone());
-            sender
-        });
+        let sender = watches
+            .entry((epoch, handle.to_string()))
+            .or_insert_with(|| {
+                let (sender, _receiver) = tokio::sync::watch::channel(current.clone());
+                sender
+            });
         if current.is_some() && sender.borrow().is_none() {
             sender.send_replace(current);
         }
         sender.subscribe()
     }
 
-    fn publish_generation(&self, handle: &str, generation: Option<Arc<Sandbox>>) {
+    pub(crate) fn watch_generation_for_account(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<tokio::sync::watch::Receiver<Option<Arc<Sandbox>>>, String> {
+        self.validate_account_epoch(epoch)?;
+        let receiver = self.watch_generation(epoch, handle);
+        self.validate_account_epoch(epoch)?;
+        Ok(receiver)
+    }
+
+    fn publish_generation(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+        generation: Option<Arc<Sandbox>>,
+    ) {
+        debug_assert!(
+            generation
+                .as_ref()
+                .is_none_or(|sandbox| sandbox.account_epoch == epoch),
+            "generation published to the wrong account epoch"
+        );
         let mut watches = self
             .generation_watches
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let sender = watches.entry(handle.to_string()).or_insert_with(|| {
-            let (sender, _receiver) = tokio::sync::watch::channel(None);
-            sender
-        });
+        let sender = watches
+            .entry((epoch, handle.to_string()))
+            .or_insert_with(|| {
+                let (sender, _receiver) = tokio::sync::watch::channel(None);
+                sender
+            });
         sender.send_replace(generation);
     }
 
-    pub fn set_active(&self, handle: &str) -> Result<(), String> {
+    fn set_active_at(&self, epoch: AccountEpoch, handle: &str) -> Result<(), String> {
+        let _admission = self.admit_materialization(epoch)?;
         self.registry.set_active(handle)?;
         if let Ok(mut guard) = self.active_handle.lock() {
             *guard = Some(handle.to_string());
@@ -227,12 +572,23 @@ impl SandboxManager {
         Ok(())
     }
 
-    /// Whether `handle` has durable config, independently of whether this
-    /// process has materialized its live Rust objects yet.
-    /// The worktree handle an agent uses for `branch`, via the registry —
+    #[cfg(test)]
+    pub(crate) fn set_active(&self, handle: &str) -> Result<(), String> {
+        self.set_active_at(self.account_epoch(), handle)
+    }
+
+    pub(crate) fn set_active_for_account(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<(), String> {
+        self.set_active_at(epoch, handle)
+    }
+
+    /// The worktree handle a virtual MCP uses for `branch`, via the registry —
     /// the routes the shell calls carry `(virtualMcpId, branch)`, never a
     /// clone URL, and the handle is derived from the repository.
-    pub fn handle_for_agent(
+    fn handle_for_virtual_mcp(
         &self,
         virtual_mcp_id: &str,
         branch: &str,
@@ -241,34 +597,91 @@ impl SandboxManager {
         // so a thread that persisted `main` before the never-on-main rule
         // resolves to the staging sandbox instead of resurrecting the old one.
         self.registry
-            .handle_for_agent(virtual_mcp_id, super::normalize_branch(Some(branch)))
+            .handle_for_virtual_mcp(virtual_mcp_id, super::normalize_branch(Some(branch)))
     }
 
-    pub fn is_registered(&self, handle: &str) -> Result<bool, String> {
+    pub(crate) fn handle_for_virtual_mcp_for_account(
+        &self,
+        epoch: AccountEpoch,
+        virtual_mcp_id: &str,
+        branch: &str,
+    ) -> Result<Option<String>, String> {
+        self.validate_account_epoch(epoch)?;
+        let handle = self.handle_for_virtual_mcp(virtual_mcp_id, branch)?;
+        self.validate_account_epoch(epoch)?;
+        Ok(handle)
+    }
+
+    /// Whether `handle` has durable config, independently of whether this
+    /// process has materialized its live Rust objects yet.
+    fn is_registered(&self, handle: &str) -> Result<bool, String> {
         self.registry.contains(handle)
     }
 
+    pub(crate) fn is_registered_for_account(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<bool, String> {
+        self.validate_account_epoch(epoch)?;
+        let registered = self.is_registered(handle)?;
+        self.validate_account_epoch(epoch)?;
+        Ok(registered)
+    }
+
     /// Durable active pointer without materializing or starting its sandbox.
-    pub fn registered_active_handle(&self) -> Result<Option<String>, String> {
+    fn registered_active_handle(&self) -> Result<Option<String>, String> {
         self.registry.active_handle()
     }
 
+    pub(crate) fn registered_active_handle_for_account(
+        &self,
+        epoch: AccountEpoch,
+    ) -> Result<Option<String>, String> {
+        self.validate_account_epoch(epoch)?;
+        let handle = self.registered_active_handle()?;
+        self.validate_account_epoch(epoch)?;
+        Ok(handle)
+    }
+
     /// Returns the durable record for lifecycle/API responses.
-    pub(crate) fn registry_record(
+    fn registry_record(
         &self,
         handle: &str,
     ) -> Result<Option<super::registry::SandboxRecord>, String> {
         self.registry.record(handle)
     }
 
-    /// Every durable sandbox this agent has claimed — the registry-backed
+    pub(crate) fn registry_record_for_account(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Option<super::registry::SandboxRecord>, String> {
+        self.validate_account_epoch(epoch)?;
+        let record = self.registry_record(handle)?;
+        self.validate_account_epoch(epoch)?;
+        Ok(record)
+    }
+
+    /// Every durable sandbox this virtual MCP has claimed — the registry-backed
     /// replacement for walking `worktrees/` and reading sidecars on request
     /// paths.
-    pub(crate) fn records_for_agent(
+    fn records_for_virtual_mcp(
         &self,
         virtual_mcp_id: &str,
     ) -> Result<Vec<super::registry::SandboxRecord>, String> {
-        self.registry.records_for_agent(virtual_mcp_id)
+        self.registry.records_for_virtual_mcp(virtual_mcp_id)
+    }
+
+    pub(crate) fn records_for_virtual_mcp_for_account(
+        &self,
+        epoch: AccountEpoch,
+        virtual_mcp_id: &str,
+    ) -> Result<Vec<super::registry::SandboxRecord>, String> {
+        self.validate_account_epoch(epoch)?;
+        let records = self.records_for_virtual_mcp(virtual_mcp_id)?;
+        self.validate_account_epoch(epoch)?;
+        Ok(records)
     }
 
     /// The handle whose preview label matches `label`, if any.
@@ -276,7 +689,7 @@ impl SandboxManager {
     /// Served from an in-memory map so the preview proxy's per-asset lookups
     /// never touch the filesystem or the database; the map is rebuilt from
     /// the registry after any registration change.
-    pub(crate) fn handle_for_preview_label(&self, label: &str) -> Option<String> {
+    fn handle_for_preview_label(&self, label: &str) -> Option<String> {
         if let Some(cached) = self
             .preview_labels
             .read()
@@ -298,6 +711,17 @@ impl SandboxManager {
         found
     }
 
+    pub(crate) fn handle_for_preview_label_for_account(
+        &self,
+        epoch: AccountEpoch,
+        label: &str,
+    ) -> Result<Option<String>, String> {
+        self.validate_account_epoch(epoch)?;
+        let handle = self.handle_for_preview_label(label);
+        self.validate_account_epoch(epoch)?;
+        Ok(handle)
+    }
+
     /// Register a handle with the minimum a preview lookup needs, WITHOUT
     /// cloning anything. Test-only — production registration always goes
     /// through `provision`, which needs a real repository on disk; the preview
@@ -310,7 +734,9 @@ impl SandboxManager {
             virtual_mcp_id: "test-agent".to_string(),
             ..Default::default()
         };
-        let handle = Self::compute_handle(clone_url, branch).expect("scopeable clone url");
+        let handle = self
+            .resolve_handle_for_config(&config, normalized_branch(&config))
+            .expect("scopeable clone url");
         let sandbox_path = self.app_root.join(super::WORKTREES_DIR).join(&handle);
         let workdir = sandbox_path.join("repo");
         self.registry
@@ -332,23 +758,107 @@ impl SandboxManager {
     /// `<host>/<owner>/<repo>/<branch>` — the worktree's path under
     /// `worktrees/`, and its identity everywhere else.
     ///
-    /// No hash and no `virtualMcpId`: the repository scope already makes this
-    /// unique, so the handle can simply BE the branch under its repo. That is
-    /// what lets the directory, the local git branch, the remote branch and
-    /// the UI carry ONE name — a hashed handle forced a second, different name
-    /// into the git layer, and every bug that followed came from the two
-    /// disagreeing.
+    /// No `virtualMcpId`: the repository scope plus the FULL normalized branch
+    /// identifies a worktree shared by every agent using that branch.
     ///
-    /// The branch is slugified, so it is always exactly one path segment:
-    /// `feature/foo` becomes `feature-foo` rather than nesting a level.
+    /// The branch is slugified into one readable path segment. Whenever that
+    /// transform changes or truncates the branch, a SHA-256 suffix of the full
+    /// branch carries the identity that slugging would otherwise discard.
+    /// Thus `feature/foo` and `feature-foo`, and two thread branches that only
+    /// differ after the readable prefix, cannot silently share a worktree.
     ///
     /// One worktree per `(repo, branch)` is the deliberate consequence — two
     /// agents on one branch share it, which is the only honest thing to do
     /// with two working copies of the same branch.
     pub fn compute_handle(clone_url: &str, branch: &str) -> Option<String> {
+        let branch = super::normalize_branch(Some(branch));
+        let mut scope = super::repo_store::repo_scope(clone_url)?;
+        scope.push(branch_handle_component(branch));
+        Some(scope.join("/"))
+    }
+
+    /// Pre-hash identity accepted only when opening durable rows/sidecars
+    /// written by an older build. New materializations always use
+    /// [`Self::compute_handle`], while `resolve_handle_for_config` reuses an
+    /// existing matching row so upgrades do not orphan a user's worktree.
+    pub(crate) fn legacy_compute_handle(clone_url: &str, branch: &str) -> Option<String> {
+        let branch = super::normalize_branch(Some(branch));
         let mut scope = super::repo_store::repo_scope(clone_url)?;
         scope.push(slugify_branch(branch));
         Some(scope.join("/"))
+    }
+
+    /// Collision escape for a readable component that was safe on its own but
+    /// is already occupied by a legacy lossy branch row (for example an old
+    /// `feature/foo` row at `feature-foo`).
+    pub(crate) fn hashed_compute_handle(clone_url: &str, branch: &str) -> Option<String> {
+        let branch = super::normalize_branch(Some(branch));
+        let mut scope = super::repo_store::repo_scope(clone_url)?;
+        scope.push(hashed_branch_handle_component(branch));
+        Some(scope.join("/"))
+    }
+
+    fn resolve_handle_for_config(
+        &self,
+        cfg: &GitSandboxConfig,
+        branch: &str,
+    ) -> Result<String, String> {
+        let branch = super::normalize_branch(Some(branch));
+        let expected = Self::compute_handle(&cfg.clone_url, branch)
+            .ok_or_else(|| format!("clone URL cannot be scoped: {}", cfg.clone_url))?;
+        let expected_scope = super::repo_store::repo_scope(&cfg.clone_url);
+        let matches_config = |record: &super::registry::SandboxRecord| {
+            normalized_branch(&record.config) == branch
+                && super::repo_store::repo_scope(&record.config.clone_url) == expected_scope
+        };
+        let existing = self
+            .registry
+            .records_for_virtual_mcp(&cfg.virtual_mcp_id)?
+            .into_iter()
+            .filter(|record| matches_config(record))
+            .max_by_key(|record| (record.handle == expected, record.last_seen_at));
+        if let Some(existing) = existing {
+            return Ok(existing.handle);
+        }
+
+        let expected_record = self.registry.record(&expected)?;
+        if expected_record.as_ref().is_some_and(matches_config) {
+            return Ok(expected);
+        }
+        let expected_sidecar = super::persist::read_sidecar(&self.app_root, &expected);
+        if expected_sidecar.as_ref().is_some_and(|config| {
+            normalized_branch(config) == branch
+                && super::repo_store::repo_scope(&config.clone_url) == expected_scope
+        }) {
+            return Ok(expected);
+        }
+        if expected_record.is_none() && expected_sidecar.is_none() {
+            return Ok(expected);
+        }
+
+        let fallback = Self::hashed_compute_handle(&cfg.clone_url, branch)
+            .ok_or_else(|| format!("clone URL cannot be scoped: {}", cfg.clone_url))?;
+        if fallback == expected {
+            return Err(format!(
+                "sandbox handle {expected} is already occupied by a different branch"
+            ));
+        }
+        let fallback_record = self.registry.record(&fallback)?;
+        let fallback_sidecar = super::persist::read_sidecar(&self.app_root, &fallback);
+        let fallback_sidecar_mismatch = fallback_sidecar.as_ref().is_some_and(|config| {
+            normalized_branch(config) != branch
+                || super::repo_store::repo_scope(&config.clone_url) != expected_scope
+        });
+        if fallback_record
+            .as_ref()
+            .is_some_and(|record| !matches_config(record))
+            || fallback_sidecar_mismatch
+        {
+            return Err(format!(
+                "sandbox handle {fallback} is already occupied by a different branch"
+            ));
+        }
+        Ok(fallback)
     }
 
     /// Bring up this sandbox's organization filesystem, and say in the
@@ -429,7 +939,7 @@ impl SandboxManager {
 
     /// Where a git-backed run's checkout belongs —
     /// `<app_root>/worktrees/<handle>/repo` — computed from the config alone,
-    /// so it is known even when [`Self::ensure`] never succeeded.
+    /// so it is known even when [`Self::ensure_for_account`] never succeeded.
     ///
     /// Exists so a failed `ensure` cannot route a git-backed run into the
     /// process-global `state.repo_dir`. That directory is shared by every
@@ -437,10 +947,15 @@ impl SandboxManager {
     /// other's files, and would put the agent somewhere the user's worktree
     /// isn't — writes would silently land outside the branch they belong to.
     /// A git-backed run stays under its own handle or it doesn't run at all.
-    pub fn workdir_for(&self, cfg: &GitSandboxConfig) -> PathBuf {
+    #[cfg(test)]
+    fn workdir_for(&self, cfg: &GitSandboxConfig) -> PathBuf {
         // An unscopeable clone URL is not a git-backed sandbox; fall back to
         // the global repo dir exactly as a config with no repository does.
-        let Some(handle) = Self::compute_handle(&cfg.clone_url, normalized_branch(cfg)) else {
+        let Some(handle) = self
+            .resolve_handle_for_config(cfg, normalized_branch(cfg))
+            .ok()
+            .or_else(|| Self::compute_handle(&cfg.clone_url, normalized_branch(cfg)))
+        else {
             return self.app_root.join("repo");
         };
         crate::sandbox::worktree_repo_dir(&self.app_root, &handle)
@@ -450,13 +965,30 @@ impl SandboxManager {
     /// `routes/proxy.rs` to resolve the sniffed dev port for a specific
     /// handle. Returns `None` for a handle never `ensure()`-d (never
     /// creates one — that's `ensure()`'s job).
-    pub fn get(&self, handle: &str) -> Option<Arc<Sandbox>> {
+    fn get(&self, handle: &str) -> Option<Arc<Sandbox>> {
         self.lock_sandboxes().get(handle).cloned()
+    }
+
+    pub(crate) fn get_for_account(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Option<Arc<Sandbox>>, String> {
+        self.validate_account_epoch(epoch)?;
+        let sandbox = self.get(handle);
+        if sandbox
+            .as_ref()
+            .is_some_and(|sandbox| sandbox.account_epoch != epoch)
+        {
+            return Err(STALE_ACCOUNT_EPOCH.to_string());
+        }
+        self.validate_account_epoch(epoch)?;
+        Ok(sandbox)
     }
 
     /// Stable `Arc` snapshot used by shutdown. No manager lock is held while
     /// child processes are signaled or awaited.
-    pub fn snapshot(&self) -> Vec<Arc<Sandbox>> {
+    fn snapshot(&self) -> Vec<Arc<Sandbox>> {
         self.lock_sandboxes().values().cloned().collect()
     }
 
@@ -495,6 +1027,66 @@ impl SandboxManager {
         .await
     }
 
+    /// Capture the current account epoch while the caller holds the upstream
+    /// account-transition lock. The opaque ticket must accompany every later
+    /// account-derived sandbox resolution or materialization.
+    pub(crate) fn account_epoch(&self) -> AccountEpoch {
+        self.materialization_gate.account_epoch()
+    }
+
+    /// Revalidate a ticket immediately before an account-derived side effect.
+    /// Launch preparation uses this for phases that do not materialize a git
+    /// sandbox (for example org directories and managed harness artifacts).
+    pub(crate) fn validate_account_epoch(&self, epoch: AccountEpoch) -> Result<(), String> {
+        self.materialization_gate.validate(epoch)
+    }
+
+    /// Subscribe to account replacement without a validate/subscribe gap.
+    /// Long-lived streams exit when the receiver differs from their ticket or
+    /// reports a change.
+    pub(crate) fn watch_account_epoch(
+        &self,
+        epoch: AccountEpoch,
+    ) -> Result<tokio::sync::watch::Receiver<AccountEpoch>, String> {
+        self.materialization_gate.watch_account_epoch(epoch)
+    }
+
+    /// Linearize one synchronous account-derived commit with epoch advance.
+    /// This is for device-local/global handlers whose actual mutation is a
+    /// non-async queue insertion or registry update; long work must not run in
+    /// this closure.
+    pub(crate) fn with_account_epoch<T>(
+        &self,
+        epoch: AccountEpoch,
+        commit: impl FnOnce() -> T,
+    ) -> Result<T, String> {
+        let _admission = self.admit_materialization(epoch)?;
+        Ok(commit())
+    }
+
+    fn admit_materialization(
+        &self,
+        epoch: AccountEpoch,
+    ) -> Result<MaterializationAdmission, String> {
+        self.materialization_gate.admit(epoch)
+    }
+
+    /// Begin the native half of an account/logout transition. Epoch advance
+    /// and publication close are one synchronous state-lock operation, so an
+    /// old request either already owns a short materialization admission (and
+    /// will be drained) or can never publish behind the later sweep snapshot.
+    pub(crate) async fn begin_account_transition(
+        self: &Arc<Self>,
+    ) -> Result<SandboxAccountTransitionGuard, String> {
+        let transition = self.account_transition_lock.clone().lock_owned().await;
+        let closure = self.materialization_gate.advance_and_close()?;
+        Ok(SandboxAccountTransitionGuard {
+            manager: self.clone(),
+            _transition: transition,
+            closure,
+        })
+    }
+
     /// Resolves `handle`, resurrecting it from its persisted
     /// [`GitSandboxConfig`] sidecar (see the `persist` module doc) when it
     /// isn't currently known in memory — the common case after a backend
@@ -503,7 +1095,7 @@ impl SandboxManager {
     /// workdir + sidecar survive on disk.
     ///
     /// - `Ok(Some(sandbox))` — already known, or successfully resurrected via
-    ///   a fresh [`Self::ensure`] call against the persisted config (which
+    ///   a fresh [`Self::ensure_for_account`] call against the persisted config (which
     ///   re-runs the safe `checkout_existing` path against the already-cloned
     ///   workdir — see `setup::clone::run`'s own doc comment — and, since a
     ///   restarted process always starts with a fresh, unconfigured
@@ -515,18 +1107,41 @@ impl SandboxManager {
     ///   workdir's git remote is no longer reachable) — distinct from
     ///   `Ok(None)` so a caller can surface a more specific error than
     ///   "unknown handle".
-    pub async fn resurrect(self: &Arc<Self>, handle: &str) -> Result<Option<Arc<Sandbox>>, String> {
-        if let Some(sandbox) = self.get(handle) {
-            return Ok(Some(sandbox));
+    #[cfg(test)]
+    async fn resurrect(self: &Arc<Self>, handle: &str) -> Result<Option<Arc<Sandbox>>, String> {
+        self.resurrect_at(self.account_epoch(), handle).await
+    }
+
+    pub(crate) async fn resurrect_for_account(
+        self: &Arc<Self>,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Option<Arc<Sandbox>>, String> {
+        self.resurrect_at(epoch, handle).await
+    }
+
+    async fn resurrect_at(
+        self: &Arc<Self>,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Option<Arc<Sandbox>>, String> {
+        self.validate_account_epoch(epoch)?;
+        if let Some(sandbox) = self.get_for_account(epoch, handle)? {
+            if !sandbox.tasks.is_admission_closed() {
+                return Ok(Some(sandbox));
+            }
         }
         let cfg = match self.registry.record(handle)? {
             Some(record) => record.config,
             None => match super::persist::read_sidecar(&self.app_root, handle) {
                 Some(config) => config,
-                None => return Ok(None),
+                None => {
+                    self.validate_account_epoch(epoch)?;
+                    return Ok(None);
+                }
             },
         };
-        let sandbox = self.provision(&cfg).await?;
+        let sandbox = self.provision_at(epoch, &cfg).await?;
         tracing::info!(
             handle = %handle,
             "sandbox resurrected from its persisted config (in-memory state was lost, likely a backend restart)"
@@ -534,51 +1149,99 @@ impl SandboxManager {
         Ok(Some(sandbox))
     }
 
-    /// Headerless counterpart of [`Self::resurrect`]: consults the persisted
+    /// Headerless counterpart of [`Self::resurrect_for_account`]: consults the persisted
     /// "last active handle" pointer (survives a restart even though the
-    /// in-memory `active_handle` field above doesn't — see [`Self::active`])
+    /// in-memory `active_handle` field above doesn't — see [`Self::active_for_account`])
     /// and resurrects THAT handle. `Ok(None)` when nothing was ever
     /// persisted — a genuinely fresh process, or one that only ever used the
     /// plain non-git path.
-    pub async fn resurrect_active(self: &Arc<Self>) -> Result<Option<Arc<Sandbox>>, String> {
-        if let Some(sandbox) = self.active() {
-            return Ok(Some(sandbox));
+    #[cfg(test)]
+    async fn resurrect_active(self: &Arc<Self>) -> Result<Option<Arc<Sandbox>>, String> {
+        self.resurrect_active_at(self.account_epoch()).await
+    }
+
+    pub(crate) async fn resurrect_active_for_account(
+        self: &Arc<Self>,
+        epoch: AccountEpoch,
+    ) -> Result<Option<Arc<Sandbox>>, String> {
+        self.resurrect_active_at(epoch).await
+    }
+
+    async fn resurrect_active_at(
+        self: &Arc<Self>,
+        epoch: AccountEpoch,
+    ) -> Result<Option<Arc<Sandbox>>, String> {
+        if let Some(sandbox) = self.active_for_account(epoch)? {
+            if !sandbox.tasks.is_admission_closed() {
+                return Ok(Some(sandbox));
+            }
         }
         let handle = self
             .registry
             .active_handle()?
             .or_else(|| super::persist::read_active_handle(&self.app_root));
+        self.validate_account_epoch(epoch)?;
         let Some(handle) = handle else {
             return Ok(None);
         };
-        self.resurrect(&handle).await
+        self.resurrect_at(epoch, &handle).await
     }
 
     /// Materialize only the in-process routing objects for a persisted
-    /// sandbox. Unlike [`Self::resurrect`], this never clones, installs, or
+    /// sandbox. Unlike [`Self::resurrect_for_account`], this never clones, installs, or
     /// starts anything. Observability uses it after a backend restart so an
     /// explicit `events?handle=...` can replay retained files before the user
     /// chooses to resume the sandbox.
-    pub async fn adopt(&self, handle: &str) -> Result<Option<Arc<Sandbox>>, String> {
-        if let Some(sandbox) = self.get(handle) {
+    #[cfg(test)]
+    async fn adopt(&self, handle: &str) -> Result<Option<Arc<Sandbox>>, String> {
+        self.adopt_at(self.account_epoch(), handle).await
+    }
+
+    pub(crate) async fn adopt_for_account(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Option<Arc<Sandbox>>, String> {
+        self.adopt_at(epoch, handle).await
+    }
+
+    async fn adopt_at(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Option<Arc<Sandbox>>, String> {
+        self.validate_account_epoch(epoch)?;
+        if let Some(sandbox) = self.get_for_account(epoch, handle)? {
             return Ok(Some(sandbox));
         }
+        let handle_lock = self.handle_lock(handle);
+        let _permit = handle_lock.lock().await;
+        if let Some(sandbox) = self.get_for_account(epoch, handle)? {
+            return Ok(Some(sandbox));
+        }
+        let materialization = self.admit_materialization(epoch)?;
+        // Re-read durable state only after winning the same handle lock used
+        // by Stop. Reading before the lock can capture desired=running, wait
+        // behind Stop, then accidentally reopen a generation after Stop has
+        // durably changed the row to desired=stopped.
         let Some(record) = self.registry.record(handle)? else {
             return Ok(None);
         };
-        let handle_lock = self.handle_lock(handle);
-        let _permit = handle_lock.lock().await;
-        if let Some(sandbox) = self.get(handle) {
-            return Ok(Some(sandbox));
-        }
-        let sandbox = self.get_or_create_locked(handle)?;
+        let stopped = record.desired_status == "stopped";
+        let sandbox = if stopped {
+            self.get_or_create_stopped_locked(epoch, handle)?
+        } else {
+            self.get_or_create_locked(epoch, handle)?
+        };
         let branch = normalized_branch(&record.config).to_string();
         if let Err(error) = self.apply_config(&sandbox, &record.config, &branch) {
             self.lock_sandboxes().remove(handle);
             return Err(error);
         }
+        drop(materialization);
+        self.validate_account_epoch(epoch)?;
         Self::monitor_branch_status(&sandbox);
-        self.publish_generation(handle, Some(sandbox.clone()));
+        self.publish_generation(epoch, handle, Some(sandbox.clone()));
         tracing::info!(
             handle,
             "adopted persisted sandbox metadata without starting it"
@@ -586,73 +1249,147 @@ impl SandboxManager {
         Ok(Some(sandbox))
     }
 
-    /// Metadata-only counterpart of [`Self::resurrect_active`].
-    pub async fn adopt_active(&self) -> Result<Option<Arc<Sandbox>>, String> {
-        if let Some(sandbox) = self.active() {
-            return Ok(Some(sandbox));
-        }
-        let Some(handle) = self.registry.active_handle()? else {
-            return Ok(None);
-        };
-        self.adopt(&handle).await
-    }
-
-    /// Stop fence for a durable sandbox generation. Closing the current
-    /// orchestrator before signaling its setup/dev children guarantees an
-    /// in-flight install cannot cascade into Start after Stop returned. The
-    /// live object is evicted; a later `ensure`/Start creates a fresh
-    /// orchestrator from the durable config, which is the next generation.
+    /// Stop fence for a durable sandbox generation. The first phase snapshots
+    /// the live generation without waiting for its operation lock, closes
+    /// setup admission, and reaps every task in that generation. That lets Stop
+    /// preempt an `ensure` that is itself waiting on clone/checkout while it
+    /// holds the operation lock. The second phase acquires that lock and
+    /// evicts only when the snapshot is still current; a stale Stop can never
+    /// remove or mark stopped a replacement generation. A stopped registered
+    /// sandbox has no surviving child processes, including arbitrary execs.
     ///
     /// `Ok(None)` means the handle is truly unknown. A registered handle with
     /// no live object is already stopped and returns `Ok(Some(0))` without
     /// materializing it.
-    pub async fn stop_registered(&self, handle: &str) -> Result<Option<usize>, String> {
-        if !self.registry.contains(handle)? {
-            return Ok(None);
-        }
-        let handle_lock = self.handle_lock(handle);
-        let _permit = handle_lock.lock().await;
-        self.stop_locked(handle).await.map(Some)
+    #[cfg(test)]
+    async fn stop_registered(&self, handle: &str) -> Result<Option<usize>, String> {
+        self.stop_registered_generation(handle).await
     }
 
-    /// The stop itself, with this handle's operation lock ALREADY held.
-    ///
-    /// Split out so [`Self::remove_registered`] can stop and then delete under
-    /// ONE acquisition: the per-handle lock is not reentrant, and releasing it
-    /// between the two would let an `ensure` re-clone the worktree into the
-    /// directory about to be removed.
-    async fn stop_locked(&self, handle: &str) -> Result<usize, String> {
-        let Some(sandbox) = self.get(handle) else {
-            let record = self
-                .registry
-                .record(handle)?
-                .ok_or_else(|| format!("unknown sandbox handle: {handle}"))?;
-            let observed = if record.sandbox_path.is_dir() {
-                "stopped"
-            } else {
-                "absent"
-            };
-            self.registry
-                .mark_state(handle, "stopped", observed, record.error.as_deref())?;
-            return Ok(0);
-        };
+    pub(crate) async fn stop_registered_for_account(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Option<usize>, String> {
+        self.stop_registered_generation_at(Some(epoch), handle)
+            .await
+    }
 
-        // The close flag is the generation fence checked between every
-        // clone/install/start cascade step. Set it before signaling children.
-        sandbox.setup.close();
-        let task_ids: Vec<String> = sandbox
-            .tasks
-            .list(Some(&[TaskStatus::Running]))
-            .into_iter()
-            .filter(|task| {
-                matches!(
-                    task.log_name.as_deref(),
-                    Some("setup") | Some("dev") | Some("start")
-                )
-            })
-            .map(|task| task.id)
-            .collect();
-        let killed = match terminate_task_ids(&sandbox.tasks, &task_ids).await {
+    /// Intent-named alias for callers deleting the whole sandbox generation.
+    /// Registered Stop already guarantees full process quiescence, so delete
+    /// deliberately shares the exact same fence and result contract. Durable
+    /// registry metadata and the worktree remain available for lifecycle
+    /// reporting or a later resume.
+    #[cfg(test)]
+    async fn delete_registered(&self, handle: &str) -> Result<Option<usize>, String> {
+        self.stop_registered_generation(handle).await
+    }
+
+    pub(crate) async fn delete_registered_for_account(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Option<usize>, String> {
+        self.stop_registered_generation_at(Some(epoch), handle)
+            .await
+    }
+
+    /// Quiesce only live synthetic sandboxes owned by one exact Studio agent
+    /// and thread. Account replacement calls this after terminal preparation
+    /// drains: at that point a completed preparation may no longer have an
+    /// active cancellation waiter, but its `thread:<id>` generation must not
+    /// survive the account fence.
+    ///
+    /// Each durable identity is checked while holding the handle operation
+    /// lock, then that exact live generation is closed and removed under the
+    /// same lock. A concurrent provision therefore cannot replace the record
+    /// with a real/shared branch between filtering and deletion.
+    #[cfg(test)]
+    async fn delete_live_thread_sandboxes(
+        &self,
+        virtual_mcp_id: &str,
+        thread_id: &str,
+    ) -> Result<usize, String> {
+        self.delete_live_thread_sandboxes_at(None, virtual_mcp_id, thread_id)
+            .await
+    }
+
+    pub(crate) async fn delete_live_thread_sandboxes_for_account(
+        &self,
+        epoch: AccountEpoch,
+        virtual_mcp_id: &str,
+        thread_id: &str,
+    ) -> Result<usize, String> {
+        self.delete_live_thread_sandboxes_at(Some(epoch), virtual_mcp_id, thread_id)
+            .await
+    }
+
+    async fn delete_live_thread_sandboxes_at(
+        &self,
+        epoch: Option<AccountEpoch>,
+        virtual_mcp_id: &str,
+        thread_id: &str,
+    ) -> Result<usize, String> {
+        if let Some(epoch) = epoch {
+            self.validate_account_epoch(epoch)?;
+        }
+        if virtual_mcp_id.is_empty() || thread_id.is_empty() {
+            return Ok(0);
+        }
+        let handles = self.lock_sandboxes().keys().cloned().collect::<Vec<_>>();
+        let mut deleted = 0;
+        let mut failures = Vec::new();
+        for handle in handles {
+            match self
+                .delete_live_thread_sandbox(epoch, &handle, virtual_mcp_id, thread_id)
+                .await
+            {
+                Ok(true) => deleted += 1,
+                Ok(false) => {}
+                Err(error) => failures.push(format!("{handle}: {error}")),
+            }
+        }
+        if failures.is_empty() {
+            Ok(deleted)
+        } else {
+            Err(format!(
+                "could not delete synthetic thread sandbox(es): {}",
+                failures.join("; ")
+            ))
+        }
+    }
+
+    async fn delete_live_thread_sandbox(
+        &self,
+        epoch: Option<AccountEpoch>,
+        handle: &str,
+        virtual_mcp_id: &str,
+        thread_id: &str,
+    ) -> Result<bool, String> {
+        let handle_lock = self.handle_lock(handle);
+        let _permit = handle_lock.lock().await;
+        if let Some(epoch) = epoch {
+            self.validate_account_epoch(epoch)?;
+        }
+        let Some(record) = self.registry.record(handle)? else {
+            return Ok(false);
+        };
+        if record.config.virtual_mcp_id != virtual_mcp_id
+            || !matches!(
+                super::synthetic_thread_id(normalized_branch(&record.config)),
+                Ok(Some(record_thread_id)) if record_thread_id == thread_id
+            )
+        {
+            return Ok(false);
+        }
+        let Some(sandbox) = self.get(handle) else {
+            return Ok(false);
+        };
+        if epoch.is_some_and(|epoch| sandbox.account_epoch != epoch) {
+            return Err(STALE_ACCOUNT_EPOCH.to_string());
+        }
+
+        let killed = match close_and_reap_generation(&sandbox).await {
             Ok(killed) => killed,
             Err(message) => {
                 self.registry
@@ -660,93 +1397,260 @@ impl SandboxManager {
                 return Err(message);
             }
         };
+        let still_current = self
+            .get(handle)
+            .is_some_and(|current| Arc::ptr_eq(&current, &sandbox));
+        if !still_current {
+            return Ok(false);
+        }
         sandbox
             .setup
             .transition_lifecycle(json!({ "phase": "idle" }));
         self.lock_sandboxes().remove(handle);
-        self.publish_generation(handle, None);
+        self.publish_generation(sandbox.account_epoch, handle, None);
         self.registry
             .mark_state(handle, "stopped", "stopped", None)?;
-        Ok(killed)
+        tracing::info!(
+            handle,
+            virtual_mcp_id,
+            thread_id,
+            killed,
+            "deleted live synthetic thread sandbox"
+        );
+        Ok(true)
     }
 
-    /// Reclaim a durable sandbox: stop it, delete its worktree directory, and
-    /// forget it — the only path in this process that removes a worktree a user
-    /// asked for.
-    ///
-    /// **This never refuses.** A worktree with uncommitted or unpushed work is
-    /// removed exactly like a clean one: the decision belongs to the confirm
-    /// the caller already collected, which is the only place that can state
-    /// what is about to be lost. A primitive that sometimes declined would
-    /// split that policy across two layers and make the outcome depend on state
-    /// the caller cannot see. The errors below are all infrastructure failures
-    /// (a stop that cannot reap its children, a directory that cannot be
-    /// unlinked), never a judgment about the worktree's contents.
-    ///
-    /// `Ok(None)` for an unknown handle, like [`Self::stop_registered`], so a
-    /// repeated reclaim stays idempotent.
-    pub async fn remove_registered(&self, handle: &str) -> Result<Option<usize>, String> {
-        let Some(record) = self.registry.record(handle)? else {
+    async fn stop_registered_generation(&self, handle: &str) -> Result<Option<usize>, String> {
+        self.stop_registered_generation_at(None, handle).await
+    }
+
+    async fn stop_registered_generation_at(
+        &self,
+        epoch: Option<AccountEpoch>,
+        handle: &str,
+    ) -> Result<Option<usize>, String> {
+        if let Some(epoch) = epoch {
+            self.validate_account_epoch(epoch)?;
+        }
+        if !self.registry.contains(handle)? {
             return Ok(None);
-        };
-        let handle_lock = self.handle_lock(handle);
-        let _permit = handle_lock.lock().await;
-
-        let killed = self.stop_locked(handle).await?;
-
-        let root = crate::sandbox::worktree_root(&self.app_root, handle);
-        match tokio::fs::remove_dir_all(&root).await {
-            Ok(()) => {}
-            // Already gone is the outcome that was asked for.
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => {
-                return Err(format!(
-                    "failed to remove sandbox worktree {root:?}: {error}"
-                ));
-            }
         }
 
-        // NOT cleanup — a required step. This workdir is a worktree of the
-        // shared canonical repo (see `sandbox::repo_store`), which keeps
-        // listing it after the directory is gone and then refuses to re-add a
-        // worktree at that path. Without this prune the branch could never be
-        // re-created.
-        super::repo_store::prune_worktrees(&self.app_root, &record.config.clone_url).await;
+        loop {
+            let Some(sandbox) = self.get(handle) else {
+                let handle_lock = self.handle_lock(handle);
+                let _permit = handle_lock.lock().await;
+                if let Some(epoch) = epoch {
+                    self.validate_account_epoch(epoch)?;
+                }
+                // A concurrent ensure may have inserted the generation before
+                // releasing the lock we just acquired. Restart the preemption
+                // phase so it is closed and reaped outside this lock too.
+                if self.get(handle).is_some() {
+                    continue;
+                }
+                let record = self
+                    .registry
+                    .record(handle)?
+                    .ok_or_else(|| format!("unknown sandbox handle: {handle}"))?;
+                let observed = if record.sandbox_path.is_dir() {
+                    "stopped"
+                } else {
+                    "absent"
+                };
+                self.registry
+                    .mark_state(handle, "stopped", observed, record.error.as_deref())?;
+                return Ok(Some(0));
+            };
+            if epoch.is_some_and(|epoch| sandbox.account_epoch != epoch) {
+                return Err(STALE_ACCOUNT_EPOCH.to_string());
+            }
 
-        self.registry.remove(handle)?;
-        self.invalidate_preview_labels();
-        // The durable active pointer went with the row; clear the in-memory
-        // one too, or `active()` keeps naming a sandbox that no longer exists.
-        let was_active = {
-            let mut active = self
-                .active_handle
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let was_active = active.as_deref() == Some(handle);
+            let termination = close_and_reap_generation(&sandbox).await;
+
+            let handle_lock = self.handle_lock(handle);
+            let _permit = handle_lock.lock().await;
+            if let Some(epoch) = epoch {
+                self.validate_account_epoch(epoch)?;
+            }
+            let still_current = self
+                .get(handle)
+                .is_some_and(|current| Arc::ptr_eq(&current, &sandbox));
+            if !still_current {
+                // Another stop already evicted this snapshot and a later
+                // provision installed a replacement. Its lifecycle and
+                // durable state belong to that newer generation.
+                return termination.map(Some);
+            }
+
+            let killed = match termination {
+                Ok(killed) => killed,
+                Err(message) => {
+                    self.registry
+                        .mark_state(handle, "stopped", "failed", Some(&message))?;
+                    return Err(message);
+                }
+            };
+            sandbox
+                .setup
+                .transition_lifecycle(json!({ "phase": "idle" }));
+            self.lock_sandboxes().remove(handle);
+            self.publish_generation(sandbox.account_epoch, handle, None);
+            self.registry
+                .mark_state(handle, "stopped", "stopped", None)?;
+            return Ok(Some(killed));
+        }
+    }
+
+    /// Reclaim a durable sandbox after the caller has explicitly confirmed
+    /// that its worktree may be removed. Unlike Stop, this deletes the local
+    /// worktree and durable registry row so the branch can later be recreated.
+    #[cfg(test)]
+    async fn remove_registered(&self, handle: &str) -> Result<Option<usize>, String> {
+        self.remove_registered_at(None, handle).await
+    }
+
+    pub(crate) async fn remove_registered_for_account(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Option<usize>, String> {
+        self.remove_registered_at(Some(epoch), handle).await
+    }
+
+    async fn remove_registered_at(
+        &self,
+        epoch: Option<AccountEpoch>,
+        handle: &str,
+    ) -> Result<Option<usize>, String> {
+        if let Some(epoch) = epoch {
+            self.validate_account_epoch(epoch)?;
+        }
+        if !self.registry.contains(handle)? {
+            return Ok(None);
+        }
+
+        let mut killed = 0usize;
+        loop {
+            let Some(stopped) = self.stop_registered_generation_at(epoch, handle).await? else {
+                return Ok(None);
+            };
+            killed = killed.saturating_add(stopped);
+
+            let handle_lock = self.handle_lock(handle);
+            let _permit = handle_lock.lock().await;
+            if let Some(epoch) = epoch {
+                self.validate_account_epoch(epoch)?;
+            }
+
+            // A provision can win the gap after Stop releases the operation
+            // lock. Preempt that replacement before deleting the directory;
+            // once this lock is held with no live generation, provision and
+            // git mutations are fenced until reclamation is complete.
+            if self.get(handle).is_some() {
+                continue;
+            }
+            let Some(record) = self.registry.record(handle)? else {
+                return Ok(None);
+            };
+
+            let root = crate::sandbox::worktree_root(&self.app_root, handle);
+            match tokio::fs::remove_dir_all(&root).await {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(format!(
+                        "failed to remove sandbox worktree {root:?}: {error}"
+                    ));
+                }
+            }
+
+            // Removing the directory is not enough: the shared canonical repo
+            // still records it as a git worktree until it is pruned.
+            super::repo_store::prune_worktrees(&self.app_root, &record.config.clone_url).await;
+
+            self.registry.remove(handle)?;
+            self.invalidate_preview_labels();
+            let was_active = {
+                let mut active = self
+                    .active_handle
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let was_active = active.as_deref() == Some(handle);
+                if was_active {
+                    *active = None;
+                }
+                was_active
+            };
             if was_active {
-                *active = None;
+                let _ = self.active_watch.send(None);
             }
-            was_active
-        };
-        if was_active {
-            let _ = self.active_watch.send(None);
+            tracing::info!(handle, killed, "sandbox reclaimed: worktree removed");
+            return Ok(Some(killed));
         }
-        tracing::info!(handle, killed, "sandbox reclaimed: worktree removed");
+    }
+
+    /// Close exactly one in-memory process generation. This is used by the
+    /// terminal cancellation owner, which already holds the Arc it created;
+    /// resolving by handle again could otherwise let a delayed account-A
+    /// cancellation stop account B's replacement generation.
+    async fn stop_exact_generation(&self, sandbox: &Arc<Sandbox>) -> Result<Option<usize>, String> {
+        let termination = close_and_reap_generation(sandbox).await;
+        let handle_lock = self.handle_lock(&sandbox.handle);
+        let _permit = handle_lock.lock().await;
+        let still_current = self
+            .get(&sandbox.handle)
+            .is_some_and(|current| Arc::ptr_eq(&current, sandbox));
+        if !still_current {
+            return termination.map(Some);
+        }
+        let killed = match termination {
+            Ok(killed) => killed,
+            Err(message) => {
+                self.registry
+                    .mark_state(&sandbox.handle, "stopped", "failed", Some(&message))?;
+                return Err(message);
+            }
+        };
+        sandbox
+            .setup
+            .transition_lifecycle(json!({ "phase": "idle" }));
+        self.lock_sandboxes().remove(&sandbox.handle);
+        self.publish_generation(sandbox.account_epoch, &sandbox.handle, None);
+        self.registry
+            .mark_state(&sandbox.handle, "stopped", "stopped", None)?;
         Ok(Some(killed))
     }
 
     /// Restart one live registered generation without closing it. The old
     /// dev process is fully reaped under the per-handle lock before Start is
     /// admitted, preventing old/new servers from racing for the same port.
-    pub async fn restart_registered(&self, handle: &str) -> Result<Option<usize>, String> {
+    pub(crate) async fn restart_registered_for_account(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Option<usize>, String> {
+        self.restart_registered_at(epoch, handle).await
+    }
+
+    async fn restart_registered_at(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Option<usize>, String> {
+        self.validate_account_epoch(epoch)?;
         if !self.registry.contains(handle)? {
             return Ok(None);
         }
         let handle_lock = self.handle_lock(handle);
         let _permit = handle_lock.lock().await;
+        self.validate_account_epoch(epoch)?;
         let Some(sandbox) = self.get(handle) else {
             return Ok(None);
         };
+        if sandbox.account_epoch != epoch {
+            return Err(STALE_ACCOUNT_EPOCH.to_string());
+        }
         let task_ids: Vec<String> = sandbox
             .tasks
             .list(Some(&[TaskStatus::Running]))
@@ -767,37 +1671,103 @@ impl SandboxManager {
 
     /// UI control-plane entry point. It durably registers and activates the
     /// sandbox, then returns as soon as the serialized setup worker accepts
-    /// the appropriate step. Unlike [`Self::ensure`], it does not await git:
+    /// the appropriate step. Unlike [`Self::ensure_for_account`], it does not await git:
     /// the caller can connect `events?handle=...` immediately and watch clone
     /// output live, and Stop can fence/cancel that generation while clone or
     /// install is still running.
-    pub async fn provision(
+    #[cfg(test)]
+    async fn provision(self: &Arc<Self>, cfg: &GitSandboxConfig) -> Result<Arc<Sandbox>, String> {
+        self.provision_at(self.account_epoch(), cfg).await
+    }
+
+    pub(crate) async fn provision_for_account(
         self: &Arc<Self>,
+        epoch: AccountEpoch,
         cfg: &GitSandboxConfig,
     ) -> Result<Arc<Sandbox>, String> {
+        self.provision_at(epoch, cfg).await
+    }
+
+    async fn provision_at(
+        self: &Arc<Self>,
+        epoch: AccountEpoch,
+        cfg: &GitSandboxConfig,
+    ) -> Result<Arc<Sandbox>, String> {
+        self.validate_account_epoch(epoch)?;
         if self.is_closing() {
             return Err("sandbox manager is shutting down".to_string());
         }
         let branch = normalized_branch(cfg).to_string();
-        let handle = Self::compute_handle(&cfg.clone_url, &branch)
-            .ok_or_else(|| format!("clone URL cannot be scoped: {}", cfg.clone_url))?;
+        let handle = self.resolve_handle_for_config(cfg, &branch)?;
         let handle_lock = self.handle_lock(&handle);
         let _permit = handle_lock.lock().await;
+        self.provision_locked(epoch, cfg, &handle, &branch).await
+    }
+
+    /// Fail-fast control-plane variant for callers that already retain a
+    /// higher-level lifecycle fence. `Ok(None)` means another ensure/provision
+    /// owns this handle's operation lock; the caller must surface Busy instead
+    /// of queuing behind a potentially stalled clone while holding its fence.
+    #[cfg(test)]
+    async fn try_provision(
+        self: &Arc<Self>,
+        cfg: &GitSandboxConfig,
+    ) -> Result<Option<Arc<Sandbox>>, String> {
+        self.try_provision_at(self.account_epoch(), cfg).await
+    }
+
+    pub(crate) async fn try_provision_for_account(
+        self: &Arc<Self>,
+        epoch: AccountEpoch,
+        cfg: &GitSandboxConfig,
+    ) -> Result<Option<Arc<Sandbox>>, String> {
+        self.try_provision_at(epoch, cfg).await
+    }
+
+    async fn try_provision_at(
+        self: &Arc<Self>,
+        epoch: AccountEpoch,
+        cfg: &GitSandboxConfig,
+    ) -> Result<Option<Arc<Sandbox>>, String> {
+        self.validate_account_epoch(epoch)?;
+        if self.is_closing() {
+            return Err("sandbox manager is shutting down".to_string());
+        }
+        let branch = normalized_branch(cfg).to_string();
+        let handle = self.resolve_handle_for_config(cfg, &branch)?;
+        let handle_lock = self.handle_lock(&handle);
+        let Ok(_permit) = handle_lock.try_lock_owned() else {
+            return Ok(None);
+        };
+        self.provision_locked(epoch, cfg, &handle, &branch)
+            .await
+            .map(Some)
+    }
+
+    async fn provision_locked(
+        self: &Arc<Self>,
+        epoch: AccountEpoch,
+        cfg: &GitSandboxConfig,
+        handle: &str,
+        branch: &str,
+    ) -> Result<Arc<Sandbox>, String> {
         if self.is_closing() {
             return Err("sandbox manager is shutting down".to_string());
         }
 
-        let was_known = self.get(&handle).is_some();
-        let previous_record = self.registry.record(&handle)?;
+        let materialization = self.admit_materialization(epoch)?;
+        self.evict_closed_generation_locked(handle);
+        let was_known = self.get(handle).is_some();
+        let previous_record = self.registry.record(handle)?;
         let canonical_config = merge_durable_config(cfg, previous_record.as_ref())?;
-        let sandbox = self.get_or_create_locked(&handle)?;
+        let sandbox = self.get_or_create_locked(epoch, handle)?;
         let was_running = dev_task_running(&sandbox);
         let pipeline_in_flight = sandbox.setup.is_running() || sandbox.setup.pending_count() > 0;
-        let transition = match self.apply_config(&sandbox, &canonical_config, &branch) {
+        let transition = match self.apply_config(&sandbox, &canonical_config, branch) {
             Ok(transition) => transition,
             Err(error) => {
                 if !was_known {
-                    self.lock_sandboxes().remove(&handle);
+                    self.lock_sandboxes().remove(handle);
                 }
                 return Err(error);
             }
@@ -805,26 +1775,36 @@ impl SandboxManager {
         let sandbox_path = self
             .app_root
             .join(crate::sandbox::WORKTREES_DIR)
-            .join(&handle);
+            .join(handle);
         self.registry
-            .upsert_config(&handle, &canonical_config, &sandbox_path, &sandbox.workdir)?;
+            .upsert_config(handle, &canonical_config, &sandbox_path, &sandbox.workdir)?;
+        // This is the complete materialization commit: the Arc is visible in
+        // `sandboxes` and its durable row makes it addressable by Stop. Keep
+        // the manager-wide account-transition drain independent of org I/O,
+        // sidecars, monitors, checkout, and setup.
+        drop(materialization);
         self.invalidate_preview_labels();
         // The sandbox's view onto the shared org filesystem. Best-effort by
         // design (see `org_view`): a sandbox whose view cannot be built still
         // runs, the agent simply has no org files — the same outcome as a
         // mount that is down.
         if let Some(org_slug) = canonical_config.org_slug.as_deref() {
-            self.ensure_org_filesystem(&sandbox, &handle, org_slug)
-                .await;
+            self.ensure_org_filesystem(&sandbox, handle, org_slug).await;
         }
-        self.set_active(&handle)?;
-        super::persist::write_sidecar(&self.app_root, &handle, &canonical_config);
-        self.publish_generation(&handle, Some(sandbox.clone()));
+        self.set_active_at(epoch, handle)?;
+        super::persist::write_sidecar(&self.app_root, handle, &canonical_config);
+        self.validate_account_epoch(epoch)?;
+        self.publish_generation(epoch, handle, Some(sandbox.clone()));
         Self::monitor_branch_status(&sandbox);
 
         if transition == "no-op" && (was_running || pipeline_in_flight) {
             if sandbox.broadcaster.subscriber_count() > 0 {
-                crate::routes::git::emit_branch_event(&sandbox.workdir, &sandbox.broadcaster).await;
+                crate::routes::git::emit_branch_event(
+                    sandbox.tasks.clone(),
+                    &sandbox.workdir,
+                    &sandbox.broadcaster,
+                )
+                .await;
             }
             let observed = previous_record
                 .as_ref()
@@ -838,7 +1818,8 @@ impl SandboxManager {
                 .as_ref()
                 .and_then(|record| record.error.as_deref());
             self.registry
-                .mark_state(&handle, "running", observed, error)?;
+                .mark_state(handle, "running", observed, error)?;
+            self.validate_account_epoch(epoch)?;
             return Ok(sandbox);
         }
 
@@ -862,38 +1843,16 @@ impl SandboxManager {
             // repo before it reaches this subsequently queued install.
             true
         } else {
-            crate::routes::git::is_git_repo(&sandbox.workdir).await
+            crate::routes::git::owned_is_git_repo(sandbox.tasks.clone(), sandbox.workdir.clone())
+                .await?
         };
         if !repo_valid {
-            // A cancelled git clone can leave `.git` and object files behind
-            // without being a usable repository. `git clone <url> <dir>`
-            // refuses that non-empty destination, so clear only this managed
-            // workdir before retrying the full Clone step.
-            if sandbox.workdir.exists() {
-                tokio::fs::remove_dir_all(&sandbox.workdir)
-                    .await
-                    .map_err(|error| {
-                        format!(
-                            "failed to clear invalid sandbox workdir {:?}: {error}",
-                            sandbox.workdir
-                        )
-                    })?;
-                // This workdir is a worktree of the shared canonical repo (see
-                // `sandbox::repo_store`), which still lists it after the
-                // directory is gone — and git refuses to re-add a worktree at a
-                // path it already knows. Prune so the Clone step below can
-                // re-create it.
-                super::repo_store::prune_worktrees(&self.app_root, &canonical_config.clone_url)
-                    .await;
-            }
-            tokio::fs::create_dir_all(&sandbox.workdir)
-                .await
-                .map_err(|error| {
-                    format!(
-                        "failed to recreate sandbox workdir {:?}: {error}",
-                        sandbox.workdir
-                    )
-                })?;
+            repair_invalid_workdir_owned(
+                &sandbox,
+                self.app_root.clone(),
+                canonical_config.clone_url.clone(),
+            )
+            .await?;
         }
         let resume_step = previous_record
             .as_ref()
@@ -911,13 +1870,18 @@ impl SandboxManager {
             }
         };
         if repo_valid && sandbox.broadcaster.subscriber_count() > 0 {
-            crate::routes::git::emit_branch_event(&sandbox.workdir, &sandbox.broadcaster).await;
+            crate::routes::git::emit_branch_event(
+                sandbox.tasks.clone(),
+                &sandbox.workdir,
+                &sandbox.broadcaster,
+            )
+            .await;
         }
         if !sandbox.setup.resume_from(step) {
             let message = format!("setup worker rejected the {} step", step.as_str());
             let _ = self
                 .registry
-                .mark_state(&handle, "running", "failed", Some(&message));
+                .mark_state(handle, "running", "failed", Some(&message));
             return Err(format!("sandbox {handle} {message}"));
         }
         let observed = if step == Step::Start {
@@ -926,9 +1890,10 @@ impl SandboxManager {
             "provisioning"
         };
         self.registry
-            .mark_state(&handle, "running", observed, None)?;
+            .mark_state(handle, "running", observed, None)?;
         self.registry
-            .mark_observed(&handle, observed, None, Some(step.as_str()))?;
+            .mark_observed(handle, observed, None, Some(step.as_str()))?;
+        self.validate_account_epoch(epoch)?;
         Ok(sandbox)
     }
 
@@ -1014,11 +1979,180 @@ impl SandboxManager {
     /// continue asynchronously on the sandbox's own orchestrator worker — a
     /// dev server can take much longer to boot than a caller dispatching a
     /// harness run should have to wait.
-    pub async fn ensure(self: &Arc<Self>, cfg: &GitSandboxConfig) -> Result<Arc<Sandbox>, String> {
-        let sandbox = self.ensure_inner(cfg, std::future::ready(())).await?;
+    #[cfg(test)]
+    pub(crate) async fn ensure(
+        self: &Arc<Self>,
+        cfg: &GitSandboxConfig,
+    ) -> Result<Arc<Sandbox>, String> {
+        self.ensure_at(self.account_epoch(), cfg).await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn ensure_for_account(
+        self: &Arc<Self>,
+        epoch: AccountEpoch,
+        cfg: &GitSandboxConfig,
+    ) -> Result<Arc<Sandbox>, String> {
+        self.ensure_at(epoch, cfg).await
+    }
+
+    #[cfg(test)]
+    async fn ensure_at(
+        self: &Arc<Self>,
+        epoch: AccountEpoch,
+        cfg: &GitSandboxConfig,
+    ) -> Result<Arc<Sandbox>, String> {
+        let sandbox = self
+            .ensure_inner_at(epoch, cfg, std::future::ready(()))
+            .await?;
         self.monitor_registry_lifecycle(&sandbox);
         Self::monitor_branch_status(&sandbox);
         Ok(sandbox)
+    }
+
+    /// Account-scoped terminal preparation with a lifecycle
+    /// cancellation owner that outlives the caller's future. Before the
+    /// generation is materialized, cancellation prevents any sandbox from
+    /// being created. Afterwards, a synthetic per-thread branch is torn down
+    /// through the normal Stop fence, while a real shared branch transfers
+    /// the in-flight ensure to the manager-owned coordinator.
+    pub(crate) async fn ensure_for_terminal(
+        self: &Arc<Self>,
+        epoch: AccountEpoch,
+        cfg: &GitSandboxConfig,
+        cancel: tokio::sync::watch::Receiver<bool>,
+        teardown_on_cancel: bool,
+    ) -> Result<Arc<Sandbox>, TerminalEnsureError> {
+        let manager = self.clone();
+        let config = cfg.clone();
+        tokio::spawn(async move {
+            manager
+                .ensure_for_terminal_owned(epoch, &config, cancel, teardown_on_cancel)
+                .await
+        })
+        .await
+        .map_err(|error| {
+            TerminalEnsureError::Failed(format!(
+                "terminal sandbox preparation coordinator failed: {error}"
+            ))
+        })?
+    }
+
+    async fn ensure_for_terminal_owned(
+        self: &Arc<Self>,
+        epoch: AccountEpoch,
+        cfg: &GitSandboxConfig,
+        mut cancel: tokio::sync::watch::Receiver<bool>,
+        teardown_on_cancel: bool,
+    ) -> Result<Arc<Sandbox>, TerminalEnsureError> {
+        if *cancel.borrow() {
+            return Err(TerminalEnsureError::Canceled);
+        }
+
+        let canceled = Arc::new(AtomicBool::new(false));
+        let (materialized_tx, mut materialized_rx) = tokio::sync::oneshot::channel();
+        let control = TerminalEnsureControl {
+            canceled: canceled.clone(),
+            cancel: cancel.clone(),
+            materialized: materialized_tx,
+        };
+        let manager = self.clone();
+        let config = cfg.clone();
+        let mut ensure_task = tokio::spawn(async move {
+            let sandbox = manager
+                .ensure_inner_with_control(epoch, &config, std::future::ready(()), Some(control))
+                .await?;
+            manager.monitor_registry_lifecycle(&sandbox);
+            Self::monitor_branch_status(&sandbox);
+            Ok::<_, String>(sandbox)
+        });
+
+        // Cancellation and materialization form one linearized race. If the
+        // cancellation observer wins, the core owner either exits before
+        // creating anything or reports the exact generation it created; it
+        // cannot publish or spawn clone/setup work between those outcomes.
+        let mut cancellation_seen = false;
+        let materialized = loop {
+            if cancellation_seen {
+                tokio::select! {
+                    materialized = &mut materialized_rx => match materialized {
+                        Ok(materialized) => break materialized,
+                        Err(_) => return map_terminal_ensure_result(ensure_task.await),
+                    },
+                    result = &mut ensure_task => return map_terminal_ensure_result(result),
+                }
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = wait_terminal_cancellation(&mut cancel) => {
+                        canceled.store(true, Ordering::SeqCst);
+                        cancellation_seen = true;
+                    }
+                    materialized = &mut materialized_rx => match materialized {
+                        Ok(materialized) => break materialized,
+                        Err(_) => return map_terminal_ensure_result(ensure_task.await),
+                    },
+                    result = &mut ensure_task => return map_terminal_ensure_result(result),
+                }
+            }
+        };
+
+        let sandbox = materialized.sandbox;
+        // Never leave the core ensure holding the per-handle operation lock
+        // behind this coordination latch. Stop can now close the materialized
+        // generation before it queues for that same lock.
+        let _ = materialized.resume.send(());
+
+        if cancellation_seen || *cancel.borrow() {
+            canceled.store(true, Ordering::SeqCst);
+            return self
+                .finish_terminal_ensure_cancellation(sandbox, teardown_on_cancel, ensure_task)
+                .await;
+        }
+
+        tokio::select! {
+            biased;
+            _ = wait_terminal_cancellation(&mut cancel) => {
+                canceled.store(true, Ordering::SeqCst);
+                self.finish_terminal_ensure_cancellation(
+                    sandbox,
+                    teardown_on_cancel,
+                    ensure_task,
+                ).await
+            }
+            result = &mut ensure_task => map_terminal_ensure_result(result),
+        }
+    }
+
+    async fn finish_terminal_ensure_cancellation(
+        self: &Arc<Self>,
+        sandbox: Arc<Sandbox>,
+        teardown_on_cancel: bool,
+        ensure_task: tokio::task::JoinHandle<Result<Arc<Sandbox>, String>>,
+    ) -> Result<Arc<Sandbox>, TerminalEnsureError> {
+        if !teardown_on_cancel {
+            // Dropping a Tokio JoinHandle detaches the manager-owned owner;
+            // the shared branch remains valid for other terminals/threads.
+            drop(ensure_task);
+            return Err(TerminalEnsureError::Canceled);
+        }
+
+        // `delete_registered` snapshots and closes this generation before it
+        // waits for the handle lock held by ensure. If a later provision wins
+        // that lock first, its pointer check preserves the replacement.
+        let teardown = self.stop_exact_generation(&sandbox).await;
+        let _ = ensure_task.await;
+        match teardown {
+            Ok(Some(_)) => Err(TerminalEnsureError::Canceled),
+            Ok(None) => Err(TerminalEnsureError::Failed(format!(
+                "materialized terminal sandbox disappeared before teardown: {}",
+                sandbox.handle
+            ))),
+            Err(error) => Err(TerminalEnsureError::Failed(format!(
+                "could not tear down canceled terminal sandbox {}: {error}",
+                sandbox.handle
+            ))),
+        }
     }
 
     /// Implementation seam used by the concurrency regression test to pause a
@@ -1027,6 +2161,7 @@ impl SandboxManager {
     /// the seam lets the test prove the second caller cannot enter until the
     /// first has completed the whole git/config operation (rather than merely
     /// waiting for the `Sandbox` map insertion).
+    #[cfg(test)]
     async fn ensure_inner<F>(
         &self,
         cfg: &GitSandboxConfig,
@@ -1035,12 +2170,40 @@ impl SandboxManager {
     where
         F: std::future::Future<Output = ()>,
     {
+        self.ensure_inner_at(self.account_epoch(), cfg, after_lock)
+            .await
+    }
+
+    #[cfg(test)]
+    async fn ensure_inner_at<F>(
+        &self,
+        epoch: AccountEpoch,
+        cfg: &GitSandboxConfig,
+        after_lock: F,
+    ) -> Result<Arc<Sandbox>, String>
+    where
+        F: std::future::Future<Output = ()>,
+    {
+        self.ensure_inner_with_control(epoch, cfg, after_lock, None)
+            .await
+    }
+
+    async fn ensure_inner_with_control<F>(
+        &self,
+        epoch: AccountEpoch,
+        cfg: &GitSandboxConfig,
+        after_lock: F,
+        mut terminal_control: Option<TerminalEnsureControl>,
+    ) -> Result<Arc<Sandbox>, String>
+    where
+        F: std::future::Future<Output = ()>,
+    {
+        self.validate_account_epoch(epoch)?;
         if self.is_closing() {
             return Err("sandbox manager is shutting down".to_string());
         }
         let branch = normalized_branch(cfg).to_string();
-        let handle = Self::compute_handle(&cfg.clone_url, &branch)
-            .ok_or_else(|| format!("clone URL cannot be scoped: {}", cfg.clone_url))?;
+        let handle = self.resolve_handle_for_config(cfg, &branch)?;
 
         // Serialize the ENTIRE ensure operation for one handle. The previous
         // implementation released this lock immediately after inserting the
@@ -1049,16 +2212,58 @@ impl SandboxManager {
         // That produced intermittent successful `ensure()` results backed by
         // a missing/half-created worktree under the full parallel test suite.
         let handle_lock = self.handle_lock(&handle);
-        let _permit = handle_lock.lock().await;
+        let _permit = if let Some(control) = terminal_control.as_mut() {
+            tokio::select! {
+                biased;
+                _ = wait_terminal_cancellation(&mut control.cancel) => {
+                    return Err(TERMINAL_ENSURE_CANCELED.to_string());
+                }
+                permit = handle_lock.lock() => permit,
+            }
+        } else {
+            handle_lock.lock().await
+        };
+        // Stop deliberately closes a live generation before waiting for this
+        // operation lock. Remember the generation visible on entry so a
+        // concurrent Stop cannot turn this in-flight owner into an implicit
+        // restart after `after_lock` releases its process.
+        let generation_at_entry = self.get(&handle);
         after_lock.await;
+
+        if generation_at_entry
+            .as_ref()
+            .is_some_and(|sandbox| sandbox.tasks.is_admission_closed())
+        {
+            // A metadata generation that was already durably stopped before
+            // this ensure won the handle lock may be explicitly resumed. A
+            // concurrent Stop has only closed task admission at this point;
+            // it cannot mark the durable row stopped until we release this
+            // same lock, so reject it here even if the close raced the entry
+            // snapshot above.
+            let was_durably_stopped = self
+                .registry
+                .record(&handle)?
+                .is_some_and(|record| record.desired_status == "stopped");
+            if !was_durably_stopped {
+                return Err("sandbox generation stopped during ensure".to_string());
+            }
+        }
 
         if self.is_closing() {
             return Err("sandbox manager is shutting down".to_string());
         }
+        if terminal_control
+            .as_ref()
+            .is_some_and(|control| control.canceled.load(Ordering::SeqCst))
+        {
+            return Err(TERMINAL_ENSURE_CANCELED.to_string());
+        }
 
+        let materialization = self.admit_materialization(epoch)?;
+        self.evict_closed_generation_locked(&handle);
         let previous_record = self.registry.record(&handle)?;
         let canonical_config = merge_durable_config(cfg, previous_record.as_ref())?;
-        let sandbox = self.get_or_create_locked(&handle)?;
+        let sandbox = self.get_or_create_locked(epoch, &handle)?;
         let transition = self.apply_config(&sandbox, &canonical_config, &branch)?;
         let sandbox_path = self
             .app_root
@@ -1066,6 +2271,29 @@ impl SandboxManager {
             .join(&handle);
         self.registry
             .upsert_config(&handle, &canonical_config, &sandbox_path, &sandbox.workdir)?;
+        // The Arc and durable row are now one Stop-addressable generation.
+        // Terminal coordination and all repository/setup work happen outside
+        // the manager-wide drain lease.
+        drop(materialization);
+        if let Some(control) = terminal_control.take() {
+            // This is the exact materialization latch: the generation is now
+            // both present in-memory and durably addressable by Stop, while
+            // no clone/setup process has started yet. Terminal cancellation
+            // decides whether this owner resumes or is torn down.
+            let (resume, resumed) = tokio::sync::oneshot::channel();
+            if let Err(materialized) = control.materialized.send(TerminalEnsureMaterialized {
+                sandbox: sandbox.clone(),
+                resume,
+            }) {
+                // The public future may itself have been dropped. Its
+                // manager-owned coordinator normally remains alive, but if
+                // that coordinator was aborted too, completing ensure is
+                // safer than stranding a half-materialized open generation.
+                let _ = materialized.resume.send(());
+            } else if resumed.await.is_err() {
+                return Err(TERMINAL_ENSURE_CANCELED.to_string());
+            }
+        }
         self.invalidate_preview_labels();
         // The sandbox's view onto the shared org filesystem. Best-effort by
         // design (see `org_view`): a sandbox whose view cannot be built still
@@ -1077,16 +2305,17 @@ impl SandboxManager {
         }
         // This dispatch's sandbox becomes the headerless-preview target only
         // after its complete identity is durably registered.
-        self.set_active(&handle)?;
+        self.set_active_at(epoch, &handle)?;
         // Persist the exact config that got this handle here — see the
         // `persist` module doc: `compute_handle` is a one-way hash, so this
         // sidecar is the only way a LATER process (a restarted one that
         // forgot this handle's in-memory `Sandbox`) can `ensure()` it again
-        // via [`Self::resurrect`]. Written only after `apply_config` above
+        // via [`Self::resurrect_for_account`]. Written only after `apply_config` above
         // succeeded, so a rejected/invalid patch never persists a bogus
         // sidecar.
         super::persist::write_sidecar(&self.app_root, &handle, &canonical_config);
-        self.publish_generation(&handle, Some(sandbox.clone()));
+        self.validate_account_epoch(epoch)?;
+        self.publish_generation(epoch, &handle, Some(sandbox.clone()));
 
         // Repeated dispatches dominate this path. For an unchanged live
         // sandbox, one branch probe preserves the checkout guarantee; the
@@ -1096,14 +2325,13 @@ impl SandboxManager {
         let (clone_ok, git_path) = match sandbox.setup.current_config() {
             Some(config)
                 if transition == "no-op"
-                    && crate::setup::clone::checkout_is_current(&sandbox.setup, &config).await =>
+                    && checkout_is_current_owned(&sandbox, config.clone()).await? =>
             {
                 (true, "current-checkout")
             }
             Some(config) => {
                 let repaired = crate::setup::clone::run(&sandbox.setup, &config).await;
-                let verified = repaired
-                    && crate::setup::clone::checkout_is_current(&sandbox.setup, &config).await;
+                let verified = repaired && checkout_is_current_owned(&sandbox, config).await?;
                 (verified, "clone-or-checkout")
             }
             None => (true, "no-repository"),
@@ -1127,7 +2355,12 @@ impl SandboxManager {
             return Err(format!("sandbox {handle}: {message}"));
         }
         if git_path == "current-checkout" && sandbox.broadcaster.subscriber_count() > 0 {
-            crate::routes::git::emit_branch_event(&sandbox.workdir, &sandbox.broadcaster).await;
+            crate::routes::git::emit_branch_event(
+                sandbox.tasks.clone(),
+                &sandbox.workdir,
+                &sandbox.broadcaster,
+            )
+            .await;
         }
 
         if transition != "no-op" {
@@ -1175,6 +2408,7 @@ impl SandboxManager {
                 .mark_observed(&handle, "running", None, Some("start"))?;
         }
 
+        self.validate_account_epoch(epoch)?;
         Ok(sandbox)
     }
 
@@ -1182,7 +2416,28 @@ impl SandboxManager {
     /// corresponding [`Self::handle_lock`] permit; keeping this helper
     /// synchronous makes it impossible to accidentally suspend while a
     /// partially-built value is being inserted.
-    fn get_or_create_locked(&self, handle: &str) -> Result<Arc<Sandbox>, String> {
+    fn get_or_create_locked(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Arc<Sandbox>, String> {
+        self.get_or_create_locked_with_state(epoch, handle, false)
+    }
+
+    fn get_or_create_stopped_locked(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+    ) -> Result<Arc<Sandbox>, String> {
+        self.get_or_create_locked_with_state(epoch, handle, true)
+    }
+
+    fn get_or_create_locked_with_state(
+        &self,
+        epoch: AccountEpoch,
+        handle: &str,
+        stopped: bool,
+    ) -> Result<Arc<Sandbox>, String> {
         // One lock acquisition linearizes close-vs-create: if shutdown sets
         // `closing` while an ensure already holds this guard, its insertion is
         // visible to shutdown's later snapshot; if shutdown wins first, no new
@@ -1192,6 +2447,9 @@ impl SandboxManager {
             return Err("sandbox manager is shutting down".to_string());
         }
         if let Some(sandbox) = sandboxes.get(handle) {
+            if sandbox.account_epoch != epoch {
+                return Err(STALE_ACCOUNT_EPOCH.to_string());
+            }
             return Ok(sandbox.clone());
         }
 
@@ -1206,10 +2464,12 @@ impl SandboxManager {
         // Isolated per handle so two branches of the same repo never share
         // (or race) a "setup"/"dev" transcript.
         let logs = Arc::new(LogStore::new(sandbox_root.join("logs")));
-        let tasks = Arc::new(TaskRegistry::new_with_child_lifetime_lock(
-            logs,
-            self.app_root.join(".decocms").join("child-lifetime.lock"),
-        ));
+        let child_lifetime_lock = self.app_root.join(".decocms").join("child-lifetime.lock");
+        let tasks = Arc::new(if stopped {
+            TaskRegistry::new_closed_with_child_lifetime_lock(logs, child_lifetime_lock)
+        } else {
+            TaskRegistry::new_with_child_lifetime_lock(logs, child_lifetime_lock)
+        });
         let broadcaster = Arc::new(Broadcaster::new());
         let setup = SetupOrchestrator::new(
             workdir.clone(),
@@ -1218,6 +2478,9 @@ impl SandboxManager {
             tasks.clone(),
             broadcaster.clone(),
         );
+        if stopped {
+            setup.close();
+        }
         let sandbox = Arc::new(Sandbox {
             handle: handle.to_string(),
             workdir,
@@ -1225,12 +2488,28 @@ impl SandboxManager {
             tasks,
             broadcaster,
             setup,
+            account_epoch: epoch,
             registry_monitor_started: AtomicBool::new(false),
             branch_monitor_started: AtomicBool::new(false),
             org_fs_announced: Mutex::new(None),
         });
         sandboxes.insert(handle.to_string(), sandbox.clone());
         Ok(sandbox)
+    }
+
+    /// Explicit Start/provisioning replaces a metadata-only stopped
+    /// generation instead of trying to reopen its permanent close fence.
+    /// The caller holds this handle's async operation lock, so no two resume
+    /// paths can install competing replacements.
+    fn evict_closed_generation_locked(&self, handle: &str) -> bool {
+        let mut sandboxes = self.lock_sandboxes();
+        let closed = sandboxes
+            .get(handle)
+            .is_some_and(|sandbox| sandbox.tasks.is_admission_closed());
+        if closed {
+            sandboxes.remove(handle);
+        }
+        closed
     }
 
     /// Keep branch metadata live while this sandbox has an SSE observer.
@@ -1243,6 +2522,9 @@ impl SandboxManager {
     /// recomputes one; doing so closes the race where a worktree edit lands
     /// between handshake computation and the poller's first baseline.
     fn monitor_branch_status(sandbox: &Arc<Sandbox>) {
+        if sandbox.tasks.is_admission_closed() {
+            return;
+        }
         if sandbox.branch_monitor_started.swap(true, Ordering::SeqCst) {
             return;
         }
@@ -1263,7 +2545,11 @@ impl SandboxManager {
                     continue;
                 }
 
-                let next = crate::routes::git::branch_snapshot(&sandbox.workdir).await;
+                let next = crate::routes::git::owned_branch_snapshot(
+                    sandbox.tasks.clone(),
+                    sandbox.workdir.clone(),
+                )
+                .await;
                 if next == last {
                     continue;
                 }
@@ -1380,6 +2666,92 @@ async fn wait_tasks_terminal(tasks: &TaskRegistry, ids: &[String]) {
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
+}
+
+async fn checkout_is_current_owned(sandbox: &Arc<Sandbox>, config: Value) -> Result<bool, String> {
+    let setup = sandbox.setup.clone();
+    let generation = sandbox.tasks.clone();
+    let is_current = crate::routes::git::run_owned_git_probe(
+        sandbox.tasks.clone(),
+        "git checkout-current probe",
+        async move { crate::setup::clone::checkout_is_current(&setup, &config).await },
+    )
+    .await?;
+    if generation.is_admission_closed() {
+        return Err("sandbox generation stopped during checkout-current probe".to_string());
+    }
+    Ok(is_current)
+}
+
+async fn repair_invalid_workdir_owned(
+    sandbox: &Arc<Sandbox>,
+    app_root: PathBuf,
+    clone_url: String,
+) -> Result<(), String> {
+    let workdir = sandbox.workdir.clone();
+    let canonical = super::repo_store::canonical_repo_dir(&app_root, &clone_url);
+    let generation = sandbox.tasks.clone();
+    let operation_generation = generation.clone();
+    crate::routes::git::run_owned_git_probe(
+        sandbox.tasks.clone(),
+        "repair invalid git worktree",
+        async move {
+            // A cancelled clone can leave an unusable non-empty destination.
+            // The complete clear -> canonical prune -> recreate transaction is
+            // a hidden generation task, so Stop cannot return while any part
+            // of this repair is still mutating the worktree.
+            let existed = tokio::fs::symlink_metadata(&workdir).await.is_ok();
+            if existed {
+                tokio::fs::remove_dir_all(&workdir).await.map_err(|error| {
+                    format!("failed to clear invalid sandbox workdir {workdir:?}: {error}")
+                })?;
+                if let Some(canonical) = canonical.as_deref() {
+                    // Best-effort for ordinary Git failures, as before. A
+                    // lifecycle cancellation is detected from the generation
+                    // fence after the directory has been restored below.
+                    let _ = crate::routes::git::prune_worktree_registrations(canonical).await;
+                }
+            }
+            tokio::fs::create_dir_all(&workdir).await.map_err(|error| {
+                format!("failed to recreate sandbox workdir {workdir:?}: {error}")
+            })?;
+            if operation_generation.is_admission_closed() {
+                return Err("sandbox generation stopped during worktree repair".to_string());
+            }
+            Ok(())
+        },
+    )
+    .await??;
+    if generation.is_admission_closed() {
+        return Err("sandbox generation stopped during worktree repair".to_string());
+    }
+    Ok(())
+}
+
+/// Closes one generation's setup admission, then boundedly TERM/KILLs and
+/// reaps every task registered to that generation.
+///
+/// This helper signals task owners through [`TaskRegistry`]; it does not own
+/// or abort their futures. A caller cancelling a directly-driven setup future
+/// (such as `clone::run`) must keep that owner polled concurrently until it
+/// publishes terminal state. That is what makes the registry's terminal proof
+/// trustworthy instead of dropping an owner and stranding its entry Running.
+async fn close_and_reap_generation(sandbox: &Sandbox) -> Result<usize, String> {
+    // Close the setup queue first, then the registry-owned generation fence.
+    // The latter waits for every direct route or setup registration that won
+    // admission before taking one all-inclusive exposed+internal snapshot.
+    sandbox.setup.close();
+    let result = sandbox
+        .tasks
+        .close_and_kill_all_and_wait(TASK_TERM_GRACE, TASK_KILL_REAP_DEADLINE)
+        .await;
+    if result.remaining.is_empty() {
+        return Ok(result.term_signaled);
+    }
+    Err(format!(
+        "could not reap process task(s): {}",
+        result.remaining.join(", ")
+    ))
 }
 
 const TASK_TERM_GRACE: Duration = Duration::from_secs(2);
@@ -1602,6 +2974,26 @@ fn slugify_branch(branch: &str) -> String {
     }
 }
 
+fn branch_handle_component(branch: &str) -> String {
+    let slug = slugify_branch(branch);
+    if slug == branch {
+        return slug;
+    }
+    hashed_branch_handle_component(branch)
+}
+
+fn hashed_branch_handle_component(branch: &str) -> String {
+    use sha2::{Digest, Sha256};
+
+    let slug = slugify_branch(branch);
+    let digest = Sha256::digest(branch.as_bytes());
+    let hash = digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("{slug}--{hash}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1674,6 +3066,14 @@ mod tests {
         id: &str,
         controller: Option<&crate::tasks::ProcessController>,
     ) -> crate::tasks::TaskEntry {
+        running_task_with_log_name(id, controller, "dev")
+    }
+
+    fn running_task_with_log_name(
+        id: &str,
+        controller: Option<&crate::tasks::ProcessController>,
+        log_name: &str,
+    ) -> crate::tasks::TaskEntry {
         crate::tasks::TaskEntry::new(
             crate::tasks::TaskSummary {
                 id: id.to_string(),
@@ -1684,7 +3084,7 @@ mod tests {
                 finished_at: None,
                 timed_out: false,
                 truncated: false,
-                log_name: Some("dev".to_string()),
+                log_name: Some(log_name.to_string()),
                 intentional: None,
             },
             controller.map(crate::tasks::ProcessController::kill_handle),
@@ -1831,13 +3231,106 @@ mod tests {
             Some("acme/repo-1/work")
         );
         // A branch with a slash stays ONE segment, so the tree never nests
-        // deeper than the scheme promises.
+        // deeper than the scheme promises. Its full-branch digest keeps it
+        // distinct from the already-safe `feature-foo` branch.
         let nested =
             SandboxManager::compute_handle("https://github.com/acme/repo-1", "feature/foo")
                 .expect("scopeable clone url");
-        assert_eq!(nested, "acme/repo-1/feature-foo");
+        let dashed =
+            SandboxManager::compute_handle("https://github.com/acme/repo-1", "feature-foo")
+                .expect("scopeable clone url");
+        assert!(nested.starts_with("acme/repo-1/feature-foo--"));
+        assert_eq!(dashed, "acme/repo-1/feature-foo");
+        assert_ne!(nested, dashed);
         // A remote this cannot scope is not a git-backed sandbox.
         assert!(SandboxManager::compute_handle("", "work").is_none());
+    }
+
+    #[test]
+    fn compute_handle_hashes_every_lossy_or_truncated_branch_identity() {
+        let clone_url = "https://github.com/acme/repo-1";
+        let slash = SandboxManager::compute_handle(clone_url, "feature/foo").unwrap();
+        let dash = SandboxManager::compute_handle(clone_url, "feature-foo").unwrap();
+        assert_ne!(slash, dash);
+        assert_eq!(
+            SandboxManager::legacy_compute_handle(clone_url, "feature/foo"),
+            SandboxManager::legacy_compute_handle(clone_url, "feature-foo")
+        );
+
+        let thread_id = "thread:01234567890123456789012345678901234567890123456789";
+        let first =
+            SandboxManager::compute_handle(clone_url, &format!("{thread_id}/connection-one"))
+                .unwrap();
+        let second =
+            SandboxManager::compute_handle(clone_url, &format!("{thread_id}/connection-two"))
+                .unwrap();
+        assert_ne!(first, second);
+        assert_eq!(
+            SandboxManager::legacy_compute_handle(
+                clone_url,
+                &format!("{thread_id}/connection-one")
+            ),
+            SandboxManager::legacy_compute_handle(
+                clone_url,
+                &format!("{thread_id}/connection-two")
+            )
+        );
+    }
+
+    #[test]
+    fn persisted_legacy_handle_is_reused_after_hash_upgrade() {
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let config = GitSandboxConfig {
+            virtual_mcp_id: "vmcp-legacy-handle".to_string(),
+            clone_url: "https://github.com/acme/legacy-handle.git".to_string(),
+            branch: Some("feature/foo".to_string()),
+            ..Default::default()
+        };
+        let branch = normalized_branch(&config);
+        let legacy = SandboxManager::legacy_compute_handle(&config.clone_url, branch).unwrap();
+        let current = SandboxManager::compute_handle(&config.clone_url, branch).unwrap();
+        assert_ne!(legacy, current);
+        let sandbox_path = app_root
+            .path()
+            .join(crate::sandbox::WORKTREES_DIR)
+            .join(&legacy);
+        let workdir = sandbox_path.join("repo");
+        manager
+            .registry
+            .upsert_config(&legacy, &config, &sandbox_path, &workdir)
+            .unwrap();
+
+        assert_eq!(
+            manager.resolve_handle_for_config(&config, branch).unwrap(),
+            legacy
+        );
+        assert_eq!(manager.workdir_for(&config), workdir);
+
+        let mut formerly_colliding = config.clone();
+        formerly_colliding.branch = Some("feature-foo".to_string());
+        let collision_safe = manager
+            .resolve_handle_for_config(&formerly_colliding, "feature-foo")
+            .unwrap();
+        assert_eq!(
+            collision_safe,
+            SandboxManager::hashed_compute_handle(&config.clone_url, "feature-foo").unwrap()
+        );
+        assert_ne!(collision_safe, legacy);
+        assert_ne!(collision_safe, current);
+        let collision_path = app_root
+            .path()
+            .join(crate::sandbox::WORKTREES_DIR)
+            .join(&collision_safe);
+        manager
+            .registry
+            .upsert_config(
+                &collision_safe,
+                &formerly_colliding,
+                &collision_path,
+                &collision_path.join("repo"),
+            )
+            .unwrap();
     }
 
     /// A git-backed run must resolve under its OWN handle even when `ensure`
@@ -1899,14 +3392,15 @@ mod tests {
     async fn generation_watch_is_scoped_to_one_handle_and_survives_replacement() {
         let app_root = tempfile::tempdir().unwrap();
         let manager = SandboxManager::new(app_root.path().to_path_buf());
-        let mut watched = manager.watch_generation("sandbox-a");
+        let epoch = manager.account_epoch();
+        let mut watched = manager.watch_generation(epoch, "sandbox-a");
 
         let first = {
             let lock = manager.handle_lock("sandbox-a");
             let _permit = lock.lock().await;
-            manager.get_or_create_locked("sandbox-a").unwrap()
+            manager.get_or_create_locked(epoch, "sandbox-a").unwrap()
         };
-        manager.publish_generation("sandbox-a", Some(first.clone()));
+        manager.publish_generation(epoch, "sandbox-a", Some(first.clone()));
         watched.changed().await.unwrap();
         assert!(Arc::ptr_eq(
             watched.borrow_and_update().as_ref().unwrap(),
@@ -1918,9 +3412,9 @@ mod tests {
         let other = {
             let lock = manager.handle_lock("sandbox-b");
             let _permit = lock.lock().await;
-            manager.get_or_create_locked("sandbox-b").unwrap()
+            manager.get_or_create_locked(epoch, "sandbox-b").unwrap()
         };
-        manager.publish_generation("sandbox-b", Some(other));
+        manager.publish_generation(epoch, "sandbox-b", Some(other));
         assert!(
             tokio::time::timeout(Duration::from_millis(25), watched.changed())
                 .await
@@ -1928,16 +3422,16 @@ mod tests {
         );
 
         manager.lock_sandboxes().remove("sandbox-a");
-        manager.publish_generation("sandbox-a", None);
+        manager.publish_generation(epoch, "sandbox-a", None);
         watched.changed().await.unwrap();
         assert!(watched.borrow_and_update().is_none());
 
         let replacement = {
             let lock = manager.handle_lock("sandbox-a");
             let _permit = lock.lock().await;
-            manager.get_or_create_locked("sandbox-a").unwrap()
+            manager.get_or_create_locked(epoch, "sandbox-a").unwrap()
         };
-        manager.publish_generation("sandbox-a", Some(replacement.clone()));
+        manager.publish_generation(epoch, "sandbox-a", Some(replacement.clone()));
         watched.changed().await.unwrap();
         assert!(Arc::ptr_eq(
             watched.borrow_and_update().as_ref().unwrap(),
@@ -2103,7 +3597,7 @@ mod tests {
         assert!(manager.active().is_none());
         assert!(manager.get(&handle).is_none());
         assert!(manager
-            .handle_for_agent(&cfg.virtual_mcp_id, "work")
+            .handle_for_virtual_mcp(&cfg.virtual_mcp_id, "work")
             .unwrap()
             .is_none());
 
@@ -2405,6 +3899,932 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stop_preempts_an_ensure_holding_the_handle_lock() {
+        let (_origin, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let handle = manager.register_for_test(&clone_url, "work");
+        let sandbox = manager.adopt(&handle).await.unwrap().unwrap();
+        let config = manager.registry_record(&handle).unwrap().unwrap().config;
+
+        let controller = crate::tasks::ProcessController::new();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let gate_sandbox = sandbox.clone();
+        let gate_controller = controller.clone();
+        let after_lock = async move {
+            gate_sandbox.tasks.insert(running_task_with_log_name(
+                "ensure-clone-in-flight",
+                Some(&gate_controller),
+                "setup",
+            ));
+            entered_tx.send(()).unwrap();
+            let signal = gate_controller.wait_for_change(None).await;
+            gate_sandbox.tasks.finalize(
+                "ensure-clone-in-flight",
+                TaskStatus::Killed,
+                signal.exit_code(),
+                false,
+            );
+        };
+        let ensure_manager = manager.clone();
+        let ensure =
+            tokio::spawn(async move { ensure_manager.ensure_inner(&config, after_lock).await });
+        entered_rx
+            .await
+            .expect("ensure holds the operation lock with a visible setup task");
+
+        let killed = tokio::time::timeout(Duration::from_secs(5), manager.stop_registered(&handle))
+            .await
+            .expect("Stop preempts the clone task instead of waiting behind ensure")
+            .unwrap()
+            .unwrap();
+        assert_eq!(killed, 1);
+        assert_eq!(controller.requested(), Some(KillSignal::Term));
+        assert!(
+            ensure.await.unwrap().is_err(),
+            "the closed generation cannot finish ensure successfully"
+        );
+        assert!(manager.get(&handle).is_none());
+    }
+
+    #[tokio::test]
+    async fn stop_preempts_an_in_flight_provision_clone() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            accepted_tx.send(()).unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let config = GitSandboxConfig {
+            virtual_mcp_id: "vmcp-preempt-provision".to_string(),
+            clone_url: format!("http://{address}/acme/repo.git"),
+            branch: Some("work".to_string()),
+            ..Default::default()
+        };
+        let sandbox = manager.provision(&config).await.unwrap();
+        tokio::time::timeout(Duration::from_secs(5), accepted_rx)
+            .await
+            .expect("the provisioned clone reaches the deliberately stalled remote")
+            .expect("the stalled remote remains available");
+
+        let killed = tokio::time::timeout(
+            Duration::from_secs(5),
+            manager.stop_registered(&sandbox.handle),
+        )
+        .await
+        .expect("Stop cancels the provisioned clone without waiting for its remote")
+        .unwrap()
+        .unwrap();
+        server.abort();
+
+        assert_eq!(killed, 1);
+        assert!(sandbox.setup.is_closed());
+        assert!(manager.get(&sandbox.handle).is_none());
+    }
+
+    #[tokio::test]
+    async fn stop_during_owned_repo_probe_prevents_late_workdir_repair() {
+        let (_origin, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let handle = manager.register_for_test(&clone_url, "probe-stop");
+        let sandbox = manager.adopt(&handle).await.unwrap().unwrap();
+        let marker = sandbox.workdir.join("must-survive-stop.txt");
+        tokio::fs::write(&marker, b"owned before stop")
+            .await
+            .unwrap();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let flow_sandbox = sandbox.clone();
+        let flow_root = app_root.path().to_path_buf();
+        let flow_clone_url = clone_url.clone();
+        let probe_then_repair = tokio::spawn(async move {
+            let probe_generation = flow_sandbox.tasks.clone();
+            let observed_generation = probe_generation.clone();
+            let repo_valid = crate::routes::git::run_owned_git_probe(
+                probe_generation,
+                "git stopped repository probe",
+                async move {
+                    entered_tx.send(()).unwrap();
+                    while !observed_generation.is_admission_closed() {
+                        tokio::task::yield_now().await;
+                    }
+                    false
+                },
+            )
+            .await?;
+            if !repo_valid {
+                repair_invalid_workdir_owned(&flow_sandbox, flow_root, flow_clone_url).await?;
+            }
+            Ok::<(), String>(())
+        });
+        entered_rx.await.expect("repository probe is registered");
+
+        assert_eq!(manager.stop_registered(&handle).await.unwrap(), Some(1));
+        assert!(
+            probe_then_repair.await.unwrap().is_err(),
+            "a stopped observation cannot flow into invalid-workdir repair"
+        );
+        assert_eq!(
+            tokio::fs::read(&marker).await.unwrap(),
+            b"owned before stop",
+            "Stop must not be followed by remove/recreate from a canceled false probe"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_cancellation_before_materialization_creates_no_generation() {
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let config = GitSandboxConfig {
+            virtual_mcp_id: "vmcp-terminal-pre-materialization".to_string(),
+            clone_url: "https://github.com/acme/terminal-pre-materialization.git".to_string(),
+            branch: Some("thread:before-materialization".to_string()),
+            ..Default::default()
+        };
+        let handle =
+            SandboxManager::compute_handle(&config.clone_url, normalized_branch(&config)).unwrap();
+        let permit = manager.handle_lock(&handle).lock_owned().await;
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let epoch = manager.account_epoch();
+        let ensure_manager = manager.clone();
+        let mut ensure = tokio::spawn(async move {
+            ensure_manager
+                .ensure_for_terminal(epoch, &config, cancel_rx, true)
+                .await
+        });
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut ensure)
+                .await
+                .is_err(),
+            "the held operation lock keeps terminal ensure before materialization"
+        );
+        cancel_tx.send(true).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(1), ensure)
+            .await
+            .expect("pre-materialization cancellation does not wait for the handle lock")
+            .unwrap();
+        assert!(matches!(result, Err(TerminalEnsureError::Canceled)));
+        assert!(manager.get(&handle).is_none());
+        assert!(!manager.is_registered(&handle).unwrap());
+
+        drop(permit);
+        tokio::task::yield_now().await;
+        assert!(
+            manager.get(&handle).is_none(),
+            "the canceled manager-owned ensure cannot create a delayed generation"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_cancellation_reaps_a_materialized_synthetic_generation() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            accepted_tx.send(()).unwrap();
+            std::future::pending::<()>().await;
+        });
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let config = GitSandboxConfig {
+            virtual_mcp_id: "vmcp-terminal-synthetic".to_string(),
+            clone_url: format!("http://{address}/acme/terminal-synthetic.git"),
+            branch: Some("thread:synthetic".to_string()),
+            ..Default::default()
+        };
+        let handle =
+            SandboxManager::compute_handle(&config.clone_url, normalized_branch(&config)).unwrap();
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let epoch = manager.account_epoch();
+        let ensure_manager = manager.clone();
+        let ensure = tokio::spawn(async move {
+            ensure_manager
+                .ensure_for_terminal(epoch, &config, cancel_rx, true)
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(5), accepted_rx)
+            .await
+            .expect("terminal ensure reaches the deliberately stalled remote")
+            .expect("stalled remote remains available");
+        let materialized = manager
+            .get(&handle)
+            .expect("clone starts only after the generation is materialized");
+
+        cancel_tx.send(true).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(5), ensure)
+            .await
+            .expect("synthetic cancellation preempts and reaps the clone")
+            .unwrap();
+        server.abort();
+
+        assert!(matches!(result, Err(TerminalEnsureError::Canceled)));
+        assert!(materialized.tasks.is_admission_closed());
+        assert!(manager.get(&handle).is_none());
+        assert_eq!(
+            manager
+                .registry_record(&handle)
+                .unwrap()
+                .unwrap()
+                .desired_status,
+            "stopped"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_cancellation_transfers_a_materialized_shared_generation() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            accepted_tx.send(()).unwrap();
+            std::future::pending::<()>().await;
+        });
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let config = GitSandboxConfig {
+            virtual_mcp_id: "vmcp-terminal-shared".to_string(),
+            clone_url: format!("http://{address}/acme/terminal-shared.git"),
+            branch: Some("shared-branch".to_string()),
+            ..Default::default()
+        };
+        let handle =
+            SandboxManager::compute_handle(&config.clone_url, normalized_branch(&config)).unwrap();
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let epoch = manager.account_epoch();
+        let ensure_manager = manager.clone();
+        let ensure = tokio::spawn(async move {
+            ensure_manager
+                .ensure_for_terminal(epoch, &config, cancel_rx, false)
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(5), accepted_rx)
+            .await
+            .expect("terminal ensure reaches the deliberately stalled remote")
+            .expect("stalled remote remains available");
+        let materialized = manager
+            .get(&handle)
+            .expect("clone starts only after the generation is materialized");
+
+        cancel_tx.send(true).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(1), ensure)
+            .await
+            .expect("shared cancellation transfers ownership without waiting for clone")
+            .unwrap();
+        assert!(matches!(result, Err(TerminalEnsureError::Canceled)));
+        assert!(
+            manager
+                .get(&handle)
+                .is_some_and(|current| Arc::ptr_eq(&current, &materialized)),
+            "a shared branch remains manager-owned after this terminal leaves"
+        );
+        assert!(!materialized.tasks.is_admission_closed());
+
+        tokio::time::timeout(Duration::from_secs(5), manager.delete_registered(&handle))
+            .await
+            .expect("test cleanup reaps the transferred clone")
+            .unwrap()
+            .unwrap();
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn thread_cleanup_matches_exact_agent_and_synthetic_thread_identity() {
+        let (_origin, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let exact = manager.register_for_test(&clone_url, "thread:thread-1");
+        let suffix = manager.register_for_test(&clone_url, "thread:thread-1/retry-2");
+        let prefix_collision = manager.register_for_test(&clone_url, "thread:thread-10");
+        let shared = manager.register_for_test(&clone_url, "feature/thread-1");
+        for handle in [&exact, &suffix, &prefix_collision, &shared] {
+            manager
+                .adopt(handle)
+                .await
+                .unwrap()
+                .expect("registered fixture is live");
+        }
+
+        assert_eq!(
+            manager
+                .delete_live_thread_sandboxes("another-agent", "thread-1")
+                .await
+                .unwrap(),
+            0,
+            "a reused thread id cannot cross the virtual-MCP fence"
+        );
+        assert!(manager.get(&exact).is_some());
+        assert!(manager.get(&suffix).is_some());
+
+        assert_eq!(
+            manager
+                .delete_live_thread_sandboxes("test-agent", "thread-1")
+                .await
+                .unwrap(),
+            2
+        );
+        assert!(manager.get(&exact).is_none());
+        assert!(manager.get(&suffix).is_none());
+        for handle in [&prefix_collision, &shared] {
+            let sandbox = manager
+                .get(handle)
+                .expect("prefix collisions and real branches remain live");
+            assert!(!sandbox.tasks.is_admission_closed());
+        }
+        assert_eq!(
+            manager
+                .registry_record(&exact)
+                .unwrap()
+                .unwrap()
+                .desired_status,
+            "stopped"
+        );
+        assert_eq!(
+            manager
+                .registry_record(&prefix_collision)
+                .unwrap()
+                .unwrap()
+                .desired_status,
+            "running"
+        );
+    }
+
+    #[tokio::test]
+    async fn account_transition_drains_materialization_stops_all_and_reopens_start() {
+        let (_origin, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let real = manager.register_for_test(&clone_url, "feature/shared");
+        let synthetic = manager.register_for_test(&clone_url, "thread:thread-1/retry");
+        let malformed = manager.register_for_test(&clone_url, "thread:");
+        let inside = manager.register_for_test(&clone_url, "thread:inside-transition");
+        let mut old_generations = Vec::new();
+        for handle in [&real, &synthetic, &malformed] {
+            old_generations.push(manager.adopt(handle).await.unwrap().unwrap());
+        }
+
+        // Model an old-account operation already inside the short
+        // Arc-insertion/durable-registration section.
+        let old_epoch = manager.account_epoch();
+        let inside_admission = manager
+            .materialization_gate
+            .admit(old_epoch)
+            .expect("account gate starts open");
+        let transition_guard = Arc::new(manager.begin_account_transition().await.unwrap());
+        let draining_guard = transition_guard.clone();
+        let transition = tokio::spawn(async move { draining_guard.drain_and_stop_live().await });
+        assert!(
+            !transition.is_finished(),
+            "snapshot waits for an operation already inside materialization"
+        );
+
+        let before_config = GitSandboxConfig {
+            virtual_mcp_id: "test-agent".to_string(),
+            clone_url: clone_url.clone(),
+            branch: Some("must-not-materialize".to_string()),
+            ..Default::default()
+        };
+        let before_handle = SandboxManager::compute_handle(
+            &before_config.clone_url,
+            normalized_branch(&before_config),
+        )
+        .unwrap();
+        assert!(manager
+            .provision_for_account(old_epoch, &before_config)
+            .await
+            .is_err());
+        assert!(!manager.is_registered(&before_handle).unwrap());
+
+        let inside_generation = {
+            let handle_lock = manager.handle_lock(&inside);
+            let _permit = handle_lock.lock().await;
+            manager.get_or_create_locked(old_epoch, &inside).unwrap()
+        };
+        manager.publish_generation(
+            inside_generation.account_epoch,
+            &inside,
+            Some(inside_generation.clone()),
+        );
+        old_generations.push(inside_generation);
+        drop(inside_admission);
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), transition)
+                .await
+                .expect("transition drains and sweeps every materialized generation")
+                .unwrap()
+                .unwrap(),
+            4
+        );
+        assert!(
+            manager
+                .provision_for_account(manager.account_epoch(), &before_config)
+                .await
+                .is_err(),
+            "the guard keeps publication closed after the sweep"
+        );
+        for generation in &old_generations {
+            assert!(generation.tasks.is_admission_closed());
+            assert!(manager.get(&generation.handle).is_none());
+            assert!(generation.workdir.is_dir(), "worktree is retained");
+            assert_eq!(
+                manager
+                    .registry_record(&generation.handle)
+                    .unwrap()
+                    .unwrap()
+                    .desired_status,
+                "stopped"
+            );
+        }
+
+        drop(transition_guard);
+        let config = manager.registry_record(&real).unwrap().unwrap().config;
+        let next_epoch = manager.account_epoch();
+        let resumed = manager
+            .provision_for_account(next_epoch, &config)
+            .await
+            .expect("materialization reopens after the account sweep");
+        assert!(!resumed.tasks.is_admission_closed());
+        assert_eq!(resumed.account_epoch, next_epoch);
+        assert!(!Arc::ptr_eq(&resumed, &old_generations[0]));
+    }
+
+    #[tokio::test]
+    async fn account_transition_drain_timeout_does_not_snapshot_or_stop() {
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let handle = manager.register_for_test(
+            "https://github.com/acme/materialization-timeout.git",
+            "feature/account-a",
+        );
+        let sandbox = manager.adopt(&handle).await.unwrap().unwrap();
+        let old_epoch = manager.account_epoch();
+        let stuck = manager
+            .materialization_gate
+            .admit(old_epoch)
+            .expect("materialization starts admitted");
+        let guard = manager.begin_account_transition().await.unwrap();
+
+        let error = guard
+            .drain_and_stop_live_with_timeout(Duration::from_millis(10))
+            .await
+            .expect_err("a stuck commit section must hit the named deadline");
+        assert!(error.contains("timed out after 10ms"), "{error}");
+        assert!(
+            manager
+                .get(&handle)
+                .is_some_and(|current| Arc::ptr_eq(&current, &sandbox)),
+            "timeout returns before taking the stop snapshot"
+        );
+        assert!(!sandbox.tasks.is_admission_closed());
+        assert_eq!(
+            manager
+                .registry_record(&handle)
+                .unwrap()
+                .unwrap()
+                .desired_status,
+            "running"
+        );
+
+        drop(stuck);
+        assert_eq!(
+            guard
+                .drain_and_stop_live()
+                .await
+                .expect("a retry snapshots after the stuck admission quiesces"),
+            1
+        );
+        assert!(manager.get(&handle).is_none());
+        assert!(sandbox.tasks.is_admission_closed());
+        assert_eq!(
+            manager
+                .registry_record(&handle)
+                .unwrap()
+                .unwrap()
+                .desired_status,
+            "stopped"
+        );
+        drop(guard);
+        manager
+            .materialization_gate
+            .admit(manager.account_epoch())
+            .expect("RAII reopens publication when the failed transition is dropped");
+    }
+
+    #[tokio::test]
+    async fn exhausted_account_epoch_fails_permanently_closed() {
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        manager
+            .materialization_gate
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .epoch = u64::MAX;
+        manager
+            .materialization_gate
+            .epoch_watch
+            .send_replace(AccountEpoch(u64::MAX));
+        let mut watch = manager.watch_account_epoch(AccountEpoch(u64::MAX)).unwrap();
+
+        assert_eq!(
+            manager
+                .begin_account_transition()
+                .await
+                .err()
+                .expect("epoch exhaustion rejects the transition"),
+            "sandbox account epoch exhausted"
+        );
+        tokio::time::timeout(Duration::from_secs(1), watch.changed())
+            .await
+            .expect("fail-closed exhaustion terminates epoch watchers")
+            .unwrap();
+        assert!(manager
+            .validate_account_epoch(AccountEpoch(u64::MAX))
+            .is_err());
+        assert!(
+            manager
+                .materialization_gate
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .closed
+        );
+    }
+
+    #[tokio::test]
+    async fn account_epoch_watch_cannot_miss_transition_advance() {
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let old_epoch = manager.account_epoch();
+        let mut watch = manager.watch_account_epoch(old_epoch).unwrap();
+
+        let transition = manager.begin_account_transition().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(1), watch.changed())
+            .await
+            .expect("epoch watcher is notified synchronously with close")
+            .unwrap();
+        let next_epoch = *watch.borrow_and_update();
+        assert_ne!(old_epoch, next_epoch);
+        assert!(manager.watch_account_epoch(old_epoch).is_err());
+
+        drop(transition);
+        assert_eq!(manager.account_epoch(), next_epoch);
+        assert!(manager.watch_account_epoch(next_epoch).is_ok());
+    }
+
+    #[tokio::test]
+    async fn stale_account_ticket_cannot_target_the_replacement_generation() {
+        let (_origin, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let config = GitSandboxConfig {
+            virtual_mcp_id: "vmcp-account-epoch".to_string(),
+            clone_url,
+            branch: Some("work".to_string()),
+            ..Default::default()
+        };
+        let old_epoch = manager.account_epoch();
+        let (resume_stale_tx, resume_stale_rx) = tokio::sync::oneshot::channel();
+        let stale_manager = manager.clone();
+        let stale_config = config.clone();
+        let stale = tokio::spawn(async move {
+            resume_stale_rx.await.unwrap();
+            stale_manager
+                .try_provision_for_account(old_epoch, &stale_config)
+                .await
+        });
+
+        let transition = manager.begin_account_transition().await.unwrap();
+        assert_eq!(transition.drain_and_stop_live().await.unwrap(), 0);
+        drop(transition);
+
+        let next_epoch = manager.account_epoch();
+        let replacement = manager
+            .provision_for_account(next_epoch, &config)
+            .await
+            .expect("account B materializes after publication reopens");
+        resume_stale_tx.send(()).unwrap();
+        match stale.await.unwrap() {
+            Err(error) => assert_eq!(error, STALE_ACCOUNT_EPOCH),
+            Ok(_) => panic!("account A's paused request targeted account B's generation"),
+        }
+        let resolved = manager
+            .get_for_account(next_epoch, &replacement.handle)
+            .unwrap()
+            .unwrap();
+        assert!(Arc::ptr_eq(&resolved, &replacement));
+        assert_eq!(replacement.account_epoch, next_epoch);
+        assert!(manager
+            .get_for_account(old_epoch, &replacement.handle)
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn stop_and_delete_both_reap_arbitrary_execs() {
+        let (_origin, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+
+        let stop_handle = manager.register_for_test(&clone_url, "stop-scope");
+        let stop_sandbox = manager.adopt(&stop_handle).await.unwrap().unwrap();
+        let stop_controller = crate::tasks::ProcessController::new();
+        stop_sandbox.tasks.insert(running_task_with_log_name(
+            "stop-scope-exec",
+            Some(&stop_controller),
+            "arbitrary-exec",
+        ));
+        let stop_owner = {
+            let tasks = stop_sandbox.tasks.clone();
+            let controller = stop_controller.clone();
+            tokio::spawn(async move {
+                let signal = controller.wait_for_change(None).await;
+                tasks.finalize(
+                    "stop-scope-exec",
+                    TaskStatus::Killed,
+                    signal.exit_code(),
+                    false,
+                );
+            })
+        };
+        assert_eq!(
+            manager.stop_registered(&stop_handle).await.unwrap(),
+            Some(1)
+        );
+        stop_owner.await.unwrap();
+        assert_eq!(stop_controller.requested(), Some(KillSignal::Term));
+        assert!(manager.get(&stop_handle).is_none());
+
+        let delete_handle = manager.register_for_test(&clone_url, "delete-scope");
+        let delete_sandbox = manager.adopt(&delete_handle).await.unwrap().unwrap();
+        let delete_controller = crate::tasks::ProcessController::new();
+        delete_sandbox.tasks.insert(running_task_with_log_name(
+            "delete-scope-exec",
+            Some(&delete_controller),
+            "arbitrary-exec",
+        ));
+        let delete_owner = {
+            let tasks = delete_sandbox.tasks.clone();
+            let controller = delete_controller.clone();
+            tokio::spawn(async move {
+                let signal = controller.wait_for_change(None).await;
+                tasks.finalize(
+                    "delete-scope-exec",
+                    TaskStatus::Killed,
+                    signal.exit_code(),
+                    false,
+                );
+            })
+        };
+        assert_eq!(
+            manager.delete_registered(&delete_handle).await.unwrap(),
+            Some(1)
+        );
+        delete_owner.await.unwrap();
+        assert_eq!(delete_controller.requested(), Some(KillSignal::Term));
+        assert!(manager.get(&delete_handle).is_none());
+    }
+
+    #[tokio::test]
+    async fn stop_reaps_internal_generation_tasks_hidden_from_public_lists() {
+        let (_origin, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let handle = manager.register_for_test(&clone_url, "internal-task");
+        let sandbox = manager.adopt(&handle).await.unwrap().unwrap();
+        let controller = crate::tasks::ProcessController::new();
+        sandbox.tasks.insert(crate::tasks::TaskEntry::new_internal(
+            crate::tasks::TaskSummary {
+                id: "hidden-git-owner".to_string(),
+                command: "git status --porcelain".to_string(),
+                status: TaskStatus::Running,
+                exit_code: None,
+                started_at: 0,
+                finished_at: None,
+                timed_out: false,
+                truncated: false,
+                log_name: None,
+                intentional: None,
+            },
+            Some(controller.kill_handle()),
+        ));
+        assert!(
+            sandbox.tasks.list(None).is_empty(),
+            "the fixture must exercise a task omitted from public task lists"
+        );
+        let owner = {
+            let tasks = sandbox.tasks.clone();
+            let controller = controller.clone();
+            tokio::spawn(async move {
+                let signal = controller.wait_for_change(None).await;
+                tasks.finalize(
+                    "hidden-git-owner",
+                    TaskStatus::Killed,
+                    signal.exit_code(),
+                    false,
+                );
+            })
+        };
+
+        assert_eq!(manager.stop_registered(&handle).await.unwrap(), Some(1));
+        owner.await.unwrap();
+        assert_eq!(controller.requested(), Some(KillSignal::Term));
+        assert!(manager.get(&handle).is_none());
+    }
+
+    #[tokio::test]
+    async fn stop_waits_for_an_admitted_pure_mutation_and_rejects_late_commits() {
+        let (_origin, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let handle = manager.register_for_test(&clone_url, "mutation-fence");
+        let sandbox = manager.adopt(&handle).await.unwrap().unwrap();
+        let admission = sandbox.tasks.admit().expect("generation is open");
+        let committed_path = sandbox.workdir.join("committed-before-stop.txt");
+        let late_path = sandbox.workdir.join("must-not-commit-after-stop.txt");
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let (committed_tx, committed_rx) = tokio::sync::oneshot::channel();
+        let mutation = tokio::spawn(async move {
+            release_rx.await.unwrap();
+            tokio::fs::write(&committed_path, b"owned mutation")
+                .await
+                .unwrap();
+            drop(admission);
+            committed_tx.send(()).unwrap();
+        });
+
+        let stop_manager = manager.clone();
+        let stop_handle = handle.clone();
+        let stop = tokio::spawn(async move { stop_manager.stop_registered(&stop_handle).await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !sandbox.tasks.is_admission_closed() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("Stop closes generation admission");
+        assert!(
+            !stop.is_finished(),
+            "Stop must wait for the admitted mutation before its reap snapshot"
+        );
+
+        release_tx.send(()).unwrap();
+        committed_rx.await.unwrap();
+        assert_eq!(stop.await.unwrap().unwrap(), Some(0));
+        mutation.await.unwrap();
+        assert!(sandbox.workdir.join("committed-before-stop.txt").is_file());
+
+        if let Some(_late_admission) = sandbox.tasks.admit() {
+            tokio::fs::write(&late_path, b"late mutation")
+                .await
+                .unwrap();
+        }
+        assert!(
+            !late_path.exists(),
+            "a route resolved before Stop must not commit after Stop returns"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_delete_cannot_evict_or_mark_a_replacement_generation_stopped() {
+        let (_origin, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let handle = manager.register_for_test(&clone_url, "work");
+        let old = manager.adopt(&handle).await.unwrap().unwrap();
+        let config = manager.registry_record(&handle).unwrap().unwrap().config;
+        let controller = crate::tasks::ProcessController::new();
+        old.tasks.insert(running_task_with_log_name(
+            "old-setup",
+            Some(&controller),
+            "arbitrary-exec",
+        ));
+
+        // Hold the operation lock only to deterministically install a new
+        // generation after Stop has completed its preemptive first phase but
+        // before it can perform the generation-checked eviction phase.
+        let handle_lock = manager.handle_lock(&handle);
+        let permit = handle_lock.lock().await;
+        let stop_manager = manager.clone();
+        let stop_handle = handle.clone();
+        let stop = tokio::spawn(async move { stop_manager.delete_registered(&stop_handle).await });
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), controller.wait_for_change(None))
+                .await
+                .expect("Stop signals the old generation before waiting for the operation lock"),
+            KillSignal::Term
+        );
+        old.tasks
+            .finalize("old-setup", TaskStatus::Killed, 143, false);
+
+        manager.lock_sandboxes().remove(&handle);
+        let replacement = manager
+            .get_or_create_locked(manager.account_epoch(), &handle)
+            .unwrap();
+        manager
+            .apply_config(&replacement, &config, normalized_branch(&config))
+            .unwrap();
+        manager.publish_generation(
+            replacement.account_epoch,
+            &handle,
+            Some(replacement.clone()),
+        );
+        manager
+            .registry
+            .mark_state(&handle, "running", "running", None)
+            .unwrap();
+        drop(permit);
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(2), stop)
+                .await
+                .expect("the stale Stop finishes once the operation lock is released")
+                .unwrap()
+                .unwrap(),
+            Some(1)
+        );
+        let current = manager.get(&handle).expect("replacement remains live");
+        assert!(Arc::ptr_eq(&current, &replacement));
+        assert!(!replacement.setup.is_closed());
+        let record = manager.registry_record(&handle).unwrap().unwrap();
+        assert_eq!(record.desired_status, "running");
+        assert_eq!(record.observed_status, "running");
+    }
+
+    #[tokio::test]
+    async fn stale_account_reclaim_cannot_remove_a_replacement_worktree_or_row() {
+        let (_origin, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let handle = manager.register_for_test(&clone_url, "work");
+        let worktree = crate::sandbox::worktree_root(app_root.path(), &handle);
+        std::fs::create_dir_all(worktree.join("repo")).unwrap();
+        std::fs::write(worktree.join("account-b-marker"), b"keep").unwrap();
+        let old = manager.adopt(&handle).await.unwrap().unwrap();
+        let config = manager.registry_record(&handle).unwrap().unwrap().config;
+        let old_epoch = manager.account_epoch();
+
+        // Pause reclaim after it snapshots and closes account A's generation,
+        // but before it can take the operation lock for filesystem removal.
+        let handle_lock = manager.handle_lock(&handle);
+        let permit = handle_lock.lock().await;
+        let reclaim_manager = manager.clone();
+        let reclaim_handle = handle.clone();
+        let reclaim = tokio::spawn(async move {
+            reclaim_manager
+                .remove_registered_for_account(old_epoch, &reclaim_handle)
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !old.setup.is_closed() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("reclaim closes the old generation before waiting for the lock");
+
+        // Advance the account fence and install the replacement while reclaim
+        // is still paused. Releasing the lock must make the stale request fail,
+        // not remove account B's row or worktree.
+        let transition = manager.begin_account_transition().await.unwrap();
+        let next_epoch = manager.account_epoch();
+        manager.lock_sandboxes().remove(&handle);
+        let replacement = manager.get_or_create_locked(next_epoch, &handle).unwrap();
+        manager
+            .apply_config(&replacement, &config, normalized_branch(&config))
+            .unwrap();
+        manager.publish_generation(next_epoch, &handle, Some(replacement.clone()));
+        manager
+            .registry
+            .mark_state(&handle, "running", "running", None)
+            .unwrap();
+        drop(transition);
+        drop(permit);
+
+        let error = tokio::time::timeout(Duration::from_secs(2), reclaim)
+            .await
+            .expect("stale reclaim finishes after the operation lock is released")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error, STALE_ACCOUNT_EPOCH);
+        assert!(worktree.join("account-b-marker").is_file());
+        assert!(manager.registry_record(&handle).unwrap().is_some());
+        let current = manager.get(&handle).expect("replacement remains live");
+        assert!(Arc::ptr_eq(&current, &replacement));
+        assert_eq!(replacement.account_epoch, next_epoch);
+        let record = manager.registry_record(&handle).unwrap().unwrap();
+        assert_eq!(record.desired_status, "running");
+        assert_eq!(record.observed_status, "running");
+    }
+
+    #[tokio::test]
     async fn concurrent_provision_calls_coalesce_one_setup_generation() {
         let (_root, clone_url) = setup_two_branch_repo();
         let app_root = tempfile::tempdir().unwrap();
@@ -2441,6 +4861,28 @@ mod tests {
             clone_tasks, 1,
             "repeat provision must not queue Clone twice"
         );
+    }
+
+    #[tokio::test]
+    async fn try_provision_fails_fast_while_the_handle_lock_is_owned() {
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let config = GitSandboxConfig {
+            virtual_mcp_id: "vmcp-busy-start".to_string(),
+            clone_url: "https://github.com/acme/busy-start.git".to_string(),
+            branch: Some("work".to_string()),
+            ..Default::default()
+        };
+        let handle = SandboxManager::compute_handle(&config.clone_url, "work").unwrap();
+        let permit = manager.handle_lock(&handle).lock_owned().await;
+
+        let attempted =
+            tokio::time::timeout(Duration::from_millis(100), manager.try_provision(&config))
+                .await
+                .expect("try_provision must not queue behind a held handle lock")
+                .expect("busy is not an internal error");
+        assert!(attempted.is_none(), "held handle lock reports Busy");
+        drop(permit);
     }
 
     #[tokio::test]
@@ -2869,7 +5311,7 @@ mod tests {
             let _permit = lock.lock().await;
             sandboxes.push(
                 manager
-                    .get_or_create_locked(handle)
+                    .get_or_create_locked(manager.account_epoch(), handle)
                     .expect("sandbox construction succeeds"),
             );
         }

--- a/apps/native/crates/local-api/src/sandbox/mod.rs
+++ b/apps/native/crates/local-api/src/sandbox/mod.rs
@@ -56,6 +56,7 @@ pub(crate) fn handle_is_path_safe(handle: &str) -> bool {
             .all(|part| !part.is_empty() && part != "." && part != "..")
 }
 
+#[cfg(test)]
 pub(crate) fn worktree_repo_dir(app_root: &std::path::Path, handle: &str) -> std::path::PathBuf {
     worktree_root(app_root, handle).join("repo")
 }
@@ -144,6 +145,86 @@ pub const PROTECTED_BRANCHES: [&str; 2] = ["main", "master"];
 /// up checking out a routing key the other side still treats as synthetic.
 pub(crate) fn is_synthetic_branch(branch: &str) -> bool {
     branch == "ephemeral" || branch.starts_with("thread:")
+}
+
+/// Parse the tenant-authority component of a reserved `thread:` routing key.
+///
+/// This is deliberately stricter than [`is_synthetic_branch`]. The latter is
+/// a cross-language git-routing predicate and must classify even malformed
+/// `thread:` prefixes as non-git refs. Authority boundaries need a complete
+/// identity: `thread:<id>` and `thread:<id>/<suffix>` are accepted only when
+/// the complete reserved ref and both path segments obey the same bounded,
+/// Git-safe vocabulary used by every authority caller.
+pub(crate) fn synthetic_thread_id(branch: &str) -> Result<Option<&str>, &'static str> {
+    let Some(path) = branch.strip_prefix("thread:") else {
+        return Ok(None);
+    };
+    if branch.len() > 255 {
+        return Err("thread-backed sandbox branch exceeds 255 bytes");
+    }
+    let (thread_id, suffix) = match path.split_once('/') {
+        Some((thread_id, suffix)) => (thread_id, Some(suffix)),
+        None => (path, None),
+    };
+    if suffix.is_some_and(|suffix| suffix.contains('/')) {
+        return Err("thread-backed sandbox branch has too many path segments");
+    }
+    validate_synthetic_thread_segment(
+        thread_id,
+        "thread-backed sandbox branch is missing its thread id",
+    )?;
+    if let Some(suffix) = suffix {
+        validate_synthetic_thread_segment(
+            suffix,
+            "thread-backed sandbox branch has an empty suffix",
+        )?;
+    }
+    Ok(Some(thread_id))
+}
+
+/// Strict ingress wrapper for branch values supplied by a request. Trimming
+/// remains part of ordinary branch normalization, but a whitespace-wrapped
+/// reserved key must not be persisted in a noncanonical form. Legacy rows are
+/// handled separately by normalizing before calling [`synthetic_thread_id`]
+/// on launch.
+pub(crate) fn synthetic_thread_id_from_input(branch: &str) -> Result<Option<&str>, &'static str> {
+    let trimmed = branch.trim();
+    if trimmed != branch && trimmed.starts_with("thread:") {
+        return Err("thread-backed sandbox branch has leading or trailing whitespace");
+    }
+    synthetic_thread_id(normalize_branch(Some(branch)))
+}
+
+fn validate_synthetic_thread_segment(
+    segment: &str,
+    empty_error: &'static str,
+) -> Result<(), &'static str> {
+    if segment.is_empty() {
+        return Err(empty_error);
+    }
+    if segment == "." || segment == ".." {
+        return Err("thread-backed sandbox branch contains a reserved path segment");
+    }
+    if !segment
+        .as_bytes()
+        .first()
+        .is_some_and(u8::is_ascii_alphanumeric)
+    {
+        return Err("thread-backed sandbox branch segments must start with an alphanumeric byte");
+    }
+    if !segment
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    {
+        return Err("thread-backed sandbox branch contains an invalid byte");
+    }
+    if segment.contains("..") {
+        return Err("thread-backed sandbox branch contains two consecutive dots");
+    }
+    if segment.ends_with(".lock") {
+        return Err("thread-backed sandbox branch segment ends with .lock");
+    }
+    Ok(())
 }
 
 /// Longest DNS label the preview host may use. 63 is the protocol limit.
@@ -292,5 +373,58 @@ mod tests {
         assert!(!is_synthetic_branch("ephemeral-foo"));
         assert!(!is_synthetic_branch("Ephemeral"));
         assert!(!is_synthetic_branch("my-thread:1"));
+    }
+
+    #[test]
+    fn synthetic_thread_parser_requires_a_complete_reserved_identity() {
+        assert_eq!(
+            synthetic_thread_id("thread:chat-1").unwrap(),
+            Some("chat-1")
+        );
+        assert_eq!(
+            synthetic_thread_id("thread:chat-1/connection-2").unwrap(),
+            Some("chat-1")
+        );
+        assert_eq!(
+            synthetic_thread_id("thread:A0._-/9x._-").unwrap(),
+            Some("A0._-")
+        );
+        assert_eq!(synthetic_thread_id("feature/thread:chat-1").unwrap(), None);
+        assert!(synthetic_thread_id_from_input(" thread:chat-1 ").is_err());
+        assert_eq!(
+            synthetic_thread_id_from_input(" feature/chat-1 ").unwrap(),
+            None
+        );
+        assert!(synthetic_thread_id("thread:").is_err());
+        assert!(synthetic_thread_id("thread:/connection-2").is_err());
+        assert!(synthetic_thread_id("thread:chat-1/").is_err());
+        let longest_valid_id = "a".repeat(248);
+        assert_eq!(
+            synthetic_thread_id(&format!("thread:{longest_valid_id}")).unwrap(),
+            Some(longest_valid_id.as_str())
+        );
+        for branch in [
+            format!("thread:{}", "a".repeat(249)),
+            "thread:_chat".to_string(),
+            "thread:-chat".to_string(),
+            "thread:.chat".to_string(),
+            "thread:.".to_string(),
+            "thread:..".to_string(),
+            "thread:chat/_connection".to_string(),
+            "thread:chat/connection/extra".to_string(),
+            "thread:chat id".to_string(),
+            "thread:chat@id".to_string(),
+            "thread:chat..id".to_string(),
+            "thread:chat.lock".to_string(),
+            "thread:chat/.".to_string(),
+            "thread:chat/..".to_string(),
+            "thread:chat/connection..2".to_string(),
+            "thread:chat/connection.lock".to_string(),
+        ] {
+            assert!(
+                synthetic_thread_id(&branch).is_err(),
+                "invalid reserved branch was accepted: {branch}"
+            );
+        }
     }
 }

--- a/apps/native/crates/local-api/src/sandbox/persist.rs
+++ b/apps/native/crates/local-api/src/sandbox/persist.rs
@@ -129,10 +129,17 @@ fn config_handle(cfg: &GitSandboxConfig) -> Option<String> {
     SandboxManager::compute_handle(&cfg.clone_url, branch)
 }
 
+fn config_matches_handle(cfg: &GitSandboxConfig, handle: &str) -> bool {
+    let branch = crate::sandbox::normalize_branch(cfg.branch.as_deref());
+    config_handle(cfg).as_deref() == Some(handle)
+        || SandboxManager::legacy_compute_handle(&cfg.clone_url, branch).as_deref() == Some(handle)
+        || SandboxManager::hashed_compute_handle(&cfg.clone_url, branch).as_deref() == Some(handle)
+}
+
 /// Best-effort write of `cfg` as `handle`'s resurrection sidecar. Called by
 /// `SandboxManager::ensure` after a successful config apply.
 pub(crate) fn write_sidecar(app_root: &Path, handle: &str, cfg: &GitSandboxConfig) {
-    if !is_safe_handle_component(handle) || config_handle(cfg).as_deref() != Some(handle) {
+    if !is_safe_handle_component(handle) || !config_matches_handle(cfg, handle) {
         tracing::warn!(
             handle,
             "sandbox: refusing to persist mismatched sidecar identity"
@@ -165,7 +172,7 @@ pub(crate) fn read_sidecar(app_root: &Path, handle: &str) -> Option<GitSandboxCo
     }
     let bytes = std::fs::read(sidecar_path(app_root, handle)).ok()?;
     let cfg: GitSandboxConfig = serde_json::from_slice(&bytes).ok()?;
-    if config_handle(&cfg).as_deref() != Some(handle) {
+    if !config_matches_handle(&cfg, handle) {
         tracing::warn!(
             handle,
             "sandbox: resurrection sidecar identity does not match its path"
@@ -303,6 +310,22 @@ mod tests {
         assert_eq!(read_back.branch.as_deref(), Some("main"));
         assert_eq!(read_back.runtime.as_deref(), Some("node"));
         assert_eq!(read_back.package_manager.as_deref(), Some("npm"));
+    }
+
+    #[test]
+    fn legacy_lossy_handle_sidecar_remains_readable_after_hash_upgrade() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = sample_cfg();
+        config.branch = Some("feature/foo".to_string());
+        let branch = crate::sandbox::normalize_branch(config.branch.as_deref());
+        let legacy = SandboxManager::legacy_compute_handle(&config.clone_url, branch).unwrap();
+        assert_ne!(
+            Some(legacy.clone()),
+            SandboxManager::compute_handle(&config.clone_url, branch)
+        );
+
+        write_sidecar(dir.path(), &legacy, &config);
+        assert_eq!(read_sidecar(dir.path(), &legacy), Some(config));
     }
 
     #[test]

--- a/apps/native/crates/local-api/src/sandbox/registry.rs
+++ b/apps/native/crates/local-api/src/sandbox/registry.rs
@@ -201,14 +201,14 @@ impl SandboxRegistry {
         Ok(rows.pop())
     }
 
-    /// Every durable sandbox this agent has claimed, joined through
+    /// Every durable sandbox this virtual MCP has claimed, joined through
     /// `sandbox_agents` — the `virtual_mcp_id` COLUMN on `sandboxes` only
-    /// remembers whichever agent wrote last (see `handle_for_agent`).
+    /// remembers whichever virtual MCP wrote last (see `handle_for_virtual_mcp`).
     ///
     /// This is the registry-backed replacement for walking `worktrees/` and
     /// reading sidecars on request paths: one indexed query instead of a
     /// recursive directory scan per request.
-    pub(crate) fn records_for_agent(
+    pub(crate) fn records_for_virtual_mcp(
         &self,
         virtual_mcp_id: &str,
     ) -> Result<Vec<SandboxRecord>, String> {
@@ -310,15 +310,15 @@ impl SandboxRegistry {
             .map_err(|error| format!("failed to look up sandbox {handle}: {error}"))
     }
 
-    /// The handle of the worktree an agent is using for `branch`.
+    /// The handle of the worktree a virtual MCP is using for `branch`.
     ///
     /// The handle is derived from the REPOSITORY and branch, but the routes
     /// the shell calls are keyed by `(virtualMcpId, branch)` — they never see
     /// a clone URL. The registry stores all three, so it is the one place that
     /// can bridge them without a filesystem scan.
     ///
-    /// `None` when this agent has no worktree for that branch yet.
-    pub(crate) fn handle_for_agent(
+    /// `None` when this virtual MCP has no worktree for that branch yet.
+    pub(crate) fn handle_for_virtual_mcp(
         &self,
         virtual_mcp_id: &str,
         branch: &str,
@@ -902,7 +902,12 @@ fn validate_identity(handle: &str, config: &GitSandboxConfig) -> Result<(), Stri
             config.clone_url
         ));
     };
-    if handle != expected {
+    let legacy =
+        SandboxManager::legacy_compute_handle(&config.clone_url, normalized_branch(config));
+    let hashed =
+        SandboxManager::hashed_compute_handle(&config.clone_url, normalized_branch(config));
+    if handle != expected && legacy.as_deref() != Some(handle) && hashed.as_deref() != Some(handle)
+    {
         return Err(format!(
             "sandbox handle/config mismatch: expected {expected}, got {handle}"
         ));
@@ -971,14 +976,14 @@ mod tests {
         // Same repo + branch => one sandbox, reachable by BOTH agents.
         assert_eq!(
             registry
-                .handle_for_agent(&first.virtual_mcp_id, &branch)
+                .handle_for_virtual_mcp(&first.virtual_mcp_id, &branch)
                 .unwrap()
                 .as_deref(),
             Some(handle.as_str())
         );
         assert_eq!(
             registry
-                .handle_for_agent(&second.virtual_mcp_id, &branch)
+                .handle_for_virtual_mcp(&second.virtual_mcp_id, &branch)
                 .unwrap()
                 .as_deref(),
             Some(handle.as_str())
@@ -1131,7 +1136,7 @@ mod tests {
         assert!(registry.record(&handle).unwrap().is_none());
         assert!(registry.active_handle().unwrap().is_none());
         assert!(registry
-            .handle_for_agent(&cfg.virtual_mcp_id, cfg.branch.as_deref().unwrap())
+            .handle_for_virtual_mcp(&cfg.virtual_mcp_id, cfg.branch.as_deref().unwrap())
             .unwrap()
             .is_none());
         let agent_rows: i64 = registry

--- a/apps/native/crates/local-api/src/sandbox/repo_store.rs
+++ b/apps/native/crates/local-api/src/sandbox/repo_store.rs
@@ -120,7 +120,7 @@ fn split_remote(url: &str) -> Option<(String, String)> {
 /// Best-effort by design: a canonical repo that doesn't exist yet, or a `git`
 /// that fails, is not a reason to fail the caller's operation — the worst case
 /// is a stale entry that the next prune clears.
-pub async fn prune_worktrees(app_root: &Path, clone_url: &str) {
+pub(super) async fn prune_worktrees(app_root: &Path, clone_url: &str) {
     let Some(canonical) = canonical_repo_dir(app_root, clone_url) else {
         return;
     };

--- a/apps/native/crates/local-api/src/sandbox/target.rs
+++ b/apps/native/crates/local-api/src/sandbox/target.rs
@@ -68,13 +68,17 @@ impl AppState {
     /// shape — but NEVER yields "nothing": an unknown handle falls back to the
     /// global target so an SSE stream is never dead (see this module's doc,
     /// plan D1/O3). An empty handle string is treated as absent.
-    pub fn resolve_sandbox_target(&self, handle: Option<&str>) -> SandboxTarget {
+    pub(crate) fn resolve_sandbox_target_for_account(
+        &self,
+        epoch: crate::sandbox::manager::AccountEpoch,
+        handle: Option<&str>,
+    ) -> Result<SandboxTarget, String> {
         let handle = handle.filter(|s| !s.is_empty());
         let sandbox = match handle {
-            Some(h) => self.sandbox_manager.get(h), // known handle -> that sandbox
-            None => self.sandbox_manager.active(),  // headerless -> active sandbox
+            Some(h) => self.sandbox_manager.get_for_account(epoch, h)?,
+            None => self.sandbox_manager.active_for_account(epoch)?,
         };
-        match sandbox {
+        Ok(match sandbox {
             Some(sb) => SandboxTarget::from_sandbox(&sb),
             // Unknown handle OR no active sandbox -> the process-global path
             // (unchanged plain-path behavior).
@@ -85,7 +89,7 @@ impl AppState {
                 config: self.config.clone(),
                 repo_dir: self.repo_dir.clone(),
             },
-        }
+        })
     }
 }
 
@@ -172,12 +176,15 @@ mod tests {
         // on the already-cloned workdir, never the origin again).
         state
             .sandbox_manager
-            .ensure(&GitSandboxConfig {
-                virtual_mcp_id: vmcp.to_string(),
-                clone_url: bare_str.to_string(),
-                branch: Some("main".to_string()),
-                ..Default::default()
-            })
+            .ensure_for_account(
+                state.sandbox_manager.account_epoch(),
+                &GitSandboxConfig {
+                    virtual_mcp_id: vmcp.to_string(),
+                    clone_url: bare_str.to_string(),
+                    branch: Some("main".to_string()),
+                    ..Default::default()
+                },
+            )
             .await
             .expect("ensure succeeds against a real one-commit bare repo")
     }
@@ -186,8 +193,11 @@ mod tests {
     async fn known_handle_resolves_to_that_sandboxs_arcs() {
         let state = fresh_state();
         let sandbox = ensure_one_sandbox(&state, "vmcp-target-known").await;
+        let epoch = state.sandbox_manager.account_epoch();
 
-        let target = state.resolve_sandbox_target(Some(&sandbox.handle));
+        let target = state
+            .resolve_sandbox_target_for_account(epoch, Some(&sandbox.handle))
+            .unwrap();
         assert!(Arc::ptr_eq(&target.setup, &sandbox.setup));
         assert!(Arc::ptr_eq(&target.tasks, &sandbox.tasks));
         assert!(Arc::ptr_eq(&target.broadcaster, &sandbox.broadcaster));
@@ -201,8 +211,11 @@ mod tests {
         // `ensure()` marks its handle active, so a headerless resolve follows
         // the active sandbox — NOT the global orchestrator.
         let sandbox = ensure_one_sandbox(&state, "vmcp-target-active").await;
+        let epoch = state.sandbox_manager.account_epoch();
 
-        let target = state.resolve_sandbox_target(None);
+        let target = state
+            .resolve_sandbox_target_for_account(epoch, None)
+            .unwrap();
         assert!(Arc::ptr_eq(&target.setup, &sandbox.setup));
         assert!(Arc::ptr_eq(&target.tasks, &sandbox.tasks));
         assert!(Arc::ptr_eq(&target.broadcaster, &sandbox.broadcaster));
@@ -211,7 +224,9 @@ mod tests {
     #[test]
     fn no_handle_without_active_resolves_to_the_global_target() {
         let state = fresh_state();
-        let target = state.resolve_sandbox_target(None);
+        let target = state
+            .resolve_sandbox_target_for_account(state.sandbox_manager.account_epoch(), None)
+            .unwrap();
         assert!(Arc::ptr_eq(&target.setup, &state.setup));
         assert!(Arc::ptr_eq(&target.tasks, &state.tasks));
         assert!(Arc::ptr_eq(&target.broadcaster, &state.broadcaster));
@@ -227,7 +242,12 @@ mod tests {
         // which would return `None` here) — see this module's doc.
         let _sandbox = ensure_one_sandbox(&state, "vmcp-target-unknown").await;
 
-        let target = state.resolve_sandbox_target(Some("never-ensured-handle"));
+        let target = state
+            .resolve_sandbox_target_for_account(
+                state.sandbox_manager.account_epoch(),
+                Some("never-ensured-handle"),
+            )
+            .unwrap();
         assert!(Arc::ptr_eq(&target.setup, &state.setup));
         assert!(Arc::ptr_eq(&target.tasks, &state.tasks));
         assert!(Arc::ptr_eq(&target.broadcaster, &state.broadcaster));
@@ -237,7 +257,9 @@ mod tests {
     fn empty_handle_is_treated_as_absent() {
         let state = fresh_state();
         // Empty string -> global (no active sandbox in this fixture).
-        let target = state.resolve_sandbox_target(Some(""));
+        let target = state
+            .resolve_sandbox_target_for_account(state.sandbox_manager.account_epoch(), Some(""))
+            .unwrap();
         assert!(Arc::ptr_eq(&target.setup, &state.setup));
         // sanity: the global setup is idle
         assert_eq!(target.setup.lifecycle_snapshot(), json!({"phase": "idle"}));

--- a/apps/native/crates/local-api/src/setup/clone.rs
+++ b/apps/native/crates/local-api/src/setup/clone.rs
@@ -287,7 +287,16 @@ pub(crate) async fn run(orch: &Arc<SetupOrchestrator>, config: &Value) -> bool {
     let branch = get_str(config, &["git", "repository", "branch"])
         .filter(|b| !b.is_empty() && !is_synthetic_branch(b));
 
-    if !is_git_repo(&orch.repo_dir).await {
+    let repo_exists = match crate::routes::git::owned_is_git_repo(
+        orch.tasks.clone(),
+        orch.repo_dir.clone(),
+    )
+    .await
+    {
+        Ok(repo_exists) => repo_exists,
+        Err(_) => return false,
+    };
+    if !repo_exists {
         if orch.is_closed() {
             return false;
         }
@@ -304,7 +313,7 @@ pub(crate) async fn run(orch: &Arc<SetupOrchestrator>, config: &Value) -> bool {
     if !configure_git_identity(orch, config).await || orch.is_closed() {
         return false;
     }
-    emit_branch_event(&orch.repo_dir, &orch.broadcaster).await;
+    emit_branch_event(orch.tasks.clone(), &orch.repo_dir, &orch.broadcaster).await;
     !orch.is_closed()
 }
 

--- a/apps/native/crates/local-api/src/setup/dev.rs
+++ b/apps/native/crates/local-api/src/setup/dev.rs
@@ -27,15 +27,22 @@ use futures_util::FutureExt;
 use regex::Regex;
 use serde_json::{json, Value};
 use tokio::io::AsyncReadExt;
+use tokio::sync::oneshot;
 
 use super::install::{manifest_present, pm_root};
 use super::SetupOrchestrator;
 use crate::process_group::ProcessGroupChild;
-use crate::process_util::{classify_status, emit_tasks_event, exit_status_to_code, kill_group};
+#[cfg(test)]
+use crate::process_util::kill_group;
+use crate::process_util::{
+    classify_status, drive_group_to_exit, emit_tasks_event, exit_status_to_code, CancelOnDrop,
+    OutputSink,
+};
 use crate::routes::scripts::{build_command, discover_scripts, run_prefix_for};
 use crate::sandbox::persist::{DevProcessIdentity, DevProcessRecord};
 use crate::tasks::{
-    now_ms, KillSignal, OutputStream, ProcessController, TaskEntry, TaskStatus, TaskSummary,
+    now_ms, KillSignal, OutputStream, ProcessController, TaskEntry, TaskRegistry, TaskStatus,
+    TaskSummary,
 };
 
 const WELL_KNOWN_STARTERS: [&str; 2] = ["dev", "start"];
@@ -60,6 +67,7 @@ const PROBE_INTERVAL: Duration = Duration::from_millis(250);
 const IDENTITY_CAPTURE_ATTEMPTS: u32 = 20;
 const IDENTITY_CAPTURE_INTERVAL: Duration = Duration::from_millis(25);
 const IDENTITY_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+const PROCESS_OBSERVER_TIMEOUT: Duration = Duration::from_secs(5);
 const STALE_TERM_GRACE: Duration = Duration::from_millis(800);
 const STALE_KILL_GRACE: Duration = Duration::from_secs(1);
 
@@ -170,7 +178,15 @@ pub(super) async fn run(orch: &Arc<SetupOrchestrator>, config: &Value) {
     let previous = crate::sandbox::persist::read_dev_process(&sandbox_root);
     let previous_port = previous.as_ref().and_then(|record| record.port);
     if let Some(record) = previous {
-        if let Err(error) = reap_persisted_dev_group(&record).await {
+        let Some(_cleanup_admission) = orch.tasks.admit() else {
+            orch.finish_dev_task(&id);
+            return;
+        };
+        if let Err(error) = reap_persisted_dev_group(orch.tasks.clone(), &record).await {
+            if orch.is_closed() || orch.tasks.is_admission_closed() {
+                orch.finish_dev_task(&id);
+                return;
+            }
             tracing::warn!(
                 pid = record.pid,
                 pgid = record.pgid,
@@ -274,8 +290,9 @@ pub(super) async fn run(orch: &Arc<SetupOrchestrator>, config: &Value) {
         return;
     };
     let record_started_at = now_ms() as u64;
+    let identity_tasks = orch.tasks.clone();
     let identities = match capture_process_group_identity(
-        || observe_process_group(pid),
+        || observe_process_group(identity_tasks.clone(), pid),
         IDENTITY_CAPTURE_ATTEMPTS,
         IDENTITY_CAPTURE_INTERVAL,
     )
@@ -498,6 +515,7 @@ async fn drain_and_watch(
             _ = identity_refresh.tick() => {
                 if let (Some(pid), Some(started_at)) = (pid, record_started_at) {
                     refresh_persisted_group_identities(
+                        orch.tasks.clone(),
                         &sandbox_root,
                         pid,
                         started_at,
@@ -590,8 +608,11 @@ async fn confirm_running(orch: Arc<SetupOrchestrator>, task_id: String, port: u1
     }
 }
 
-async fn reap_persisted_dev_group(record: &DevProcessRecord) -> Result<(), String> {
-    let current = observe_process_group(record.pgid).await?;
+async fn reap_persisted_dev_group(
+    tasks: Arc<TaskRegistry>,
+    record: &DevProcessRecord,
+) -> Result<(), String> {
+    let current = observe_process_group(tasks.clone(), record.pgid).await?;
     let authorized = match match_group_identity(&record.identities, current) {
         GroupIdentityMatch::Gone => return Ok(()),
         GroupIdentityMatch::Verified(current) => current,
@@ -605,21 +626,30 @@ async fn reap_persisted_dev_group(record: &DevProcessRecord) -> Result<(), Strin
         pgid = record.pgid,
         "stopping previous dev server before start"
     );
-    kill_group(record.pgid, KillSignal::Term).await;
+    signal_persisted_process_group(tasks.clone(), record.pgid, KillSignal::Term).await?;
     tokio::time::sleep(STALE_TERM_GRACE).await;
+    if tasks.is_admission_closed() {
+        return Err("sandbox generation stopped while reaping the previous dev server".to_string());
+    }
 
-    let after_term = observe_process_group(record.pgid).await?;
+    let after_term = observe_process_group(tasks.clone(), record.pgid).await?;
     match match_group_identity(&authorized, after_term) {
         GroupIdentityMatch::Gone => Ok(()),
         GroupIdentityMatch::Unverifiable => {
             Err("process group identity changed after TERM; refusing KILL".to_string())
         }
         GroupIdentityMatch::Verified(survivors) => {
-            kill_group(record.pgid, KillSignal::Kill).await;
+            signal_persisted_process_group(tasks.clone(), record.pgid, KillSignal::Kill).await?;
             let deadline = tokio::time::Instant::now() + STALE_KILL_GRACE;
             loop {
                 tokio::time::sleep(Duration::from_millis(50)).await;
-                let after_kill = observe_process_group(record.pgid).await?;
+                if tasks.is_admission_closed() {
+                    return Err(
+                        "sandbox generation stopped while reaping the previous dev server"
+                            .to_string(),
+                    );
+                }
+                let after_kill = observe_process_group(tasks.clone(), record.pgid).await?;
                 match match_group_identity(&survivors, after_kill) {
                     GroupIdentityMatch::Gone => return Ok(()),
                     GroupIdentityMatch::Unverifiable => {
@@ -669,8 +699,13 @@ where
     ))
 }
 
-async fn refresh_persisted_group_identities(sandbox_root: &Path, pid: u32, started_at: u64) {
-    let identities = match observe_process_group(pid).await {
+async fn refresh_persisted_group_identities(
+    tasks: Arc<TaskRegistry>,
+    sandbox_root: &Path,
+    pid: u32,
+    started_at: u64,
+) {
+    let identities = match observe_process_group(tasks, pid).await {
         Ok(identities) if !identities.is_empty() => identities,
         Ok(_) => return,
         Err(error) => {
@@ -692,13 +727,200 @@ async fn refresh_persisted_group_identities(sandbox_root: &Path, pid: u32, start
     crate::sandbox::persist::write_dev_process(sandbox_root, &record);
 }
 
-#[cfg(unix)]
-async fn observe_process_group(pgid: u32) -> Result<Vec<DevProcessIdentity>, String> {
-    let group = tokio::process::Command::new("pgrep")
-        .args(["-g", &pgid.to_string()])
-        .output()
+#[derive(Default)]
+struct ProcessObserverOutput {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+#[async_trait::async_trait]
+impl OutputSink for ProcessObserverOutput {
+    async fn write(&mut self, stream: OutputStream, bytes: &[u8]) {
+        match stream {
+            OutputStream::Stdout => self.stdout.extend_from_slice(bytes),
+            OutputStream::Stderr => self.stderr.extend_from_slice(bytes),
+        }
+    }
+}
+
+type ProcessObserverReceiver = oneshot::Receiver<Result<std::process::Output, String>>;
+
+/// Spawns one process-inspection helper under the sandbox generation's hidden
+/// task registry. Setup shutdown can therefore signal and positively join an
+/// in-flight `pgrep`/`ps` before Stop evicts the generation; aborting the setup
+/// worker merely cancels the waiter and leaves this detached owner responsible
+/// for the complete process-group reap.
+async fn spawn_process_observer(
+    tasks: Arc<TaskRegistry>,
+    program: &str,
+    args: Vec<String>,
+) -> Result<(crate::tasks::KillHandle, ProcessObserverReceiver), String> {
+    let admission = tasks
+        .admit()
+        .ok_or_else(|| "sandbox generation is stopped".to_string())?;
+    let command_label = format!("{program} {}", args.join(" "));
+    let mut command = tokio::process::Command::new(program);
+    command
+        .args(&args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = ProcessGroupChild::spawn(&mut command, tasks.child_lifetime_lock_path())
         .await
-        .map_err(|error| format!("cannot enumerate process group {pgid}: {error}"))?;
+        .map_err(|error| format!("cannot spawn {program}: {error}"))?;
+    let (Some(stdout), Some(stderr)) = (child.take_stdout(), child.take_stderr()) else {
+        child
+            .kill_and_reap(
+                PROCESS_OBSERVER_TIMEOUT,
+                "process observer missing-stdio cleanup",
+            )
+            .await;
+        return Err(format!("cannot capture {program} output"));
+    };
+
+    let id = format!("internal-process-observer-{}", uuid::Uuid::new_v4());
+    let controller = ProcessController::new();
+    let kill_handle = controller.kill_handle();
+    admission.register(TaskEntry::new_internal(
+        TaskSummary {
+            id: id.clone(),
+            command: command_label,
+            status: TaskStatus::Running,
+            exit_code: None,
+            started_at: now_ms(),
+            finished_at: None,
+            timed_out: false,
+            truncated: false,
+            log_name: None,
+            intentional: None,
+        },
+        Some(kill_handle.clone()),
+    ));
+
+    let owner_tasks = tasks.clone();
+    let owner_id = id.clone();
+    let (result_tx, result_rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let mut captured = ProcessObserverOutput::default();
+        let driven = std::panic::AssertUnwindSafe(drive_group_to_exit(
+            &mut child,
+            stdout,
+            stderr,
+            Some(PROCESS_OBSERVER_TIMEOUT),
+            &controller,
+            &mut captured,
+        ))
+        .catch_unwind()
+        .await;
+
+        let (result, status, exit_code, timed_out) = match driven {
+            Ok(outcome) => match outcome.exit_status {
+                Some(exit_status) if outcome.timed_out => (
+                    Err("process observer timed out".to_string()),
+                    TaskStatus::Timeout,
+                    exit_status_to_code(exit_status),
+                    true,
+                ),
+                Some(exit_status) => {
+                    let exit_code = exit_status_to_code(exit_status);
+                    (
+                        Ok(std::process::Output {
+                            status: exit_status,
+                            stdout: captured.stdout,
+                            stderr: captured.stderr,
+                        }),
+                        classify_status(false, exit_code),
+                        exit_code,
+                        false,
+                    )
+                }
+                None => (
+                    Err("process observer exited without status".to_string()),
+                    TaskStatus::Failed,
+                    -1,
+                    outcome.timed_out,
+                ),
+            },
+            Err(_) => {
+                child
+                    .kill_and_reap(PROCESS_OBSERVER_TIMEOUT, "process observer panic cleanup")
+                    .await;
+                (
+                    Err("process observer owner panicked".to_string()),
+                    TaskStatus::Failed,
+                    -1,
+                    false,
+                )
+            }
+        };
+        owner_tasks.finalize(&owner_id, status, exit_code, timed_out);
+        let _ = owner_tasks.remove(&owner_id).await;
+        let _ = result_tx.send(result);
+    });
+
+    Ok((kill_handle, result_rx))
+}
+
+async fn run_process_observer(
+    tasks: Arc<TaskRegistry>,
+    program: &str,
+    args: Vec<String>,
+) -> Result<std::process::Output, String> {
+    let (kill_handle, result_rx) = spawn_process_observer(tasks, program, args).await?;
+    let mut cancel_on_drop = CancelOnDrop::new(kill_handle, KillSignal::Kill);
+    let result = result_rx
+        .await
+        .map_err(|_| "process observer owner stopped unexpectedly".to_string())?;
+    cancel_on_drop.disarm();
+    result
+}
+
+#[cfg(unix)]
+async fn signal_persisted_process_group(
+    tasks: Arc<TaskRegistry>,
+    pgid: u32,
+    signal: KillSignal,
+) -> Result<(), String> {
+    let output = run_process_observer(
+        tasks,
+        "kill",
+        vec![signal.flag().to_string(), format!("-{pgid}")],
+    )
+    .await
+    .map_err(|error| format!("cannot signal process group {pgid}: {error}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "cannot signal process group {pgid}: kill exited {:?}: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
+}
+
+#[cfg(not(unix))]
+async fn signal_persisted_process_group(
+    _tasks: Arc<TaskRegistry>,
+    _pgid: u32,
+    _signal: KillSignal,
+) -> Result<(), String> {
+    Err("durable process-group signaling is unavailable on this platform".to_string())
+}
+
+#[cfg(unix)]
+async fn observe_process_group(
+    tasks: Arc<TaskRegistry>,
+    pgid: u32,
+) -> Result<Vec<DevProcessIdentity>, String> {
+    let group = run_process_observer(
+        tasks.clone(),
+        "pgrep",
+        vec!["-g".to_string(), pgid.to_string()],
+    )
+    .await
+    .map_err(|error| format!("cannot enumerate process group {pgid}: {error}"))?;
     if !group.status.success() {
         if group.status.code() == Some(1) {
             return Ok(Vec::new());
@@ -717,7 +939,7 @@ async fn observe_process_group(pgid: u32) -> Result<Vec<DevProcessIdentity>, Str
             .trim()
             .parse::<u32>()
             .map_err(|error| format!("pgrep returned invalid pid {raw_pid:?}: {error}"))?;
-        if let Some(identity) = observe_process_identity(pid, pgid).await? {
+        if let Some(identity) = observe_process_identity(tasks.clone(), pid, pgid).await? {
             identities.push(identity);
         }
     }
@@ -727,28 +949,31 @@ async fn observe_process_group(pgid: u32) -> Result<Vec<DevProcessIdentity>, Str
 
 #[cfg(unix)]
 async fn observe_process_identity(
+    tasks: Arc<TaskRegistry>,
     pid: u32,
     expected_pgid: u32,
 ) -> Result<Option<DevProcessIdentity>, String> {
-    let process = tokio::process::Command::new("ps")
-        .args([
-            "-ww",
-            "-p",
-            &pid.to_string(),
-            "-o",
-            "pid=",
-            "-o",
-            "pgid=",
-            "-o",
-            "state=",
-            "-o",
-            "lstart=",
-            "-o",
-            "comm=",
-        ])
-        .output()
-        .await
-        .map_err(|error| format!("cannot inspect process {pid}: {error}"))?;
+    let process = run_process_observer(
+        tasks,
+        "ps",
+        vec![
+            "-ww".to_string(),
+            "-p".to_string(),
+            pid.to_string(),
+            "-o".to_string(),
+            "pid=".to_string(),
+            "-o".to_string(),
+            "pgid=".to_string(),
+            "-o".to_string(),
+            "state=".to_string(),
+            "-o".to_string(),
+            "lstart=".to_string(),
+            "-o".to_string(),
+            "comm=".to_string(),
+        ],
+    )
+    .await
+    .map_err(|error| format!("cannot inspect process {pid}: {error}"))?;
     if !process.status.success() {
         if process.status.code() == Some(1) {
             return Ok(None);
@@ -787,13 +1012,22 @@ async fn observe_process_identity(
 }
 
 #[cfg(not(unix))]
-async fn observe_process_group(_pgid: u32) -> Result<Vec<DevProcessIdentity>, String> {
+async fn observe_process_group(
+    _tasks: Arc<TaskRegistry>,
+    _pgid: u32,
+) -> Result<Vec<DevProcessIdentity>, String> {
     Err("durable process-group identity is unavailable on this platform".to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn observer_tasks(dir: &tempfile::TempDir) -> Arc<TaskRegistry> {
+        Arc::new(TaskRegistry::new(Arc::new(
+            crate::log_store::LogStore::new(dir.path().join("observer-logs")),
+        )))
+    }
 
     fn identity(pid: u32, birth: &str, executable: &str) -> DevProcessIdentity {
         DevProcessIdentity {
@@ -968,8 +1202,9 @@ mod tests {
         command.process_group(0);
         let mut child = command.spawn().unwrap();
         let pid = child.id().unwrap();
+        let tasks = observer_tasks(&dir);
         let observed = capture_process_group_identity(
-            || observe_process_group(pid),
+            || observe_process_group(tasks.clone(), pid),
             IDENTITY_CAPTURE_ATTEMPTS,
             IDENTITY_CAPTURE_INTERVAL,
         )
@@ -999,7 +1234,8 @@ mod tests {
         let pgid = leader.id().unwrap();
         let _ = leader.wait().await;
 
-        let identities = observe_process_group(pgid).await.unwrap();
+        let tasks = observer_tasks(&dir);
+        let identities = observe_process_group(tasks.clone(), pgid).await.unwrap();
         assert!(
             !identities.is_empty(),
             "the background child must survive its group leader"
@@ -1012,7 +1248,7 @@ mod tests {
             port: None,
             identities,
         };
-        let reaped = reap_persisted_dev_group(&record).await;
+        let reaped = reap_persisted_dev_group(tasks.clone(), &record).await;
         if reaped.is_err() {
             // Exact group created by this test; cleanup must not leak it even
             // if the assertion below reports an observation regression.
@@ -1020,7 +1256,30 @@ mod tests {
         }
 
         reaped.unwrap();
-        assert!(observe_process_group(pgid).await.unwrap().is_empty());
+        assert!(observe_process_group(tasks, pgid).await.unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn generation_stop_joins_an_in_flight_process_observer() {
+        let dir = tempfile::tempdir().unwrap();
+        let tasks = observer_tasks(&dir);
+        let (_kill_handle, result_rx) = spawn_process_observer(
+            tasks.clone(),
+            "sh",
+            vec!["-c".to_string(), "sleep 30".to_string()],
+        )
+        .await
+        .unwrap();
+
+        let stopped = tasks
+            .close_and_kill_all_and_wait(Duration::from_secs(1), Duration::from_secs(1))
+            .await;
+
+        assert_eq!(stopped.initially_running, 1);
+        assert!(stopped.remaining.is_empty());
+        let output = result_rx.await.unwrap().unwrap();
+        assert!(!output.status.success());
     }
 
     #[tokio::test]

--- a/apps/native/crates/local-api/src/setup/mod.rs
+++ b/apps/native/crates/local-api/src/setup/mod.rs
@@ -264,11 +264,14 @@ impl SetupOrchestrator {
     /// durable signal state handles shutdown landing between registration and
     /// the subsequent `Command::spawn`.
     pub(crate) fn register_task(&self, entry: TaskEntry) -> bool {
+        let Some(admission) = self.tasks.admit() else {
+            return false;
+        };
         let _registration = self.lock_task_registration();
         if self.is_closed() {
             return false;
         }
-        self.tasks.insert(entry);
+        admission.register(entry);
         true
     }
 
@@ -313,7 +316,10 @@ impl SetupOrchestrator {
         kill_grace: Duration,
     ) -> SetupShutdownResult {
         self.close();
-        let tasks = self.tasks.kill_all_and_wait(term_grace, kill_grace).await;
+        let tasks = self
+            .tasks
+            .close_and_kill_all_and_wait(term_grace, kill_grace)
+            .await;
 
         let worker = self.lock_worker().take();
         let worker_stopped = match worker {

--- a/apps/native/crates/local-api/src/tasks/mod.rs
+++ b/apps/native/crates/local-api/src/tasks/mod.rs
@@ -13,4 +13,4 @@ pub use registry::{
 // documented cross-family contract above) that `routes/bash.rs` reuses for
 // its own await-mode output capture, to avoid re-implementing the same
 // cap/truncate logic twice.
-pub(crate) use registry::{now_ms, RingBuffer};
+pub(crate) use registry::{now_ms, GenerationAdmission, RingBuffer};

--- a/apps/native/crates/local-api/src/tasks/registry.rs
+++ b/apps/native/crates/local-api/src/tasks/registry.rs
@@ -397,11 +397,57 @@ impl TaskEntry {
 
 pub struct TaskRegistry {
     inner: Mutex<HashMap<String, TaskEntry>>,
+    admission: Mutex<AdmissionState>,
+    admission_changed: Notify,
     id_counter: AtomicU64,
     storage_namespace: uuid::Uuid,
     logs: Arc<LogStore>,
     child_lifetime_lock_path: PathBuf,
     terminal_changed: Notify,
+}
+
+#[derive(Default)]
+struct AdmissionState {
+    closed: bool,
+    active: usize,
+}
+
+/// One operation admitted to a single [`TaskRegistry`] generation.
+///
+/// Process owners acquire this before creating a child and consume it only
+/// after the child has a durable registry entry. Non-process workspace
+/// operations may retain the same lease for their whole critical section.
+/// Closing a generation rejects new leases and waits for every existing lease
+/// to drop before shutdown snapshots the registry.
+pub(crate) struct GenerationAdmission {
+    registry: Arc<TaskRegistry>,
+    active: bool,
+}
+
+impl GenerationAdmission {
+    /// Atomically transfers an admitted process into registry ownership.
+    /// An admission that predates `close_admission` is still allowed to
+    /// register: close waits for it, so the subsequent reap snapshot includes
+    /// the entry. No async cancellation point exists between an OS spawn and
+    /// this synchronous handoff at any production call site.
+    pub(crate) fn register(mut self, entry: TaskEntry) {
+        self.registry.insert_admitted(entry);
+        self.release();
+    }
+
+    fn release(&mut self) {
+        if !self.active {
+            return;
+        }
+        self.active = false;
+        self.registry.release_admission();
+    }
+}
+
+impl Drop for GenerationAdmission {
+    fn drop(&mut self) {
+        self.release();
+    }
 }
 
 impl TaskRegistry {
@@ -422,8 +468,28 @@ impl TaskRegistry {
         logs: Arc<LogStore>,
         child_lifetime_lock_path: PathBuf,
     ) -> Self {
+        Self::new_with_admission_state(logs, child_lifetime_lock_path, false)
+    }
+
+    /// Metadata-only stopped sandbox constructor. Admission is closed before
+    /// the registry can be published through the manager's generation map, so
+    /// no concurrent resolver can observe a transient runnable generation.
+    pub(crate) fn new_closed_with_child_lifetime_lock(
+        logs: Arc<LogStore>,
+        child_lifetime_lock_path: PathBuf,
+    ) -> Self {
+        Self::new_with_admission_state(logs, child_lifetime_lock_path, true)
+    }
+
+    fn new_with_admission_state(
+        logs: Arc<LogStore>,
+        child_lifetime_lock_path: PathBuf,
+        closed: bool,
+    ) -> Self {
         Self {
             inner: Mutex::new(HashMap::new()),
+            admission: Mutex::new(AdmissionState { closed, active: 0 }),
+            admission_changed: Notify::new(),
             id_counter: AtomicU64::new(0),
             storage_namespace: uuid::Uuid::new_v4(),
             logs,
@@ -454,11 +520,76 @@ impl TaskRegistry {
         format!("task{n}")
     }
 
-    /// Register a new (or replace an existing) task entry by
-    /// `entry.summary.id`.
-    pub fn insert(&self, entry: TaskEntry) {
+    /// Admit work against this exact registry generation. The returned lease
+    /// must be acquired before a child is created and retained through its
+    /// synchronous [`GenerationAdmission::register`] handoff.
+    pub(crate) fn admit(self: &Arc<Self>) -> Option<GenerationAdmission> {
+        let mut state = self.lock_admission();
+        if state.closed {
+            return None;
+        }
+        state.active += 1;
+        Some(GenerationAdmission {
+            registry: Arc::clone(self),
+            active: true,
+        })
+    }
+
+    /// Permanently close this generation and wait until every operation that
+    /// won admission before the close has either registered its child or
+    /// abandoned the operation. Repeated callers share the same fence.
+    pub(crate) async fn close_admission(&self) -> bool {
+        let first = {
+            let mut state = self.lock_admission();
+            let first = !state.closed;
+            state.closed = true;
+            first
+        };
+
+        loop {
+            let changed = self.admission_changed.notified();
+            tokio::pin!(changed);
+            changed.as_mut().enable();
+            if self.lock_admission().active == 0 {
+                return first;
+            }
+            changed.await;
+        }
+    }
+
+    pub(crate) fn is_admission_closed(&self) -> bool {
+        self.lock_admission().closed
+    }
+
+    fn release_admission(&self) {
+        let quiescent = {
+            let mut state = self.lock_admission();
+            debug_assert!(state.active > 0, "generation admission underflow");
+            state.active = state.active.saturating_sub(1);
+            state.active == 0
+        };
+        if quiescent {
+            self.admission_changed.notify_waiters();
+        }
+    }
+
+    fn insert_admitted(&self, entry: TaskEntry) {
         let mut guard = self.lock();
         guard.insert(entry.summary.id.clone(), entry);
+    }
+
+    /// Fixture-only insertion for tests that exercise registry behavior
+    /// independently of process creation. Production process owners must use
+    /// [`Self::admit`] before spawn and hand off through
+    /// [`GenerationAdmission::register`].
+    #[cfg(test)]
+    pub(crate) fn insert(&self, entry: TaskEntry) -> bool {
+        let state = self.lock_admission();
+        if state.closed {
+            return false;
+        }
+        self.insert_admitted(entry);
+        true
     }
 
     /// Mutate a task's summary in place. Returns `false` if `id` is
@@ -769,6 +900,19 @@ impl TaskRegistry {
         }
     }
 
+    /// Close this generation's operation/task admission before taking the
+    /// all-inclusive process snapshot. Both exposed tasks and hidden internal
+    /// owners are reaped; no child can appear behind the snapshot because all
+    /// pre-close leases have quiesced and later admission is permanent-fail.
+    pub(crate) async fn close_and_kill_all_and_wait(
+        &self,
+        term_grace: Duration,
+        kill_grace: Duration,
+    ) -> KillAllResult {
+        self.close_admission().await;
+        self.kill_all_and_wait(term_grace, kill_grace).await
+    }
+
     fn running_ids(&self) -> Vec<String> {
         self.lock()
             .iter()
@@ -872,6 +1016,13 @@ impl TaskRegistry {
             Err(poisoned) => poisoned.into_inner(),
         }
     }
+
+    fn lock_admission(&self) -> std::sync::MutexGuard<'_, AdmissionState> {
+        match self.admission.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -936,6 +1087,67 @@ mod tests {
         assert_eq!(result.kill_signaled, 1);
         assert_eq!(result.remaining, vec!["internal"]);
         assert_eq!(controller.requested(), Some(KillSignal::Kill));
+    }
+
+    #[tokio::test]
+    async fn close_waits_for_pre_registration_admission_and_reaps_hidden_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(TaskRegistry::new(Arc::new(LogStore::new(
+            dir.path().to_path_buf(),
+        ))));
+        let admission = registry.admit().expect("fresh generation is open");
+        let controller = ProcessController::new();
+        let (register_tx, register_rx) = tokio::sync::oneshot::channel();
+        let owner_registry = registry.clone();
+        let owner_controller = controller.clone();
+        let owner = tokio::spawn(async move {
+            register_rx.await.unwrap();
+            admission.register(TaskEntry::new_internal(
+                summary("paused-hidden-owner", TaskStatus::Running),
+                Some(owner_controller.kill_handle()),
+            ));
+            let signal = owner_controller.wait_for_change(None).await;
+            owner_registry.finalize(
+                "paused-hidden-owner",
+                TaskStatus::Killed,
+                signal.exit_code(),
+                false,
+            );
+        });
+
+        let close_registry = registry.clone();
+        let close = tokio::spawn(async move {
+            close_registry
+                .close_and_kill_all_and_wait(Duration::from_secs(1), Duration::from_secs(1))
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !registry.is_admission_closed() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("close flips admission before waiting");
+        assert!(
+            !close.is_finished(),
+            "close must not snapshot before a pre-close spawn registers"
+        );
+        assert!(
+            registry.admit().is_none(),
+            "post-close process spawn is rejected"
+        );
+
+        register_tx.send(()).unwrap();
+        let result = close.await.unwrap();
+        owner.await.unwrap();
+        assert_eq!(result.initially_running, 1);
+        assert_eq!(result.term_signaled, 1);
+        assert!(result.remaining.is_empty());
+        assert!(registry.list(None).is_empty(), "hidden owner stays hidden");
+        assert_eq!(
+            registry.get("paused-hidden-owner").unwrap().status,
+            TaskStatus::Killed
+        );
     }
 
     #[test]

--- a/apps/native/crates/local-api/src/terminal/launch_context.rs
+++ b/apps/native/crates/local-api/src/terminal/launch_context.rs
@@ -18,6 +18,7 @@ use sha2::{Digest, Sha256};
 
 use crate::routes::threads::db::{RtThread, RtThreadFence, ThreadsDb};
 use crate::state::AppState;
+use crate::terminal::registry::PreparationCancellation;
 
 const MCP_SERVER_NAME: &str = "cms";
 const MCP_URL_ENV: &str = "DECOCMS_MCP_URL";
@@ -318,6 +319,8 @@ impl PreparedLaunch {
 
 #[derive(Debug, thiserror::Error)]
 pub enum LaunchContextError {
+    #[error("coding agent preparation was canceled")]
+    Canceled,
     #[error("thread is no longer available")]
     StaleThread,
     #[error("the selected agent is unavailable: {0}")]
@@ -349,6 +352,9 @@ pub struct LaunchRequest<'a> {
     pub mcp_token: &'a str,
     /// Newest checkpoint read before the new `starting` row is reserved.
     pub provider_session_id: Option<&'a str>,
+    pub cancellation: &'a PreparationCancellation,
+    pub account_epoch: crate::sandbox::manager::AccountEpoch,
+    pub identity_generation: u64,
 }
 
 pub async fn prepare(
@@ -356,6 +362,8 @@ pub async fn prepare(
     db: &'static ThreadsDb,
     request: LaunchRequest<'_>,
 ) -> Result<PreparedLaunch, LaunchContextError> {
+    require_account_epoch(state, request.account_epoch)?;
+    require_active_preparation(request.cancellation)?;
     let thread = db
         .rt_get_thread_for_fence(request.fence)
         .map_err(|error| LaunchContextError::Storage(error.to_string()))?
@@ -364,11 +372,40 @@ pub async fn prepare(
     // The picker consumes the same compatibility probe, but repeat it at the
     // process boundary so a stale renderer or direct WebSocket request cannot
     // launch an installed-yet-unsupported provider.
-    harness::detect::require_launch_ready(request.harness, &argv).await?;
-    let virtual_mcp = load_virtual_mcp(request.fence, &thread).await?;
-    let cwd = resolve_cwd(state, request.fence, &thread, &virtual_mcp).await?;
-    let system_prompt =
-        build_system_prompt(state, request.fence, &thread, &virtual_mcp, &cwd).await;
+    tokio::select! {
+        biased;
+        () = request.cancellation.cancelled() => return Err(LaunchContextError::Canceled),
+        result = harness::detect::require_launch_ready(request.harness, &argv) => {
+            result?;
+        },
+    }
+    require_account_epoch(state, request.account_epoch)?;
+    let virtual_mcp = load_virtual_mcp(
+        state,
+        request.fence,
+        &thread,
+        request.cancellation,
+        request.account_epoch,
+        request.identity_generation,
+    )
+    .await?;
+    require_active_preparation(request.cancellation)?;
+    let cwd = resolve_cwd(
+        state,
+        request.fence,
+        &thread,
+        &virtual_mcp,
+        request.cancellation,
+        request.account_epoch,
+    )
+    .await?;
+    require_active_preparation(request.cancellation)?;
+    let system_prompt = tokio::select! {
+        biased;
+        () = request.cancellation.cancelled() => return Err(LaunchContextError::Canceled),
+        prompt = build_system_prompt(state, request.fence, &thread, &virtual_mcp, &cwd) => prompt,
+    };
+    require_active_preparation(request.cancellation)?;
     let credentials = crate::sandbox::org_mount::local_credentials()
         .cloned()
         .ok_or(LaunchContextError::LocalEndpointUnavailable)?;
@@ -377,7 +414,13 @@ pub async fn prepare(
     let mut codex_hook_trust = None;
 
     let state_dir = managed_state_dir(&state.app_root, request.fence);
+    // Managed filesystem operations run to completion inside the preparation
+    // phase. Dropping a Tokio filesystem future on cancellation can leave its
+    // blocking worker writing after lifecycle cleanup has already returned.
+    require_account_epoch(state, request.account_epoch)?;
     create_private_dir(&state_dir).await?;
+    require_account_epoch(state, request.account_epoch)?;
+    require_active_preparation(request.cancellation)?;
     let hook_url = format!(
         "{}/_local/agent-hooks/{}",
         credentials.base_url, request.terminal_session_id
@@ -408,7 +451,11 @@ pub async fn prepare(
     let mut title_environment = harness::title::TitleEnvironment::default();
     match request.harness {
         HarnessId::ClaudeCode => {
-            let trust_roots = workspace_trust_roots(&cwd).await?;
+            let trust_roots = tokio::select! {
+                biased;
+                () = request.cancellation.cancelled() => return Err(LaunchContextError::Canceled),
+                roots = workspace_trust_roots(&cwd) => roots?,
+            };
             let project_key = trust_roots
                 .claude
                 .to_str()
@@ -418,13 +465,20 @@ pub async fn prepare(
                     )
                 })?
                 .to_string();
+            let state_path = tokio::select! {
+                biased;
+                () = request.cancellation.cancelled() => return Err(LaunchContextError::Canceled),
+                path = claude_state_path(&cwd) => path?,
+            };
             claude_workspace_trust = Some(ClaudeWorkspaceTrust {
-                state_path: claude_state_path(&cwd).await?,
+                state_path,
                 project_key,
             });
             // Claude settings are thread-owned, so deletion removes the
             // complete overlay without affecting another chat.
-            let hook_script = ensure_hook_forwarder(&state_dir).await?;
+            require_active_preparation(request.cancellation)?;
+            let hook_script = ensure_hook_forwarder(&state_dir, request.cancellation).await?;
+            require_active_preparation(request.cancellation)?;
             prepare_claude(
                 &state_dir,
                 &hook_script,
@@ -434,9 +488,14 @@ pub async fn prepare(
                 &mut argv,
             )
             .await?;
+            require_active_preparation(request.cancellation)?;
         }
         HarnessId::Codex => {
-            let trust_roots = workspace_trust_roots(&cwd).await?;
+            let trust_roots = tokio::select! {
+                biased;
+                () = request.cancellation.cancelled() => return Err(LaunchContextError::Canceled),
+                roots = workspace_trust_roots(&cwd) => roots?,
+            };
             let codex_prefix_argv = argv.clone();
             // Codex refreshes auth.json by replacing it. All chats for one
             // Studio account therefore share a regular, account-owned home;
@@ -445,7 +504,12 @@ pub async fn prepare(
             let home_lock = state
                 .agent_sessions
                 .codex_home_lock(&request.fence.account_scope);
-            let home_guard = home_lock.lock_owned().await;
+            let home_guard = tokio::select! {
+                biased;
+                () = request.cancellation.cancelled() => return Err(LaunchContextError::Canceled),
+                guard = home_lock.lock_owned() => guard,
+            };
+            require_active_preparation(request.cancellation)?;
             let codex_home = prepare_codex(
                 &state.app_root,
                 &system_prompt,
@@ -456,6 +520,7 @@ pub async fn prepare(
                 &trust_roots.codex,
             )
             .await?;
+            require_active_preparation(request.cancellation)?;
             let managed_hook_command = shell_quote_path(
                 &codex_home
                     .join("studio-runtime")
@@ -472,6 +537,7 @@ pub async fn prepare(
             env.push(("CODEX_HOME".to_string(), codex_home.display().to_string()));
         }
         HarnessId::OpenCode => {
+            require_active_preparation(request.cancellation)?;
             let config = prepare_opencode(
                 &state_dir,
                 &system_prompt,
@@ -480,6 +546,7 @@ pub async fn prepare(
                 provider_session_id.as_deref(),
             )
             .await?;
+            require_active_preparation(request.cancellation)?;
             env.push((OPENCODE_CONFIG_CONTENT_ENV.to_string(), config));
             // Override ambient shell/dev-runner state on fresh launches too.
             // Otherwise an inherited stale resume id would make the plugin
@@ -487,6 +554,9 @@ pub async fn prepare(
             env.push(opencode_resume_environment(provider_session_id.as_deref()));
         }
     }
+
+    require_account_epoch(state, request.account_epoch)?;
+    require_active_preparation(request.cancellation)?;
 
     Ok(PreparedLaunch {
         harness: request.harness,
@@ -503,16 +573,33 @@ pub async fn prepare(
 }
 
 async fn load_virtual_mcp(
+    state: &AppState,
     fence: &RtThreadFence,
     thread: &RtThread,
+    cancellation: &PreparationCancellation,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+    identity_generation: u64,
 ) -> Result<Value, LaunchContextError> {
-    let response = crate::routes::upstream::call_org_tool(
-        &fence.organization_id,
-        "COLLECTION_VIRTUAL_MCP_GET",
-        &json!({ "id": thread.virtual_mcp_id }),
-    )
-    .await
-    .map_err(LaunchContextError::VirtualMcp)?;
+    let input = json!({ "id": thread.virtual_mcp_id });
+    let response = tokio::select! {
+        biased;
+        () = cancellation.cancelled() => return Err(LaunchContextError::Canceled),
+        response = crate::routes::upstream::call_org_tool_for_identity(
+            state,
+            account_epoch,
+            identity_generation,
+            &fence.organization_id,
+            "COLLECTION_VIRTUAL_MCP_GET",
+            &input,
+        ) => match response {
+            Ok(response) => response,
+            Err(crate::routes::upstream::OrgToolCallError::StaleIdentity) => {
+                return Err(LaunchContextError::Canceled);
+            }
+            Err(error) => return Err(LaunchContextError::VirtualMcp(error.to_string())),
+        },
+    };
+    require_active_preparation(cancellation)?;
     virtual_mcp_entity(response).map_err(|error| LaunchContextError::VirtualMcp(error.to_string()))
 }
 
@@ -541,7 +628,20 @@ async fn resolve_cwd(
     fence: &RtThreadFence,
     thread: &RtThread,
     virtual_mcp: &Value,
+    cancellation: &PreparationCancellation,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
 ) -> Result<PathBuf, LaunchContextError> {
+    let sandbox_branch = crate::sandbox::normalize_branch(thread.branch.as_deref());
+    let teardown_on_cancel = match crate::sandbox::synthetic_thread_id(sandbox_branch) {
+        Ok(Some(thread_id)) if thread_id == fence.thread_id => true,
+        Ok(Some(_)) => {
+            return Err(LaunchContextError::Workspace(
+                "thread-backed sandbox branch belongs to a different chat".to_string(),
+            ))
+        }
+        Ok(None) => false,
+        Err(error) => return Err(LaunchContextError::Workspace(error.to_string())),
+    };
     if let Some(mut config) = crate::routes::intercept::config_from_virtual_mcp(
         &thread.virtual_mcp_id,
         thread.branch.as_deref(),
@@ -553,17 +653,52 @@ async fn resolve_cwd(
             .get_or_insert_with(|| fence.organization_id.clone());
         return state
             .sandbox_manager
-            .ensure(&config)
+            .ensure_for_terminal(
+                account_epoch,
+                &config,
+                cancellation.subscribe(),
+                teardown_on_cancel,
+            )
             .await
             .map(|sandbox| sandbox.workdir.clone())
-            .map_err(LaunchContextError::Sandbox);
+            .map_err(|error| match error {
+                crate::sandbox::manager::TerminalEnsureError::Canceled => {
+                    LaunchContextError::Canceled
+                }
+                crate::sandbox::manager::TerminalEnsureError::Failed(error) => {
+                    LaunchContextError::Sandbox(error)
+                }
+            });
     }
 
+    require_active_preparation(cancellation)?;
+    require_account_epoch(state, account_epoch)?;
     let org_dir = crate::sandbox::org_view::org_mount_root(&state.app_root, &fence.organization_id)
         .ok_or_else(|| LaunchContextError::Workspace("invalid organization path".to_string()))?;
     crate::sandbox::org_mount::warm(&state.app_root, &fence.organization_id);
     tokio::fs::create_dir_all(&org_dir).await?;
+    require_active_preparation(cancellation)?;
     Ok(org_dir)
+}
+
+fn require_account_epoch(
+    state: &AppState,
+    account_epoch: crate::sandbox::manager::AccountEpoch,
+) -> Result<(), LaunchContextError> {
+    state
+        .sandbox_manager
+        .validate_account_epoch(account_epoch)
+        .map_err(|_| LaunchContextError::Canceled)
+}
+
+fn require_active_preparation(
+    cancellation: &PreparationCancellation,
+) -> Result<(), LaunchContextError> {
+    if cancellation.is_cancelled() {
+        Err(LaunchContextError::Canceled)
+    } else {
+        Ok(())
+    }
 }
 
 async fn build_system_prompt(
@@ -606,11 +741,14 @@ async fn prepare_claude(
     provider_session_id: Option<&str>,
     argv: &mut Vec<String>,
 ) -> Result<(), LaunchContextError> {
+    require_active_preparation(request.cancellation)?;
     let prompt_path = state_dir.join("claude-system-prompt.txt");
     write_private_file(&prompt_path, system_prompt.as_bytes(), false).await?;
+    require_active_preparation(request.cancellation)?;
     let settings_path = state_dir.join("claude-hooks.json");
     let settings = claude_hook_settings(hook_script);
     write_private_file(&settings_path, &serde_json::to_vec(&settings)?, false).await?;
+    require_active_preparation(request.cancellation)?;
 
     argv.extend([
         "--append-system-prompt-file".to_string(),
@@ -658,6 +796,7 @@ async fn prepare_codex(
         request.fence,
         codex_auth_source_path().as_deref(),
         &config,
+        request.cancellation,
     )
     .await?;
 
@@ -701,8 +840,10 @@ async fn prepare_opencode(
     argv: &mut Vec<String>,
     provider_session_id: Option<&str>,
 ) -> Result<String, LaunchContextError> {
+    require_active_preparation(request.cancellation)?;
     let plugin_path = state_dir.join("opencode-lifecycle.js");
     write_private_file(&plugin_path, OPENCODE_LIFECYCLE_PLUGIN.as_bytes(), false).await?;
+    require_active_preparation(request.cancellation)?;
     let plugin_url = reqwest::Url::from_file_path(&plugin_path).map_err(|()| {
         LaunchContextError::Workspace(format!(
             "could not encode OpenCode lifecycle plugin path: {}",
@@ -1573,10 +1714,16 @@ fn opencode_config(
     .to_string()
 }
 
-async fn ensure_hook_forwarder(state_dir: &Path) -> Result<PathBuf, std::io::Error> {
+async fn ensure_hook_forwarder(
+    state_dir: &Path,
+    cancellation: &PreparationCancellation,
+) -> Result<PathBuf, LaunchContextError> {
+    require_active_preparation(cancellation)?;
     create_private_dir(state_dir).await?;
+    require_active_preparation(cancellation)?;
     let path = state_dir.join(HOOK_FORWARDER_FILENAME);
     write_private_file(&path, HOOK_FORWARDER_SCRIPT.as_bytes(), true).await?;
+    require_active_preparation(cancellation)?;
     Ok(path)
 }
 
@@ -1676,18 +1823,23 @@ async fn prepare_codex_managed_files(
     fence: &RtThreadFence,
     auth_source: Option<&Path>,
     profile_config: &str,
+    cancellation: &PreparationCancellation,
 ) -> Result<(PathBuf, String), LaunchContextError> {
+    require_active_preparation(cancellation)?;
     let codex_home = managed_codex_home(app_root, &fence.account_scope);
-    initialize_codex_home(&codex_home, auth_source).await?;
+    initialize_codex_home(&codex_home, auth_source, cancellation).await?;
+    require_active_preparation(cancellation)?;
 
     let runtime_dir = codex_home.join("studio-runtime");
-    let hook_script = ensure_hook_forwarder(&runtime_dir).await?;
+    let hook_script = ensure_hook_forwarder(&runtime_dir, cancellation).await?;
+    require_active_preparation(cancellation)?;
     write_private_file(
         &codex_home.join("hooks.json"),
         &serde_json::to_vec(&codex_hook_settings(&hook_script))?,
         false,
     )
     .await?;
+    require_active_preparation(cancellation)?;
 
     let profile_name = codex_profile_name(fence);
     write_private_file(
@@ -1696,22 +1848,28 @@ async fn prepare_codex_managed_files(
         false,
     )
     .await?;
+    require_active_preparation(cancellation)?;
     Ok((codex_home, profile_name))
 }
 
 async fn initialize_codex_home(
     codex_home: &Path,
     auth_source: Option<&Path>,
-) -> Result<(), std::io::Error> {
+    cancellation: &PreparationCancellation,
+) -> Result<(), LaunchContextError> {
+    require_active_preparation(cancellation)?;
     create_private_dir(codex_home).await?;
+    require_active_preparation(cancellation)?;
     let marker = codex_home.join(CODEX_HOME_INITIALIZED_MARKER);
     let destination = codex_home.join("auth.json");
     let initialized = regular_file_if_present(&marker, "Codex home marker").await?;
     let destination_exists = regular_file_if_present(&destination, "managed Codex auth").await?;
+    require_active_preparation(cancellation)?;
 
     if initialized {
         if destination_exists {
             set_private_file_permissions(&destination, false).await?;
+            require_active_preparation(cancellation)?;
         }
         // Absence after initialization is authoritative (for example, Codex
         // logged out). Never silently restore an older system credential.
@@ -1728,20 +1886,25 @@ async fn initialize_codex_home(
                             "Codex auth source exceeds {MAX_CODEX_AUTH_BYTES} bytes: {}",
                             source.display()
                         ),
-                    ));
+                    )
+                    .into());
                 }
                 let contents = tokio::fs::read(source).await?;
+                require_active_preparation(cancellation)?;
                 write_private_file(&destination, &contents, false).await?;
+                require_active_preparation(cancellation)?;
             }
         }
     } else {
         set_private_file_permissions(&destination, false).await?;
+        require_active_preparation(cancellation)?;
     }
 
     // The marker lands last. A crash before it is safe: a complete regular
     // destination is preserved on retry, and a missing destination may be
     // seeded again before any provider process has been admitted.
-    write_private_file(&marker, b"initialized\n", false).await
+    write_private_file(&marker, b"initialized\n", false).await?;
+    require_active_preparation(cancellation)
 }
 
 async fn regular_file_if_present(path: &Path, description: &str) -> Result<bool, std::io::Error> {
@@ -2273,6 +2436,7 @@ mod tests {
     #[test]
     fn claude_normal_launches_bypass_permissions_before_resume() {
         let fence = test_fence("account", "thread");
+        let cancellation = PreparationCancellation::test_uncancelled();
         for approval_mode in ["default", "auto"] {
             let request = LaunchRequest {
                 fence: &fence,
@@ -2283,6 +2447,9 @@ mod tests {
                 hook_token: "hook",
                 mcp_token: "mcp",
                 provider_session_id: Some("session"),
+                cancellation: &cancellation,
+                account_epoch: crate::sandbox::manager::AccountEpoch::for_test(),
+                identity_generation: 0,
             };
             let mut argv = Vec::new();
             append_claude_launch_args(request, Some("session"), &mut argv);
@@ -2306,6 +2473,7 @@ mod tests {
     #[test]
     fn claude_plan_and_readonly_launches_never_bypass_permissions() {
         let fence = test_fence("account", "thread");
+        let cancellation = PreparationCancellation::test_uncancelled();
         for (approval_mode, plan_mode) in [("readonly", false), ("default", true), ("auto", true)] {
             let request = LaunchRequest {
                 fence: &fence,
@@ -2316,6 +2484,9 @@ mod tests {
                 hook_token: "hook",
                 mcp_token: "mcp",
                 provider_session_id: None,
+                cancellation: &cancellation,
+                account_epoch: crate::sandbox::manager::AccountEpoch::for_test(),
+                identity_generation: 0,
             };
             let mut argv = Vec::new();
             append_claude_launch_args(request, None, &mut argv);
@@ -2331,6 +2502,7 @@ mod tests {
     #[test]
     fn codex_workspace_trust_override_is_launch_scoped_and_precedes_resume() {
         let fence = test_fence("account", "thread");
+        let cancellation = PreparationCancellation::test_uncancelled();
         let request = LaunchRequest {
             fence: &fence,
             terminal_session_id: "terminal",
@@ -2340,6 +2512,9 @@ mod tests {
             hook_token: "hook",
             mcp_token: "mcp",
             provider_session_id: Some("session"),
+            cancellation: &cancellation,
+            account_epoch: crate::sandbox::manager::AccountEpoch::for_test(),
+            identity_generation: 0,
         };
         let trust_root = Path::new("/tmp/quote-\"-backslash-\\-café");
         let mut argv = Vec::new();
@@ -2376,6 +2551,7 @@ mod tests {
     #[test]
     fn codex_plan_and_readonly_launches_remain_sandboxed_read_only() {
         let fence = test_fence("account", "thread");
+        let cancellation = PreparationCancellation::test_uncancelled();
         for (approval_mode, plan_mode) in [("readonly", false), ("default", true), ("auto", true)] {
             let request = LaunchRequest {
                 fence: &fence,
@@ -2386,6 +2562,9 @@ mod tests {
                 hook_token: "hook",
                 mcp_token: "mcp",
                 provider_session_id: None,
+                cancellation: &cancellation,
+                account_epoch: crate::sandbox::manager::AccountEpoch::for_test(),
+                identity_generation: 0,
             };
             let mut argv = Vec::new();
             append_codex_launch_args(
@@ -2409,6 +2588,7 @@ mod tests {
     #[test]
     fn codex_auto_launch_is_yolo_without_separate_approval_or_sandbox_flags() {
         let fence = test_fence("account", "thread");
+        let cancellation = PreparationCancellation::test_uncancelled();
         let request = LaunchRequest {
             fence: &fence,
             terminal_session_id: "terminal",
@@ -2418,6 +2598,9 @@ mod tests {
             hook_token: "hook",
             mcp_token: "mcp",
             provider_session_id: None,
+            cancellation: &cancellation,
+            account_epoch: crate::sandbox::manager::AccountEpoch::for_test(),
+            identity_generation: 0,
         };
         let mut argv = Vec::new();
         append_codex_launch_args(
@@ -2647,9 +2830,74 @@ mod tests {
         }
     }
 
+    fn test_thread(fence: &RtThreadFence, virtual_mcp_id: &str, branch: &str) -> RtThread {
+        RtThread {
+            id: fence.thread_id.clone(),
+            organization_id: fence.organization_id.clone(),
+            title: "Chat".to_string(),
+            description: None,
+            hidden: false,
+            status: "active".to_string(),
+            created_by: "user".to_string(),
+            updated_by: None,
+            virtual_mcp_id: virtual_mcp_id.to_string(),
+            trigger_id: None,
+            branch: Some(branch.to_string()),
+            sandbox_provider_kind: None,
+            harness_id: None,
+            metadata: None,
+            run_config: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn mismatched_reserved_branch_is_rejected_before_sandbox_materialization() {
+        let root = tempfile::tempdir().unwrap();
+        let state = crate::routes::intercept::test_state(root.path());
+        let fence = test_fence("account", "expected-thread");
+        let clone_url = "https://github.com/acme/reserved-branch.git";
+        let mismatched_branch = "thread:another-thread/connection-1";
+        let thread = test_thread(&fence, "vmcp-reserved", mismatched_branch);
+        let virtual_mcp = json!({
+            "metadata": {
+                "githubRepo": { "url": clone_url }
+            }
+        });
+        let cancellation = PreparationCancellation::test_uncancelled();
+        let account_epoch = state.sandbox_manager.account_epoch();
+
+        let error = resolve_cwd(
+            &state,
+            &fence,
+            &thread,
+            &virtual_mcp,
+            &cancellation,
+            account_epoch,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, LaunchContextError::Workspace(_)));
+        let handle = crate::sandbox::SandboxManager::compute_handle(clone_url, mismatched_branch)
+            .expect("test clone URL is scopeable");
+        assert!(!state
+            .sandbox_manager
+            .is_registered_for_account(account_epoch, &handle)
+            .unwrap());
+        assert!(state
+            .sandbox_manager
+            .get_for_account(account_epoch, &handle)
+            .unwrap()
+            .is_none());
+        assert!(!crate::sandbox::worktree_root(root.path(), &handle).exists());
+    }
+
     #[tokio::test]
     async fn codex_threads_share_regular_account_auth_but_keep_distinct_profiles() {
         let root = tempfile::tempdir().unwrap();
+        let cancellation = PreparationCancellation::test_uncancelled();
         let system_home = root.path().join("system-codex");
         tokio::fs::create_dir_all(&system_home).await.unwrap();
         let source_auth = system_home.join("auth.json");
@@ -2664,6 +2912,7 @@ mod tests {
             &first_fence,
             Some(&source_auth),
             "developer_instructions = \"first\"\n",
+            &cancellation,
         )
         .await
         .unwrap();
@@ -2672,6 +2921,7 @@ mod tests {
             &second_fence,
             Some(&source_auth),
             "developer_instructions = \"second\"\n",
+            &cancellation,
         )
         .await
         .unwrap();
@@ -2719,6 +2969,7 @@ mod tests {
     #[tokio::test]
     async fn opencode_normal_launches_enable_auto_before_exact_session_resume() {
         let fence = test_fence("account", "thread-one");
+        let cancellation = PreparationCancellation::test_uncancelled();
         for approval_mode in ["default", "auto"] {
             let root = tempfile::tempdir().unwrap();
             let request = LaunchRequest {
@@ -2730,6 +2981,9 @@ mod tests {
                 hook_token: "hook-token",
                 mcp_token: "mcp-token",
                 provider_session_id: Some("ses_exact"),
+                cancellation: &cancellation,
+                account_epoch: crate::sandbox::manager::AccountEpoch::for_test(),
+                identity_generation: 0,
             };
             let mut argv = Vec::new();
             let config = prepare_opencode(
@@ -2761,6 +3015,7 @@ mod tests {
 
     #[tokio::test]
     async fn opencode_readonly_and_plan_launches_never_enable_auto() {
+        let cancellation = PreparationCancellation::test_uncancelled();
         for (approval_mode, plan_mode) in [("readonly", false), ("default", true), ("auto", true)] {
             let root = tempfile::tempdir().unwrap();
             let fence = test_fence("account", "thread-one");
@@ -2773,6 +3028,9 @@ mod tests {
                 hook_token: "hook-token",
                 mcp_token: "mcp-token",
                 provider_session_id: None,
+                cancellation: &cancellation,
+                account_epoch: crate::sandbox::manager::AccountEpoch::for_test(),
+                identity_generation: 0,
             };
             let mut argv = Vec::new();
             let config = prepare_opencode(root.path(), "instructions", request, &mut argv, None)
@@ -2795,6 +3053,7 @@ mod tests {
     #[tokio::test]
     async fn initialized_codex_home_does_not_reseed_deleted_auth() {
         let root = tempfile::tempdir().unwrap();
+        let cancellation = PreparationCancellation::test_uncancelled();
         let source_auth = root.path().join("system-auth.json");
         tokio::fs::write(&source_auth, br#"{"token":"first"}"#)
             .await
@@ -2805,6 +3064,7 @@ mod tests {
             &fence,
             Some(&source_auth),
             "developer_instructions = \"first\"\n",
+            &cancellation,
         )
         .await
         .unwrap();
@@ -2820,6 +3080,7 @@ mod tests {
             &fence,
             Some(&source_auth),
             "developer_instructions = \"second\"\n",
+            &cancellation,
         )
         .await
         .unwrap();
@@ -2833,6 +3094,7 @@ mod tests {
         use std::os::unix::fs::symlink;
 
         let root = tempfile::tempdir().unwrap();
+        let cancellation = PreparationCancellation::test_uncancelled();
         let actual_auth = root.path().join("actual-auth.json");
         tokio::fs::write(&actual_auth, b"{}").await.unwrap();
         let source_link = root.path().join("source-auth.json");
@@ -2843,6 +3105,7 @@ mod tests {
             &source_fence,
             Some(&source_link),
             "developer_instructions = \"source\"\n",
+            &cancellation,
         )
         .await
         .unwrap_err();
@@ -2857,6 +3120,7 @@ mod tests {
             &destination_fence,
             Some(&actual_auth),
             "developer_instructions = \"destination\"\n",
+            &cancellation,
         )
         .await
         .unwrap_err();

--- a/apps/native/crates/local-api/src/terminal/registry.rs
+++ b/apps/native/crates/local-api/src/terminal/registry.rs
@@ -14,13 +14,14 @@ use terminal_session::{
     ManagerConfig, SessionExit, SessionKey, TerminalSession, TerminalSessionManager,
     TerminationPolicy,
 };
-use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+use tokio::sync::{watch, Mutex as AsyncMutex, Notify, OwnedMutexGuard};
 
 use crate::routes::threads::db::{RtThreadFence, ThreadsDb};
 
 const TERM_GRACE: Duration = Duration::from_secs(2);
 const KILL_GRACE: Duration = Duration::from_secs(2);
 const PROMPT_RECEIPT_CAPACITY: usize = 512;
+const PREPARATION_QUIESCE_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Default)]
 struct OpenCodeTurnState {
@@ -277,6 +278,240 @@ pub(crate) struct WriterLeaseGuard {
     generation: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct PreparationKey {
+    fence: RtThreadFence,
+    terminal_session_id: String,
+}
+
+#[derive(Debug, Default)]
+struct PreparationPhaseState {
+    cancelled: bool,
+    active_phases: usize,
+}
+
+#[derive(Debug)]
+struct PreparationState {
+    phase: Mutex<PreparationPhaseState>,
+    cancellation: watch::Sender<bool>,
+    phase_changed: Notify,
+}
+
+impl PreparationState {
+    fn new() -> Arc<Self> {
+        let (cancellation, _) = watch::channel(false);
+        Arc::new(Self {
+            phase: Mutex::new(PreparationPhaseState::default()),
+            cancellation,
+            phase_changed: Notify::new(),
+        })
+    }
+
+    fn lock_phase(&self) -> MutexGuard<'_, PreparationPhaseState> {
+        self.phase
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn cancel(&self) {
+        let changed = {
+            let mut phase = self.lock_phase();
+            if phase.cancelled {
+                false
+            } else {
+                phase.cancelled = true;
+                true
+            }
+        };
+        if changed {
+            self.cancellation.send_replace(true);
+            self.phase_changed.notify_waiters();
+        }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.lock_phase().cancelled
+    }
+
+    fn begin_phase(self: &Arc<Self>) -> Option<PreparationPhase> {
+        let mut phase = self.lock_phase();
+        if phase.cancelled {
+            return None;
+        }
+        phase.active_phases += 1;
+        drop(phase);
+        Some(PreparationPhase {
+            state: self.clone(),
+        })
+    }
+
+    async fn wait_for_phase_completion(&self) {
+        self.wait_for_phase_completion_with(|| {}).await;
+    }
+
+    async fn wait_for_phase_completion_with<F>(&self, mut after_check: F)
+    where
+        F: FnMut(),
+    {
+        let changed = self.phase_changed.notified();
+        tokio::pin!(changed);
+        loop {
+            // `notify_waiters` does not retain a permit for a future waiter.
+            // Register this waiter before inspecting the phase count so a
+            // phase that completes between the check and `.await` cannot be
+            // missed.
+            changed.as_mut().enable();
+            let complete = self.lock_phase().active_phases == 0;
+            after_check();
+            if complete {
+                return;
+            }
+            changed.as_mut().await;
+            changed.set(self.phase_changed.notified());
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PreparationCancellation {
+    state: Arc<PreparationState>,
+}
+
+impl PreparationCancellation {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.state.is_cancelled()
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        let mut cancellation = self.state.cancellation.subscribe();
+        if *cancellation.borrow() {
+            return;
+        }
+        while cancellation.changed().await.is_ok() {
+            if *cancellation.borrow() {
+                return;
+            }
+        }
+    }
+
+    pub(crate) fn subscribe(&self) -> watch::Receiver<bool> {
+        self.state.cancellation.subscribe()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_uncancelled() -> Self {
+        Self {
+            state: PreparationState::new(),
+        }
+    }
+}
+
+pub(crate) struct PreparationPhase {
+    state: Arc<PreparationState>,
+}
+
+impl PreparationPhase {
+    pub(crate) fn cancellation(&self) -> PreparationCancellation {
+        PreparationCancellation {
+            state: self.state.clone(),
+        }
+    }
+}
+
+impl Drop for PreparationPhase {
+    fn drop(&mut self) {
+        let mut phase = self.state.lock_phase();
+        debug_assert!(phase.active_phases > 0);
+        phase.active_phases = phase.active_phases.saturating_sub(1);
+        let complete = phase.active_phases == 0;
+        drop(phase);
+        if complete {
+            self.state.phase_changed.notify_waiters();
+        }
+    }
+}
+
+pub(crate) struct PreparationBarrier {
+    preparations: Vec<(PreparationKey, Arc<PreparationState>)>,
+}
+
+impl PreparationBarrier {
+    pub(crate) fn had_preparations(&self) -> bool {
+        !self.preparations.is_empty()
+    }
+
+    pub(crate) fn fences(&self) -> Vec<RtThreadFence> {
+        let mut fences = Vec::new();
+        for (key, _) in &self.preparations {
+            if !fences.contains(&key.fence) {
+                fences.push(key.fence.clone());
+            }
+        }
+        fences
+    }
+
+    pub(crate) async fn wait(&self) -> Result<(), String> {
+        self.wait_for(PREPARATION_QUIESCE_TIMEOUT).await
+    }
+
+    async fn wait_for(&self, timeout: Duration) -> Result<(), String> {
+        let wait = futures::future::join_all(
+            self.preparations
+                .iter()
+                .map(|(_, state)| state.wait_for_phase_completion()),
+        );
+        tokio::time::timeout(timeout, wait)
+            .await
+            .map(|_| ())
+            .map_err(|_| {
+                "coding agent preparation did not stop within 15 seconds after cancellation"
+                    .to_string()
+            })
+    }
+}
+
+/// Process-local proof that an exact durable `starting` row is still being
+/// prepared by this app instance. Durable rows without this proof are stale
+/// restart debris and may be self-healed by the next start request.
+pub(crate) struct PreparationReservation {
+    registry: Arc<AgentSessionRegistry>,
+    key: PreparationKey,
+    state: Arc<PreparationState>,
+}
+
+impl PreparationReservation {
+    pub(crate) fn is_active(&self) -> bool {
+        if self.state.is_cancelled() {
+            return false;
+        }
+        self.registry
+            .lock_preparations()
+            .get(&self.key)
+            .is_some_and(|state| Arc::ptr_eq(state, &self.state))
+    }
+
+    pub(crate) fn begin_phase(&self) -> Option<PreparationPhase> {
+        self.state.begin_phase()
+    }
+}
+
+impl Drop for PreparationReservation {
+    fn drop(&mut self) {
+        // Aborting or panicking the spawn owner must wake any manager-owned
+        // preparation it was awaiting. Publish the explicit cancellation
+        // before the last sender can disappear instead of making every
+        // receiver infer owner loss from channel closure.
+        self.state.cancel();
+        let mut preparations = self.registry.lock_preparations();
+        if preparations
+            .get(&self.key)
+            .is_some_and(|state| Arc::ptr_eq(state, &self.state))
+        {
+            preparations.remove(&self.key);
+        }
+    }
+}
+
 impl WriterLeaseGuard {
     /// Lock the mutation boundary and prove this attachment still owns input.
     /// Holding the returned guard across the PTY/DB operation prevents a new
@@ -308,6 +543,7 @@ pub struct AgentSessionRegistry {
     manager: TerminalSessionManager,
     sessions: Mutex<HashMap<RtThreadFence, ManagedTerminal>>,
     hooks: Mutex<HashMap<String, Arc<HookRegistration>>>,
+    preparations: Mutex<HashMap<PreparationKey, Arc<PreparationState>>>,
     start_locks: Mutex<HashMap<RtThreadFence, Arc<AsyncMutex<()>>>>,
     codex_home_locks: Mutex<HashMap<String, Arc<AsyncMutex<()>>>>,
     claude_state_locks: Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>,
@@ -331,6 +567,7 @@ impl AgentSessionRegistry {
             manager: TerminalSessionManager::new(ManagerConfig::default()),
             sessions: Mutex::new(HashMap::new()),
             hooks: Mutex::new(HashMap::new()),
+            preparations: Mutex::new(HashMap::new()),
             start_locks: Mutex::new(HashMap::new()),
             codex_home_locks: Mutex::new(HashMap::new()),
             claude_state_locks: Mutex::new(HashMap::new()),
@@ -346,6 +583,12 @@ impl AgentSessionRegistry {
 
     fn lock_hooks(&self) -> MutexGuard<'_, HashMap<String, Arc<HookRegistration>>> {
         self.hooks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn lock_preparations(&self) -> MutexGuard<'_, HashMap<PreparationKey, Arc<PreparationState>>> {
+        self.preparations
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
@@ -398,6 +641,63 @@ impl AgentSessionRegistry {
 
     pub fn get(&self, fence: &RtThreadFence) -> Option<ManagedTerminal> {
         self.lock_sessions().get(fence).cloned()
+    }
+
+    pub(crate) fn reserve_preparation(
+        self: &Arc<Self>,
+        fence: RtThreadFence,
+        terminal_session_id: String,
+    ) -> Option<PreparationReservation> {
+        let key = PreparationKey {
+            fence,
+            terminal_session_id,
+        };
+        let state = PreparationState::new();
+        let mut preparations = self.lock_preparations();
+        if preparations.contains_key(&key) {
+            return None;
+        }
+        preparations.insert(key.clone(), state.clone());
+        drop(preparations);
+        Some(PreparationReservation {
+            registry: self.clone(),
+            key,
+            state,
+        })
+    }
+
+    pub(crate) fn is_preparing(&self, fence: &RtThreadFence, terminal_session_id: &str) -> bool {
+        self.lock_preparations()
+            .get(&PreparationKey {
+                fence: fence.clone(),
+                terminal_session_id: terminal_session_id.to_string(),
+            })
+            .is_some_and(|state| !state.is_cancelled())
+    }
+
+    pub(crate) fn cancel_preparation(&self, fence: &RtThreadFence) -> PreparationBarrier {
+        let preparations = self
+            .lock_preparations()
+            .iter()
+            .filter(|(key, _)| key.fence == *fence)
+            .map(|(key, state)| (key.clone(), state.clone()))
+            .collect::<Vec<_>>();
+        for (_, state) in &preparations {
+            state.cancel();
+        }
+        PreparationBarrier { preparations }
+    }
+
+    pub(crate) fn cancel_all_preparations(&self) -> PreparationBarrier {
+        let preparations = self
+            .lock_preparations()
+            .iter()
+            .map(|(key, state)| (key.clone(), state.clone()))
+            .collect::<Vec<_>>();
+        for (_, state) in &preparations {
+            state.cancel();
+        }
+        PreparationBarrier { preparations }
     }
 
     pub fn hook(&self, terminal_session_id: &str) -> Option<Arc<HookRegistration>> {
@@ -521,6 +821,10 @@ impl AgentSessionRegistry {
             self.unregister_hook(managed.session.id());
         }
         self.lock_hooks().retain(|_, hook| hook.fence != *fence);
+        let barrier = self.cancel_preparation(fence);
+        self.lock_preparations()
+            .retain(|preparation, _| preparation.fence != *fence);
+        drop(barrier);
         self.start_locks
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -528,12 +832,30 @@ impl AgentSessionRegistry {
     }
 
     pub async fn shutdown(&self) -> terminal_session::ShutdownReport {
+        let barrier = self.cancel_all_preparations();
+        if let Err(error) = barrier.wait().await {
+            tracing::error!(%error, "coding agent preparation did not quiesce before shutdown");
+        }
         self.manager.shutdown(termination_policy()).await
     }
 
     /// Reap all current terminals without closing future admission. Logout
     /// and account switching use this; app shutdown uses [`Self::shutdown`].
     pub async fn terminate_all(&self) -> Vec<String> {
+        let barrier = self.cancel_all_preparations();
+        let preparation_failure = barrier.wait().await.err();
+        let mut failures = self.terminate_active_sessions().await;
+        if let Some(error) = preparation_failure {
+            failures.push(error);
+        }
+        failures
+    }
+
+    /// Reap registered PTYs after the caller has already canceled and awaited
+    /// its preparation barrier. Account transitions use this to keep the
+    /// cancellation wait single and bounded while still stopping older live
+    /// terminals when a preparation itself fails to quiesce.
+    pub(crate) async fn terminate_active_sessions(&self) -> Vec<String> {
         let sessions = self
             .lock_sessions()
             .values()
@@ -714,5 +1036,69 @@ mod tests {
         assert!(second.mutation_permit().await.is_some());
         drop(second);
         assert_eq!(lease.current_generation.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn preparation_barrier_cannot_miss_phase_completion_after_its_check() {
+        let state = PreparationState::new();
+        let phase = state.begin_phase().expect("phase should begin");
+        state.cancel();
+        let mut phase = Some(phase);
+
+        // Complete the phase in the exact interval that used to lose a
+        // `notify_waiters` wakeup: after the waiter observed a non-zero phase
+        // count but before it first awaited the notification.
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            state.wait_for_phase_completion_with(|| drop(phase.take())),
+        )
+        .await
+        .expect("registered waiter must observe phase completion");
+        assert!(phase.is_none());
+    }
+
+    #[tokio::test]
+    async fn timed_out_preparation_barrier_can_be_rechecked_before_artifact_cleanup() {
+        let registry = AgentSessionRegistry::new();
+        let fence = RtThreadFence {
+            account_scope: "account".to_string(),
+            organization_id: "org".to_string(),
+            thread_id: "thread".to_string(),
+            generation: "generation".to_string(),
+        };
+        let reservation = registry
+            .reserve_preparation(fence.clone(), "terminal".to_string())
+            .unwrap();
+        let phase = reservation.begin_phase().unwrap();
+        let barrier = registry.cancel_preparation(&fence);
+
+        assert!(barrier.wait_for(Duration::ZERO).await.is_err());
+        drop(phase);
+        barrier.wait_for(Duration::from_secs(1)).await.unwrap();
+        drop(reservation);
+    }
+
+    #[tokio::test]
+    async fn dropping_preparation_reservation_publishes_cancellation() {
+        let registry = AgentSessionRegistry::new();
+        let fence = RtThreadFence {
+            account_scope: "account".to_string(),
+            organization_id: "org".to_string(),
+            thread_id: "thread".to_string(),
+            generation: "generation".to_string(),
+        };
+        let reservation = registry
+            .reserve_preparation(fence.clone(), "terminal".to_string())
+            .unwrap();
+        let mut cancellation = reservation.state.cancellation.subscribe();
+
+        drop(reservation);
+
+        tokio::time::timeout(Duration::from_secs(1), cancellation.changed())
+            .await
+            .expect("reservation drop must wake the preparation owner")
+            .expect("the cancellation sender remains observable");
+        assert!(*cancellation.borrow());
+        assert!(!registry.is_preparing(&fence, "terminal"));
     }
 }

--- a/apps/native/e2e/git-sandbox.e2e.test.ts
+++ b/apps/native/e2e/git-sandbox.e2e.test.ts
@@ -43,6 +43,11 @@ import { afterAll, beforeAll, expect, it } from "bun:test";
 import { computeHandle, repoDirFor } from "./sandbox-handle";
 
 import {
+  signInAndCompleteSession,
+  startAuthenticatedUpstream,
+} from "./authenticated-upstream";
+
+import {
   describeLocalApi,
   HOOK_TIMEOUT_MS,
   jsonAuthHeaders,
@@ -202,16 +207,20 @@ describeLocalApi(
   "local-api e2e: per-handle git sandbox (one workdir per branch)",
   () => {
     let a: LocalApi;
+    let upstream: ReturnType<typeof startAuthenticatedUpstream>;
     let fixture: { root: string; bareDir: string };
     const virtualMcpId = "git-sandbox-e2e-vmcp";
 
     beforeAll(async () => {
       fixture = setupFixtureRepo();
-      a = await startLocalApi();
+      upstream = startAuthenticatedUpstream();
+      a = await startLocalApi({ DECOCMS_UPSTREAM_URL: upstream.url });
+      await signInAndCompleteSession(a);
     }, HOOK_TIMEOUT_MS);
 
     afterAll(async () => {
       await stopLocalApi(a);
+      upstream.server.stop(true);
       rmSync(fixture.root, { recursive: true, force: true });
     }, HOOK_TIMEOUT_MS);
 

--- a/apps/native/e2e/sandbox-fs-bridge.e2e.test.ts
+++ b/apps/native/e2e/sandbox-fs-bridge.e2e.test.ts
@@ -29,6 +29,11 @@ import { afterAll, beforeAll, expect, it } from "bun:test";
 import { computeHandle, normalizeBranch, repoDirFor } from "./sandbox-handle";
 
 import {
+  signInAndCompleteSession,
+  startAuthenticatedUpstream,
+} from "./authenticated-upstream";
+
+import {
   describeLocalApi,
   HOOK_TIMEOUT_MS,
   jsonAuthHeaders,
@@ -42,6 +47,9 @@ const ORG = "blocks-native-e2e";
 const VIRTUAL_MCP_ID = "blocks/vmcp/with-slashes";
 const FEATURE_BRANCH = "feature/blocks/save";
 const OTHER_BRANCH = "main";
+const THREAD_ID = "sandbox-authority-thread";
+const THREAD_VIRTUAL_MCP_ID = "sandbox-authority-vmcp";
+const THREAD_BRANCH = `thread:${THREAD_ID}`;
 
 function git(cwd: string, args: string[]): void {
   const result = spawnSync("git", args, { cwd, encoding: "utf8" });
@@ -104,12 +112,13 @@ async function ensureSandbox(
   a: LocalApi,
   cloneUrl: string,
   branch: string,
+  virtualMcpId = VIRTUAL_MCP_ID,
 ): Promise<string> {
   const response = await fetch(url(a, "/_sandbox/setup/ensure"), {
     method: "POST",
     headers: jsonAuthHeaders(),
     body: JSON.stringify({
-      virtualMcpId: VIRTUAL_MCP_ID,
+      virtualMcpId,
       repo: { cloneUrl, branch },
       workload: { runtime: "bun", packageManager: "bun" },
     }),
@@ -166,6 +175,7 @@ describeLocalApi(
   "local-api e2e: Blocks editor native sandbox filesystem bridge",
   () => {
     let a: LocalApi;
+    let upstream: ReturnType<typeof startAuthenticatedUpstream>;
     let fixture: { root: string; bareDir: string };
     let appRoot: string;
     let featureHandle: string;
@@ -175,7 +185,12 @@ describeLocalApi(
 
     beforeAll(async () => {
       fixture = setupFixtureRepo();
-      a = await startLocalApi({ LOCAL_API_TOKEN_STORE: "memory" });
+      upstream = startAuthenticatedUpstream();
+      a = await startLocalApi({
+        DECOCMS_UPSTREAM_URL: upstream.url,
+        LOCAL_API_TOKEN_STORE: "memory",
+      });
+      await signInAndCompleteSession(a);
       appRoot = a.workdir;
 
       featureHandle = await ensureSandbox(a, fixture.bareDir, FEATURE_BRANCH);
@@ -188,13 +203,115 @@ describeLocalApi(
       otherHandle = await ensureSandbox(a, fixture.bareDir, OTHER_BRANCH);
       otherRepo = repoDirFor(appRoot, otherHandle);
       await waitForFile(join(otherRepo, "BRANCH.txt"), "main\n");
+
+      const created = await fetch(
+        url(a, `/api/${ORG}/tools/COLLECTION_THREADS_CREATE`),
+        {
+          method: "POST",
+          headers: jsonAuthHeaders(),
+          body: JSON.stringify({
+            data: {
+              id: THREAD_ID,
+              title: "Sandbox authority",
+              virtual_mcp_id: THREAD_VIRTUAL_MCP_ID,
+            },
+          }),
+        },
+      );
+      expect(created.status).toBe(200);
+      const threadHandle = await ensureSandbox(
+        a,
+        fixture.bareDir,
+        THREAD_BRANCH,
+        THREAD_VIRTUAL_MCP_ID,
+      );
+      await waitForFile(
+        join(repoDirFor(appRoot, threadHandle), "BRANCH.txt"),
+        "main\n",
+      );
     }, HOOK_TIMEOUT_MS);
 
     afterAll(async () => {
       await stopLocalApi(a, { keepWorkdir: true });
+      upstream.server.stop(true);
       rmSync(appRoot, { recursive: true, force: true });
       rmSync(fixture.root, { recursive: true, force: true });
     }, HOOK_TIMEOUT_MS);
+
+    it("requires a signed-in Studio account in addition to the loopback bearer", async () => {
+      const signedOut = await startLocalApi({
+        DECOCMS_UPSTREAM_URL: upstream.url,
+        LOCAL_API_TOKEN_STORE: "memory",
+      });
+      try {
+        const response = await writeSandboxFile(
+          signedOut,
+          FEATURE_BRANCH,
+          "must-not-write.json",
+          "{}",
+        );
+        expect(response.status).toBe(401);
+      } finally {
+        await stopLocalApi(signedOut);
+      }
+    });
+
+    it("lets an owner mutate its active thread workspace, rejects a virtual MCP mismatch, and leaves archived workspaces read-only", async () => {
+      const path = "thread-authority.json";
+      const write = await writeSandboxFile(
+        a,
+        THREAD_BRANCH,
+        path,
+        '{"owner":true}',
+        THREAD_VIRTUAL_MCP_ID,
+      );
+      const writeBody = await write.json();
+      expect({ status: write.status, body: writeBody }).toMatchObject({
+        status: 200,
+        body: { ok: true },
+      });
+
+      const mismatchedVirtualMcp = await writeSandboxFile(
+        a,
+        THREAD_BRANCH,
+        "mismatched-virtual-mcp.json",
+        "{}",
+        "different-vmcp",
+      );
+      expect(mismatchedVirtualMcp.status).toBe(404);
+
+      const archived = await fetch(
+        url(a, `/api/${ORG}/tools/COLLECTION_THREADS_UPDATE`),
+        {
+          method: "POST",
+          headers: jsonAuthHeaders(),
+          body: JSON.stringify({ id: THREAD_ID, data: { hidden: true } }),
+        },
+      );
+      expect(archived.status).toBe(200);
+
+      const archivedWrite = await writeSandboxFile(
+        a,
+        THREAD_BRANCH,
+        "archived-write.json",
+        "{}",
+        THREAD_VIRTUAL_MCP_ID,
+      );
+      expect(archivedWrite.status).toBe(409);
+
+      const archivedRead = await readSandboxFile(
+        a,
+        THREAD_BRANCH,
+        path,
+        THREAD_VIRTUAL_MCP_ID,
+      );
+      expect(archivedRead.status).toBe(200);
+      expect(await archivedRead.json()).toMatchObject({
+        kind: "text",
+        content: '1\t{"owner":true}',
+        lineCount: 1,
+      });
+    });
 
     it("URL-decodes virtualMcpId + branch and never follows the other active sandbox", async () => {
       const path = ".deco/blocks/identity.json";
@@ -307,9 +424,13 @@ describeLocalApi(
 
       await stopLocalApi(a, { keepWorkdir: true });
       a = await startLocalApi(
-        { LOCAL_API_TOKEN_STORE: "memory" },
+        {
+          DECOCMS_UPSTREAM_URL: upstream.url,
+          LOCAL_API_TOKEN_STORE: "memory",
+        },
         { workdir: appRoot },
       );
+      await signInAndCompleteSession(a);
 
       // No setup/ensure call after relaunch: this request must recover the
       // explicit URL identity from the registry (studio.db). The persisted active

--- a/apps/native/e2e/sandbox-handle.ts
+++ b/apps/native/e2e/sandbox-handle.ts
@@ -12,6 +12,7 @@
  * mismatch. If this file and the Rust ever disagree, that is the bug — fix it
  * here, not by loosening the assertion.
  */
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 /** Sandbox workdirs live under this directory of the app root. */
@@ -118,7 +119,12 @@ export function computeHandle(cloneUrl: string, branch: string): string {
   if (scope === null) {
     throw new Error(`no repo scope for clone url ${cloneUrl}`);
   }
-  return [...scope, slugifyBranch(branch)].join("/");
+  const slug = slugifyBranch(branch);
+  const branchComponent =
+    slug === branch
+      ? slug
+      : `${slug}--${createHash("sha256").update(branch).digest("hex")}`;
+  return [...scope, branchComponent].join("/");
 }
 
 /** A handle's workdir under an app root. Handles nest — they contain `/`. */


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## How did you verify your code works?
> Name the tests you ran or added and what you observed. "Verified manually" or "existing tests" without specifics doesn't count.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens native sandbox authority by making all workspace routes account- and thread-aware, gating work by generation, and auto-closing long responses when the signed-in account changes. Adds account-epoch fencing to upstream proxy/WS and enforces canonical thread ownership for `thread:` branches.

- **New Features**
  - Account + thread authority on all sandbox intercepts (FS, ops, events, preview-invoke, terminals/tools); SSE/WS/proxy streams end on account change.
  - Generation-scoped task admission across the app; Stop closes the gate and returns 409 for new work; setup Stop quiesces the generation.
  - Owned git/FS and repo info: probes, branch events/snapshots, and `git exclude` resolution run under the current generation; repo-dir/events validate the current account.

- **Refactors**
  - `SandboxManager` and routes are account-aware (`*_for_account`) with account-epoch fencing; new `sandbox_account` helper; upstream proxy/WS and watch/events use epoch watchers to close long responses.
  - Interceptors consolidate auth in `sandbox_authority`; strict `thread:` parsing and canonical authority prevent cross-account access; used by sandbox fs/ops, agent-sessions, preview-invoke.
  - `TaskRegistry` adds `GenerationAdmission` and close-and-kill shutdown; setup/dev/scripts register via admissions; e2e runs with authenticated upstream; handle computation hashes unsluggable branches.

<sup>Written for commit 56ff65bf3209cec42cc9d57cb70fae025e2cbccf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

