### PR TITLE
fix(native): stop a sandbox nobody started from claiming it is serving

### DIFF
--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs
@@ -492,7 +492,13 @@ fn local_sandbox_entries(state: &AppState, virtual_mcp_id: &str) -> Vec<(String,
         // Omitting a dead sandbox is self-correcting: the shell auto-starts,
         // `SANDBOX_START` ensures/adopts it here, and the next read publishes
         // it with a preview origin that is actually listening.
-        if state.sandbox_manager.get(&handle).is_none() {
+        // `adopt` inserts a sandbox it has NOT started, so map presence stopped
+        // meaning "live in this process" and this test began forging the very
+        // entry the comment above says must not exist.
+        let Some(sandbox) = state.sandbox_manager.get(&handle) else {
+            continue;
+        };
+        if !crate::sandbox::manager::is_serving(&sandbox) {
             continue;
         }
         let branch = config

--- a/apps/native/crates/local-api/src/sandbox/manager.rs
+++ b/apps/native/crates/local-api/src/sandbox/manager.rs
@@ -32,6 +32,45 @@ fn dev_task_running(sandbox: &Sandbox) -> bool {
         .any(|t| matches!(t.log_name.as_deref(), Some("dev") | Some("start")))
 }
 
+/// Phases in which a sandbox is on its way to serving, or already is. A
+/// sandbox mid-install must still count as serving or the shell double-starts
+/// it under the boot overlay.
+const SERVING_PHASES: [&str; 5] = [
+    "cloning",
+    "checking-out",
+    "installing",
+    "starting",
+    "running",
+];
+
+/// Whether this sandbox has, or is actively acquiring, a dev server.
+///
+/// The one answer to "is a VM serving this branch?", and deliberately a
+/// UNION so it fails safe toward publishing: a too-narrow predicate would
+/// hide a working preview, whereas a too-broad one only delays a restart the
+/// user can still trigger. Cheap terms first — this runs on a dispatch path,
+/// so it reads the task registry, a phase string and an atomic, and never
+/// inspects a process (see [`SandboxManager::reconcile_persisted_dev_process`],
+/// which does that once, asynchronously, at adopt).
+///
+/// Presence in the `sandboxes` map is NOT one of the terms, which is the
+/// whole point: `adopt` inserts a sandbox it has not started, so map presence
+/// answers "do we have a row" rather than "is anything serving".
+pub(crate) fn is_serving(sandbox: &Sandbox) -> bool {
+    if dev_task_running(sandbox) {
+        return true;
+    }
+    if sandbox.dev_orphan_alive.load(Ordering::Relaxed) {
+        return true;
+    }
+    sandbox
+        .setup
+        .lifecycle_snapshot()
+        .get("phase")
+        .and_then(Value::as_str)
+        .is_some_and(|phase| SERVING_PHASES.contains(&phase))
+}
+
 /// The clone target + workload hints a caller resolved from a dispatch
 /// payload (decopilot's `sandbox` block, or the daemon-parity family's
 /// `workspace.repo`/`workspace.branch`) — everything [`SandboxManager::ensure`]
@@ -87,6 +126,10 @@ pub struct Sandbox {
     /// Last `[org-fs]` outcome announced for this sandbox, so `ensure` — which
     /// runs on every dispatch — reports only transitions.
     org_fs_announced: Mutex<Option<bool>>,
+    /// Whether a dev process outside this app's task registry was found alive
+    /// for this sandbox. Written by the async reconcile on adopt; read by
+    /// [`is_serving`] on a dispatch path that must not inspect processes.
+    dev_orphan_alive: AtomicBool,
 }
 
 /// `HashMap<Handle, Arc<Sandbox>>` plus a per-handle async lock so two
@@ -578,12 +621,50 @@ impl SandboxManager {
             return Err(error);
         }
         Self::monitor_branch_status(&sandbox);
+        Self::reconcile_persisted_dev_process(&sandbox).await;
         self.publish_generation(handle, Some(sandbox.clone()));
         tracing::info!(
             handle,
             "adopted persisted sandbox metadata without starting it"
         );
         Ok(Some(sandbox))
+    }
+
+    /// Settle what the persisted dev-process record actually describes,
+    /// BEFORE the generation is published.
+    ///
+    /// A record outlives its process across an app restart and stays well
+    /// formed forever, so `read_dev_process` alone cannot distinguish a
+    /// serving dev server from one that died with last week's app. This is
+    /// the one place that asks, and it caches the answer in
+    /// `dev_orphan_alive` so [`is_serving`] — which runs on a dispatch path
+    /// that must never inspect processes — reads an atomic instead.
+    ///
+    /// A provably-`Gone` group is cleared: the record is fiction and keeping
+    /// it makes every reader above decline to start a server. `Unverifiable`
+    /// (a reused pgid) is left as found AND counted as alive — the
+    /// conservative direction, because omitting the entry would auto-start,
+    /// and `dev::run`'s reap would then signal a group we could not identify.
+    async fn reconcile_persisted_dev_process(sandbox: &Arc<Sandbox>) {
+        use crate::setup::dev::PersistedDevLiveness;
+
+        let sandbox_root = super::dev_port::sandbox_root_for(&sandbox.workdir);
+        let Some(record) = super::persist::read_dev_process(&sandbox_root) else {
+            sandbox.dev_orphan_alive.store(false, Ordering::Relaxed);
+            return;
+        };
+        let gone =
+            crate::setup::dev::persisted_dev_liveness(&record).await == PersistedDevLiveness::Gone;
+        sandbox.dev_orphan_alive.store(!gone, Ordering::Relaxed);
+        if gone {
+            super::persist::clear_dev_process(&sandbox_root);
+            tracing::info!(
+                handle = sandbox.handle,
+                pid = record.pid,
+                pgid = record.pgid,
+                "cleared a dev-process record whose process is gone"
+            );
+        }
     }
 
     /// Metadata-only counterpart of [`Self::resurrect_active`].
@@ -1228,6 +1309,7 @@ impl SandboxManager {
             registry_monitor_started: AtomicBool::new(false),
             branch_monitor_started: AtomicBool::new(false),
             org_fs_announced: Mutex::new(None),
+            dev_orphan_alive: AtomicBool::new(false),
         });
         sandboxes.insert(handle.to_string(), sandbox.clone());
         Ok(sandbox)

