### PR TITLE
fix(task-board): assign chat PR-open cards to the Super Agent so reviewers run

### DIFF
--- a/apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts
@@ -3,6 +3,7 @@
  *  update whitelist or the link tables, so this runs against real Postgres. */
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import { sql } from "kysely";
 import type { StudioDatabase } from "../../database";
 import {
@@ -31,7 +32,13 @@ describe("applyBoardDecision", () => {
   let database: StudioDatabase;
   let taskBoard: TaskBoardStorage;
 
-  const THREADS = ["thr_create", "thr_update", "thr_fallback", "thr_done"];
+  const THREADS = [
+    "thr_create",
+    "thr_update",
+    "thr_human",
+    "thr_fallback",
+    "thr_done",
+  ];
 
   const apply = (
     decision: BoardDecision,
@@ -95,6 +102,8 @@ describe("applyBoardDecision", () => {
     expect(item).not.toBeNull();
     expect(item!.status).toBe("in_review");
     expect(item!.title).toBe("Ship the widget");
+    // Owned by the Super Agent — otherwise the reviewers never pick the card up.
+    expect(item!.assigneeId).toBe(SUPER_AGENT_ASSIGNEE_ID);
 
     const prs = await taskBoard.listPrs(item!.id, ORG);
     expect(prs.map((p) => p.number)).toEqual([7]);
@@ -120,9 +129,30 @@ describe("applyBoardDecision", () => {
     );
     expect(item!.id).toBe(card.id);
     expect(item!.status).toBe("in_review");
+    // Was unassigned, so advancing into review claims it for the Super Agent.
+    expect(item!.assigneeId).toBe(SUPER_AGENT_ASSIGNEE_ID);
     const prs = await taskBoard.listPrs(card.id, ORG);
     expect(prs.map((p) => p.number)).toEqual([7]);
     expect(await taskBoard.linkedTaskIds("thr_update", ORG)).toContain(card.id);
+  });
+
+  it("update leaves a human assignee in place when advancing to review", async () => {
+    const card = await taskBoard.create({
+      organizationId: ORG,
+      title: "human owned",
+      status: "in_progress",
+      assigneeId: USER,
+      by: USER,
+    });
+    const item = await apply(
+      { action: "update", taskId: card.id },
+      [card],
+      "thr_human",
+    );
+    expect(item!.id).toBe(card.id);
+    expect(item!.status).toBe("in_review");
+    // A human owns it — the claim must not steal the card from them.
+    expect(item!.assigneeId).toBe(USER);
   });
 
   it("update with an unknown taskId falls back to creating a card", async () => {
@@ -159,6 +189,8 @@ describe("applyBoardDecision", () => {
     );
     expect(item!.id).toBe(card.id);
     expect(item!.status).toBe("done");
+    // A terminal card is not advanced, so it is not claimed either.
+    expect(item!.assigneeId).toBeNull();
     const prs = await taskBoard.listPrs(card.id, ORG);
     expect(prs.map((p) => p.number)).toEqual([7]);
   });

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -5,7 +5,7 @@
  * `advanceTaskBoardForRun` + `capturePrForRun` move/link it. A plain chat with
  * a GitHub-imported agent has no card, so nothing happens. This reaction fills
  * that gap: one focused LLM call decides whether the work is already tracked,
- * then the action runs in code (create/update the card, link the PR + thread).
+ * then the action runs in code (create/update the card, link the PR + thread, claim it for the Super Agent so reviewers pick it up).
  *
  * Kept as code (not a system-prompt instruction the main loop may skip) so the
  * bookkeeping is deterministic; kept as a single LLM call (not a heuristic) so
@@ -15,6 +15,7 @@
 
 import { generateObject } from "ai";
 import { z } from "zod";
+import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import type { StudioContext } from "@/core/studio-context";
 import { resolveTier } from "@/core/resolve-tier";
 import type { TaskBoardStorage } from "@/storage/task-board";
@@ -155,14 +156,28 @@ export async function applyBoardDecision(
   let item: TaskBoardItem | null;
   if (target) {
     // Advance into review only from an earlier lane; never regress a finished card.
-    const status = ADVANCEABLE.has(target.status) ? "in_review" : undefined;
-    item = await storage.update(target.id, orgId, { status }, userId);
+    const advancing = ADVANCEABLE.has(target.status);
+    // Claim an unowned card for the Super Agent (reviewer dispatch gates on it); never a human's.
+    const claimSuperAgent = advancing && target.assigneeId == null;
+    item = await storage.update(
+      target.id,
+      orgId,
+      {
+        status: advancing ? "in_review" : undefined,
+        ...(claimSuperAgent
+          ? { assigneeId: SUPER_AGENT_ASSIGNEE_ID, assignedBy: userId }
+          : {}),
+      },
+      userId,
+    );
   } else {
-    // create (also the fallback when an `update` pointed at an unknown card)
+    // Create (also the unknown-taskId fallback), owned by the Super Agent so reviewers pick it up.
     item = await storage.create({
       organizationId: orgId,
       title: decision.title?.trim() || `PR #${pr.number}`,
       status: "in_review",
+      assigneeId: SUPER_AGENT_ASSIGNEE_ID,
+      assignedBy: userId,
       by: userId,
     });
   }


### PR DESCRIPTION
## Summary

Follow-up to #6344. When you open a PR from a plain chat, `reactToPrOpenedForBoard` puts the work on the board **for review** — but the card it created/updated (`applyBoardDecision`) was left **unassigned**. Both reviewer-dispatch paths gate on `assigneeId === SUPER_AGENT_ASSIGNEE_ID`:

- the review sweeper's `reconcileItem` (`review-sweeper.ts` — `if (!owned) return false` right before `enqueueEnabledReviewers`), and
- the dialog poll `TASK_BOARD_ITEM_PRS_GET` (`prs-get.ts`).

So an unassigned In Review card was **never handed to QA / code review**. And because no reviewer ever approved, `reviewsSatisfiedForPromotion` stayed false and the **"Ship to production"** button never appeared — the card just sat In Review with a linked PR and no reviewers.

## What changed

`applyBoardDecision` now claims the card for the Super Agent:

- **Create** (and the unknown-`taskId` fallback): `assigneeId: SUPER_AGENT_ASSIGNEE_ID` + `assignedBy: userId`.
- **Update**: when advancing an **unowned** card into review, claim it. Never steals an existing **human** assignee; never touches a **terminal** (`done`) card.

Effect: the sweeper (≤60s/tick, ≤5min/card) now passes the `owned` gate and dispatches QA + code review; once both approve, "Ship to production" shows.

## Testing

- Integration (real Postgres) `pr-open-board-reaction.integration.test.ts`: asserts the assignee on create, on unowned-update (claimed), on **human-owned update (preserved)** — a new case — and on done (stays `null`). **5 pass / 0 fail.**
- `bun run check` (tsc), `bun run fmt`, `bun run lint` clean (only pre-existing warnings in untouched files).

## Note

No retroactive backfill: cards already created unassigned by the old code stay unowned. They can be reassigned to the Super Agent manually to unstick them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Assigns PR-open chat task-board cards to the Super Agent so review dispatch runs. Old: cards advanced to In Review but stayed unassigned and never reached QA/code review; New: on create and when advancing an unowned card, assign to the Super Agent, never overwriting a human assignee or touching a done card.

- Review notes: `applyBoardDecision` now sets `assigneeId` to the Super Agent on create and on update when advancing an unowned card; unknown `taskId` falls back to create with Super Agent ownership.
- Tests: Integration covers create, unowned update (claimed), human-owned update (preserved), and done (untouched); all pass. Lint/format/type checks clean.
- Migration: Existing unassigned In Review cards remain; manually assign them to the Super Agent to trigger reviewers and surface “Ship to production.”

<sup>Written for commit 3fae77e7c21f033801463617e9caa37d165c3e8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

