### PR TITLE
refactor(task-board): a task owns the branch its sessions share

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1632,6 +1632,7 @@ export class TaskBoardStorage {
       ])
       .where("link.organization_id", "=", organizationId)
       .where("link.task_board_item_id", "in", ids)
+      .where("t.hidden", "=", false)
       .orderBy("link.created_at", "desc")
       .execute();
 

--- a/apps/web/src/components/thread/open-in-board-button.tsx
+++ b/apps/web/src/components/thread/open-in-board-button.tsx
@@ -7,7 +7,7 @@ import {
   TooltipTrigger,
 } from "@decocms/ui/components/tooltip.tsx";
 import { useChatTask } from "@/components/chat/chat-context";
-import { useTaskForThread } from "@/hooks/use-task-for-thread";
+import { useBoardTaskForThread } from "@/hooks/use-task-for-thread";
 import { useT } from "@/i18n/use-t.ts";
 import { ToolbarIconButton } from "@/components/toolbar-icon-button";
 
@@ -21,7 +21,7 @@ export function OpenInBoardButton() {
   const t = useT();
   const { taskId } = useChatTask();
   const navigate = useNavigate();
-  const boardTaskId = useTaskForThread(taskId);
+  const boardTaskId = useBoardTaskForThread(taskId)?.id ?? null;
 
   if (!boardTaskId) return null;
 

--- a/apps/web/src/hooks/use-start-task-session.ts
+++ b/apps/web/src/hooks/use-start-task-session.ts
@@ -1,0 +1,103 @@
+import type { StudioToolOutput as ToolOutput } from "@decocms/shared/tools/tool-io";
+import { getWellKnownDecopilotVirtualMCP, useProjectContext } from "@/sdk";
+import { useThreadActions, useThreads } from "@/components/chat/store/hooks";
+import { useStudioTools } from "@/lib/studio-tools";
+import { usePanelActions } from "@/layouts/shell-layout";
+import { useTaskBoardItemActions } from "@/hooks/use-task-board-items";
+import { writeChatDraft } from "@/lib/chat-draft";
+import { createMentionDoc } from "@/components/chat/tiptap/mention";
+import type { TiptapDoc } from "@/components/chat/types";
+import { buildTaskChatContext } from "@/layouts/task-board/build-task-chat-context";
+import {
+  resolveNewestSession,
+  resolveTaskBranch,
+} from "@/layouts/task-board/task-branch";
+
+type TaskBoardItem = ToolOutput<"TASK_BOARD_ITEM_LIST">["items"][number];
+
+/**
+ * Start another agent session inside a task.
+ *
+ * A task owns a branch and holds N sessions on it, so a new session inherits
+ * the branch rather than starting a second one (see `resolveTaskBranch`) and is
+ * linked to the task before we navigate. Shared by the task workspace's "New
+ * session" and the chat panel's session tabs so there is one implementation of
+ * what "another session on this task" means.
+ */
+export function useStartTaskSession() {
+  const { org, locator } = useProjectContext();
+  const studio = useStudioTools();
+  const { create } = useThreadActions();
+  const { threads } = useThreads();
+  const { setTaskId } = usePanelActions();
+  const actions = useTaskBoardItemActions();
+
+  /** The branch this task's sessions share: local store first (the user's own
+   *  sessions are cached with it), then the server for someone else's. */
+  const taskBranch = async (task: TaskBoardItem): Promise<string | null> => {
+    const local = resolveTaskBranch(
+      task.threads.map((thread) => ({
+        threadId: thread.threadId,
+        createdAt: thread.createdAt,
+        branch: threads.find((t) => t.id === thread.threadId)?.branch,
+      })),
+    );
+    if (local) return local;
+    const newest = resolveNewestSession(task.threads);
+    if (!newest) return null;
+    return await studio
+      .call("COLLECTION_THREADS_GET", { id: newest.threadId })
+      .then((r) => r.item?.branch?.trim() || null)
+      .catch(() => null);
+  };
+
+  return async (task: TaskBoardItem) => {
+    const newId = crypto.randomUUID();
+    const agentId = getWellKnownDecopilotVirtualMCP(org.id).id;
+    // Best-effort: the session opens regardless, just with less context.
+    const prs = await studio
+      .call("TASK_BOARD_ITEM_PRS_GET", { taskBoardItemId: task.id })
+      .then((r) => r.prs)
+      .catch(() => []);
+    const context = buildTaskChatContext(task, prs);
+    /** A removable task @ref chip, NOT auto-sent: the user reviews and adds to
+     *  it, and the chip expands to the task context at send time. */
+    const doc: TiptapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            createMentionDoc({
+              id: task.id,
+              name: task.title,
+              char: "@",
+              kind: "task",
+              metadata: {
+                title: task.title,
+                description: task.description,
+                context,
+              },
+            }),
+            { type: "text", text: " " },
+          ],
+        },
+      ],
+    };
+    writeChatDraft(sessionStorage, locator, newId, doc);
+    const branch = await taskBranch(task);
+    try {
+      await create({
+        id: newId,
+        virtual_mcp_id: agentId,
+        ...(branch ? { branch } : {}),
+      });
+      // Best-effort: a link failure shouldn't block navigating into the chat.
+      await actions.link.mutateAsync({ id: task.id, linkThreadId: newId });
+    } catch {
+      /* Toast already fired by the manager; navigate anyway so the route
+         loader's ensure-fallback can retry the create. */
+    }
+    setTaskId(newId, agentId);
+  };
+}

