### PR TITLE
fix(sandbox): stop already-committed org-fs skills from reading as user changes

### DIFF
--- a/packages/sandbox/daemon-go/internal/gitx/exclude.go
+++ b/packages/sandbox/daemon-go/internal/gitx/exclude.go
@@ -23,11 +23,17 @@ func EnsureExclude(repoDir, line string) {
 	if err != nil || !st.IsDir() {
 		return
 	}
-	excludePath := filepath.Join(gitDir, "info", "exclude")
+	appendExcludeLine(filepath.Join(gitDir, "info", "exclude"), line)
+	// An exclude covers UNTRACKED paths only, so it cannot hide a daemon-managed
+	// path that some build already committed — hence the index bit as well.
+	ignoreTracked(repoDir, strings.TrimPrefix(line, "/"))
+}
+
+func appendExcludeLine(excludePath, line string) {
 	existing, err := os.ReadFile(excludePath)
 	if err != nil {
 		// Template-less clones (libgit2/JGit, bare templates) lack info/exclude.
-		if mkErr := os.MkdirAll(filepath.Join(gitDir, "info"), 0o755); mkErr != nil {
+		if mkErr := os.MkdirAll(filepath.Dir(excludePath), 0o755); mkErr != nil {
 			return
 		}
 		os.WriteFile(excludePath, []byte(line+"\n"), 0o644)
@@ -44,6 +50,46 @@ func EnsureExclude(repoDir, line string) {
 	}
 	defer f.Close()
 	f.WriteString(line + "\n")
+}
+
+// ignoreTracked stops git reporting TRACKED paths matching `pathspec` by setting
+// their skip-worktree bit. Nothing to do in a healthy repo — but a build that
+// predated {@link ReapplyExcludes} committed the org-fs skill symlinks onto real
+// site repos, and a committed path is one an exclude can never mask: every clone
+// of that repo tracks it, and the org-fs sync replacing each symlink with a real
+// directory surfaced 33 phantom deletions in the publish dialog of every new
+// chat, indefinitely.
+//
+// The index bit is the only fix the daemon owns. The residue itself lives on the
+// user's default branch, where only they can delete it, and until they do these
+// paths must read as "not a change" — they are the daemon's, not the user's.
+//
+// ponytail: no history rewrite, no `git rm`. Staging a deletion would put the
+// daemon's cleanup into the user's next commit; skip-worktree just makes git
+// stop looking. The known ceiling: a later branch switch that wants to change
+// one of these paths refuses with "Entry not uptodate" — acceptable for paths
+// nothing but this daemon writes.
+func ignoreTracked(repoDir, pathspec string) {
+	if pathspec == "" {
+		return
+	}
+	listed, ok := Try([]string{"ls-files", "-z", "--", pathspec}, RunOpts{
+		Cwd: repoDir, Env: ReadEnv(repoDir),
+	})
+	if !ok || listed == "" {
+		return
+	}
+	var paths []string
+	for _, p := range strings.Split(listed, "\x00") {
+		if p != "" {
+			paths = append(paths, p)
+		}
+	}
+	if len(paths) == 0 {
+		return
+	}
+	args := append([]string{"update-index", "--skip-worktree", "--"}, paths...)
+	Try(args, RunOpts{Cwd: repoDir})
 }
 
 // ReapplyExcludes re-registers every line EnsureExclude was asked for on this

--- a/packages/sandbox/daemon-go/internal/gitx/exclude_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/exclude_test.go
@@ -70,3 +70,43 @@ func TestPublishNeverCommitsTheEndpointCredential(t *testing.T) {
 		t.Fatalf("publish dropped the user's work too: %q", committed)
 	}
 }
+
+// The residue case: a build that predated ReapplyExcludes committed the org-fs
+// skill symlinks onto real site repos, so every clone TRACKS them — and an
+// exclude covers untracked paths only. The org-fs sync then replaces each
+// committed symlink with a real directory, which git reports as a deletion: 33
+// phantom changes in the publish dialog of every new chat, in perpetuity.
+func TestEnsureExcludeHidesAlreadyCommittedDaemonPaths(t *testing.T) {
+	dir := t.TempDir()
+	gitIn(t, dir, "init", "-q")
+	gitIn(t, dir, "config", "user.email", "t@t.t")
+	gitIn(t, dir, "config", "user.name", "t")
+	if err := os.MkdirAll(filepath.Join(dir, ".claude", "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// What the pre-fix daemon committed: a symlink into the org-fs mount.
+	if err := os.Symlink("/mnt/org/public/core/brand", filepath.Join(dir, ".claude", "skills", "orgfs-core-brand")); err != nil {
+		t.Fatal(err)
+	}
+	gitIn(t, dir, "add", "-A")
+	gitIn(t, dir, "commit", "-qm", "residue")
+
+	// What today's daemon does on top: clear the entry, publish a real copy.
+	os.RemoveAll(filepath.Join(dir, ".claude", "skills", "orgfs-core-brand"))
+	if err := os.MkdirAll(filepath.Join(dir, ".claude", "skills", "orgfs-core-brand"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".claude", "skills", "orgfs-core-brand", "SKILL.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureExclude(dir, "/.claude/skills/orgfs-*")
+
+	if status := gitIn(t, dir, "status", "--porcelain"); strings.TrimSpace(status) != "" {
+		t.Fatalf("daemon-managed path still reads as a user change: %q", status)
+	}
+	gitIn(t, dir, "add", "-A")
+	if staged := gitIn(t, dir, "diff", "--cached", "--name-only"); strings.TrimSpace(staged) != "" {
+		t.Fatalf("`git add -A` staged a daemon-managed path: %q", staged)
+	}
+}


### PR DESCRIPTION
## The bug

Every new chat on `deco-sites/casaevideo-tanstack` opens the publish dialog with 33 phantom changes — all `.claude/skills/orgfs-*` — and it has survived every fix so far.

It is not recurring. It is one artifact, permanently committed:

```
# live prod pod, branch tavano-njiv03tm
/app/repo/.git/info/exclude  →  /.claude/skills/orgfs-*        # the exclude IS there
git ls-tree origin/main .claude/skills/  →  120000 blob … orgfs-core-brand
git status --porcelain       →  33 × " D .claude/skills/orgfs-*"
```

`.git/info/exclude` ignores **untracked** paths only. These are tracked.

## How they got tracked

A build predating #6028 wrote the skill symlinks into the checkout *before* the clone; `EnsureExclude` had no `.git` to write to, `git init` on the non-empty dir handed the shutdown `git add -A` a clean slate, and the symlinks were committed:

| repo | commit | date |
|---|---|---|
| `deco-sites/casaevideo-tanstack` | `ef7d4ef0` | 2026-08-07 |
| `deco-sites/decocms-tanstack` | `27bf6858` | 2026-08-12 |

#6028 (Aug 13) closed that write path — GitHub code search finds no third repo. What is left is residue on those repos' default branch, and since #6375 swapped symlinks for copied directories, the daemon now deletes each tracked symlink and drops a real dir there. git calls that a deletion. Hence 33 changes, in every clone, forever.

## The fix

`EnsureExclude` now also sets the **skip-worktree** bit on tracked paths matching the line it registers, so git stops looking at daemon-managed paths whether or not something once committed them. It rides the existing `ReapplyExcludes` machinery, so it applies in both orders (clone-then-sync and sync-then-clone).

No history rewrite and no `git rm`: staging the daemon's own cleanup would fold it into the user's next commit. The residue lives on the customer's default branch, where only they can delete it — until they do, these paths must read as "not a change", because they are the daemon's, not the user's.

Known ceiling, named in the comment: a later branch switch that wants to change one of these paths refuses with "Entry not uptodate". Acceptable for paths nothing but this daemon writes.

## Test

`TestEnsureExcludeHidesAlreadyCommittedDaemonPaths` builds the exact prod state — commit a symlink at `.claude/skills/orgfs-core-brand`, replace it with a real copy directory — and asserts both that `git status` is clean and that `git add -A` stages nothing. Without the fix it fails with the literal prod symptom:

```
daemon-managed path still reads as a user change: " D .claude/skills/orgfs-core-brand"
```

## Follow-up (not in this PR)

The 33 symlinks should still be deleted from `main` in both repos — that is a change to customer repos, so it needs its own decision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops org-fs skills already committed in site repos from appearing as user changes by setting skip-worktree on matching tracked paths. This removes the recurring 33 phantom deletions in publish dialogs without touching user history.

- In `EnsureExclude`, also append the exclude line and set skip-worktree on tracked matches via `ignoreTracked`; applied through `ReapplyExcludes` in both clone orders.
- Side effect: switching to a branch that modifies these daemon-owned paths can fail with “Entry not uptodate”; acceptable for these paths.
- Tests assert a clean status and no staged changes when a committed symlink under `/.claude/skills/orgfs-*` is replaced by a real directory.

<sup>Written for commit 8f439b4cfab16e56d2cb15163a740e123014ebef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

