### PR TITLE
fix(native): create TLS private keys at mode 0600, not chmod after write

### DIFF
--- a/apps/native/src-tauri/src/local_tls.rs
+++ b/apps/native/src-tauri/src/local_tls.rs
@@ -438,26 +438,73 @@ fn write(path: &Path, bytes: &[u8]) -> Result<(), TlsError> {
     })
 }
 
-/// Private keys are written `0600`. They never leave this machine, and nothing
-/// else on it has any business reading them.
+/// Private keys are written `0600`, mode-restricted from the moment the file
+/// is created rather than chmod'd afterward — a create-then-chmod ordering
+/// would leave the key at the process's default (umask-derived, typically
+/// `0644`) permissions for the window between the two syscalls, readable by
+/// any other process running as this user. They never leave this machine,
+/// and nothing else on it has any business reading them.
 fn write_private(path: &Path, bytes: &[u8]) -> Result<(), TlsError> {
-    write(path, bytes)?;
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600)).map_err(|source| {
-            TlsError::Io {
+        use std::io::Write;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|source| TlsError::Io {
                 path: path.to_path_buf(),
                 source,
-            }
-        })?;
+            })?;
+        // `mode()` only governs the permissions of a newly-created file — an
+        // existing file from a run predating this fix keeps its old mode on
+        // `truncate`, so re-assert it explicitly too.
+        file.set_permissions(fs::Permissions::from_mode(0o600))
+            .map_err(|source| TlsError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        file.write_all(bytes).map_err(|source| TlsError::Io {
+            path: path.to_path_buf(),
+            source,
+        })
     }
-    Ok(())
+    #[cfg(not(unix))]
+    write(path, bytes)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn write_private_creates_the_file_mode_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("key.pem");
+        write_private(&path, b"secret").expect("write_private");
+        let mode = fs::metadata(&path).expect("metadata").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        assert_eq!(fs::read(&path).expect("read"), b"secret");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_private_tightens_a_pre_existing_looser_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("key.pem");
+        fs::write(&path, b"stale").expect("seed file");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("loosen perms");
+        write_private(&path, b"fresh").expect("write_private");
+        let mode = fs::metadata(&path).expect("metadata").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        assert_eq!(fs::read(&path).expect("read"), b"fresh");
+    }
 
     /// Apple rejects a TLS server certificate valid for more than 398 days, so
     /// a leaf that drifts past it fails as an untrusted connection rather than


### PR DESCRIPTION
**Bug, found while auditing `apps/native` release/updater code.**

`local_tls::write_private` is the only place the per-machine CA root key and the per-launch leaf key ever hit disk. It wrote the key bytes with `fs::write` (which creates the file at the process's default, umask-derived mode — typically `0644`), then called `fs::set_permissions` to tighten it to `0600` in a second syscall. Between those two steps the key sat world/group-readable.

The file's own module doc calls out exactly this threat model: "a stolen `ca-key.pem` — readable by any process running as this user, **including code the app itself runs in sandboxes** — would be a general-purpose authority for every TLS connection this user makes." The write-then-chmod ordering left a real (if narrow) window for that.

**Fix:** open the file with `OpenOptionsExt::mode(0o600)` so it's created at `0600` from the first syscall — no window. Also re-asserts the mode after open (via `set_permissions`) to handle the case where a key file predating this fix already exists on disk with looser permissions from a prior run.

**Verification:** added two unit tests — `write_private_creates_the_file_mode_0600` (new file lands at exactly `0600`) and `write_private_tightens_a_pre_existing_looser_file` (a pre-existing `0644` file gets tightened and its contents replaced). Both pass:
```
cd apps/native/src-tauri && cargo test --lib local_tls::
```
(Needed a placeholder `binaries/rclone-<target>` file locally to satisfy `build.rs`'s sidecar-binary check — that's an unrelated pre-existing dev-setup requirement, not part of this diff.)

Ran `cargo fmt -- --check src/local_tls.rs` (clean). `cargo clippy` isn't installed in this sandbox's toolchain; CI's rust-checks job covers it.

Only `apps/native/src-tauri/src/local_tls.rs` is touched — one file, one concern, +56/-9.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes TLS private keys with mode 0600 at creation on Unix, removing the write-then-chmod window that briefly exposed keys at umask-derived perms (typically 0644). New behavior opens the file with `OpenOptionsExt::mode(0o600)` and also re-asserts 0600 after open to tighten pre-existing files when rewritten.

- Scope: `apps/native/src-tauri/src/local_tls.rs` only; behavior change is Unix-only. Non-Unix still uses the existing write path.
- Security impact: closes a race that could leave `ca-key.pem` or leaf keys group/world-readable between syscalls.
- Tests: adds two unit tests to verify 0600 creation and tightening on rewrite.
- Migration: if a machine has an existing key at 0644 that is not rewritten, manually `chmod 600` or rotate the key; future writes will auto-tighten.

<sup>Written for commit 259a21f9f7e67f1b8e3117b47ac855ba56528849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

