### PR TITLE
fix(task-board): collapse the search filter chip when cleared externally

### DIFF
--- a/apps/web/src/layouts/task-board/task-filters-search.test.tsx
+++ b/apps/web/src/layouts/task-board/task-filters-search.test.tsx
@@ -75,3 +75,71 @@ describe("task filter options — searchable value matches the displayed label",
     }
   });
 });
+
+describe("search toggle — collapses when cleared externally", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("an unfocused search chip collapses when 'Clear all' resets filters", () => {
+    const { getByPlaceholderText, queryByPlaceholderText, rerender } = render(
+      <TaskFiltersBar
+        filters={{ ...EMPTY_FILTERS, search: "login" }}
+        members={[]}
+        tags={[]}
+        repos={[]}
+        sprints={[]}
+        sprintConfig={null}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = getByPlaceholderText("Search tasks…");
+    fireEvent.blur(input);
+
+    rerender(
+      <TaskFiltersBar
+        filters={EMPTY_FILTERS}
+        members={[]}
+        tags={[]}
+        repos={[]}
+        sprints={[]}
+        sprintConfig={null}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(queryByPlaceholderText("Search tasks…")).toBeNull();
+  });
+
+  test("a focused search box stays open while backspaced to empty", () => {
+    const { getByPlaceholderText, rerender } = render(
+      <TaskFiltersBar
+        filters={{ ...EMPTY_FILTERS, search: "login" }}
+        members={[]}
+        tags={[]}
+        repos={[]}
+        sprints={[]}
+        sprintConfig={null}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = getByPlaceholderText("Search tasks…");
+    fireEvent.focus(input);
+
+    rerender(
+      <TaskFiltersBar
+        filters={EMPTY_FILTERS}
+        members={[]}
+        tags={[]}
+        repos={[]}
+        sprints={[]}
+        sprintConfig={null}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(getByPlaceholderText("Search tasks…")).not.toBeNull();
+  });
+});

--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -724,6 +724,15 @@ function SearchToggle({
 }) {
   const t = useT();
   const [open, setOpen] = useState(value !== "");
+  const [focused, setFocused] = useState(false);
+
+  // Collapse a filter cleared externally while unfocused (not one emptied by typing).
+  const [prevValue, setPrevValue] = useState(value);
+  if (value !== prevValue) {
+    setPrevValue(value);
+    if (value === "" && !focused) setOpen(false);
+  }
+
   const expanded = open || block;
 
   return (
@@ -747,7 +756,9 @@ function SearchToggle({
           autoFocus={!block}
           value={value}
           onChange={(e) => onChange(e.target.value)}
+          onFocus={() => setFocused(true)}
           onBlur={() => {
+            setFocused(false);
             if (value === "") setOpen(false);
           }}
           placeholder={t("taskBoard.taskFilters.searchPlaceholder")}


### PR DESCRIPTION
**Source:** a state-sync bug found while reading the task-board filter UI (`apps/web/src/layouts/task-board/task-filters.tsx`), not tied to a specific issue.

**Payoff:** after clicking "Clear all" (drawer) or the inline "Clear" link (desktop bar) with an active search term, every other filter chip collapses back to its default icon-only state — except the search chip, which stayed visually expanded and empty because its `open` state was purely internal and only ever reset on its own `onBlur`. A parent-driven reset (any external change to `filters.search`, not just the user's own X-button click) never ran that handler.

**Failure scenario:** type a search term, click elsewhere to blur the search box (it correctly stays expanded showing the term), then click "Clear all" — the search chip remains an empty expanded box instead of collapsing like the rest of the bar.

**Fix:** track `focused` via the input's `onFocus`/`onBlur`, and when `value` transitions to `""` while the field is not focused, close it. A field the user is actively backspacing to empty (still focused) is untouched — it keeps closing only on its own blur, exactly as before.

**Regression test** (`task-filters-search.test.tsx`): re-renders `TaskFiltersBar` with the search filter cleared (a) after blurring the input — asserts it collapses (input unmounts), and (b) while it's still focused — asserts it stays open, so the fix can't regress into closing under the user mid-edit.

**Reviewer command:** `bun test apps/web/src/layouts/task-board/task-filters-search.test.tsx`

**Local checks run:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean on the touched files), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above (4/4 pass). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses the task-board search chip when its value is cleared by a parent action. Previously it stayed expanded and empty after “Clear all” or the inline “Clear”; now it collapses unless the input is focused, preserving mid-edit behavior.

- Track focus with `onFocus`/`onBlur`; when `value` changes to empty while unfocused, close the chip.
- Keep the focused case unchanged: clearing by typing leaves the chip open until blur.
- Add regression tests covering both scenarios in `apps/web/src/layouts/task-board/task-filters-search.test.tsx`.
- Run tests: `bun test apps/web/src/layouts/task-board/task-filters-search.test.tsx`.

<sup>Written for commit 7996323b8c970661c0f9144a87980b8d7a6733c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

