### PR TITLE
fix(cms): translate the post-calendar scheduling toasts

### DIFF
--- a/apps/web/src/components/sandbox/content/content-browser.tsx
+++ b/apps/web/src/components/sandbox/content/content-browser.tsx
@@ -33,6 +33,7 @@ import {
   TooltipTrigger,
 } from "@decocms/ui/components/tooltip.tsx";
 import { cn } from "@decocms/ui/lib/utils.ts";
+import { useT } from "@/i18n/use-t.ts";
 import { useProjectContext } from "@/sdk";
 import { useInsetContext } from "@/layouts/agent-shell-layout";
 import { useChatTask } from "@/components/chat/context";
@@ -345,6 +346,7 @@ function ContentBrowserReady({
   devServerReady: boolean;
   sandboxWarming: boolean;
 }) {
+  const t = useT();
   const threadId = useOptionalChatTask()?.taskId ?? null;
   const fetchParams = { orgSlug, virtualMcpId, branch, threadId, previewUrl };
   const { data: decofile, isLoading: decofileLoading } = useDecofile(
@@ -831,13 +833,17 @@ function ContentBrowserReady({
     const data = buildBlogBlock(key, "posts", scheduledPostPayload(day));
     try {
       await saveBlock.mutateAsync({ blockKey: key, data });
-      toast.success("Created scheduled post");
+      toast.success(t("sandbox.postCalendar.createdScheduledPost"));
       setActiveCollection("posts");
       setPrevCollection("posts");
       setSelection({ collection: "posts", key });
       setOpenPageSeoKey(null);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Could not create");
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : t("sandbox.postCalendar.couldNotCreate"),
+      );
     }
   };
 
@@ -848,7 +854,7 @@ function ContentBrowserReady({
       ? rescheduleToDay(getBlogPayload(source, "posts"), day)
       : null;
     if (!payload) {
-      toast.error("Only scheduled posts can be moved.");
+      toast.error(t("sandbox.postCalendar.onlyScheduledCanMove"));
       return;
     }
     try {
@@ -857,7 +863,11 @@ function ContentBrowserReady({
         data: buildBlogBlock(key, "posts", payload),
       });
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Could not reschedule");
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : t("sandbox.postCalendar.couldNotReschedule"),
+      );
     }
   };
 

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -317,9 +317,14 @@ export const sandbox = {
   "sandbox.plainBlocks.listItemPlaceholder": "List item",
   "sandbox.plainBlocks.numberedLabel": "Numbered",
   "sandbox.plainBlocks.quotePlaceholder": "Quote",
+  "sandbox.postCalendar.couldNotCreate": "Could not create",
+  "sandbox.postCalendar.couldNotReschedule": "Could not reschedule",
+  "sandbox.postCalendar.createdScheduledPost": "Created scheduled post",
   "sandbox.postCalendar.legendScheduled": "Scheduled",
   "sandbox.postCalendar.legendUnscheduled": "Not scheduled",
   "sandbox.postCalendar.next": "Next month",
+  "sandbox.postCalendar.onlyScheduledCanMove":
+    "Only scheduled posts can be moved.",
   "sandbox.postCalendar.outdatedAppsDescription":
     "Scheduling needs deco apps {required} or newer. Update this site's pin by running:",
   "sandbox.postCalendar.outdatedAppsTitle": "Update this site's apps version",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -327,9 +327,14 @@ export const sandbox = {
   "sandbox.plainBlocks.listItemPlaceholder": "Item de lista",
   "sandbox.plainBlocks.numberedLabel": "Numerada",
   "sandbox.plainBlocks.quotePlaceholder": "Citação",
+  "sandbox.postCalendar.couldNotCreate": "Não foi possível criar",
+  "sandbox.postCalendar.couldNotReschedule": "Não foi possível reagendar",
+  "sandbox.postCalendar.createdScheduledPost": "Post agendado criado",
   "sandbox.postCalendar.legendScheduled": "Agendado",
   "sandbox.postCalendar.legendUnscheduled": "Não agendado",
   "sandbox.postCalendar.next": "Próximo mês",
+  "sandbox.postCalendar.onlyScheduledCanMove":
+    "Apenas posts agendados podem ser movidos.",
   "sandbox.postCalendar.outdatedAppsDescription":
     "Agendamento precisa do deco apps {required} ou mais novo. Atualize o pin deste site rodando:",
   "sandbox.postCalendar.outdatedAppsTitle":


### PR DESCRIPTION
Follows #6421 (post calendar / blog scheduling): the new schedule/reschedule flow's four toast strings ("Created scheduled post", "Could not create", "Only scheduled posts can be moved.", "Could not reschedule") were hardcoded in `content-browser.tsx` instead of going through `t()`, unlike every other user-facing string that same PR added in `post-editor.tsx`/`post-calendar.tsx`. Per this repo's i18n rule, any string a user reads in `apps/web/src` must go through `t()` so pt-br users don't see raw English mid-flow.

Adds `sandbox.postCalendar.{couldNotCreate,couldNotReschedule,createdScheduledPost,onlyScheduledCanMove}` to both `en/sandbox.ts` and `pt-br/sandbox.ts`, and wires them into `handleCreateScheduledPost`/`handleReschedulePost`.

To confirm: open a site with blog scheduling support, switch to pt-br in preferences, create a post from the calendar's "+" button and drag a scheduled post to another day — the toasts now read in pt-br instead of English.

Verified locally: `bun run fmt`, `bunx tsc --noEmit` in `apps/web` (no new errors), `bunx oxlint` on the three changed files (0 warnings/errors). Full CI (typecheck across all workspaces, lint, tests) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes post calendar scheduling toasts to follow `apps/web` i18n rules. Previously these four toasts were hardcoded in English; now they use t() so pt-br users see translated messages.

- Adds `sandbox.postCalendar.{couldNotCreate,couldNotReschedule,createdScheduledPost,onlyScheduledCanMove}` to `en/sandbox.ts` and `pt-br/sandbox.ts`.
- Replaces string literals in `content-browser.tsx` (`handleCreateScheduledPost`, `handleReschedulePost`) with `t()`, preserving `err.message` when present and using localized fallbacks otherwise.

<sup>Written for commit 8c02470049494649c5d809d637351af5b706a177. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

