### PR TITLE
fix(sandbox): cap the Go daemon's file-edit path at 10MB

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/fs.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	maxImageBytes    = 5 * 1024 * 1024
+	maxEditFileBytes = 10 * 1024 * 1024
 	maxTransferBytes = 500 * 1024 * 1024
 	transferDeadline = 5 * time.Minute
 )
@@ -417,6 +418,10 @@ func Edit(deps FsDeps) http.HandlerFunc {
 		}
 		if body.OldString == *body.NewString {
 			httpx.Error(w, 400, "old_string and new_string must differ")
+			return
+		}
+		if stat, err := os.Stat(filePath); err == nil && stat.Size() > maxEditFileBytes {
+			httpx.Error(w, 400, fmt.Sprintf("File too large (%d bytes; cap is %d)", stat.Size(), maxEditFileBytes))
 			return
 		}
 		raw, err := os.ReadFile(filePath)

--- a/packages/sandbox/daemon-go/internal/routes/fs_edit_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs_edit_test.go
@@ -1,0 +1,64 @@
+package routes
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newEditRequest(t *testing.T, path, oldString, newString string) *http.Request {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"path":       path,
+		"old_string": oldString,
+		"new_string": newString,
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	return httptest.NewRequest(http.MethodPost, "/_sandbox/edit", bytes.NewReader(body))
+}
+
+// TestEditRejectsOversizedFile guards the same untrusted-size boundary as the
+// read route: without a cap, editing a large file reads it entirely into
+// memory to compute the replacement, which can OOM the daemon.
+func TestEditRejectsOversizedFile(t *testing.T) {
+	repoDir := t.TempDir()
+	big := strings.Repeat("a", maxEditFileBytes+1)
+	filePath := filepath.Join(repoDir, "big.txt")
+	if err := os.WriteFile(filePath, []byte(big), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	handler := Edit(FsDeps{AppRoot: repoDir, RepoDir: repoDir})
+	rec := httptest.NewRecorder()
+	handler(rec, newEditRequest(t, "big.txt", "a", "b"))
+
+	if rec.Code != 400 {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "too large") {
+		t.Fatalf("body = %s, want a too-large error", rec.Body.String())
+	}
+}
+
+func TestEditAllowsFileUnderCap(t *testing.T) {
+	repoDir := t.TempDir()
+	filePath := filepath.Join(repoDir, "small.txt")
+	if err := os.WriteFile(filePath, []byte("hello world"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	handler := Edit(FsDeps{AppRoot: repoDir, RepoDir: repoDir})
+	rec := httptest.NewRecorder()
+	handler(rec, newEditRequest(t, "small.txt", "hello", "goodbye"))
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
Follows the open PR #5608, which caps the plain-text `read` route at 10MB but leaves the `edit` route (`internal/routes/fs.go`'s `Edit` handler) doing an unbounded `os.ReadFile` on the same untrusted repo files.

A maintainer wants this because the edit route is the same trust boundary as read (any tool call can target an arbitrary file under the repo root), and it's exercised even more often (every write-side tool call), so a large generated file (a log, a lockfile, a big commit) reading unbounded into memory can OOM the daemon and take the sandbox pod down — the daemon's health probe then marks it dead mid-session.

Failure scenario: an agent calls edit on a >10MB text file in the repo; before this fix, `os.ReadFile` loads the whole file (plus the computed replacement string) into memory with no bound. Regression test: `TestEditRejectsOversizedFile` in `fs_edit_test.go` writes an 11MB fixture and asserts a 400 with a "too large" message; `TestEditAllowsFileUnderCap` asserts a normal small edit still succeeds.

To verify: `cd packages/sandbox/daemon-go && go test ./internal/routes/... -run TestEdit -v`.

Locally ran: `gofmt -l`, `go vet ./internal/routes/...`, `go test ./internal/routes/...` — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the `/_sandbox/edit` route at 10MB to match the existing plain-text `read` cap and prevent OOMs from unbounded file reads. Previously the handler read the whole file regardless of size; now files over 10MB return 400 "File too large" before reading.

• Introduces `maxEditFileBytes = 10 * 1024 * 1024` and a size check in `Edit` (`packages/sandbox/daemon-go/internal/routes/fs.go`).
• Adds `TestEditRejectsOversizedFile` and `TestEditAllowsFileUnderCap` (`packages/sandbox/daemon-go/internal/routes/fs_edit_test.go`).
• Verify with: `cd packages/sandbox/daemon-go && go test ./internal/routes/... -run TestEdit -v`.
• Migration: callers of `/_sandbox/edit` must avoid targeting files >10MB; such requests will receive 400.

<sup>Written for commit 3f3676f2509a3a4e758aaa9756744aa34585e7a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

