### PR TITLE
perf(storage): skip the slug recompute query on non-slug connection updates

### DIFF
--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -380,22 +380,27 @@ export class ConnectionStorage implements ConnectionStoragePort {
     // every update, using presence (not `??`) so an explicit null clears the field
     // it was derived from instead of silently keeping the old slug.
     const slugData: Record<string, unknown> = { ...data };
-    // Skip findById() here — it decrypts secrets we don't need just for a slug merge.
-    const existing = await this.db
-      .selectFrom("connections")
-      .select(["app_name", "connection_url", "title"])
-      .where("id", "=", id)
-      .executeTakeFirst();
-    if (existing) {
-      const merged = <K extends "app_name" | "connection_url" | "title">(
-        key: K,
-      ) => (data[key] === undefined ? existing[key] : data[key]);
-      slugData.slug = getConnectionSlug({
-        app_name: merged("app_name"),
-        connection_url: merged("connection_url"),
-        title: merged("title"),
-        id,
-      });
+    // Skip the slug lookup/recompute entirely for updates that don't touch a slug field (e.g. a status/heartbeat write).
+    const touchesSlugField =
+      "app_name" in data || "connection_url" in data || "title" in data;
+    if (touchesSlugField) {
+      // Skip findById() here — it decrypts secrets we don't need just for a slug merge.
+      const existing = await this.db
+        .selectFrom("connections")
+        .select(["app_name", "connection_url", "title"])
+        .where("id", "=", id)
+        .executeTakeFirst();
+      if (existing) {
+        const merged = <K extends "app_name" | "connection_url" | "title">(
+          key: K,
+        ) => (data[key] === undefined ? existing[key] : data[key]);
+        slugData.slug = getConnectionSlug({
+          app_name: merged("app_name"),
+          connection_url: merged("connection_url"),
+          title: merged("title"),
+          id,
+        });
+      }
     }
 
     const serialized = await this.serializeConnection({


### PR DESCRIPTION
Follows #6240, which stopped `ConnectionStorage.update()` decrypting secrets for the slug-merge lookup but still ran that lookup (and the slug recompute) unconditionally on every call.

Most calls to `update()` never touch `app_name`/`connection_url`/`title` — the fields the slug is derived from. The hottest one is on the proxy request path (`apps/api/src/api/routes/proxy.ts`), which calls `update(connectionId, { status: "active" | "error" })` on connection recovery/failure and was paying an extra unnecessary SELECT round-trip for a slug that can't have changed.

This adds a presence check (`"app_name" in data || ...`) before running the lookup+recompute, so a pure status/heartbeat write skips it entirely. Behavior is unchanged: any update that does touch a slug-source field still goes through the exact same lookup/merge/recompute path as before.

How to confirm: read `apps/api/src/storage/connection.ts` `update()` — the recompute block is now gated on `touchesSlugField`, and `serializeConnection` still only writes fields present in `data`, so a status-only update still doesn't touch `slug`.

Local checks: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint apps/api/src/storage/connection.ts` (0 warnings/errors). No unit test exists for this path (only Postgres-backed integration tests in `connection.integration.test.ts`, not runnable here) — full CI validates those.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip slug lookup and recompute in `ConnectionStorage.update()` when the update does not touch slug-source fields, removing an extra SELECT on hot status/heartbeat writes. Previously `update()` always fetched `app_name`, `connection_url`, and `title` to recompute the slug; now it does so only if any of those keys are present in `data`.

Behavior for slug-affecting updates is unchanged: the same lookup/merge/recompute path runs, and `serializeConnection` still only persists provided fields, so status-only updates leave `slug` untouched. This targets the proxy path in `apps/api/src/api/routes/proxy.ts` that calls `update(connectionId, { status: ... })`.

<sup>Written for commit 2292c28f4da7996e801d571076df4fdd8bd4d0f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

