### PR TITLE
fix(mcp): return 400 on malformed call-tool body instead of 500

### DIFF
--- a/apps/api/src/api/routes/proxy.integration.test.ts
+++ b/apps/api/src/api/routes/proxy.integration.test.ts
@@ -224,6 +224,87 @@ describe("MCP Proxy call-tool disabled-connection gate", () => {
   });
 });
 
+describe("MCP Proxy call-tool malformed body", () => {
+  let database: StudioDatabase;
+  let app: Awaited<ReturnType<typeof createApp>>;
+
+  const memberUserId = "user_member";
+  const orgId = "org_owner";
+  const connectionId = "conn_active_123";
+
+  beforeEach(async () => {
+    ensureEncryptionKey();
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    app = await createApp({ database, disableNats: true });
+
+    const now = new Date().toISOString();
+    const { sql } = await import("kysely");
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${memberUserId}, 'member@example.com', false, 'Member', ${now}, ${now})
+    `.execute(database.db);
+
+    await database.db
+      .insertInto("organization" as any)
+      .values({
+        id: orgId,
+        name: "Owner Org",
+        slug: "owner-org",
+        createdAt: now,
+      })
+      .execute();
+
+    await sql`
+      INSERT INTO "member" (id, "userId", "organizationId", role, "createdAt")
+      VALUES ('mem_owner', ${memberUserId}, ${orgId}, 'member', ${now})
+    `.execute(database.db);
+
+    await database.db
+      .insertInto("connections")
+      .values({
+        id: connectionId,
+        organization_id: orgId,
+        created_by: memberUserId,
+        title: "Active Connection",
+        connection_type: "HTTP",
+        connection_url: "https://example.com/mcp",
+        status: "active",
+        pinned: false,
+        created_at: now,
+        updated_at: now,
+      })
+      .execute();
+
+    vi.spyOn(auth.api, "getMcpSession").mockResolvedValue(null);
+    vi.spyOn(auth.api, "setActiveOrganization").mockResolvedValue(null as any);
+    vi.spyOn(auth.api, "getSession" as any).mockImplementation(async () => ({
+      user: { id: memberUserId, email: "member@example.com" },
+      session: { activeOrganizationId: null },
+    }));
+  });
+
+  afterEach(async () => {
+    await closeTestPgDatabase(database);
+    vi.restoreAllMocks();
+  });
+
+  it("should reject a non-JSON call-tool body with 400, not 500", async () => {
+    const response = await app.request(
+      `/mcp/${connectionId}/call-tool/some_tool`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-org-id": orgId },
+        body: "not json",
+      },
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("valid JSON");
+  });
+});
+
 describe("MCP Proxy call-tool organization ownership", () => {
   let database: StudioDatabase;
   let app: Awaited<ReturnType<typeof createApp>>;

--- a/apps/api/src/api/routes/proxy.ts
+++ b/apps/api/src/api/routes/proxy.ts
@@ -502,11 +502,19 @@ export const createProxyRoutes = () => {
         throw new Error(`Connection inactive: ${connection.status}`);
       }
 
+      // Malformed JSON must surface as 400, not fall through as a 500.
+      let args: unknown;
+      try {
+        args = await c.req.json();
+      } catch {
+        return c.json({ error: "Request body must be valid JSON" }, 400);
+      }
+
       // Client pool manages lifecycle, no need for await using
       const client = await clientFromConnection(connection, ctx, false);
       const result = await client.callTool({
         name: toolName,
-        arguments: await c.req.json(),
+        arguments: args as Record<string, unknown>,
       });
 
       if (result.isError) {


### PR DESCRIPTION
The `/:connectionId/call-tool/:toolName` proxy route parses the request body via `c.req.json()` inline while building the `callTool` arguments. A caller sending a non-JSON body (e.g. an empty body, or a client bug) causes a `SyntaxError` that falls into the route's generic catch block, which reports it as `"Internal server error"` (500) — masking a client input error as a server-side fault, and making it look like a real incident when it's just a bad request.

This is a real trust-boundary gap: the body is untrusted caller input, and the route already distinguishes client-caused failures (403 no-org, 404 not-found, 503 inactive) from real internal errors everywhere else — malformed JSON should follow the same pattern, not fall through to 500.

Fix: parse the body up front in its own try/catch and return 400 with a clear message on parse failure, before reaching the connection/client logic.

Regression test added to `apps/api/src/api/routes/proxy.integration.test.ts`: POSTs a non-JSON body (`"not json"`) to an active connection's call-tool route and asserts a 400 with a JSON-parse-error message instead of a 500.

To confirm: `bun test apps/api/src/api/routes/proxy.integration.test.ts` (requires a local Postgres per the file's existing pattern).

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/api/routes/proxy.ts apps/api/src/api/routes/proxy.integration.test.ts`, and the full targeted test file (5/5 pass, including the new test). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns 400 Bad Request when `/:connectionId/call-tool/:toolName` receives a malformed JSON body. Previously, a non-JSON body triggered a 500 Internal Server Error via the generic catch; now it fails fast with a clear error message.

- Parses the body once up front; on JSON parse failure returns `{ "error": "Request body must be valid JSON" }` with 400.
- Leaves existing 403/404/503 mappings unchanged; only malformed body handling differs from before.
- Adds a regression test in `apps/api/src/api/routes/proxy.integration.test.ts` that posts a non-JSON body and asserts 400.

<sup>Written for commit 6cdcc27f029304111d704f210d8a8b648ef37206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

