### PR TITLE
fix(connections): only skip the ownership check for the caller's own self-connection

### DIFF
--- a/apps/api/src/tools/connection/credential-grants.test.ts
+++ b/apps/api/src/tools/connection/credential-grants.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import type { StudioContext } from "../../core/studio-context";
+import { validateConfiguration } from "./credential-grants";
+
+function fakeCtx(
+  connections: Record<string, { organization_id: string }>,
+): StudioContext {
+  return {
+    storage: {
+      connections: {
+        findById: async (id: string) => connections[id] ?? null,
+      },
+    },
+    access: {
+      check: async () => {},
+    },
+  } as unknown as StudioContext;
+}
+
+describe("validateConfiguration", () => {
+  test("rejects a SELF value pointing at another org's self-connection", async () => {
+    const ctx = fakeCtx({
+      "victim-org_self": { organization_id: "victim-org" },
+    });
+    const state = { SELF: { value: "victim-org_self" } };
+
+    await expect(
+      validateConfiguration(
+        state,
+        ["SELF::CONFIGURATION_READ"],
+        "caller-org",
+        ctx,
+      ),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  test("allows the caller's own self-connection without a DB lookup", async () => {
+    const ctx = fakeCtx({});
+    const state = { SELF: { value: "caller-org_self" } };
+
+    await expect(
+      validateConfiguration(
+        state,
+        ["SELF::CONFIGURATION_READ"],
+        "caller-org",
+        ctx,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/tools/connection/credential-grants.ts
+++ b/apps/api/src/tools/connection/credential-grants.ts
@@ -101,9 +101,11 @@ export async function validateConfiguration(
   }
 
   const referencedConnections = getReferencedConnectionIds(state, scopes);
+  const selfConnectionId = `${organizationId}_self`;
 
   for (const refConnectionId of referencedConnections) {
-    if (refConnectionId.endsWith("_self")) {
+    // Only the caller's own self-connection skips the ownership/access checks below.
+    if (refConnectionId === selfConnectionId) {
       continue;
     }
 


### PR DESCRIPTION
**Source:** a bug found while auditing `apps/api/src/tools/connection/credential-grants.ts` for the "MCP connection ownership" focus area (issue #5661's own scaffolding doesn't exist yet on main, so this is a bounded correctness/security fix in the same files instead).

**The gap:** `validateConfiguration()` is the security gate that checks any connection referenced by a `SELF::`/credential-read scope belongs to the caller's org and that the caller has access to it (`ctx.access.check(refConnectionId)`). It skipped both checks for any `refConnectionId` ending in `"_self"`. But self-connections are real per-org rows (`WellKnownOrgMCPId.SELF(orgId) => \`${orgId}_self\``), not a single synthetic sentinel — so a caller could reference `"<victimOrgId>_self"` (another org's real self-connection) and this function would let it through without an ownership or access check.

**Why it matters (and why it's still worth fixing):** the credential-grant storage layer (`ConnectionCredentialVaultStorage.replaceGrantsForSubject`) independently re-checks that every `target_connection_id` belongs to the caller's org before persisting a grant, so this specific gap doesn't currently let a cross-org grant land in the DB. But `validateConfiguration` is the function whose own doc comment says it's the place referenced-connection ownership/access gets validated — relying on an unrelated downstream layer as the only real backstop is fragile, and any future caller of `validateConfiguration` without that backstop would be exploitable.

**Fix:** match the exact caller-org self id (`\`${organizationId}_self\``, the same string `injectSelfSentinel` constructs) instead of any string ending in `_self`.

**Regression test:** `apps/api/src/tools/connection/credential-grants.test.ts` — asserts a `SELF` value pointing at another org's self-connection is rejected, and the caller's own self-connection still passes without a DB lookup.

**To verify:** `bun test apps/api/src/tools/connection/credential-grants.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint` on both touched files, and the targeted test above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the SELF-scope bypass in validateConfiguration so only the caller’s own self-connection (`${organizationId}_self`) skips ownership/access checks. Previously, any id ending in `_self` bypassed checks, allowing cross-org references; now validateConfiguration enforces org isolation as intended.

**Review notes**
- Adds a regression test at apps/api/src/tools/connection/credential-grants.test.ts: cross-org SELF is rejected; caller’s own SELF passes without a DB lookup.
- Impact: valid same-org SELF calls are unaffected; invalid cross-org SELF references now fail earlier (storage layer behavior unchanged).
- Verify with: bun test apps/api/src/tools/connection/credential-grants.test.ts

<sup>Written for commit fc6ec7bd4976d951681d1d55a0c495397f21c7fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

