### PR TITLE
feat(task-board): put a code agent's PR on the board for review

### DIFF
--- a/apps/api/src/api/routes/decopilot/cluster-mcp-tool-hooks.ts
+++ b/apps/api/src/api/routes/decopilot/cluster-mcp-tool-hooks.ts
@@ -25,6 +25,7 @@ import {
   capturePrForRun,
   isPrCreateMcpTool,
 } from "@/tools/task-board/run-reactions";
+import { reactToPrOpenedForBoard } from "@/tools/task-board/pr-open-board-reaction";
 
 export interface ClusterMcpToolHooks {
   resolveArgs: (
@@ -81,6 +82,8 @@ export function buildClusterMcpToolHooks(
       // the source connection so the modal can fetch it back live. Separate
       // from the In Review advance above (which rides onToolCalled).
       void capturePrForRun(ctx, event.result, event.connectionId, threadId);
+      // Ad-hoc code agent with no linked card: decide + record it on the board (no-ops if a card already exists).
+      void reactToPrOpenedForBoard(ctx, event.result, threadId);
     },
   };
 }

--- a/apps/api/src/mcp-clients/virtual-mcp/code-agent-board-connection.test.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/code-agent-board-connection.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { WellKnownOrgMCPId } from "@decocms/shared/sdk";
+import type { VirtualMCPEntity } from "../../tools/virtual/schema";
+import { codeAgentBoardConnection } from "./index";
+
+type VmcpArg = Pick<
+  VirtualMCPEntity,
+  "organization_id" | "metadata" | "connections"
+>;
+
+function vmcp(overrides: Record<string, unknown> = {}): VmcpArg {
+  return {
+    organization_id: "org_1",
+    metadata: { githubRepo: { url: "https://github.com/acme/widget" } },
+    connections: [{ connection_id: "conn_github" }],
+    ...overrides,
+  } as VmcpArg;
+}
+
+describe("codeAgentBoardConnection", () => {
+  test("grafts a scoped SELF connection onto a coding agent", () => {
+    const conn = codeAgentBoardConnection(vmcp());
+    expect(conn).not.toBeNull();
+    expect(conn?.connection_id).toBe(WellKnownOrgMCPId.SELF("org_1"));
+    expect(conn?.selected_tools).toEqual([
+      "TASK_BOARD_ITEM_LIST",
+      "TASK_BOARD_ITEM_CREATE",
+      "TASK_BOARD_ITEM_UPDATE",
+      "TASK_BOARD_COMMENT_CREATE",
+    ]);
+    // Never REVIEW_DECISION or PROMOTE — an agent must not sign off on its own work.
+    expect(conn?.selected_tools).not.toContain("TASK_BOARD_REVIEW_DECISION");
+    expect(conn?.selected_tools).not.toContain(
+      "TASK_BOARD_PROMOTE_TO_PRODUCTION",
+    );
+  });
+
+  test("skips an agent without a github repo (no checkout, not a coding agent)", () => {
+    expect(codeAgentBoardConnection(vmcp({ metadata: {} }))).toBeNull();
+    expect(
+      codeAgentBoardConnection(vmcp({ metadata: { githubRepo: null } })),
+    ).toBeNull();
+  });
+
+  test("skips a well-known agent that resolves with no organization", () => {
+    expect(codeAgentBoardConnection(vmcp({ organization_id: "" }))).toBeNull();
+  });
+
+  test("does not double-graft when the agent already declares SELF", () => {
+    const selfId = WellKnownOrgMCPId.SELF("org_1");
+    const conn = codeAgentBoardConnection(
+      vmcp({
+        connections: [
+          { connection_id: "conn_github" },
+          { connection_id: selfId },
+        ],
+      }),
+    );
+    expect(conn).toBeNull();
+  });
+});

