### PR TITLE
fix(sandbox): stop AdoptStrayRepoSkills holding orgfs.Links.mu across the CopyFS

### DIFF
--- a/packages/sandbox/daemon-go/internal/orgfs/links.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links.go
@@ -732,8 +732,12 @@ func (l *Links) AdoptStrayRepoSkills() {
 	if l == nil || l.RepoDir == "" || !l.Expected() {
 		return
 	}
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	// Deliberately unlocked: CopyFS below writes through the org mount, and
+	// holding mu across that would stall every other org-fs caller — the same
+	// class of bug RepointForRun's mount wait had to be moved out from under
+	// mu for. Nothing here touches a field mu protects (lastOutputThread,
+	// skillsLinked, publicSkillsRun/Done, api); it only touches the checkout's
+	// `.claude/skills` dir and the home mount, neither written by a locked path.
 	if !l.volumeMounted("home") {
 		return
 	}


### PR DESCRIPTION
Follows #6400 (`RepointForRun` moved its mount wait outside `orgfs.Links.mu` because holding the lock across slow mount I/O stalls every other org-fs caller). `AdoptStrayRepoSkills` (called from the daemon's `AfterRun` hook, `main.go`) still has that exact shape: it takes `l.mu` for its whole body, including the `os.CopyFS`/`os.RemoveAll` calls that write through the `org/home` mount — a network filesystem.

Every fs/exec request on the pod goes through the `linked` HTTP middleware, which calls `RepointForRun`/`EnsureRepoLink` — both also take `l.mu`. So a slow or wedged home mount during `AfterRun`'s skill adoption blocks every concurrent request the daemon is serving for the rest of the run, the same class of stall #6400 fixed (and the daemon's health probe tears the pod down on a single miss, per CLAUDE.md).

`AdoptStrayRepoSkills` never touches the fields `mu` actually protects (`lastOutputThread`, `skillsLinked`, `publicSkillsRun`/`Done`, `api`) — it only reads/writes the checkout's `.claude/skills` dir and the home mount, neither of which any locked path touches. So the fix drops the lock entirely rather than narrowing it (there's nothing left needing protection).

Behavior-preserving: no logic changed, just the lock scope. Existing tests (`TestAdoptStrayRepoSkills`, `TestPrefetchedSkillsAreNotAdopted`) still assert the same adoption/exclusion behavior and pass unchanged.

How to verify: `cd packages/sandbox/daemon-go && go test ./internal/orgfs/...`

Locally ran: `go build ./...`, `go test ./internal/orgfs/...` (pass), `gofmt -l` + `go vet ./internal/orgfs/...` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids pod-wide stalls by stopping `AdoptStrayRepoSkills` from holding `orgfs.Links.mu` across network FS operations. Previously it locked `mu` during `CopyFS`/`RemoveAll` on the `org/home` mount; now it runs unlocked since it does not touch `mu`-protected fields. Behavior is unchanged; lock contention and health-probe false negatives are reduced (same class of stall as #6400).

- The unlocked path only touches the checkout `.claude/skills` dir and the home mount; `lastOutputThread`, `skillsLinked`, `publicSkillsRun`/`Done`, and `api` are untouched.
- Scope: `packages/sandbox/daemon-go/internal/orgfs/links.go`. Existing tests (`TestAdoptStrayRepoSkills`, `TestPrefetchedSkillsAreNotAdopted`) pass.
- Verify: `cd packages/sandbox/daemon-go && go test ./internal/orgfs/...`

<sup>Written for commit 254317c7910eb26e7bee9950914a4e9ecff255ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

