### PR TITLE
feat(commerce): provisional-claim topbar on the report — click to verify

### DIFF
--- a/apps/api/src/tools/reports/auth-client.test.ts
+++ b/apps/api/src/tools/reports/auth-client.test.ts
@@ -517,6 +517,34 @@ describe("fetchCommerceDiscoveryConnectionStatus", () => {
           Response.json({ error: "not_upgraded" }, { status: 409 }),
       },
     );
-    expect(out).toEqual({ providers: {}, claimed: false });
+    expect(out).toEqual({ providers: {}, claimed: false, claim: null });
+  });
+
+  test("passes the claim state through, and tolerates a worker without it", async () => {
+    const withClaim = await fetchCommerceDiscoveryConnectionStatus(
+      { siteUrl: "https://example.com", orgId: "org_123" },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async () =>
+          Response.json({
+            providers: {},
+            claim: { method: "provisional", verified: false },
+          }),
+      },
+    );
+    expect(withClaim.claim).toEqual({ method: "provisional", verified: false });
+
+    // A worker deployed before the claim field: absent ⇒ null, never a throw.
+    const without = await fetchCommerceDiscoveryConnectionStatus(
+      { siteUrl: "https://example.com", orgId: "org_123" },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async () => Response.json({ providers: {} }),
+      },
+    );
+    expect(without.claim).toBeNull();
+    expect(without.claimed).toBe(true);
   });
 });

--- a/apps/api/src/tools/reports/auth-client.ts
+++ b/apps/api/src/tools/reports/auth-client.ts
@@ -378,6 +378,14 @@ const ConnectionStatusSchema = z.object({
       resource: z.string().nullable(),
     }),
   ),
+  // How this org's claim on the domain was granted (reports PR #313). Absent
+  // on older worker deploys; null when the asking org doesn't hold the
+  // diagnostic. verified=false ⇒ provisional: the UI nudges the user to
+  // verify (connecting GA4/GSC verifies automatically).
+  claim: z
+    .object({ method: z.string().nullable(), verified: z.boolean() })
+    .nullable()
+    .optional(),
 });
 
 export type CommerceDiscoveryConnectionStatus = z.infer<
