### PR TITLE
fix(mcp-clients): support JSON Schema union type arrays in the validation hint

### DIFF
--- a/apps/api/src/mcp-clients/validation-hint.test.ts
+++ b/apps/api/src/mcp-clients/validation-hint.test.ts
@@ -58,6 +58,26 @@ describe("buildValidationHint", () => {
     const hint = buildValidationHint("t", { properties: {} }, { a: 1 });
     expect(hint).toBe('Invalid arguments for "t". You sent: a.');
   });
+
+  it("does not flag a nullable union type's matching member as wrong-typed", () => {
+    const hint = buildValidationHint(
+      "t",
+      { properties: { note: { type: ["string", "null"] } } },
+      { note: "hi" },
+    );
+    expect(hint).not.toContain("Wrong type");
+  });
+
+  it("flags a value matching none of a union type's members", () => {
+    const hint = buildValidationHint(
+      "t",
+      { properties: { note: { type: ["string", "null"] } } },
+      { note: 5 },
+    );
+    expect(hint).toContain(
+      "Wrong type: note (expected string|null, got number).",
+    );
+  });
 });
 
 describe("enrichInvalidParams", () => {
@@ -135,6 +155,19 @@ describe("coerceArgsToSchema", () => {
     expect(coerceArgsToSchema(schema, { patch: "[1,2]" })).toBeNull();
     expect(coerceArgsToSchema(schema, { save: "yes" })).toBeNull();
     expect(coerceArgsToSchema(schema, { limit: "1.5" })).toBeNull();
+  });
+
+  it("coerces against a union type, skipping when string is already a member", () => {
+    const unionSchema = {
+      properties: {
+        flag: { type: ["boolean", "null"] },
+        name: { type: ["string", "null"] },
+      },
+    };
+    expect(coerceArgsToSchema(unionSchema, { flag: "true" })).toEqual({
+      flag: true,
+    });
+    expect(coerceArgsToSchema(unionSchema, { name: "hi" })).toBeNull();
   });
 
   it("returns null when nothing changed, and keeps untouched keys", () => {

--- a/apps/api/src/mcp-clients/validation-hint.ts
+++ b/apps/api/src/mcp-clients/validation-hint.ts
@@ -20,7 +20,14 @@ import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 
 export interface ToolInputSchema {
   required?: string[];
-  properties?: Record<string, { type?: string }>;
+  properties?: Record<string, { type?: string | string[] }>;
+}
+
+/** JSON Schema allows `type` to be a single name or a union array (e.g. a
+ * nullable field declared as `["string", "null"]`). Normalize to an array so
+ * every caller checks the same shape. */
+function declaredTypes(declared: string | string[]): string[] {
+  return Array.isArray(declared) ? declared : [declared];
 }
 
 /** The JSON Schema `type` name for a runtime value. */
@@ -35,12 +42,18 @@ function jsonTypeOf(value: unknown): string {
  * "integer" is a whole-number `number`, not a distinct JS runtime type —
  * `jsonTypeOf` alone would call a correctly-sent `5` a type mismatch because
  * `typeof 5 === "number"` never equals the declared string `"integer"`.
+ * `declared` may also be a union array (e.g. a nullable field's
+ * `["string", "null"]`) — matching any member is enough.
  */
-function matchesDeclaredType(value: unknown, declared: string): boolean {
-  if (declared === "integer") {
-    return typeof value === "number" && Number.isInteger(value);
-  }
-  return jsonTypeOf(value) === declared;
+function matchesDeclaredType(
+  value: unknown,
+  declared: string | string[],
+): boolean {
+  return declaredTypes(declared).some((d) => {
+    if (d === "integer")
+      return typeof value === "number" && Number.isInteger(value);
+    return jsonTypeOf(value) === d;
+  });
 }
 
 /**
@@ -95,8 +108,11 @@ export function coerceArgsToSchema(
   for (const [key, value] of Object.entries(args)) {
     if (typeof value !== "string") continue;
     const declared = schema.properties[key]?.type;
-    if (!declared || declared === "string") continue;
-    const coerced = coerceString(value, declared);
+    // "string" already valid means the sent value needs no reinterpreting.
+    if (!declared || declaredTypes(declared).includes("string")) continue;
+    const coerced = declaredTypes(declared)
+      .map((d) => coerceString(value, d))
+      .find((c) => c !== undefined);
     if (coerced === undefined) continue;
     out[key] = coerced;
     changed = true;
@@ -117,9 +133,11 @@ export function buildValidationHint(
   const required = schema?.required ?? [];
   const missing = required.filter((k) => !sent.includes(k));
 
+  const formatType = (type: string | string[]) => declaredTypes(type).join("|");
+
   const describe = (name: string) => {
     const type = schema?.properties?.[name]?.type;
-    return type ? `${name} (${type})` : name;
+    return type ? `${name} (${formatType(type)})` : name;
   };
 
   // A present-but-wrong-typed argument is the common failure when nothing is
@@ -131,7 +149,7 @@ export function buildValidationHint(
     })
     .map(
       (k) =>
-        `${k} (expected ${schema?.properties?.[k]?.type}, got ${jsonTypeOf(args?.[k])})`,
+        `${k} (expected ${formatType(schema!.properties![k]!.type!)}, got ${jsonTypeOf(args?.[k])})`,
     );
 
   const parts = [


### PR DESCRIPTION
**Source:** bug found auditing `apps/api/src/mcp-clients/validation-hint.ts` after this week's coerce/retry hardening (#6210, #6216, #6242).

**Why a maintainer wants it:** JSON Schema lets a property's `type` be a union array (e.g. a nullable field as `["string", "null"]"`), and the MCP SDK's `Tool.inputSchema.properties` values are untyped custom objects, so nothing stops an upstream server from advertising one. `matchesDeclaredType` and `coerceArgsToSchema` only ever compared against a single type string, so any correctly-typed value against a union-typed property was always reported as "Wrong type" in the repair hint sent back to the agent — actively misleading it about what's actually wrong — and `coerceArgsToSchema` could never recognize a string value as already valid for such a property.

**Failure scenario:** a tool declares `note: { type: ["string", "null"] }`. The agent sends a correct string value but the call still fails validation for an unrelated reason (e.g. a missing required field). The generated hint falsely says `note (expected string,null, got string)` even though `note` was fine, confusing the retry. Regression test: `validation-hint.test.ts` — "does not flag a nullable union type's matching member as wrong-typed" / "flags a value matching none of a union type's members" / "coerces against a union type, skipping when string is already a member".

**Verify:** `bun test apps/api/src/mcp-clients/validation-hint.test.ts` (19 pass).

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/mcp-clients/validation-hint.ts apps/api/src/mcp-clients/validation-hint.test.ts` (0 warnings/errors), targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes validation and repair hints for tools that declare JSON Schema union types (e.g., ["string", "null"]). Previously, union-typed properties were always flagged as wrong-typed; now we correctly match and coerce across union members.

- Accepts `type` as `string | string[]` and normalizes to an array.
- `matchesDeclaredType` matches any union member (keeps special handling for `"integer"`).
- `coerceArgsToSchema` tries coercion across union members and skips coercion when `"string"` is already allowed.
- `buildValidationHint` formats expected union types as `a|b` and no longer flags values that match a union member.
- Adds targeted tests; no behavior change for single-type schemas.

<sup>Written for commit 1c2adfb308a274ead50ae90e8dbff4d5ec0d6e56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