--- a/apps/native/crates/local-api/src/setup/dev.rs
+++ b/apps/native/crates/local-api/src/setup/dev.rs
@@ -100,6 +100,47 @@ fn match_group_identity(
     }
 }
 
+/// Whether a persisted dev-process record still describes a live process.
+///
+/// `persist::is_valid_dev_process_record` answers a different question —
+/// whether the record is well *formed*. A record for a
+/// process that exited days ago passes every one of its checks, so a caller
+/// that treats `read_dev_process` as "this sandbox has a dev server" is
+/// reading fiction.
+///
+/// `Unverifiable` carries the same discipline as the sandbox-claim liveness
+/// probe: the pgid is occupied by processes that do not match the recorded
+/// identities (the kernel reused it), so nothing may be concluded and
+/// nothing may be signalled. Never act on it.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PersistedDevLiveness {
+    Alive,
+    Gone,
+    Unverifiable,
+}
+
+/// The pure half of [`persisted_dev_liveness`], split out so the mapping is
+/// exhaustively unit-tested without a live process table.
+fn liveness_from_match(matched: GroupIdentityMatch) -> PersistedDevLiveness {
+    match matched {
+        GroupIdentityMatch::Gone => PersistedDevLiveness::Gone,
+        GroupIdentityMatch::Verified(_) => PersistedDevLiveness::Alive,
+        GroupIdentityMatch::Unverifiable => PersistedDevLiveness::Unverifiable,
+    }
+}
+
+/// Judge a persisted record against the live process table, reusing the same
+/// observation and identity matching [`reap_persisted_dev_group`] signals on.
+///
+/// An observation that fails is `Unverifiable`, never `Gone` — a platform
+/// that cannot enumerate a process group must not be read as proof of death.
+pub(crate) async fn persisted_dev_liveness(record: &DevProcessRecord) -> PersistedDevLiveness {
+    let Ok(current) = observe_process_group(record.pgid).await else {
+        return PersistedDevLiveness::Unverifiable;
+    };
+    liveness_from_match(match_group_identity(&record.identities, current))
+}
+
 fn port_pattern() -> &'static Regex {
     static RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
     RE.get_or_init(|| {
@@ -847,6 +888,52 @@ mod tests {
             birth: birth.to_string(),
             executable: executable.to_string(),
         }
+    }
+
+    #[test]
+    fn liveness_reads_an_empty_group_as_gone() {
+        assert_eq!(
+            liveness_from_match(GroupIdentityMatch::Gone),
+            PersistedDevLiveness::Gone
+        );
+    }
+
+    #[test]
+    fn liveness_reads_a_matching_member_as_alive() {
+        assert_eq!(
+            liveness_from_match(GroupIdentityMatch::Verified(vec![identity(
+                7, "birth", "bun"
+            )])),
+            PersistedDevLiveness::Alive
+        );
+    }
+
+    #[test]
+    fn liveness_never_reads_a_reused_pgid_as_gone() {
+        // A pgid the kernel handed to an unrelated group must not be cleared:
+        // that is the case where acting on a guess disowns a live process.
+        assert_eq!(
+            liveness_from_match(GroupIdentityMatch::Unverifiable),
+            PersistedDevLiveness::Unverifiable
+        );
+    }
+
+    #[tokio::test]
+    async fn a_well_formed_record_for_a_dead_process_is_not_alive() {
+        // The regression this exists for: `is_valid_dev_process_record` passes
+        // a record forever, so shape must never be mistaken for liveness.
+        let record = DevProcessRecord {
+            pid: 999_999,
+            pgid: 999_999,
+            command: "bun run dev".to_string(),
+            started_at: 1,
+            port: Some(54083),
+            identities: vec![identity(999_999, "long ago", "bun")],
+        };
+        assert_ne!(
+            persisted_dev_liveness(&record).await,
+            PersistedDevLiveness::Alive
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The bug

Opening a project on the desktop app sat on **"Preparing sandbox…" forever**, replaying a previous day's install log into the terminal panel. No error, no console entry, no filesystem write, no process — nothing anywhere to show for it.

Debugged live against a wedged instance. The worktree's `dev-process.json` recorded pid 53236 on port 54083 from the day before; the pid was dead and nothing listened on that port.

## Two halves, both silent

**1. Map presence stopped meaning what the predicate thought it meant.**

`local_sandbox_entries` gated on `state.sandbox_manager.get(&handle).is_none()`. The comment directly above it already states the invariant:

> Publish ONLY a sandbox that is live in this process — not merely one the registry still has a row for. […] Publishing a registered-but-stopped sandbox therefore told the shell someone was already serving, which suppressed the very auto-start that would have revived it.

`SandboxManager::adopt` inserts a sandbox it has *deliberately not started*. So map presence stopped meaning "live in this process", and the predicate began forging exactly the entry that comment says must not exist. `shouldAutoStart` requires `!args.vmEntry` (`apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx:75`), so `SANDBOX_START` never fired, so `ensure_inner`'s revive branch — `else if !dev_task_running(&sandbox) { … resume_from(Step::Start) }`, **written for precisely this case** — never ran.

The recovery path was correct all along. Nothing could reach it.

**2. A dead pid read as a live dev server.**

`is_valid_dev_process_record` (`sandbox/persist.rs:548`) validates the record's **shape** — `pid > 1`, `pgid == pid`, non-empty command, well-formed identities. A record for a process that died with last week's app satisfies every clause forever, so `read_dev_process` handed back `Some(record)` and every reader above it treated that as "this sandbox has a dev server."

## The fix — one oracle, no bypass

- **`persisted_dev_liveness`** (`setup/dev.rs`) judges a record against the live process table, reusing the same `observe_process_group` / `match_group_identity` that `reap_persisted_dev_group` already signals on. A failed observation is `Unverifiable`, **never** `Gone` — a platform that cannot enumerate a process group is not proof of death. `liveness_from_match` is a pure seam so the mapping is exhaustively unit-tested without a process table.
- **`reconcile_persisted_dev_process`** runs in `adopt` *before* `publish_generation`, so a generation is never published carrying a fiction. A provably-`Gone` group is cleared; the verdict is cached in a `dev_orphan_alive` atomic so the dispatch path never inspects a process.
- **`is_serving`** answers the question the entry predicate always meant to ask. **Map presence is deliberately not one of its terms.**

## Why this is safe without a flag

An earlier draft had a default-off flag. Removing it made the change more defensible, not less: the predicate's own comment already declares this behavior, so the diff restores documented intent rather than introducing new behavior — and a flag would ship the codebase with *two* answers to one question, which is the shape of the original bug.

Three properties carry the safety:

- **A live orphan is protected by the same term that fixes the bug.** It reports as serving → its entry stays published → auto-start never fires → the reap never signals it. Without that term, omitting the entry would auto-start, and `dev::run`'s `reap_persisted_dev_group` would **TERM a healthy dev server** before respawning it. This is the highest-severity regression available here and it is designed out rather than mitigated.
- **`is_serving` is a UNION, failing safe toward publishing.** A too-narrow predicate hides a working preview; a too-broad one only delays a restart the user can still trigger by hand. That is also why the in-flight phases (`cloning`, `checking-out`, `installing`, `starting`) count — a sandbox mid-install must keep its entry or the shell double-starts it under the boot overlay.
- **`Unverifiable` never counts as dead.** A reused pgid leaves the record untouched and the sandbox treated as alive — the direction where a wrong guess costs a stuck spinner instead of a killed process.

**Hot path:** `local_sandbox_entries` is sync and stays that way. `is_serving` reads a task list, a phase string and an atomic — no `pgrep`, no HTTP probe, no lock held across either. The single process inspection happens once, asynchronously, in `adopt`. Per CLAUDE.md, Studio marks a sandbox dead on one missed health probe, so nothing on that path may block.

## Testing

`cargo test -p local-api` — **882 pass / 0 fail**, including 4 new. `cargo clippy -p local-api --all-targets` — 0 warnings. `cargo fmt` clean. Pre-commit `rust-fmt` + `rust-clippy` green.

The load-bearing new test is `a_well_formed_record_for_a_dead_process_is_not_alive`, which pins the exact regression: shape must never be read as liveness. The others fix the tri-state mapping, in particular that `Unverifiable` never maps to `Gone`.

**Manual verification is still pending and cannot be automated here.** Neither tier can reach it: `packages/e2e` has no sandbox pod and no dev server, and the scenario needs a real worktree with a stale `dev-process.json`. Reproducing it means an app restart over a worktree whose dev server died with a previous launch, then opening that project — it should omit the forged entry, auto-start, and revive via `resume_from(Start)` without re-cloning.

## Follow-ups, filed not fixed

- **`dev_orphan_alive` is written once, at adopt.** If an orphan dies afterwards the cached value goes stale in the *publishing* direction, which re-suppresses auto-start until the next adopt. The durable answer is the supervisor ported from `daemon-go/internal/devwatch` — deliberately out of scope here, since it restarts processes unattended and deserves its own PR and its own flag.
- **`Unverifiable` still wedges.** A reused pgid keeps the sandbox published and stuck. Fixing it means clearing a record we cannot prove is dead, and `dev_port::allocate`'s `ours` short-circuit would then aim a respawn at a port a possibly-live original holds.
- **An e2e for this belongs in `apps/native/e2e/`** (harness `crates/local-api/src/bin/e2e-embedded.rs`), seeding a worktree with a dead-pid record and asserting on the artifact's bytes — not `packages/e2e`, which cannot reach local-api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the desktop app from hanging on “Preparing sandbox…” by only publishing entries for sandboxes that are live or actively starting. Previously, manager map presence plus a well‑formed `dev-process.json` could falsely advertise a dead dev server; now liveness is verified and reconciled before publishing so auto‑start can revive it.

- Key changes
  - `local_sandbox_entries` now uses `is_serving(sandbox)` instead of map presence. `is_serving` unions: dev task running, cached orphan liveness, and serving phases (`cloning`→`running`) to avoid double-starts.
  - `persisted_dev_liveness` checks `dev-process.json` against the live process table and returns Alive/Gone/Unverifiable; Unverifiable is never treated as dead.
  - `adopt` runs `reconcile_persisted_dev_process` before `publish_generation`: clears provably gone records, caches the verdict in `dev_orphan_alive` (atomic), and keeps dispatch paths synchronous.
  - Matches the documented invariant: only sandboxes live in this process (or in-flight to serve) publish entries; live orphans remain published to avoid terminating a healthy server.

<sup>Written for commit 9f05f1cfcf88418033e69462db53b03a2acab85e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

