### PR TITLE
fix(settings): translate join-request approve/deny toasts

### DIFF
--- a/apps/web/src/hooks/use-join-requests.ts
+++ b/apps/web/src/hooks/use-join-requests.ts
@@ -2,6 +2,7 @@ import { useCapabilities } from "@/hooks/use-capability";
 import { KEYS } from "@/lib/query-keys";
 import { useStudioTools } from "@/lib/studio-tools";
 import { useProjectContext } from "@/sdk";
+import { useT } from "@/i18n/use-t.ts";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
@@ -38,6 +39,7 @@ export function useJoinRequestActions() {
   const { org, locator } = useProjectContext();
   const studio = useStudioTools();
   const queryClient = useQueryClient();
+  const t = useT();
 
   const invalidate = () => {
     queryClient.invalidateQueries({
@@ -51,10 +53,14 @@ export function useJoinRequestActions() {
       studio.call("ORGANIZATION_JOIN_REQUEST_APPROVE", { requestId }),
     onSuccess: () => {
       invalidate();
-      toast.success("Request approved");
+      toast.success(t("settings.joinRequestsSection.approved"));
     },
     onError: (err) =>
-      toast.error(err instanceof Error ? err.message : "Failed to approve"),
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : t("settings.joinRequestsSection.approveFailed"),
+      ),
   });
 
   const deny = useMutation({
@@ -62,10 +68,14 @@ export function useJoinRequestActions() {
       studio.call("ORGANIZATION_JOIN_REQUEST_DENY", { requestId }),
     onSuccess: () => {
       invalidate();
-      toast.success("Request denied");
+      toast.success(t("settings.joinRequestsSection.denied"));
     },
     onError: (err) =>
-      toast.error(err instanceof Error ? err.message : "Failed to deny"),
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : t("settings.joinRequestsSection.denyFailed"),
+      ),
   });
 
   return { approve, deny };

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -433,7 +433,11 @@ export const settings = {
   "settings.editProviderDialog.saving": "Saving...",
   "settings.editProviderDialog.showApiKey": "Show API key",
   "settings.joinRequestsSection.approve": "Approve",
+  "settings.joinRequestsSection.approveFailed": "Failed to approve",
+  "settings.joinRequestsSection.approved": "Request approved",
   "settings.joinRequestsSection.deny": "Deny",
+  "settings.joinRequestsSection.denied": "Request denied",
+  "settings.joinRequestsSection.denyFailed": "Failed to deny",
   "settings.joinRequestsSection.description":
     "People who requested to join via a domain in approval mode.",
   "settings.joinRequestsSection.title": "Join requests",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -448,7 +448,11 @@ export const settings = {
   "settings.editProviderDialog.saving": "Salvando...",
   "settings.editProviderDialog.showApiKey": "Mostrar chave de API",
   "settings.joinRequestsSection.approve": "Aprovar",
+  "settings.joinRequestsSection.approveFailed": "Falha ao aprovar",
+  "settings.joinRequestsSection.approved": "Solicita\u00e7\u00e3o aprovada",
   "settings.joinRequestsSection.deny": "Recusar",
+  "settings.joinRequestsSection.denied": "Solicita\u00e7\u00e3o recusada",
+  "settings.joinRequestsSection.denyFailed": "Falha ao recusar",
   "settings.joinRequestsSection.description":
     "Pessoas que solicitaram entrada por um dom\u00ednio em modo de aprova\u00e7\u00e3o.",
   "settings.joinRequestsSection.title": "Solicita\u00e7\u00f5es de entrada",


### PR DESCRIPTION
The admin billing page (#5863) is still an open PR — nothing on main under apps/web/src/routes/admin lands billing yet, so this focuses on the adjacent components/settings surface (join-requests-section.tsx, used on the org members admin page for domain-join approvals).

**Bug:** `useJoinRequestActions` in `use-join-requests.ts` hardcoded the approve/deny success and fallback-error toast strings in English (`"Request approved"`, `"Request denied"`, `"Failed to approve"`, `"Failed to deny"`), bypassing the repo's i18n system even though the surrounding `join-requests-section.tsx` component and its dictionary keys (`settings.joinRequestsSection.*`) already exist and are threaded through `t()`. A pt-br user approving/denying a join request saw English toasts.

**Fix:** added `approved`/`denied`/`approveFailed`/`denyFailed` keys to `en/settings.ts` and `pt-br/settings.ts`, and routed the four toast calls through `useT()`.

How to confirm: switch language to pt-br in preferences, approve or deny a pending join request on the org members page, see the toast in Portuguese.

Checks run locally: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on the three touched files (0 warnings/errors). No test needed — this is a pure string/translation-plumbing change, not new logic. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes join-request approval/denial toasts. Previously success and fallback error toasts were hardcoded in English; now they use existing i18n keys so users see messages in their selected language (including pt-BR).

- Route toast messages in `useJoinRequestActions` through `useT()`. Use the server error message when present; otherwise use translated fallbacks.
- Add `approved`, `denied`, `approveFailed`, and `denyFailed` keys to `en/settings.ts` and `pt-br/settings.ts`.
- No logic changes to mutations or cache invalidation; no migration required. QA: set language to pt-BR, approve/deny a join request, verify localized toasts.

<sup>Written for commit 3748d7cbcd19915adb048f2f35c9731499e34d4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