--- a/apps/api/src/mcp-clients/virtual-mcp/index.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { isDecopilot } from "@decocms/shared/sdk";
+import { isDecopilot, WellKnownOrgMCPId } from "@decocms/shared/sdk";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { getMcpListCache } from "../mcp-list-cache";
 import type { StudioContext } from "../../core/studio-context";
@@ -54,6 +54,46 @@ export async function createVirtualClient(
 
   // Create client from virtual MCP entity
   return createVirtualClientFrom(virtualMcp, ctx, superUser);
+}
+
+/**
+ * Board tools a coding agent (one with a checkout) is granted at runtime so it
+ * can surface a PR it opens as a card in review. Narrow on purpose: never
+ * REVIEW_DECISION or PROMOTE — an agent must not sign off on its own work.
+ */
+const CODE_AGENT_BOARD_TOOLS = [
+  "TASK_BOARD_ITEM_LIST",
+  "TASK_BOARD_ITEM_CREATE",
+  "TASK_BOARD_ITEM_UPDATE",
+  "TASK_BOARD_COMMENT_CREATE",
+] as const;
+
+/**
+ * The scoped SELF connection entry to graft onto a coding agent so it can put a
+ * PR it opens into review, or null when the agent isn't a coding agent (no
+ * `metadata.githubRepo.url`) or already declares its own SELF connection. Pure
+ * so the inject/skip decision is unit-tested without a StudioContext.
+ */
+export function codeAgentBoardConnection(
+  virtualMcp: Pick<
+    VirtualMCPEntity,
+    "organization_id" | "metadata" | "connections"
+  >,
+): VirtualMCPEntity["connections"][number] | null {
+  const githubRepoUrl = (
+    virtualMcp.metadata as { githubRepo?: { url?: string } | null } | undefined
+  )?.githubRepo?.url;
+  if (!virtualMcp.organization_id || !githubRepoUrl) return null;
+  const selfId = WellKnownOrgMCPId.SELF(virtualMcp.organization_id);
+  if (virtualMcp.connections.some((c) => c.connection_id === selfId)) {
+    return null;
+  }
+  return {
+    connection_id: selfId,
+    selected_tools: [...CODE_AGENT_BOARD_TOOLS],
+    selected_resources: null,
+    selected_prompts: null,
+  };
 }
 
 /**
@@ -161,10 +201,30 @@ export async function createVirtualClientFrom(
     ? ((await renderSkillsCatalogBlock(ctx, virtualMcp)) ?? undefined)
     : undefined;
 
+  // Graft scoped board access onto a coding agent at runtime (see codeAgentBoardConnection).
+  let effectiveVirtualMcp = virtualMcp;
+  const boardConn = codeAgentBoardConnection(virtualMcp);
+  if (
+    boardConn &&
+    !loadedConnections.some((c) => c.id === boardConn.connection_id)
+  ) {
+    const self = await ctx.storage.connections.findById(
+      boardConn.connection_id,
+      virtualMcp.organization_id,
+    );
+    if (self && self.status === "active") {
+      loadedConnections.push(self);
+      effectiveVirtualMcp = {
+        ...virtualMcp,
+        connections: [...virtualMcp.connections, boardConn],
+      };
+    }
+  }
+
   // Build aggregator options
   const clientOptions: VirtualClientOptions = {
     connections: loadedConnections,
-    virtualMcp,
+    virtualMcp: effectiveVirtualMcp,
     superUser,
     mcpListCache: getMcpListCache() ?? undefined,
     listTimeoutMs: options?.listTimeoutMs,

--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -11,6 +11,7 @@ import { assertValidAssignee } from "./validate-assignee";
 import { reactToSuperAgentDelegation } from "./enqueue-super-agent";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
+import { extractPrFromText } from "./pr-extract";
 
 export const TASK_BOARD_ITEM_CREATE = defineTool({
   name: "TASK_BOARD_ITEM_CREATE",
@@ -31,6 +32,16 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
     repo: z.string().nullable().optional(),
     dueDate: z.string().datetime().nullable().optional(),
     tagIds: z.array(z.string()).optional(),
+    prUrl: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "GitHub pull request URL to link to the new task, e.g. " +
+          "https://github.com/owner/repo/pull/123. Pass this with " +
+          '`status: "in_review"` right after you open a PR so the card lands ' +
+          "on the board with its PR already attached for review.",
+      ),
   }),
   outputSchema: z.object({ item: TaskBoardItemSchema }),
   handler: async (input, ctx) => {
@@ -41,6 +52,15 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
     if (!organizationId) {
       throw new Error(
         "Organization ID required (no active organization in context)",
+      );
+    }
+
+    // Parse the PR link before any write, so a bad URL fails without orphaning a card.
+    const pr = input.prUrl ? extractPrFromText(input.prUrl) : null;
+    if (input.prUrl && !pr) {
+      throw new Error(
+        `Not a GitHub pull request URL: ${input.prUrl} (expected ` +
+          "https://github.com/<owner>/<repo>/pull/<number>)",
       );
     }
 
@@ -81,6 +101,18 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
         getUserId(ctx)!,
       );
       item = (await ctx.storage.taskBoard.getById(item.id, organizationId))!;
+    }
+
+    if (pr) {
+      await ctx.storage.taskBoard.linkPr({
+        taskBoardItemId: item.id,
+        organizationId,
+        url: pr.url,
+        prNumber: pr.number,
+        repoOwner: pr.owner,
+        repoName: pr.repo,
+        connectionId: null,
+      });
     }
 
     await recordTaskActivity(ctx, {

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts
@@ -1,0 +1,165 @@
+/** applyBoardDecision writes across task_board_items, _prs, _threads and
+ *  _comments and reads status back — an in-memory fake wouldn't reproduce the
+ *  update whitelist or the link tables, so this runs against real Postgres. */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../../database/test-db-pg";
+import { TaskBoardStorage } from "../../storage/task-board";
+import type { TaskBoardItem } from "../../storage/types";
+import type { ExtractedPr } from "./pr-extract";
+import {
+  applyBoardDecision,
+  type BoardDecision,
+} from "./pr-open-board-reaction";
+
+const ORG = "org_propen_1";
+const USER = "user_propen_1";
+const PR: ExtractedPr = {
+  url: "https://github.com/acme/widget/pull/7",
+  number: 7,
+  owner: "acme",
+  repo: "widget",
+};
+
+describe("applyBoardDecision", () => {
+  let database: StudioDatabase;
+  let taskBoard: TaskBoardStorage;
+
+  const THREADS = ["thr_create", "thr_update", "thr_fallback", "thr_done"];
+
+  const apply = (
+    decision: BoardDecision,
+    openCards: TaskBoardItem[],
+    thread: string,
+  ) =>
+    applyBoardDecision(taskBoard, {
+      orgId: ORG,
+      userId: USER,
+      threadId: thread,
+      pr: PR,
+      decision,
+      openCards,
+    });
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values([{ id: ORG, name: ORG, slug: "org-propen-1", createdAt: now }])
+      .execute();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"propen@propen.test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    // linkThread FKs the thread row, so referenced threads must exist.
+    await database.db
+      .insertInto("threads")
+      .values(
+        THREADS.map((id) => ({
+          id,
+          organization_id: ORG,
+          created_by: USER,
+          title: id,
+          status: "completed",
+          virtual_mcp_id: "",
+          created_at: now,
+          updated_at: now,
+        })),
+      )
+      .execute();
+    taskBoard = new TaskBoardStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("create: opens a new card in review with the PR and thread linked", async () => {
+    const item = await apply(
+      {
+        action: "create",
+        title: "Ship the widget",
+        comment: "left the CSS alone",
+      },
+      [],
+      "thr_create",
+    );
+    expect(item).not.toBeNull();
+    expect(item!.status).toBe("in_review");
+    expect(item!.title).toBe("Ship the widget");
+
+    const prs = await taskBoard.listPrs(item!.id, ORG);
+    expect(prs.map((p) => p.number)).toEqual([7]);
+
+    const linked = await taskBoard.linkedTaskIds("thr_create", ORG);
+    expect(linked).toContain(item!.id);
+
+    const comments = await taskBoard.listComments(item!.id, ORG);
+    expect(comments.map((c) => c.body)).toContain("left the CSS alone");
+  });
+
+  it("update: moves an in-progress card to review and links the PR", async () => {
+    const card = await taskBoard.create({
+      organizationId: ORG,
+      title: "Existing work",
+      status: "in_progress",
+      by: USER,
+    });
+    const item = await apply(
+      { action: "update", taskId: card.id },
+      [card],
+      "thr_update",
+    );
+    expect(item!.id).toBe(card.id);
+    expect(item!.status).toBe("in_review");
+    const prs = await taskBoard.listPrs(card.id, ORG);
+    expect(prs.map((p) => p.number)).toEqual([7]);
+    expect(await taskBoard.linkedTaskIds("thr_update", ORG)).toContain(card.id);
+  });
+
+  it("update with an unknown taskId falls back to creating a card", async () => {
+    const card = await taskBoard.create({
+      organizationId: ORG,
+      title: "unrelated",
+      status: "in_progress",
+      by: USER,
+    });
+    const item = await apply(
+      { action: "update", taskId: "board_does_not_exist" },
+      [card],
+      "thr_fallback",
+    );
+    expect(item).not.toBeNull();
+    expect(item!.id).not.toBe(card.id);
+    expect(item!.status).toBe("in_review");
+    expect(await taskBoard.linkedTaskIds("thr_fallback", ORG)).toContain(
+      item!.id,
+    );
+  });
+
+  it("update never regresses a done card, but still links the PR", async () => {
+    const card = await taskBoard.create({
+      organizationId: ORG,
+      title: "already shipped",
+      status: "done",
+      by: USER,
+    });
+    const item = await apply(
+      { action: "update", taskId: card.id },
+      [card],
+      "thr_done",
+    );
+    expect(item!.id).toBe(card.id);
+    expect(item!.status).toBe("done");
+    const prs = await taskBoard.listPrs(card.id, ORG);
+    expect(prs.map((p) => p.number)).toEqual([7]);
+  });
+});

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -1,0 +1,234 @@
+/**
+ * Ad-hoc code agent opened a PR — put it on the board for review.
+ *
+ * A task-dispatched run (Super Agent) already has a linked card, and
+ * `advanceTaskBoardForRun` + `capturePrForRun` move/link it. A plain chat with
+ * a GitHub-imported agent has no card, so nothing happens. This reaction fills
+ * that gap: one focused LLM call decides whether the work is already tracked,
+ * then the action runs in code (create/update the card, link the PR + thread).
+ *
+ * Kept as code (not a system-prompt instruction the main loop may skip) so the
+ * bookkeeping is deterministic; kept as a single LLM call (not a heuristic) so
+ * the "is there already a card for this?" judgement stays with the model. The
+ * whole thing is best-effort: it never throws into the run that opened the PR.
+ */
+
+import { generateObject } from "ai";
+import { z } from "zod";
+import type { StudioContext } from "@/core/studio-context";
+import { resolveTier } from "@/core/resolve-tier";
+import type { TaskBoardStorage } from "@/storage/task-board";
+import type { TaskBoardItem, TaskBoardItemStatus } from "@/storage/types";
+import { extractPrFromValue, type ExtractedPr } from "./pr-extract";
+import { resolveRunTaskTargets, emitTaskBoardUpdated } from "./run-reactions";
+
+/** Statuses from which a PR-open advance may move a card into review. Terminal
+ *  lanes (and in_review itself) are left alone so a re-opened PR never regresses
+ *  a finished card. */
+const ADVANCEABLE: ReadonlySet<TaskBoardItemStatus> = new Set([
+  "triage",
+  "todo",
+  "in_progress",
+]);
+
+export interface BoardDecision {
+  action: "create" | "update";
+  /** The existing card to update. Required for `update`, ignored for `create`. */
+  taskId?: string | null;
+  /** Short title for a new card. Used for `create`; a fallback covers absence. */
+  title?: string | null;
+  /** Optional note for the reviewer, posted as a comment on the card. */
+  comment?: string | null;
+}
+
+const BoardDecisionSchema = z.object({
+  action: z
+    .enum(["create", "update"])
+    .describe(
+      "`update` when an existing card already tracks this work, else `create`.",
+    ),
+  taskId: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "Id of the existing card to update. Required when action=update.",
+    ),
+  title: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Short title for the new card. Used when action=create."),
+  comment: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "Optional short note for the reviewer (a decision made, an open question). Omit if there is nothing useful to add.",
+    ),
+});
+
+const SYSTEM = `You maintain a team's task board. A coding agent just opened a pull request inside a chat. Decide how the board should reflect it.
+
+- If one of the existing cards already tracks this work, choose \`update\` and return its \`taskId\` — do NOT create a duplicate. Match on the intent of the work, not exact wording.
+- If no existing card covers it, choose \`create\` and return a short \`title\` describing the change.
+- Optionally add a one-line \`comment\` for the reviewer. Leave it empty when there is nothing worth saying.
+
+Be conservative about creating: when a plausible card already exists, prefer \`update\`.`;
+
+/**
+ * Ask the org's cheap "fast" tier whether this PR maps to an existing card.
+ * Best-effort: returns null when there is no model provider or the call fails,
+ * so the caller falls back to doing nothing rather than guessing.
+ */
+async function decideBoardActionForPr(
+  ctx: StudioContext,
+  orgId: string,
+  openCards: TaskBoardItem[],
+  threadTitle: string | null,
+  pr: ExtractedPr,
+): Promise<BoardDecision | null> {
+  try {
+    const tier = await resolveTier(ctx, "fast");
+    const provider = await ctx.aiProviders.activate(tier.credentialId, orgId);
+    const model = provider.aiSdk.languageModel(tier.modelId);
+
+    const cardList = openCards.length
+      ? openCards.map((t) => `- [${t.id}] (${t.status}) ${t.title}`).join("\n")
+      : "(none)";
+    const prompt = `Work summary (chat title): ${threadTitle ?? "(untitled)"}
+Pull request: ${pr.url} (${pr.owner}/${pr.repo}#${pr.number})
+
+Existing open cards:
+${cardList}`;
+
+    const { object } = await generateObject({
+      model,
+      schema: BoardDecisionSchema,
+      system: SYSTEM,
+      prompt,
+      temperature: 0,
+    });
+    return object;
+  } catch (err) {
+    console.warn("[task-board] PR-open board decision failed", err);
+    return null;
+  }
+}
+
+/**
+ * Carry out a {@link BoardDecision}: create or update the card, link the PR and
+ * the thread, and post the optional reviewer note. Pure of any LLM call so it
+ * can be exercised against real Postgres. Returns the affected card, or null
+ * when nothing could be done (e.g. an `update` whose taskId isn't this org's).
+ */
+export async function applyBoardDecision(
+  storage: TaskBoardStorage,
+  params: {
+    orgId: string;
+    userId: string;
+    threadId: string;
+    pr: ExtractedPr;
+    decision: BoardDecision;
+    /** The card set the decision was made against (this org's), for taskId validation. */
+    openCards: TaskBoardItem[];
+  },
+): Promise<TaskBoardItem | null> {
+  const { orgId, userId, threadId, pr, decision, openCards } = params;
+
+  const linkPr = (taskBoardItemId: string) =>
+    storage.linkPr({
+      taskBoardItemId,
+      organizationId: orgId,
+      url: pr.url,
+      prNumber: pr.number,
+      repoOwner: pr.owner,
+      repoName: pr.repo,
+      connectionId: null,
+    });
+
+  const target =
+    decision.action === "update" && decision.taskId
+      ? openCards.find((t) => t.id === decision.taskId)
+      : undefined;
+
+  let item: TaskBoardItem | null;
+  if (target) {
+    // Advance into review only from an earlier lane; never regress a finished card.
+    const status = ADVANCEABLE.has(target.status) ? "in_review" : undefined;
+    item = await storage.update(target.id, orgId, { status }, userId);
+  } else {
+    // create (also the fallback when an `update` pointed at an unknown card)
+    item = await storage.create({
+      organizationId: orgId,
+      title: decision.title?.trim() || `PR #${pr.number}`,
+      status: "in_review",
+      by: userId,
+    });
+  }
+  if (!item) return null;
+
+  await linkPr(item.id);
+  await storage.linkThread(item.id, threadId, orgId);
+  if (decision.comment?.trim()) {
+    await storage.createComment({
+      taskBoardItemId: item.id,
+      organizationId: orgId,
+      authorId: userId,
+      body: decision.comment.trim(),
+    });
+  }
+
+  const fresh = await storage.getById(item.id, orgId);
+  const result = fresh ?? item;
+  emitTaskBoardUpdated(orgId, result);
+  return result;
+}
+
+/**
+ * Entry point wired into the PR-open MCP hook. No-op for a run that already has
+ * a linked card (the Super Agent path) or when there's no org/user/thread/PR.
+ * Fire-and-forget; failures are logged, never thrown.
+ */
+export async function reactToPrOpenedForBoard(
+  ctx: StudioContext,
+  source: unknown,
+  threadId?: string,
+): Promise<void> {
+  const orgId = ctx.organization?.id;
+  const userId = ctx.auth?.user?.id;
+  if (!orgId || !userId || !threadId) return;
+  try {
+    const alreadyLinked = await resolveRunTaskTargets(ctx, orgId, threadId);
+    if (alreadyLinked.length > 0) return;
+
+    const pr = extractPrFromValue(source);
+    if (!pr) return;
+
+    const cards = await ctx.storage.taskBoard.list(orgId);
+    const openCards = cards.filter(
+      (t) => t.status !== "done" && t.status !== "archived",
+    );
+    const thread = await ctx.storage.threads.get(threadId);
+
+    const decision = await decideBoardActionForPr(
+      ctx,
+      orgId,
+      openCards,
+      thread?.title ?? null,
+      pr,
+    );
+    if (!decision) return;
+
+    await applyBoardDecision(ctx.storage.taskBoard, {
+      orgId,
+      userId,
+      threadId,
+      pr,
+      decision,
+      openCards,
+    });
+  } catch (err) {
+    console.error("[task-board] PR-open board reaction failed", err);
+  }
+}

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -17,6 +17,7 @@ import { reactToSuperAgentDelegation } from "./enqueue-super-agent";
 import { recordTaskActivities } from "./activity";
 import { taskRunContextStore } from "./task-run-context";
 import { emitTaskBoardUpdated } from "./run-reactions";
