### PR TITLE
fix(github): guard list-user-orgs against GitHub rate limits

### DIFF
--- a/apps/api/src/tools/github/list-user-orgs.ts
+++ b/apps/api/src/tools/github/list-user-orgs.ts
@@ -8,6 +8,12 @@ import {
 } from "@/oauth/token-refresh";
 import { getRepoScope } from "@decocms/shared/github-repo-scope";
 import { DownstreamTokenStorage } from "../../storage/downstream-token";
+import {
+  countGithubRateLimited,
+  githubRetryAfterMs,
+  isGithubRateLimited,
+  recordGithubRateLimit,
+} from "@/observability/github-rate-limit";
 
 const GITHUB_API = "https://api.github.com";
 /** Matches the Git Data client's per-attempt timeout in `decofile/github-git-data.ts`. */
@@ -158,6 +164,27 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
         if (res.status === 401) {
           throw new Error(RECONNECT_ERROR);
         }
+      }
+
+      recordGithubRateLimit(res.headers, {
+        lane: "rest",
+        operation: "list_user_installations",
+      });
+
+      if (isGithubRateLimited(res)) {
+        const kind =
+          res.headers.get("retry-after") !== null ? "secondary" : "primary";
+        countGithubRateLimited({
+          lane: "rest",
+          operation: "list_user_installations",
+          kind,
+        });
+        const waitMs = githubRetryAfterMs(res.headers);
+        throw new Error(
+          `GitHub ${kind} rate limit reached${
+            waitMs === null ? "" : `; retry in ${Math.ceil(waitMs / 1000)}s`
+          }`,
+        );
       }
 
       if (!res.ok) {


### PR DESCRIPTION
Closes: #6282 (series)

## What
GITHUB_LIST_USER_ORGS uses REST API directly but didn't guard against rate limiting like the shared GraphQL transport does. When GitHub's API is rate-limited (429 or 403 with retry-after), the tool threw a bare status code without extracting retry guidance or recording observability.

## Why
Rate limits can happen mid-pagination on a long installations list. The caller deserves to know:
1. That the failure is a rate limit (not a permission or connectivity issue)
2. How long to wait before retrying
3. Whether it's a primary (window exhausted) or secondary (burst/abuse) limit

This mirrors the hardening already in place for the GraphQL transport (`graphql.ts:204-218`).

## How
- Import the existing rate-limit utilities from `@/observability/github-rate-limit`
- Check for rate limiting with `isGithubRateLimited(res)` before generic error throw
- Record the rate-limit snapshot with `recordGithubRateLimit()` on every response
- Count the rate-limit event with `countGithubRateLimited()` for observability
- Surface retry-after guidance in the error message if GitHub provided it

## Verification
- `bun run fmt`: ✓
- `bunx tsc --noEmit` in apps/api: ✓
- `bun test ./apps/api/src/tools/github/list-user-orgs.test.ts`: ✓ (3/3 pass)
- `bunx oxlint apps/api/src/tools/github/list-user-orgs.ts`: ✓ (0 errors)

Diff: -4 / +22 (net +18 lines; one concern: rate-limit handling).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards the `GITHUB_LIST_USER_ORGS` REST call against GitHub rate limits, aligning behavior with the GraphQL transport. Previously it threw a bare 429/403; now it detects rate limiting, classifies primary vs secondary, and surfaces retry-after guidance to improve resilience during pagination.

- Uses `@/observability/github-rate-limit` utilities: `isGithubRateLimited`, `githubRetryAfterMs`, `recordGithubRateLimit`, `countGithubRateLimited`.
- Records rate-limit headers on every response and increments a counter when limited.
- Throws an Error with retry-after seconds when limited; error type and tool API remain unchanged.

<sup>Written for commit 053fb746cb6ed31a3f9af7e29fd10ba0c5e8e942. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

