### PR TITLE
fix(sidebar): make the sidebar resize handle keyboard-operable

### DIFF
--- a/apps/web/src/components/sidebar/sidebar-resize-handle.tsx
+++ b/apps/web/src/components/sidebar/sidebar-resize-handle.tsx
@@ -1,6 +1,10 @@
-import type { PointerEvent as ReactPointerEvent } from "react";
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+} from "react";
 import { useSidebar } from "@decocms/ui/components/sidebar.tsx";
 import { useT } from "@/i18n/use-t.ts";
+import { SIDEBAR_RESIZE_KEYBOARD_STEP } from "@/hooks/use-sidebar-resize";
 
 /**
  * Vertical handle positioned at the sidebar's right edge that lets the user
@@ -8,27 +12,71 @@ import { useT } from "@/i18n/use-t.ts";
  * rail mode) or on mobile.
  *
  * Hit area is wider than the visible line so it's easy to grab. The visible
- * line is subtle until hover/drag, then thickens and brightens.
+ * line is subtle until hover/drag, then thickens and brightens. Also
+ * keyboard-operable: focus it and use the arrow keys (or Home/End) to resize,
+ * matching the WAI-ARIA APG pattern for a separator that moves its sibling.
  */
 export function SidebarResizeHandle({
+  width,
+  minWidth,
+  maxWidth,
   onPointerDown,
   onDoubleClick,
+  onAdjustWidth,
+  onResetWidth,
 }: {
+  width: number;
+  minWidth: number;
+  maxWidth: number;
   onPointerDown: (e: ReactPointerEvent<HTMLDivElement>) => void;
   onDoubleClick?: () => void;
+  onAdjustWidth: (delta: number) => void;
+  onResetWidth?: () => void;
 }) {
   const t = useT();
   const { state, isMobile } = useSidebar();
   if (isMobile || state === "collapsed") return null;
+
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    switch (e.key) {
+      case "ArrowLeft":
+        e.preventDefault();
+        onAdjustWidth(-SIDEBAR_RESIZE_KEYBOARD_STEP);
+        break;
+      case "ArrowRight":
+        e.preventDefault();
+        onAdjustWidth(SIDEBAR_RESIZE_KEYBOARD_STEP);
+        break;
+      case "Home":
+        e.preventDefault();
+        onAdjustWidth(minWidth - width);
+        break;
+      case "End":
+        e.preventDefault();
+        onAdjustWidth(maxWidth - width);
+        break;
+      case "Enter":
+        onResetWidth?.();
+        break;
+      default:
+        break;
+    }
+  };
+
   return (
     <div
       role="separator"
       aria-orientation="vertical"
       aria-label={t("sidebar.sidebarResizeHandle.ariaLabel")}
+      aria-valuenow={width}
+      aria-valuemin={minWidth}
+      aria-valuemax={maxWidth}
       title={t("sidebar.sidebarResizeHandle.title")}
+      tabIndex={0}
       onPointerDown={onPointerDown}
       onDoubleClick={onDoubleClick}
-      className="group/resize absolute top-0 z-20 h-full w-2 -translate-x-1/2 cursor-col-resize"
+      onKeyDown={handleKeyDown}
+      className="group/resize absolute top-0 z-20 h-full w-2 -translate-x-1/2 cursor-col-resize focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       style={{ left: "var(--sidebar-width)" }}
     >
       <span className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors duration-150 group-hover/resize:bg-border group-active/resize:bg-border" />

--- a/apps/web/src/hooks/use-sidebar-resize.ts
+++ b/apps/web/src/hooks/use-sidebar-resize.ts
@@ -13,11 +13,16 @@ function clamp(w: number) {
   return Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, w));
 }
 
