### PR TITLE
fix(sandbox): load the org's skills from a plugin dir, not the checkout

### DIFF
--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -181,6 +181,22 @@ describe("buildOptions", () => {
     expect(options().skills).toBe("all");
   });
 
+  test("loads the daemon's prefetched org skills as plugins, none when unset", () => {
+    // The read-only shared sets used to be copied into the checkout's
+    // `.claude/skills/` — the only dir the SDK scanned that was also writable —
+    // and every git workaround downstream existed to hide them. A plugin dir is
+    // out of the tree, so there is nothing to hide.
+    expect("plugins" in options()).toBe(false);
+    process.env.CLAUDE_CODE_PLUGIN_DIRS = "/app/orgfs-skills";
+    try {
+      expect(options().plugins).toEqual([
+        { type: "local", path: "/app/orgfs-skills" },
+      ]);
+    } finally {
+      delete process.env.CLAUDE_CODE_PLUGIN_DIRS;
+    }
+  });
+
   test("runs in the repo checkout when the workspace has one", () => {
     const opts = options({
       workspace: {

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -28,6 +28,10 @@ const ENVS = {
   STUDIO_MCP_SERVER_NAME: "studio",
   MODEL_ENV: "CLAUDE_CODE_MODEL",
   EXECUTABLE_ENV: "CLAUDE_CODE_PATH",
+  // Absolute plugin dirs the sandbox daemon prefetched the org's skills into,
+  // colon-separated. Set by the daemon, not by Studio: it is the daemon that
+  // knows where it wrote them, and the value must not outlive that pod.
+  PLUGIN_DIRS_ENV: "CLAUDE_CODE_PLUGIN_DIRS",
 };
 
 /**
@@ -187,6 +191,9 @@ export function buildOptions(args: {
     .filter(Boolean)
     .join("\n\n");
   const executable = process.env[ENVS.EXECUTABLE_ENV];
+  const pluginDirs = (process.env[ENVS.PLUGIN_DIRS_ENV] ?? "")
+    .split(":")
+    .filter(Boolean);
   return {
     ...(cwd ? { cwd } : {}),
     ...(executable ? { pathToClaudeCodeExecutable: executable } : {}),
@@ -199,10 +206,17 @@ export function buildOptions(args: {
       preset: "claude_code",
       append: instructionsWithSkills,
     },
-    // The org's skills reach the pod as `~/.claude/skills` (the daemon links it
-    // onto the org-fs mount), which the SDK discovers from the `user` setting
-    // source — but only once skills are turned on for the session.
+    // Two sources, both wired by the daemon. The org's writable skills are
+    // `~/.claude/skills`, symlinked onto the org-fs mount and discovered from
+    // the `user` setting source. The read-only shared sets are prefetched to pod
+    // disk and loaded as local plugins — out of the checkout, so nothing about
+    // them is the repo's business.
     skills: "all",
+    ...(pluginDirs.length
+      ? {
+          plugins: pluginDirs.map((path) => ({ type: "local" as const, path })),
+        }
+      : {}),
     ...(model ? { model } : {}),
     // ponytail: fixed, not configurable — raise it here if runs come back thin.
     effort: "low",

--- a/packages/sandbox/daemon-go/internal/orgfs/links.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links.go
@@ -69,6 +69,7 @@ type Links struct {
 	lastOutputThread string
 	skillsLinked     bool
 	publicSkillsRun  bool
+	skillPluginReady bool
 	// Closed when the in-flight skill-link sync finishes; nil before the first
 	// one starts. `WaitSkillLinks` is what turns the async sync back into a
 	// barrier for the run that needs it.
@@ -406,30 +407,79 @@ func (l *Links) volumeMounted(dir string) bool {
 	return false
 }
 
-// Prefix for the symlinks this daemon plants in the checkout's skills dir. It
-// is what makes them ours: everything matching it is removed and rebuilt on
-// sync, and one git-exclude line covers the whole set.
+// Prefix for the skill dirs this daemon plants. Kept now that they live in the
+// daemon's own plugin dir purely to keep two sets that ship a same-named skill
+// from colliding; the name the model sees comes from SKILL.md's frontmatter.
 const publicSkillPrefix = "orgfs-"
+
+// The org's skills reach Claude Code as a LOCAL PLUGIN, in the daemon's own
+// directory — never in the checkout. `<appRoot>/orgfs-skills` holds a plugin
+// manifest and one `skills/<name>/` per prefetched skill, and the harness loads
+// it by absolute path.
+//
+// This is the whole reason the git plumbing is gone. The first version wrote
+// these into `<repoDir>/.claude/skills/` — the one writable dir the SDK already
+// scanned — and every consequence followed from that: a git-exclude line per
+// path, re-registering the excludes after a clone, a staging dir inside
+// `.claude/`, an adopt sweep that had to know which entries were ours. Worse,
+// an exclude only masks UNTRACKED paths, so the build that committed them once
+// (before the reapply existed) put them on two site repos' default branch,
+// where they still surface as phantom "changes to publish" in every new chat.
+// Out of the tree, git never has an opinion.
+const (
+	skillPluginDirName = "orgfs-skills"
+	skillPluginName    = "orgfs"
+)
+
+// SkillPluginDir is the plugin dir to hand the harness, or "" when this pod
+// prefetched no skills — an empty plugin would only cost the SDK a load.
+func (l *Links) SkillPluginDir() string {
+	if l == nil {
+		return ""
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.skillPluginReady {
+		return ""
+	}
+	return filepath.Join(l.AppRoot, skillPluginDirName)
+}
+
+// writeSkillPluginManifest makes the dir a plugin the SDK will load. Rewritten
+// on every sync: it is three static fields, cheaper to write than to check.
+func writeSkillPluginManifest(pluginDir string) error {
+	dir := filepath.Join(pluginDir, ".claude-plugin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	manifest, err := json.Marshal(map[string]string{
+		"name":        skillPluginName,
+		"description": "Skills shared by this organization",
+		"version":     "1.0.0",
+	})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "plugin.json"), manifest, 0o644)
+}
 
 // Volume-name prefix the studio gives the shared public sets (`public-core` is
 // mounted at `org/public/core`), mirroring publicVolumeForSet server-side.
 const publicVolumePrefix = "public-"
 
 // ensurePublicSkillLinksLocked exposes the read-only public skill sets
-// (`org/public/<set>/<skill>`) to Claude Code as PROJECT skills — one symlink
-// per skill under `<repoDir>/.claude/skills/`.
+// (`org/public/<set>/<skill>`) to Claude Code as PLUGIN skills, prefetched into
+// the daemon's own plugin dir — see skillPluginDirName.
 //
 // Why not the user dir like home skills: that dir IS the home mount now, so a
-// symlink dropped there would be written into org-fs — pod-local paths synced
+// copy dropped there would be written into org-fs — pod-local bytes synced
 // org-wide. And the public mounts are read-only, so a plugin manifest cannot go
-// next to them either. The checkout's skills dir is the one writable place the
-// SDK already scans.
+// next to them either.
 //
-// Additive and disposable: the repo's own skills are untouched (only `orgfs-*`
-// entries are ours, and they are cleared before rebuild so a removed set leaves
-// no dangling skill), and one exclude line keeps them out of every commit.
+// Additive and disposable: nothing but this sync writes the plugin dir, so a
+// set that lost a skill leaves nothing dangling, and the checkout is untouched.
 func (l *Links) ensurePublicSkillLinksLocked() {
-	if l.publicSkillsRun || l.RepoDir == "" {
+	if l.publicSkillsRun || l.AppRoot == "" {
 		return
 	}
 	// Claimed before the work starts, so concurrent fs calls don't each launch a
@@ -529,10 +579,9 @@ func (l *Links) skillSetRoots() []skillSet {
 	return out
 }
 
-// syncPublicSkills copies every read-only set's skills onto the pod's disk under
-// `<repoDir>/.claude/skills/`, reporting whether anything landed. Runs without
-// `mu`: it touches only the checkout's skills dir and the read-only mounts,
-// which no other link path writes.
+// syncPublicSkills copies every read-only set's skills into the daemon's plugin
+// dir, reporting whether anything landed. Runs without `mu`: it touches only
+// that dir and the read-only mounts, which no other link path writes.
 //
 // Copied rather than symlinked — see skillcopy.go for why. The pod therefore
 // holds a snapshot for its lifetime, which is what we want: this already ran
@@ -544,20 +593,23 @@ func (l *Links) syncPublicSkills() bool {
 		// No public or synced mount on this pod (older sandbox, or none configured).
 		return false
 	}
-	dir := filepath.Join(l.RepoDir, ".claude", "skills")
+	pluginDir := filepath.Join(l.AppRoot, skillPluginDirName)
+	dir := filepath.Join(pluginDir, "skills")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		slog.Warn("org-fs skills dir failed", "err", err)
 		return false
 	}
-	gitx.EnsureExclude(l.RepoDir, "/.claude/skills/"+publicSkillPrefix+"*")
+	if err := writeSkillPluginManifest(pluginDir); err != nil {
+		slog.Warn("org-fs skill plugin manifest failed", "err", err)
+		return false
+	}
 
 	// Staged next to the destination so publishing is a rename on the same
 	// filesystem. Cleared first: a partial stage from a killed attempt must
 	// never be published.
-	staging := filepath.Join(l.RepoDir, ".claude", ".orgfs-staging")
+	staging := filepath.Join(pluginDir, ".staging")
 	os.RemoveAll(staging)
 	defer os.RemoveAll(staging)
-	gitx.EnsureExclude(l.RepoDir, "/.claude/.orgfs-staging")
 
 	// One budget across every set and both transports: the cap protects the
 	// pod's disk, so it cannot be per volume, per worker, or per transport.
@@ -594,8 +646,14 @@ func (l *Links) syncPublicSkills() bool {
 	}
 	slog.Info("org-fs skills prefetched",
 		"skills", len(published), "fromTar", fromTar, "fromMount", fromMount,
-		"unreadable", unreadable, "pruned", pruned)
-	return len(published) > 0
+		"unreadable", unreadable, "pruned", pruned, "plugin", pluginDir)
+	if len(published) == 0 {
+		return false
+	}
+	l.mu.Lock()
+	l.skillPluginReady = true
+	l.mu.Unlock()
+	return true
 }
 
 // copySetToStage is the fallback for a studio without the bulk route: probe the
@@ -724,8 +782,9 @@ func (l *Links) repointThreadLink(threadId, mountDir, linkName string) bool {
 // nobody notices until they look for it next week.
 //
 // Only UNTRACKED dirs move: the repo's own committed skills are the one thing
-// that legitimately lives there, and `--exclude-standard` already drops the
-// `orgfs-*` symlinks this daemon plants (they are in `.git/info/exclude`).
+// that legitimately lives there. The `orgfs-` prefix is skipped as well — this
+// daemon no longer writes the checkout at all, but a repo carrying the entries
+// an older build committed must not have them "adopted" into the org.
 // Copy-then-remove, not rename — the checkout is local disk and the target is
 // FUSE, so a rename is EXDEV.
 func (l *Links) AdoptStrayRepoSkills() {

--- a/packages/sandbox/daemon-go/internal/orgfs/links_test.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links_test.go
@@ -285,7 +285,7 @@ func TestPublicSkillLinks(t *testing.T) {
 	l := &Links{AppRoot: appRoot, RepoDir: repoDir, ConfigPath: "unused"}
 	l.syncPublicSkills()
 
-	skillsDir := filepath.Join(repoDir, ".claude", "skills")
+	skillsDir := filepath.Join(appRoot, skillPluginDirName, "skills")
 	assertSkillPresent(t, skillsDir, "orgfs-core-slides")
 	if _, err := os.Lstat(filepath.Join(skillsDir, "orgfs-core-not-a-skill")); err == nil {
 		t.Error("copied a directory with no SKILL.md")
@@ -294,9 +294,27 @@ func TestPublicSkillLinks(t *testing.T) {
 		t.Errorf("clobbered the repo's own skill: %v", err)
 	}
 
-	excl, err := os.ReadFile(filepath.Join(repoDir, ".git", "info", "exclude"))
-	if err != nil || !strings.Contains(string(excl), "/.claude/skills/orgfs-*") {
-		t.Errorf("links not git-excluded — a run would commit them: %q %v", excl, err)
+	// The point of the plugin dir: git is never involved. Nothing of ours lands
+	// in the checkout, so there is no exclude to keep honest and no path an
+	// older build's commit can leave stranded there.
+	entries, err := os.ReadDir(filepath.Join(repoDir, ".claude", "skills"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), publicSkillPrefix) {
+			t.Errorf("prefetched %q into the checkout", e.Name())
+		}
+	}
+	// And the dir has to be a plugin, or the SDK loads none of it.
+	manifest, err := os.ReadFile(filepath.Join(
+		appRoot, skillPluginDirName, ".claude-plugin", "plugin.json",
+	))
+	if err != nil || !strings.Contains(string(manifest), skillPluginName) {
+		t.Errorf("no plugin manifest: %q %v", manifest, err)
+	}
+	if l.SkillPluginDir() != filepath.Join(appRoot, skillPluginDirName) {
+		t.Errorf("plugin dir not reported to the harness: %q", l.SkillPluginDir())
 	}
 
 	// A rebuild after `pdf` disappeared must not leave it dangling.
@@ -343,7 +361,7 @@ func TestSyncedVolumeSkillLinks(t *testing.T) {
 	l := &Links{AppRoot: appRoot, RepoDir: repoDir, StatusPath: statusPath, ConfigPath: "unused"}
 	l.syncPublicSkills()
 
-	skillsDir := filepath.Join(repoDir, ".claude", "skills")
+	skillsDir := filepath.Join(appRoot, skillPluginDirName, "skills")
 	assertSkillPresent(t, skillsDir, "orgfs-decocms-skills-unslopify")
 	for _, name := range []string{"orgfs-home-skills", "orgfs-.outputs-t1"} {
 		if _, err := os.Lstat(filepath.Join(skillsDir, name)); err == nil {
@@ -388,7 +406,7 @@ func TestUnreadableSkillDoesNotCondemnSet(t *testing.T) {
 	if !l.syncPublicSkills() {
 		t.Fatal("set condemned by one unreadable skill")
 	}
-	assertSkillPresent(t, filepath.Join(repoDir, ".claude", "skills"), "orgfs-core-slides")
+	assertSkillPresent(t, filepath.Join(appRoot, skillPluginDirName, "skills"), "orgfs-core-slides")
 }
 
 func TestWaitSkillLinks(t *testing.T) {
@@ -417,7 +435,7 @@ func TestWaitSkillLinks(t *testing.T) {
 	// one-shot startup scan cannot miss them.
 	l.WaitSkillLinks(10 * time.Second)
 	// The whole point of the barrier: the bytes are on disk before the run starts.
-	assertSkillPresent(t, filepath.Join(repoDir, ".claude", "skills"), "orgfs-core-slides")
+	assertSkillPresent(t, filepath.Join(appRoot, skillPluginDirName, "skills"), "orgfs-core-slides")
 }
 
 // Prefetched skills are real directories with real content now, not symlinks, so
@@ -458,7 +476,7 @@ func TestPrefetchedSkillsAreNotAdopted(t *testing.T) {
 
 	l := &Links{AppRoot: appRoot, RepoDir: repoDir, StatusPath: statusPath, ConfigPath: "unused"}
 	l.syncPublicSkills()
-	assertSkillPresent(t, filepath.Join(repoDir, ".claude", "skills"), "orgfs-core-slides")
+	assertSkillPresent(t, filepath.Join(appRoot, skillPluginDirName, "skills"), "orgfs-core-slides")
 
 	l.AdoptStrayRepoSkills()
 
@@ -466,7 +484,7 @@ func TestPrefetchedSkillsAreNotAdopted(t *testing.T) {
 		t.Error("prefetched skill was adopted into the org home")
 	}
 	// And it is still where the harness expects it.
-	assertSkillPresent(t, filepath.Join(repoDir, ".claude", "skills"), "orgfs-core-slides")
+	assertSkillPresent(t, filepath.Join(appRoot, skillPluginDirName, "skills"), "orgfs-core-slides")
 }
 
 func TestAdoptStrayRepoSkills(t *testing.T) {

--- a/packages/sandbox/daemon-go/internal/orgfs/skilltar_test.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/skilltar_test.go
@@ -182,11 +182,12 @@ func TestSetIsStagedThenPublished(t *testing.T) {
 	}
 
 	l := &Links{AppRoot: appRoot, RepoDir: repoDir, ConfigPath: "unused"}
-	skillsDir := filepath.Join(repoDir, ".claude", "skills")
+	pluginDir := filepath.Join(appRoot, skillPluginDirName)
+	skillsDir := filepath.Join(pluginDir, "skills")
 	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	stage := filepath.Join(repoDir, ".claude", ".orgfs-staging", "core")
+	stage := filepath.Join(pluginDir, ".staging", "core")
 
 	var unreadable int
 	landed := l.copySetToStage(
@@ -235,9 +236,9 @@ func TestPruneRemovesVanishedSkill(t *testing.T) {
 	}
 }
 
-// Staging is scratch space in the user's checkout: it must not survive the sync
-// and must never be committable.
-func TestStagingIsCleanedAndExcluded(t *testing.T) {
+// Staging is scratch space in the plugin dir: it must not survive the sync, and
+// it is out of the checkout entirely — nothing to exclude, nothing to commit.
+func TestStagingIsCleanedUp(t *testing.T) {
 	appRoot := t.TempDir()
 	repoDir := filepath.Join(appRoot, "repo")
 	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
@@ -256,12 +257,12 @@ func TestStagingIsCleanedAndExcluded(t *testing.T) {
 	if !l.syncPublicSkills() {
 		t.Fatal("sync published nothing")
 	}
-	assertSkillPresent(t, filepath.Join(repoDir, ".claude", "skills"), "orgfs-core-slides")
-	if _, err := os.Stat(filepath.Join(repoDir, ".claude", ".orgfs-staging")); err == nil {
-		t.Error("staging dir left behind in the checkout")
+	pluginDir := filepath.Join(appRoot, skillPluginDirName)
+	assertSkillPresent(t, filepath.Join(pluginDir, "skills"), "orgfs-core-slides")
+	if _, err := os.Stat(filepath.Join(pluginDir, ".staging")); err == nil {
+		t.Error("staging dir left behind")
 	}
-	excl, err := os.ReadFile(filepath.Join(repoDir, ".git", "info", "exclude"))
-	if err != nil || !strings.Contains(string(excl), "/.claude/.orgfs-staging") {
-		t.Errorf("staging not git-excluded: %q %v", excl, err)
+	if _, err := os.Stat(filepath.Join(repoDir, ".claude")); err == nil {
+		t.Error("the sync touched the checkout")
 	}
 }

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -977,9 +977,15 @@ func main() {
 			if cfg == nil {
 				return nil
 			}
-			env := make(map[string]string, len(cfg.Env)+1)
+			env := make(map[string]string, len(cfg.Env)+2)
 			if token := config.TokenFromCloneUrl(cfg.CloneUrl()); token != "" {
 				env["GH_TOKEN"] = token
+			}
+			// The org's prefetched skills, as a local plugin the harness loads by
+			// absolute path. Empty until a sync published something, so a pod with
+			// no org skills hands the SDK nothing to load.
+			if dir := d.orgFsLinks.SkillPluginDir(); dir != "" {
+				env["CLAUDE_CODE_PLUGIN_DIRS"] = dir
 			}
 			// Tenant env last: an explicit GH_TOKEN from Studio wins.
 			for k, v := range cfg.Env {


### PR DESCRIPTION
Follow-up to #6419, which stops the bleeding. This removes the cause.

## Why any of that git code exists

The org's read-only skill sets were prefetched into `<repoDir>/.claude/skills/`. Not because the checkout is a good home for them — because it was the only dir the SDK scanned that was also writable: `~/.claude/skills` **is** the org-fs mount (that's how an agent-authored skill syncs back), and the public sets are mounted read-only, so a manifest can't go next to them either.

Everything downstream was there to undo that one choice:

- a `.git/info/exclude` line for the skills, and another for the staging dir
- `ReapplyExcludes`, because a repo-less pod writes them before the clone
- a staging dir *inside* `.claude/`, so publish could be a same-filesystem rename
- the `orgfs-` prefix, so the prune loop knew which entries were ours
- `AdoptStrayRepoSkills` having to skip that prefix

And an exclude only masks **untracked** paths — which is why the build that committed them once (pre-#6028) put 33 symlinks on two site repos' default branch, where they still surface as phantom "changes to publish" in every new chat. #6419 hides those with the index bit; it doesn't stop us putting files there in the first place.

## The move

The SDK takes local plugin dirs, and a plugin provides skills. So:

```
<appRoot>/orgfs-skills/.claude-plugin/plugin.json
<appRoot>/orgfs-skills/skills/orgfs-<set>-<skill>/SKILL.md
```

The daemon publishes there and hands the path to the harness in `CLAUDE_CODE_PLUGIN_DIRS` (set by the daemon, not Studio — the daemon is what knows where it wrote them, and the value dies with the pod). `buildOptions` turns it into `plugins: [{ type: "local", path }]`.

Deleted, not moved: both `EnsureExclude` calls for skills. The checkout is untouched, so there is nothing to exclude, nothing to re-register after a clone, and nothing for an older build's commit to leave stranded. The `orgfs-` prefix stays for one narrow reason only — two sets shipping a same-named skill must not collide — and the `/org` exclude stays, because that symlink is in the tree on purpose.

Side effect worth naming: on the two repos with committed symlinks, the daemon stops replacing them, so they match HEAD again and read as clean even without #6419.

## Verification

Not a mock. Against the real SDK, with the same option shape `buildOptions` emits:

```
$ bun probe.ts /path/to/plugin        # query({ skills: "all", plugins: [{type:"local",path}] })
skills:  [ "orgfs:orgfs-core-brand" ]
plugins: [ "orgfs", "ponytail" ]
```

That was the one thing I couldn't settle from the types — whether `skills: "all"` picks up plugin-provided skills. It does.

Tests inverted rather than appended, per the repo's rule: the assertions that encoded "prefetched into the checkout" and "staging is git-excluded" now assert the opposite — nothing of ours in `.claude/`, a valid manifest, and the dir reported to the harness. Plus a `buildOptions` case for the plugin wiring. `go vet`, the full daemon suite, `bun run check` (harness-runner), `oxlint` and `bun run fmt` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load org read-only skills as a local plugin from `<appRoot>/orgfs-skills` instead of copying them into the repo checkout. Previously we wrote to `<repoDir>/.claude/skills` and hid the files with git excludes; now we prefetch to a daemon-owned plugin dir and load via plugins, eliminating git noise and stopping stray “changes to publish.”

- Daemon prefetches skills to `<appRoot>/orgfs-skills/skills/<name>` and writes `.claude-plugin/plugin.json`; when skills are published it sets `CLAUDE_CODE_PLUGIN_DIRS` to that path. `harness-runner` reads the env var and adds `plugins: [{ type: "local", path }]` alongside `skills: "all"`.
- Removed both skill-related git excludes and the checkout staging path; staging now lives at `<appRoot>/orgfs-skills/.staging`. The repo’s `.claude/skills` is untouched, and previously committed symlinks are no longer overwritten, so affected repos read clean.
- Keep the `orgfs-` prefix only to avoid name collisions; adoption logic continues to skip `orgfs-` entries to prevent migrating plugin skills into org home.
- Tests assert plugin loading and manifest presence, clean checkout, and `buildOptions` wiring; no change to how user-writable home skills are discovered.

<sup>Written for commit 8ec51664c38ac7e85596142a5afd81569cbf5408. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

