### PR TITLE
fix(preview): rank page picker by relevance, not alphabetically

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -257,6 +257,34 @@ export function resolvePreviewUrl(path: string, base: string): string | null {
 }
 
 /**
+ * Relevance score for a page-picker hit against a lowercased query `q`.
+ * Higher is better; `0` means no match. Ranks closer/more-specific matches
+ * first so `/masculino` beats `/joias/colares/masculino` for the query
+ * "masculino", instead of falling back to alphabetical order by title.
+ */
+function pageMatchScore(name: string, path: string, q: string): number {
+  const n = name.toLowerCase();
+  const p = path.toLowerCase();
+  const segments = p.split("/").filter(Boolean);
+  const textScore = (text: string): number => {
+    if (text === q) return 100;
+    const idx = text.indexOf(q);
+    if (idx === -1) return 0;
+    let s = 40;
+    if (idx === 0)
+      s += 30; // starts with the query
+    else if (/[\s/-]/.test(text[idx - 1] ?? "")) s += 20; // segment boundary
+    s += Math.round((q.length / text.length) * 20); // query covers more = closer
+    return s;
+  };
+  let score = Math.max(textScore(n), textScore(p));
+  if (segments.at(-1) === q)
+    score = Math.max(score, 95); // query is the path's leaf segment
+  else if (segments.includes(q)) score = Math.max(score, 90); // whole segment
+  return score;
+}
+
+/**
  * Renders nothing; fires `onOpen` exactly once when mounted to auto-open the
  * CMS. Headless run-once helper mirroring `PathParamAutoFill`: the parent
  * mounts it only while the auto-open should happen (see `shouldAutoOpenCms`)
@@ -488,13 +516,23 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const globalLoaders =
     decofile && meta ? listSavedRunnables(meta, decofile, "loaders") : [];
   const normPath = normalizePagePath;
-  const filteredPages = pages.filter((page) => {
-    if (!pagesSearch) return true;
-    const q = pagesSearch.toLowerCase();
-    return (
-      page.name.toLowerCase().includes(q) || page.path.toLowerCase().includes(q)
-    );
-  });
+  const filteredPages = !pagesSearch
+    ? pages
+    : (() => {
+        const q = pagesSearch.toLowerCase();
+        // Stable sort keeps `pages`' alpha order as tie-break; shorter path wins.
+        return pages
+          .map((page) => ({
+            page,
+            score: pageMatchScore(page.name, page.path, q),
+          }))
+          .filter(({ score }) => score > 0)
+          .sort(
+            (a, b) =>
+              b.score - a.score || a.page.path.length - b.page.path.length,
+          )
+          .map(({ page }) => page);
+      })();
   const filteredGlobalSections = globalSections.filter((section) => {
     if (!pagesSearch) return true;
     const q = pagesSearch.toLowerCase();


### PR DESCRIPTION
## Summary

The page-search dropdown in the sandbox preview ranked results **alphabetically by title** and the search only did a substring filter that preserved that order. So when a shorter, more specific path existed — e.g. `/masculino` while searching "masculino" — it sank below deeper paths (`/joias/colares/masculino`, `/acessorios/carteiras/masculino`) that happened to sort earlier alphabetically.

Now results are **ranked by relevance** when there's a query.

## Changes

`apps/web/src/components/sandbox/preview/preview.tsx`

- New `pageMatchScore(name, path, q)` helper — higher score = closer match, `0` = no match:
  - exact string match → 100
  - query is the path's **leaf** segment (e.g. `/masculino`) → 95
  - query is a whole path segment anywhere → 90
  - otherwise a substring score boosting prefix / segment-boundary matches and matches where the query covers more of the string
- `filteredPages` now scores → drops non-matches → sorts by score desc, tie-breaking on **shorter path** then the pre-existing alphabetical order (stable sort).

Sections/loaders lists are unchanged.

## Example (query `masculino`)

`/masculino` now surfaces at the top, ahead of `/joias/colares/masculino` and friends; plural/partial hits (`/acessorios/masculinos`) and title-only matches ("Aniversário MC Masculino") rank below the exact-segment hits.

## Testing

- `bun run fmt` ✅
- `bun run --cwd=apps/web check` (tsc) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ranks sandbox preview page picker results by relevance instead of alphabetical title so exact and segment matches surface first. Previously we substring-filtered and preserved alphabetical order, which hid short exact paths under deeper ones.

- Add a relevance score helper to `preview.tsx`: exact match > leaf segment > whole segment > boosted substring (prefix/boundary and coverage). Score 0 means no match.
- When a query exists, map pages to scores, drop non-matches, and sort by score desc. Tie-break by shorter path, then the existing alphabetical order (stable).
- No changes to sections/loaders lists or the no-query behavior.

<sup>Written for commit eb4b40329291f66d2e6e3f8137c5905182c7362c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

