### PR TITLE
fix(connections): stop dev-assets pagination from dropping a real connection

### DIFF
--- a/apps/api/src/tools/connection/dev-assets-page.test.ts
+++ b/apps/api/src/tools/connection/dev-assets-page.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   finalizeNonBindingPage,
+  resolveDevAssetsSqlWindow,
   shouldConsiderDevAssetsForPage,
 } from "./dev-assets-page";
 
@@ -42,5 +43,44 @@ describe("finalizeNonBindingPage", () => {
     expect(result.items).toEqual([0, 1, 2, 3, 4]);
     expect(result.totalCount).toBe(5);
     expect(result.hasMore).toBe(false);
+  });
+});
+
+describe("resolveDevAssetsSqlWindow", () => {
+  test("passes the requested window through unchanged when it doesn't qualify", () => {
+    expect(resolveDevAssetsSqlWindow(100, 50, false)).toEqual({
+      sqlOffset: 100,
+      sqlLimit: 50,
+    });
+  });
+
+  test("reserves one slot on page 1 when it qualifies", () => {
+    expect(resolveDevAssetsSqlWindow(0, 100, true)).toEqual({
+      sqlOffset: 0,
+      sqlLimit: 99,
+    });
+  });
+
+  test("never goes negative when limit is 0", () => {
+    expect(resolveDevAssetsSqlWindow(0, 0, true)).toEqual({
+      sqlOffset: 0,
+      sqlLimit: 0,
+    });
+  });
+
+  test("shifts a later page's real-row offset back by one", () => {
+    expect(resolveDevAssetsSqlWindow(100, 100, true)).toEqual({
+      sqlOffset: 99,
+      sqlLimit: 100,
+    });
+  });
+
+  test("proves no real row is lost across the page-1/page-2 boundary", () => {
+    // 100 real rows, limit 100: page 1 fetches rows [0, 99) plus dev-assets.
+    const page1 = resolveDevAssetsSqlWindow(0, 100, true);
+    expect(page1).toEqual({ sqlOffset: 0, sqlLimit: 99 });
+    // Page 2 must resume at row 99, the one page 1's synthetic slot bumped.
+    const page2 = resolveDevAssetsSqlWindow(100, 100, true);
+    expect(page2).toEqual({ sqlOffset: 99, sqlLimit: 100 });
   });
 });

--- a/apps/api/src/tools/connection/dev-assets-page.ts
+++ b/apps/api/src/tools/connection/dev-assets-page.ts
@@ -17,15 +17,39 @@ export function shouldConsiderDevAssetsForPage(
   return needsBindingFilter || offset === 0;
 }
 
+/**
+ * `devAssetsQualifies` is whether the row qualifies for this listing at all,
+ * not whether it landed on this specific page — totalCount must include it
+ * on every page or a later page's `hasMore` undercounts by one.
+ */
 export function finalizeNonBindingPage<T>(
   connections: T[],
-  devAssetsInjected: boolean,
+  devAssetsQualifies: boolean,
   limit: number,
   offset: number,
   sqlTotalCount: number,
 ): { items: T[]; totalCount: number; hasMore: boolean } {
-  const totalCount = devAssetsInjected ? sqlTotalCount + 1 : sqlTotalCount;
-  const items = devAssetsInjected ? connections.slice(0, limit) : connections;
+  const totalCount = devAssetsQualifies ? sqlTotalCount + 1 : sqlTotalCount;
+  const items = connections.slice(0, limit);
   const hasMore = offset + limit < totalCount;
   return { items, totalCount, hasMore };
+}
+
+/**
+ * The synthetic row occupies one slot of the virtual list
+ * `[dev-assets, ...real rows]`; translate the caller's offset/limit over
+ * that virtual list into the SQL offset/limit over real rows, so the
+ * synthetic row never displaces — and then permanently drops — a real row
+ * across a page boundary.
+ */
+export function resolveDevAssetsSqlWindow(
+  offset: number,
+  limit: number,
+  devAssetsQualifies: boolean,
+): { sqlOffset: number; sqlLimit: number } {
+  if (!devAssetsQualifies) return { sqlOffset: offset, sqlLimit: limit };
+  if (offset === 0) {
+    return { sqlOffset: 0, sqlLimit: Math.max(limit - 1, 0) };
+  }
+  return { sqlOffset: offset - 1, sqlLimit: limit };
 }

