### PR TITLE
fix(sections-editor): make the "Always" matcher option searchable by its translated label

### DIFF
--- a/apps/web/src/components/sections-editor/matcher-picker.tsx
+++ b/apps/web/src/components/sections-editor/matcher-picker.tsx
@@ -201,7 +201,7 @@ export function MatcherPicker({
           </CommandEmpty>
           <CommandGroup>
             <CommandItem
-              value="always Target all users"
+              value={`${t("sectionsEditor.matcherPicker.alwaysLabel")} ${t("sectionsEditor.matcherPicker.targetAllUsers")}`}
               onSelect={() => handleSelect("")}
               className={cn(
                 "gap-2.5",


### PR DESCRIPTION
Follows the same bug class fixed in #6408 (task-board filters), found while hunting for hardening follow-ups to recent merges.

**Bug**: In `matcher-picker.tsx`, the "Always" rule's `CommandItem` had a hardcoded English search `value` ("always Target all users") while its rendered label is fully translated (`alwaysLabel` / `targetAllUsers`). cmdk's fuzzy filter matches against the `value` prop, not the rendered children, so a pt-BR user typing what they actually see on screen ("Sempre", "Direcionar todos os usuários") gets zero results and can't find the option — exactly the failure #6408 fixed for the assignee/repo filters.

**Fix**: build the search value from the same two translation keys already used for the visible label, so the searchable text always matches what's rendered in the active locale.

**Verify**: open the matcher picker (sections-editor rule dialog) with `language: pt-BR` in preferences and type "Sempre" — the "Always / Target all users" option should now show up.

**Checks run locally**: `bun run fmt`, `bun test apps/web/src/components/sections-editor/matcher-picker.test.ts` (8 pass), `bunx oxlint apps/web/src/components/sections-editor/matcher-picker.tsx` (0 warnings/errors), `cd apps/web && bunx tsc --noEmit` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the "Always" matcher option searchable in all locales by building its search value from the same translated strings used in the label. Previously the `CommandItem.value` was hardcoded to English, so `cmdk` search failed for non-English users; now it matches the rendered locale with no UI change.

- Verify: switch language to pt-BR, open the sections editor matcher picker, type "Sempre" and confirm the "Always / Target all users" option appears.

<sup>Written for commit dae1a8c36184090b82bf78ab541ba7cbdb4b5ccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