+import { extractPrFromText } from "./pr-extract";
 import {
   ensureTaskExecutionAllowed,
   isReportsTask,
@@ -153,6 +154,15 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     tagIds: z.array(z.string()).optional(),
     /** Link an existing chat thread to this task (many-to-many, idempotent). */
     linkThreadId: z.string().optional(),
+    prUrl: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "GitHub pull request URL to link to this task, e.g. " +
+          "https://github.com/owner/repo/pull/123. Pass this with " +
+          '`status: "in_review"` after opening a PR for an existing card.',
+      ),
   }),
   outputSchema: z.object({ item: TaskBoardItemSchema }),
   handler: async (input, ctx) => {
@@ -163,6 +173,15 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     if (!organizationId) {
       throw new Error(
         "Organization ID required (no active organization in context)",
+      );
+    }
+
+    // Parse the PR link before any write, so a bad URL fails without a partial edit.
+    const pr = input.prUrl ? extractPrFromText(input.prUrl) : null;
+    if (input.prUrl && !pr) {
+      throw new Error(
+        `Not a GitHub pull request URL: ${input.prUrl} (expected ` +
+          "https://github.com/<owner>/<repo>/pull/<number>)",
       );
     }
 
@@ -313,6 +332,18 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
       item = fetched;
     }
 
