### PR TITLE
fix(sandbox): cap the Go daemon's config-update body size

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/config.go
+++ b/packages/sandbox/daemon-go/internal/routes/config.go
@@ -2,7 +2,6 @@ package routes
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -99,7 +98,7 @@ func ConfigRead(deps ConfigDeps) http.HandlerFunc {
 
 func ConfigUpdate(deps ConfigDeps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		raw, err := io.ReadAll(r.Body)
+		raw, err := readLimitedBody(r, maxConfigBytes)
 		if err != nil {
 			httpx.Error(w, 400, "bad body: "+err.Error())
 			return

--- a/packages/sandbox/daemon-go/internal/routes/misc.go
+++ b/packages/sandbox/daemon-go/internal/routes/misc.go
@@ -1,7 +1,6 @@
 package routes
 
 import (
-	"io"
 	"log/slog"
 	"net/http"
 
@@ -59,7 +58,7 @@ type OrgFsDeps struct {
 
 func OrgFsConfig(deps OrgFsDeps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		raw, err := io.ReadAll(r.Body)
+		raw, err := readLimitedBody(r, maxConfigBytes)
 		if err != nil {
 			httpx.Error(w, 400, "invalid org-fs config")
 			return

--- a/packages/sandbox/daemon-go/internal/routes/util.go
+++ b/packages/sandbox/daemon-go/internal/routes/util.go
@@ -2,11 +2,33 @@ package routes
 
 import (
 	"bufio"
+	"fmt"
 	"io"
+	"net/http"
 )
 
 func bufioScanner(r io.Reader) *bufio.Scanner {
 	s := bufio.NewScanner(r)
 	s.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	return s
+}
+
+// maxConfigBytes bounds config-style JSON request bodies (tenant config
+// patches, org-fs config) — these are always small hand-written objects, never
+// file transfers, so 1MB is generous headroom, not a real ceiling.
+const maxConfigBytes = 1024 * 1024
+
+// readLimitedBody reads r.Body capped at maxBytes: without a limit, a
+// misbehaving or malicious caller could stream an unbounded body into memory
+// and crash the daemon, tearing down the sandbox pod on the next missed
+// health probe.
+func readLimitedBody(r *http.Request, maxBytes int64) ([]byte, error) {
+	raw, err := io.ReadAll(io.LimitReader(r.Body, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read body: %s", err.Error())
+	}
+	if int64(len(raw)) > maxBytes {
+		return nil, fmt.Errorf("request body exceeded %d bytes", maxBytes)
+	}
+	return raw, nil
 }

--- a/packages/sandbox/daemon-go/internal/routes/util_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/util_test.go
@@ -1,0 +1,23 @@
+package routes
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Without a cap, ConfigUpdate/OrgFsConfig's former io.ReadAll(r.Body) would
+// buffer an unbounded request body into memory and could crash the daemon,
+// tearing down the sandbox pod on the next missed health probe.
+func TestReadLimitedBodyRejectsOversizedRequest(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "/_sandbox/config", io.NopCloser(infiniteReader{}))
+	_, err := readLimitedBody(req, maxConfigBytes)
+	if err == nil {
+		t.Fatal("expected readLimitedBody to reject an oversized body, got nil error")
+	}
+	if !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("expected a size-limit error, got: %v", err)
+	}
+}


### PR DESCRIPTION
**Source:** bug found while auditing the Go sandbox daemon (`packages/sandbox/daemon-go/internal/routes`) for reliability gaps — the same class already fixed for the file-transfer routes (`fs.go`'s `decodeBody`, see #6215/#6039).

**Payoff:** `ConfigUpdate` (`PUT /_sandbox/config`) and `OrgFsConfig` both read the request body with a raw, unbounded `io.ReadAll(r.Body)`. A misbehaving or malicious caller can stream an unbounded body into memory and crash the daemon — this is a single static binary per sandbox pod, and Studio tears the pod down on the next missed health probe, so an OOM here kills the whole session.

**Failure scenario:** POST a multi-GB body to `/_sandbox/config` or the org-fs config route → `io.ReadAll` buffers it all into memory with no limit → daemon OOMs/crashes → pod dies. `fs.go` already guards its routes against exactly this with a capped `decodeBody`; these two routes were missed.

**Fix:** added a shared `readLimitedBody(r, maxBytes)` helper in `util.go` (same pattern as `fs.go`'s `decodeBody`, just returning raw bytes since these two callers each unmarshal differently) and wired both routes through it, capped at 1MB — config/org-fs payloads are always small hand-written JSON, never file transfers, so 1MB is generous headroom not a real ceiling.

**Regression test:** `TestReadLimitedBodyRejectsOversizedRequest` in `util_test.go`, mirroring the existing `TestDecodeBodyRejectsOversizedRequest` in `fs_test.go` — drives an infinite reader through the helper and asserts it's rejected instead of buffered.

**To confirm:** `cd packages/sandbox/daemon-go && go build ./... && go vet ./... && go test ./internal/routes/...`

**Locally verified:** `go build`, `go vet`, `gofmt -l` (clean), and the full `internal/routes` test package (including the existing config-redaction tests) — all green. CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the request body for config endpoints at 1 MB to prevent daemon OOMs. Previously, `ConfigUpdate` and `OrgFsConfig` read unbounded bodies into memory; now oversized bodies are rejected with 400.

- Adds `readLimitedBody` in `internal/routes/util.go` and applies it to `ConfigUpdate` and `OrgFsConfig`.
- Sets `maxConfigBytes` to 1 MB; normal small JSON payloads are unaffected.
- Aligns config routes with the existing `fs.go` protection pattern.
- Adds `TestReadLimitedBodyRejectsOversizedRequest` to prevent regressions.

<sup>Written for commit de5fff6bb04ae7f1aa605d0a2bcd09e6e3912be3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