+const KEYBOARD_STEP = 16;
+
 export interface SidebarResize {
   width: number;
+  minWidth: number;
+  maxWidth: number;
   wrapperRef: RefObject<HTMLDivElement | null>;
   onStartResize: (e: ReactPointerEvent<HTMLDivElement>) => void;
   resetWidth: () => void;
+  adjustWidth: (delta: number) => void;
 }
 
 /**
@@ -84,5 +89,19 @@ export function useSidebarResize(): SidebarResize {
     setWidth(SIDEBAR_MIN_WIDTH);
   };
 
-  return { width: clamp(width), wrapperRef, onStartResize, resetWidth };
+  const adjustWidth = (delta: number) => {
+    setWidth((prev) => clamp(prev + delta));
+  };
+
+  return {
+    width: clamp(width),
+    minWidth: SIDEBAR_MIN_WIDTH,
+    maxWidth: SIDEBAR_MAX_WIDTH,
+    wrapperRef,
+    onStartResize,
+    resetWidth,
+    adjustWidth,
+  };
 }
+
+export { KEYBOARD_STEP as SIDEBAR_RESIZE_KEYBOARD_STEP };

--- a/apps/web/src/layouts/org-shell-layout/index.tsx
+++ b/apps/web/src/layouts/org-shell-layout/index.tsx
@@ -75,7 +75,15 @@ export default function OrgShellLayout() {
     SIDEBAR_OPEN_STORAGE_KEY,
     false,
   );
-  const { width, wrapperRef, onStartResize, resetWidth } = useSidebarResize();
+  const {
+    width,
+    minWidth,
+    maxWidth,
+    wrapperRef,
+    onStartResize,
+    resetWidth,
+    adjustWidth,
+  } = useSidebarResize();
 
   // On desktop each panel owns its own 48px header (see WorkspacePanelGroup), so
   // there is no shared top bar spanning the panels — only the mobile layout,
@@ -151,8 +159,13 @@ export default function OrgShellLayout() {
                   <>
                     <StudioSidebar />
                     <SidebarResizeHandle
+                      width={width}
+                      minWidth={minWidth}
+                      maxWidth={maxWidth}
                       onPointerDown={onStartResize}
                       onDoubleClick={resetWidth}
+                      onAdjustWidth={adjustWidth}
+                      onResetWidth={resetWidth}
                     />
                   </>
                 )}


### PR DESCRIPTION
The sidebar's resize handle (`SidebarResizeHandle`) is `role="separator"` but had no `tabIndex` and no `onKeyDown` — a keyboard-only user had no way to resize the sidebar at all, only drag it with a mouse. This is a real accessibility gap: WAI-ARIA's separator pattern for a moveable divider expects it to be focusable and support arrow-key adjustment plus `aria-valuenow`/`valuemin`/`valuemax`, none of which were present.

Changes:
- `use-sidebar-resize.ts`: exposes `minWidth`, `maxWidth`, and a new `adjustWidth(delta)` setter (reusing the existing `clamp`/localStorage persistence), plus a small `SIDEBAR_RESIZE_KEYBOARD_STEP` constant.
- `sidebar-resize-handle.tsx`: adds `tabIndex={0}`, a focus ring, `aria-valuenow/min/max`, and an `onKeyDown` handler — ArrowLeft/ArrowRight step the width, Home/End jump to min/max, Enter resets to default (mirrors the existing double-click reset).
- `org-shell-layout/index.tsx`: wires the new props through from `useSidebarResize()`.

No behavior change for existing mouse/touch drag-resize or double-click-reset; this only adds a previously-missing keyboard path.

To confirm: focus the resize handle (desktop, expanded sidebar) with Tab and use the arrow keys — the sidebar width should change; Home/End should snap to min/max; Enter should reset to the default width.

Verified locally: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (one pre-existing unrelated `mustache` module error confirmed present on main via `git stash`, not touched by this change), `bunx oxlint` on all three changed files (0 warnings/errors). No test added — this is a pure UI interaction/accessibility change with no trust boundary; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the sidebar resize handle keyboard-operable to meet the WAI-ARIA separator pattern and close an accessibility gap. Before: the handle was not focusable and only worked with mouse drag. Now: it is focusable and supports Arrow/Home/End keys and Enter to reset; mouse/touch drag and double-click reset are unchanged.

**Review notes**
- `SidebarResizeHandle`: adds `tabIndex={0}`, `aria-valuenow/min/max`, a focus ring, and `onKeyDown` (ArrowLeft/Right ±16px, Home/End to min/max, Enter resets).
- `useSidebarResize`: exposes `minWidth`, `maxWidth`, and `adjustWidth(delta)`; clamping and persistence are unchanged; exports `SIDEBAR_RESIZE_KEYBOARD_STEP=16`.
- `OrgShellLayout`: wires the new props to the handle.
- Migration: if you render `SidebarResizeHandle` elsewhere, pass `width`, `minWidth`, `maxWidth`, `onAdjustWidth`, and optionally `onResetWidth`.

<sup>Written for commit 17f8f5a013cc0a188dc02e5e64c9539a0996423e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

