### PR TITLE
refactor(connection): dedupe MCP tool-list mapping across fetch-tools transports

### DIFF
--- a/apps/api/src/tools/connection/fetch-tools.ts
+++ b/apps/api/src/tools/connection/fetch-tools.ts
@@ -112,6 +112,39 @@ export function buildConnectionRequestHeaders(
 }
 
 /**
+ * Maps a `listTools()` result into our stored `ToolDefinition[]` shape.
+ * Shared by the HTTP and SSE fetchers, which map identically; STDIO omits
+ * the `additionalProperties` relaxation since its output schemas aren't
+ * meant to be lenient the same way a remote server's are.
+ */
+function mapListedTools(
+  tools: Array<{
+    name: string;
+    description?: string;
+    inputSchema?: unknown;
+    outputSchema?: Record<string, unknown>;
+    annotations?: unknown;
+    _meta?: unknown;
+  }>,
+  { relaxOutputSchema }: { relaxOutputSchema: boolean },
+): ToolDefinition[] | null {
+  if (tools.length === 0) return null;
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description ?? undefined,
+    inputSchema: tool.inputSchema ?? {},
+    outputSchema: tool.outputSchema
+      ? relaxOutputSchema
+        ? // We strive to have lenient output schemas, so allow additional properties
+          { ...tool.outputSchema, additionalProperties: true }
+        : tool.outputSchema
+      : undefined,
+    annotations: tool.annotations ?? undefined,
+    _meta: tool._meta ?? undefined,
+  })) as ToolDefinition[];
+}
+
+/**
  * Try to fetch configuration scopes from the MCP_CONFIGURATION tool.
  * Returns null if the tool is not implemented or the call fails.
  */
@@ -184,20 +217,9 @@ async function fetchToolsFromHttpMCP(
       "Connection timeout",
     );
 
-    const tools =
-      result.tools && result.tools.length > 0
-        ? result.tools.map((tool) => ({
-            name: tool.name,
-            description: tool.description ?? undefined,
-            inputSchema: tool.inputSchema ?? {},
-            outputSchema: tool.outputSchema
-              ? // We strive to have lenient output schemas, so allow additional properties
-                { ...tool.outputSchema, additionalProperties: true }
-              : undefined,
-            annotations: tool.annotations ?? undefined,
-            _meta: tool._meta ?? undefined,
-          }))
-        : null;
+    const tools = mapListedTools(result.tools ?? [], {
+      relaxOutputSchema: true,
+    });
 
     const scopes = await fetchScopesFromMCP(client);
 
@@ -262,19 +284,9 @@ async function fetchToolsFromSSEMCP(
       "SSE connection timeout",
     );
 
-    const tools =
-      result.tools && result.tools.length > 0
-        ? result.tools.map((tool) => ({
-            name: tool.name,
-            description: tool.description ?? undefined,
-            inputSchema: tool.inputSchema ?? {},
-            outputSchema: tool.outputSchema
-              ? { ...tool.outputSchema, additionalProperties: true }
-              : undefined,
-            annotations: tool.annotations ?? undefined,
-            _meta: tool._meta ?? undefined,
-          }))
-        : null;
+    const tools = mapListedTools(result.tools ?? [], {
+      relaxOutputSchema: true,
+    });
 
     const scopes = await fetchScopesFromMCP(client);
 
@@ -345,17 +357,9 @@ async function fetchToolsFromStdioMCP(
       "Tool fetch timeout",
     );
 
-    const tools =
-      result.tools && result.tools.length > 0
-        ? result.tools.map((tool) => ({
-            name: tool.name,
-            description: tool.description ?? undefined,
-            inputSchema: tool.inputSchema ?? {},
-            outputSchema: tool.outputSchema ?? undefined,
-            annotations: tool.annotations ?? undefined,
-            _meta: tool._meta ?? undefined,
-          }))
-        : null;
+    const tools = mapListedTools(result.tools ?? [], {
+      relaxOutputSchema: false,
+    });
 
     const scopes = await fetchScopesFromMCP(client);
 


### PR DESCRIPTION
**Source:** reduction found while auditing `apps/api/src/tools/connection/` for the per-user/org-shared MCP connections area (issue #5661 has no bounded scaffolding to work with yet — every prior pass on this area confirms it's ground-up work; see repo memory `mcp-connection-outbound-area-dry-w4-2026-08-21`).

**What:** `fetch-tools.ts`'s HTTP, SSE, and STDIO tool fetchers each hand-rolled the identical `result.tools.map(tool => ({ name, description, inputSchema, outputSchema, annotations, _meta }))` block (HTTP and SSE were byte-identical; STDIO only differs by not relaxing `outputSchema.additionalProperties`). Extracted a single `mapListedTools(tools, { relaxOutputSchema })` helper and call it from all three fetchers instead.

**Why a maintainer wants it:** one call site to touch when the tool-shape mapping changes (a new field, a schema tweak) instead of three that can silently drift — HTTP/SSE were already in sync by coincidence, not by construction.

**Behavior preserved:** same field mapping, same `relaxOutputSchema` semantics per transport (HTTP/SSE keep `additionalProperties: true` on the output schema, STDIO does not), same `null` return when the tool list is empty.

**Verify:** `cd apps/api && bunx tsc --noEmit` (clean) and `bun test apps/api/src/tools/connection/fetch-tools.test.ts` (4 pass, unchanged). `bunx oxlint apps/api/src/tools/connection/fetch-tools.ts` — 0 warnings/errors. `bun run fmt` — no changes needed.

Locally ran: typecheck (api workspace), the one targeted test file, and per-file oxlint, all above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the MCP tool-list mapping across HTTP, SSE, and STDIO fetchers by introducing a shared mapper. This prevents transport drift and makes tool-shape changes single-touch; behavior is unchanged.

**Review notes**
- Added `mapListedTools(tools, { relaxOutputSchema })`; HTTP/SSE call with `true`, STDIO with `false`.
- Mapping preserves: `name`, `description`, `annotations`, `_meta`; `inputSchema` defaults to `{}`; `outputSchema` passes through or adds `additionalProperties: true` when relaxed; returns `null` when no tools.
- Scope: only `apps/api/src/tools/connection/fetch-tools.ts` changed; existing tests and type checks remain green.

<sup>Written for commit 29f3a95ffc6540bd7cb1f9125459799566c3e5aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

