### PR TITLE
fix(task-board): stop the task dialog's action menu from freezing the app

### DIFF
--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -579,7 +579,11 @@ export function TaskBoardItemDialog({
                 >
                   {linkCopied ? <Check size={16} /> : <Link03 size={16} />}
                 </Button>
-                <DropdownMenu>
+                {/* Non-modal: a modal menu blocks outside pointer events by
+                    setting `pointer-events: none` on <body>, and half these
+                    items unmount the dialog they live in — leaving that style
+                    behind with no layer to restore it. */}
+                <DropdownMenu modal={false}>
                   <DropdownMenuTrigger asChild>
                     <Button
                       variant="ghost"

--- a/packages/e2e/tests/task-board-dialog-menu.spec.ts
+++ b/packages/e2e/tests/task-board-dialog-menu.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * The task dialog's "More actions" menu (`/$org?main=board` → card → ⋯).
+ *
+ * Guards the regression the dialog redesign shipped when Delete/Archive/Clone
+ * moved from footer buttons into a Radix menu *inside* the dialog: picking an
+ * item that closes the dialog tore two overlapping modal layers down in the
+ * same tick, and the `pointer-events: none` the outer one puts on <body> was
+ * left behind with no layer to restore it. The board kept updating over SSE
+ * but the whole app stopped taking clicks — invisible to a unit test, since
+ * the leak lives in the overlay teardown, not in the component's output.
+ */
+
+import type { APIRequestContext, Page } from "@playwright/test";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, test } from "../fixtures/test";
+
+// Black-box wire-contract shape (owned by this test, per e2e isolation rules).
+interface ListedItem {
+  title: string;
+  status: string;
+}
+
+async function seedCards(
+  request: APIRequestContext,
+  orgSlug: string,
+  count: number,
+) {
+  for (let i = 0; i < count; i++) {
+    await callSelfMcpTool(request, orgSlug, "TASK_BOARD_ITEM_CREATE", {
+      title: `Card ${i}`,
+    });
+  }
+}
+
+async function openBoard(page: Page, orgSlug: string) {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto(`/${orgSlug}?main=board`);
+  // Generous: the board's first paint waits on the shell's route chunks.
+  await expect(page.locator('button:has-text("Card 0")')).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+// Every item in this menu closes the dialog the same way, so the two that
+// change the board prove the whole menu.
+for (const action of ["Delete", "Archive"] as const) {
+  test(`${action} from the dialog menu leaves the app clickable`, async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const request = page.context().request;
+    await seedCards(request, orgSlug, 2);
+    await openBoard(page, orgSlug);
+
+    await page.locator('button:has-text("Card 1")').click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "More actions" }).click();
+    await page.getByRole("menuitem", { name: action }).click();
+
+    // Deleted or archived, the card leaves the board either way.
+    await expect(page.locator('button:has-text("Card 1")')).toHaveCount(0);
+    await expect
+      .poll(() =>
+        callSelfMcpTool<{ items: ListedItem[] }>(
+          request,
+          orgSlug,
+          "TASK_BOARD_ITEM_LIST",
+          {},
+        ).then(({ items }) =>
+          items.map((i) => `${i.title}:${i.status}`).sort(),
+        ),
+      )
+      .toEqual(
+        action === "Delete"
+          ? ["Card 0:triage"]
+          : ["Card 0:triage", "Card 1:archived"],
+      );
+
+    // The regression, named: a leaked overlay style blocked every click.
+    await expect
+      .poll(() =>
+        page.evaluate(() => getComputedStyle(document.body).pointerEvents),
+      )
+      .toBe("auto");
+
+    // The symptom a person hits: the very next click has to land.
+    await page.locator('button:has-text("Card 0")').click();
+    await expect(page.getByRole("dialog")).toContainText("Card 0");
+  });
+}


### PR DESCRIPTION
## What was broken

Picking **Delete** in the task dialog's "More actions" menu made the app stop responding to clicks. The delete itself worked — the card left the board, the row was gone from `TASK_BOARD_ITEM_LIST`, SSE kept flowing — but nothing on the page could be clicked again until a reload. Same for **Archive**, **Clone**, **Auto-fix**, **Re-run** and **New chat**: every item in that menu closes the dialog, and every one of them froze the app.

Regression from #6342, which moved these actions out of the dialog footer (plain buttons) and into a Radix `DropdownMenu` rendered *inside* the dialog.

## Why

The menu and the dialog are both modal Radix layers, and a modal layer sets `pointer-events: none` on `<body>` to block everything outside itself. These items unmount the dialog from inside the menu's own `onSelect`, so both layers tear down in the same commit — and the last cleanup to run writes the saved style back rather than clearing it. Nothing is left mounted to restore it, so `<body>` keeps `pointer-events: none` forever.

Measured after a delete, with everything correctly unmounted (`dialogs: 0, menus: 0`, scroll-lock released, `aria-hidden` back to baseline):

```
{"inline":"none","computed":"none","scrollLocked":null,"dialogs":0,"menus":0,"poppers":0}
```

## The fix

One line: that menu becomes non-modal, so the dialog's teardown is the only thing touching `<body>`. The menu still dismisses on outside click and on Escape — it just no longer blocks outside pointer events while open, which inside a modal dialog is not something a user can observe.

## Testing

New `packages/e2e/tests/task-board-dialog-menu.spec.ts` drives the real menu for Delete and Archive, then asserts the computed `pointer-events` on `<body>` **and** that the next click actually lands (opens another card's dialog).

Verified in both configurations, since the dev server and the production bundle could plausibly differ here:

| | before | after |
|---|---|---|
| dev server (local e2e default) | 2 failed — `Received: "none"` | 2 passed |
| production build + preview (CI) | 2 failed — `Received: "none"` | 2 passed |

`bun run fmt`, `bun run lint` and `bun run check` pass.

## Notes

Seven other files pair a `DialogContent` with a `DropdownMenuItem`, but none of them close the surrounding dialog from a menu item, so none reproduce this. Worth remembering the shape: a menu item that unmounts the dialog it lives in needs the menu to be non-modal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the task dialog’s “More actions” menu from freezing the app. Previously, selecting Delete/Archive/Clone/Auto‑fix/Re‑run/New chat closed the dialog and left `<body>` with `pointer-events: none`; now the dialog closes and the page stays clickable.

- Change: render the Radix `DropdownMenu` inside the dialog with `modal={false}` so only the dialog touches `<body>`; outside click and Escape still dismiss; no user-visible behavior change.
- Coverage: adds `packages/e2e/tests/task-board-dialog-menu.spec.ts` to exercise Delete and Archive; verifies `pointer-events` resets and the next click lands; reproduced and fixed in both dev and production builds.
- Scope: only this dialog’s menu changed; other `Dialog` + `DropdownMenu` pairs do not close their surrounding dialog and are unaffected.

<sup>Written for commit 57e989b43180e21ecf7b1d32d1dac867431a7ced. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

