### PR TITLE
fix(harness-runner): end the SDK session on any attempt failure, not just broken MCP

### DIFF
--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -444,6 +444,18 @@ export async function runClaudeCode(
       options: buildOptions({ input, sessionId, resume: resumeSession }),
     });
 
+    try {
+      return await consumeStream(stream);
+    } catch (err) {
+      // Any throw here otherwise leaves the session locked for the next attempt.
+      await endSession(stream);
+      throw err;
+    }
+  }
+
+  async function consumeStream(
+    stream: ReturnType<typeof query>,
+  ): Promise<string | null> {
     const startedAt = Date.now();
     for await (const message of stream) {
       // Every SDK message, with the seconds it took to arrive. Without this a


### PR DESCRIPTION
**Bug, found while auditing `packages/harness-runner/claude-code.ts` for resource-leak risk.**

`runClaudeCode`'s retry loop already knows the Claude Code CLI child process holds `sessionId` and refuses a resume/recreate while it's alive — that's exactly why the broken-Studio-MCP path calls `endSession(stream)` before returning to the caller for a retry (see the comment at that call site). But every OTHER way `attemptTurn` could end — any throw out of the SDK message loop (stream error, malformed message, anything the SDK itself raises mid-turn) — skipped that call and propagated straight to the outer catch. That leaves the child process alive holding the session id, so the *next* attempt (a resume, or the existing fork-once recovery) can die on \"Session ID ... is already in use\" instead of getting the real retry the backoff loop exists to provide.

**Fix:** extracted the message-consuming loop into `consumeStream()` and wrapped its call in `attemptTurn()` with a try/catch that calls `endSession(stream)` before rethrowing. Every exit path — success, broken MCP, or an uncaught SDK error — now ends the session before control leaves `attemptTurn`.

Why a maintainer wants this: it closes a real leak in the same retry machinery this file already went out of its way to protect for one specific case (see the "Observed live" comment a few lines up) — this generalizes that same protection to every other failure mode instead of just the one that was noticed.

**Verification:**
- `cd packages/harness-runner && bunx tsc --noEmit` — clean
- `bunx oxlint packages/harness-runner/claude-code.ts` — 0 warnings/errors
- `bun test packages/harness-runner/claude-code.test.ts` — 21/21 pass (unaffected pure-function tests)

No new test: `attemptTurn`/`consumeStream` aren't exported and exercising this catch path means mocking the SDK's `query()` async generator, which the repo's own testing philosophy (`TESTING.md`) puts in the e2e tier, not unit — and there's no Docker/Postgres/e2e harness available in this environment to add one. Reviewer can confirm the change's shape by reading `attemptTurn`/`consumeStream` directly; full CI still runs the existing suite.

A reviewer can reproduce the reasoning by reading the existing comment at the broken-MCP `endSession` call site (line ~497 pre-change) — it already documents exactly the failure mode this generalizes a fix for.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ends the Claude Code SDK session on any attempt failure to avoid session-id locks between retries. Previously only the broken-MCP path ended the session; other errors left the child process alive and caused subsequent attempts to fail with “Session ID ... is already in use.”

- Extracts the message loop into `consumeStream()` and wraps its call in `attemptTurn()` with a try/catch that invokes `endSession(stream)` before rethrowing.
- Behavior: all exit paths (success, broken MCP, unexpected SDK errors) now release the session before the retry/backoff loop continues.
- Scope: small, localized change in `packages/harness-runner/claude-code.ts`; no API changes or migrations.

<sup>Written for commit ba71f52296d7abb9c30733f1d413e313a44b237b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

