### PR TITLE
fix(assets-tab): slugify the project title before matching a bucket

### DIFF
--- a/apps/web/src/components/file-picker/match-site-slug-config.test.ts
+++ b/apps/web/src/components/file-picker/match-site-slug-config.test.ts
@@ -71,4 +71,13 @@ describe("matchSiteSlugConfig", () => {
     const second = config("second", { bucket: "storefront" });
     expect(matchSiteSlugConfig([first, second], "storefront")).toBe(first);
   });
+
+  test("slugifies a free-form project title before matching (#6296)", () => {
+    const matching = config("assets", { bucket: "deco-assets-deco-cms" });
+    expect(matchSiteSlugConfig([matching], "Deco CMS")).toBe(matching);
+  });
+
+  test("returns null when a slugified title is empty", () => {
+    expect(matchSiteSlugConfig([config("one", {})], "!!!")).toBeNull();
+  });
 });

--- a/apps/web/src/components/file-picker/match-site-slug-config.ts
+++ b/apps/web/src/components/file-picker/match-site-slug-config.ts
@@ -1,8 +1,14 @@
+import { slugify } from "@decocms/shared/utils/slugify";
 import type { FileConfigInfo } from "@/hooks/use-file-configs";
 
 /**
  * Find the file config that owns a site slug so the CMS picker can lock to it.
  * Matches managed tenancy siteSlug and BYOB bucket naming conventions.
+ *
+ * Callers now pass the project's free-form display name (`entity.title`), not
+ * a guaranteed-slug value (see #6296) — slugify it first so a title like
+ * "Deco CMS" still matches a `deco-assets-decocms` bucket instead of silently
+ * missing because of the space. A no-op for values that were already slugs.
  */
 export function matchSiteSlugConfig(
   configs: FileConfigInfo[],
@@ -10,7 +16,8 @@ export function matchSiteSlugConfig(
 ): FileConfigInfo | null {
   if (!siteSlug) return null;
 
-  const slug = siteSlug.toLowerCase();
+  const slug = slugify(siteSlug);
+  if (!slug) return null;
   return (
     configs.find((config) => {
       const bucket = config.bucket.toLowerCase();


### PR DESCRIPTION
## Source

Follows #6296 ("gate assets tab on project name, not metadata.siteSlug"), which switched `matchSiteSlugConfig`'s callers from `entity.metadata.siteSlug` to `entity.title`. That PR's own description flagged the gap it left open:

> `title` is a free-form display name while the match target is a strict lowercase slug (`deco-assets-<slug>`). A project titled "Deco CMS" won't match `decocms`. Fine if projects import with the exact slug as the title; if titles can diverge we'd slugify the title before comparing.

## Why a maintainer wants this

Any project whose display title isn't already a bare slug (has a space, capital letter, or punctuation) silently loses its Assets tab even though the matching bucket exists — a real regression class for any non-imported or renamed project, not just deco.cx imports.

## The fix

`matchSiteSlugConfig` now runs its input through the existing `@decocms/shared` `slugify()` (no new dependency, no hand-rolled normalization) before comparing against `config.siteSlug`/`config.bucket`. This is a no-op for inputs that were already slugs, so both existing call sites (`use-main-panel-tabs.ts`, `assets-tab.tsx`) keep behaving exactly as before for the common case, and now also match titles like "Deco CMS" against a `deco-assets-deco-cms` bucket.

Added two test cases: a free-form title matching its slugified bucket, and an all-punctuation title slugifying to empty (still returns null, same as an empty string).

## Verify

`bun test apps/web/src/components/file-picker/match-site-slug-config.test.ts`

## Checks run locally

- `bun run fmt` — clean
- `cd apps/web && bunx tsc --noEmit` — clean
- `bunx oxlint` on both changed files — 0 warnings/errors
- Targeted test file above — 9/9 pass

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slugifies project titles before matching an Assets bucket so titles with spaces or punctuation still match. Previously we only lowercased titles and missed matches; now we use `slugify()` and return null if the slug is empty. Inputs already in slug form behave the same.

- **Review notes**
  - Uses `slugify` from `@decocms/shared/utils/slugify`; no new dependency.
  - Change is limited to `matchSiteSlugConfig`; call sites and common cases remain unchanged.
  - Adds tests for a free-form title matching its slugified bucket and for an all-punctuation title returning null.

<sup>Written for commit 1db6d7aec61f787c705ea91228558e24b8548b1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

