### PR TITLE
fix(details): translate the OAuth connect button's default label

### DIFF
--- a/apps/web/src/components/details/connection/settings-tab/index.tsx
+++ b/apps/web/src/components/details/connection/settings-tab/index.tsx
@@ -64,7 +64,7 @@ interface OAuthAuthenticationStateProps {
 
 export function OAuthAuthenticationState({
   onAuthenticate,
-  buttonText = "Authenticate",
+  buttonText,
 }: OAuthAuthenticationStateProps) {
   const t = useT();
   return (
@@ -79,7 +79,7 @@ export function OAuthAuthenticationState({
           </p>
         </div>
         <Button onClick={onAuthenticate} size="default">
-          {buttonText}
+          {buttonText ?? t("details.settingsTab.authenticate")}
         </Button>
       </div>
     </div>

--- a/apps/web/src/i18n/en/details.ts
+++ b/apps/web/src/i18n/en/details.ts
@@ -111,6 +111,7 @@ export const details = {
   "details.prompt.notFoundTitle": "Prompt not found",
   "details.prompt.title": "Title",
   "details.prompt.titlePlaceholder": "Untitled prompt",
+  "details.settingsTab.authenticate": "Authenticate",
   "details.settingsTab.authenticationRequired": "Authentication Required",
   "details.settingsTab.manualAuthenticationDescription":
     "This server requires an API key or token that must be configured manually. Check the server's documentation for instructions on obtaining credentials.",

--- a/apps/web/src/i18n/pt-br/details.ts
+++ b/apps/web/src/i18n/pt-br/details.ts
@@ -115,6 +115,7 @@ export const details = {
   "details.prompt.notFoundTitle": "Prompt não encontrado",
   "details.prompt.title": "Título",
   "details.prompt.titlePlaceholder": "Prompt sem título",
+  "details.settingsTab.authenticate": "Autenticar",
   "details.settingsTab.authenticationRequired": "Autenticação Obrigatória",
   "details.settingsTab.manualAuthenticationDescription":
     "Este servidor requer uma chave de API ou token que deve ser configurado manualmente. Verifique a documentação do servidor para instruções sobre como obter credenciais.",


### PR DESCRIPTION
Bug found while working the MCP connections UI focus area (issue #5661).

`OAuthAuthenticationState` (apps/web/src/components/details/connection/settings-tab/index.tsx) defaults its button label to a hardcoded English string `"Authenticate"` when no `buttonText` prop is passed. This is exactly the path hit from `SettingsTab` (settings-tab/index.tsx:230), so any pt-br user who opens the settings tab of a connection requiring OAuth and hasn't authenticated yet sees an untranslated English button, breaking the i18n rule that all user-facing UI strings go through `t()`.

Fix: added `details.settingsTab.authenticate` to both `en/details.ts` and `pt-br/details.ts`, and changed the component default to `buttonText ?? t("details.settingsTab.authenticate")` instead of a hardcoded string literal. The one existing caller that already passes an explicit `buttonText` (apps/web/src/components/details/tool.tsx) is unaffected.

To confirm: open a connection's Settings tab for a connection requiring OAuth while not authenticated, with pt-br language selected — the button now reads "Autenticar" instead of "Authenticate".

Checks run locally: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on the three changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the OAuth authenticate button’s default label. Previously it defaulted to the hardcoded English "Authenticate" when no `buttonText` was provided; now it uses the i18n key "details.settingsTab.authenticate" so pt-br and other locales render correctly.

- Add "details.settingsTab.authenticate" to `apps/web/src/i18n/en/details.ts` and `apps/web/src/i18n/pt-br/details.ts`.
- Update `OAuthAuthenticationState` to use `t("details.settingsTab.authenticate")` only when `buttonText` is not provided; callers that pass `buttonText` are unchanged.
- Verify: open a not-yet-authenticated OAuth connection’s Settings tab in pt-br; the button reads "Autenticar".

<sup>Written for commit e7f6d6c51cea843ac439f38310bbff30dabe86ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