+    if (pr) {
+      await ctx.storage.taskBoard.linkPr({
+        taskBoardItemId: item.id,
+        organizationId,
+        url: pr.url,
+        prNumber: pr.number,
+        repoOwner: pr.owner,
+        repoName: pr.repo,
+        connectionId: null,
+      });
+    }
+
     // Log every changed field to the activity timeline in one batched write
     // instead of one sequential DB round-trip per changed field. Best-effort.
     if (previous) {
@@ -335,7 +366,7 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     // this tool over MCP — e.g. moving its task to In Review — has no client
     // mutation to invalidate, so without this the card only moves on refresh.
     // Same for a teammate's board.
-    if (hasFieldUpdate || input.linkThreadId) {
+    if (hasFieldUpdate || input.linkThreadId || pr) {
       emitTaskBoardUpdated(organizationId, item);
     }
     if (becameSuperAgent) {

--- a/packages/e2e/tests/task-board-pr-link.spec.ts
+++ b/packages/e2e/tests/task-board-pr-link.spec.ts
@@ -1,0 +1,86 @@
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, test } from "../fixtures/test";
+
+// Black-box wire-contract shapes (owned by this test, per e2e isolation rules).
+interface TaskBoardItem {
+  id: string;
+  status: string;
+}
+interface TaskBoardItemPr {
+  url: string;
+  number: number;
+  repoOwner: string;
+  repoName: string;
+}
+
+test.describe("task board PR linking via create/update", () => {
+  test("creates a card in review with the PR attached in one call", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const request = page.context().request;
+    const call = <T>(name: string, args: unknown) =>
+      callSelfMcpTool<T>(request, orgSlug, name, args);
+
+    const prUrl = "https://github.com/acme-e2e/widget/pull/4242";
+    const { item } = await call<{ item: TaskBoardItem }>(
+      "TASK_BOARD_ITEM_CREATE",
+      { title: "Ship the widget", status: "in_review", prUrl },
+    );
+    expect(item.status).toBe("in_review");
+
+    const { prs } = await call<{ prs: TaskBoardItemPr[] }>(
+      "TASK_BOARD_ITEM_PRS_GET",
+      { taskBoardItemId: item.id },
+    );
+    expect(prs).toHaveLength(1);
+    expect(prs[0]).toMatchObject({
+      url: prUrl,
+      number: 4242,
+      repoOwner: "acme-e2e",
+      repoName: "widget",
+    });
+  });
+
+  test("links a PR to an existing card on update", async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    const request = page.context().request;
+    const call = <T>(name: string, args: unknown) =>
+      callSelfMcpTool<T>(request, orgSlug, name, args);
+
+    const { item } = await call<{ item: TaskBoardItem }>(
+      "TASK_BOARD_ITEM_CREATE",
+      { title: "Existing card" },
+    );
+
+    const prUrl = "https://github.com/acme-e2e/widget/pull/77";
+    const { item: updated } = await call<{ item: TaskBoardItem }>(
+      "TASK_BOARD_ITEM_UPDATE",
+      { id: item.id, status: "in_review", prUrl },
+    );
+    expect(updated.status).toBe("in_review");
+
+    const { prs } = await call<{ prs: TaskBoardItemPr[] }>(
+      "TASK_BOARD_ITEM_PRS_GET",
+      { taskBoardItemId: item.id },
+    );
+    expect(prs).toHaveLength(1);
+    expect(prs[0]).toMatchObject({ url: prUrl, number: 77 });
+  });
+
+  test("rejects a URL that is not a GitHub pull request", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const request = page.context().request;
+    const call = <T>(name: string, args: unknown) =>
+      callSelfMcpTool<T>(request, orgSlug, name, args);
+
+    await expect(
+      call("TASK_BOARD_ITEM_CREATE", {
+        title: "Bad link",
+        prUrl: "https://github.com/acme-e2e/widget/issues/9",
+      }),
+    ).rejects.toThrow(/not a github pull request url/i);
+  });
+});


