### PR TITLE
fix(sandbox): cap the Go daemon's file-read path at 10MB

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/fs.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	maxImageBytes    = 5 * 1024 * 1024
+	maxTextReadBytes = 10 * 1024 * 1024
 	maxTransferBytes = 500 * 1024 * 1024
 	transferDeadline = 5 * time.Minute
 )
@@ -169,6 +170,11 @@ func Read(deps FsDeps) http.HandlerFunc {
 
 		if bytes.IndexByte(probe, 0) >= 0 {
 			httpx.Error(w, 400, "File appears to be binary and is not a supported image format (jpeg/png/gif/webp).")
+			return
+		}
+
+		if stat.Size() > maxTextReadBytes {
+			httpx.Error(w, 400, fmt.Sprintf("File too large (%d bytes; cap is %d)", stat.Size(), maxTextReadBytes))
 			return
 		}
 

--- a/packages/sandbox/daemon-go/internal/routes/fs_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs_test.go
@@ -143,6 +143,39 @@ func TestReadDecofileFallbackRefusesAbsolute(t *testing.T) {
 	}
 }
 
+// Without a cap, /read's text path buffers the whole file into memory via
+// os.ReadFile regardless of size — unlike the image path (maxImageBytes)
+// a few lines above it. A large text file (a log, a generated artifact)
+// could OOM the daemon, tearing down the sandbox pod on the next missed
+// health probe.
+func TestReadRejectsOversizedTextFile(t *testing.T) {
+	repoDir := t.TempDir()
+	big := strings.Repeat("a", maxTextReadBytes+1)
+	if err := os.WriteFile(filepath.Join(repoDir, "big.txt"), []byte(big), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	deps := FsDeps{AppRoot: repoDir, RepoDir: repoDir}
+	rec := readReq(t, deps, "big.txt")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "too large") {
+		t.Fatalf("body = %s, want a too-large error", rec.Body.String())
+	}
+}
+
+func TestReadAllowsTextFileUnderCap(t *testing.T) {
+	repoDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoDir, "small.txt"), []byte("hello\nworld"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	deps := FsDeps{AppRoot: repoDir, RepoDir: repoDir}
+	rec := readReq(t, deps, "small.txt")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
 // The 400 an out-of-root write returns must name the root it wants. A model
 // that guessed `/tmp` (writable from its own bash tool, not from here) has to
 // be able to correct itself from the message alone — prod thread 38147122


### PR DESCRIPTION
Follows the same bug class as open PR #6039 (`/edit` file-read cap), but on a different route: `Read`'s text path (`packages/sandbox/daemon-go/internal/routes/fs.go`).

`/read` already caps its image path at `maxImageBytes` (5MB), but for a text file it falls through to an unconditional `os.ReadFile(filePath)` regardless of size. A large text file (a log, a generated artifact, an oversized decofile) gets read fully into memory with no bound, which can OOM the daemon and tear down the sandbox pod on the next missed health probe — the exact failure mode the file's own `decodeBody` comment already documents for the request-body side.

Added a `maxTextReadBytes` (10MB, matching the cap #6039 is adding to `/edit`) check right before the read, returning a 400 with the file size and cap instead of buffering the whole file.

Failure scenario: an agent runs `/read` against a >10MB text file in the sandbox → daemon buffers the entire file into memory → repeated/concurrent large reads can push the daemon over its memory limit and get the pod killed mid-session.

Regression test: `TestReadRejectsOversizedTextFile` (fixture file just over the cap, expects 400 with a "too large" message) and `TestReadAllowsTextFileUnderCap` (small file still reads fine) in `fs_test.go`.

Reviewer check: `cd packages/sandbox/daemon-go && go test ./internal/routes/...`

Locally ran: `go build ./...`, `go test ./internal/routes/...`, `gofmt -l` (clean), `go vet ./internal/routes/...` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps text-file reads in the sandbox Go daemon’s `/read` route at 10MB to prevent OOMs. Previously, the text path used unbounded `os.ReadFile`; now requests for files >10MB return 400 with the file size and cap. This aligns with the `/edit` 10MB cap.

**Review notes**
- Adds `maxTextReadBytes` and a pre-read size check in `packages/sandbox/daemon-go/internal/routes/fs.go`.
- Adds `TestReadRejectsOversizedTextFile` and `TestReadAllowsTextFileUnderCap` in `packages/sandbox/daemon-go/internal/routes/fs_test.go`.
- Verify with: `cd packages/sandbox/daemon-go && go test ./internal/routes/...`

<sup>Written for commit 134f0f2c2485c2139370ad2a570c62ff8d88d3f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

