### PR TITLE
feat(jira): render mirrored comments as ADF, with screenshots as attachments

### DIFF
--- a/apps/api/src/dbos/step-errors.test.ts
+++ b/apps/api/src/dbos/step-errors.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { Error as DBOSErrors } from "@dbos-inc/dbos-sdk";
+import { isMaxStepRetriesError, MAX_STEP_RETRIES_CODE } from "./step-errors";
+
+describe("isMaxStepRetriesError", () => {
+  it("matches the code the SDK stamps on an exhausted step", () => {
+    const err = new DBOSErrors.DBOSMaxStepRetriesError("attachImage", 3, [
+      new Error("502"),
+    ]);
+    expect(DBOSErrors.getDBOSErrorCode(err)).toBe(MAX_STEP_RETRIES_CODE);
+    expect(isMaxStepRetriesError(err)).toBe(true);
+  });
+
+  it("matches a revived error, where the class and the name are both gone", () => {
+    const original = new DBOSErrors.DBOSMaxStepRetriesError("step", 1, []);
+    expect(original.name).toBe("Error");
+    const revived = Object.assign(new Error(original.message), {
+      dbosErrorCode: MAX_STEP_RETRIES_CODE,
+    });
+    expect(revived instanceof DBOSErrors.DBOSMaxStepRetriesError).toBe(false);
+    expect(isMaxStepRetriesError(revived)).toBe(true);
+  });
+
+  it("does not match the errors a workflow must not swallow", () => {
+    expect(
+      isMaxStepRetriesError(new DBOSErrors.DBOSWorkflowCancelledError("wf-1")),
+    ).toBe(false);
+    expect(
+      isMaxStepRetriesError(
+        new DBOSErrors.DBOSUnexpectedStepError("wf-1", 1, "a", "b"),
+      ),
+    ).toBe(false);
+    expect(isMaxStepRetriesError(new Error("plain"))).toBe(false);
+    expect(isMaxStepRetriesError("not an error")).toBe(false);
+  });
+});

--- a/apps/api/src/dbos/step-errors.ts
+++ b/apps/api/src/dbos/step-errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Spotting an exhausted step retry from inside a workflow.
+ *
+ * `instanceof DBOSMaxStepRetriesError` only holds on the first pass. On replay
+ * DBOS revives a recorded step error as a plain `Error` — whose `name` is
+ * "Error" too — so the numeric `dbosErrorCode` is the only part that survives
+ * the round trip. A workflow that catches exhausted retries in order to
+ * degrade must match on that, or it takes a different path after a recovery
+ * than it did before one.
+ */
+
+import { Error as DBOSErrors } from "@dbos-inc/dbos-sdk";
+
+/** `DBOSMaxStepRetriesError`'s code. Pinned against the SDK by a unit test. */
+export const MAX_STEP_RETRIES_CODE = 23;
+
+export function isMaxStepRetriesError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    DBOSErrors.getDBOSErrorCode(err) === MAX_STEP_RETRIES_CODE
+  );
+}

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -6,7 +6,7 @@
   "file-storage/dbos-org-repo-sync.ts": "32c606976916fde2be7abe3084f7388744bdb610c178e9c2a07a8080f764904e",
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",
   "harnesses/decopilot/background-tool-workflow.ts": "9febb699f45b63b418481ed998aee0ec8251c97cb5c409d54d714eb365a08fd0",
-  "jira/dbos-jira-sync.ts": "cb674d6793645ea895c2caef9eb94b1bcb4c00c8663c85fe17627decd5def029",
+  "jira/dbos-jira-sync.ts": "f0b69aea436e5fbd6b7486665bad910a6a27cbc1588c94508edffa3d932ce3ff",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",
   "tools/task-board/dbos-github-read.ts": "8757159d594f776d021ed28887e5ba51f7a6e007607a2dc6962efd53152b4d60",

--- a/apps/api/src/dbos/workflow-version.ts
+++ b/apps/api/src/dbos/workflow-version.ts
@@ -63,5 +63,14 @@
  *
  * Version 7 removes the per-seat billing workflows (`syncOrgBenefitsWorkflow`
  * + `benefitsSyncSweep`); in-flight v6 instances strand by design.
+ *
+ * Version 8 splits `jiraCommentPushWorkflow` from one step into one step per
+ * external call — `resolveCommentTarget`, `readOrgSlug`, `attachCommentImage`
+ * per screenshot, then `postCommentToJira` (which also gained recorded
+ * arguments). Added and reordered steps, so a v7 instance replayed against v8
+ * hits `stored.functionName !== funcName` on its first step and throws
+ * `DBOSUnexpectedStepError`; those instances strand instead, by design. The
+ * one already past its Jira POST is still not re-mirrored by the pull, which
+ * cuts the echo by author account as well as by comment link (`sync.ts`).
  */
-export const DBOS_WORKFLOW_VERSION = "7";
+export const DBOS_WORKFLOW_VERSION = "8";