@@ -399,6 +407,7 @@ export async function fetchCommerceDiscoveryConnectionStatus(
 ): Promise<{
   providers: CommerceDiscoveryConnectionStatus;
   claimed: boolean;
+  claim: { method: string | null; verified: boolean } | null;
 }> {
   const baseUrl = resolveBaseUrl(options);
   const apiKey = resolveApiKey(options);
@@ -414,7 +423,7 @@ export async function fetchCommerceDiscoveryConnectionStatus(
   });
 
   if (response.status === 404 || response.status === 409) {
-    return { providers: {}, claimed: false };
+    return { providers: {}, claimed: false, claim: null };
   }
   if (!response.ok) {
     throw new Error(await responseErrorMessage(response));
@@ -423,5 +432,6 @@ export async function fetchCommerceDiscoveryConnectionStatus(
   return {
     providers: parsed.success ? parsed.data.providers : {},
     claimed: true,
+    claim: parsed.success ? (parsed.data.claim ?? null) : null,
   };
 }

--- a/apps/api/src/tools/reports/status.ts
+++ b/apps/api/src/tools/reports/status.ts
@@ -22,6 +22,12 @@ const CommerceDiscoveryStatusOutputSchema = z.object({
     .describe(
       "False when the site isn't claimed/upgraded for this org — providers is then empty because the status is unreadable, NOT because nothing is connected. The UI must warn instead of rendering existing bindings as disconnected.",
     ),
+  claim: z
+    .object({ method: z.string().nullable(), verified: z.boolean() })
+    .nullable()
+    .describe(
+      "How this org's claim on the domain was granted. verified=false ⇒ provisional: the org sees its report but should be nudged to verify (connecting GA4/GSC verifies automatically). Null when the org doesn't hold the diagnostic or the worker predates the field.",
+    ),
 });
 
 export const COMMERCE_DISCOVERY_CONNECTION_STATUS = defineTool({

--- a/apps/web/src/hooks/use-commerce-diagnostic.ts
+++ b/apps/web/src/hooks/use-commerce-diagnostic.ts
@@ -60,6 +60,9 @@ export interface UseCommerceDiagnosticResult {
   isSuccess: boolean;
   /** The store's hostname from the connection metadata, for copy. */
   host: string | null;
+  /** The store's full siteUrl from the connection metadata — the argument the
+   *  reports tools (e.g. COMMERCE_DISCOVERY_CONNECTION_STATUS) expect. */
+  siteUrl: string | null;
   connectionId: string;
   /** The CD MCP client (once gate 2 opens), for tool calls like start_checkout. */
   cdClient: CommerceDiscoveryClient | null;
@@ -131,6 +134,11 @@ export function useCommerceDiagnostic(): UseCommerceDiagnosticResult {
     diagnostic: diagnosticQuery.data ?? null,
     isSuccess: diagnosticQuery.isSuccess,
     host: hostFromSiteUrl(connectionItem?.metadata?.siteUrl),
+    siteUrl:
+      typeof connectionItem?.metadata?.siteUrl === "string" &&
+      connectionItem.metadata.siteUrl
+        ? connectionItem.metadata.siteUrl
+        : null,
     connectionId,
     cdClient: (cdClient as CommerceDiscoveryClient | undefined) ?? null,
   };

--- a/apps/web/src/i18n/en/reports.ts
+++ b/apps/web/src/i18n/en/reports.ts
@@ -148,4 +148,6 @@ export const reports = {
   "reports.commerceBanner.generatingSubtitle":
     "Analyzing {store}. This takes a few minutes.",
   "reports.commerceBanner.readySubtitle": "See the full analysis of {store}.",
+  "reports.claimBanner.provisional":
+    "Your store isn't verified yet — connect its Google Analytics or Search Console to verify ownership",
 } as const;

--- a/apps/web/src/i18n/pt-br/reports.ts
+++ b/apps/web/src/i18n/pt-br/reports.ts
@@ -150,4 +150,6 @@ export const reports = {
   "reports.commerceBanner.generatingSubtitle":
     "Analisando {store}. Isso leva alguns minutos.",
   "reports.commerceBanner.readySubtitle": "Veja a análise completa de {store}.",
+  "reports.claimBanner.provisional":
+    "Sua loja ainda não foi verificada — conecte o Google Analytics ou Search Console dela para verificar a propriedade",
 } satisfies Record<keyof typeof reportsEn, string>;

--- a/apps/web/src/layouts/main-panel-tabs/commerce-claim-banner.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/commerce-claim-banner.tsx
@@ -1,0 +1,83 @@
+/**
+ * Provisional-claim topbar for the Commerce Discovery report tab.
+ *
+ * Shown only while the org's claim on the store is PROVISIONAL (reports
+ * PR #313: the ownership ladder graded the claim instead of blocking it —
+ * e.g. a gmail login). A slim, full-width yellow strip above the report:
+ * clicking it opens the connect-sources tab, where connecting GA4/GSC
+ * verifies the claim automatically (the binding proves access to the
+ * domain's own property).
+ *
+ * Fail-soft by construction: no siteUrl, a loading/failed status query, a
+ * worker that predates the `claim` field, or a verified claim all render
+ * nothing. The report must never break because of this strip.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight } from "@untitledui/icons";
+import {
+  mcpClientQueryOptions,
+  SELF_MCP_ALIAS_ID,
+  useProjectContext,
+} from "@/sdk";
+import { ErrorBoundary } from "@/components/error-boundary";
+import { useCommerceDiagnostic } from "@/hooks/use-commerce-diagnostic";
+import { useT } from "@/i18n/use-t";
+import { usePanelActions } from "@/layouts/shell-layout";
+import { KEYS } from "@/lib/query-keys";
+import { unwrapToolResult } from "@/routes/commerce-onboarding/companions-core";
+
+interface ConnectionStatusResult {
+  claim?: { method: string | null; verified: boolean } | null;
+}
+
+function CommerceClaimBannerInner() {
+  const { org } = useProjectContext();
+  const { siteUrl } = useCommerceDiagnostic();
+  const { openTab } = usePanelActions();
+  const t = useT();
+
+  const { data: selfClient } = useQuery(
+    mcpClientQueryOptions({
+      connectionId: SELF_MCP_ALIAS_ID,
+      orgId: org.id,
+      orgSlug: org.slug,
+    }),
+  );
+
+  // Same key + tool as the connect-sources cards, so the caches cooperate and
+  // a binding write over there invalidates this strip too.
+  const statusQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryConnectionStatus(org.id, siteUrl ?? ""),
+    enabled: !!siteUrl && !!selfClient,
+    queryFn: async () => {
+      if (!selfClient) throw new Error("selfClient not ready");
+      const result = await selfClient.callTool({
+        name: "COMMERCE_DISCOVERY_CONNECTION_STATUS",
+        arguments: { siteUrl },
+      });
+      return unwrapToolResult<ConnectionStatusResult>(result);
+    },
+  });
+
+  const claim = statusQuery.data?.claim;
+  if (!claim || claim.verified) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => openTab("connect-sources")}
+      className="flex w-full shrink-0 cursor-pointer items-center justify-center gap-1.5 bg-warning px-3 py-1.5 text-xs font-medium text-black transition-opacity hover:opacity-90"
+    >
+      <span>{t("reports.claimBanner.provisional")}</span>
+      <ArrowRight className="size-3.5 shrink-0" aria-hidden />
+    </button>
+  );
+}
+
+export function CommerceClaimBanner() {
+  return (
+    <ErrorBoundary fallback={null}>
+      <CommerceClaimBannerInner />
+    </ErrorBoundary>
+  );
+}

--- a/apps/web/src/layouts/main-panel-tabs/index.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/index.tsx
@@ -20,6 +20,8 @@ import { ContentTab } from "./content-tab";
 import { AutomationTab } from "./automation-tab";
 import { AutomationsListTab } from "./automations-list-tab";
 import { FileTab } from "./file-tab";
+import { COMMERCE_DISCOVERY_REPORT_TOOL_NAME } from "@/sdk";
+import { CommerceClaimBanner } from "./commerce-claim-banner";
 import { ConnectSourcesTab } from "./connect-sources-tab";
 import { DeckTab } from "./deck-tab";
 import { LibraryFileTab } from "./library-file-tab";
@@ -140,7 +142,7 @@ function TabBody({
         t.appId === pinnedView.connectionId &&
         t.toolName === pinnedView.toolName,
     );
-    return (
+    const body = (
       <Suspense fallback={<MainPanelLoading />}>
         <AppViewContent
           key={activeTab}
@@ -150,6 +152,17 @@ function TabBody({
         />
       </Suspense>
     );
+    // The Commerce Discovery report gets a verify-your-store topbar while the
+    // org's claim is provisional (renders nothing otherwise — see the banner).
+    if (pinnedView.toolName === COMMERCE_DISCOVERY_REPORT_TOOL_NAME) {
+      return (
+        <div className="flex h-full min-h-0 flex-col">
+          <CommerceClaimBanner />
+          <div className="min-h-0 flex-1">{body}</div>
+        </div>
+      );
+    }
+    return body;
   }
 
   const agentTab = layoutTabs.find((t) => t.id === activeTab);

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -1984,6 +1984,7 @@ export interface StudioToolIO {
         }
       >;
       claimed: boolean;
+      claim: { method: string | null; verified: boolean } | null;
     };
   };
   COLLECTION_VIRTUAL_MCP_CREATE: {


### PR DESCRIPTION
## Summary

The reports worker now grades a claim instead of blocking it (decocms/reports#313): a store owner logging in with a gmail gets a **provisional** claim — they see their report normally, but subscription/weekly runs require a **verified** one, and connecting the store's own GA4/GSC verifies it automatically.

This PR surfaces that state in Studio:

- A slim, full-width **yellow topbar** (black small text) above the Commerce Discovery report tab, shown only while the org's claim is provisional. Clicking it opens the **connect-sources** tab, where connecting a source resolves it.
- Fail-soft by construction: no siteUrl, a loading/failed status query, a worker deployed before the `claim` field, or a verified claim all render nothing — the report never breaks because of the strip.

## Plumbing

- `fetchCommerceDiscoveryConnectionStatus` + `COMMERCE_DISCOVERY_CONNECTION_STATUS` pass the new `claim: { method, verified } | null` through (schema is optional-tolerant for older workers); `tool-io.ts` updated to match (hand-edited — the local generator run produced an env-dependent subset, so only the changed entry was touched).
- `useCommerceDiagnostic` now exposes the connection's `siteUrl` (the argument the reports tools expect).
- Banner reuses the same query key as the connect-sources cards, so a binding write over there invalidates the strip too.

## Testing

- `bun run --cwd=apps/web check` and `--cwd=apps/api check` pass; `bun run fmt` clean.
- `apps/api` reports tests: 29 pass, incl. new cases — claim passthrough and absent-field tolerance.

Depends on decocms/reports#313 being deployed for the field to be non-null (already merged; without it the banner simply never shows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a slim yellow topbar to the Commerce Discovery report when a store’s claim is provisional. Clicking the bar opens Connect Sources to verify ownership by linking GA4 or GSC. The UI fails soft and never blocks the report.

- **New Features**
  - Show the banner only when `claim.verified` is false; clicking opens `connect-sources`.
  - Shares the same query key/tool as connect-sources, so binding updates invalidate the banner.
  - API now returns `claim` via `fetchCommerceDiscoveryConnectionStatus`; `COMMERCE_DISCOVERY_CONNECTION_STATUS` output and `tool-io` updated.
  - `use-commerce-diagnostic` exposes `siteUrl` for tool calls.
  - Handles missing `siteUrl`, loading/failed queries, older workers without `claim`, or verified claim by rendering nothing.

<sup>Written for commit 91d7ef6b86dc4d50b7022f519f2b44398bbe8b61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

