### PR TITLE
refactor(mcp-clients): dedupe HTTP/Websocket and SSE transport setup

### DIFF
--- a/apps/api/src/mcp-clients/outbound/index.ts
+++ b/apps/api/src/mcp-clients/outbound/index.ts
@@ -28,6 +28,45 @@ import {
 // Separate from the per-request pool on StudioContext (used by HTTP/SSE).
 const stdioPool = createClientPool();
 
+// Shared by HTTP/Websocket and SSE — only the transport class differs.
+async function buildHttpLikeTransport(
+  connection: ConnectionEntity,
+  ctx: StudioContext,
+  superUser: boolean,
+  virtualMcpId: string | undefined,
+  TransportCtor: new (
+    url: URL,
+    opts: { requestInit: { headers: Record<string, string> } },
+  ) => Transport,
+): Promise<Transport> {
+  if (!connection.connection_url) {
+    throw new Error(`${connection.connection_type} connection missing URL`);
+  }
+
+  const headers = await buildRequestHeaders(connection, ctx, superUser);
+
+  const httpParams = connection.connection_headers;
+  if (httpParams && "headers" in httpParams) {
+    Object.assign(headers, httpParams.headers);
+  }
+
+  const transport: Transport = new TransportCtor(
+    new URL(connection.connection_url),
+    { requestInit: { headers } },
+  );
+
+  return composeTransport(
+    transport,
+    (t) => new AuthTransport(t, { ctx, connection, superUser }),
+    (t) =>
+      new MonitoringTransport(t, {
+        ctx,
+        connectionId: connection.id,
+        virtualMcpId,
+      }),
+  );
+}
+
 /**
  * Create an MCP client for outbound connections (STDIO, HTTP, Websocket, SSE)
  *
@@ -94,66 +133,24 @@ export async function createOutboundClient(
 
     case "HTTP":
     case "Websocket": {
-      if (!connection.connection_url) {
-        throw new Error(`${connection.connection_type} connection missing URL`);
-      }
-
-      const headers = await buildRequestHeaders(connection, ctx, superUser);
-
-      const httpParams = connection.connection_headers;
-      if (httpParams && "headers" in httpParams) {
-        Object.assign(headers, httpParams.headers);
-      }
-
-      let transport: Transport = new StreamableHTTPClientTransport(
-        new URL(connection.connection_url),
-        { requestInit: { headers } },
+      const transport = await buildHttpLikeTransport(
+        connection,
+        ctx,
+        superUser,
+        virtualMcpId,
+        StreamableHTTPClientTransport,
       );
-
-      // Compose with auth and monitoring transports
-      transport = composeTransport(
-        transport,
-        (t) => new AuthTransport(t, { ctx, connection, superUser }),
-        (t) =>
-          new MonitoringTransport(t, {
-            ctx,
-            connectionId,
-            virtualMcpId,
-          }),
-      );
-
       return ctx.getOrCreateClient(transport, connectionId);
     }
 
     case "SSE": {
-      if (!connection.connection_url) {
-        throw new Error("SSE connection missing URL");
-      }
-
-      const headers = await buildRequestHeaders(connection, ctx, superUser);
-
-      const httpParams = connection.connection_headers;
-      if (httpParams && "headers" in httpParams) {
-        Object.assign(headers, httpParams.headers);
-      }
-
-      let transport: Transport = new SSEClientTransport(
-        new URL(connection.connection_url),
-        { requestInit: { headers } },
+      const transport = await buildHttpLikeTransport(
+        connection,
+        ctx,
+        superUser,
+        virtualMcpId,
+        SSEClientTransport,
       );
-
-      // Compose with auth and monitoring transports
-      transport = composeTransport(
-        transport,
-        (t) => new AuthTransport(t, { ctx, connection, superUser }),
-        (t) =>
-          new MonitoringTransport(t, {
-            ctx,
-            connectionId,
-            virtualMcpId,
-          }),
-      );
-
       return ctx.getOrCreateClient(transport, connectionId);
     }
 


### PR DESCRIPTION
Follows issue #4468 (simplify the MCP-mesh machinery).

`createOutboundClient` in `apps/api/src/mcp-clients/outbound/index.ts` had three near-identical blocks for the HTTP, Websocket, and SSE connection types: validate `connection_url`, build request headers, merge any custom headers, construct the transport, then compose it with `AuthTransport` + `MonitoringTransport`. Only the transport constructor (`StreamableHTTPClientTransport` vs `SSEClientTransport`) differed. Extracted the shared steps into one `buildHttpLikeTransport(connection, ctx, superUser, virtualMcpId, TransportCtor)` helper, parameterized only by the constructor.

A maintainer gets a smaller, single home for this logic instead of three call sites that must all be kept in sync by hand whenever header-building or transport composition changes.

Behavior-preserving: the error message stays `${connection.connection_type} connection missing URL` — for the SSE branch this was already the literal string "SSE connection missing URL" before this change, since `connection.connection_type` is `"SSE"` in that branch, so the template produces the identical text. Header building, transport composition order (`AuthTransport` then `MonitoringTransport`), and the final `ctx.getOrCreateClient` call are all unchanged — this is a pure code-motion, no new branches or altered control flow.

Net diff: -54/+51 lines in one file.

Reviewer check: `cd apps/api && bunx tsc --noEmit` (clean) — there's no existing unit test isolating `createOutboundClient` (it needs a live/mocked MCP transport, which is e2e territory per this repo's testing tiers), so this is verified by typecheck + a line-by-line diff of the extracted logic against the original three blocks.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/mcp-clients/outbound/index.ts` (0 errors/warnings). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dedupes outbound HTTP/Websocket and SSE transport setup in createOutboundClient by extracting a shared helper, buildHttpLikeTransport. This reduces duplication and centralizes header and composition logic without changing behavior.

- The helper validates the URL, builds request headers, merges connection_headers.headers, constructs the transport, and composes with AuthTransport then MonitoringTransport.
- It is parameterized only by the transport constructor: StreamableHTTPClientTransport for HTTP/Websocket and SSEClientTransport for SSE.
- Preserves error text ("${connection.connection_type} connection missing URL"), header-building semantics, composition order, and ctx.getOrCreateClient usage.
- Review focus: confirm the helper mirrors the removed blocks, especially header merge order, SSE error string, and passing connectionId and virtualMcpId to MonitoringTransport.

<sup>Written for commit 05d8c2da37d6fcf252d9a5f8e5ad4ea6f2d2ee7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

