### PR TITLE
fix(sections-editor): add bounds checks to array field operations

### DIFF
--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -211,7 +211,7 @@ export function ArrayField({
     getArrayItemLabel(arrayItemDisplayValue(item), index, itemSchema);
 
   const openItem = (index: number) => {
-    if (suppressClickRef.current) return;
+    if (suppressClickRef.current || index < 0 || index >= items.length) return;
     const labelText = itemLabel(items[index], index);
     setOpenIndex(index);
     onBreadcrumbChange?.(
@@ -297,6 +297,7 @@ export function ArrayField({
   };
 
   const duplicateItem = (index: number) => {
+    if (index < 0 || index >= items.length) return;
     const original = items[index];
     const copy =
       typeof structuredClone === "function"
@@ -312,6 +313,7 @@ export function ArrayField({
   };
 
   const toggleItemHidden = (index: number) => {
+    if (index < 0 || index >= items.length) return;
     const item = items[index];
     const next = [...items];
     next[index] = isArrayItemHidden(item)
@@ -321,11 +323,13 @@ export function ArrayField({
   };
 
   const removeItem = (index: number) => {
+    if (index < 0 || index >= items.length) return;
     onChange(items.filter((_, i) => i !== index));
     setEntries((current) => removeEntryAt(current, index));
   };
 
   const updateItem = (index: number, val: unknown) => {
+    if (index < 0 || index >= items.length) return;
     const next = [...items];
     // Preserve the hidden wrapper when editing a hidden item's inner value.
     next[index] = isArrayItemHidden(items[index]) ? hideArrayItem(val) : val;


### PR DESCRIPTION
## Summary

Adds defensive bounds checks to array field operations (`openItem`, `duplicateItem`, `toggleItemHidden`, `removeItem`, `updateItem`) to prevent undefined item access if entry indices ever become desynchronized with items.

## Why This Matters

The rendering loop already has a defensive bounds check (line 551-552: `if (item === undefined) return null;`), but the action handlers were missing equivalent checks. If entry indices ever become out-of-bounds due to a bug in `resizeArrayEntries`, `removeEntryAt`, or `insertEntryAfter`, these handlers would operate on undefined items, leading to crashes or silent failures in label computation, item cloning, or hidden-item toggling.

This fix ensures all array operations fail safely on invalid indices instead of propagating undefined values.

## Changes

- `openItem()`: Guard against `index < 0 || index >= items.length`
- `duplicateItem()`: Guard against `index < 0 || index >= items.length`
- `toggleItemHidden()`: Guard against `index < 0 || index >= items.length`
- `removeItem()`: Guard against `index < 0 || index >= items.length`
- `updateItem()`: Guard against `index < 0 || index >= items.length`

## Verification

- All 628 sections-editor tests pass
- TypeScript (`bunx tsc --noEmit`) green in apps/web
- Linter (`bunx oxlint`) clean on modified file
- Formatting verified with `bun run fmt`

## Testing Command

```bash
bun test apps/web/src/components/sections-editor/
bunx tsc --noEmit --cwd apps/web
bunx oxlint apps/web/src/components/sections-editor/fields/array-field.tsx
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents undefined item access in the sections editor by adding bounds checks to array field handlers. Previously these handlers acted on out-of-range indices; now they return early to avoid crashes and unintended mutations.

**Details for review**
- Add `index < 0 || index >= items.length` guards to `openItem`, `duplicateItem`, `toggleItemHidden`, `removeItem`, and `updateItem` in `apps/web/src/components/sections-editor/fields/array-field.tsx`; `openItem` also preserves the `suppressClickRef` check.
- Aligns handler behavior with the existing render-time guard, containing issues from desynchronized entries produced by `resizeArrayEntries`, `removeEntryAt`, or `insertEntryAfter`.

**Rollout**
- No migration required.

<sup>Written for commit e91b8dae86ef1756dffe3f7d9a97bb721f596469. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