--- a/apps/web/src/hooks/use-task-for-thread.ts
+++ b/apps/web/src/hooks/use-task-for-thread.ts
@@ -2,13 +2,18 @@ import { useProjectContext } from "@/sdk";
 import { useQuery } from "@tanstack/react-query";
 import { KEYS } from "@/lib/query-keys";
 import { useStudioTools } from "@/lib/studio-tools";
+import type { StudioToolOutput as ToolOutput } from "@decocms/shared/tools/tool-io";
+
+type TaskBoardItem = ToolOutput<"TASK_BOARD_ITEM_LIST">["items"][number];
 
 /**
- * The task board item id a chat thread is linked to, or null — derived from the
+ * The task board item a chat thread is linked to, or null — derived from the
  * task list (each item carries its linked `threads`), so no dedicated tool is
  * needed. Shares the board's query key so the list is fetched once and cached.
  */
-export function useTaskForThread(threadId: string | undefined): string | null {
+export function useBoardTaskForThread(
+  threadId: string | undefined,
+): TaskBoardItem | null {
   const { locator } = useProjectContext();
   const studio = useStudioTools();
   const { data } = useQuery({
@@ -17,7 +22,7 @@ export function useTaskForThread(threadId: string | undefined): string | null {
   });
   if (!threadId || !data) return null;
   return (
-    data.find((item) => item.threads.some((t) => t.threadId === threadId))
-      ?.id ?? null
+    data.find((item) => item.threads.some((t) => t.threadId === threadId)) ??
+    null
   );
 }

--- a/apps/web/src/layouts/resolve-task-switch-search.test.ts
+++ b/apps/web/src/layouts/resolve-task-switch-search.test.ts
@@ -142,3 +142,14 @@ describe("resolveTaskSwitchSearch — restoring per-thread memory", () => {
     });
   });
 });
+
+describe("resolveTaskSwitchSearch — explicit side panel", () => {
+  test("opts.sidepanel forces the chat panel open over remembered layout", () => {
+    expect(
+      resolve({
+        savedLayout: { main: "board", sidepanel: 0 } as ThreadLayout,
+        opts: { sidepanel: "chat" },
+      }),
+    ).toEqual({ main: "board", sidepanel: "chat" });
+  });
+});

--- a/apps/web/src/layouts/resolve-task-switch-search.ts
+++ b/apps/web/src/layouts/resolve-task-switch-search.ts
@@ -30,7 +30,12 @@ export interface ResolveTaskSwitchInput {
   decopilotId: string;
   /** The target thread's remembered layout, or null if none. */
   savedLayout: ThreadLayout | null;
-  opts?: { autosend?: boolean; main?: string };
+  opts?: {
+    autosend?: boolean;
+    main?: string;
+    /** Force the chat panel open (or closed) regardless of remembered layout. */
+    sidepanel?: "chat" | 0;
+  };
   /** `?autosend` sentinel value, injected to avoid an import cycle. */
   autosendValue: string;
 }
