### PR TITLE
fix(thread/github): degrade a non-JSON sandbox-git response instead of raw SyntaxError

### DIFF
--- a/apps/web/src/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/web/src/components/thread/github/sandbox-git-api.test.ts
@@ -12,8 +12,10 @@ import {
   isDecoOnlyPaths,
   needsSmartReviewJudgment,
   normalizePublishPolicy,
+  parseJson,
   resolvePathGate,
   reviewDiffSignature,
+  SandboxGitError,
   sandboxGitStatusQueryKey,
   sandboxGitStatusQueryOptions,
   shouldUseBaseDiff,
@@ -653,5 +655,33 @@ describe("hasNothingToReview", () => {
     ).toBe(false);
     expect(hasNothingToReview({ ...cleanStatus, aheadOfBase: 1 })).toBe(false);
     expect(hasNothingToReview({ ...cleanStatus, unpushed: 1 })).toBe(false);
+  });
+});
+
+describe("parseJson", () => {
+  test("returns the parsed body on a 2xx JSON response", async () => {
+    const res = new Response(JSON.stringify({ ok: true }), { status: 200 });
+    expect(await parseJson<{ ok: boolean }>(res)).toEqual({ ok: true });
+  });
+
+  test("throws a SandboxGitError with the response's error field on non-2xx JSON", async () => {
+    const res = new Response(JSON.stringify({ error: "no runner" }), {
+      status: 503,
+    });
+    await expect(parseJson(res)).rejects.toMatchObject(
+      new SandboxGitError("no runner", 503),
+    );
+  });
+
+  test("degrades a non-JSON error page instead of throwing a raw SyntaxError", async () => {
+    const page = () =>
+      new Response("<html>502 Bad Gateway</html>", { status: 502 });
+    await expect(parseJson(page())).rejects.toBeInstanceOf(SandboxGitError);
+    await expect(parseJson(page())).rejects.toMatchObject({ status: 502 });
+  });
+
+  test("degrades a non-JSON 2xx body instead of throwing a raw SyntaxError", async () => {
+    const res = new Response("not json", { status: 200 });
+    await expect(parseJson(res)).rejects.toBeInstanceOf(SandboxGitError);
   });
 });

--- a/apps/web/src/components/thread/github/sandbox-git-api.ts
+++ b/apps/web/src/components/thread/github/sandbox-git-api.ts
@@ -71,7 +71,7 @@ function buildSandboxGitUrl(
 
 /** Error carrying the HTTP status so callers can back off on unreachable
  *  sandboxes (503 no runner, 410 handle gone) instead of polling forever. */
-class SandboxGitError extends Error {
+export class SandboxGitError extends Error {
   constructor(
     message: string,
     readonly status: number,
@@ -103,11 +103,24 @@ function retryGitRequest(failureCount: number, error: unknown): boolean {
   return failureCount < 1;
 }
 
-async function parseJson<T>(res: Response): Promise<T> {
-  const body = (await res.json()) as T & { error?: string };
-  if (!res.ok) {
+/**
+ * A gateway/proxy hiccup between the browser and the sandbox daemon (a 502/504
+ * error page, an empty body on a dropped connection) is not guaranteed to be
+ * JSON even on a non-2xx response. `res.json()` throwing a raw `SyntaxError`
+ * on that would surface as an opaque "Unexpected token" instead of a
+ * `SandboxGitError` callers can branch on (e.g. `isSandboxUnreachable`).
+ */
+export async function parseJson<T>(res: Response): Promise<T> {
+  const text = await res.text();
+  let body: (T & { error?: string }) | undefined;
+  try {
+    body = text ? (JSON.parse(text) as T & { error?: string }) : undefined;
+  } catch {
+    body = undefined;
+  }
+  if (!res.ok || body === undefined) {
     throw new SandboxGitError(
-      typeof body.error === "string"
+      typeof body?.error === "string"
         ? body.error
         : `Request failed (${res.status})`,
       res.status,


### PR DESCRIPTION
**Source:** bug found while auditing the GitHub tooling layer (`apps/web/src/components/thread/github/`). This is the same failure-mode this repo has already fixed at several other HTTP boundaries (see `apps/api/src/tools/github/graphql.ts`'s `parseGraphqlBody`, and the merged "degrade a malformed 2xx body instead of raw SyntaxError" lane, e.g. #6289/#6293/#6161) — `sandbox-git-api.ts`'s shared `parseJson` helper never got the same treatment.

**Payoff:** every Fast Preview git call (`/git/status`, `/git/diff`, `/git/publish`, `/git/rebase`, `/git/discard`, `/git/suggest-commit`, `/git/judge-review`) goes through `sandboxFetch` + `parseJson`. A gateway/proxy hiccup between the browser and the sandbox daemon (a 502/504 HTML error page, or an empty body on a dropped connection) is not guaranteed to be JSON even when it's a real response, and `res.json()` throws a raw, unhandled `SyntaxError` in that case (`"Unexpected token '<'"`) instead of the typed `SandboxGitError` every caller in this file branches on — including `isSandboxUnreachable`, which backs off polling instead of hammering a downed sandbox. A raw SyntaxError bypasses that backoff and surfaces as an opaque toast.

**Fix:** `parseJson` now reads the body as text and tolerates a JSON-parse failure on both the success and failure path, always throwing `SandboxGitError` (carrying the real HTTP status) instead of letting `JSON.parse`'s exception escape uncaught. Behavior for a well-formed JSON response (ok or error-shaped) is unchanged.

**Regression test:** added to the existing `sandbox-git-api.test.ts` (which already covers this file's pure logic) — a non-JSON error page on a non-2xx status, and a non-JSON body on a 2xx status, both now reject with `SandboxGitError` carrying the response's status instead of an unhandled `SyntaxError`.

**To verify:** `bun test apps/web/src/components/thread/github/sandbox-git-api.test.ts`

**Locally ran:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, the targeted test file above (76 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Degrades non-JSON responses from sandbox git endpoints to a typed `SandboxGitError` with HTTP status instead of leaking a raw `SyntaxError`. This restores backoff and consistent error handling across Fast Preview git operations; behavior for valid JSON is unchanged.

- `parseJson` now reads the body as text, attempts JSON parse, and throws `SandboxGitError(status)` on parse failure or any non-2xx response.
- Exports `SandboxGitError` and `parseJson`; adds tests covering non-JSON bodies (2xx and non-2xx) and JSON error shapes.
- No call-site changes required; callers that branch on `SandboxGitError` (e.g., `isSandboxUnreachable`) now back off on gateway errors instead of showing opaque toasts.

<sup>Written for commit 4c8d5fca1bf3f05f71c321374fc567ac1d007cff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

