### PR TITLE
fix(preview): stop flattenTree overflowing the stack on a huge directory

### DIFF
--- a/apps/web/src/components/sandbox/preview/file-explorer/utils.test.ts
+++ b/apps/web/src/components/sandbox/preview/file-explorer/utils.test.ts
@@ -60,6 +60,20 @@ describe("file-explorer utils", () => {
     expect(rows.some((row) => row.node.name === "tavano-folder")).toBe(true);
   });
 
+  it("flattenTree doesn't overflow the stack on a huge expanded directory", () => {
+    const children = Array.from({ length: 700_000 }, (_, i) => ({
+      name: `f${i}`,
+      path: `/dir/f${i}`,
+      kind: "file" as const,
+      children: [],
+    }));
+    const tree = [
+      { name: "dir", path: "/dir", kind: "directory" as const, children },
+    ];
+    const rows = flattenTree(tree, new Set(["/dir"]));
+    expect(rows).toHaveLength(700_001);
+  });
+
   it("decoBlockKeyFromTreePath decodes block keys", () => {
     expect(decoBlockKeyFromTreePath("/.deco/blocks/Header.json")).toBe(
       "Header",

--- a/apps/web/src/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/web/src/components/sandbox/preview/file-explorer/utils.ts
@@ -332,7 +332,14 @@ export function flattenTree(
       node.children.length > 0 &&
       expandedDirectories.has(node.path)
     ) {
-      rows.push(...flattenTree(node.children, expandedDirectories, depth + 1));
+      // A loop, not `rows.push(...flattenTree(...))` — spreading a huge array as call args overflows the stack.
+      for (const row of flattenTree(
+        node.children,
+        expandedDirectories,
+        depth + 1,
+      )) {
+        rows.push(row);
+      }
     }
   }
 


### PR DESCRIPTION
## The bug

`flattenTree` (the file-explorer's tree→row flattener, `apps/web/src/components/sandbox/preview/file-explorer/utils.ts`) recursed into an expanded directory's children and merged the result back with `rows.push(...flattenTree(...))`. Spreading an array into a call's argument list is bounded by the JS engine's max-arguments limit, well below what a legitimate sandbox directory can hold (build output, generated assets, a large `node_modules/.bin`-style dump, etc.) — once a single expanded directory has enough direct children (~700k in this engine), the spread throws `RangeError: Maximum call stack size exceeded` and the whole file explorer crashes instead of rendering a (possibly slow but working) tree.

## The fix

Replaced the spread-push with a plain `for...of` loop appending one row at a time — same output, no argument-list ceiling. Net change: +8/-1 in `utils.ts`.

## Failure scenario + regression test

Expanding a directory with a very large number of direct children (build output, a huge asset dump, etc.) crashed the whole panel. Added a test in `utils.test.ts` building a 700,000-child directory and asserting `flattenTree` returns all rows instead of throwing — this reproducibly threw the `RangeError` before the fix (confirmed by hand against the old spread-based implementation) and passes after it.

## How a reviewer confirms

`bun test apps/web/src/components/sandbox/preview/file-explorer/utils.test.ts` — 33 pass / 0 fail.

## Checks run locally

- `bun run fmt` — clean
- `cd apps/web && bunx tsc --noEmit` — clean
- `bun test apps/web/src/components/sandbox/preview/file-explorer/utils.test.ts` — 33 pass / 0 fail
- `bunx oxlint` on both changed files — 0 warnings / 0 errors

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the file explorer from crashing when expanding a directory with a very large number of children. Previously `flattenTree` used `rows.push(...flattenTree(...))`, which hit the engine’s max-arguments limit and threw; now it appends rows in a loop and renders the full tree.

- Change is limited to `flattenTree`: replace spread-push with a `for...of` loop. Output is identical; no API changes.
- Adds a regression test that builds a directory with 700,000 children and asserts `flattenTree` returns all rows without throwing.

<sup>Written for commit c94cb0b11d05771ac3486cd6ac833a1739e6d8e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