### PR DESCRIPTION
## Summary

A GitHub-imported (or template-clone) coding agent had no way to record work for review after opening a PR. This does the board bookkeeping **in code**, triggered off the existing PR-open signal, so it's deterministic — with a **single focused LLM call** for the one judgement that isn't mechanical: *is this work already tracked by a card?*

Design chosen after discussion: not an always-on system-prompt instruction (the main loop skips it, and it taxes every turn of every coding agent), and not a blind auto-create (loses the dedup judgement). A code hook fires reliably and still delegates the create-vs-update decision to the model.

## What changed

- **Reaction on PR-open.** `reactToPrOpenedForBoard` is wired into the PR-open MCP hook (`cluster-mcp-tool-hooks.ts` `onPrOpened`). It **no-ops for a run that already has a linked card** (the Super Agent path — handled by `advanceTaskBoardForRun`/`capturePrForRun`), so it can't double up. For an ad-hoc chat with no card it: loads the org's open cards → one `generateObject` call on the cheap `fast` tier decides `create` vs `update(taskId)` → acts in code: create/update the card **in review**, link the **PR** and the **thread**, and post an optional reviewer note. Best-effort — it never throws into the run that opened the PR.
- **Split for testability.** `applyBoardDecision` (no LLM) performs the storage writes and is covered by a **real-Postgres integration test** (create; update from an earlier lane; unknown-taskId → fallback create; never regress a `done` card). The LLM decision (`decideBoardActionForPr`) is best-effort and degrades to no-op without a model provider.
- **`prUrl` on CREATE/UPDATE.** `TASK_BOARD_ITEM_CREATE`/`UPDATE` accept an optional `prUrl` to link a PR in one call (parsed before any write, so a bad/non-PR URL fails without orphaning a card). Used by the reaction and available for an explicit user request.
- **Scoped board tools at runtime.** `codeAgentBoardConnection` grafts an in-memory SELF connection scoped to `TASK_BOARD_ITEM_LIST/CREATE/UPDATE` + `COMMENT_CREATE` onto agents with a checkout — for explicit user asks ("open a PR and put it in review"). Never `REVIEW_DECISION`/`PROMOTE`: an agent must not sign off on its own work. Nothing is persisted on the agent, so it covers existing and new agents with no backfill.

## Why code, not prompt

- **Reliability** — the org-tracking value depends on the card actually reflecting reality; a system-prompt instruction is best-effort per turn. A hook always fires.
- **Cost/latency** — the instruction taxed every turn of every coding agent forever; the hook pays one cheap call only when a PR is actually opened.
- **Right trigger** — hangs off the existing `onPrOpened` signal (a real PR was opened), not `onThreadFinished` (most threads finish without a PR).

## Testing

- Integration (real Postgres): `pr-open-board-reaction.integration.test.ts` — create / update / fallback / no-regress.
- Unit: `codeAgentBoardConnection` inject/skip decision.
- E2E: `prUrl` linking on create/update, and rejection of a non-PR URL.
- `bun run check` (api/web/e2e), `fmt`, `lint`, `knip` clean.

## Follow-up (not in this PR)

- **Tell the user in the chat.** There's no SSE-aware "append assistant message" helper, and `onPrOpened` fires mid-run, so injecting a chat line ("Task created: …") is a separate, delicate change (best done at thread-finish). For now the new/updated card broadcasts live to the board and carries the agent's note as a comment.
- In a plain chat the `closesOwnReview` guard doesn't apply, so an imported agent could move its own card `in_review → done`; left as-is since a human drives the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)