--- a/apps/api/src/tools/connection/list.ts
+++ b/apps/api/src/tools/connection/list.ts
@@ -39,6 +39,7 @@ import {
 } from "./dev-assets";
 import {
   finalizeNonBindingPage,
+  resolveDevAssetsSqlWindow,
   shouldConsiderDevAssetsForPage,
 } from "./dev-assets-page";
 import { type ConnectionEntity, ConnectionEntitySchema } from "./schema";
@@ -159,6 +160,27 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
     const limit = input.limit ?? 100;
     const offset = input.offset ?? 0;
 
+    // Whether dev-assets qualifies for this listing, needed up front to size the SQL window — see dev-assets-page.ts.
+    const baseUrl = getBaseUrl();
+    const devAssetsId = WellKnownOrgMCPId.DEV_ASSETS(organization.id);
+    const devAssetsCandidate = createDevAssetsConnectionEntity(
+      organization.id,
+      baseUrl,
+    );
+    const devAssetsMatchesFilters =
+      (!input.slug || getConnectionSlug(devAssetsCandidate) === input.slug) &&
+      connectionMatchesWhere(devAssetsCandidate, input.where);
+    const devAssetsQualifies =
+      usesLocalObjectStorage() &&
+      !needsBindingFilter &&
+      devAssetsMatchesFilters;
+
+    const { sqlOffset, sqlLimit } = resolveDevAssetsSqlWindow(
+      offset,
+      limit,
+      devAssetsQualifies,
+    );
+
     const { items: connections, totalCount: sqlTotalCount } =
       await ctx.storage.connections.list(organization.id, {
         includeVirtual: input.include_virtual ?? false,
@@ -166,8 +188,8 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
         where: input.where,
         orderBy: input.orderBy,
         // Only push pagination to SQL when no post-filtering is needed
-        limit: needsBindingFilter ? undefined : limit,
-        offset: needsBindingFilter ? undefined : offset,
+        limit: needsBindingFilter ? undefined : sqlLimit,
+        offset: needsBindingFilter ? undefined : sqlOffset,
       });
 
     // Only fetch tools from MCP servers when we need them for binding filtering.
@@ -216,35 +238,13 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
     // When no external S3 bucket is configured, inject the dev-assets
     // connection so the OBJECT_STORAGE binding is satisfied by the local
     // DevObjectStorage filesystem fallback.
-    let devAssetsInjected = false;
     if (
       usesLocalObjectStorage() &&
-      shouldConsiderDevAssetsForPage(needsBindingFilter, offset)
+      shouldConsiderDevAssetsForPage(needsBindingFilter, offset) &&
+      devAssetsMatchesFilters &&
+      !connections.some((c) => c.id === devAssetsId)
     ) {
-      const baseUrl = getBaseUrl();
-      const devAssetsId = WellKnownOrgMCPId.DEV_ASSETS(organization.id);
-
-      // Only add it when it isn't already present and when it would satisfy the
-      // caller's filters. The dev-assets row is injected after the SQL query, so
-      // without re-checking the slug and `where` filters here it would bypass
-      // them — e.g. leaking into the agent instance selector's `app_name` filter
-      // and appearing as a selectable instance for every connection.
-      if (!connections.some((c) => c.id === devAssetsId)) {
-        const devAssetsConnection = createDevAssetsConnectionEntity(
-          organization.id,
-          baseUrl,
-        );
-        const slugMatches =
-          !input.slug || getConnectionSlug(devAssetsConnection) === input.slug;
-        const whereMatches = connectionMatchesWhere(
-          devAssetsConnection,
-          input.where,
-        );
-        if (slugMatches && whereMatches) {
-          connections.unshift(devAssetsConnection);
-          devAssetsInjected = true;
-        }
-      }
+      connections.unshift(devAssetsCandidate);
     }
 
     // Binding filter: SQL already handled where/orderBy, we just need to
