### PR TITLE
feat(reports): always show Reports and let a diagnostic start in-product

### DIFF
--- a/apps/web/src/components/home/commerce-report-banner.tsx
+++ b/apps/web/src/components/home/commerce-report-banner.tsx
@@ -29,97 +29,7 @@ import {
   deriveCommerceReportBannerStatus,
 } from "@/hooks/commerce-diagnostic-status";
 import { useT } from "@/i18n/use-t";
-
-/** The tilted miniature report page bleeding out of the banner's bottom
- *  edge. Pure decoration (aria-hidden); `generating` swaps the score ring
- *  and chart for shimmering placeholders. */
-function MiniReportPage({ generating }: { generating: boolean }) {
-  return (
-    <div
-      aria-hidden
-      className={cn(
-        // Decorative — hidden below sm so it never crowds the copy on narrow
-        // screens; the text reclaims the full width there.
-        "pointer-events-none absolute -bottom-14 left-6 hidden h-48 w-36 -rotate-6 rounded-xl border border-border bg-background shadow-lg sm:block",
-        "transition-transform duration-500 ease-out group-hover:-translate-y-2 group-hover:-rotate-3",
-      )}
-    >
-      <div className="flex h-full flex-col gap-3 p-4">
-        {/* page header: score ring + title lines */}
-        <div className="flex items-center gap-2.5">
-          <svg viewBox="0 0 32 32" className="size-9 shrink-0 -rotate-90">
-            <circle
-              cx="16"
-              cy="16"
-              r="12"
-              fill="none"
-              strokeWidth="4"
-              className="stroke-muted"
-            />
-            <circle
-              cx="16"
-              cy="16"
-              r="12"
-              fill="none"
-              strokeWidth="4"
-              strokeLinecap="round"
-              strokeDasharray="75.4"
-              strokeDashoffset={generating ? "75.4" : "22"}
-              className={cn(
-                "transition-[stroke-dashoffset] duration-1000 ease-out",
-                generating ? "stroke-muted" : "stroke-success",
-              )}
-            />
-          </svg>
-          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-            <div
-              className={cn(
-                "h-1.5 w-full rounded-full bg-muted",
-                generating && "animate-pulse",
-              )}
-            />
-            <div
-              className={cn(
-                "h-1.5 w-2/3 rounded-full bg-muted",
-                generating && "animate-pulse",
-              )}
-            />
-          </div>
-        </div>
-        {/* mini bar chart */}
-        <div className="flex h-10 items-end gap-1.5">
-          {[7, 10, 5, 9, 6, 8].map((h, i) => (
-            <div
-              key={`bar-${i}`}
-              style={{ height: `${h * 4}px` }}
-              className={cn(
-                "flex-1 rounded-sm",
-                generating
-                  ? "animate-pulse bg-muted"
-                  : i % 2 === 0
-                    ? "bg-success/70"
-                    : "bg-success/30",
-              )}
-            />
-          ))}
-        </div>
-        {/* body lines running past the clipped edge */}
-        <div className="flex flex-col gap-1.5">
-          {["w-full", "w-5/6", "w-full", "w-2/3", "w-full"].map((w, i) => (
-            <div
-              key={`line-${i}`}
-              className={cn(
-                "h-1.5 rounded-full bg-muted",
-                w,
-                generating && "animate-pulse",
-              )}
-            />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
+import { MiniReportPage } from "./mini-report-page";
 
 function BannerShell({
   status,
@@ -152,7 +62,14 @@ function BannerShell({
           generating ? "bg-warning/15" : "bg-success/15",
         )}
       />
-      <MiniReportPage generating={generating} />
+      <MiniReportPage
+        generating={generating}
+        className={cn(
+          // Decorative: hidden below sm so the copy keeps the full width.
+          "absolute -bottom-14 left-6 hidden h-48 w-36 -rotate-6 sm:block",
+          "transition-transform duration-500 ease-out group-hover:-translate-y-2 group-hover:-rotate-3",
+        )}
+      />
       {/* pl steps up to clear the decorative page once it appears at sm. */}
       <div className="relative flex min-h-28 items-center gap-4 px-5 py-5 sm:h-36 sm:gap-6 sm:pr-6 sm:pl-52">
         <div className="flex min-w-0 flex-1 flex-col gap-1">

--- a/apps/web/src/components/home/mini-report-page.tsx
+++ b/apps/web/src/components/home/mini-report-page.tsx
@@ -1,0 +1,101 @@
+/**
+ * The miniature report page used as decoration wherever the diagnostic is
+ * offered: bleeding out of the home banner's clipped edge, and above the
+ * Reports empty state's start form. Pure decoration (aria-hidden).
+ *
+ * `generating` swaps the score ring and chart for shimmering placeholders.
+ * Position, size and rotation come from `className` — the caller frames it.
+ */
+import { cn } from "@decocms/ui/lib/utils.ts";
+
+export function MiniReportPage({
+  generating,
+  className,
+}: {
+  generating?: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none rounded-xl border border-border bg-background shadow-lg",
+        className,
+      )}
+    >
+      <div className="flex h-full flex-col gap-3 p-4">
+        {/* page header: score ring + title lines */}
+        <div className="flex items-center gap-2.5">
+          <svg viewBox="0 0 32 32" className="size-9 shrink-0 -rotate-90">
+            <circle
+              cx="16"
+              cy="16"
+              r="12"
+              fill="none"
+              strokeWidth="4"
+              className="stroke-muted"
+            />
+            <circle
+              cx="16"
+              cy="16"
+              r="12"
+              fill="none"
+              strokeWidth="4"
+              strokeLinecap="round"
+              strokeDasharray="75.4"
+              strokeDashoffset={generating ? "75.4" : "22"}
+              className={cn(
+                "transition-[stroke-dashoffset] duration-1000 ease-out",
+                generating ? "stroke-muted" : "stroke-success",
+              )}
+            />
+          </svg>
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <div
+              className={cn(
+                "h-1.5 w-full rounded-full bg-muted",
+                generating && "animate-pulse",
+              )}
+            />
+            <div
+              className={cn(
+                "h-1.5 w-2/3 rounded-full bg-muted",
+                generating && "animate-pulse",
+              )}
+            />
+          </div>
+        </div>
+        {/* mini bar chart */}
+        <div className="flex h-10 items-end gap-1.5">
+          {[7, 10, 5, 9, 6, 8].map((h, i) => (
+            <div
+              key={`bar-${i}`}
+              style={{ height: `${h * 4}px` }}
+              className={cn(
+                "flex-1 rounded-sm",
+                generating
+                  ? "animate-pulse bg-muted"
+                  : i % 2 === 0
+                    ? "bg-success/70"
+                    : "bg-success/30",
+              )}
+            />
+          ))}
+        </div>
+        {/* body lines running past the clipped edge */}
+        <div className="flex flex-col gap-1.5">
+          {["w-full", "w-5/6", "w-full", "w-2/3", "w-full"].map((w, i) => (
+            <div
+              key={`line-${i}`}
+              className={cn(
+                "h-1.5 rounded-full bg-muted",
+                w,
+                generating && "animate-pulse",
+              )}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/sidebar/nav-destinations.tsx
+++ b/apps/web/src/components/sidebar/nav-destinations.tsx
@@ -55,10 +55,7 @@ function useDecopilotId(): string {
   return getWellKnownDecopilotVirtualMCP(org.id).id;
 }
 
-/**
- * The destinations, in display order. Reports only appears once the org
- * actually has a report — the entry opens that report's MCP app.
- */
+/** The destinations, in display order. */
 function useNavDestinations({
   onNavigate,
 }: {
@@ -140,18 +137,18 @@ function useNavDestinations({
     ),
   ];
 
-  if (diagnostic) {
-    destinations.push(
-      destination(
-        formatPinnedViewTabId(
-          connectionId,
-          COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
-        ),
-        t("sidebar.navDestinations.reports"),
-        <BarChartSquare02 size={16} />,
-      ),
-    );
-  }
+  destinations.push(
+    destination(
+      diagnostic
+        ? formatPinnedViewTabId(
+            connectionId,
+            COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+          )
+        : "reports",
+      t("sidebar.navDestinations.reports"),
+      <BarChartSquare02 size={16} />,
+    ),
+  );
   destinations.push(
     destination(
       "board",

--- a/apps/web/src/hooks/use-commerce-diagnostic.ts
+++ b/apps/web/src/hooks/use-commerce-diagnostic.ts
@@ -58,6 +58,15 @@ export interface UseCommerceDiagnosticResult {
   diagnostic: CommerceDiagnosticRunState | null;
   /** True once the diagnostic query has resolved (vs still loading / disabled). */
   isSuccess: boolean;
+  /**
+   * True while we still can't tell whether a report exists — either gate 1 is in
+   * flight, or it found the connection and the diagnostic read is in flight. It
+   * goes false (with a null diagnostic) as soon as gate 1 says the org has no CD
+   * connection, so "no report" is distinguishable from "not known yet".
+   */
+  isLoading: boolean;
+  /** The org's Commerce Discovery site, as claimed on the connection. */
+  siteUrl: string | null;
   /** The store's hostname from the connection metadata, for copy. */
   host: string | null;
   connectionId: string;
@@ -127,10 +136,16 @@ export function useCommerceDiagnostic(): UseCommerceDiagnosticResult {
     },
   });
 
+  const siteUrl = connectionItem?.metadata?.siteUrl;
+
   return {
     diagnostic: diagnosticQuery.data ?? null,
     isSuccess: diagnosticQuery.isSuccess,
-    host: hostFromSiteUrl(connectionItem?.metadata?.siteUrl),
+    isLoading:
+      connectionQuery.isPending ||
+      (!!connectionItem && diagnosticQuery.isPending),
+    siteUrl: typeof siteUrl === "string" && siteUrl ? siteUrl : null,
+    host: hostFromSiteUrl(siteUrl),
     connectionId,
     cdClient: (cdClient as CommerceDiscoveryClient | undefined) ?? null,
   };

--- a/apps/web/src/i18n/en/reports.ts
+++ b/apps/web/src/i18n/en/reports.ts
@@ -172,4 +172,11 @@ export const reports = {
   "reports.commerceBanner.generatingSubtitle":
     "Analyzing {store}. This takes a few minutes.",
   "reports.commerceBanner.readySubtitle": "See the full analysis of {store}.",
+  "reports.emptyState.title": "No reports yet",
+  "reports.emptyState.description":
+    "Run a diagnostic on your store to see how it performs and what to fix first.",
+  "reports.emptyState.siteUrlLabel": "Store URL",
+  "reports.emptyState.siteUrlPlaceholder": "yourstore.com",
+  "reports.emptyState.start": "Start diagnostic",
+  "reports.emptyState.starting": "Starting...",
 } as const;

--- a/apps/web/src/i18n/en/reports.ts
+++ b/apps/web/src/i18n/en/reports.ts
@@ -179,4 +179,8 @@ export const reports = {
   "reports.emptyState.siteUrlPlaceholder": "yourstore.com",
   "reports.emptyState.start": "Start diagnostic",
   "reports.emptyState.starting": "Starting...",
+  "reports.emptyState.checkPerformance": "Performance",
+  "reports.emptyState.checkSeo": "SEO",
+  "reports.emptyState.checkFunnel": "Conversion funnel",
+  "reports.emptyState.checkTracking": "Analytics & tracking",
 } as const;

--- a/apps/web/src/i18n/pt-br/reports.ts
+++ b/apps/web/src/i18n/pt-br/reports.ts
@@ -176,4 +176,11 @@ export const reports = {
   "reports.commerceBanner.generatingSubtitle":
     "Analisando {store}. Isso leva alguns minutos.",
   "reports.commerceBanner.readySubtitle": "Veja a análise completa de {store}.",
+  "reports.emptyState.title": "Nenhum relatório ainda",
+  "reports.emptyState.description":
+    "Rode um diagnóstico da sua loja para ver como ela está e o que corrigir primeiro.",
+  "reports.emptyState.siteUrlLabel": "URL da loja",
+  "reports.emptyState.siteUrlPlaceholder": "sualoja.com.br",
+  "reports.emptyState.start": "Iniciar diagnóstico",
+  "reports.emptyState.starting": "Iniciando...",
 } satisfies Record<keyof typeof reportsEn, string>;

--- a/apps/web/src/i18n/pt-br/reports.ts
+++ b/apps/web/src/i18n/pt-br/reports.ts
@@ -183,4 +183,8 @@ export const reports = {
   "reports.emptyState.siteUrlPlaceholder": "sualoja.com.br",
   "reports.emptyState.start": "Iniciar diagnóstico",
   "reports.emptyState.starting": "Iniciando...",
+  "reports.emptyState.checkPerformance": "Performance",
+  "reports.emptyState.checkSeo": "SEO",
+  "reports.emptyState.checkFunnel": "Funil de conversão",
+  "reports.emptyState.checkTracking": "Dados e rastreamento",
 } satisfies Record<keyof typeof reportsEn, string>;

--- a/apps/web/src/layouts/main-panel-tabs/index.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/index.tsx
@@ -22,6 +22,7 @@ import { AutomationTab } from "./automation-tab";
 import { AutomationsListTab } from "./automations-list-tab";
 import { FileTab } from "./file-tab";
 import { ConnectSourcesTab } from "./connect-sources-tab";
+import { ReportsTab } from "./reports-tab";
 import { DeckTab } from "./deck-tab";
 import { LibraryFileTab } from "./library-file-tab";
 import { LibraryTab } from "./library-tab";
@@ -110,6 +111,10 @@ function TabBody({
   }
   if (activeTab === "files") {
     return <LibraryTab />;
+  }
+  if (activeTab === "reports") {
+    // The Reports destination for an org with no report yet: start a diagnostic.
+    return <ReportsTab />;
   }
   if (activeTab === "connect-sources") {
     // Report app hand-off (`?main=connect-sources`) for a client who skipped

--- a/apps/web/src/layouts/main-panel-tabs/reports-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/reports-tab.tsx
@@ -1,0 +1,214 @@
+/**
+ * ReportsTab — what the sidebar's Reports destination opens for an org that has
+ * no report yet (`?main=reports`).
+ *
+ * Reports used to be hidden until a diagnostic existed, which left no way to ask
+ * for one from inside the product: the only entry was the public
+ * /commerce-onboarding funnel. So the destination is always listed now and lands
+ * here, on an empty state that starts the diagnostic.
+ *
+ * Starting it is exactly the onboarding hand-off, reused rather than
+ * reimplemented: COMMERCE_DISCOVERY_SETUP claims the site, then we navigate to
+ * the org home thread with `?connect=1`, which mounts the blocking
+ * CommerceConnectModal — the step that asks for the data sources (GA4/GSC/VTEX/
+ * GitHub), triggers COMMERCE_DISCOVERY_RUN and opens the report.
+ *
+ * Once a diagnostic does exist this tab is a redirect to the report app, so a
+ * click made while the diagnostic read was still in flight (or a stale
+ * `?main=reports` URL) still lands on the report.
+ */
+import { useMutation } from "@tanstack/react-query";
+import { Navigate, useNavigate } from "@tanstack/react-router";
+import { ArrowRight, BarChartSquare02 } from "@untitledui/icons";
+import { Suspense, useState } from "react";
+import type { FormEvent, ReactNode } from "react";
+import {
+  normalizeReportsSiteUrl,
+  siteUrlToHost,
+} from "@decocms/shared/reports/site-url";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { EmptyState } from "@/components/empty-state";
+import { ErrorBoundary } from "@/components/error-boundary";
+import { useT } from "@/i18n/use-t.ts";
+import { track } from "@/lib/posthog-client";
+import { useCommerceDiagnostic } from "@/hooks/use-commerce-diagnostic";
+import {
+  COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+  getWellKnownDecopilotVirtualMCP,
+  SELF_MCP_ALIAS_ID,
+  useMCPClient,
+  useProjectContext,
+} from "@/sdk";
+import { parseSelfToolResult } from "@/routes/commerce-onboarding/self-tool-result.ts";
+import { translateSiteError } from "@/routes/commerce-onboarding/site-error.ts";
+import { MainPanelLoading } from "./main-panel-loading";
+import { formatPinnedViewTabId } from "./tab-id";
+
+export function ReportsTab() {
+  const { diagnostic, isLoading, siteUrl, connectionId } =
+    useCommerceDiagnostic();
+
+  if (isLoading) return <MainPanelLoading />;
+
+  if (diagnostic) {
+    return (
+      <Navigate
+        to="."
+        search={(prev: Record<string, unknown>) => ({
+          ...prev,
+          main: formatPinnedViewTabId(
+            connectionId,
+            COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+          ),
+        })}
+        replace
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto">
+      <ErrorBoundary
+        fallback={() => <StartDiagnosticState claimedSiteUrl={siteUrl} />}
+      >
+        <Suspense fallback={<MainPanelLoading />}>
+          <StartDiagnostic claimedSiteUrl={siteUrl} />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+}
+
+/** The empty state's chrome. Without `children` (the error fallback, where no
+ *  self client is available) the form is replaced by the claimed store's host,
+ *  so the panel still explains itself instead of rendering an error. */
+function StartDiagnosticState({
+  claimedSiteUrl,
+  children,
+}: {
+  claimedSiteUrl: string | null;
+  children?: ReactNode;
+}) {
+  const t = useT();
+  const host = siteUrlToHost(claimedSiteUrl ?? undefined);
+  return (
+    <EmptyState
+      className="h-full w-full"
+      image={<BarChartSquare02 size={48} className="text-muted-foreground" />}
+      title={t("reports.emptyState.title")}
+      description={t("reports.emptyState.description")}
+      descriptionClassName="max-w-[420px]"
+      actionsClassName="w-full max-w-md flex-col items-stretch"
+      actions={
+        children ??
+        (host ? (
+          <p className="text-center text-sm text-muted-foreground">{host}</p>
+        ) : null)
+      }
+    />
+  );
+}
+
+function StartDiagnostic({
+  claimedSiteUrl,
+}: {
+  claimedSiteUrl: string | null;
+}) {
+  const t = useT();
+  const navigate = useNavigate();
+  const { org } = useProjectContext();
+  const selfClient = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+
+  const [siteInput, setSiteInput] = useState(
+    siteUrlToHost(claimedSiteUrl ?? undefined) ?? "",
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const setupMutation = useMutation({
+    mutationFn: async (url: string) =>
+      parseSelfToolResult<unknown>(
+        await selfClient.callTool({
+          name: "COMMERCE_DISCOVERY_SETUP",
+          arguments: { siteUrl: url },
+        }),
+      ),
+    retry: false,
+  });
+
+  const start = async (rawSiteUrl: string) => {
+    const normalized = normalizeReportsSiteUrl(rawSiteUrl);
+    if (!normalized.ok) {
+      setError(normalized.error);
+      return;
+    }
+    setError(null);
+    const domain = siteUrlToHost(normalized.value) ?? undefined;
+    track("reports_start_diagnostic_submitted", {
+      organization_id: org.id,
+      domain,
+    });
+    try {
+      await setupMutation.mutateAsync(normalized.value);
+    } catch (err) {
+      track("reports_start_diagnostic_failed", {
+        organization_id: org.id,
+        domain,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Server errors pass through; the sentinel is translated at render.
+      setError(err instanceof Error ? err.message : "__configurationFailed");
+      return;
+    }
+    // The connections step triggers the run and opens the report.
+    navigate({
+      to: "/$org/$taskId",
+      params: { org: org.slug, taskId: crypto.randomUUID() },
+      search: {
+        virtualmcpid: getWellKnownDecopilotVirtualMCP(org.id).id,
+        connect: "1",
+        siteUrl: normalized.value,
+      },
+    });
+  };
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void start(siteInput);
+  };
+
+  return (
+    <StartDiagnosticState claimedSiteUrl={claimedSiteUrl}>
+      <form className="flex w-full flex-col gap-2" onSubmit={onSubmit}>
+        <div className="flex items-center gap-2">
+          <Input
+            aria-label={t("reports.emptyState.siteUrlLabel")}
+            type="text"
+            inputMode="url"
+            className="min-w-0 flex-1"
+            value={siteInput}
+            onChange={(event) => setSiteInput(event.target.value)}
+            placeholder={t("reports.emptyState.siteUrlPlaceholder")}
+            aria-invalid={!!error}
+            disabled={setupMutation.isPending}
+          />
+          <Button type="submit" disabled={setupMutation.isPending}>
+            {setupMutation.isPending
+              ? t("reports.emptyState.starting")
+              : t("reports.emptyState.start")}
+            <ArrowRight size={16} />
+          </Button>
+        </div>
+        {error ? (
+          <p className="text-sm leading-5 text-destructive" role="alert">
+            {translateSiteError(t, error)}
+          </p>
+        ) : null}
+      </form>
+    </StartDiagnosticState>
+  );
+}

--- a/apps/web/src/layouts/main-panel-tabs/reports-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/reports-tab.tsx
@@ -19,7 +19,7 @@
  */
 import { useMutation } from "@tanstack/react-query";
 import { Navigate, useNavigate } from "@tanstack/react-router";
-import { ArrowRight, BarChartSquare02 } from "@untitledui/icons";
+import { ArrowRight } from "@untitledui/icons";
 import { Suspense, useState } from "react";
 import type { FormEvent, ReactNode } from "react";
 import {
@@ -28,11 +28,11 @@ import {
 } from "@decocms/shared/reports/site-url";
 import { Button } from "@decocms/ui/components/button.tsx";
 import { Input } from "@decocms/ui/components/input.tsx";
-import { EmptyState } from "@/components/empty-state";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { useT } from "@/i18n/use-t.ts";
 import { track } from "@/lib/posthog-client";
 import { useCommerceDiagnostic } from "@/hooks/use-commerce-diagnostic";
+import { MiniReportPage } from "@/components/home/mini-report-page";
 import {
   COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
   getWellKnownDecopilotVirtualMCP,
@@ -80,6 +80,15 @@ export function ReportsTab() {
   );
 }
 
+/** What the diagnostic looks at. Concrete enough to be worth the wait, short
+ *  enough to scan — the report itself covers far more. */
+const CHECK_KEYS = [
+  "reports.emptyState.checkPerformance",
+  "reports.emptyState.checkSeo",
+  "reports.emptyState.checkFunnel",
+  "reports.emptyState.checkTracking",
+] as const;
+
 /** The empty state's chrome. Without `children` (the error fallback, where no
  *  self client is available) the form is replaced by the claimed store's host,
  *  so the panel still explains itself instead of rendering an error. */
@@ -93,20 +102,43 @@ function StartDiagnosticState({
   const t = useT();
   const host = siteUrlToHost(claimedSiteUrl ?? undefined);
   return (
-    <EmptyState
-      className="h-full w-full"
-      image={<BarChartSquare02 size={48} className="text-muted-foreground" />}
-      title={t("reports.emptyState.title")}
-      description={t("reports.emptyState.description")}
-      descriptionClassName="max-w-[420px]"
-      actionsClassName="w-full max-w-md flex-col items-stretch"
-      actions={
-        children ??
-        (host ? (
-          <p className="text-center text-sm text-muted-foreground">{host}</p>
-        ) : null)
-      }
-    />
+    <div className="flex min-h-full w-full flex-col items-center justify-center gap-8 p-6">
+      {/* The report you don't have yet, tilted under its own glow. */}
+      <div className="relative flex items-end justify-center pt-4">
+        <div
+          aria-hidden
+          className="absolute -bottom-6 size-56 rounded-full bg-success/10 blur-3xl"
+        />
+        <MiniReportPage className="relative h-52 w-40 -rotate-6" />
+        <MiniReportPage className="relative -ml-14 h-56 w-44 rotate-3" />
+      </div>
+
+      <div className="flex flex-col items-center gap-2 text-center">
+        <h2 className="text-lg font-medium leading-7 text-foreground">
+          {t("reports.emptyState.title")}
+        </h2>
+        <p className="max-w-sm text-sm leading-5 text-muted-foreground">
+          {t("reports.emptyState.description")}
+        </p>
+      </div>
+
+      <div className="flex w-full max-w-md flex-col items-center gap-4">
+        {children ??
+          (host ? (
+            <p className="text-sm text-muted-foreground">{host}</p>
+          ) : null)}
+        <ul className="flex flex-wrap items-center justify-center gap-2">
+          {CHECK_KEYS.map((key) => (
+            <li
+              key={key}
+              className="rounded-full border border-border bg-card px-3 py-1 text-xs text-muted-foreground"
+            >
+              {t(key)}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
   );
 }
 
@@ -184,7 +216,7 @@ function StartDiagnostic({
   return (
     <StartDiagnosticState claimedSiteUrl={claimedSiteUrl}>
       <form className="flex w-full flex-col gap-2" onSubmit={onSubmit}>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
           <Input
             aria-label={t("reports.emptyState.siteUrlLabel")}
             type="text"
@@ -196,7 +228,11 @@ function StartDiagnostic({
             aria-invalid={!!error}
             disabled={setupMutation.isPending}
           />
-          <Button type="submit" disabled={setupMutation.isPending}>
+          <Button
+            type="submit"
+            className="shrink-0"
+            disabled={setupMutation.isPending}
+          >
             {setupMutation.isPending
               ? t("reports.emptyState.starting")
               : t("reports.emptyState.start")}

--- a/apps/web/src/layouts/main-panel-tabs/tab-id.ts
+++ b/apps/web/src/layouts/main-panel-tabs/tab-id.ts
@@ -184,10 +184,15 @@ export const FIXED_SYSTEM_TABS = [
 const FIXED_SYSTEM_TAB_SET = new Set<string>(FIXED_SYSTEM_TABS);
 
 // Agent-independent overlays (Tasks `board`, Library `files`, the commerce
-// report's `connect-sources`) take over the whole panel and aren't
+// report's `connect-sources`, the empty `reports`) take over the panel and aren't
 // sandbox-backed views. Shared by the drawer-visibility check and the
 // in-panel-app navigate allowlist so the two stay in sync.
-export const OVERLAY_TABS = new Set(["board", "files", "connect-sources"]);
+export const OVERLAY_TABS = new Set([
+  "board",
+  "files",
+  "connect-sources",
+  "reports",
+]);
 
 /**
  * Returns true for tab ids that are scoped to a specific thread and must not

--- a/apps/web/src/layouts/main-panel-tabs/terminal-drawer-gate.test.ts
+++ b/apps/web/src/layouts/main-panel-tabs/terminal-drawer-gate.test.ts
@@ -39,6 +39,7 @@ describe("shouldShowTerminalDrawer", () => {
     expect(
       shouldShowTerminalDrawer(input({ mainTab: "connect-sources" })),
     ).toBe(false);
+    expect(shouldShowTerminalDrawer(input({ mainTab: "reports" }))).toBe(false);
   });
 
   test("shows under a non-overlay tab", () => {

--- a/apps/web/src/routes/commerce-onboarding.tsx
+++ b/apps/web/src/routes/commerce-onboarding.tsx
@@ -51,6 +51,7 @@ import {
 import { SiteBadge } from "./commerce-onboarding/site-badge.tsx";
 import { CommerceOnboardingLoadingIndicator } from "./commerce-onboarding/loading-state.tsx";
 import { parseSelfToolResult } from "./commerce-onboarding/self-tool-result.ts";
+import { translateSiteError } from "./commerce-onboarding/site-error.ts";
 import { cn } from "@decocms/ui/lib/utils.ts";
 
 interface CommerceOrganization {
@@ -240,24 +241,6 @@ function getCommerceAuthCopy(t: ReturnType<typeof useT>) {
       "routes.commerceOnboarding.authCopy.signInWithEmailCode",
     ),
   };
-}
-
-// Translates raw error strings (from normalizeReportsSiteUrl or well-known
-// internal sentinels) into the current locale. Dynamic server errors fall
-// through to the default and are shown as-is.
-function translateSiteError(t: ReturnType<typeof useT>, error: string): string {
-  switch (error) {
-    case "Enter a website URL.":
-      return t("routes.commerceOnboarding.siteUrl.enterUrl");
-    case "Use an HTTP or HTTPS website URL.":
-      return t("routes.commerceOnboarding.siteUrl.useHttpOrHttps");
-    case "Enter a valid website URL.":
-      return t("routes.commerceOnboarding.siteUrl.enterValidUrl");
-    case "__configurationFailed":
-      return t("routes.commerceOnboarding.configurationFailed");
-    default:
-      return error;
-  }
 }
 
 // One-shot per SPA load, render-time (useEffect is banned in this app; same

--- a/apps/web/src/routes/commerce-onboarding/site-error.ts
+++ b/apps/web/src/routes/commerce-onboarding/site-error.ts
@@ -1,0 +1,27 @@
+/**
+ * Translates raw site-URL error strings (from `normalizeReportsSiteUrl` or the
+ * well-known internal sentinels) into the current locale. Dynamic server errors
+ * fall through and are shown as-is.
+ *
+ * Shared by the onboarding site form and the Reports empty state, so both spell
+ * the same validation failures the same way.
+ */
+import type { useT } from "@/i18n/use-t.ts";
+
+export function translateSiteError(
+  t: ReturnType<typeof useT>,
+  error: string,
+): string {
+  switch (error) {
+    case "Enter a website URL.":
+      return t("routes.commerceOnboarding.siteUrl.enterUrl");
+    case "Use an HTTP or HTTPS website URL.":
+      return t("routes.commerceOnboarding.siteUrl.useHttpOrHttps");
+    case "Enter a valid website URL.":
+      return t("routes.commerceOnboarding.siteUrl.enterValidUrl");
+    case "__configurationFailed":
+      return t("routes.commerceOnboarding.configurationFailed");
+    default:
+      return error;
+  }
+}

--- a/packages/e2e/tests/nav-v2.spec.ts
+++ b/packages/e2e/tests/nav-v2.spec.ts
@@ -282,19 +282,26 @@ test.describe("first-class navigation", () => {
     ).toBeVisible();
   });
 
-  test("Reports is hidden until the org has a report, then opens the report app", async ({
+  test("Reports offers a diagnostic until the org has a report, then opens the report app", async ({
     authedPage: { page, orgSlug },
   }) => {
     await page.goto(`/${orgSlug}`);
     await expandSidebar(page, "Home");
 
-    // No Commerce Discovery connection yet → no Reports destination.
+    // No Commerce Discovery connection yet → the empty state, which starts one.
     await expect(
       page.getByRole("button", { name: "Tasks", exact: true }),
     ).toBeVisible({ timeout: SHELL_TIMEOUT_MS });
+    await page
+      .getByRole("button", { name: "Reports", exact: true })
+      .click({ timeout: SHELL_TIMEOUT_MS });
+    await expect(page).toHaveURL(/[?&]main=reports\b/);
+    await expect(page.getByText("No reports yet")).toBeVisible({
+      timeout: SHELL_TIMEOUT_MS,
+    });
     await expect(
-      page.getByRole("button", { name: "Reports", exact: true }),
-    ).toHaveCount(0);
+      page.getByRole("button", { name: "Start diagnostic" }),
+    ).toBeVisible();
 
     const request = page.context().request;
     const orgId = await findOrgId(request, orgSlug);


### PR DESCRIPTION
## Summary

Reports is now **always visible**, and a diagnostic can be **started from inside the product**. Before this, the only way to run one was the commerce onboarding route, so an org that never went through onboarding had no way to start a diagnostic and the Reports surface was hidden entirely.

Because a Reports tab with no report has to offer a way to create one, the empty state *is* the in-product entry point. It shows what a report actually looks like (via a shared `MiniReportPage`, extracted from the commerce banner's inline preview markup so both surfaces render the same thing) and names what a diagnostic checks: performance, SEO, conversion funnel, analytics & tracking.

## Commits

- `always show Reports, with a start-a-diagnostic empty state`
- `invert the nav-v2 Reports spec to the new empty state`
- `shared MiniReportPage for the in-product entry point`

## Testing

- `tsc --noEmit` clean on `apps/web`.
- `packages/e2e/tests/nav-v2.spec.ts` updated: the spec that asserted Reports was absent now asserts the empty state, per the "invert the test that encodes the old behavior" rule.

## Notes for the reviewer

Independent of the board/thread work in the sibling PRs; no shared files. One open question worth a look: the empty state asks for a site URL. If a diagnostic started from inside an org should infer that from org/brand context instead of asking again, that's a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always shows Reports and lets users start a diagnostic in-product. Previously Reports was hidden until a diagnostic existed; now it opens an empty state with a start form and redirects to the report app once a diagnostic exists.

- Navigation: Always render Reports; if no diagnostic, open `?main=reports`, otherwise open the pinned report tab. Treat `reports` as an overlay tab and keep the terminal drawer hidden there.
- New ReportsTab: Empty state previews a report via a shared MiniReportPage, lists what the diagnostic checks, and includes a site URL form. On submit it runs `COMMERCE_DISCOVERY_SETUP`, then navigates to the connect modal (`?connect=1`) which collects data sources, triggers the run, and opens the report.
- Shared UI: Extracts MiniReportPage from the commerce banner and reuses it in the empty state.
- Hook: `useCommerceDiagnostic` now exposes `isLoading` and `siteUrl` to prefill/drive the empty state.
- i18n: Adds empty-state strings in `en` and `pt-br`.
- Tests: Updates the nav spec to expect the empty state before a diagnostic and adds a drawer gate check for `reports`.

<sup>Written for commit b47c199183bf45ddb8f9860fe72c91ab36196057. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

