### PR TITLE
fix(sandbox): stop RepointForRun holding orgfs.Links.mu across the mount wait

### DIFF
--- a/packages/sandbox/daemon-go/internal/orgfs/links.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links.go
@@ -149,15 +149,29 @@ func (l *Links) RepointForRun(threadId string) bool {
 		return false
 	}
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	if threadId != "" && threadId == l.lastOutputThread {
 		// Already pointing here; keep the repo link fresh (one lstat).
 		l.ensureRepoLinkLocked()
+		l.mu.Unlock()
 		return true
 	}
+	l.mu.Unlock()
+
+	// Paid unlocked: mountsOrWait can block for the whole firstMountWait grace
+	// period on the pod's first call, and holding mu across that would stall
+	// every other org-fs caller behind it — including WaitSkillLinks, whose own
+	// bounded wait exists specifically so a run never hangs behind org-fs.
 	mounts := l.mountsOrWait()
 	if len(mounts) == 0 {
 		return false
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	// Re-check: another call may have repointed this thread while we waited.
+	if threadId != "" && threadId == l.lastOutputThread {
+		l.ensureRepoLinkLocked()
+		return true
 	}
 	l.ensureRepoLinkLocked()
 	mounted := func(dir string) bool {

--- a/packages/sandbox/daemon-go/internal/orgfs/links_test.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links_test.go
@@ -104,6 +104,27 @@ func TestRepointHealsAnEmptyRealOutputDir(t *testing.T) {
 	}
 }
 
+// RepointForRun's grace wait for the sidecar's first mounts can take up to
+// firstMountWait. If it held mu across that wait, every other org-fs call —
+// notably WaitSkillLinks, whose whole job is to bound how long a run waits on
+// org-fs — would be stuck behind it regardless of its own budget.
+func TestRepointForRunDoesNotBlockOtherCallsWhileWaitingForMounts(t *testing.T) {
+	appRoot := t.TempDir()
+	// Never written: ActiveMounts stays empty, so RepointForRun falls into the
+	// first-touch grace wait.
+	statusPath := filepath.Join(t.TempDir(), "status.json")
+	l := &Links{AppRoot: appRoot, StatusPath: statusPath, ConfigPath: "unused"}
+
+	go l.RepointForRun("t1")
+	time.Sleep(50 * time.Millisecond) // let it enter the wait
+
+	start := time.Now()
+	l.WaitSkillLinks(time.Second)
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("WaitSkillLinks took %s — blocked behind RepointForRun's mount wait", elapsed)
+	}
+}
+
 func TestExpectedRequiresSidecarEnv(t *testing.T) {
 	if (&Links{}).Expected() {
 		t.Error("org-fs expected with no sidecar env — every call would pay the mount wait")


### PR DESCRIPTION
**Bug:** `Links.RepointForRun` acquires `mu` and only then calls `mountsOrWait()`. On a pod's very first org-fs call — before the sidecar has reported any mount yet — `mountsOrWait()` falls into `waitForFirstMounts()`, which polls for up to `firstMountWait` (10s) before giving up. That whole wait happened with `mu` held, so any other org-fs caller that needs `mu` was blocked behind it for up to 10s.

The caller that matters most is `WaitSkillLinks`, whose entire documented purpose is to bound how long a run waits on org-fs ("a run must never hang behind a symlink, so the deadline is the backstop") — but its own `mu.Lock()` to read the sync-done channel would sit behind `RepointForRun`'s wait regardless of the `budget` argument passed in, silently defeating that guarantee on a pod's first dispatch.

**Fix:** moved the `mountsOrWait()` call in `RepointForRun` outside the lock (matching how `EnsureRepoLink` already does it), re-checking `lastOutputThread` after reacquiring `mu` in case another call already repointed for this thread while this one was waiting on mounts. No behavior change on the already-mounted path (the common case, and what the existing tests cover) — only the first-touch wait is now unlocked.

**Regression test:** `TestRepointForRunDoesNotBlockOtherCallsWhileWaitingForMounts` starts `RepointForRun` against a status file that never reports a mount (forcing the grace wait), then asserts `WaitSkillLinks` returns within its own 1s budget instead of being stuck behind the other call's 10s wait. Verified this fails (times out around 10s) against the pre-fix code and passes in ~80ms with the fix.

**To verify:** `cd packages/sandbox/daemon-go && go test ./internal/orgfs/... -run TestRepoint -race -v`

**Checks run locally:** `gofmt -l`, `go vet ./internal/orgfs/...`, `go build ./...`, and the full `go test ./internal/orgfs/...` package (10.7s, all green). CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent org-fs from blocking behind the first-mount grace wait. Previously `RepointForRun` held `Links.mu` while waiting up to 10s for initial mounts, which blocked other calls (including `WaitSkillLinks`) regardless of their budgets. Now it waits without the lock and re-checks state after reacquiring; already-mounted behavior is unchanged.

- Moves `mountsOrWait()` outside the mutex, then re-acquires and re-checks `lastOutputThread` before repointing. Matches the locking pattern used elsewhere and only affects the first-touch path.
- Adds regression test `TestRepointForRunDoesNotBlockOtherCallsWhileWaitingForMounts` in `packages/sandbox/daemon-go/internal/orgfs`, which ensures `WaitSkillLinks` returns within its own budget even if the first-mount wait is ongoing.
- Verify locally: cd `packages/sandbox/daemon-go` and run `go test ./internal/orgfs/... -run TestRepoint -race -v`.

<sup>Written for commit 121da9fdd14b13690f5810049b0bbc0d95734df0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