@@ -289,7 +289,7 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
     // Non-binding path: SQL already handled where/orderBy/pagination.
     return finalizeNonBindingPage(
       connections,
-      devAssetsInjected,
+      devAssetsQualifies,
       limit,
       offset,
       sqlTotalCount,


### PR DESCRIPTION
**Bug**, found while auditing `apps/api/src/tools/connection/list.ts` (`COLLECTION_CONNECTIONS_LIST`).

When no external object storage is configured (`usesLocalObjectStorage()`), the tool injects a synthetic "Local Files" (dev-assets) pseudo-connection on top of the SQL page. On a non-binding listing whose first page's SQL result was already exactly `limit` rows, the synthetic row got `unshift`ed onto the full page and then sliced back down to `limit` in `finalizeNonBindingPage`, silently dropping the last real connection returned by SQL. `totalCount` was bumped by 1 to account for the synthetic row, so `hasMore` correctly stayed `true` and the client requested page 2 — but page 2's SQL `offset` was never adjusted for the row the synthetic slot had displaced, so that connection was skipped and never returned on **any** page.

**Failure scenario:** an org with no external S3 bucket configured and more real connections than one page size (e.g. exactly `limit=100` or more real rows) permanently loses one connection from every non-binding, paginated listing.

**Fix:** compute whether dev-assets qualifies for the listing (`usesLocalObjectStorage() && !needsBindingFilter && slug/where match`) *before* the SQL call, independent of the requested page. A new pure helper, `resolveDevAssetsSqlWindow(offset, limit, devAssetsQualifies)` (`dev-assets-page.ts`), translates the caller's virtual offset/limit (over `[dev-assets, ...real rows]`) into the correct SQL offset/limit over real rows: page 1 fetches one fewer real row to leave room for the synthetic one, and every later page starts its real-row offset one earlier. `finalizeNonBindingPage`'s `totalCount` bump now also uses "qualifies" instead of "was actually injected on this page", since the real total needs the +1 on every page for `hasMore` to stay correct.

**Regression test:** `dev-assets-page.test.ts` adds a `resolveDevAssetsSqlWindow` suite, including one test that walks page 1 → page 2 with 100 real rows and a `limit=100` and asserts no row is skipped across the boundary (the exact scenario that was broken).

**Verify:** `bun test apps/api/src/tools/connection/dev-assets-page.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test above (11 pass), and `bunx oxlint` on the three changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops non-binding pagination from dropping a real connection when injecting the dev‑assets pseudo‑connection under local object storage. Old: page 1 overflowed and sliced off one real row, and page 2 used an unadjusted offset so that row was never returned; new: decide dev‑assets eligibility before SQL and translate the requested window to the correct SQL offset/limit, with `totalCount` reflecting the synthetic row on every page so `hasMore` stays correct.

- Precompute `devAssetsQualifies` and use `resolveDevAssetsSqlWindow(offset, limit, devAssetsQualifies)` so page 1 fetches one fewer real row and later pages shift the SQL offset back by one.
- Inject the dev‑assets candidate only on page 1 when it qualifies and is not already present, while still honoring `slug` and `where`.
- `finalizeNonBindingPage` now bumps `totalCount` based on eligibility and always slices to `limit`; regression tests cover the page‑1/page‑2 boundary (`bun test apps/api/src/tools/connection/dev-assets-page.test.ts`).

<sup>Written for commit 7c501c89dfdce8b75181c2e02396645e2f7b65df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

