### PR TITLE
fix(organization): unwrap Better Auth's { members, total } response in ORGANIZATION_MEMBER_LIST

### DIFF
--- a/apps/api/src/tools/organization/member-list.test.ts
+++ b/apps/api/src/tools/organization/member-list.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, mock } from "bun:test";
+import { ORGANIZATION_MEMBER_LIST } from "./member-list";
+
+function makeCtx() {
+  const listMembers = mock(async () => ({
+    members: [
+      {
+        id: "member-1",
+        organizationId: "org-a",
+        userId: "user-1",
+        role: "admin",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    ],
+    total: 1,
+  }));
+  const ctx = {
+    auth: { user: { id: "user-1" } },
+    organization: { id: "org-a" },
+    access: { check: mock(async () => {}) },
+    boundAuth: { organization: { listMembers } },
+  } as unknown as Parameters<typeof ORGANIZATION_MEMBER_LIST.handler>[1];
+  return { ctx, listMembers };
+}
+
+describe("ORGANIZATION_MEMBER_LIST", () => {
+  it("returns the members from Better Auth's { members, total } response", async () => {
+    // Regression: this used to only accept a bare array, so it always returned [].
+    const { ctx } = makeCtx();
+
+    const result = await ORGANIZATION_MEMBER_LIST.handler({}, ctx);
+
+    expect(result.members).toHaveLength(1);
+    expect(result.members[0]).toMatchObject({
+      id: "member-1",
+      userId: "user-1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+  });
+});

--- a/apps/api/src/tools/organization/member-list.ts
+++ b/apps/api/src/tools/organization/member-list.ts
@@ -57,7 +57,7 @@ export const ORGANIZATION_MEMBER_LIST = defineTool({
       );
     }
 
-    // List members via Better Auth
+    // List members via Better Auth — the endpoint returns `{ members, total }`.
     const result = await ctx.boundAuth.organization.listMembers({
       organizationId,
       limit: input.limit,
@@ -65,13 +65,15 @@ export const ORGANIZATION_MEMBER_LIST = defineTool({
     });
 
     // Convert dates to ISO strings for JSON Schema compatibility
-    const members = (Array.isArray(result) ? result : []).map((member) => ({
-      ...member,
-      createdAt:
-        member.createdAt instanceof Date
-          ? member.createdAt.toISOString()
-          : member.createdAt,
-    }));
+    const members = (result?.members ?? []).map(
+      (member: NonNullable<typeof result>["members"][number]) => ({
+        ...member,
+        createdAt:
+          member.createdAt instanceof Date
+            ? member.createdAt.toISOString()
+            : member.createdAt,
+      }),
+    );
 
     return { members };
   },


### PR DESCRIPTION
Found while auditing org tooling (`apps/api/src/tools/organization/`) for data-shape mismatches.

**Bug**: `ORGANIZATION_MEMBER_LIST`'s handler called `ctx.boundAuth.organization.listMembers(...)`, which delegates to Better Auth's `/organization/list-members` endpoint. That endpoint always responds `{ members, total }` (see `ctx.json({ members, total })` in `@decocms/better-auth`'s organization plugin) — it never returns a bare array. The handler guarded with `Array.isArray(result) ? result : []`, which is always false for that shape, so the tool silently returned an empty `members: []` for every organization, regardless of actual membership.

**Failure scenario**: any MCP caller of `ORGANIZATION_MEMBER_LIST` (e.g. the built-in `usage-manager` studio-pack tool that resolves user IDs to names) always saw zero members and could never map a user id to a name or role.

**Fix**: read `result.members` directly instead of type-guarding on `Array.isArray`.

**Regression test**: `apps/api/src/tools/organization/member-list.test.ts` mocks `boundAuth.organization.listMembers` to return the real `{ members, total }` shape and asserts the tool surfaces the member — this fails on the old code (returns `[]`) and passes now.

Reviewer check: `bun test apps/api/src/tools/organization/member-list.test.ts`

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (passes), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ORGANIZATION_MEMBER_LIST` to unwrap Better Auth’s `{ members, total }` response so org tools return real members. Previously it assumed a bare array and always returned `members: []`.

- Reads `result.members` and preserves behavior of ISO-normalizing `createdAt`.
- Adds regression test at `apps/api/src/tools/organization/member-list.test.ts`.
- No API shape change; callers now get actual members. No migration required.
- To verify: `bun test apps/api/src/tools/organization/member-list.test.ts`.

<sup>Written for commit 868c063f39429a6a78b4f05bd7d95fcb14bf6a35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