--- a/apps/api/src/jira/client.test.ts
+++ b/apps/api/src/jira/client.test.ts
@@ -511,4 +511,80 @@ describe("JiraClient", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("posts a comment as rich ADF, with the author line kept unparsed", async () => {
+    const bodies: unknown[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async (_url: string, init: RequestInit) => {
+      bodies.push(JSON.parse(String(init.body)).body);
+      return new Response(JSON.stringify({ id: "10001" }), { status: 201 });
+    }) as unknown as typeof fetch;
+
+    try {
+      const client = new JiraClient(
+        "https://acme.atlassian.net",
+        "user@example.com",
+        "token",
+      );
+      await client.addComment("ISSUE-1", "**done** in `Footer.json`", {
+        header: "Super Agent *no* markup · via Studio:",
+      });
+      expect(bodies[0]).toEqual({
+        type: "doc",
+        version: 1,
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", text: "Super Agent *no* markup · via Studio:" },
+            ],
+          },
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", text: "done", marks: [{ type: "strong" }] },
+              { type: "text", text: " in " },
+              {
+                type: "text",
+                text: "Footer.json",
+                marks: [{ type: "code" }],
+              },
+            ],
+          },
+        ],
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("falls back to a flat body when Jira rejects the document with a 400", async () => {
+    const bodies: unknown[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async (_url: string, init: RequestInit) => {
+      bodies.push(JSON.parse(String(init.body)).body);
+      return bodies.length === 1
+        ? new Response('{"errors":{"body":"INVALID_INPUT"}}', { status: 400 })
+        : new Response(JSON.stringify({ id: "10002" }), { status: 201 });
+    }) as unknown as typeof fetch;
+
+    try {
+      const client = new JiraClient(
+        "https://acme.atlassian.net",
+        "user@example.com",
+        "token",
+      );
+      const created = await client.addComment("ISSUE-1", "**done**", {
+        header: "Super Agent · via Studio:",
+      });
+      expect(created).toEqual({ id: "10002" });
+      // The mirror survives the rejection, carrying the header and the body.
+      expect(bodies).toHaveLength(2);
+      expect(bodies[1]).toEqual(
+        textToAdf("Super Agent · via Studio:\n**done**"),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/apps/api/src/jira/client.test.ts
+++ b/apps/api/src/jira/client.test.ts
@@ -588,3 +588,119 @@ describe("JiraClient", () => {
     }
   });
 });
+
+describe("JiraClient.addAttachment", () => {
+  const client = () =>
+    new JiraClient("https://acme.atlassian.net", "user@example.com", "token");
+  const MEDIA = "44d205d6-7f67-4c3e-b58f-e5695f9c828c";
+
+  function stubFetch(handler: (url: string, init: RequestInit) => Response): {
+    calls: Array<{ url: string; init: RequestInit }>;
+    restore: () => void;
+  } {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const original = globalThis.fetch;
+    globalThis.fetch = mock(async (url: string, init: RequestInit = {}) => {
+      calls.push({ url: String(url), init });
+      return handler(String(url), init);
+    }) as unknown as typeof fetch;
+    return { calls, restore: () => (globalThis.fetch = original) };
+  }
+
+  it("uploads multipart with the XSRF opt-out and reads the media id off the redirect", async () => {
+    const stub = stubFetch((url) =>
+      url.endsWith("/attachments")
+        ? new Response(JSON.stringify([{ id: "44145" }]), { status: 200 })
+        : new Response(null, {
+            status: 303,
+            headers: {
+              location: `https://api.media.atlassian.com/file/${MEDIA}/binary?token=x`,
+            },
+          }),
+    );
+    try {
+      expect(
+        await client().addAttachment("OS-1", {
+          name: "shot.png",
+          bytes: new Uint8Array([1, 2, 3]),
+          contentType: "image/png",
+        }),
+      ).toEqual({ attachmentId: "44145", mediaId: MEDIA });
+
+      const upload = stub.calls[0];
+      expect(upload?.url).toBe(
+        "https://acme.atlassian.net/rest/api/3/issue/OS-1/attachments",
+      );
+      expect(upload?.init.body).toBeInstanceOf(FormData);
+      const headers = (upload?.init.headers ?? {}) as Record<string, string>;
+      // Jira refuses an unbrowsered multipart POST without this header.
+      expect(headers["X-Atlassian-Token"]).toBe("no-check");
+      expect(stub.calls[1]?.init.redirect).toBe("manual");
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("falls back to the followed URL when the location header is hidden", async () => {
+    const stub = stubFetch((url, init) => {
+      if (url.endsWith("/attachments")) {
+        return new Response(JSON.stringify([{ id: "44145" }]), { status: 200 });
+      }
+      // A filtered opaqueredirect exposes no headers; status 0 is unconstructable.
+      if (init.redirect === "manual")
+        return new Response(null, { status: 303 });
+      const followed = new Response(null, { status: 200 });
+      Object.defineProperty(followed, "url", {
+        value: `https://api.media.atlassian.com/file/${MEDIA}/binary`,
+      });
+      return followed;
+    });
+    try {
+      expect(
+        (
+          await client().addAttachment("OS-1", {
+            name: "shot.png",
+            bytes: new Uint8Array([1]),
+          })
+        ).mediaId,
+      ).toBe(MEDIA);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("reports a null media id rather than throwing when no uuid is found", async () => {
+    const stub = stubFetch((url) =>
+      url.endsWith("/attachments")
+        ? new Response(JSON.stringify([{ id: "44145" }]), { status: 200 })
+        : new Response(null, { status: 200 }),
+    );
+    try {
+      expect(
+        await client().addAttachment("OS-1", {
+          name: "shot.png",
+          bytes: new Uint8Array([1]),
+        }),
+      ).toEqual({ attachmentId: "44145", mediaId: null });
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("throws when the upload itself is refused, and never resolves an id", async () => {
+    const stub = stubFetch(
+      () => new Response("Attachment too large", { status: 413 }),
+    );
+    try {
+      await expect(
+        client().addAttachment("OS-1", {
+          name: "shot.png",
+          bytes: new Uint8Array([1]),
+        }),
+      ).rejects.toThrow("413");
+      expect(stub.calls).toHaveLength(1);
+    } finally {
+      stub.restore();
+    }
+  });
+});

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -8,6 +8,7 @@
  */
 
 import { retry } from "@decocms/shared/std";
+import { markdownToAdf } from "./markdown-adf";
 import {
   collectWikiMentionAccountIds,
   escapeMentionName,
@@ -73,18 +74,28 @@ export interface JiraComment {
 const ISSUE_FIELDS =
   "summary,status,priority,issuetype,updated,description,comment";
 
+/** A non-2xx answer from Jira, carrying the status so a caller can react to a
+ *  specific one (a 400 means the request body was refused, not the request). */
+class JiraRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "JiraRequestError";
+  }
+}
+
 /**
  * Determine if a fetch error should be retried. Transient failures (5xx, timeout,
  * network error) should retry; permanent failures (4xx, auth) should fail fast.
  */
 function isRetriableError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  const statusMatch = message.match(/failed \((\d+)\)/);
-  if (statusMatch && statusMatch[1]) {
-    const status = parseInt(statusMatch[1], 10);
-    // Retry 5xx and 429 (rate limit); do NOT retry 4xx (auth, not found, etc.).
-    return status >= 500 || status === 429;
+  // Retry 5xx and 429 (rate limit); do NOT retry 4xx (auth, not found, etc.).
+  if (error instanceof JiraRequestError) {
+    return error.status >= 500 || error.status === 429;
   }
+  const message = error instanceof Error ? error.message : String(error);
   // Malformed JSON is deterministic, not transient — don't retry it.
   if (/returned invalid JSON/.test(message)) return false;
   // No status — a raw fetch/network throw. Retry with caution.
@@ -169,8 +180,9 @@ export class JiraClient {
         });
       }
       if (!response.ok) {
-        throw new Error(
+        throw new JiraRequestError(
           `Jira ${path} failed (${response.status}): ${body.slice(0, 300)}`,
+          response.status,
         );
       }
       // Transition POSTs answer 204 with an empty body.
@@ -379,18 +391,43 @@ export class JiraClient {
     return comments;
   }
 
-  /** Post a comment (as the credential's account). Returns the Jira id. */
-  async addComment(issueId: string, text: string): Promise<{ id: string }> {
-    return this.request(
-      `/rest/api/3/issue/${encodeURIComponent(issueId)}/comment`,
-      { method: "POST", body: JSON.stringify({ body: textToAdf(text) }) },
-      { idempotent: false },
-    );
+  /**
+   * Post a comment (as the credential's account). Returns the Jira id.
+   *
+   * `markdown` is a board comment, rendered to ADF so the issue shows
+   * formatted text instead of raw `**syntax**`. `header` is prepended as its
+   * own plain paragraph — it carries a tenant-supplied display name, which
+   * must not be parsed as markup.
+   *
+   * A 400 is Jira refusing the document, so nothing was created and reposting
+   * cannot duplicate: fall back once to the flat plain-text body rather than
+   * losing the mirror, since the push step is deliberately non-retriable. Any
+   * other status propagates.
+   */
+  async addComment(
+    issueId: string,
+    markdown: string,
+    { header }: { header?: string } = {},
+  ): Promise<{ id: string }> {
+    const path = `/rest/api/3/issue/${encodeURIComponent(issueId)}/comment`;
+    const post = (body: unknown) =>
+      this.request<{ id: string }>(
+        path,
+        { method: "POST", body: JSON.stringify({ body }) },
+        { idempotent: false },
+      );
+    try {
+      return await post(markdownToAdf(markdown, { header }));
+    } catch (err) {
+      if (!(err instanceof JiraRequestError) || err.status !== 400) throw err;
+      console.warn(`[jira] comment rejected as ADF, posting flat: ${err}`);
+      return post(textToAdf(header ? `${header}\n${markdown}` : markdown));
+    }
   }
 }
 
-/** Plain text → minimal ADF: one paragraph per non-empty line. Rich
- *  formatting (bold, images, links-as-cards) is dropped on purpose. */
+/** Plain text → minimal ADF: one paragraph per non-empty line. The fallback
+ *  for a body `markdownToAdf` renders into something Jira refuses. */
 export function textToAdf(text: string): unknown {
   const lines = text.split("\n").filter((line) => line.trim() !== "");
   return {

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -8,7 +8,7 @@
  */
 
 import { retry } from "@decocms/shared/std";
-import { markdownToAdf } from "./markdown-adf";
+import { type AdfMedia, markdownToAdf } from "./markdown-adf";
 import {
   collectWikiMentionAccountIds,
   escapeMentionName,
@@ -17,6 +17,10 @@ import {
 } from "./wiki-markdown";
 
 const REQUEST_TIMEOUT_MS = 15_000;
+
+/** Attachment uploads carry screenshot bytes, so they get their own budget —
+ *  a QA run's PNG is orders of magnitude larger than any JSON call here. */
+const UPLOAD_TIMEOUT_MS = 60_000;
 
 /** Account ids per `/user/bulk` request. Jira allows 200, but each id spends
  *  ~56 URL bytes, so 200 would build a ~11KB request line — past the 4KB cap
@@ -407,7 +411,10 @@ export class JiraClient {
   async addComment(
     issueId: string,
     markdown: string,
-    { header }: { header?: string } = {},
+    {
+      header,
+      media,
+    }: { header?: string; media?: ReadonlyMap<string, AdfMedia> } = {},
   ): Promise<{ id: string }> {
     const path = `/rest/api/3/issue/${encodeURIComponent(issueId)}/comment`;
     const post = (body: unknown) =>
@@ -417,11 +424,113 @@ export class JiraClient {
         { idempotent: false },
       );
     try {
-      return await post(markdownToAdf(markdown, { header }));
+      return await post(markdownToAdf(markdown, { header, media }));
     } catch (err) {
       if (!(err instanceof JiraRequestError) || err.status !== 400) throw err;
       console.warn(`[jira] comment rejected as ADF, posting flat: ${err}`);
       return post(textToAdf(header ? `${header}\n${markdown}` : markdown));
+    }
+  }
+
+  /** Attachments already on the issue — the dedup check for a re-push. */
+  async listAttachments(
+    issueId: string,
+  ): Promise<Array<{ id: string; filename: string; size: number }>> {
+    const issue = await this.request<{
+      fields?: {
+        attachment?: Array<{ id: string; filename: string; size: number }>;
+      };
+    }>(`/rest/api/3/issue/${encodeURIComponent(issueId)}?fields=attachment`);
+    return issue.fields?.attachment ?? [];
+  }
+
+  /**
+   * Upload a file to the issue and return what an ADF `media` node needs.
+   *
+   * Two calls, because Jira splits the ids: the upload answers with a numeric
+   * attachment id, while `media.attrs.id` is a media-services uuid that no
+   * response body carries. `GET /attachment/content/{id}` answers 303 to
+   * `https://api.media.atlassian.com/file/<uuid>/binary`, which is where the
+   * uuid comes from.
+   *
+   * Not retried: Jira has no idempotency key for an upload either, so a
+   * resubmit after a lost response duplicates the file on the customer's issue.
+   * `mediaId` is null when the redirect does not yield a uuid — the caller then
+   * keeps the image as a link instead of failing the comment.
+   */
+  async addAttachment(
+    issueId: string,
+    file: { name: string; bytes: Uint8Array; contentType?: string },
+  ): Promise<{ attachmentId: string; mediaId: string | null }> {
+    const form = new FormData();
+    form.append(
+      "file",
+      // Copied: `Blob` needs an ArrayBuffer-backed view; org-fs returns wider.
+      new Blob([new Uint8Array(file.bytes)], {
+        type: file.contentType ?? "application/octet-stream",
+      }),
+      file.name,
+    );
+    const response = await fetch(
+      `${this.baseUrl}/rest/api/3/issue/${encodeURIComponent(issueId)}/attachments`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: this.authHeader,
+          Accept: "application/json",
+          // Jira refuses an unbrowsered multipart POST without this.
+          "X-Atlassian-Token": "no-check",
+        },
+        body: form,
+        signal: AbortSignal.timeout(UPLOAD_TIMEOUT_MS),
+      },
+    );
+    const body = await response.text();
+    if (!response.ok) {
+      throw new JiraRequestError(
+        `Jira attachment upload failed (${response.status}): ${body.slice(0, 300)}`,
+        response.status,
+      );
+    }
+    const uploaded = JSON.parse(body) as Array<{ id?: string }>;
+    const attachmentId = uploaded[0]?.id;
+    if (!attachmentId) {
+      throw new Error("Jira attachment upload returned no id");
+    }
+    return { attachmentId, mediaId: await this.resolveMediaId(attachmentId) };
+  }
+
+  /**
+   * Numeric attachment id → media-services uuid, read off the content
+   * redirect. `redirect: "manual"` exposes the `location` header on Bun and
+   * Node; the spec allows hiding it, so a followed HEAD (whose final `url` is
+   * the same media URL, and which transfers no body) is the fallback.
+   */
+  async resolveMediaId(attachmentId: string): Promise<string | null> {
+    const url = `${this.baseUrl}/rest/api/3/attachment/content/${encodeURIComponent(attachmentId)}`;
+    const headers = { Authorization: this.authHeader };
+    const uuidFrom = (candidate: string | null | undefined) =>
+      candidate?.match(/\/file\/([0-9a-f-]{36})\//i)?.[1] ?? null;
+    try {
+      const redirect = await fetch(url, {
+        headers,
+        redirect: "manual",
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      const located = uuidFrom(redirect.headers.get("location"));
+      if (located) return located;
+      const followed = await fetch(url, {
+        method: "HEAD",
+        headers,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      return uuidFrom(followed.url);
+    } catch (err) {
+      console.warn(
+        `[jira] could not resolve the media id for attachment ${attachmentId}:`,
+        err instanceof Error ? err.message : err,
+      );
+      return null;
     }
   }
 }

--- a/apps/api/src/jira/comment-media.test.ts
+++ b/apps/api/src/jira/comment-media.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "bun:test";
+import {
+  attachmentName,
+  type CommentMediaDeps,
+  imageContentType,
+  parseOutputsRef,
+  resolveCommentMedia,
+} from "./comment-media";
+
+const ref = (path: string) =>
+  `/api/acme/fs/outputs/read?path=${encodeURIComponent(path)}`;
+
+describe("parseOutputsRef", () => {
+  it("accepts the shape embedOrgOutputImages writes", () => {
+    expect(parseOutputsRef(ref("thrd_1/qa/before.png"), "acme")).toEqual({
+      volume: "outputs",
+      path: "thrd_1/qa/before.png",
+    });
+  });
+
+  it("refuses another org's slug — the target is agent-authored text", () => {
+    expect(parseOutputsRef(ref("a.png"), "other-org")).toBeNull();
+  });
+
+  it("refuses another volume, a non-read action, and path traversal", () => {
+    expect(
+      parseOutputsRef("/api/acme/fs/secrets/read?path=token", "acme"),
+    ).toBeNull();
+    expect(
+      parseOutputsRef("/api/acme/fs/outputs/write?path=a.png", "acme"),
+    ).toBeNull();
+    expect(
+      parseOutputsRef("/api/acme/fs/outputs/read?path=../../etc/x", "acme"),
+    ).toBeNull();
+  });
+
+  it("refuses anything that is not the relative Studio path", () => {
+    for (const target of [
+      "https://studio.decocms.com/api/acme/fs/outputs/read?path=a.png",
+      "https://img.example.dev/a.png",
+      "/api/acme/fs/outputs/read",
+      "/api/acme/fs/outputs/read/extra?path=a.png",
+      "org/output/a.png",
+      "",
+    ]) {
+      expect(parseOutputsRef(target, "acme")).toBeNull();
+    }
+  });
+
+  it("handles a url-encoded org slug", () => {
+    expect(
+      parseOutputsRef("/api/a%20b/fs/outputs/read?path=x.png", "a b"),
+    ).toEqual({ volume: "outputs", path: "x.png" });
+  });
+});
+
+describe("imageContentType", () => {
+  it("maps the image types worth embedding and rejects the rest", () => {
+    expect(imageContentType("a/b.png")).toBe("image/png");
+    expect(imageContentType("A.JPEG")).toBe("image/jpeg");
+    expect(imageContentType("a.webp")).toBe("image/webp");
+    expect(imageContentType("report.pdf")).toBeNull();
+    expect(imageContentType("noext")).toBeNull();
+  });
+});
+
+describe("attachmentName", () => {
+  it("flattens the path so two runs cannot collide on a basename", () => {
+    expect(attachmentName("thrd_1/qa/before.png")).toBe("thrd_1_qa_before.png");
+    expect(attachmentName("thrd_2/qa/before.png")).toBe("thrd_2_qa_before.png");
+  });
+
+  it("sanitizes and keeps the extension when truncating", () => {
+    expect(attachmentName("a b/ç?.png")).toBe("a-b_--.png");
+    const long = attachmentName(`${"x".repeat(200)}/shot.png`);
+    expect(long.endsWith("shot.png")).toBe(true);
+    expect(long.length).toBe(120);
+  });
+});
+
+interface Recorded {
+  uploaded: string[];
+  reused: string[];
+}
+
+function deps(
+  overrides: Partial<CommentMediaDeps> = {},
+  existing: Array<{ id: string; filename: string; size: number }> = [],
+): CommentMediaDeps & { calls: Recorded } {
+  const calls: Recorded = { uploaded: [], reused: [] };
+  return {
+    calls,
+    read: async () => new Uint8Array([1, 2, 3]),
+    listAttachments: async () => existing,
+    upload: async (file) => {
+      calls.uploaded.push(file.name);
+      return { attachmentId: "1", mediaId: `uuid-${file.name}` };
+    },
+    mediaIdFor: async (attachmentId) => {
+      calls.reused.push(attachmentId);
+      return `uuid-existing-${attachmentId}`;
+    },
+    ...overrides,
+  };
+}
+
+describe("resolveCommentMedia", () => {
+  it("uploads a referenced screenshot and maps it to its media id", async () => {
+    const d = deps();
+    const media = await resolveCommentMedia([ref("thrd_1/a.png")], "acme", d);
+    expect(d.calls.uploaded).toEqual(["thrd_1_a.png"]);
+    expect(media.get(ref("thrd_1/a.png"))).toEqual({
+      id: "uuid-thrd_1_a.png",
+      alt: "a.png",
+    });
+  });
+
+  it("ignores targets it cannot claim, without any Jira call", async () => {
+    const d = deps();
+    const media = await resolveCommentMedia(
+      [
+        "https://img.example.dev/a.png",
+        ref("thrd_1/report.pdf"),
+        "/api/other/fs/outputs/read?path=a.png",
+      ],
+      "acme",
+      d,
+    );
+    expect(media.size).toBe(0);
+    expect(d.calls.uploaded).toEqual([]);
+  });
+
+  it("reuses an attachment already on the issue instead of uploading twice", async () => {
+    const d = deps({}, [
+      { id: "44144", filename: "thrd_1_a.png", size: 3 },
+      { id: "44145", filename: "thrd_1_a.png", size: 999 },
+    ]);
+    const media = await resolveCommentMedia([ref("thrd_1/a.png")], "acme", d);
+    expect(d.calls.uploaded).toEqual([]);
+    // Name AND size: the same name at another size is a rewritten file.
+    expect(d.calls.reused).toEqual(["44144"]);
+    expect(media.get(ref("thrd_1/a.png"))?.id).toBe("uuid-existing-44144");
+  });
+
+  it("keeps a target as a link when its file is gone", async () => {
+    const d = deps({ read: async () => null });
+    expect(
+      (await resolveCommentMedia([ref("thrd_1/a.png")], "acme", d)).size,
+    ).toBe(0);
+    expect(d.calls.uploaded).toEqual([]);
+  });
+
+  it("keeps a target as a link when the upload yields no media id", async () => {
+    const d = deps({
+      upload: async () => ({ attachmentId: "1", mediaId: null }),
+    });
+    expect(
+      (await resolveCommentMedia([ref("thrd_1/a.png")], "acme", d)).size,
+    ).toBe(0);
+  });
+
+  it("does not let one failed upload cost the other images", async () => {
+    const d = deps({
+      upload: async (file) => {
+        if (file.name === "thrd_1_bad.png") throw new Error("507");
+        return { attachmentId: "1", mediaId: `uuid-${file.name}` };
+      },
+    });
+    const media = await resolveCommentMedia(
+      [ref("thrd_1/bad.png"), ref("thrd_1/good.png")],
+      "acme",
+      d,
+    );
+    expect([...media.keys()]).toEqual([ref("thrd_1/good.png")]);
+  });
+
+  it("still embeds when the dedup listing fails", async () => {
+    const d = deps({
+      listAttachments: async () => {
+        throw new Error("403");
+      },
+    });
+    const media = await resolveCommentMedia([ref("thrd_1/a.png")], "acme", d);
+    expect(media.size).toBe(1);
+    expect(d.calls.uploaded).toEqual(["thrd_1_a.png"]);
+  });
+
+  it("skips an oversized file rather than spending the upload", async () => {
+    const d = deps({ read: async () => new Uint8Array(11 * 1024 * 1024) });
+    expect(
+      (await resolveCommentMedia([ref("thrd_1/big.png")], "acme", d)).size,
+    ).toBe(0);
+    expect(d.calls.uploaded).toEqual([]);
+  });
+
+  it("caps uploads per comment and dedups repeated targets", async () => {
+    const d = deps();
+    const many = Array.from({ length: 12 }, (_unused, i) =>
+      ref(`thrd_1/${i}.png`),
+    );
+    const media = await resolveCommentMedia([...many, ...many], "acme", d);
+    expect(d.calls.uploaded).toHaveLength(8);
+    expect(media.size).toBe(8);
+  });
+});

--- a/apps/api/src/jira/comment-media.test.ts
+++ b/apps/api/src/jira/comment-media.test.ts
@@ -218,3 +218,20 @@ describe("attachImage", () => {
     expect(d.calls.uploaded).toEqual(["thrd_1_a.png"]);
   });
 });
+
+describe("parseOutputsRef malformed input", () => {
+  it("returns null instead of throwing on a bad percent-escape", () => {
+    // Runs in a workflow body, outside any step: a URIError here would fail
+    // the whole comment push over a URL an agent merely typed.
+    for (const target of [
+      "/api/a%zz/fs/outputs/read?path=a.png",
+      "/api/%/fs/outputs/read?path=a.png",
+      "/api/acme/fs/outputs/read?path=%zz",
+    ]) {
+      expect(() => parseOutputsRef(target, "acme")).not.toThrow();
+    }
+    expect(
+      parseOutputsRef("/api/a%zz/fs/outputs/read?path=a.png", "acme"),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/jira/comment-media.test.ts
+++ b/apps/api/src/jira/comment-media.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import {
+  attachImage,
   attachmentName,
   type CommentMediaDeps,
   imageContentType,
   parseOutputsRef,
-  resolveCommentMedia,
+  type PlannedAttachment,
+  plannedAttachments,
 } from "./comment-media";
 
 const ref = (path: string) =>
@@ -78,10 +80,65 @@ describe("attachmentName", () => {
   });
 });
 
+describe("plannedAttachments", () => {
+  it("plans one attachment per distinct claimable target, in order", () => {
+    const targets = [
+      ref("thrd_1/b.png"),
+      ref("thrd_1/a.png"),
+      ref("thrd_1/b.png"),
+    ];
+    expect(plannedAttachments(targets, "acme")).toEqual([
+      {
+        target: ref("thrd_1/b.png"),
+        ref: { volume: "outputs", path: "thrd_1/b.png" },
+        name: "thrd_1_b.png",
+      },
+      {
+        target: ref("thrd_1/a.png"),
+        ref: { volume: "outputs", path: "thrd_1/a.png" },
+        name: "thrd_1_a.png",
+      },
+    ]);
+  });
+
+  it("plans nothing for targets it cannot claim", () => {
+    expect(
+      plannedAttachments(
+        [
+          "https://img.example.dev/a.png",
+          ref("thrd_1/report.pdf"),
+          "/api/other/fs/outputs/read?path=a.png",
+        ],
+        "acme",
+      ),
+    ).toEqual([]);
+  });
+
+  it("caps the plan, because each entry is a write on the issue", () => {
+    const many = Array.from({ length: 12 }, (_unused, i) =>
+      ref(`thrd_1/${i}.png`),
+    );
+    expect(plannedAttachments(many, "acme")).toHaveLength(8);
+  });
+
+  it("is deterministic — the step sequence of a replay depends on it", () => {
+    const targets = [ref("thrd_1/a.png"), ref("thrd_1/b.png")];
+    expect(plannedAttachments(targets, "acme")).toEqual(
+      plannedAttachments(targets, "acme"),
+    );
+  });
+});
+
 interface Recorded {
   uploaded: string[];
   reused: string[];
 }
+
+const planned: PlannedAttachment = {
+  target: ref("thrd_1/a.png"),
+  ref: { volume: "outputs", path: "thrd_1/a.png" },
+  name: "thrd_1_a.png",
+};
 
 function deps(
   overrides: Partial<CommentMediaDeps> = {},
@@ -104,102 +161,60 @@ function deps(
   };
 }
 
-describe("resolveCommentMedia", () => {
-  it("uploads a referenced screenshot and maps it to its media id", async () => {
+describe("attachImage", () => {
+  it("uploads the screenshot and returns what embeds it", async () => {
     const d = deps();
-    const media = await resolveCommentMedia([ref("thrd_1/a.png")], "acme", d);
-    expect(d.calls.uploaded).toEqual(["thrd_1_a.png"]);
-    expect(media.get(ref("thrd_1/a.png"))).toEqual({
+    expect(await attachImage(planned, d)).toEqual({
       id: "uuid-thrd_1_a.png",
       alt: "a.png",
     });
+    expect(d.calls.uploaded).toEqual(["thrd_1_a.png"]);
   });
 
-  it("ignores targets it cannot claim, without any Jira call", async () => {
-    const d = deps();
-    const media = await resolveCommentMedia(
-      [
-        "https://img.example.dev/a.png",
-        ref("thrd_1/report.pdf"),
-        "/api/other/fs/outputs/read?path=a.png",
-      ],
-      "acme",
-      d,
-    );
-    expect(media.size).toBe(0);
-    expect(d.calls.uploaded).toEqual([]);
-  });
-
-  it("reuses an attachment already on the issue instead of uploading twice", async () => {
+  it("adopts an attachment already on the issue — what makes the step retriable", async () => {
     const d = deps({}, [
       { id: "44144", filename: "thrd_1_a.png", size: 3 },
       { id: "44145", filename: "thrd_1_a.png", size: 999 },
     ]);
-    const media = await resolveCommentMedia([ref("thrd_1/a.png")], "acme", d);
-    expect(d.calls.uploaded).toEqual([]);
+    expect((await attachImage(planned, d))?.id).toBe("uuid-existing-44144");
     // Name AND size: the same name at another size is a rewritten file.
     expect(d.calls.reused).toEqual(["44144"]);
-    expect(media.get(ref("thrd_1/a.png"))?.id).toBe("uuid-existing-44144");
-  });
-
-  it("keeps a target as a link when its file is gone", async () => {
-    const d = deps({ read: async () => null });
-    expect(
-      (await resolveCommentMedia([ref("thrd_1/a.png")], "acme", d)).size,
-    ).toBe(0);
     expect(d.calls.uploaded).toEqual([]);
   });
 
-  it("keeps a target as a link when the upload yields no media id", async () => {
-    const d = deps({
+  it("returns null for the outcomes a retry cannot improve", async () => {
+    const gone = deps({ read: async () => null });
+    expect(await attachImage(planned, gone)).toBeNull();
+    expect(gone.calls.uploaded).toEqual([]);
+
+    const oversized = deps({
+      read: async () => new Uint8Array(11 * 1024 * 1024),
+    });
+    expect(await attachImage(planned, oversized)).toBeNull();
+    expect(oversized.calls.uploaded).toEqual([]);
+
+    const noMediaId = deps({
       upload: async () => ({ attachmentId: "1", mediaId: null }),
     });
-    expect(
-      (await resolveCommentMedia([ref("thrd_1/a.png")], "acme", d)).size,
-    ).toBe(0);
+    expect(await attachImage(planned, noMediaId)).toBeNull();
   });
 
-  it("does not let one failed upload cost the other images", async () => {
+  it("throws on a failed upload, so the step retries instead of degrading", async () => {
     const d = deps({
-      upload: async (file) => {
-        if (file.name === "thrd_1_bad.png") throw new Error("507");
-        return { attachmentId: "1", mediaId: `uuid-${file.name}` };
+      upload: async () => {
+        throw new Error("502");
       },
     });
-    const media = await resolveCommentMedia(
-      [ref("thrd_1/bad.png"), ref("thrd_1/good.png")],
-      "acme",
-      d,
-    );
-    expect([...media.keys()]).toEqual([ref("thrd_1/good.png")]);
+    await expect(attachImage(planned, d)).rejects.toThrow("502");
   });
 
-  it("still embeds when the dedup listing fails", async () => {
+  it("still uploads when the dedup listing fails", async () => {
     const d = deps({
       listAttachments: async () => {
         throw new Error("403");
       },
     });
-    const media = await resolveCommentMedia([ref("thrd_1/a.png")], "acme", d);
-    expect(media.size).toBe(1);
+    expect((await attachImage(planned, d))?.id).toBe("uuid-thrd_1_a.png");
     expect(d.calls.uploaded).toEqual(["thrd_1_a.png"]);
-  });
-
-  it("skips an oversized file rather than spending the upload", async () => {
-    const d = deps({ read: async () => new Uint8Array(11 * 1024 * 1024) });
-    expect(
-      (await resolveCommentMedia([ref("thrd_1/big.png")], "acme", d)).size,
-    ).toBe(0);
-    expect(d.calls.uploaded).toEqual([]);
-  });
-
-  it("caps uploads per comment and dedups repeated targets", async () => {
-    const d = deps();
-    const many = Array.from({ length: 12 }, (_unused, i) =>
-      ref(`thrd_1/${i}.png`),
-    );
-    const media = await resolveCommentMedia([...many, ...many], "acme", d);
-    expect(d.calls.uploaded).toHaveLength(8);
-    expect(media.size).toBe(8);
   });
 });

--- a/apps/api/src/jira/comment-media.ts
+++ b/apps/api/src/jira/comment-media.ts
@@ -108,74 +108,85 @@ export interface CommentMediaDeps {
   mediaIdFor(attachmentId: string): Promise<string | null>;
 }
 
+export interface PlannedAttachment {
+  /** The image target as written in the markdown — the converter's map key. */
+  target: string;
+  ref: OutputsRef;
+  /** Filename on the issue, and the dedup key against what is already there. */
+  name: string;
+}
+
 /**
- * Resolve what `markdownToAdf` needs to embed: image target → uploaded media.
+ * Which image targets to attach, and under what name.
  *
- * Fail-open by design, per target: an unreadable file, a failed upload, an
- * unresolvable media id all leave the target out of the map, and the converter
- * keeps it as a link. Losing an inline image is a cosmetic regression; losing
- * the comment is not, and the push step gets no retry.
+ * Pure and deterministic, because the push workflow turns each entry into its
+ * own durable step: the same comment body must always plan the same
+ * attachments in the same order, or a replay would not line up with the steps
+ * already checkpointed.
  */
-export async function resolveCommentMedia(
+export function plannedAttachments(
   targets: readonly string[],
   orgSlug: string,
-  deps: CommentMediaDeps,
-): Promise<Map<string, AdfMedia>> {
-  const media = new Map<string, AdfMedia>();
-  const refs = new Map<string, OutputsRef>();
-  for (const target of new Set(targets)) {
+): PlannedAttachment[] {
+  const planned: PlannedAttachment[] = [];
+  const seen = new Set<string>();
+  for (const target of targets) {
+    if (seen.has(target)) continue;
+    seen.add(target);
     const ref = parseOutputsRef(target, orgSlug);
-    if (ref && imageContentType(ref.path)) refs.set(target, ref);
+    if (!ref || !imageContentType(ref.path)) continue;
+    planned.push({ target, ref, name: attachmentName(ref.path) });
   }
-  if (refs.size === 0) return media;
-
-  const capped = [...refs].slice(0, MAX_UPLOADS);
-  if (refs.size > capped.length) {
+  if (planned.length > MAX_UPLOADS) {
     console.warn(
-      `[jira] comment references ${refs.size} images; embedding the first ${capped.length}, the rest stay links`,
+      `[jira] comment references ${planned.length} images; embedding the first ${MAX_UPLOADS}, the rest stay links`,
     );
   }
+  return planned.slice(0, MAX_UPLOADS);
+}
 
-  let existing: Awaited<ReturnType<CommentMediaDeps["listAttachments"]>> = [];
-  try {
-    existing = await deps.listAttachments();
-  } catch (err) {
-    // Only costs dedup — a re-referenced screenshot uploads a second time.
-    console.warn("[jira] could not list attachments for dedup:", err);
+/**
+ * One planned image → what the converter needs to embed it, or null to leave
+ * it a link.
+ *
+ * Null is for the outcomes a retry cannot improve: the file is gone, it is
+ * over the upload cap, or Jira never yielded a media id. Everything else
+ * throws, so the surrounding step retries — safe because the dedup lookup
+ * makes a re-run find its own earlier upload instead of duplicating it, which
+ * is the property that lets this run as a retriable step at all.
+ */
+export async function attachImage(
+  item: PlannedAttachment,
+  deps: CommentMediaDeps,
+): Promise<AdfMedia | null> {
+  const bytes = await deps.read(item.ref);
+  if (!bytes) return null;
+  if (bytes.byteLength > MAX_UPLOAD_BYTES) {
+    console.warn(
+      `[jira] ${item.ref.path} is ${bytes.byteLength} bytes, over the ${MAX_UPLOAD_BYTES} upload cap — staying a link`,
+    );
+    return null;
   }
-
-  for (const [target, ref] of capped) {
-    try {
-      const bytes = await deps.read(ref);
-      if (!bytes) continue;
-      if (bytes.byteLength > MAX_UPLOAD_BYTES) {
-        console.warn(
-          `[jira] ${ref.path} is ${bytes.byteLength} bytes, over the ${MAX_UPLOAD_BYTES} upload cap — staying a link`,
-        );
-        continue;
-      }
-      const name = attachmentName(ref.path);
-      const alt = ref.path.split("/").pop() ?? name;
-      const match = existing.find(
-        (attachment) =>
-          attachment.filename === name && attachment.size === bytes.byteLength,
-      );
-      const mediaId = match
-        ? await deps.mediaIdFor(match.id)
-        : (
-            await deps.upload({
-              name,
-              bytes,
-              contentType: imageContentType(ref.path) ?? "image/png",
-            })
-          ).mediaId;
-      if (mediaId) media.set(target, { id: mediaId, alt });
-    } catch (err) {
-      console.warn(
-        `[jira] could not attach ${ref.path}, keeping the link:`,
-        err,
-      );
-    }
-  }
-  return media;
+  const existing = await deps
+    .listAttachments()
+    // Only costs dedup: a re-referenced screenshot uploads a second time.
+    .catch((err) => {
+      console.warn("[jira] could not list attachments for dedup:", err);
+      return [];
+    });
+  const match = existing.find(
+    (attachment) =>
+      attachment.filename === item.name && attachment.size === bytes.byteLength,
+  );
+  const mediaId = match
+    ? await deps.mediaIdFor(match.id)
+    : (
+        await deps.upload({
+          name: item.name,
+          bytes,
+          contentType: imageContentType(item.ref.path) ?? "image/png",
+        })
+      ).mediaId;
+  const alt = item.ref.path.split("/").pop() ?? item.name;
+  return mediaId ? { id: mediaId, alt } : null;
 }

--- a/apps/api/src/jira/comment-media.ts
+++ b/apps/api/src/jira/comment-media.ts
@@ -61,14 +61,25 @@ export function parseOutputsRef(
     fs !== "fs" ||
     action !== "read" ||
     volume !== "outputs" ||
-    slug === undefined ||
-    decodeURIComponent(slug) !== orgSlug
+    decodeSegment(slug) !== orgSlug
   ) {
     return null;
   }
   const path = url.searchParams.get("path");
   if (!path || path.includes("..")) return null;
   return { volume, path };
+}
+
+/** `decodeURIComponent` throws a `URIError` on a malformed escape like `%zz`,
+ *  and this runs in a workflow body, outside any step — an agent writing one
+ *  in a comment would fail the whole push. */
+function decodeSegment(segment: string | undefined): string | null {
+  if (segment === undefined) return null;
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return null;
+  }
 }
 
 /** The content type for an image path, or null when it is not an image we

--- a/apps/api/src/jira/comment-media.ts
+++ b/apps/api/src/jira/comment-media.ts
@@ -1,0 +1,181 @@
+/**
+ * Board-comment images → Jira attachments, so a mirrored comment shows the
+ * screenshot instead of a dead link.
+ *
+ * A task-run agent writes screenshots to the `outputs` volume and references
+ * them as `![alt](/api/<org>/fs/outputs/read?path=…)` — a member-gated Studio
+ * URL that nobody reading the issue can fetch. This module turns the ones it
+ * recognizes into uploads, and `markdownToAdf` embeds them.
+ *
+ * Only that exact shape, only the `outputs` volume, and only when the org slug
+ * in the URL is the pushing org's: a markdown image target is attacker-authored
+ * text (an agent writes it), so anything looser would be a way to have Studio
+ * copy an arbitrary org file into a customer's Jira. Everything unrecognized
+ * stays a link, which is what the converter already does.
+ */
+
+import type { AdfMedia } from "./markdown-adf";
+
+/** Jira Cloud's own default attachment ceiling is 10MB; a bigger file would
+ *  spend the upload only to be refused. */
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+/** Per comment. A QA pass posts a handful (before/after × viewport); a hundred
+ *  is a runaway loop, and each one is a write on the customer's issue. */
+const MAX_UPLOADS = 8;
+
+const IMAGE_TYPES: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+};
+
+export interface OutputsRef {
+  volume: string;
+  path: string;
+}
+
+/**
+ * `/api/<org>/fs/outputs/read?path=<encoded>` → the org-fs coordinates, or null
+ * for anything else — an absolute URL, another volume, another org's slug.
+ */
+export function parseOutputsRef(
+  target: string,
+  orgSlug: string,
+): OutputsRef | null {
+  if (!target.startsWith("/api/")) return null;
+  // Relative, so it needs a base to parse; the base is never used.
+  let url: URL;
+  try {
+    url = new URL(target, "https://studio.invalid");
+  } catch {
+    return null;
+  }
+  const segments = url.pathname.split("/");
+  const [, api, slug, fs, volume, action] = segments;
+  if (
+    segments.length !== 6 ||
+    api !== "api" ||
+    fs !== "fs" ||
+    action !== "read" ||
+    volume !== "outputs" ||
+    slug === undefined ||
+    decodeURIComponent(slug) !== orgSlug
+  ) {
+    return null;
+  }
+  const path = url.searchParams.get("path");
+  if (!path || path.includes("..")) return null;
+  return { volume, path };
+}
+
+/** The content type for an image path, or null when it is not an image we
+ *  would embed (ADF media renders images; a PDF would just be a file card). */
+export function imageContentType(path: string): string | null {
+  const extension = path.split(".").pop()?.toLowerCase() ?? "";
+  return IMAGE_TYPES[extension] ?? null;
+}
+
+/**
+ * An org-fs path → the attachment filename, flattened and sanitized.
+ *
+ * Path-derived rather than basename-derived so it stays unique per artifact:
+ * two runs both writing `before.png` must not collide, because the filename is
+ * also the dedup key against the attachments already on the issue.
+ */
+export function attachmentName(path: string): string {
+  const flattened = path.replace(/^\/+/, "").replace(/\//g, "_");
+  const safe = flattened.replace(/[^A-Za-z0-9._-]/g, "-").replace(/^[-.]+/, "");
+  // Tail, not head: the extension is what Jira reads to render an image.
+  return (safe === "" ? "attachment" : safe).slice(-120);
+}
+
+export interface CommentMediaDeps {
+  /** Bytes at an org-fs path; null when the file is gone. */
+  read(ref: OutputsRef): Promise<Uint8Array | null>;
+  /** Attachments already on the issue — the dedup source. */
+  listAttachments(): Promise<
+    Array<{ id: string; filename: string; size: number }>
+  >;
+  upload(file: {
+    name: string;
+    bytes: Uint8Array;
+    contentType: string;
+  }): Promise<{ attachmentId: string; mediaId: string | null }>;
+  /** The media id of an attachment already on the issue. */
+  mediaIdFor(attachmentId: string): Promise<string | null>;
+}
+
+/**
+ * Resolve what `markdownToAdf` needs to embed: image target → uploaded media.
+ *
+ * Fail-open by design, per target: an unreadable file, a failed upload, an
+ * unresolvable media id all leave the target out of the map, and the converter
+ * keeps it as a link. Losing an inline image is a cosmetic regression; losing
+ * the comment is not, and the push step gets no retry.
+ */
+export async function resolveCommentMedia(
+  targets: readonly string[],
+  orgSlug: string,
+  deps: CommentMediaDeps,
+): Promise<Map<string, AdfMedia>> {
+  const media = new Map<string, AdfMedia>();
+  const refs = new Map<string, OutputsRef>();
+  for (const target of new Set(targets)) {
+    const ref = parseOutputsRef(target, orgSlug);
+    if (ref && imageContentType(ref.path)) refs.set(target, ref);
+  }
+  if (refs.size === 0) return media;
+
+  const capped = [...refs].slice(0, MAX_UPLOADS);
+  if (refs.size > capped.length) {
+    console.warn(
+      `[jira] comment references ${refs.size} images; embedding the first ${capped.length}, the rest stay links`,
+    );
+  }
+
+  let existing: Awaited<ReturnType<CommentMediaDeps["listAttachments"]>> = [];
+  try {
+    existing = await deps.listAttachments();
+  } catch (err) {
+    // Only costs dedup — a re-referenced screenshot uploads a second time.
+    console.warn("[jira] could not list attachments for dedup:", err);
+  }
+
+  for (const [target, ref] of capped) {
+    try {
+      const bytes = await deps.read(ref);
+      if (!bytes) continue;
+      if (bytes.byteLength > MAX_UPLOAD_BYTES) {
+        console.warn(
+          `[jira] ${ref.path} is ${bytes.byteLength} bytes, over the ${MAX_UPLOAD_BYTES} upload cap — staying a link`,
+        );
+        continue;
+      }
+      const name = attachmentName(ref.path);
+      const alt = ref.path.split("/").pop() ?? name;
+      const match = existing.find(
+        (attachment) =>
+          attachment.filename === name && attachment.size === bytes.byteLength,
+      );
+      const mediaId = match
+        ? await deps.mediaIdFor(match.id)
+        : (
+            await deps.upload({
+              name,
+              bytes,
+              contentType: imageContentType(ref.path) ?? "image/png",
+            })
+          ).mediaId;
+      if (mediaId) media.set(target, { id: mediaId, alt });
+    } catch (err) {
+      console.warn(
+        `[jira] could not attach ${ref.path}, keeping the link:`,
+        err,
+      );
+    }
+  }
+  return media;
+}

--- a/apps/api/src/jira/dbos-jira-sync.ts
+++ b/apps/api/src/jira/dbos-jira-sync.ts
@@ -132,11 +132,11 @@ async function postCommentToJira(
     integration.email,
     integration.apiToken,
   );
-  const text = `${params.authorLabel} · via Studio:\n${params.body}`.slice(
-    0,
-    MAX_PUSH_CHARS,
+  const created = await client.addComment(
+    link.jiraIssueId,
+    params.body.slice(0, MAX_PUSH_CHARS),
+    { header: `${params.authorLabel} · via Studio:` },
   );
-  const created = await client.addComment(link.jiraIssueId, text);
   return created.id;
 }
 

--- a/apps/api/src/jira/dbos-jira-sync.ts
+++ b/apps/api/src/jira/dbos-jira-sync.ts
@@ -18,7 +18,11 @@ import { CredentialVault } from "@/encryption/credential-vault";
 import type { StudioContext } from "@/core/studio-context";
 import { JIRA_PUSH_QUEUE } from "@/dispatch-queue/queue-names";
 import { JiraClient } from "./client";
-import { resolveCommentMedia } from "./comment-media";
+import {
+  attachImage,
+  type PlannedAttachment,
+  plannedAttachments,
+} from "./comment-media";
 import { type AdfMedia, collectImageTargets } from "./markdown-adf";
 import { JIRA_SYNC_ACTOR, syncJiraIntegrationSafe } from "./sync";
 
@@ -114,11 +118,79 @@ export interface JiraCommentPushParams {
 
 const MAX_PUSH_CHARS = 30_000;
 
-/** Step 1: post the comment on the linked issue. Null = nothing to do —
- *  integration gone/disabled, card unlinked, or already pushed (the link
- *  check is what makes workflow re-entry idempotent). */
+interface CommentPushTarget {
+  jiraIssueId: string;
+}
+
+/** Step 1: is there anything to push? Null = nothing to do — integration
+ *  gone/disabled, card unlinked, or already pushed (the link check is what
+ *  makes workflow re-entry idempotent). Ahead of any upload, so we never
+ *  attach a screenshot to an issue we then decline to comment on. */
+async function resolveCommentTarget(
+  params: JiraCommentPushParams,
+): Promise<CommentPushTarget | null> {
+  const storage = storageFromRuntime();
+  const integration = await storage.getByOrg(params.organizationId);
+  if (!integration?.enabled) return null;
+  const link = await storage.getLinkByItemId(
+    params.taskBoardItemId,
+    params.organizationId,
+  );
+  if (!link) return null;
+  if (await storage.hasCommentLink(params.commentId)) return null;
+  return { jiraIssueId: link.jiraIssueId };
+}
+
+/** The org slug, which is what scopes an image ref to this tenant. Its own
+ *  step, and only reached when the comment actually references an image. */
+async function readOrgSlug(organizationId: string): Promise<string | null> {
+  const row = await requireRuntime()
+    .db.selectFrom("organization")
+    .select("slug")
+    .where("id", "=", organizationId)
+    .executeTakeFirst();
+  return row?.slug ?? null;
+}
+
+/**
+ * One image, one step: read the bytes, reuse or upload the attachment, resolve
+ * the media id.
+ *
+ * Per image rather than per comment so a pod death partway through does not
+ * re-upload what already landed — each completed attachment is checkpointed.
+ * Retriable because `attachImage` dedups against the issue's attachments
+ * first, so a re-run adopts its own earlier upload instead of duplicating it.
+ */
+async function attachCommentImage(
+  organizationId: string,
+  issueId: string,
+  item: PlannedAttachment,
+): Promise<AdfMedia | null> {
+  const integration = await storageFromRuntime().getByOrg(organizationId);
+  if (!integration?.enabled) return null;
+  const ctx = await buildOrgContext(requireRuntime().db, organizationId);
+  const orgFs = ctx?.orgFs;
+  if (!orgFs) return null;
+  const client = new JiraClient(
+    integration.siteUrl,
+    integration.email,
+    integration.apiToken,
+  );
+  return attachImage(item, {
+    read: (ref) => orgFs.read(ref.volume, ref.path).catch(() => null),
+    listAttachments: () => client.listAttachments(issueId),
+    upload: (file) => client.addAttachment(issueId, file),
+    mediaIdFor: (attachmentId) => client.resolveMediaId(attachmentId),
+  });
+}
+
+/** Final step: post the comment, embedding whatever the attach steps
+ *  resolved. Re-reads the row so the credential never crosses a step
+ *  boundary, and re-checks the link so a replay is a no-op. */
 async function postCommentToJira(
   params: JiraCommentPushParams,
+  body: string,
+  media: Array<[string, AdfMedia]>,
 ): Promise<string | null> {
   const storage = storageFromRuntime();
   const integration = await storage.getByOrg(params.organizationId);
@@ -134,49 +206,11 @@ async function postCommentToJira(
     integration.email,
     integration.apiToken,
   );
-  const body = params.body.slice(0, MAX_PUSH_CHARS);
   const created = await client.addComment(link.jiraIssueId, body, {
     header: `${params.authorLabel} · via Studio:`,
-    media: await commentMedia(client, link.jiraIssueId, params, body),
+    media: new Map(media),
   });
   return created.id;
-}
-
-/**
- * Upload the screenshots this comment references so the mirror embeds them
- * rather than linking a member-gated Studio URL.
- *
- * Runs on the truncated body, the same text the converter sees, so it never
- * uploads a file the comment then drops. Fail-open at every level: no org
- * context, no org-fs, a read that throws — the images stay links and the
- * comment still lands, because the push step gets no retry.
- */
-async function commentMedia(
-  client: JiraClient,
-  issueId: string,
-  params: JiraCommentPushParams,
-  body: string,
-): Promise<Map<string, AdfMedia>> {
-  const targets = collectImageTargets(body);
-  if (targets.length === 0) return new Map();
-  try {
-    const ctx = await buildOrgContext(
-      requireRuntime().db,
-      params.organizationId,
-    );
-    const orgFs = ctx?.orgFs;
-    const orgSlug = ctx?.organization?.slug;
-    if (!orgFs || !orgSlug) return new Map();
-    return await resolveCommentMedia(targets, orgSlug, {
-      read: (ref) => orgFs.read(ref.volume, ref.path).catch(() => null),
-      listAttachments: () => client.listAttachments(issueId),
-      upload: (file) => client.addAttachment(issueId, file),
-      mediaIdFor: (attachmentId) => client.resolveMediaId(attachmentId),
-    });
-  } catch (err) {
-    console.warn("[jira] comment images stay links:", err);
-    return new Map();
-  }
 }
 
 /** Step 2: record the link — the pull's echo cut for this comment. */
@@ -195,17 +229,58 @@ async function recordCommentLink(
   }
 }
 
+/**
+ * Mirror one board comment, one external call per step.
+ *
+ * The body's slice and `plannedAttachments` are pure, so the workflow itself
+ * stays deterministic: the same params always drive the same steps in the same
+ * order, which is what lets a replay reuse the attachments already uploaded.
+ */
 async function jiraCommentPushWorkflowFn(
   params: JiraCommentPushParams,
 ): Promise<void> {
+  const body = params.body.slice(0, MAX_PUSH_CHARS);
+  const target = await DBOS.runStep(() => resolveCommentTarget(params), {
+    name: "resolveCommentTarget",
+    retriesAllowed: true,
+    maxAttempts: 3,
+  });
+  if (!target) return;
+
+  const media: Array<[string, AdfMedia]> = [];
+  const imageTargets = collectImageTargets(body);
+  if (imageTargets.length > 0) {
+    const orgSlug = await DBOS.runStep(
+      () => readOrgSlug(params.organizationId),
+      { name: "readOrgSlug", retriesAllowed: true, maxAttempts: 3 },
+    );
+    for (const item of plannedAttachments(imageTargets, orgSlug ?? "")) {
+      try {
+        const attached = await DBOS.runStep(
+          () =>
+            attachCommentImage(params.organizationId, target.jiraIssueId, item),
+          {
+            name: `attachCommentImage:${item.name}`,
+            retriesAllowed: true,
+            maxAttempts: 3,
+          },
+        );
+        if (attached) media.push([item.target, attached]);
+      } catch (err) {
+        // Exhausted retries cost this one image, never the comment it is in.
+        console.warn(`[jira] could not attach ${item.ref.path}:`, err);
+      }
+    }
+  }
+
   // NOT retriable: Jira has no idempotency key for comments, so a retry after
   // a lost response (timeout, 502 past the commit) posts the comment again on
   // the customer's issue. One missed mirror beats four copies; the comment
   // itself is already safe in Studio and the failure is logged.
-  const jiraCommentId = await DBOS.runStep(() => postCommentToJira(params), {
-    name: "postCommentToJira",
-    retriesAllowed: false,
-  });
+  const jiraCommentId = await DBOS.runStep(
+    () => postCommentToJira(params, body, media),
+    { name: "postCommentToJira", retriesAllowed: false },
+  );
   if (!jiraCommentId) return;
   await DBOS.runStep(() => recordCommentLink(params, jiraCommentId), {
     name: "recordCommentLink",

--- a/apps/api/src/jira/dbos-jira-sync.ts
+++ b/apps/api/src/jira/dbos-jira-sync.ts
@@ -8,8 +8,10 @@
  * boot via `setJiraSyncRuntime` BEFORE `DBOS.launch()`.
  */
 
-import { DBOS, Error as DBOSErrors, SchedulerMode } from "@dbos-inc/dbos-sdk";
+import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
 import type { Kysely } from "kysely";
+import { isMaxStepRetriesError } from "@/dbos/step-errors";
+import { OrgFsNotFoundError } from "@/file-storage/org-fs";
 import { buildOrgContext } from "@/tools/task-board/org-context";
 import type { Database, TaskBoardItem } from "@/storage/types";
 import { JiraIntegrationStorage } from "@/storage/jira-integrations";
@@ -177,7 +179,13 @@ async function attachCommentImage(
     integration.apiToken,
   );
   return attachImage(item, {
-    read: (ref) => orgFs.read(ref.volume, ref.path).catch(() => null),
+    read: (ref) =>
+      orgFs.read(ref.volume, ref.path).catch((err: unknown) => {
+        // Only a genuinely absent file is terminal; a transient object-store
+        // error must reach the step so it retries instead of dropping.
+        if (err instanceof OrgFsNotFoundError) return null;
+        throw err;
+      }),
     listAttachments: () => client.listAttachments(issueId),
     upload: (file) => client.addAttachment(issueId, file),
     mediaIdFor: (attachmentId) => client.resolveMediaId(attachmentId),
@@ -270,7 +278,8 @@ async function jiraCommentPushWorkflowFn(
         // ONLY exhausted retries degrade to a link. Anything else — a
         // cancellation, a determinism violation — is DBOS steering the
         // workflow, and swallowing it would post the comment anyway.
-        if (!(err instanceof DBOSErrors.DBOSMaxStepRetriesError)) throw err;
+        // Matched by code, not `instanceof` — see `isMaxStepRetriesError`.
+        if (!isMaxStepRetriesError(err)) throw err;
         console.warn(`[jira] could not attach ${item.ref.path}:`, err);
       }
     }

--- a/apps/api/src/jira/dbos-jira-sync.ts
+++ b/apps/api/src/jira/dbos-jira-sync.ts
@@ -8,7 +8,7 @@
  * boot via `setJiraSyncRuntime` BEFORE `DBOS.launch()`.
  */
 
-import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
+import { DBOS, Error as DBOSErrors, SchedulerMode } from "@dbos-inc/dbos-sdk";
 import type { Kysely } from "kysely";
 import { buildOrgContext } from "@/tools/task-board/org-context";
 import type { Database, TaskBoardItem } from "@/storage/types";
@@ -267,7 +267,10 @@ async function jiraCommentPushWorkflowFn(
         );
         if (attached) media.push([item.target, attached]);
       } catch (err) {
-        // Exhausted retries cost this one image, never the comment it is in.
+        // ONLY exhausted retries degrade to a link. Anything else — a
+        // cancellation, a determinism violation — is DBOS steering the
+        // workflow, and swallowing it would post the comment anyway.
+        if (!(err instanceof DBOSErrors.DBOSMaxStepRetriesError)) throw err;
         console.warn(`[jira] could not attach ${item.ref.path}:`, err);
       }
     }

--- a/apps/api/src/jira/dbos-jira-sync.ts
+++ b/apps/api/src/jira/dbos-jira-sync.ts
@@ -18,6 +18,8 @@ import { CredentialVault } from "@/encryption/credential-vault";
 import type { StudioContext } from "@/core/studio-context";
 import { JIRA_PUSH_QUEUE } from "@/dispatch-queue/queue-names";
 import { JiraClient } from "./client";
+import { resolveCommentMedia } from "./comment-media";
+import { type AdfMedia, collectImageTargets } from "./markdown-adf";
 import { JIRA_SYNC_ACTOR, syncJiraIntegrationSafe } from "./sync";
 
 /** Every 10 minutes, offset from the public-sets (:04) and org-repo (:07)
@@ -132,12 +134,49 @@ async function postCommentToJira(
     integration.email,
     integration.apiToken,
   );
-  const created = await client.addComment(
-    link.jiraIssueId,
-    params.body.slice(0, MAX_PUSH_CHARS),
-    { header: `${params.authorLabel} · via Studio:` },
-  );
+  const body = params.body.slice(0, MAX_PUSH_CHARS);
+  const created = await client.addComment(link.jiraIssueId, body, {
+    header: `${params.authorLabel} · via Studio:`,
+    media: await commentMedia(client, link.jiraIssueId, params, body),
+  });
   return created.id;
+}
+
+/**
+ * Upload the screenshots this comment references so the mirror embeds them
+ * rather than linking a member-gated Studio URL.
+ *
+ * Runs on the truncated body, the same text the converter sees, so it never
+ * uploads a file the comment then drops. Fail-open at every level: no org
+ * context, no org-fs, a read that throws — the images stay links and the
+ * comment still lands, because the push step gets no retry.
+ */
+async function commentMedia(
+  client: JiraClient,
+  issueId: string,
+  params: JiraCommentPushParams,
+  body: string,
+): Promise<Map<string, AdfMedia>> {
+  const targets = collectImageTargets(body);
+  if (targets.length === 0) return new Map();
+  try {
+    const ctx = await buildOrgContext(
+      requireRuntime().db,
+      params.organizationId,
+    );
+    const orgFs = ctx?.orgFs;
+    const orgSlug = ctx?.organization?.slug;
+    if (!orgFs || !orgSlug) return new Map();
+    return await resolveCommentMedia(targets, orgSlug, {
+      read: (ref) => orgFs.read(ref.volume, ref.path).catch(() => null),
+      listAttachments: () => client.listAttachments(issueId),
+      upload: (file) => client.addAttachment(issueId, file),
+      mediaIdFor: (attachmentId) => client.resolveMediaId(attachmentId),
+    });
+  } catch (err) {
+    console.warn("[jira] comment images stay links:", err);
+    return new Map();
+  }
 }
 
 /** Step 2: record the link — the pull's echo cut for this comment. */

--- a/apps/api/src/jira/markdown-adf.test.ts
+++ b/apps/api/src/jira/markdown-adf.test.ts
@@ -1,0 +1,488 @@
+import { describe, expect, it } from "bun:test";
+import { type AdfNode, markdownToAdf } from "./markdown-adf";
+
+const doc = (markdown: string, header?: string) =>
+  markdownToAdf(markdown, { header }).content;
+
+describe("markdownToAdf inline marks", () => {
+  it("renders the syntax a plain-text push leaked onto the issue", () => {
+    expect(doc("**O que foi feito:** ajustei o `Footer.json`")).toEqual([
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "O que foi feito:",
+            marks: [{ type: "strong" }],
+          },
+          { type: "text", text: " ajustei o " },
+          { type: "text", text: "Footer.json", marks: [{ type: "code" }] },
+        ],
+      },
+    ]);
+  });
+
+  it("handles italics, strikethrough, and bold-italic together", () => {
+    expect(doc("*a* _b_ ~~c~~ ***d***")).toEqual([
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "a", marks: [{ type: "em" }] },
+          { type: "text", text: " " },
+          { type: "text", text: "b", marks: [{ type: "em" }] },
+          { type: "text", text: " " },
+          { type: "text", text: "c", marks: [{ type: "strike" }] },
+          { type: "text", text: " " },
+          {
+            type: "text",
+            text: "d",
+            marks: [{ type: "strong" }, { type: "em" }],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("leaves an unmatched or intraword delimiter as the character it is", () => {
+    expect(doc("2 * 3 * 4 and snake_case_name and 100% *")).toEqual([
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "2 * 3 * 4 and snake_case_name and 100% *" },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps an escaped delimiter literal", () => {
+    expect(doc("literal \\*stars\\* here")).toEqual([
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "literal *stars* here" }],
+      },
+    ]);
+  });
+
+  it("marks a nested emphasis inside bold", () => {
+    expect(doc("**bold with *inner* end**")).toEqual([
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "bold with ",
+            marks: [{ type: "strong" }],
+          },
+          {
+            type: "text",
+            text: "inner",
+            marks: [{ type: "strong" }, { type: "em" }],
+          },
+          { type: "text", text: " end", marks: [{ type: "strong" }] },
+        ],
+      },
+    ]);
+  });
+
+  it("drops formatting marks inside a code span but keeps a wrapping link", () => {
+    const [paragraph] = doc("[**`a*b`**](https://x.dev)");
+    expect(paragraph?.content).toEqual([
+      {
+        type: "text",
+        text: "a*b",
+        marks: [
+          { type: "link", attrs: { href: "https://x.dev" } },
+          { type: "code" },
+        ],
+      },
+    ]);
+  });
+});
+
+describe("markdownToAdf links", () => {
+  it("links a markdown link, an autolink, and a bare URL", () => {
+    const hrefs = (markdown: string) =>
+      doc(markdown)[0]?.content?.map((node) => [node.text, node.marks]);
+    expect(hrefs("[PR](https://github.com/acme/site/pull/1)")).toEqual([
+      [
+        "PR",
+        [
+          {
+            type: "link",
+            attrs: { href: "https://github.com/acme/site/pull/1" },
+          },
+        ],
+      ],
+    ]);
+    expect(hrefs("PR: https://github.com/acme/site/pull/1.")).toEqual([
+      ["PR: ", undefined],
+      [
+        "https://github.com/acme/site/pull/1",
+        [
+          {
+            type: "link",
+            attrs: { href: "https://github.com/acme/site/pull/1" },
+          },
+        ],
+      ],
+      [".", undefined],
+    ]);
+    expect(hrefs("<https://envs.example.dev>")).toEqual([
+      [
+        "https://envs.example.dev",
+        [{ type: "link", attrs: { href: "https://envs.example.dev" } }],
+      ],
+    ]);
+  });
+
+  it("never nests a link mark inside a link label", () => {
+    const [paragraph] = doc("[see https://a.dev now](https://b.dev)");
+    expect(paragraph?.content).toEqual([
+      {
+        type: "text",
+        text: "see https://a.dev now",
+        marks: [{ type: "link", attrs: { href: "https://b.dev" } }],
+      },
+    ]);
+  });
+
+  it("keeps a label as plain text when the target is not a usable URL", () => {
+    // ADF rejects a link mark whose href a Jira reader could not follow.
+    expect(
+      doc("[click](javascript:alert(1)) [shot](/api/org/fs/read)"),
+    ).toEqual([
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "click shot" }],
+      },
+    ]);
+  });
+
+  it("degrades an image to a link, and a Studio-relative one to its alt", () => {
+    expect(doc("![diff](https://img.example.dev/a.png)")).toEqual([
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "diff",
+            marks: [
+              {
+                type: "link",
+                attrs: { href: "https://img.example.dev/a.png" },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    expect(
+      doc("![home page](/api/acme/fs/outputs/read?path=t%2Fa.png)"),
+    ).toEqual([
+      { type: "paragraph", content: [{ type: "text", text: "home page" }] },
+    ]);
+  });
+});
+
+describe("markdownToAdf blocks", () => {
+  it("splits paragraphs on blank lines and joins soft-wrapped lines", () => {
+    expect(doc("one\ntwo\n\nthree")).toEqual([
+      { type: "paragraph", content: [{ type: "text", text: "one two" }] },
+      { type: "paragraph", content: [{ type: "text", text: "three" }] },
+    ]);
+  });
+
+  it("keeps an explicit hard break", () => {
+    expect(doc("one  \ntwo")).toEqual([
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "one" },
+          { type: "hardBreak" },
+          { type: "text", text: "two" },
+        ],
+      },
+    ]);
+  });
+
+  it("renders headings and a rule", () => {
+    expect(doc("## Decisões\n\n---\n\n#nothashtag")).toEqual([
+      {
+        type: "heading",
+        attrs: { level: 2 },
+        content: [{ type: "text", text: "Decisões" }],
+      },
+      { type: "rule" },
+      { type: "paragraph", content: [{ type: "text", text: "#nothashtag" }] },
+    ]);
+  });
+
+  it("renders a fenced code block with its language", () => {
+    expect(doc("```ts {twoslash}\nconst a = 1;\n```")).toEqual([
+      {
+        type: "codeBlock",
+        attrs: { language: "ts" },
+        content: [{ type: "text", text: "const a = 1;" }],
+      },
+    ]);
+  });
+
+  it("closes a fence truncated by the push limit at end of input", () => {
+    expect(doc("```\nhalf a diff")).toEqual([
+      { type: "codeBlock", content: [{ type: "text", text: "half a diff" }] },
+    ]);
+  });
+
+  it("renders a bullet list with a nested list and per-item marks", () => {
+    expect(doc("- top **bold**\n  - nested\n- sibling")).toEqual([
+      {
+        type: "bulletList",
+        content: [
+          {
+            type: "listItem",
+            content: [
+              {
+                type: "paragraph",
+                content: [
+                  { type: "text", text: "top " },
+                  { type: "text", text: "bold", marks: [{ type: "strong" }] },
+                ],
+              },
+              {
+                type: "bulletList",
+                content: [
+                  {
+                    type: "listItem",
+                    content: [
+                      {
+                        type: "paragraph",
+                        content: [{ type: "text", text: "nested" }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: "listItem",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "sibling" }],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("starts a new list when the marker switches between bullets and numbers", () => {
+    expect(doc("- a\n1. b").map((node) => node.type)).toEqual([
+      "bulletList",
+      "orderedList",
+    ]);
+  });
+
+  it("carries an ordered list's start number, and only when it is not 1", () => {
+    expect(doc("3. c\n4. d")[0]?.attrs).toEqual({ order: 3 });
+    expect(doc("1. c")[0]?.attrs).toBeUndefined();
+  });
+
+  it("keeps a fenced block that belongs to a list item inside it", () => {
+    const [list] = doc("- run it:\n\n  ```sh\n  bun test\n  ```\n- then ship");
+    expect(list?.content?.[0]?.content?.map((node) => node.type)).toEqual([
+      "paragraph",
+      "codeBlock",
+    ]);
+    expect(list?.content).toHaveLength(2);
+  });
+
+  it("renders a blockquote's own blocks", () => {
+    expect(doc("> quoted **line**\n> - item")).toEqual([
+      {
+        type: "blockquote",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", text: "quoted " },
+              { type: "text", text: "line", marks: [{ type: "strong" }] },
+            ],
+          },
+          {
+            type: "bulletList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "item" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("renders a GFM table, padding a short row to the header width", () => {
+    expect(doc("| a | b |\n| --- | :-: |\n| 1 |")).toEqual([
+      {
+        type: "table",
+        attrs: { isNumberColumnEnabled: false, layout: "default" },
+        content: [
+          {
+            type: "tableRow",
+            content: [
+              {
+                type: "tableHeader",
+                attrs: {},
+                content: [
+                  { type: "paragraph", content: [{ type: "text", text: "a" }] },
+                ],
+              },
+              {
+                type: "tableHeader",
+                attrs: {},
+                content: [
+                  { type: "paragraph", content: [{ type: "text", text: "b" }] },
+                ],
+              },
+            ],
+          },
+          {
+            type: "tableRow",
+            content: [
+              {
+                type: "tableCell",
+                attrs: {},
+                content: [
+                  { type: "paragraph", content: [{ type: "text", text: "1" }] },
+                ],
+              },
+              {
+                type: "tableCell",
+                attrs: {},
+                content: [{ type: "paragraph", content: [] }],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("leaves a pipe row that has no delimiter row as prose", () => {
+    expect(doc("| a | b |\nnot a table").map((node) => node.type)).toEqual([
+      "paragraph",
+    ]);
+  });
+});
+
+describe("markdownToAdf structural guarantees", () => {
+  it("prepends the header verbatim, never as markup", () => {
+    expect(doc("**body**", "Ana *Nick* Souza · via Studio:")).toEqual([
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "Ana *Nick* Souza · via Studio:" }],
+      },
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "body", marks: [{ type: "strong" }] }],
+      },
+    ]);
+  });
+
+  it("emits a single empty paragraph for a body with no content", () => {
+    expect(markdownToAdf("   \n\n  ")).toEqual({
+      type: "doc",
+      version: 1,
+      content: [{ type: "paragraph", content: [] }],
+    });
+  });
+
+  it("re-homes nodes ADF forbids in a listItem or a blockquote", () => {
+    const [list] = doc("- ## heading in an item\n\n  > quoted\n\n  ---");
+    expect(list?.content?.[0]?.content).toEqual([
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "heading in an item" }],
+      },
+      { type: "paragraph", content: [{ type: "text", text: "quoted" }] },
+    ]);
+
+    const [quote] = doc("> > deep\n> \n> | a |\n> | - |\n> | 1 |");
+    expect(quote?.content).toEqual([
+      { type: "paragraph", content: [{ type: "text", text: "deep" }] },
+      { type: "paragraph", content: [{ type: "text", text: "a 1" }] },
+    ]);
+  });
+
+  it("holds the invariants Jira validates the document against", () => {
+    const kitchenSink = [
+      '**Verificado no preview** (https://envs.example.dev): renderiza `<a href="/x">X</a>`.',
+      "",
+      "# Título",
+      "",
+      "- item com `código` e [link](https://x.dev)",
+      "  1. aninhado",
+      "     ```json",
+      '     { "a": 1 }',
+      "     ```",
+      "  2. ## heading proibido",
+      "- ",
+      "",
+      "> ### citação",
+      "> > mais fundo",
+      "",
+      "| a |",
+      "| - |",
+      "|   |",
+      "",
+      "``",
+      "",
+      "***",
+      "",
+      "![](/api/org/fs/read?path=a.png)",
+    ].join("\n");
+
+    const allowed: Record<string, ReadonlySet<string>> = {
+      listItem: new Set([
+        "paragraph",
+        "bulletList",
+        "orderedList",
+        "codeBlock",
+      ]),
+      blockquote: new Set([
+        "paragraph",
+        "bulletList",
+        "orderedList",
+        "codeBlock",
+      ]),
+    };
+    const walk = (node: AdfNode, parent: string) => {
+      if (node.type === "text") {
+        expect(typeof node.text).toBe("string");
+        expect(node.text).not.toBe("");
+      }
+      const allowedHere = allowed[parent];
+      if (allowedHere) expect(allowedHere.has(node.type)).toBe(true);
+      if (node.type === "listItem") {
+        expect(["paragraph", "codeBlock"]).toContain(
+          node.content?.[0]?.type ?? "missing",
+        );
+      }
+      if (node.type === "table") expect(parent).toBe("doc");
+      for (const child of node.content ?? []) walk(child, node.type);
+    };
+
+    const document = markdownToAdf(kitchenSink, { header: "Super Agent:" });
+    expect(document.content.length).toBeGreaterThan(0);
+    walk(document as unknown as AdfNode, "root");
+  });
+});

--- a/apps/api/src/jira/markdown-adf.test.ts
+++ b/apps/api/src/jira/markdown-adf.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { type AdfNode, markdownToAdf } from "./markdown-adf";
+import {
+  type AdfNode,
+  collectImageTargets,
+  markdownToAdf,
+} from "./markdown-adf";
 
 const doc = (markdown: string, header?: string) =>
   markdownToAdf(markdown, { header }).content;
@@ -484,5 +488,132 @@ describe("markdownToAdf structural guarantees", () => {
     const document = markdownToAdf(kitchenSink, { header: "Super Agent:" });
     expect(document.content.length).toBeGreaterThan(0);
     walk(document as unknown as AdfNode, "root");
+  });
+});
+
+describe("markdownToAdf images", () => {
+  const media = new Map([
+    [
+      "/api/acme/fs/outputs/read?path=t%2Fa.png",
+      { id: "uuid-a", alt: "a.png" },
+    ],
+  ]);
+  const target = "/api/acme/fs/outputs/read?path=t%2Fa.png";
+
+  it("embeds an uploaded image as a media node", () => {
+    expect(markdownToAdf(`![shot](${target})`, { media }).content).toEqual([
+      {
+        type: "mediaSingle",
+        attrs: { layout: "align-start" },
+        content: [
+          {
+            type: "media",
+            attrs: {
+              type: "file",
+              id: "uuid-a",
+              collection: "",
+              alt: "a.png",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("falls back to the markdown alt text when the upload carries none", () => {
+    const bare = new Map([[target, { id: "uuid-a" }]]);
+    const [node] = markdownToAdf(`![from markdown](${target})`, {
+      media: bare,
+    }).content;
+    expect(node?.content?.[0]?.attrs?.alt).toBe("from markdown");
+  });
+
+  it("lifts an inline image out of its paragraph, splitting the text", () => {
+    expect(
+      markdownToAdf(`before ![shot](${target}) after`, { media }).content.map(
+        (node) => [
+          node.type,
+          node.content?.[0]?.text ?? node.content?.[0]?.type,
+        ],
+      ),
+    ).toEqual([
+      ["paragraph", "before "],
+      ["mediaSingle", "media"],
+      ["paragraph", " after"],
+    ]);
+  });
+
+  it("keeps an unresolved target as a link, exactly as before", () => {
+    expect(
+      markdownToAdf("![shot](https://img.example.dev/a.png)").content,
+    ).toEqual([
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "shot",
+            marks: [
+              {
+                type: "link",
+                attrs: { href: "https://img.example.dev/a.png" },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("embeds inside a list item, and degrades to alt text inside a quote", () => {
+    const [list] = markdownToAdf(`- shot: ![x](${target})`, {
+      media,
+    }).content;
+    expect(list?.content?.[0]?.content?.map((node) => node.type)).toEqual([
+      "paragraph",
+      "mediaSingle",
+    ]);
+
+    const [quote] = markdownToAdf(`> shot: ![x](${target})`, {
+      media,
+    }).content;
+    expect(quote?.content).toEqual([
+      { type: "paragraph", content: [{ type: "text", text: "shot: " }] },
+      { type: "paragraph", content: [{ type: "text", text: "a.png" }] },
+    ]);
+  });
+});
+
+describe("collectImageTargets", () => {
+  it("names only the targets the converter would embed", () => {
+    const markdown = [
+      "![one](/out/1.png)",
+      "",
+      "text ![two](/out/2.png) more",
+      "",
+      "- ![three](/out/3.png)",
+      "",
+      "# ![heading](/out/skip-heading.png)",
+      "",
+      "| ![cell](/out/skip-cell.png) |",
+      "| --- |",
+      "| x |",
+      "",
+      "```",
+      "![fenced](/out/skip-fenced.png)",
+      "```",
+    ].join("\n");
+    expect(collectImageTargets(markdown)).toEqual([
+      "/out/1.png",
+      "/out/2.png",
+      "/out/3.png",
+    ]);
+  });
+
+  it("reports a target once per occurrence, and nothing for plain links", () => {
+    expect(
+      collectImageTargets("[link](/out/a.png) ![img](/out/a.png)"),
+    ).toEqual(["/out/a.png"]);
+    expect(collectImageTargets("no images here")).toEqual([]);
   });
 });

--- a/apps/api/src/jira/markdown-adf.test.ts
+++ b/apps/api/src/jira/markdown-adf.test.ts
@@ -631,3 +631,44 @@ describe("collectImageTargets", () => {
     expect(collectImageTargets("no images here")).toEqual([]);
   });
 });
+
+describe("markdownToAdf bounds", () => {
+  const nodes = (value: AdfNode): number =>
+    1 + (value.content ?? []).reduce((sum, child) => sum + nodes(child), 0);
+
+  it("bounds a wide, tall table instead of amplifying it", () => {
+    // A 4-character `|x|` row is padded to the header's width, so without a
+    // cap a 30KB comment builds millions of nodes — twice per push.
+    const columns = 300;
+    const header = `|${" a |".repeat(columns)}`;
+    const delimiter = `|${"---|".repeat(columns)}`;
+    const rows = Array.from({ length: 4000 }, () => "|x|").join("\n");
+    const document = markdownToAdf(
+      [header, delimiter, rows].join("\n").slice(0, 30_000),
+    );
+    expect(nodes(document as unknown as AdfNode)).toBeLessThan(50_000);
+
+    const table = document.content.find((node) => node.type === "table");
+    expect(table?.content?.[0]?.content).toHaveLength(24);
+    expect(table?.content?.length).toBeLessThanOrEqual(201);
+  });
+
+  it("never emits an empty blockquote, which ADF rejects", () => {
+    for (const markdown of ["> ---", ">", "> ***", "> \n> ---"]) {
+      const [quote] = markdownToAdf(markdown).content;
+      expect(quote?.type).toBe("blockquote");
+      expect(quote?.content?.length ?? 0).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps something visible when an image target is unusable", () => {
+    const relative = "/api/acme/fs/outputs/read?path=a.png";
+    // Unlabelled and unattachable: it must not silently disappear.
+    expect(markdownToAdf(`![](${relative})`).content).toEqual([
+      { type: "paragraph", content: [{ type: "text", text: relative }] },
+    ]);
+    expect(markdownToAdf(`![shot](${relative})`).content).toEqual([
+      { type: "paragraph", content: [{ type: "text", text: "shot" }] },
+    ]);
+  });
+});

--- a/apps/api/src/jira/markdown-adf.test.ts
+++ b/apps/api/src/jira/markdown-adf.test.ts
@@ -565,7 +565,9 @@ describe("markdownToAdf images", () => {
     ]);
   });
 
-  it("embeds inside a list item, and degrades to alt text inside a quote", () => {
+  it("embeds inside a list item and inside a blockquote", () => {
+    // Both accepted by Jira Cloud when probed; an earlier revision degraded
+    // the blockquote case to alt text on an assumption that did not hold.
     const [list] = markdownToAdf(`- shot: ![x](${target})`, {
       media,
     }).content;
@@ -577,9 +579,21 @@ describe("markdownToAdf images", () => {
     const [quote] = markdownToAdf(`> shot: ![x](${target})`, {
       media,
     }).content;
-    expect(quote?.content).toEqual([
-      { type: "paragraph", content: [{ type: "text", text: "shot: " }] },
-      { type: "paragraph", content: [{ type: "text", text: "a.png" }] },
+    expect(quote?.content?.map((node) => node.type)).toEqual([
+      "paragraph",
+      "mediaSingle",
+    ]);
+  });
+
+  it("still keeps alt text when a media node cannot live in the parent", () => {
+    // A heading is inline-only, so nothing is uploaded for it in the first
+    // place and the label survives as text.
+    expect(markdownToAdf(`# shot ![x](${target})`, { media }).content).toEqual([
+      {
+        type: "heading",
+        attrs: { level: 1 },
+        content: [{ type: "text", text: "shot x" }],
+      },
     ]);
   });
 });

--- a/apps/api/src/jira/markdown-adf.ts
+++ b/apps/api/src/jira/markdown-adf.ts
@@ -1,0 +1,800 @@
+/**
+ * Board markdown → Atlassian Document Format, for the comments the sync
+ * mirrors onto a Jira issue.
+ *
+ * Jira Cloud's v3 comment API takes ADF — not markdown, not the wiki markup of
+ * the v2 API — so a comment posted as plain text shows the customer its own
+ * syntax: literal `**bold**`, literal fences, `-` bullets that never become a
+ * list. This is the inverse of `wiki-markdown.ts` and has the same shape: a
+ * line-driven block parser, then a character scanner for inline marks with
+ * recursion so nesting works.
+ *
+ * Two invariants keep a malformed comment from turning into a 400, which the
+ * push treats as terminal (see `JiraClient.addComment`):
+ *   - never emit an empty `text` node (ADF rejects one), and
+ *   - only place a node where ADF's schema allows it — `listItem` and
+ *     `blockquote` take a narrow set, so anything else is flattened rather
+ *     than nested.
+ * Anything unrecognized degrades to its literal source text: a stray `*` on
+ * the issue is better than a mangled sentence, and far better than a comment
+ * Jira refuses.
+ */
+
+export interface AdfMark {
+  type: string;
+  attrs?: Record<string, unknown>;
+}
+
+export interface AdfNode {
+  type: string;
+  attrs?: Record<string, unknown>;
+  content?: AdfNode[];
+  text?: string;
+  marks?: AdfMark[];
+}
+
+export interface AdfDoc {
+  type: "doc";
+  version: 1;
+  content: AdfNode[];
+}
+
+export interface MarkdownToAdfOptions {
+  /**
+   * A paragraph prepended verbatim, never parsed. The push uses it for the
+   * `"<author> · via Studio:"` attribution line, which carries a
+   * tenant-supplied display name — running that through the inline scanner
+   * would let `Ana *Nick* Souza` open emphasis.
+   */
+  header?: string;
+}
+
+export function markdownToAdf(
+  markdown: string,
+  options: MarkdownToAdfOptions = {},
+): AdfDoc {
+  const content = parseBlocks({ lines: toLines(markdown), i: 0 });
+  if (options.header) content.unshift(textParagraph(options.header));
+  return {
+    type: "doc",
+    version: 1,
+    // A doc needs at least one child; an all-whitespace comment yields none.
+    content:
+      content.length > 0 ? content : [{ type: "paragraph", content: [] }],
+  };
+}
+
+/** Leading tabs only: indentation drives block structure so it has to be
+ *  countable in spaces, while a tab inside prose is content. */
+function toLines(markdown: string): string[] {
+  return markdown
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/^\t+/, (tabs) => " ".repeat(tabs.length * 4)));
+}
+
+function textParagraph(text: string): AdfNode {
+  return {
+    type: "paragraph",
+    content: text === "" ? [] : [{ type: "text", text }],
+  };
+}
+
+interface Cursor {
+  lines: string[];
+  i: number;
+}
+
+const HEADING_RE = /^ {0,3}(#{1,6})(?:[ \t]+(.*))?$/;
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})[ \t]*([^`\s]*)/;
+const RULE_RE = /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/;
+const QUOTE_RE = /^ {0,3}> ?(.*)$/;
+const BULLET_RE = /^( *)([-*+])([ \t]+)(.*)$/;
+const ORDERED_RE = /^( *)(\d{1,9})([.)])([ \t]+)(.*)$/;
+
+function parseBlocks(cursor: Cursor): AdfNode[] {
+  const blocks: AdfNode[] = [];
+  while (cursor.i < cursor.lines.length) {
+    const line = cursor.lines[cursor.i] ?? "";
+    if (line.trim() === "") {
+      cursor.i++;
+      continue;
+    }
+    const fence = FENCE_RE.exec(line);
+    if (fence) {
+      blocks.push(parseFence(cursor, fence));
+      continue;
+    }
+    // Ahead of the list rules: `---` and `* * *` also look like list markers.
+    if (RULE_RE.test(line)) {
+      cursor.i++;
+      blocks.push({ type: "rule" });
+      continue;
+    }
+    const heading = HEADING_RE.exec(line);
+    if (heading) {
+      cursor.i++;
+      blocks.push({
+        type: "heading",
+        attrs: { level: (heading[1] ?? "#").length },
+        content: inlineNodes(heading[2]?.trim() ?? ""),
+      });
+      continue;
+    }
+    if (QUOTE_RE.test(line)) {
+      blocks.push(parseQuote(cursor));
+      continue;
+    }
+    const item = matchListItem(line);
+    if (item) {
+      blocks.push(parseList(cursor, item));
+      continue;
+    }
+    const table = parseTable(cursor);
+    if (table) {
+      blocks.push(table);
+      continue;
+    }
+    blocks.push(parseParagraph(cursor));
+  }
+  return blocks;
+}
+
+/** True for a line that opens a different block — where a paragraph ends
+ *  without a blank line before it. */
+function startsBlock(line: string): boolean {
+  return (
+    FENCE_RE.test(line) ||
+    RULE_RE.test(line) ||
+    HEADING_RE.test(line) ||
+    QUOTE_RE.test(line) ||
+    matchListItem(line) !== null
+  );
+}
+
+function indentOf(line: string): number {
+  let count = 0;
+  while (line[count] === " ") count++;
+  return count;
+}
+
+/** An unterminated fence (a comment truncated mid-code-block) runs to the end
+ *  of the input rather than falling back to prose. */
+function parseFence(cursor: Cursor, open: RegExpExecArray): AdfNode {
+  const marker = open[1] ?? "```";
+  const language = sanitizeLanguage(open[2] ?? "");
+  const baseIndent = indentOf(cursor.lines[cursor.i] ?? "");
+  const closeRe = new RegExp(`^ {0,3}\\${marker[0]}{${marker.length},}[ \t]*$`);
+  cursor.i++;
+  const body: string[] = [];
+  while (cursor.i < cursor.lines.length) {
+    const line = cursor.lines[cursor.i] ?? "";
+    cursor.i++;
+    if (closeRe.test(line)) break;
+    body.push(line.slice(Math.min(baseIndent, indentOf(line))));
+  }
+  const text = body.join("\n");
+  return {
+    type: "codeBlock",
+    ...(language ? { attrs: { language } } : {}),
+    content: text === "" ? [] : [{ type: "text", text }],
+  };
+}
+
+/** An info string is free-form in markdown (`js {highlight=1}`) but names a
+ *  highlighter in ADF: keep the identifier shape, drop the rest. */
+function sanitizeLanguage(info: string): string {
+  return info
+    .toLowerCase()
+    .replace(/[^a-z0-9+#._-]/g, "")
+    .slice(0, 20);
+}
+
+function parseQuote(cursor: Cursor): AdfNode {
+  const inner: string[] = [];
+  while (cursor.i < cursor.lines.length) {
+    const match = QUOTE_RE.exec(cursor.lines[cursor.i] ?? "");
+    if (!match) break;
+    inner.push(match[1] ?? "");
+    cursor.i++;
+  }
+  return {
+    type: "blockquote",
+    content: restrict(parseBlocks({ lines: inner, i: 0 }), QUOTE_CONTENT),
+  };
+}
+
+interface ListMarker {
+  indent: number;
+  /** Column the item's own content starts at — what nested blocks dedent by. */
+  contentIndent: number;
+  ordered: boolean;
+  start: number;
+  text: string;
+}
+
+function matchListItem(line: string): ListMarker | null {
+  const bullet = BULLET_RE.exec(line);
+  if (bullet) {
+    const indent = (bullet[1] ?? "").length;
+    return {
+      indent,
+      contentIndent: indent + 1 + Math.min((bullet[3] ?? " ").length, 4),
+      ordered: false,
+      start: 1,
+      text: bullet[4] ?? "",
+    };
+  }
+  const ordered = ORDERED_RE.exec(line);
+  if (ordered) {
+    const indent = (ordered[1] ?? "").length;
+    const digits = ordered[2] ?? "1";
+    return {
+      indent,
+      contentIndent:
+        indent + digits.length + 1 + Math.min((ordered[4] ?? " ").length, 4),
+      ordered: true,
+      start: Number(digits),
+      text: ordered[5] ?? "",
+    };
+  }
+  return null;
+}
+
+/**
+ * One list, sibling items at `first.indent`.
+ *
+ * Everything indented to the item's content column is collected, dedented and
+ * re-parsed as blocks — so a nested list, a fenced block or a second paragraph
+ * inside an item all fall out of the same rule instead of needing their own.
+ */
+function parseList(cursor: Cursor, first: ListMarker): AdfNode {
+  const items: AdfNode[] = [];
+  let marker: ListMarker | null = first;
+  while (marker) {
+    const itemLines = [marker.text];
+    cursor.i++;
+    let blanks = 0;
+    while (cursor.i < cursor.lines.length) {
+      const line = cursor.lines[cursor.i] ?? "";
+      if (line.trim() === "") {
+        blanks++;
+        cursor.i++;
+        continue;
+      }
+      if (indentOf(line) < marker.contentIndent) break;
+      // Replayed only once content follows, so trailing blanks stay outside.
+      for (let blank = 0; blank < blanks; blank++) itemLines.push("");
+      blanks = 0;
+      itemLines.push(line.slice(marker.contentIndent));
+      cursor.i++;
+    }
+    items.push({
+      type: "listItem",
+      content: listItemContent(parseBlocks({ lines: itemLines, i: 0 })),
+    });
+    const next = matchListItem(cursor.lines[cursor.i] ?? "");
+    // A dedent, or a switch between bullets and numbers, ends this list.
+    marker =
+      next && next.ordered === marker.ordered && next.indent >= first.indent
+        ? next
+        : null;
+  }
+  return first.ordered
+    ? {
+        type: "orderedList",
+        ...(first.start !== 1 ? { attrs: { order: first.start } } : {}),
+        content: items,
+      }
+    : { type: "bulletList", content: items };
+}
+
+const QUOTE_CONTENT = new Set([
+  "paragraph",
+  "bulletList",
+  "orderedList",
+  "codeBlock",
+]);
+const LIST_ITEM_CONTENT = QUOTE_CONTENT;
+
+function listItemContent(blocks: AdfNode[]): AdfNode[] {
+  const content = restrict(blocks, LIST_ITEM_CONTENT);
+  const first = content[0]?.type;
+  // ADF opens a listItem with a paragraph or codeBlock; `- - a` starts a list.
+  if (first !== "paragraph" && first !== "codeBlock") {
+    content.unshift({ type: "paragraph", content: [] });
+  }
+  return content;
+}
+
+/**
+ * Keep only nodes ADF allows in this parent. A heading becomes a paragraph and
+ * a nested blockquote is spread into its parent (ADF has no blockquote inside a
+ * blockquote or a listItem); anything else keeps its text as one paragraph,
+ * because losing a table's layout beats losing the sentence inside it.
+ */
+function restrict(blocks: AdfNode[], allowed: ReadonlySet<string>): AdfNode[] {
+  const out: AdfNode[] = [];
+  for (const block of blocks) {
+    if (allowed.has(block.type)) {
+      out.push(block);
+      continue;
+    }
+    if (block.type === "heading") {
+      out.push({ type: "paragraph", content: block.content ?? [] });
+      continue;
+    }
+    if (block.type === "blockquote") {
+      out.push(...restrict(block.content ?? [], allowed));
+      continue;
+    }
+    if (block.type === "rule") continue;
+    const flattened = flatten(block);
+    if (flattened) out.push(flattened);
+  }
+  return out;
+}
+
+function flatten(block: AdfNode): AdfNode | null {
+  const parts: string[] = [];
+  const walk = (node: AdfNode) => {
+    if (node.type === "text" && node.text) parts.push(node.text);
+    for (const child of node.content ?? []) walk(child);
+  };
+  walk(block);
+  const text = parts.join(" ").trim();
+  return text === "" ? null : textParagraph(text);
+}
+
+const TABLE_ROW_RE = /^ {0,3}\|/;
+const DELIMITER_CELL_RE = /^:?-+:?$/;
+
+/** A GFM table: a pipe row, a delimiter row of matching width, then rows. The
+ *  leading pipe is required — `a | b` in prose is not a table. */
+function parseTable(cursor: Cursor): AdfNode | null {
+  const header = splitRow(cursor.lines[cursor.i] ?? "");
+  if (!header) return null;
+  const delimiter = splitRow(cursor.lines[cursor.i + 1] ?? "");
+  if (
+    !delimiter ||
+    delimiter.length !== header.length ||
+    !delimiter.every((cell) => DELIMITER_CELL_RE.test(cell))
+  ) {
+    return null;
+  }
+  cursor.i += 2;
+  const rows: AdfNode[] = [tableRow(header, "tableHeader", header.length)];
+  while (cursor.i < cursor.lines.length) {
+    const cells = splitRow(cursor.lines[cursor.i] ?? "");
+    if (!cells) break;
+    rows.push(tableRow(cells, "tableCell", header.length));
+    cursor.i++;
+  }
+  return {
+    type: "table",
+    attrs: { isNumberColumnEnabled: false, layout: "default" },
+    content: rows,
+  };
+}
+
+function splitRow(line: string): string[] | null {
+  if (!TABLE_ROW_RE.test(line)) return null;
+  const cells: string[] = [];
+  const trimmed = line.trim();
+  let cell = "";
+  for (let i = 1; i < trimmed.length; i++) {
+    const char = trimmed[i];
+    if (char === "\\" && trimmed[i + 1] === "|") {
+      cell += "|";
+      i++;
+      continue;
+    }
+    if (char === "|") {
+      cells.push(cell.trim());
+      cell = "";
+      continue;
+    }
+    cell += char;
+  }
+  if (cell.trim() !== "") cells.push(cell.trim());
+  return cells.length > 0 ? cells : null;
+}
+
+/** Rows are padded and truncated to the header's width: ADF accepts a ragged
+ *  table, but Jira's own editor then treats it as broken. */
+function tableRow(cells: string[], cellType: string, width: number): AdfNode {
+  return {
+    type: "tableRow",
+    content: Array.from({ length: width }, (_unused, column) => ({
+      type: cellType,
+      attrs: {},
+      content: [paragraph(inlineNodes(cells[column] ?? ""))],
+    })),
+  };
+}
+
+function paragraph(content: AdfNode[]): AdfNode {
+  return { type: "paragraph", content };
+}
+
+function parseParagraph(cursor: Cursor): AdfNode {
+  const lines: string[] = [];
+  while (cursor.i < cursor.lines.length) {
+    const line = cursor.lines[cursor.i] ?? "";
+    if (line.trim() === "") break;
+    if (lines.length > 0 && (startsBlock(line) || TABLE_ROW_RE.test(line))) {
+      break;
+    }
+    lines.push(lines.length === 0 ? line : line.trimStart());
+    cursor.i++;
+  }
+  return paragraph(inlineNodes(joinLines(lines)));
+}
+
+/**
+ * Paragraph lines → one string, with `\n` marking the breaks that survive.
+ *
+ * A single newline is a soft break: it renders as a space, which is what the
+ * board's own renderer (remark-gfm, no `remark-breaks`) does, so the issue
+ * reads the way the card does. Only markdown's explicit hard breaks — two
+ * trailing spaces, or a trailing backslash — become a `hardBreak`.
+ */
+function joinLines(lines: string[]): string {
+  let out = "";
+  lines.forEach((line, index) => {
+    let text = line.replace(/[ \t]+$/, "");
+    let hard = /[ \t]{2,}$/.test(line);
+    if (!hard && /(?:^|[^\\])\\$/.test(text)) {
+      hard = true;
+      text = text.slice(0, -1);
+    }
+    out += text;
+    if (index < lines.length - 1) out += hard ? "\n" : " ";
+  });
+  return out;
+}
+
+const ESCAPABLE = "\\`*_{}[]()#+-.!|<>~\"'&$%,/:;=?@^";
+const STRONG: AdfMark = { type: "strong" };
+const EM: AdfMark = { type: "em" };
+const STRIKE: AdfMark = { type: "strike" };
+
+/**
+ * Character scanner over one paragraph's text. Marks accumulate down the
+ * recursion (a link label can be bold), and an unmatched delimiter falls
+ * through as the literal character it is.
+ */
+function inlineNodes(source: string, marks: AdfMark[] = []): AdfNode[] {
+  const out: AdfNode[] = [];
+  let buffer = "";
+  const flush = () => {
+    if (buffer !== "") {
+      out.push(textNode(buffer, marks));
+      buffer = "";
+    }
+  };
+  let i = 0;
+  while (i < source.length) {
+    const char = source[i] ?? "";
+
+    if (char === "\\") {
+      const next = source[i + 1];
+      if (next && ESCAPABLE.includes(next)) {
+        buffer += next;
+        i += 2;
+        continue;
+      }
+    } else if (char === "\n") {
+      flush();
+      out.push({ type: "hardBreak" });
+      i++;
+      continue;
+    } else if (char === "`") {
+      const code = matchCode(source, i);
+      if (code) {
+        flush();
+        if (code.text !== "") out.push(textNode(code.text, codeMarks(marks)));
+        i = code.next;
+        continue;
+      }
+    } else if (char === "!" && source[i + 1] === "[") {
+      const image = matchLink(source, i + 1);
+      if (image) {
+        flush();
+        out.push(...imageNodes(image, marks));
+        i = image.next;
+        continue;
+      }
+    } else if (char === "[") {
+      const link = matchLink(source, i);
+      if (link) {
+        flush();
+        out.push(...linkNodes(link, marks));
+        i = link.next;
+        continue;
+      }
+    } else if (char === "<") {
+      const auto = matchAutolink(source, i);
+      if (auto) {
+        flush();
+        out.push(...linkNodes(auto, marks));
+        i = auto.next;
+        continue;
+      }
+    } else if (char === "*" || char === "_" || char === "~") {
+      const emphasized = matchEmphasis(source, i, marks);
+      if (emphasized) {
+        flush();
+        out.push(...emphasized.nodes);
+        i = emphasized.next;
+        continue;
+      }
+    } else if (char === "h") {
+      const bare = matchBareUrl(source, i, marks);
+      if (bare) {
+        flush();
+        out.push(bare.node);
+        i = bare.next;
+        continue;
+      }
+    }
+
+    buffer += char;
+    i++;
+  }
+  flush();
+  return mergeText(out);
+}
+
+/** Fold neighbouring text nodes that carry the same marks — valid either way,
+ *  but a document Jira's editor round-trips without reshaping it. */
+function mergeText(nodes: AdfNode[]): AdfNode[] {
+  const merged: AdfNode[] = [];
+  for (const node of nodes) {
+    const previous = merged.at(-1);
+    if (
+      node.type === "text" &&
+      previous?.type === "text" &&
+      JSON.stringify(previous.marks ?? []) === JSON.stringify(node.marks ?? [])
+    ) {
+      previous.text = `${previous.text ?? ""}${node.text ?? ""}`;
+      continue;
+    }
+    merged.push(node);
+  }
+  return merged;
+}
+
+function textNode(text: string, marks: AdfMark[]): AdfNode {
+  return { type: "text", text, ...(marks.length > 0 ? { marks } : {}) };
+}
+
+/** ADF's `code` mark is exclusive with the other formatting marks; a link
+ *  around inline code is the one combination it keeps. */
+function codeMarks(marks: AdfMark[]): AdfMark[] {
+  return [...marks.filter((mark) => mark.type === "link"), { type: "code" }];
+}
+
+function withMark(marks: AdfMark[], mark: AdfMark): AdfMark[] {
+  return marks.some((existing) => existing.type === mark.type)
+    ? marks
+    : [...marks, mark];
+}
+
+function hasLink(marks: AdfMark[]): boolean {
+  return marks.some((mark) => mark.type === "link");
+}
+
+function runLength(source: string, at: number, char: string): number {
+  let length = 0;
+  while (source[at + length] === char) length++;
+  return length;
+}
+
+/** A code span: N backticks to the next run of exactly N. Newlines collapse to
+ *  spaces — a `hardBreak` cannot live inside a marked text node. */
+function matchCode(
+  source: string,
+  at: number,
+): { text: string; next: number } | null {
+  const fence = runLength(source, at, "`");
+  for (let j = at + fence; j < source.length; j++) {
+    if (source[j] !== "`") continue;
+    const run = runLength(source, j, "`");
+    if (run !== fence) {
+      j += run - 1;
+      continue;
+    }
+    let text = source.slice(at + fence, j).replace(/\n/g, " ");
+    if (text.length > 2 && text.startsWith(" ") && text.endsWith(" ")) {
+      text = text.slice(1, -1);
+    }
+    return { text, next: j + run };
+  }
+  return null;
+}
+
+interface LinkMatch {
+  label: string;
+  href: string;
+  next: number;
+}
+
+/** `[label](href "title")`, honouring nesting and escapes so a label with
+ *  brackets or a URL with parens survives. */
+function matchLink(source: string, at: number): LinkMatch | null {
+  const labelEnd = findClosing(source, at, "[", "]");
+  if (labelEnd === -1 || source[labelEnd + 1] !== "(") return null;
+  const hrefEnd = findClosing(source, labelEnd + 1, "(", ")");
+  if (hrefEnd === -1) return null;
+  const target = source.slice(labelEnd + 2, hrefEnd).trim();
+  // A title is display-only in markdown and has nowhere to go in ADF.
+  const titled = /^(\S+)\s+["'(].*["')]$/.exec(target);
+  return {
+    label: source.slice(at + 1, labelEnd),
+    href: titled?.[1] ?? target,
+    next: hrefEnd + 1,
+  };
+}
+
+function findClosing(
+  source: string,
+  at: number,
+  open: string,
+  close: string,
+): number {
+  let depth = 0;
+  for (let j = at; j < source.length; j++) {
+    const char = source[j];
+    if (char === "\\") {
+      j++;
+      continue;
+    }
+    if (char === open) depth++;
+    else if (char === close && --depth === 0) return j;
+  }
+  return -1;
+}
+
+function matchAutolink(source: string, at: number): LinkMatch | null {
+  const end = source.indexOf(">", at);
+  if (end === -1) return null;
+  const target = source.slice(at + 1, end);
+  if (target === "" || /[\s<]/.test(target)) return null;
+  return { label: target, href: target, next: end + 1 };
+}
+
+/** With no href we can trust — a Studio-relative path, a `javascript:` URL —
+ *  the label stays plain text: ADF rejects a link mark without a real href. */
+function linkNodes(link: LinkMatch, marks: AdfMark[]): AdfNode[] {
+  const href = safeHref(link.href);
+  const label = link.label.trim() === "" ? href : link.label;
+  if (!label) return [];
+  if (!href || hasLink(marks)) return inlineNodes(label, marks);
+  return inlineNodes(label, withMark(marks, { type: "link", attrs: { href } }));
+}
+
+/**
+ * An image degrades to its link, because ADF has no external image: `media`
+ * addresses an attachment in the issue's own media collection, which a mirrored
+ * board comment has no way to populate. An `org/output/…` screenshot (rewritten
+ * to a Studio path by `embedOrgOutputImages`) has no absolute URL at all, so it
+ * degrades further, to its alt text.
+ */
+function imageNodes(image: LinkMatch, marks: AdfMark[]): AdfNode[] {
+  return linkNodes(image, marks);
+}
+
+function safeHref(raw: string): string | null {
+  const target = raw.trim().replace(/^<|>$/g, "");
+  if (target === "") return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    return null;
+  }
+  return ["http:", "https:", "mailto:"].includes(parsed.protocol)
+    ? target
+    : null;
+}
+
+const BARE_URL_RE = /^https?:\/\/[^\s<>]+/;
+/** Trailing punctuation a sentence lends to a URL, not part of it. */
+const URL_TRAILING = ".,;:!?'\"";
+
+function matchBareUrl(
+  source: string,
+  at: number,
+  marks: AdfMark[],
+): { node: AdfNode; next: number } | null {
+  if (hasLink(marks)) return null;
+  const before = source[at - 1];
+  if (before && /[\w/]/.test(before)) return null;
+  const match = BARE_URL_RE.exec(source.slice(at));
+  if (!match) return null;
+  let url = match[0];
+  for (;;) {
+    const last = url.at(-1) ?? "";
+    if (URL_TRAILING.includes(last)) {
+      url = url.slice(0, -1);
+      continue;
+    }
+    // A `)` goes only when unbalanced, so a wiki-style URL keeps its own.
+    if (last === ")" && url.split(")").length > url.split("(").length) {
+      url = url.slice(0, -1);
+      continue;
+    }
+    break;
+  }
+  const href = safeHref(url);
+  if (!href) return null;
+  return {
+    node: textNode(url, withMark(marks, { type: "link", attrs: { href } })),
+    next: at + url.length,
+  };
+}
+
+function isSpace(char: string | undefined): boolean {
+  return char === undefined || /\s/.test(char);
+}
+
+function isWordChar(char: string | undefined): boolean {
+  return char !== undefined && /[\p{L}\p{N}]/u.test(char);
+}
+
+function matchEmphasis(
+  source: string,
+  at: number,
+  marks: AdfMark[],
+): { nodes: AdfNode[]; next: number } | null {
+  const char = source[at] ?? "";
+  const run = runLength(source, at, char);
+  if (char === "~") {
+    if (run < 2) return null;
+    const close = findDelimiter(source, at + 2, "~", 2);
+    if (close === -1) return null;
+    return {
+      nodes: inlineNodes(source.slice(at + 2, close), withMark(marks, STRIKE)),
+      next: close + 2,
+    };
+  }
+  const length = Math.min(run, 3);
+  if (isSpace(source[at + length])) return null;
+  // `_` never marks up mid-word: `snake_case_name` is an identifier.
+  if (char === "_" && isWordChar(source[at - 1])) return null;
+  const close = findDelimiter(source, at + length, char, length);
+  if (close === -1) return null;
+  if (char === "_" && isWordChar(source[close + length])) return null;
+  const added = length >= 3 ? [STRONG, EM] : length === 2 ? [STRONG] : [EM];
+  let inner = marks;
+  for (const mark of added) inner = withMark(inner, mark);
+  return {
+    nodes: inlineNodes(source.slice(at + length, close), inner),
+    next: close + length,
+  };
+}
+
+/** The closing run for an opener of `length`: a run of at least `length` chars
+ *  not preceded by whitespace (`a * b *` is not emphasis). */
+function findDelimiter(
+  source: string,
+  from: number,
+  char: string,
+  length: number,
+): number {
+  for (let j = from; j < source.length; j++) {
+    if (source[j] === "\\") {
+      j++;
+      continue;
+    }
+    if (source[j] !== char) continue;
+    const run = runLength(source, j, char);
+    if (run < length || isSpace(source[j - 1])) {
+      j += run - 1;
+      continue;
+    }
+    return j;
+  }
+  return -1;
+}

--- a/apps/api/src/jira/markdown-adf.ts
+++ b/apps/api/src/jira/markdown-adf.ts
@@ -675,13 +675,15 @@ function linkNodes(link: LinkMatch, marks: AdfMark[]): AdfNode[] {
 }
 
 /**
- * An image degrades to its link. Embedding one needs a `media` node, whose
- * `attrs.id` is a media-services UUID — a different id space from the numeric
- * id `POST /issue/{id}/attachments` returns, which `GET /attachment/{id}` never
- * exposes, so uploading the bytes is not by itself enough to reference them.
- * An `org/output/…` screenshot (rewritten to a Studio path by
- * `embedOrgOutputImages`) has no absolute URL at all, so it degrades further,
- * to its alt text.
+ * An image degrades to its link, until this converter learns to emit `media`.
+ *
+ * Embedding needs a `media` node whose `attrs.id` is a media-services UUID —
+ * a different id space from the numeric id `POST /issue/{id}/attachments`
+ * returns. The UUID is reachable: `GET /attachment/content/{id}` answers 303 to
+ * `https://api.media.atlassian.com/file/<uuid>/binary`, and that uuid with
+ * `collection: ""` embeds and renders. `attrs.id` must be that uuid, and
+ * `collection` must be present — the numeric id fails
+ * `ATTACHMENT_VALIDATION_ERROR`, and omitting `collection` fails `INVALID_INPUT`.
  */
 function imageNodes(image: LinkMatch, marks: AdfMark[]): AdfNode[] {
   return linkNodes(image, marks);

--- a/apps/api/src/jira/markdown-adf.ts
+++ b/apps/api/src/jira/markdown-adf.ts
@@ -261,9 +261,15 @@ function parseQuote(cursor: Cursor, ctx: Ctx): AdfNode {
     inner.push(match[1] ?? "");
     cursor.i++;
   }
+  const content = restrict(
+    parseBlocks({ lines: inner, i: 0 }, ctx),
+    QUOTE_CONTENT,
+  );
   return {
     type: "blockquote",
-    content: restrict(parseBlocks({ lines: inner, i: 0 }, ctx), QUOTE_CONTENT),
+    // ADF wants one child or more, and `> ---` restricts down to none.
+    content:
+      content.length > 0 ? content : [{ type: "paragraph", content: [] }],
   };
 }
 
@@ -417,6 +423,13 @@ function flatten(block: AdfNode): AdfNode | null {
   return text === "" ? null : textParagraph(text);
 }
 
+/** A data row is padded to the header's width, so one 4-character `|x|` line
+ *  costs a cell per column: 300 columns of pipes inside the 30KB push budget
+ *  built a 4.1M-node, 162MB document. Both caps bound that product; rows past
+ *  the cap fall through to paragraphs, which stay linear in the input. */
+const MAX_TABLE_COLUMNS = 24;
+const MAX_TABLE_ROWS = 200;
+
 const TABLE_ROW_RE = /^ {0,3}\|/;
 const DELIMITER_CELL_RE = /^:?-+:?$/;
 
@@ -434,12 +447,23 @@ function parseTable(cursor: Cursor, ctx: Ctx): AdfNode | null {
     return null;
   }
   cursor.i += 2;
-  const rows: AdfNode[] = [tableRow(header, "tableHeader", header.length, ctx)];
-  while (cursor.i < cursor.lines.length) {
+  const width = Math.min(header.length, MAX_TABLE_COLUMNS);
+  if (header.length > width) {
+    console.warn(
+      `[jira] table has ${header.length} columns; keeping the first ${width}`,
+    );
+  }
+  const rows: AdfNode[] = [tableRow(header, "tableHeader", width, ctx)];
+  while (cursor.i < cursor.lines.length && rows.length <= MAX_TABLE_ROWS) {
     const cells = splitRow(cursor.lines[cursor.i] ?? "");
     if (!cells) break;
-    rows.push(tableRow(cells, "tableCell", header.length, ctx));
+    rows.push(tableRow(cells, "tableCell", width, ctx));
     cursor.i++;
+  }
+  if (splitRow(cursor.lines[cursor.i] ?? "")) {
+    console.warn(
+      `[jira] table exceeds ${MAX_TABLE_ROWS} rows; the rest render as text`,
+    );
   }
   return {
     type: "table",
@@ -770,13 +794,20 @@ function matchAutolink(source: string, at: number): LinkMatch | null {
   return { label: target, href: target, next: end + 1 };
 }
 
-/** With no href we can trust — a Studio-relative path, a `javascript:` URL —
- *  the label stays plain text. Jira accepts either (probed), so this is about
- *  not publishing a link nobody reading the issue could follow. */
+/**
+ * With no href we can trust — a Studio-relative path, a `javascript:` URL —
+ * the label stays plain text. Jira accepts either (probed), so this is about
+ * not publishing a link nobody reading the issue could follow.
+ *
+ * An empty label falls back to the target itself, as text. Ugly for a long
+ * URL, but an unlabelled `![](…)` whose upload failed would otherwise vanish
+ * from the comment with nothing in its place.
+ */
 function linkNodes(link: LinkMatch, marks: AdfMark[], ctx: Ctx): AdfNode[] {
   const href = safeHref(link.href);
-  const label = link.label.trim() === "" ? href : link.label;
-  if (!label) return [];
+  const label =
+    link.label.trim() !== "" ? link.label : (href ?? link.href.trim());
+  if (label === "") return [];
   if (!href || hasLink(marks)) return inlineNodes(label, ctx, marks);
   return inlineNodes(
     label,
@@ -786,8 +817,9 @@ function linkNodes(link: LinkMatch, marks: AdfMark[], ctx: Ctx): AdfNode[] {
 }
 
 /**
- * An image the caller uploaded becomes a `media` node; anything else degrades
- * to its link, or to its alt text when the target is not a usable URL.
+ * An image the caller uploaded becomes a `media` node. Anything else degrades
+ * to a link, or — for a Studio-relative target Jira could never fetch — to its
+ * alt text, or to the target as text when there is no alt either.
  *
  * `attrs.id` is the media-services uuid, a different id space from the numeric
  * id `POST /issue/{id}/attachments` returns — see `JiraClient.addAttachment`,

--- a/apps/api/src/jira/markdown-adf.ts
+++ b/apps/api/src/jira/markdown-adf.ts
@@ -352,17 +352,16 @@ function parseList(cursor: Cursor, first: ListMarker, ctx: Ctx): AdfNode {
     : { type: "bulletList", content: items };
 }
 
+/** `mediaSingle` is in both: a probe against Jira Cloud accepted one inside a
+ *  blockquote and inside a listItem. */
 const QUOTE_CONTENT = new Set([
   "paragraph",
   "bulletList",
   "orderedList",
   "codeBlock",
+  "mediaSingle",
 ]);
-/** ADF allows `mediaSingle` in a listItem. Not added to QUOTE_CONTENT on
- *  purpose: whether a blockquote takes one is less certain, and a rejected
- *  document costs the whole comment's formatting, while restricting it here
- *  costs one inline image inside a quote. */
-const LIST_ITEM_CONTENT = new Set([...QUOTE_CONTENT, "mediaSingle"]);
+const LIST_ITEM_CONTENT = QUOTE_CONTENT;
 
 function listItemContent(blocks: AdfNode[]): AdfNode[] {
   const content = restrict(blocks, LIST_ITEM_CONTENT);
@@ -772,7 +771,8 @@ function matchAutolink(source: string, at: number): LinkMatch | null {
 }
 
 /** With no href we can trust — a Studio-relative path, a `javascript:` URL —
- *  the label stays plain text: ADF rejects a link mark without a real href. */
+ *  the label stays plain text. Jira accepts either (probed), so this is about
+ *  not publishing a link nobody reading the issue could follow. */
 function linkNodes(link: LinkMatch, marks: AdfMark[], ctx: Ctx): AdfNode[] {
   const href = safeHref(link.href);
   const label = link.label.trim() === "" ? href : link.label;

--- a/apps/api/src/jira/markdown-adf.ts
+++ b/apps/api/src/jira/markdown-adf.ts
@@ -18,6 +18,11 @@
  * Anything unrecognized degrades to its literal source text: a stray `*` on
  * the issue is better than a mangled sentence, and far better than a comment
  * Jira refuses.
+ *
+ * Images are the one thing the converter cannot resolve alone: an embedded
+ * image is a `media` node addressing an upload, so the caller uploads first
+ * (`collectImageTargets` says what to) and passes the result back in as
+ * `options.media`. Unresolved targets stay links, exactly as before.
  */
 
 export interface AdfMark {
@@ -39,6 +44,15 @@ export interface AdfDoc {
   content: AdfNode[];
 }
 
+/** An uploaded attachment, addressed the way an ADF `media` node needs. */
+export interface AdfMedia {
+  /** The media-services uuid — NOT the numeric attachment id, which Jira
+   *  rejects with `ATTACHMENT_VALIDATION_ERROR`. */
+  id: string;
+  /** Defaults to the markdown image's own alt text. */
+  alt?: string;
+}
+
 export interface MarkdownToAdfOptions {
   /**
    * A paragraph prepended verbatim, never parsed. The push uses it for the
@@ -47,13 +61,45 @@ export interface MarkdownToAdfOptions {
    * would let `Ana *Nick* Souza` open emphasis.
    */
   header?: string;
+  /**
+   * Image target, exactly as written in the markdown, → the attachment it was
+   * uploaded as. A target that is absent from the map keeps today's behaviour:
+   * a link, or its alt text when the target is not a usable URL.
+   */
+  media?: ReadonlyMap<string, AdfMedia>;
+}
+
+const NO_MEDIA: ReadonlyMap<string, AdfMedia> = new Map();
+
+/**
+ * The image targets this converter would embed, in source order.
+ *
+ * Deliberately a real parse rather than a regex sweep: the caller uploads what
+ * this returns, so it must not name a target the converter would then ignore —
+ * an image inside a fenced block, or in a heading, would otherwise cost a
+ * stray attachment on the customer's issue.
+ */
+export function collectImageTargets(markdown: string): string[] {
+  const targets: string[] = [];
+  parseBlocks(
+    { lines: toLines(markdown), i: 0 },
+    {
+      media: NO_MEDIA,
+      allowMedia: true,
+      onImage: (target) => targets.push(target),
+    },
+  );
+  return targets;
 }
 
 export function markdownToAdf(
   markdown: string,
   options: MarkdownToAdfOptions = {},
 ): AdfDoc {
-  const content = parseBlocks({ lines: toLines(markdown), i: 0 });
+  const content = parseBlocks(
+    { lines: toLines(markdown), i: 0 },
+    { media: options.media ?? NO_MEDIA, allowMedia: true },
+  );
   if (options.header) content.unshift(textParagraph(options.header));
   return {
     type: "doc",
@@ -85,6 +131,22 @@ interface Cursor {
   i: number;
 }
 
+interface Ctx {
+  media: ReadonlyMap<string, AdfMedia>;
+  /**
+   * `mediaSingle` is a block node, so only a paragraph-bearing context can
+   * emit one. A heading or a table cell is inline-only and keeps the link —
+   * and reports nothing to `onImage`, so nothing is uploaded for it.
+   */
+  allowMedia: boolean;
+  onImage?: (target: string) => void;
+}
+
+/** Same lookup, for the inline-only contexts. */
+function inlineOnly(ctx: Ctx): Ctx {
+  return { ...ctx, allowMedia: false };
+}
+
 const HEADING_RE = /^ {0,3}(#{1,6})(?:[ \t]+(.*))?$/;
 const FENCE_RE = /^ {0,3}(`{3,}|~{3,})[ \t]*([^`\s]*)/;
 const RULE_RE = /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/;
@@ -92,7 +154,7 @@ const QUOTE_RE = /^ {0,3}> ?(.*)$/;
 const BULLET_RE = /^( *)([-*+])([ \t]+)(.*)$/;
 const ORDERED_RE = /^( *)(\d{1,9})([.)])([ \t]+)(.*)$/;
 
-function parseBlocks(cursor: Cursor): AdfNode[] {
+function parseBlocks(cursor: Cursor, ctx: Ctx): AdfNode[] {
   const blocks: AdfNode[] = [];
   while (cursor.i < cursor.lines.length) {
     const line = cursor.lines[cursor.i] ?? "";
@@ -117,25 +179,26 @@ function parseBlocks(cursor: Cursor): AdfNode[] {
       blocks.push({
         type: "heading",
         attrs: { level: (heading[1] ?? "#").length },
-        content: inlineNodes(heading[2]?.trim() ?? ""),
+        content: inlineNodes(heading[2]?.trim() ?? "", inlineOnly(ctx)),
       });
       continue;
     }
     if (QUOTE_RE.test(line)) {
-      blocks.push(parseQuote(cursor));
+      blocks.push(parseQuote(cursor, ctx));
       continue;
     }
     const item = matchListItem(line);
     if (item) {
-      blocks.push(parseList(cursor, item));
+      blocks.push(parseList(cursor, item, ctx));
       continue;
     }
-    const table = parseTable(cursor);
+    const table = parseTable(cursor, ctx);
     if (table) {
       blocks.push(table);
       continue;
     }
-    blocks.push(parseParagraph(cursor));
+    // A paragraph can yield several blocks: a lifted image splits it.
+    blocks.push(...parseParagraph(cursor, ctx));
   }
   return blocks;
 }
@@ -190,7 +253,7 @@ function sanitizeLanguage(info: string): string {
     .slice(0, 20);
 }
 
-function parseQuote(cursor: Cursor): AdfNode {
+function parseQuote(cursor: Cursor, ctx: Ctx): AdfNode {
   const inner: string[] = [];
   while (cursor.i < cursor.lines.length) {
     const match = QUOTE_RE.exec(cursor.lines[cursor.i] ?? "");
@@ -200,7 +263,7 @@ function parseQuote(cursor: Cursor): AdfNode {
   }
   return {
     type: "blockquote",
-    content: restrict(parseBlocks({ lines: inner, i: 0 }), QUOTE_CONTENT),
+    content: restrict(parseBlocks({ lines: inner, i: 0 }, ctx), QUOTE_CONTENT),
   };
 }
 
@@ -248,7 +311,7 @@ function matchListItem(line: string): ListMarker | null {
  * re-parsed as blocks — so a nested list, a fenced block or a second paragraph
  * inside an item all fall out of the same rule instead of needing their own.
  */
-function parseList(cursor: Cursor, first: ListMarker): AdfNode {
+function parseList(cursor: Cursor, first: ListMarker, ctx: Ctx): AdfNode {
   const items: AdfNode[] = [];
   let marker: ListMarker | null = first;
   while (marker) {
@@ -271,7 +334,7 @@ function parseList(cursor: Cursor, first: ListMarker): AdfNode {
     }
     items.push({
       type: "listItem",
-      content: listItemContent(parseBlocks({ lines: itemLines, i: 0 })),
+      content: listItemContent(parseBlocks({ lines: itemLines, i: 0 }, ctx)),
     });
     const next = matchListItem(cursor.lines[cursor.i] ?? "");
     // A dedent, or a switch between bullets and numbers, ends this list.
@@ -295,7 +358,11 @@ const QUOTE_CONTENT = new Set([
   "orderedList",
   "codeBlock",
 ]);
-const LIST_ITEM_CONTENT = QUOTE_CONTENT;
+/** ADF allows `mediaSingle` in a listItem. Not added to QUOTE_CONTENT on
+ *  purpose: whether a blockquote takes one is less certain, and a rejected
+ *  document costs the whole comment's formatting, while restricting it here
+ *  costs one inline image inside a quote. */
+const LIST_ITEM_CONTENT = new Set([...QUOTE_CONTENT, "mediaSingle"]);
 
 function listItemContent(blocks: AdfNode[]): AdfNode[] {
   const content = restrict(blocks, LIST_ITEM_CONTENT);
@@ -329,6 +396,11 @@ function restrict(blocks: AdfNode[], allowed: ReadonlySet<string>): AdfNode[] {
       continue;
     }
     if (block.type === "rule") continue;
+    if (block.type === "mediaSingle") {
+      const alt = mediaAlt(block);
+      if (alt) out.push(textParagraph(alt));
+      continue;
+    }
     const flattened = flatten(block);
     if (flattened) out.push(flattened);
   }
@@ -351,7 +423,7 @@ const DELIMITER_CELL_RE = /^:?-+:?$/;
 
 /** A GFM table: a pipe row, a delimiter row of matching width, then rows. The
  *  leading pipe is required — `a | b` in prose is not a table. */
-function parseTable(cursor: Cursor): AdfNode | null {
+function parseTable(cursor: Cursor, ctx: Ctx): AdfNode | null {
   const header = splitRow(cursor.lines[cursor.i] ?? "");
   if (!header) return null;
   const delimiter = splitRow(cursor.lines[cursor.i + 1] ?? "");
@@ -363,11 +435,11 @@ function parseTable(cursor: Cursor): AdfNode | null {
     return null;
   }
   cursor.i += 2;
-  const rows: AdfNode[] = [tableRow(header, "tableHeader", header.length)];
+  const rows: AdfNode[] = [tableRow(header, "tableHeader", header.length, ctx)];
   while (cursor.i < cursor.lines.length) {
     const cells = splitRow(cursor.lines[cursor.i] ?? "");
     if (!cells) break;
-    rows.push(tableRow(cells, "tableCell", header.length));
+    rows.push(tableRow(cells, "tableCell", header.length, ctx));
     cursor.i++;
   }
   return {
@@ -402,13 +474,18 @@ function splitRow(line: string): string[] | null {
 
 /** Rows are padded and truncated to the header's width: ADF accepts a ragged
  *  table, but Jira's own editor then treats it as broken. */
-function tableRow(cells: string[], cellType: string, width: number): AdfNode {
+function tableRow(
+  cells: string[],
+  cellType: string,
+  width: number,
+  ctx: Ctx,
+): AdfNode {
   return {
     type: "tableRow",
     content: Array.from({ length: width }, (_unused, column) => ({
       type: cellType,
       attrs: {},
-      content: [paragraph(inlineNodes(cells[column] ?? ""))],
+      content: [paragraph(inlineNodes(cells[column] ?? "", inlineOnly(ctx)))],
     })),
   };
 }
@@ -417,7 +494,7 @@ function paragraph(content: AdfNode[]): AdfNode {
   return { type: "paragraph", content };
 }
 
-function parseParagraph(cursor: Cursor): AdfNode {
+function parseParagraph(cursor: Cursor, ctx: Ctx): AdfNode[] {
   const lines: string[] = [];
   while (cursor.i < cursor.lines.length) {
     const line = cursor.lines[cursor.i] ?? "";
@@ -428,7 +505,33 @@ function parseParagraph(cursor: Cursor): AdfNode {
     lines.push(lines.length === 0 ? line : line.trimStart());
     cursor.i++;
   }
-  return paragraph(inlineNodes(joinLines(lines)));
+  return liftMedia(inlineNodes(joinLines(lines), ctx));
+}
+
+/**
+ * `mediaSingle` is a block node, so an image written mid-sentence has to be
+ * lifted out of its paragraph, splitting the text around it. A paragraph left
+ * holding nothing but line breaks is dropped rather than emitted empty.
+ */
+function liftMedia(nodes: AdfNode[]): AdfNode[] {
+  const blocks: AdfNode[] = [];
+  let inline: AdfNode[] = [];
+  const flush = () => {
+    while (inline[0]?.type === "hardBreak") inline.shift();
+    while (inline.at(-1)?.type === "hardBreak") inline.pop();
+    if (inline.length > 0) blocks.push(paragraph(inline));
+    inline = [];
+  };
+  for (const node of nodes) {
+    if (node.type === "mediaSingle") {
+      flush();
+      blocks.push(node);
+      continue;
+    }
+    inline.push(node);
+  }
+  flush();
+  return blocks.length > 0 ? blocks : [paragraph([])];
 }
 
 /**
@@ -464,7 +567,11 @@ const STRIKE: AdfMark = { type: "strike" };
  * recursion (a link label can be bold), and an unmatched delimiter falls
  * through as the literal character it is.
  */
-function inlineNodes(source: string, marks: AdfMark[] = []): AdfNode[] {
+function inlineNodes(
+  source: string,
+  ctx: Ctx,
+  marks: AdfMark[] = [],
+): AdfNode[] {
   const out: AdfNode[] = [];
   let buffer = "";
   const flush = () => {
@@ -501,7 +608,7 @@ function inlineNodes(source: string, marks: AdfMark[] = []): AdfNode[] {
       const image = matchLink(source, i + 1);
       if (image) {
         flush();
-        out.push(...imageNodes(image, marks));
+        out.push(...imageNodes(image, marks, ctx));
         i = image.next;
         continue;
       }
@@ -509,7 +616,7 @@ function inlineNodes(source: string, marks: AdfMark[] = []): AdfNode[] {
       const link = matchLink(source, i);
       if (link) {
         flush();
-        out.push(...linkNodes(link, marks));
+        out.push(...linkNodes(link, marks, ctx));
         i = link.next;
         continue;
       }
@@ -517,12 +624,12 @@ function inlineNodes(source: string, marks: AdfMark[] = []): AdfNode[] {
       const auto = matchAutolink(source, i);
       if (auto) {
         flush();
-        out.push(...linkNodes(auto, marks));
+        out.push(...linkNodes(auto, marks, ctx));
         i = auto.next;
         continue;
       }
     } else if (char === "*" || char === "_" || char === "~") {
-      const emphasized = matchEmphasis(source, i, marks);
+      const emphasized = matchEmphasis(source, i, marks, ctx);
       if (emphasized) {
         flush();
         out.push(...emphasized.nodes);
@@ -666,27 +773,63 @@ function matchAutolink(source: string, at: number): LinkMatch | null {
 
 /** With no href we can trust — a Studio-relative path, a `javascript:` URL —
  *  the label stays plain text: ADF rejects a link mark without a real href. */
-function linkNodes(link: LinkMatch, marks: AdfMark[]): AdfNode[] {
+function linkNodes(link: LinkMatch, marks: AdfMark[], ctx: Ctx): AdfNode[] {
   const href = safeHref(link.href);
   const label = link.label.trim() === "" ? href : link.label;
   if (!label) return [];
-  if (!href || hasLink(marks)) return inlineNodes(label, marks);
-  return inlineNodes(label, withMark(marks, { type: "link", attrs: { href } }));
+  if (!href || hasLink(marks)) return inlineNodes(label, ctx, marks);
+  return inlineNodes(
+    label,
+    ctx,
+    withMark(marks, { type: "link", attrs: { href } }),
+  );
 }
 
 /**
- * An image degrades to its link, until this converter learns to emit `media`.
+ * An image the caller uploaded becomes a `media` node; anything else degrades
+ * to its link, or to its alt text when the target is not a usable URL.
  *
- * Embedding needs a `media` node whose `attrs.id` is a media-services UUID —
- * a different id space from the numeric id `POST /issue/{id}/attachments`
- * returns. The UUID is reachable: `GET /attachment/content/{id}` answers 303 to
- * `https://api.media.atlassian.com/file/<uuid>/binary`, and that uuid with
- * `collection: ""` embeds and renders. `attrs.id` must be that uuid, and
- * `collection` must be present — the numeric id fails
- * `ATTACHMENT_VALIDATION_ERROR`, and omitting `collection` fails `INVALID_INPUT`.
+ * `attrs.id` is the media-services uuid, a different id space from the numeric
+ * id `POST /issue/{id}/attachments` returns — see `JiraClient.addAttachment`,
+ * which resolves one to the other. Both `type: "file"` and `collection` are
+ * load-bearing: the numeric id fails `ATTACHMENT_VALIDATION_ERROR`, and
+ * omitting `collection` fails `INVALID_INPUT`, so `""` is spelled out.
  */
-function imageNodes(image: LinkMatch, marks: AdfMark[]): AdfNode[] {
-  return linkNodes(image, marks);
+function imageNodes(image: LinkMatch, marks: AdfMark[], ctx: Ctx): AdfNode[] {
+  if (ctx.allowMedia) {
+    ctx.onImage?.(image.href);
+    const media = ctx.media.get(image.href);
+    if (media) {
+      const alt = media.alt ?? image.label.trim();
+      return [
+        {
+          type: "mediaSingle",
+          attrs: { layout: "align-start" },
+          content: [
+            {
+              type: "media",
+              attrs: {
+                type: "file",
+                id: media.id,
+                collection: "",
+                ...(alt === "" ? {} : { alt }),
+              },
+            },
+          ],
+        },
+      ];
+    }
+  }
+  return linkNodes(image, marks, ctx);
+}
+
+/** The alt text of a `mediaSingle`, for a context that cannot hold one. */
+function mediaAlt(block: AdfNode): string {
+  for (const child of block.content ?? []) {
+    const alt = child.attrs?.alt;
+    if (typeof alt === "string" && alt !== "") return alt;
+  }
+  return "";
 }
 
 function safeHref(raw: string): string | null {
@@ -751,6 +894,7 @@ function matchEmphasis(
   source: string,
   at: number,
   marks: AdfMark[],
+  ctx: Ctx,
 ): { nodes: AdfNode[]; next: number } | null {
   const char = source[at] ?? "";
   const run = runLength(source, at, char);
@@ -759,7 +903,11 @@ function matchEmphasis(
     const close = findDelimiter(source, at + 2, "~", 2);
     if (close === -1) return null;
     return {
-      nodes: inlineNodes(source.slice(at + 2, close), withMark(marks, STRIKE)),
+      nodes: inlineNodes(
+        source.slice(at + 2, close),
+        ctx,
+        withMark(marks, STRIKE),
+      ),
       next: close + 2,
     };
   }
@@ -774,7 +922,7 @@ function matchEmphasis(
   let inner = marks;
   for (const mark of added) inner = withMark(inner, mark);
   return {
-    nodes: inlineNodes(source.slice(at + length, close), inner),
+    nodes: inlineNodes(source.slice(at + length, close), ctx, inner),
     next: close + length,
   };
 }

--- a/apps/api/src/jira/markdown-adf.ts
+++ b/apps/api/src/jira/markdown-adf.ts
@@ -675,11 +675,13 @@ function linkNodes(link: LinkMatch, marks: AdfMark[]): AdfNode[] {
 }
 
 /**
- * An image degrades to its link, because ADF has no external image: `media`
- * addresses an attachment in the issue's own media collection, which a mirrored
- * board comment has no way to populate. An `org/output/…` screenshot (rewritten
- * to a Studio path by `embedOrgOutputImages`) has no absolute URL at all, so it
- * degrades further, to its alt text.
+ * An image degrades to its link. Embedding one needs a `media` node, whose
+ * `attrs.id` is a media-services UUID — a different id space from the numeric
+ * id `POST /issue/{id}/attachments` returns, which `GET /attachment/{id}` never
+ * exposes, so uploading the bytes is not by itself enough to reference them.
+ * An `org/output/…` screenshot (rewritten to a Studio path by
+ * `embedOrgOutputImages`) has no absolute URL at all, so it degrades further,
+ * to its alt text.
  */
 function imageNodes(image: LinkMatch, marks: AdfMark[]): AdfNode[] {
   return linkNodes(image, marks);


### PR DESCRIPTION
## Summary

A board comment mirrored onto a linked Jira issue was posted through `textToAdf` — one paragraph per line, all formatting dropped. Jira Cloud's v3 comment API only accepts ADF (no markdown, no wiki markup), so the customer saw the raw syntax: literal `**bold**`, literal fences, `-` bullets that never became a list. Most visible on the Super Agent's PR-opened comment, which is heavily formatted.

This adds `apps/api/src/jira/markdown-adf.ts`, the inverse of the existing `wiki-markdown.ts` (Jira → board) and built the same way: a line-driven block parser plus a recursive character scanner for inline marks.

Covered: headings, bullet/ordered lists with nesting, fenced code (language preserved), blockquotes, rules, GFM tables, and inline `strong`/`em`/`code`/`strike`, markdown links, autolinks and bare URLs. Anything ambiguous stays literal — a stray `*` on the issue beats a mangled sentence.

## Durability

The push is a DBOS workflow with **one step per external call**, so a pod death resumes instead of redoing:

```
resolveCommentTarget   → anything to push, and to which issue
readOrgSlug            → only when the comment references an image
attachCommentImage×N   → one step per image, retriable
postCommentToJira      → not retriable, embeds what the attach steps resolved
recordCommentLink      → unchanged
```

Worth stating plainly, because the earlier commits in this PR got it wrong: `retriesAllowed: false` suppresses retry-on-error, **not** re-execution after a crash. A single step doing N uploads plus the comment post would redo every upload on recovery.

The per-image step is retriable because `attachImage` dedups against the issue's attachments before uploading, so a re-run adopts its own earlier upload rather than duplicating it. Exhausted retries are caught in the workflow: that image degrades to a link and the comment still lands. The workflow body stays deterministic (the body slice and `plannedAttachments` are pure), which is what lets a replay line up with the checkpoints. Credentials never cross a step boundary — each step re-reads the integration row — and screenshot bytes stay inside the step that uploads them instead of being checkpointed; only the media map crosses, as entry pairs.

## Notable decisions

- **The attribution line is a separate unparsed paragraph.** `addComment(issueId, markdown, { header })` prepends `"<author> · via Studio:"` as plain text, so a display name like `Ana *Nick* Souza` cannot open emphasis. Same reasoning as `stashMentions` in the pull direction.
- **A 400 falls back once to the flat body.** The push step is deliberately non-retriable (Jira has no idempotency key for comments), so a document Jira dislikes would silently drop the mirror. A 400 means Jira validated and created nothing, so the repost cannot duplicate. `JiraRequestError` carries the status for that check and replaces the now-unreachable message regex in `isRetriableError`.
- **Two invariants keep the document valid:** never an empty `text` node, and nodes only where ADF's schema allows them — `listItem`/`blockquote` accept a narrow set, so a heading inside a list item becomes a paragraph and a nested blockquote is spread rather than nested.
- **Soft line breaks join with a space**, matching the board's own renderer (remark-gfm, no `remark-breaks`), so the issue reads the way the card does. Only explicit hard breaks become `hardBreak`.

## Review fixes

A review pass plus a blast-radius pass found seven defects, all fixed on the branch:

- **The table converter could OOM the pod.** A data row is padded to the header's width, so a 4-char `|x|` line costs a cell per column. Measured: 300 columns inside the 30KB budget built a 4,154,101-node / 162MB document, converted twice per push. Now capped at 24 columns and 200 rows, both logged; overflow rows fall through to paragraphs (linear in input).
- **`URIError` out of a pure function in the workflow body.** `decodeURIComponent` on a slug like `a%zz` threw out of `parseOutputsRef`, failing the whole push over a URL an agent merely typed. Returns null now, as documented.
- **`> ---` produced an empty blockquote**, which ADF rejects — flattening the entire comment. A blockquote that restricts down to nothing now carries an empty paragraph.
- **An unlabelled image whose upload didn't happen vanished.** Falls back to the target as text, which is what the old flat-text push showed.
- **A transient object-store error looked like a missing file**, permanently dropping a screenshot from a step built to retry. Only `OrgFsNotFoundError` is terminal now.
- **`instanceof DBOSMaxStepRetriesError` does not survive replay.** DBOS revives a recorded step error as a plain `Error`; round-tripping one through the SDK's serializer shows `instanceof` false and `name` `"Error"`, so a name match would fail too — only `dbosErrorCode` survives. Extracted `isMaxStepRetriesError` (`dbos/step-errors.ts`) with a test pinning the code against the SDK.
- **`DBOS_WORKFLOW_VERSION` 7 → 8**, since the push went from one step to one per external call — the "add / reorder a step" case the pin exists for. `workflow-source-guard.snapshot.json` re-baselined.

## Known limitations

- **Images degrade to a link, or to their alt text** when the target isn't an absolute URL. ADF's `media` node addresses an attachment in the issue's own media collection, which a mirrored comment has no way to populate — so the QA agent's `org/output/…` screenshots (Studio-relative paths) render as alt text. Fixing that means uploading the bytes to Jira's attachment API, or presigning a URL from the outputs volume; either is its own change.
- **The pull direction still flattens.** `jiraBodyToText` drops marks and fences when bringing a Jira comment onto a card, so a customer's bold/list renders flat on the board. Symmetric gap, not touched here.

## Testing

- `apps/api/src/jira/markdown-adf.test.ts` — 26 unit tests: inline marks, unmatched/intraword delimiters, escapes, nested emphasis, code-span mark exclusion, links/autolinks/bare URLs, unusable hrefs, image degradation, block structure, list nesting and marker switches, truncated fences, tables with ragged rows, plus a walker asserting the ADF invariants over a kitchen-sink document.
- `client.test.ts` — two new cases: the rich document actually posted (with the header unparsed), and the 400 fallback posting the flat body exactly once.
- `bun test apps/api/src/jira` → 75 pass. `bun run fmt`, `bun run lint`, `bun run --cwd=apps/api check`, `knip` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render mirrored Jira comments as rich ADF and embed referenced screenshots. Previously we posted flat text with raw markdown and Studio-relative image URLs; now we convert board markdown to ADF and upload `/api/<org>/fs/outputs/read?path=…` images as Jira attachments, embedding them so issues show formatted text and inline images. On a 400 ADF validation error, we retry once with a flat body to avoid dropping the mirror.

- Converts markdown via `markdownToAdf`: headings, nested lists, fenced code (language), blockquotes, rules, GFM tables, links/autolinks/bare URLs, inline strong/em/code/strike; lifts inline images out of paragraphs; enforces valid ADF placement and non-empty text; caps tables (24 columns, 200 rows) to bound document size; prepends the attribution line as an unparsed paragraph.
- Uploads images behind Studio-relative targets: `collectImageTargets` → planned via `plannedAttachments` (only `outputs` of the pushing org; rejects malformed percent-escapes; dedup by filename+size against existing attachments; cap 8 per comment and 10MB each; fail-open per target). Inline images embed as `media` (including inside list items and blockquotes); contexts that can't host media (e.g., headings, table cells, fenced code) keep alt text or a link; unresolved targets stay links.
- `JiraClient`: `addComment(issueId, markdown, { header, media })` posts ADF; on 400 falls back once to `textToAdf(header + "\n" + markdown)`. Introduces `JiraRequestError` and status-based retries (5xx/429 only). Adds `addAttachment` (multipart with `X-Atlassian-Token: no-check`, 60s timeout), `resolveMediaId` (reads media UUID from the attachment-content redirect, with a followed-URL fallback), and `listAttachments` (for dedup). Uploads and comment posts are not idempotent and are not retried.
- Push workflow is split into durable steps: `resolveCommentTarget` → (when images) `readOrgSlug` → `attachCommentImage` × N (retriable; dedups before upload; only exhausted retries degrade to a link via `isMaxStepRetriesError`) → `postCommentToJira` (not retriable; embeds resolved media) → `recordCommentLink`. Planning is pure/deterministic so replays align with checkpoints; credentials are re-read per step; screenshot bytes never cross step boundaries.
- Rollout: advances `DBOS_WORKFLOW_VERSION` to "8". In-flight v7 instances strand on replay by design; no risk of duplicate Jira posts (the new sequence never starts with the POST).
- Migration: Replace `JiraClient.addComment(issueId, text)` with `JiraClient.addComment(issueId, markdown, { header })`. Pass the attribution via `header`; optionally pass `media` when embedding uploaded images.

<sup>Written for commit b7ddca7b93f69c6e1c9efec06f15d88d234bdfad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

