### PR TITLE
fix(decopilot): don't purge a resumed run's chunk log at dispatch

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -1143,13 +1143,48 @@ async function prepareRun(
       }
     }
 
+    // Where this dispatch's chunks continue from, and whether it is continuing
+    // anything at all.
+    //
+    // `run_acked_seq` is the highest contiguous seq published for the CURRENT
+    // attempt's fence — durable, and cleared when the fence is minted
+    // (`setRunFence`), so it is per-attempt by construction. A non-zero value
+    // therefore means one thing: a previous Studio process published this run's
+    // first N chunks and then died before finishing the turn. This dispatch is
+    // that turn's continuation.
+    //
+    // Only a sandbox-hosted harness can be in that position. Decopilot's agent
+    // loop lives in this process and dies with it, so a recovered run has nothing
+    // still executing anywhere and starts over from seq 0 — its floor is never
+    // read and never written.
+    //
+    // Read BEFORE the purge below, which consumes it: this is the only honest
+    // "am I a resume?" signal at this point in the dispatch.
+    const sandboxHosted = harnessRunsInSandbox(harnessId);
+    const resumeFromSeq = sandboxHosted
+      ? await ctx.storage.threads.getAckedSeq(mem.thread.id)
+      : 0;
+    if (resumeFromSeq > 0) {
+      console.log("[dispatch] resuming a sandbox-hosted turn", {
+        runId: mem.thread.id,
+        fromSeq: resumeFromSeq,
+      });
+    }
+
     // Purge stale buffered chunks from any PREVIOUS run on this thread — but
     // NOT on resume. A resumed run (DBOS recovery after its owner pod died) IS
     // "the previous run": purging here beheads the very chunk log its projector
     // must replay, so replay hits a StreamGapError ("missing seq 1") and the
     // recovered run is marked `failed` instead of completing. Recovery depends
-    // on the seq 1..N log surviving the pod that owned it.
-    if (!input.isResume) {
+    // on the seq 1..N log surviving the pod that owned it — and this attempt
+    // EXTENDS that log from `resumeFromSeq`, so the hole is guaranteed, not
+    // racy: the projector replays from seq 1 and meets `resumeFromSeq + 1`
+    // ("missing seq 1 (next delivered is N)", prod 2026-08-21).
+    //
+    // `resumeFromSeq`, not `isResume`: no caller has ever set that flag, and a
+    // DBOS step re-executed after its pod died is handed the ORIGINAL input, so
+    // no caller can. The durable per-fence floor is the fact on the ground.
+    if (resumeFromSeq === 0) {
       streamBuffer?.purge(mem.thread.id);
     }
 
@@ -1349,31 +1384,6 @@ async function prepareRun(
         PREPARE_RUN_STATUS_STAGES[2],
       );
     }
-    // Where this dispatch's chunks continue from, and whether it is continuing
-    // anything at all.
-    //
-    // `run_acked_seq` is the highest contiguous seq published for the CURRENT
-    // attempt's fence — durable, and cleared when the fence is minted
-    // (`setRunFence`), so it is per-attempt by construction. A non-zero value
-    // therefore means one thing: a previous Studio process published this run's
-    // first N chunks and then died before finishing the turn. This dispatch is
-    // that turn's continuation.
-    //
-    // Only a sandbox-hosted harness can be in that position. Decopilot's agent
-    // loop lives in this process and dies with it, so a recovered run has nothing
-    // still executing anywhere and starts over from seq 0 — its floor is never
-    // read and never written.
-    const sandboxHosted = harnessRunsInSandbox(harnessId);
-    const resumeFromSeq = sandboxHosted
-      ? await ctx.storage.threads.getAckedSeq(mem.thread.id)
-      : 0;
-    if (resumeFromSeq > 0) {
-      console.log("[dispatch] resuming a sandbox-hosted turn", {
-        runId: mem.thread.id,
-        fromSeq: resumeFromSeq,
-      });
-    }
-
     // The dispatching user's own Claude subscription, when they linked one and
     // it has not expired. It outranks the org's thinking-slot key for a
     // sandbox-hosted run: they asked for their plan to pay. Expired or absent


### PR DESCRIPTION
## The bug