@@ -75,6 +80,7 @@ export function resolveTaskSwitchSearch(
     }
   }
 
+  if (opts?.sidepanel !== undefined) sidepanel = opts.sidepanel;
   if (sidepanel !== undefined) next.sidepanel = sidepanel;
   if (opts?.autosend) next.autosend = autosendValue;
   return next;

--- a/apps/web/src/layouts/shell-layout.tsx
+++ b/apps/web/src/layouts/shell-layout.tsx
@@ -122,7 +122,7 @@ export function usePanelActions() {
   const setTaskId = (
     id: string,
     virtualMcpId?: string,
-    opts?: { autosend?: boolean; main?: string },
+    opts?: { autosend?: boolean; main?: string; sidepanel?: "chat" | 0 },
   ) => {
     const isSameThread = !!currentTaskId && currentTaskId === id;
     // Remember the layout of the thread we're leaving so returning to it

--- a/apps/web/src/layouts/task-board/task-branch.test.ts
+++ b/apps/web/src/layouts/task-board/task-branch.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { resolveTaskBranch } from "./task-branch";
+
+describe("resolveTaskBranch", () => {
+  test("no sessions → null", () => {
+    expect(resolveTaskBranch([])).toBeNull();
+  });
+
+  test("sessions without a branch → null (the server picks)", () => {
+    // The shape the local dev org is in: three linked sessions, no branch.
+    expect(
+      resolveTaskBranch([
+        { threadId: "a", createdAt: "2026-08-01T00:00:00Z", branch: null },
+        { threadId: "b", createdAt: "2026-08-02T00:00:00Z" },
+        { threadId: "c", createdAt: "2026-08-03T00:00:00Z", branch: "" },
+      ]),
+    ).toBeNull();
+  });
+
+  test("single branched session wins", () => {
+    expect(
+      resolveTaskBranch([
+        {
+          threadId: "a",
+          createdAt: "2026-08-01T00:00:00Z",
+          branch: "thread:a",
+        },
+      ]),
+    ).toBe("thread:a");
+  });
+
+  test("newest branch wins, whatever the input order", () => {
+    expect(
+      resolveTaskBranch([
+        { threadId: "old", createdAt: "2026-08-01T00:00:00Z", branch: "old" },
+        { threadId: "new", createdAt: "2026-08-09T00:00:00Z", branch: "new" },
+        { threadId: "mid", createdAt: "2026-08-05T00:00:00Z", branch: "mid" },
+      ]),
+    ).toBe("new");
+  });
+
+  test("skips newer branchless sessions to find the branch in use", () => {
+    expect(
+      resolveTaskBranch([
+        { threadId: "newest", createdAt: "2026-08-09T00:00:00Z", branch: null },
+        {
+          threadId: "older",
+          createdAt: "2026-08-01T00:00:00Z",
+          branch: "thread:older",
+        },
+      ]),
+    ).toBe("thread:older");
+  });
+
+  test("whitespace-only branch is not a branch", () => {
+    expect(
+      resolveTaskBranch([
+        { threadId: "a", createdAt: "2026-08-01T00:00:00Z", branch: "   " },
+      ]),
+    ).toBeNull();
+  });
+
+  test("trims the branch it returns", () => {
+    expect(
+      resolveTaskBranch([
+        {
+          threadId: "a",
+          createdAt: "2026-08-01T00:00:00Z",
+          branch: " feat/x ",
+        },
+      ]),
+    ).toBe("feat/x");
+  });
+
+  test("does not mutate the input order", () => {
+    const sessions = [
+      { threadId: "old", createdAt: "2026-08-01T00:00:00Z", branch: "old" },
+      { threadId: "new", createdAt: "2026-08-09T00:00:00Z", branch: "new" },
+    ];
+    resolveTaskBranch(sessions);
+    expect(sessions.map((s) => s.threadId)).toEqual(["old", "new"]);
+  });
+});

--- a/apps/web/src/layouts/task-board/task-branch.ts
+++ b/apps/web/src/layouts/task-board/task-branch.ts
@@ -1,0 +1,41 @@
+/**
+ * The branch a task's sessions share.
+ *
+ * A task owns one branch; its sessions are conversations on it. Without this,
+ * every new session gets whatever branch `COLLECTION_THREADS_CREATE` picks
+ * (the warmest sandbox, or a fresh generated name), so two sessions on one
+ * card drift onto two branches, open two PRs, and the card stops telling the
+ * truth about what shipped.
+ */
+
+export interface SessionBranchRef {
+  threadId: string;
+  createdAt: string;
+  branch?: string | null;
+}
+
+/**
+ * The newest session that actually has a branch, or null when none do (a task
+ * whose runs never reached a sandbox — the caller then lets the server pick).
+ * Newest-first so a task that changed branch mid-life keeps its current one.
+ */
+export function resolveTaskBranch(sessions: SessionBranchRef[]): string | null {
+  for (const session of newestFirst(sessions)) {
+    const branch = session.branch?.trim();
+    if (branch) return branch;
+  }
+  return null;
+}
+
+/** The task's most recent session, or null when it has none. */
+export function resolveNewestSession<T extends { createdAt: string }>(
+  sessions: T[],
+): T | null {
+  return newestFirst(sessions)[0] ?? null;
+}
+
+function newestFirst<T extends { createdAt: string }>(sessions: T[]): T[] {
+  return [...sessions].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+}


### PR DESCRIPTION
## Summary

**Stack 1 of 3.** Foundation for treating a *task*, not a branch, as the unit of work. No user-visible change on its own; it is the model the next two PRs build on.

- `resolveTaskBranch` / `resolveNewestSession` (`layouts/task-board/task-branch.ts`) derive a task's branch from its linked sessions, so a second session **joins the branch already in flight** instead of starting its own.
- `useStartTaskSession` starts a session on a task, reusing that branch.
- `setTaskId` / `resolveTaskSwitchSearch` take a `sidepanel` override, so a caller can force the chat panel open regardless of the thread's remembered layout.
- `useTaskForThread` becomes `useBoardTaskForThread` and returns the **item** rather than just its id, which callers need in order to read its sessions.
- `TaskBoardStorage` no longer joins **hidden** threads into a task's session list.

## Testing

- `tsc --noEmit` clean on `apps/web` and `apps/api`.
- 23 unit tests pass (`task-branch.test.ts`, `resolve-task-switch-search.test.ts`) — pure logic, no mocks, per the two-tier testing rule.

## Stack

1. **this PR** → `main`
2. `rafavalls/task-pill-session-tabs` → this branch
3. `rafavalls/auto-file-pr-on-board` → #2

Review and merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats a task as the unit of work by having all of its sessions share one branch. Previously, each new session could land on a new server-picked branch; now a new session inherits the branch already in use, reducing duplicate branches/PRs and keeping a card aligned with what shipped. This lays groundwork; not user-visible until wired in the next PR.

- Adds resolveTaskBranch/resolveNewestSession: pick the newest session with a non-empty branch; trim blanks; fall back to server when none exist.
- Adds useStartTaskSession: creates a new thread on the task’s branch, seeds a draft with a removable @task mention and context, links the thread to the task, then opens chat; tolerates failures.
- Renames useTaskForThread → useBoardTaskForThread and returns the full item (callers need sessions); updates the open-in-board button to use item.id.
- Allows forcing the side panel: setTaskId and resolveTaskSwitchSearch accept an optional sidepanel override to open/close chat regardless of remembered layout.
- Excludes hidden threads from a task’s session list in TaskBoardStorage.
- Tests: new task-branch.test.ts; expands resolve-task-switch-search.test.ts.

- Migration: replace useTaskForThread with useBoardTaskForThread and update callers to read the returned item (use .id where an id is needed).

<sup>Written for commit 56fdab7d88390866bff735c77b4a178f21547f0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

