### PR TITLE
fix(task-board): make filter search options match by their displayed label

### DIFF
--- a/apps/web/src/layouts/task-board/task-filters-search.test.tsx
+++ b/apps/web/src/layouts/task-board/task-filters-search.test.tsx
@@ -1,0 +1,73 @@
+import "../../../test/setup";
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render as renderBare } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { LOCALSTORAGE_KEYS } from "@/lib/localstorage-keys.ts";
+import { TaskFiltersBar, EMPTY_FILTERS } from "./task-filters";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const render = (ui: Parameters<typeof renderBare>[0]) =>
+  renderBare(ui, { wrapper });
+
+/**
+ * cmdk's built-in fuzzy search filters each `CommandItem` by its `value`
+ * prop, not by its rendered children — so a hardcoded English `value` (e.g.
+ * "Unassigned") makes the option unfindable to a pt-BR user typing its own
+ * on-screen label ("Sem atribuição"). Asserting `data-value` (cmdk mirrors
+ * `value` there) matches the displayed label is a locale-independent proxy
+ * for "this option's search filter matches what the user actually sees" —
+ * cmdk itself doesn't apply its filtering pass in this DOM environment.
+ */
+describe("task filter options — searchable value matches the displayed label", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem(
+      LOCALSTORAGE_KEYS.preferences(),
+      JSON.stringify({ language: "pt-BR" }),
+    );
+  });
+
+  test("assignee filter", () => {
+    const { getByText } = render(
+      <TaskFiltersBar
+        filters={EMPTY_FILTERS}
+        members={[]}
+        tags={[]}
+        repos={[]}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(getByText("Responsável"));
+
+    for (const label of ["Qualquer um", "Sem atribuição", "Super Agent"]) {
+      const item = getByText(label).closest("[cmdk-item]");
+      expect(item?.getAttribute("data-value")).toBe(label);
+    }
+  });
+
+  test("repo filter", () => {
+    const { getByText } = render(
+      <TaskFiltersBar
+        filters={{ ...EMPTY_FILTERS, repo: "acme/site" }}
+        members={[]}
+        tags={[]}
+        repos={["acme/site"]}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(getByText("acme/site"));
+
+    for (const label of ["Qualquer repositório", "Sem repositório"]) {
+      const item = getByText(label).closest("[cmdk-item]");
+      expect(item?.getAttribute("data-value")).toBe(label);
+    }
+  });
+});

--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -270,11 +270,14 @@ function AssigneeFilter({
               {t("taskBoard.taskFilters.assigneeNoMembersFound")}
             </CommandEmpty>
             <CommandGroup>
-              <CommandItem value="Anyone" onSelect={() => select(null)}>
+              <CommandItem
+                value={t("taskBoard.taskFilters.assigneeAnyone")}
+                onSelect={() => select(null)}
+              >
                 {t("taskBoard.taskFilters.assigneeAnyone")}
               </CommandItem>
               <CommandItem
-                value="Unassigned"
+                value={t("taskBoard.taskFilters.assigneeUnassigned")}
                 onSelect={() => select(UNASSIGNED_FILTER)}
                 className="gap-2"
               >
@@ -282,7 +285,7 @@ function AssigneeFilter({
                 {t("taskBoard.taskFilters.assigneeUnassigned")}
               </CommandItem>
               <CommandItem
-                value="Super Agent"
+                value={t("taskBoard.taskFilters.assigneeSuperAgent")}
                 onSelect={() => select(SUPER_AGENT_ASSIGNEE_ID)}
                 className="gap-2"
               >
@@ -571,11 +574,14 @@ function RepoFilter({
               {t("taskBoard.taskFilters.repoNoReposFound")}
             </CommandEmpty>
             <CommandGroup>
-              <CommandItem value="Any repo" onSelect={() => select(null)}>
+              <CommandItem
+                value={t("taskBoard.taskFilters.repoAnyRepo")}
+                onSelect={() => select(null)}
+              >
                 {t("taskBoard.taskFilters.repoAnyRepo")}
               </CommandItem>
               <CommandItem
-                value="No repo"
+                value={t("taskBoard.taskFilters.repoNoRepo")}
                 onSelect={() => select(NO_REPO_FILTER)}
               >
                 {t("taskBoard.taskFilters.repoNoRepo")}


### PR DESCRIPTION
**Bug:** in the task-board's assignee and repo filter dropdowns, the `CommandItem` options for "Anyone"/"Unassigned"/"Super Agent" (assignee filter) and "Any repo"/"No repo" (repo filter) had their `value` prop hardcoded to English strings. cmdk's built-in search filters options by `value`, not by rendered children — so a non-English (e.g. pt-BR) user typing the label they actually see ("Sem atribuição") into the filter's search box gets zero matches and the option silently vanishes from the list, even though it's a valid choice.

**Fix:** pass the translated label (`t(...)`) as the `value` instead of the hardcoded English string, for both `AssigneeFilter` and `RepoFilter` in `task-filters.tsx`.

**Regression test:** `task-filters-search.test.tsx` renders the filter bar with the `pt-BR` locale, opens each dropdown, and asserts each option's `data-value` (cmdk mirrors its `value` prop there) equals the label actually shown on screen. I confirmed this test fails against the old code (`data-value="Unassigned"` vs. the pt-BR label `"Sem atribuição"`) and passes with the fix. Note: cmdk's live fuzzy-filtering itself doesn't run in this happy-dom test env, so the test asserts the root-cause invariant (searchable value == displayed label) rather than driving the filter end-to-end.

**To verify:** `bun test apps/web/src/layouts/task-board/task-filters-search.test.tsx` and `bun test apps/web/src/layouts/task-board/task-filters.test.ts` (existing pure-logic tests, unaffected).

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task-board assignee and repo filter search to match the displayed label. Previously `cmdk` searched by hardcoded English `value`s (“Anyone”, “Unassigned”, “Super Agent”, “Any repo”, “No repo”), so non‑English users could not find these options; now each `CommandItem.value` equals the localized label.

**Review notes**
- Scope: `AssigneeFilter` and `RepoFilter` in `task-filters.tsx` now pass `t(...)` as `CommandItem.value` for the five special options.
- Behavior: selection logic is unchanged; `onSelect` still passes the same IDs/constants.
- Tests: adds `task-filters-search.test.tsx` to assert `data-value` matches the visible label in `pt-BR`.
- Side effect: `value`/`data-value` are now localized; update any selectors or telemetry that assumed English values.

<sup>Written for commit 7579ce4468555ad0141ccdf2703e46c2217d938b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

