### PR TITLE
perf(core): parallelize resolveTier's independent storage reads

### DIFF
--- a/apps/api/src/core/resolve-tier.ts
+++ b/apps/api/src/core/resolve-tier.ts
@@ -125,24 +125,30 @@ export async function resolveTier(
   const orgId = ctx.organization?.id;
   if (!orgId) throw new Error("resolveTier called without an organization");
 
-  const settings = await ctx.storage.organizationSettings.get(orgId);
-  const orgSlot = settings?.simple_mode?.tiers?.[tier] ?? null;
-
   // Per-user override, opt-in and chat-tiers-only (see ResolveTierOptions).
   // Skipping the read entirely when it can't win also keeps a dispatch from
   // issuing three throwaway queries for image/web_search/deep_research.
   const userId = ctx.auth?.user?.id;
   const chatTier = ChatTierSchema.safeParse(tier);
-  const userSlot =
-    opts?.applyUserPrefs && chatTier.success && userId
-      ? ((await ctx.storage.userModelPreferences.get(userId, orgId))?.tiers?.[
-          chatTier.data
-        ] ?? null)
-      : null;
+  const applyUserPrefs = Boolean(
+    opts?.applyUserPrefs && chatTier.success && userId,
+  );
 
-  const keys = (
-    await ctx.storage.aiProviderKeys.list({ organizationId: orgId })
-  ).filter((key) => isHostedProviderId(key.providerId));
+  // These three reads are independent — fetch them concurrently.
+  const [settings, userPrefs, allKeys] = await Promise.all([
+    ctx.storage.organizationSettings.get(orgId),
+    applyUserPrefs
+      ? ctx.storage.userModelPreferences.get(userId as string, orgId)
+      : Promise.resolve(null),
+    ctx.storage.aiProviderKeys.list({ organizationId: orgId }),
+  ]);
+
+  const orgSlot = settings?.simple_mode?.tiers?.[tier] ?? null;
+  const userSlot =
+    applyUserPrefs && chatTier.success
+      ? (userPrefs?.tiers?.[chatTier.data] ?? null)
+      : null;
+  const keys = allKeys.filter((key) => isHostedProviderId(key.providerId));
 
   // Prefer the user override, then the org slot; take the first whose key is
   // still live. A slot pointing at a deleted key is skipped so resolution


### PR DESCRIPTION
**Source:** storage-ports latency-investigation hunt (issue #2995 — "DB latency amplifies significantly across MCP tool calls"). `resolveTier` (`apps/api/src/core/resolve-tier.ts`) is on the model-resolution path for interactive chat and every automation/task-board/review-judge call that picks a tier — it runs on essentially every agent turn.

**Payoff:** the function issued three independent DB reads back-to-back with `await`: org settings, the per-user model-preference override, and the AI provider key list. None of the three depends on another's result, so serializing them adds up to two extra round-trips of latency to every tier resolution for no reason. This change fetches all three concurrently with `Promise.all`, same conditional skip for the user-prefs read (still not issued when `applyUserPrefs` is off).

**Behavior:** unchanged — same three conditions gate the user-prefs read, same values feed `orgSlot`/`userSlot`/`keys` afterward, only the await ordering changed from serial to parallel.

**How a reviewer confirms:** run `bun test apps/api/src/core/resolve-tier.test.ts` (all 10 cases still pass, including the one asserting `userModelPreferences.get` is NOT called when `applyUserPrefs` is unset).

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/core/resolve-tier.test.ts` (10/10 pass), `bunx oxlint apps/api/src/core/resolve-tier.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelizes resolveTier’s independent storage reads to reduce per-turn latency in model resolution. Previously, org settings, user model preferences (conditionally), and AI provider keys were read sequentially; they now load in parallel with unchanged behavior, including skipping the user-preferences read when it does not apply. This supports issue #2995 on DB latency across MCP tool calls.

- Review notes
  - The gating for user preferences is unchanged: it applies only when `applyUserPrefs` is set, the tier is a chat tier, and a `userId` exists; the read is skipped otherwise.
  - Run tests: `bun test apps/api/src/core/resolve-tier.test.ts` (ensures the skip behavior and overall resolution logic remain intact).
  - No API or schema changes; no migration or config updates required.

<sup>Written for commit f1f9afa572a19446abdcc3e836cdd95dbabcf03b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

