### PR TITLE
fix(threads): restrict thread update/delete to owner or org admin

### DIFF
--- a/apps/api/src/tools/thread/delete.ts
+++ b/apps/api/src/tools/thread/delete.ts
@@ -16,7 +16,7 @@ import {
   requireAuth,
   requireOrganization,
 } from "../../core/studio-context";
-import { normalizeThreadForResponse } from "./helpers";
+import { assertThreadWritable, normalizeThreadForResponse } from "./helpers";
 import { broadcastRunCancel } from "@/api/routes/decopilot/cancel-registry";
 import { cancelHostedHarness } from "@/dispatch-queue";
 import { cancelThreadGateHead } from "@/dispatch-queue/thread-gate-queue";
@@ -45,6 +45,11 @@ export const COLLECTION_THREADS_DELETE = defineTool({
     if (!thread) {
       throw new Error(`Thread not found: ${input.id}`);
     }
+
+    assertThreadWritable(thread, {
+      userId: getUserId(ctx),
+      role: organization.role,
+    });
 
     // Stop an in-flight run before deleting its thread, or it keeps running orphaned.
     if (thread.status === "in_progress") {

--- a/apps/api/src/tools/thread/helpers.test.ts
+++ b/apps/api/src/tools/thread/helpers.test.ts
@@ -4,7 +4,11 @@
 
 import { describe, expect, test } from "bun:test";
 import type { Thread } from "../../storage/types";
-import { normalizeThreadForResponse, THREAD_EXPIRY_MS } from "./helpers";
+import {
+  assertThreadWritable,
+  normalizeThreadForResponse,
+  THREAD_EXPIRY_MS,
+} from "./helpers";
 
 const BASE_THREAD: Thread = {
   id: "thrd_test",
@@ -140,5 +144,54 @@ describe("normalizeThreadForResponse", () => {
     expect(result).not.toHaveProperty("context_start_message_id");
     expect(result).not.toHaveProperty("run_owner_pod");
     expect(result).not.toHaveProperty("run_started_at");
+  });
+});
+
+describe("assertThreadWritable", () => {
+  const OWNED = { ...BASE_THREAD, created_by: "user_owner" };
+
+  test("owner can write their own thread", () => {
+    expect(() =>
+      assertThreadWritable(OWNED, { userId: "user_owner", role: "user" }),
+    ).not.toThrow();
+  });
+
+  test("non-owner member is denied", () => {
+    expect(() =>
+      assertThreadWritable(OWNED, { userId: "user_other", role: "user" }),
+    ).toThrow(/only the chat's owner or an organization admin/);
+  });
+
+  test("org admin can write a teammate's thread", () => {
+    expect(() =>
+      assertThreadWritable(OWNED, { userId: "user_other", role: "admin" }),
+    ).not.toThrow();
+  });
+
+  test("org owner can write a teammate's thread", () => {
+    expect(() =>
+      assertThreadWritable(OWNED, { userId: "user_other", role: "owner" }),
+    ).not.toThrow();
+  });
+
+  test("admin role smuggled in a comma-joined multi-role still bypasses", () => {
+    expect(() =>
+      assertThreadWritable(OWNED, {
+        userId: "user_other",
+        role: "billing-manager,admin",
+      }),
+    ).not.toThrow();
+  });
+
+  test("undefined caller userId is denied (never matches created_by)", () => {
+    expect(() =>
+      assertThreadWritable(OWNED, { userId: undefined, role: "user" }),
+    ).toThrow(/only the chat's owner or an organization admin/);
+  });
+
+  test("undefined role is treated as non-admin", () => {
+    expect(() =>
+      assertThreadWritable(OWNED, { userId: "user_other", role: undefined }),
+    ).toThrow(/only the chat's owner or an organization admin/);
   });
 });

--- a/apps/api/src/tools/thread/helpers.ts
+++ b/apps/api/src/tools/thread/helpers.ts
@@ -5,6 +5,7 @@
  * and hidden defaulting across all thread tools.
  */
 
+import { hasAdminRole } from "@decocms/shared/auth/roles";
 import type { Thread, ThreadStatus } from "../../storage/types";
 import type { VirtualMCPStoragePort } from "../../storage/ports";
 import type { VirtualMCPEntity } from "@decocms/shared/sdk/types/virtual-mcp";
@@ -37,6 +38,36 @@ export async function requireOwnedVirtualMcp(
     throw new Error(`Virtual MCP not found: ${virtualMcpId}`);
   }
   return vmcp;
+}
+
+/**
+ * Guard thread WRITES (update/delete) to the thread's creator or an org
+ * admin/owner. Thread READS are org-wide by design — teammates can view each
+ * other's chats — but mutations are owner-only ("teammates' threads must be
+ * read-only unless owned", CLAUDE.md / PR #4230).
+ *
+ * This is a tenant-ownership check, NOT an RBAC check: `ctx.access.check()`
+ * only proves the caller holds the tool's action, and the thread collection
+ * tools are basic-usage (granted to every org member regardless of role). So
+ * without this guard any member could delete or rename a teammate's thread by
+ * id. Admin/owner bypass mirrors the role bypass in AccessControl.
+ *
+ * Throws (rather than returning a boolean) so a caller can't forget to act on
+ * a `false`.
+ */
+export function assertThreadWritable(
+  thread: Pick<Thread, "created_by">,
+  caller: { userId: string | undefined; role: string | undefined },
+): void {
+  if (caller.userId && thread.created_by === caller.userId) {
+    return;
+  }
+  if (hasAdminRole(caller.role)) {
+    return;
+  }
+  throw new Error(
+    "Forbidden: only the chat's owner or an organization admin can modify this chat",
+  );
 }
 
 /**

--- a/apps/api/src/tools/thread/update.ts
+++ b/apps/api/src/tools/thread/update.ts
@@ -13,6 +13,7 @@ import {
   requireOrganization,
 } from "../../core/studio-context";
 import {
+  assertThreadWritable,
   normalizeThreadForResponse,
   requireOwnedVirtualMcp,
   type GithubRepoMeta,
@@ -68,6 +69,8 @@ export const COLLECTION_THREADS_UPDATE = defineTool({
     if (!existing) {
       throw new Error("Thread not found in organization");
     }
+
+    assertThreadWritable(existing, { userId, role: organization.role });
 
     if (data.virtual_mcp_id !== undefined) {
       // Guards against re-pointing a thread at another org's agent.

--- a/packages/e2e/tests/thread-write-owner-guard.spec.ts
+++ b/packages/e2e/tests/thread-write-owner-guard.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * E2E: thread WRITES (update/delete) are owner-only.
+ *
+ * Thread READS are org-wide by design — teammates can view each other's chats
+ * (COLLECTION_THREADS_LIST/GET). But the write tools must reject a non-owner
+ * member: "teammates' threads must be read-only unless owned" (CLAUDE.md /
+ * PR #4230). Because the thread collection tools are basic-usage (granted to
+ * every org member regardless of role), `ctx.access.check()` alone passes for
+ * any member — the ownership guard is the only thing standing between member B
+ * and member A's thread. This spec pins that boundary over the real wire.
+ *
+ * Matrix (single org, all members):
+ *   - member B UPDATE A's thread  → DENIED
+ *   - member B DELETE A's thread  → DENIED
+ *   - member A UPDATE own thread  → ALLOWED (owner)
+ *   - org owner DELETE A's thread → ALLOWED (admin/owner bypass)
+ */
+
+import type { APIRequestContext } from "@playwright/test";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { callSelfMcpTool, findOrgId } from "../fixtures/mcp-tools";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+const FORBIDDEN = /only the chat's owner or an organization admin/;
+
+async function inviteAndAccept(
+  ownerCtx: APIRequestContext,
+  memberCtx: APIRequestContext,
+  orgId: string,
+  email: string,
+): Promise<void> {
+  const invite = await ownerCtx.post("/api/auth/organization/invite-member", {
+    data: { organizationId: orgId, email, role: "user" },
+  });
+  expect(
+    invite.ok(),
+    `invite failed: ${await invite.text().catch(() => "")}`,
+  ).toBe(true);
+  const inviteJson = (await invite.json()) as {
+    id?: string;
+    invitation?: { id?: string };
+  };
+  const invitationId = inviteJson.id ?? inviteJson.invitation?.id;
+  expect(invitationId).toBeTruthy();
+  const accept = await memberCtx.post(
+    "/api/auth/organization/accept-invitation",
+    { data: { invitationId } },
+  );
+  expect(
+    accept.ok(),
+    `accept failed: ${await accept.text().catch(() => "")}`,
+  ).toBe(true);
+}
+
+test.describe("thread write ownership guard", () => {
+  test("non-owner member cannot update/delete a teammate's thread; owner & admin can", async ({
+    playwright,
+  }) => {
+    // Org owner.
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const orgSlug = owner.orgSlug;
+    const orgId = await findOrgId(ownerCtx, orgSlug);
+
+    // Two plain "user"-role members of the same org.
+    const memberACtx = await newApiContext(playwright);
+    const memberA = await signUpViaApi(memberACtx);
+    await inviteAndAccept(ownerCtx, memberACtx, orgId, memberA.email);
+
+    const memberBCtx = await newApiContext(playwright);
+    const memberB = await signUpViaApi(memberBCtx);
+    await inviteAndAccept(ownerCtx, memberBCtx, orgId, memberB.email);
+
+    // Member A creates an agent and a thread owned by A.
+    const agent = await callSelfMcpTool<{ item: { id: string } }>(
+      memberACtx,
+      orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      { data: { title: "owner-guard agent", connections: [] } },
+    );
+    const virtualMcpId = agent.item?.id;
+    expect(virtualMcpId).toBeTruthy();
+
+    const created = await callSelfMcpTool<{ item: { id: string } }>(
+      memberACtx,
+      orgSlug,
+      "COLLECTION_THREADS_CREATE",
+      { data: { title: "A's private chat", virtual_mcp_id: virtualMcpId } },
+    );
+    const threadId = created.item?.id;
+    expect(threadId).toBeTruthy();
+
+    // Sanity: member B CAN read A's thread (reads are org-wide by design).
+    const readByB = await callSelfMcpTool<{ item: { id: string } }>(
+      memberBCtx,
+      orgSlug,
+      "COLLECTION_THREADS_GET",
+      { id: threadId },
+    );
+    expect(readByB.item?.id).toBe(threadId);
+
+    // DENY: member B updates A's thread.
+    await expect(
+      callSelfMcpTool(memberBCtx, orgSlug, "COLLECTION_THREADS_UPDATE", {
+        id: threadId,
+        data: { title: "hijacked by B" },
+      }),
+    ).rejects.toThrow(FORBIDDEN);
+
+    // DENY: member B deletes A's thread.
+    await expect(
+      callSelfMcpTool(memberBCtx, orgSlug, "COLLECTION_THREADS_DELETE", {
+        id: threadId,
+      }),
+    ).rejects.toThrow(FORBIDDEN);
+
+    // ALLOW: member A (owner) updates their own thread.
+    const updatedByA = await callSelfMcpTool<{ item: { title: string } }>(
+      memberACtx,
+      orgSlug,
+      "COLLECTION_THREADS_UPDATE",
+      { id: threadId, data: { title: "renamed by A" } },
+    );
+    expect(updatedByA.item?.title).toBe("renamed by A");
+
+    // ALLOW: org owner (admin bypass) deletes A's thread.
+    const deletedByOwner = await callSelfMcpTool<{ item: { id: string } }>(
+      ownerCtx,
+      orgSlug,
+      "COLLECTION_THREADS_DELETE",
+      { id: threadId },
+    );
+    expect(deletedByOwner.item?.id).toBe(threadId);
+
+    await ownerCtx.dispose();
+    await memberACtx.dispose();
+    await memberBCtx.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

Found during a Broken Access Control audit. `COLLECTION_THREADS_UPDATE` and `COLLECTION_THREADS_DELETE` fetched a thread by id and mutated it after only `ctx.access.check()`.

The thread collection tools are **basic-usage** (`BASIC_USAGE_TOOLS`, granted to every org member regardless of role), so `check()` passes for any member. The storage layer (`OrgScopedThreadStorage`) scopes writes by `organization_id` only — there is **no owner predicate**. Net effect: any member of an org could rename, re-flag, or **permanently delete a teammate's thread** (and abort its in-flight run) just by knowing/guessing the thread id.

This is an intra-org IDOR that violates the documented rule — CLAUDE.md checklist item 2 / PR #4230: *"teammates' threads must be read-only unless owned."* The read tools already honor it; the write tools did not.

## Fix

New shared guard `assertThreadWritable(thread, caller)` in `thread/helpers.ts`:
- allow the thread's `created_by`,
- allow an org **admin/owner** (mirrors the admin bypass in `AccessControl`, uses `hasAdminRole` so comma-joined multi-roles resolve),
- reject everyone else.

Wired into both write tool handlers right after the existing fetch. Reads stay org-wide by design.

## Testing

- **Unit** (`thread/helpers.test.ts`): owner allow, non-owner deny, admin & owner bypass, comma-joined multi-role admin, undefined `userId`/`role`. ✅ 25 pass locally.
- **E2E** (`packages/e2e/tests/thread-write-owner-guard.spec.ts`): two `user`-role members in one org — member B is denied UPDATE + DELETE of member A's thread over the wire and can still READ it; owner (A) and org owner succeed. Runs against real Postgres + Better Auth per the e2e black-box contract.
- `bun run fmt`, `bun run check` (apps/api + packages/e2e), `bun run lint` — clean (0 errors).

## Affected areas

`apps/api/src/tools/thread/{update,delete}.ts`, `helpers.ts`. No schema/storage changes. Behavior change: non-owner, non-admin members now get a Forbidden error on thread update/delete (previously silently allowed).

## Notes / follow-ups (out of scope, from the same audit)

Not fixed here — flag for separate PRs: legacy unauthenticated `/oauth-proxy/:connectionId/*` unscoped lookup; `ORGANIZATION_UPDATE/DELETE` trusting `input.id` without an `id === ctx.organization.id` guard (sibling `settings-update` has it); AI provider key preview/delete/update skipping the model-permission gate that LIST enforces; and the systemic storage-layer pattern of mutating by id with no `organization_id` predicate (downstream_tokens, virtual.delete cascade, threads.setRunFence).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts thread update/delete to the thread’s creator or an org admin/owner to fix an intra‑org IDOR. Previously, any org member could update or permanently delete a teammate’s thread by id after a passed `ctx.access.check()`; now non-owner, non-admin calls return Forbidden. Reads remain org‑wide.

- New `assertThreadWritable(thread, caller)` in helpers uses `hasAdminRole` from `@decocms/shared/auth/roles`; applied in `COLLECTION_THREADS_UPDATE` and `COLLECTION_THREADS_DELETE` after the fetch.
- No schema/storage changes. Client impact: members can no longer mutate teammates’ threads; use the owner account or an admin/owner role.

**Tests**
- Unit: owner allow; non-owner deny; admin/owner bypass; multi-role string; undefined userId/role.
- E2E: member B denied UPDATE/DELETE of member A’s thread; A and org owner allowed; READ unchanged.

<sup>Written for commit 1a9823a2877cfe6856b567a280b214fb2314864c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

