### PR TITLE
fix(sandbox): drive preview reload on Deno block saves

### DIFF
--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
@@ -32,7 +32,7 @@ import {
   type ReactNode,
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useProjectContext } from "@/sdk";
+import { useProjectContext, useVirtualMCP } from "@/sdk";
 import { KEYS, invalidateVirtualMcpQueries } from "@/lib/query-keys";
 import { exponentialBackoffWithJitter } from "@decocms/shared/std";
 
@@ -229,6 +229,16 @@ export function SandboxEventsProvider({
   const reloadHandlers = useRef(new Set<ReloadHandler>());
   const prevPortRef = useRef<number | null>(null);
   const directDaemonEventsUrl = buildDirectDaemonEventsUrl(previewUrl);
+
+  /**
+   * Deno/Fresh dev servers don't watch `.deco/blocks/*`, so unlike the Vite
+   * runtime they never reload the preview on a Blocks save (#6430 handed that
+   * refresh to the dev server). We drive the iframe reload ourselves for Deno.
+   * A ref so the SSE closure reads the latest without reconnecting.
+   */
+  const isDenoRuntimeRef = useRef(false);
+  isDenoRuntimeRef.current =
+    useVirtualMCP(virtualMcpId)?.metadata?.runtime?.selected === "deno";
 
   const getOrCreateBuffer = (source: string) => {
     let buf = buffers.current.get(source);
@@ -475,6 +485,16 @@ export function SandboxEventsProvider({
                 void queryClient.invalidateQueries({
                   queryKey: KEYS.decofile(cacheKey),
                 });
+                // Deno-only: the dev server won't refresh the preview itself.
+                if (isDenoRuntimeRef.current) {
+                  for (const fn of reloadHandlers.current) {
+                    try {
+                      fn();
+                    } catch {
+                      // swallow
+                    }
+                  }
+                }
               }, 500);
             } else {
               // Debounce liveMeta invalidation so the dev server has time to

--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
@@ -234,10 +234,10 @@ export function SandboxEventsProvider({
    * Deno/Fresh dev servers don't watch `.deco/blocks/*`, so unlike the Vite
    * runtime they never reload the preview on a Blocks save (#6430 handed that
    * refresh to the dev server). We drive the iframe reload ourselves for Deno.
-   * A ref so the SSE closure reads the latest without reconnecting.
+   * A dep of the SSE effect below; stable per project (reconnects at most once
+   * if the VM metadata resolves after mount).
    */
-  const isDenoRuntimeRef = useRef(false);
-  isDenoRuntimeRef.current =
+  const isDenoRuntime =
     useVirtualMCP(virtualMcpId)?.metadata?.runtime?.selected === "deno";
 
   const getOrCreateBuffer = (source: string) => {
@@ -486,7 +486,7 @@ export function SandboxEventsProvider({
                   queryKey: KEYS.decofile(cacheKey),
                 });
                 // Deno-only: the dev server won't refresh the preview itself.
-                if (isDenoRuntimeRef.current) {
+                if (isDenoRuntime) {
                   for (const fn of reloadHandlers.current) {
                     try {
                       fn();
@@ -648,6 +648,7 @@ export function SandboxEventsProvider({
     taskId,
     directDaemonEventsUrl,
     queryClient,
+    isDenoRuntime,
   ]);
 
   const value: SandboxEventsValue = {


### PR DESCRIPTION
## The change

#6430 handed the post-save preview refresh to the sandbox dev server: a `.deco/blocks/*` write now only invalidates Studio's caches and the dev server's own HMR reloads the page. That holds for the **Vite** runtime, but the **Deno/Fresh** dev server doesn't watch `.deco/blocks/*` and never reloads the preview on a Blocks save — the exact follow-up #6430 filed but didn't fix ("Fresh/Deno projects were not verified").

This restores the app-driven iframe reload **for Deno only**, inside the existing `file-changed` → `.deco/*` debounce. Vite is untouched: the dev server still owns the refresh.

## How

- Detect the runtime via `useVirtualMCP(virtualMcpId)?.metadata?.runtime?.selected === "deno"` (same access path `use-blog-support.ts` already uses), held in a ref so the SSE closure reads the latest without reconnecting when the metadata resolves after mount.
- Inside the same 500ms debounce that invalidates the decofile query, fire the existing `reloadHandlers` **only when the runtime is Deno**. The pre-existing `devServerRunning` guard still applies, so it only reloads with the dev server up.

Fresh resolves blocks live per request, so a reload is enough — no rebuild needed.

## Affected runtimes

- **Deno/Fresh** — restores the post-save preview refresh.
- **Vite** — unchanged; dev-server HMR still owns the refresh (as #6430 left it).

## Testing

`bun run fmt` · `apps/web` `tsc` clean · provider unit tests 12/12 pass. Lint clean for the touched file (the one `bun run lint` error is pre-existing in `section-variants.test.ts`, outside this diff).

**Be aware:** as #6430 itself noted, this behavior isn't assertable at any tier in this repo — the SSE reload decision lives in the provider closure and needs a live daemon plus a guest framework. The new condition is a two-boolean `isDenoRuntime && devServerRunning`; a pure helper for that would be over-engineering. Verified manually against a running Deno/Fresh sandbox: a Blocks save now refreshes the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores preview auto-reload on Deno/Fresh Block saves by triggering the iframe reload from the app; Vite stays dev-server-driven. This fixes the missing reload when saving `.deco/blocks/*` in Deno.

- Detects Deno via `useVirtualMCP(virtualMcpId)?.metadata?.runtime?.selected === "deno"` using a plain const included in the SSE effect deps (avoids writing refs during render; may reconnect once if metadata resolves after mount).
- Inside the existing `.deco/*` debounce after invalidating the decofile query, calls registered reload handlers only when the runtime is Deno; the `devServerRunning` guard still applies.
- No migration required.

<sup>Written for commit bbfdfffef97c5992428a675fd052812997d6183c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

