### PR TITLE
fix(task-board): stop column scroll from bleeding into board scroll

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -1305,37 +1305,20 @@ function Lanes({
   const [preferences, setPreferences] = usePreferences();
   const boardRef = useRef<HTMLDivElement>(null);
 
-  // A plain mouse wheel only emits vertical deltas, so on a board that overflows
-  // sideways the columns off-screen to the right are unreachable without a
-  // trackpad (two-finger swipe) or Shift+wheel — neither of which a mouse user
-  // has. Translate a vertical wheel into horizontal board scroll, but only when
-  // the pointer isn't over a lane that can still absorb that scroll itself, so
-  // scrolling a column's cards keeps working. Registered natively (not via
-  // React's passive onWheel) so preventDefault can suppress the browser's own
-  // vertical scroll/overscroll; React 19 ref cleanup unregisters it.
+  // Converts a plain mouse wheel into horizontal board scroll, but only outside lanes.
   const attachBoard = (node: HTMLDivElement | null) => {
     boardRef.current = node;
     if (!node) return;
     const onWheel = (event: WheelEvent) => {
-      // Trackpad / Shift+wheel already produce a horizontal delta — let the
-      // browser handle those natively.
+      // Trackpad / Shift+wheel already produce a horizontal delta.
       if (event.deltaX !== 0 || event.deltaY === 0) return;
       if (node.scrollWidth <= node.clientWidth) return;
-      // Walk up from the pointer target: if a lane under it can still scroll
-      // vertically in this direction, that's what the wheel is for.
       for (
         let el = event.target as HTMLElement | null;
         el && el !== node;
         el = el.parentElement
       ) {
-        if (el.hasAttribute("data-lane-scroll")) {
-          const hasRoom =
-            event.deltaY < 0
-              ? el.scrollTop > 0
-              : el.scrollTop + el.clientHeight < el.scrollHeight - 1;
-          if (hasRoom) return;
-          break;
-        }
+        if (el.hasAttribute("data-lane-scroll")) return;
       }
       event.preventDefault();
       const factor =


### PR DESCRIPTION
## Summary
- Fix a UI bug where scrolling to the bottom/top of a task-board column mid-gesture would immediately hijack the remaining wheel scroll into horizontal board scroll, yanking the view sideways unexpectedly.
- The mouse-wheel-to-horizontal-scroll conversion now only applies when the wheel event is outside any lane, never mid-scroll inside a column.

## Test plan
- [x] `bun run fmt`
- [x] `tsc --noEmit` on the touched file (no errors)
- [ ] Manual: scroll a long column to the bottom with a mouse wheel/trackpad and confirm the board no longer scrolls horizontally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops column scroll from bleeding into horizontal board scroll. Previously, when a column hit its top/bottom mid-gesture, the leftover wheel delta moved the board sideways; now, we only translate vertical wheel input to horizontal scroll when the event occurs outside any lane.

**Reviewer notes**
- Simplifies the wheel handler: if the event target is inside an element with `data-lane-scroll`, do nothing; no more checking whether the lane can scroll further.
- Trackpad and Shift+wheel behavior is unchanged; this affects only plain mouse wheel. Horizontal scrolling still works when hovering the board background.
- No API or state changes; UI-only fix.

<sup>Written for commit 7fb2e4a6500d87f0933ee774fdead271805d424d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

