### PR TITLE
fix(dbos): serialise the system-schema migration with an advisory lock

### DIFF
--- a/apps/api/src/database/dbos-migration-lock.ts
+++ b/apps/api/src/database/dbos-migration-lock.ts
@@ -1,0 +1,115 @@
+/**
+ * Serialises the DBOS system-schema migration across every process that boots
+ * against the same database.
+ *
+ * `DBOS.launch()` migrates the `dbos` schema, and the SDK advances its version
+ * with `UPDATE dbos.dbos_migrations SET version = $1` — no WHERE clause,
+ * assuming the table holds exactly one row. The earliest migrations create that
+ * table, and until it exists the bump is a no-op, so two processes arriving
+ * together both fall through to the INSERT and leave two rows. Every later bump
+ * then writes the same version into both rows, collides on the primary key, and
+ * the schema version can never advance again. The database is bricked
+ * permanently: it reproduces afterwards with a single pod, and only a manual
+ * DELETE recovers it. A customer hit exactly this on a first install.
+ *
+ * The chart's migration Job is not sufficient on its own. Under Argo CD the
+ * sync wave holds the Deployments until the Job finishes, but under plain
+ * `helm install` the post-install hook starts alongside the first pods — and it
+ * must be a post-install hook, because it consumes the release's ConfigMap and
+ * Secret. Nor does scaling down help by itself: one pod runs two API containers
+ * and the worker HPA's minReplicas overrides a zeroed replicaCount.
+ *
+ * So the guarantee belongs here, where it holds regardless of orchestrator,
+ * replica count, containers per pod, or whether the operator ran the Job at
+ * all. A session-scoped `pg_advisory_lock` makes the first process migrate
+ * while the rest wait; they then find the version already at max and do
+ * nothing. Postgres releases a session lock automatically when the connection
+ * drops, so a process killed mid-migration cannot wedge the others.
+ */
+
+import pg from "pg";
+
+/**
+ * Fixed 64-bit key for this lock. Arbitrary, but must never change: two builds
+ * disagreeing on it would not exclude each other. Advisory locks share one
+ * namespace per database, hence a value unlikely to collide with anything else.
+ */
+const DBOS_MIGRATION_LOCK_KEY = 8_314_027_461_559_302n;
+
+/**
+ * How long to wait for the holder before giving up. A cold migration applies
+ * every migration the SDK ships and can take minutes, so this is generous.
+ * Failing beats blocking forever: the pod exits, Kubernetes restarts it, and
+ * the retry finds the work already done.
+ */
+const LOCK_TIMEOUT_MS = 10 * 60 * 1000;
+
+export interface DbosMigrationLockOptions {
+  /** Postgres URL, already passed through withSslmode() by the caller. */
+  databaseUrl: string;
+  /** Overrides the wait budget. Tests use this; production should not. */
+  lockTimeoutMs?: number;
+  /** Defaults to console.log. */
+  log?: (message: string) => void;
+}
+
+/**
+ * Runs `fn` while holding the migration lock. Always releases, including when
+ * `fn` throws — the caller's error propagates unchanged.
+ */
+export async function withDbosMigrationLock<T>(
+  options: DbosMigrationLockOptions,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const { databaseUrl, lockTimeoutMs = LOCK_TIMEOUT_MS } = options;
+  const log = options.log ?? ((message: string) => console.log(message));
+
+  // A dedicated connection, not a pooled one: the lock lives on the session,
+  // so it must outlive nothing else and be released by closing exactly this.
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+
+  const startedAt = Date.now();
+  try {
+    // lock_timeout bounds the wait itself; without it a stuck holder blocks
+    // this process forever with no signal.
+    await client.query(`SET lock_timeout = ${Math.floor(lockTimeoutMs)}`);
+    try {
+      await client.query("SELECT pg_advisory_lock($1)", [
+        DBOS_MIGRATION_LOCK_KEY.toString(),
+      ]);
+    } catch (error) {
+      // 55P03 lock_not_available — someone else is still migrating.
+      const code = (error as { code?: string } | null)?.code;
+      if (code === "55P03") {
+        throw new Error(
+          `Timed out after ${lockTimeoutMs}ms waiting for the DBOS migration lock. ` +
+            `Another process is still migrating the dbos schema; this pod will restart and retry.`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+
+    const waitedMs = Date.now() - startedAt;
+    if (waitedMs > 1000) {
+      log(
+        `[dbos] waited ${waitedMs}ms for the migration lock; another process migrated first`,
+      );
+    }
+
+    return await fn();
+  } finally {
+    // end() drops the session, which releases the lock even if the unlock
+    // below fails — the explicit call just makes the release immediate and the
+    // intent obvious.
+    try {
+      await client.query("SELECT pg_advisory_unlock($1)", [
+        DBOS_MIGRATION_LOCK_KEY.toString(),
+      ]);
+    } catch {
+      // Releasing on disconnect is the backstop; a failure here is not fatal.
+    }
+    await client.end().catch(() => {});
+  }
+}

--- a/apps/api/src/database/migrate-dbos.ts
+++ b/apps/api/src/database/migrate-dbos.ts
@@ -23,6 +23,7 @@
  */
 
 import { buildDbosConfig } from "../dbos/config";
+import { withDbosMigrationLock } from "./dbos-migration-lock";
 import { getSettings } from "../settings";
 import { withSslmode } from "./index";
 
@@ -45,9 +46,19 @@ export async function migrateDbos(): Promise<void> {
     }),
   );
 
-  // launch() is what applies the system-schema migrations.
-  await DBOS.launch();
-  await DBOS.shutdown();
+  // launch() is what applies the system-schema migrations. Under the lock even
+  // here: this entry point is the designated writer, but nothing stops an app
+  // pod from booting alongside it, and the SDK's version bump is not safe
+  // against a second writer. See dbos-migration-lock.ts.
+  await withDbosMigrationLock(
+    {
+      databaseUrl: withSslmode(settings.databaseUrl, settings.databasePgSsl),
+    },
+    async () => {
+      await DBOS.launch();
+      await DBOS.shutdown();
+    },
+  );
 }
 
 if (import.meta.main) {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,6 +19,7 @@ import {
   THREAD_GATE_QUEUE,
 } from "./dispatch-queue/queue-names";
 import { buildDbosConfig } from "./dbos/config";
+import { withDbosMigrationLock } from "./database/dbos-migration-lock";
 import { getSettings } from "./settings";
 import { resolveShutdownDrainMs } from "./settings/resolve-config";
 import { initObservability } from "./observability";
@@ -196,10 +197,19 @@ const app = await createApp({ clientDir });
 // Conductor opt-in via env (SDK defaults conductorURL to wss://cloud.dbos.dev/...).
 const conductorKey = process.env.DBOS_CONDUCTOR_KEY?.trim();
 const conductorURL = process.env.DBOS_CONDUCTOR_URL?.trim();
-await DBOS.launch({
-  ...(conductorKey ? { conductorKey } : {}),
-  ...(conductorKey && conductorURL ? { conductorURL } : {}),
-});
+// Under the migration lock: launch() applies the DBOS system-schema migrations,
+// and the SDK bumps its version with an UPDATE that has no WHERE clause, so two
+// processes reaching it together brick the schema permanently. Every process
+// that can launch takes the lock; the first migrates, the rest wait and then
+// find nothing to do. See database/dbos-migration-lock.ts.
+await withDbosMigrationLock(
+  { databaseUrl: withSslmode(settings.databaseUrl, settings.databasePgSsl) },
+  () =>
+    DBOS.launch({
+      ...(conductorKey ? { conductorKey } : {}),
+      ...(conductorKey && conductorURL ? { conductorURL } : {}),
+    }),
+);
 // Surface the DBOS application version on every boot so the pin is verifiable
 // from pod logs (`grep "dbos] application version"`). Expect the pinned
 // DBOS_WORKFLOW_VERSION ("1"), never a 32-char hash — a hash means the pin was


### PR DESCRIPTION
The durable fix for the failure in #6435. That PR ungates the migration Job; this one removes the need to rely on it.

## The failure

`DBOS.launch()` migrates the `dbos` schema, and the SDK advances its version with:

```js
UPDATE "dbos"."dbos_migrations" SET "version" = $1
```

No `WHERE`. It assumes the table holds exactly one row. The earliest migrations create that table, and until it exists the bump is a no-op — so two processes arriving together both fall through to the `INSERT` and leave **two** rows. Every later bump then writes the same version into both, collides on the primary key, and the version can never advance.

The result is permanent: it reproduces afterwards with a single pod, and only a manual `DELETE` recovers it. A customer hit exactly this on a first install with `replicaCount: 3` against an empty RDS.

## Why the chart Job is not enough

- **Argo CD**: closed. The wave -10 hook completes before the wave 0 Deployments start.
- **Plain `helm install`**: not closed. The hook starts alongside the first pods — and it must be `post-install`, because it consumes the release's ConfigMap and Secret, neither of which exists during a `pre-install` hook.
- **"Just scale down for the first install"**: not closed either. A pod runs **two** API containers (`api-0`, `api-1`) from a hardcoded range, so `replicaCount: 1` is already two processes; and `worker.replicaCount: 0` is a no-op while the worker HPA's `minReplicas: 2` is active.

Any fix that depends on the operator using a particular GitOps tool, or on remembering three flags on exactly one command, is a footgun we document rather than remove. We cannot assume Argo.

## The change

Every path that can call `DBOS.launch()` — the app boot in `index.ts` and the standalone `migrate-dbos` entry point — takes a session-scoped `pg_advisory_lock` first. The first process migrates; the rest wait, then find the version already at max and do nothing.

It holds regardless of orchestrator, replica count, containers per pod, or whether the Job ran at all.

Two details chosen deliberately:

- **A dedicated connection**, not a pooled one. The lock lives on the session, so Postgres releases it when that connection drops — a process killed mid-migration cannot wedge the others.
- **`lock_timeout` bounds the wait** at 10 minutes. A genuinely stuck holder produces a pod restart with a clear message instead of an indefinite hang, and the retry finds the work already done.

## Relationship to #6435

Complementary, not redundant. #6435 keeps the Job as the designated writer, which is still the right shape — it puts the migration on a controlled, observable step instead of whichever pod happens to win. This PR makes correctness independent of it.

## Testing

Typecheck clean on the touched files (the pre-existing `ajv` skew error in `packages/mcp-utils` reproduces on `main` unchanged). The behaviour this guards is inherently multi-process, so it belongs in the multi-pod harness rather than a unit test — `tests/multi-pod/docker-compose.yml` already exists to reproduce the original race and is the natural place to assert the lock holds. Flagging that as the follow-up rather than claiming coverage I have not written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serializes the DBOS system-schema migration with a session-scoped Postgres advisory lock to eliminate multi-process races. Previously, concurrent `DBOS.launch()` calls could insert duplicate `dbos.dbos_migrations` rows and brick the schema; now one process migrates while others wait or no-op.

- Takes the lock in both app boot (`apps/api/src/index.ts`) and the standalone migrator (`apps/api/src/database/migrate-dbos.ts`) via `dbos-migration-lock.ts`.
- Uses a dedicated connection; Postgres auto-releases the lock on disconnect. Sets `lock_timeout` to 10 minutes; on timeout the process exits so the pod restarts and retries.
- No operator action required; works regardless of orchestrator, replica counts, containers per pod, or whether the chart’s migration Job ran.

<sup>Written for commit d181dd7d6a763a2f9b12854c52edf4fb7801a339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

