### PR TITLE
refactor(sandbox): let the dev server own the preview refresh after a Blocks save

### DIFF
--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
@@ -82,14 +82,8 @@ export interface SandboxEventsValue {
   getBuffer: (source: string) => string;
   hasData: (source: string) => boolean;
   subscribeChunks: (handler: ChunkHandler) => () => void;
-  /** "reload" SSE fires on config edits framework HMR doesn't watch. */
+  /** The preview's origin moved or came back — never a file edit. */
   subscribeReload: (handler: ReloadHandler) => () => void;
-  /**
-   * Fires the instant a `.deco/*` change is detected — before the debounced
-   * reload — so the preview can show its loading overlay immediately instead of
-   * waiting out the rebuild debounce.
-   */
-  subscribeReloadStart: (handler: ReloadHandler) => () => void;
 }
 
 const DEFAULT_VALUE: SandboxEventsValue = {
@@ -104,7 +98,6 @@ const DEFAULT_VALUE: SandboxEventsValue = {
   hasData: () => false,
   subscribeChunks: () => () => {},
   subscribeReload: () => () => {},
-  subscribeReloadStart: () => () => {},
 };
 
 export const SandboxEventsContext =
@@ -234,7 +227,6 @@ export function SandboxEventsProvider({
   const buffers = useRef(new Map<string, ChunkBuffer>());
   const chunkHandlers = useRef(new Set<ChunkHandler>());
   const reloadHandlers = useRef(new Set<ReloadHandler>());
-  const reloadStartHandlers = useRef(new Set<ReloadHandler>());
   const prevPortRef = useRef<number | null>(null);
   const directDaemonEventsUrl = buildDirectDaemonEventsUrl(previewUrl);
 
@@ -455,10 +447,7 @@ export function SandboxEventsProvider({
             const { path: filePath } =
               payload as DaemonEventPayload<"file-changed">;
             const cacheKey = `${org.slug}/${virtualMcpId}/${branch}`;
-            // A `.deco/*` change is a config edit the framework's HMR won't pick
-            // up. `/.deco/` (not just a leading `.deco/`) also matches projects
-            // whose package path isn't the repo root (`<pkg>/.deco/...`), since
-            // the daemon reports paths relative to the repo root.
+            // `/.deco/` matches packages whose path isn't the repo root.
             const isDecoFile =
               filePath.startsWith(".deco/") || filePath.includes("/.deco/");
             if (isDecoFile) {
@@ -472,16 +461,6 @@ export function SandboxEventsProvider({
               // truth until the lifecycle→running transition re-invalidates.
               const devServerRunning = prevLifecyclePhase === "running";
               if (!devServerRunning) return;
-              // Turn on the preview's loading overlay immediately — before the
-              // debounce below — so the pending refresh feels instant instead of
-              // only appearing once the reload finally fires.
-              for (const fn of reloadStartHandlers.current) {
-                try {
-                  fn();
-                } catch {
-                  // swallow
-                }
-              }
               // Debounce decofile invalidation for the same reason as liveMeta
               // below: writing a `.deco/` block emits `file-changed`, but the
               // dev server needs a moment to rebuild before `/.decofile`
@@ -493,27 +472,9 @@ export function SandboxEventsProvider({
               if (decofileDebounceTimer) clearTimeout(decofileDebounceTimer);
               decofileDebounceTimer = setTimeout(() => {
                 decofileDebounceTimer = null;
-                // Only refetch the decofile when the dev server is running (the
-                // live `/.decofile` route reflects the write). In Fast Preview
-                // the daemon serves the render straight from disk, so skip the
-                // refetch (it would revert an optimistic edit) and just reload.
-                if (devServerRunning) {
-                  void queryClient.invalidateQueries({
-                    queryKey: KEYS.decofile(cacheKey),
-                  });
-                }
-                // Reload the preview iframe once the write has landed — HMR
-                // won't reflect a decofile edit, so this is the only thing that
-                // refreshes the rendered page after a Blocks save (or an
-                // external/agent `.deco/` write). Debounced so it fires after
-                // the write lands ("save → refresh").
-                for (const fn of reloadHandlers.current) {
-                  try {
-                    fn();
-                  } catch {
-                    // swallow
-                  }
-                }
+                void queryClient.invalidateQueries({
+                  queryKey: KEYS.decofile(cacheKey),
+                });
               }, 500);
             } else {
               // Debounce liveMeta invalidation so the dev server has time to
@@ -690,12 +651,6 @@ export function SandboxEventsProvider({
       reloadHandlers.current.add(handler);
       return () => {
         reloadHandlers.current.delete(handler);
-      };
-    },
-    subscribeReloadStart: (handler: ReloadHandler) => {
-      reloadStartHandlers.current.add(handler);
-      return () => {
-        reloadStartHandlers.current.delete(handler);
       };
     },
   };

--- a/apps/web/src/components/sandbox/hooks/use-sandbox-events.ts
+++ b/apps/web/src/components/sandbox/hooks/use-sandbox-events.ts
@@ -35,7 +35,7 @@ export function useSandboxChunkHandler(handler: ChunkHandler | null) {
   }, [subscribeChunks]);
 }
 
-/** Daemon "reload" = config edits framework HMR won't catch (.ts/.tsx uses framework HMR). */
+/** The preview's origin moved or came back. File edits are the dev server's job. */
 export function useSandboxReloadHandler(handler: ReloadHandler | null) {
   const { subscribeReload } = useSandboxEvents();
   const handlerRef = useRef(handler);
@@ -50,24 +50,4 @@ export function useSandboxReloadHandler(handler: ReloadHandler | null) {
     const unsubscribe = subscribeReload(fn);
     return unsubscribe;
   }, [subscribeReload]);
-}
-
-/**
- * Fires the instant a `.deco/*` change is detected (before the debounced
- * reload), so the caller can show a loading indicator immediately.
- */
-export function useSandboxReloadStartHandler(handler: ReloadHandler | null) {
-  const { subscribeReloadStart } = useSandboxEvents();
-  const handlerRef = useRef(handler);
-  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
-  handlerRef.current = handler;
-
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect — subscription lifecycle bound to the component mount; uses ref for stable identity
-  useEffect(() => {
-    const fn: ReloadHandler = () => {
-      handlerRef.current?.();
-    };
-    const unsubscribe = subscribeReloadStart(fn);
-    return unsubscribe;
-  }, [subscribeReloadStart]);
 }

--- a/apps/web/src/components/sandbox/preview/preview-iframe-recovery.ts
+++ b/apps/web/src/components/sandbox/preview/preview-iframe-recovery.ts
@@ -23,7 +23,7 @@ const RETRY_CAP_MS = 30_000;
  * on the browser's connection-refused page and stay there: the failed
  * cross-origin navigation fires no `load`/`error` event, so nothing tells the
  * app to retry once the server is back (SSE reload signals only fire on port
- * changes / `.deco` writes / explicit daemon events — not on this recovery).
+ * changes / explicit daemon events — not on this recovery).
  *
  * This watchdog arms a timer each time the iframe is pointed at a sandbox URL;
  * if no `load` arrives in {@link LOAD_TIMEOUT_MS} it reassigns `src` to retry,

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1,6 +1,5 @@
 import { sleep } from "@decocms/shared/std";
 import { useState, useRef, useEffect, type CSSProperties } from "react";
-import { useIsMutating } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { formatCodeTabId } from "@/layouts/main-panel-tabs/tab-id";
 import { useChatTask } from "@/components/chat/context";
@@ -90,7 +89,7 @@ import {
   withDraftPointer,
 } from "@/components/sections-editor/section-preview-url";
 import { useFastPreviewDraftUrl } from "@/components/sections-editor/use-fast-preview-draft-url";
-import { decofileWriteMutationKey } from "@/components/sections-editor/decofile-api";
+import { useDecofileWriting } from "@/components/sections-editor/use-decofile-writing";
 import { useCreatePage } from "@/components/sections-editor/use-create-page";
 import { CreatePageModal } from "@/components/sections-editor/create-page-modal";
 import { toast } from "sonner";
@@ -113,7 +112,6 @@ import { VisualEditorPrompt } from "./visual-editor-prompt";
 import {
   useSandboxEvents,
   useSandboxReloadHandler,
-  useSandboxReloadStartHandler,
 } from "../hooks/use-sandbox-events";
 import { SandboxStateCard } from "./state-card";
 import {
@@ -163,7 +161,7 @@ const VSCODE_ICON_URL =
 const CURSOR_ICON_URL =
   "https://decoims.com/decocms/7583d3b5-81d0-4afb-becf-6a59bbb3a68e/cursor-logo-icon-freelogovectors.net_.png";
 
-/** Delay before reloading the preview iframe after a save, giving the dev server time to pick up file changes. */
+/** Delay before navigating to a newly created page, giving the dev server time to route it. */
 const DEV_SERVER_SETTLE_MS = 500;
 
 type PreviewDeviceSize = "mobile" | "tablet" | "desktop";
@@ -375,8 +373,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const pagesContainerRef = useRef<HTMLDivElement>(null);
   const [createPageDialogOpen, setCreatePageDialogOpen] = useState(false);
   const [createPageError, setCreatePageError] = useState<string | undefined>();
-  // Bumped after a Blocks save so the Fast Preview daemon frame re-navigates and
-  // the daemon re-reads the fresh `.deco/blocks/*` (the "save → refresh" step).
   const [activeGlobalSection, setActiveGlobalSection] =
     useState<GlobalSectionEntry | null>(null);
   /** Decofile key of the global loader open in the Blocks panel, if any. */
@@ -676,20 +672,12 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // bumped by every save). No sandbox, no SSE — a new version after a save is
   // still what re-navigates the frame.
   //
-  // Autosave indicator: an in-flight block write shows the same thin top bar
-  // as navigation. In sandbox mode the daemon's `.deco/` change SSE drives the
-  // bar; sandbox-less has no daemon, so the mutation itself is the signal. The
-  // handoff is seamless — when the write lands, the new draft version changes
-  // `draftPreviewUrl`, and the re-navigation effect keeps the bar up (via
-  // `beginNavigation`) until the reloaded iframe fires onLoad.
-  const decofileWriting =
-    useIsMutating({
-      mutationKey: decofileWriteMutationKey(
-        org.slug,
-        virtualMcpId ?? "",
-        branch ?? "",
-      ),
-    }) > 0;
+  // Autosave indicator: an in-flight block write shares navigation's top bar.
+  const decofileWriting = useDecofileWriting(
+    org.slug,
+    virtualMcpId ?? "",
+    branch ?? "",
+  );
   // Computed BEFORE `display`: it is an input to that decision, so it must not
   // depend on `display.mode` in turn.
   const { url: draftPreviewUrl } = useFastPreviewDraftUrl(
@@ -1151,10 +1139,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     iframe.src = iframeSrc;
   };
 
-  // Reload the preview without moving keyboard focus. Used both for the daemon
-  // "reload" event (config edits HMR won't catch) and, via the debounced
-  // `.deco/` file-changed signal, after a Blocks save once the dev server has
-  // rebuilt (see sandbox-events-context).
+  /** Reload the preview without moving keyboard focus. */
   const reloadPreviewPreservingScroll = () => {
     const iframe = previewIframeRef.current;
     if (!iframe) return;
@@ -1190,22 +1175,8 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     fallbackTimer = setTimeout(restore, 3000);
   };
 
-  // Fires on the daemon "reload" event and on debounced `.deco/` file changes
-  // (Blocks saves, external/agent decofile writes) — the only refresh path for
-  // decofile edits, which the framework's HMR doesn't cover. In Fast Preview
-  // the refresh is already driven by the draft VERSION: the same write emits a
-  // `decofile` event, the new version changes `draftPreviewUrl`, and the effect
-  // above re-navigates the frame. Reloading here as well would race that with a
-  // stale URL, so this path yields; the sandbox path uses the normal reload.
-  useSandboxReloadHandler(() => {
-    if (draftPreviewUrl) return;
-    reloadPreviewPreservingScroll();
-  });
-  // Show the loading overlay the instant a `.deco/` change is detected, ahead of
-  // the debounced reload above, so the pending refresh feels immediate.
-  useSandboxReloadStartHandler(() => {
-    beginNavigation();
-  });
+  // Only a moved or restarted dev server; file edits reload the page themselves.
+  useSandboxReloadHandler(reloadPreviewPreservingScroll);
 
   const handleDeviceToggle = () => {
     const idx = DEVICE_CYCLE.indexOf(previewDeviceSize);

--- a/apps/web/src/components/sections-editor/use-decofile-writing.ts
+++ b/apps/web/src/components/sections-editor/use-decofile-writing.ts
@@ -1,0 +1,19 @@
+import { useIsMutating } from "@tanstack/react-query";
+import { useMinimumDuration } from "@/hooks/use-minimum-duration";
+import { decofileWriteMutationKey } from "./decofile-api";
+
+/** Floor for how long the autosave indicator stays up, so a fast write can't flash. */
+const AUTOSAVE_INDICATOR_MIN_MS = 500;
+
+/** True while a block write is in flight, held for {@link AUTOSAVE_INDICATOR_MIN_MS}. */
+export function useDecofileWriting(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+): boolean {
+  const writing =
+    useIsMutating({
+      mutationKey: decofileWriteMutationKey(orgSlug, virtualMcpId, branch),
+    }) > 0;
+  return useMinimumDuration(writing, AUTOSAVE_INDICATOR_MIN_MS);
+}

--- a/apps/web/src/components/thread/github/cms-header-actions.tsx
+++ b/apps/web/src/components/thread/github/cms-header-actions.tsx
@@ -28,12 +28,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@decocms/ui/components/tooltip.tsx";
-import {
-  useIsMutating,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 import { GitPullRequest, RefreshCw01, Rocket02 } from "@untitledui/icons";
@@ -45,7 +40,7 @@ import { resolveGithubAttachment } from "@/lib/github-repo.ts";
 import { KEYS } from "@/lib/query-keys";
 import { useProjectContext, useVirtualMCP } from "@/sdk";
 import { useSessionRuntime } from "@/hooks/use-session-runtime";
-import { decofileWriteMutationKey } from "../../sections-editor/decofile-api.ts";
+import { useDecofileWriting } from "../../sections-editor/use-decofile-writing.ts";
 import { useFastPreviewDraftUrl } from "../../sections-editor/use-fast-preview-draft-url.ts";
 import { fillPathTemplate } from "../../sections-editor/page-path-utils.ts";
 import {
@@ -275,14 +270,7 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
   });
 
   /** Same in-flight signal the preview's autosave indicator reads. */
-  const saving =
-    useIsMutating({
-      mutationKey: decofileWriteMutationKey(
-        org.slug,
-        virtualMcpId,
-        branch ?? "",
-      ),
-    }) > 0;
+  const saving = useDecofileWriting(org.slug, virtualMcpId, branch ?? "");
 
   /**
    * Detached: repo linked via a GitHub connection that's no longer aggregated.

--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -1,6 +1,6 @@
 import { useMCPClient, useProjectContext, useVirtualMCP } from "@/sdk";
-import { useIsMutating, useQuery } from "@tanstack/react-query";
-import { decofileWriteMutationKey } from "@/components/sections-editor/decofile-api";
+import { useQuery } from "@tanstack/react-query";
+import { useDecofileWriting } from "@/components/sections-editor/use-decofile-writing";
 import { Button } from "@decocms/ui/components/button.tsx";
 import {
   SplitButton,
@@ -236,14 +236,11 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const publishPolicy = normalizePublishPolicy(vm?.metadata?.publishPolicy);
 
   /** An in-flight autosave means the branch state is mid-change — hold the publish surfaces until the write lands. */
-  const decofileSaving =
-    useIsMutating({
-      mutationKey: decofileWriteMutationKey(
-        org.slug,
-        virtualMcpId,
-        branch ?? sandboxRouteBranch ?? "",
-      ),
-    }) > 0;
+  const decofileSaving = useDecofileWriting(
+    org.slug,
+    virtualMcpId,
+    branch ?? sandboxRouteBranch ?? "",
+  );
 
   /** Detached repo: render a reconnect pill, never a blank header. */
   if (attachment.status === "detached") {

--- a/apps/web/src/hooks/use-minimum-duration.test.ts
+++ b/apps/web/src/hooks/use-minimum-duration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { remainingHoldMs } from "./use-minimum-duration";
+
+describe("remainingHoldMs", () => {
+  it("owes nothing when no run is in progress", () => {
+    expect(remainingHoldMs(null, 1_000, 300)).toBe(0);
+  });
+
+  it("owes the full window the instant a run starts", () => {
+    expect(remainingHoldMs(1_000, 1_000, 300)).toBe(300);
+  });
+
+  it("owes the remainder partway through", () => {
+    expect(remainingHoldMs(1_000, 1_120, 300)).toBe(180);
+  });
+
+  it("owes nothing once the window has elapsed", () => {
+    expect(remainingHoldMs(1_000, 1_300, 300)).toBe(0);
+  });
+
+  it("never owes a negative amount on a long run", () => {
+    expect(remainingHoldMs(1_000, 9_999, 300)).toBe(0);
+  });
+
+  it("clamps a clock that went backwards rather than owing extra", () => {
+    expect(remainingHoldMs(1_000, 900, 300)).toBe(300);
+  });
+});

--- a/apps/web/src/hooks/use-minimum-duration.ts
+++ b/apps/web/src/hooks/use-minimum-duration.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from "react";
+
+/** Milliseconds still owed before a run that began at `startedAt` may end. */
+export function remainingHoldMs(
+  startedAt: number | null,
+  now: number,
+  minMs: number,
+): number {
+  if (startedAt === null) return 0;
+  // A backwards clock (NTP) must not owe MORE than the window.
+  return Math.max(0, minMs - Math.max(0, now - startedAt));
+}
+
+/** `active`, but never true for less than `minMs` — a faster flip reads as a flicker. */
+export function useMinimumDuration(active: boolean, minMs: number): boolean {
+  const [held, setHeld] = useState(active);
+  /** Start of the current run; null while released, so re-activating extends it. */
+  const startedAtRef = useRef<number | null>(active ? Date.now() : null);
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- timer-based release has no render-time expression
+  useEffect(() => {
+    if (active) {
+      startedAtRef.current ??= Date.now();
+      setHeld(true);
+      return;
+    }
+    if (!held) return;
+    const release = () => {
+      startedAtRef.current = null;
+      setHeld(false);
+    };
+    const remaining = remainingHoldMs(startedAtRef.current, Date.now(), minMs);
+    if (remaining === 0) {
+      release();
+      return;
+    }
+    const id = setTimeout(release, remaining);
+    return () => clearTimeout(id);
+  }, [active, held, minMs]);
+
+  return held;
+}


### PR DESCRIPTION
## The change

A Blocks save wrote `.deco/blocks/<key>.json` through the daemon, and Studio then reloaded the preview iframe itself on a debounced `file-changed` signal. The sandbox's own dev server already reloads its page for that write — Studio's reload was redundant work racing the framework's.

This deletes the app-driven reload and lets the dev server own the refresh. `onBlocksChanged → save → nothing else` in sandbox; CMS is unchanged and already worked that way (the write returns a new draft version, `draftPreviewUrl` changes, the frame re-navigates).

Three comments in the tree claimed the daemon's `reload` SSE meant *"config edits the framework's HMR won't catch."* It has only ever meant **the dev server came back up** — `Emit("reload")` exists at exactly one site, `daemon-go/main.go:265`, inside `if wasDown`, asserted black-box at `daemon-e2e/daemon.sse-shapes.e2e.test.ts:337`. Corrected here, along with the docstrings the deletion falsified.

The premise is corroborated in-repo at `apps/api/src/harnesses/lib/coding-workspace-prompt.ts:37`, in the prompt Studio ships to its own coding agents: *"the dev server watches `.deco/blocks/` and hot-reloads the preview."* Verified by hand against a running sandbox before landing.

## What was deleted

- The iframe reload from the `.deco/` branch of `file-changed`.
- The entire `reloadStart` channel — type, `DEFAULT_VALUE` entry, ref, producer, provider method, and `useSandboxReloadStartHandler`. One producer, one consumer, both gone.
- A dead `if (devServerRunning)` inside the debounce timer, already guaranteed by the early `return` above it.
- `if (draftPreviewUrl) return;` in the reload handler — unreachable in both directions: `draftPreviewUrl` requires `runtime === "cms"`, and a CMS session never mounts the provider that would call the handler.

## What was kept, deliberately

**The `KEYS.decofile` invalidation.** That `.deco/` watch had two consumers wearing one coat: the iframe (deleted) and Studio's own Blocks form (kept). An agent or shell writing a block from the chat leaves no optimistic cache entry behind, and a dev-server reload tells Studio nothing about its own cache.

**`useSandboxReloadHandler`**, for its two real producers — a dev-server port change and the daemon's came-back-up event. Neither is a file edit, and no amount of HMR covers a moved origin. This is why the gate had to be on the event class rather than on the subscriber.

## Autosave indicator: 500 ms floor

With the reload gone, the indicator ends when the HTTP write does, which is fast enough to flash. `useMinimumDuration` holds it for 500 ms; the timing rule is a pure `remainingHoldMs` so it is unit-tested without fake timers (a backwards NTP jump would otherwise owe *more* than the window — clamped, with a test).

All three surfaces reading the block-write mutation key went through one hook, `useDecofileWriting`, so the floor cannot drift between them:

| surface | file |
|---|---|
| preview progress bar | `preview.tsx:676` |
| CMS header "saving" | `cms-header-actions.tsx:277` |
| sandbox header publish gate | `header-actions.tsx:238` |

## Affected runtimes

- **Sandbox only** — the reload deletion. CMS returns early at `agent-shell-layout/index.tsx:332` and never mounts `SandboxEventsProvider`, so `subscribeReload` is the inert default that discards its handler.
- **Both** — the 500 ms hold. `header-info.tsx:31-34` picks the CMS or sandbox header by session runtime, and `PreviewContent` renders in both. Intentional: flicker is if anything more likely in CMS, where the write is a plain HTTP call with no rebuild after it.

## Testing

`bun run --cwd=apps/web check` clean · `bun run lint` 0 errors · `knip` clean · `bun run fmt` applied.

`bun test apps/web/src/{components/sandbox,components/sections-editor,hooks}` — **1306 pass / 0 fail**, including 6 new tests for `remainingHoldMs`.

Hand-verified against a running sandbox: a Blocks save refreshes the preview with no app-driven reload.

**Be aware:** no test at any tier asserted the old save→reload behavior — there was nothing to invert, and no tier in this repo *can* assert the replacement. `packages/e2e` is a black-box HTTP+DB contract with no sandbox pod and no dev server; the premise needs a live daemon plus a guest framework. That makes it a manual check, not a regression test.

## Follow-ups, filed not fixed

- **`cms-editor::set-labels` is posted only on injection** (`preview.tsx:1085`), never when the derived labels change. Harmless for form-originated saves — `use-save-block.ts:97` updates the decofile cache optimistically in `onMutate`, before the POST, so labels are already fresh by the time any reload lands. It bites **agent/shell writes and "Get latest" rebases**, which have no optimistic entry: labels arrive only via the ~800 ms debounced refetch, and a faster framework reload re-injects stale ones. Fix is to post on data change.
- **The progress bar spans the write, not the rebuild.** The 500 ms floor stops the flicker, but the canvas can still be pre-save after the bar clears. Restoring a `.deco/` → `beginNavigation()` subscription would cover it, at the cost of partly resurrecting what this PR deletes — a product call, deliberately not made here.
- **`.deco/*.jsonc` config edits** take the same silenced branch as block writes. The premise was verified for `.deco/blocks/*.json`; if config edits need the reload, the fix is a narrow path-class split.
- **Fresh/Deno projects** (`use-live-meta.ts:25-27` documents the second framework family) were not verified.
- **`/live/previews` global-section URL** is frozen state nothing recomputes (`preview.tsx:1261-1277`); worth a manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let the sandbox dev server own preview refresh after a Blocks save. Previously, Studio reloaded the preview iframe on a debounced `.deco/*` file-change; now the framework dev server’s reload handles it, and Studio only invalidates its cache. This removes a race and matches CMS behavior.

- Removes the app-driven reload from the `.deco/*` path and deletes the `reloadStart` channel; keeps `KEYS.decofile` invalidation to update the Blocks form.
- Keeps `useSandboxReloadHandler` only for dev‑server port changes and the daemon “reload” (server came back up), and corrects related docstrings.
- Simplifies preview reload and drops an unreachable `draftPreviewUrl` guard; cleans up dead code and comments.
- Adds `useMinimumDuration` and `useDecofileWriting` to hold the autosave indicator for 500 ms; used by the preview progress bar and both headers.

- Sandbox only: refresh after a Blocks save is now driven by the dev server. CMS is unchanged.
- Both runtimes: autosave indicator has a 500 ms minimum to prevent flicker.
- No migrations. Review by focusing on the `.deco/*` branch removal, the `reloadStart` deletion, and the new autosave hooks.

<sup>Written for commit 3572ea2b6ae831e7103cd36bf64fd70e4a8b199e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