Users on hosted (sandbox) threads intermittently get a run killed with a cryptic bubble:

```
Error: missing seq 1 (next delivered is 146)
```

That's `StreamGapError` (`nats-chunk-source.ts`): the projector replays the thread's JetStream subject expecting the run's chunk log to start at seq 1, and the first chunk it sees for that fence is 146. Seqs 1–145 are gone from the stream.

## Why

The hosted agent loop runs inside the DBOS step `runHostedHarness` (`hosted-harness-workflow.ts`). When the owning pod dies mid-step, DBOS recovery re-executes the step with the **original** input, so `prepareRun` runs again and:

1. purged the whole thread subject — `if (!input.isResume) streamBuffer?.purge(...)` — wiping the dead attempt's seqs 1..145;
2. then read the durable floor `run_acked_seq` (145) and *extended* the log from there, publishing 146, 147, …;
3. the projector replayed from seq 1, met 146, raised `StreamGapError`, marked the run `failed` and left the synthesized error part on the thread.

The guard was never armed: **`isResume` is never set to `true` anywhere in the repo** (only the type declarations, the passthrough in `buildDurableDispatchInput`, and the two `if` sites) — and a DBOS step re-executed after a pod death is handed the original input, so no caller *can* set it. `tests/multi-pod/scenarios/rollout-churn.test.ts` and `pod-death-dbos-replay.test.ts` both already document this exact failure.

## The fix

Gate the purge on the durable floor that already exists, hoisted above the purge:

```ts
const resumeFromSeq = sandboxHosted ? await ctx.storage.threads.getAckedSeq(id) : 0;
…
if (resumeFromSeq === 0) streamBuffer?.purge(mem.thread.id);
```

`run_acked_seq` is nulled by `setRunFence` when the fence is minted, so it is non-zero only for a continuation of the current fence. Net behavior:

- **fresh turn** → purge, unchanged;
- **Decopilot run** (in-process loop, floor never written, restarts at seq 0 and *needs* the stale log gone) → purge, unchanged;
- **sandbox-hosted resume** → no purge, so the projector's replay finds the full 1..N log and the recovered run completes instead of dying.

No new state, no new flag; the only moved code is the `resumeFromSeq` read (nothing between the old and new position touches the fence or the floor).

## Testing

- `bun test apps/api/src/api/routes/decopilot/` → 541 pass, 0 fail
- `bun run check` (apps/api) clean; `bun run lint` clean (18 pre-existing warnings on `main`); `bun run fmt` applied.
- **Coverage gap, stated honestly:** there is no automated test for the sandbox-hosted resume path today. Both multi-pod scenarios that cover pod death (`rollout-churn.test.ts`, `pod-death-dbos-replay.test.ts`) are `.skip`ped for other reasons — the churn one names this exact purge as the reason its recovery assertion fails, and `pod-death-dbos-replay` lists "skip `streamBuffer.purge()` when resuming" as one of three prerequisites (the other two — per-pod `DBOS__VMID` and cross-pod death detection — are still missing, so un-skipping either here would fail for those). This PR removes one of the three; the tests should be un-skipped when the remaining two land.
- `isResume` is now unused by the purge but still drives the run-registry `RESUME` branch, so it is left in place; it is dead in practice (never set) and worth removing in a separate pass rather than widening this diff.

## Risk

Sandbox-hosted resumes only. Worst case if the floor is stale, a resumed turn sees one extra stale chunk on the subject — the projector's fence filter + `assertContiguousAndDedup` drop anything from another fence or at/below what it folded.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop purging a resumed sandbox-hosted run’s chunk log at dispatch by gating the purge on the durable `run_acked_seq` floor. This prevents recovery runs from dying with a stream gap (“missing seq 1”) after a pod death.

- Fresh turns and in-process `Decopilot` runs still purge; sandbox-hosted resumes do not.
- Read `getAckedSeq` before any purge and purge only when `resumeFromSeq === 0`.
- No new state or flags. `isResume` no longer controls purge and remains only for the run-registry path.
- Risk is limited to sandbox-hosted resumes; if the floor is stale, the projector’s fence filter and dedup drop any extra stale chunk.

<sup>Written for commit 6256138d4eb6827e580928be23e3ae4695c52f14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

