### PR TITLE
fix(thread/github): call useSandboxLifecycle unconditionally in HeaderActions

### DIFF
--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -242,6 +242,15 @@ export function HeaderActions({ virtualMcpId }: Props) {
     branch ?? sandboxRouteBranch ?? "",
   );
 
+  /**
+   * Preview URL must come from the sandbox lifecycle — the raw
+   * `vm.metadata.sandboxMap` does not always carry it. Called before the early
+   * returns below: `attachment.status` can flip from "detached" to attached
+   * (a live GitHub reconnect) while this component stays mounted, and a hook
+   * called only on some renders breaks React's hook-order invariant.
+   */
+  const { previewUrl } = useSandboxLifecycle();
+
   /** Detached repo: render a reconnect pill, never a blank header. */
   if (attachment.status === "detached") {
     return (
@@ -253,9 +262,6 @@ export function HeaderActions({ virtualMcpId }: Props) {
     );
   }
   if (!githubRepo) return null;
-
-  /** Preview URL must come from the sandbox lifecycle — the raw `vm.metadata.sandboxMap` does not always carry it. */
-  const { previewUrl } = useSandboxLifecycle();
 
   const button = githubHeadBranch
     ? selectHeaderButton({


### PR DESCRIPTION
**Source:** bug found while auditing recently-changed files (no linked issue).

**The bug:** `HeaderActions` (apps/web/src/components/thread/github/header-actions.tsx) had two early returns — a "detached" GitHub connection pill and a `!githubRepo` null return — followed by a call to `useSandboxLifecycle()`. That hook was therefore only invoked on renders that fell through both returns. `attachment.status` is derived from `resolveGithubAttachment(vm)`, and `vm` comes from a reactive query (`useVirtualMCP`) — so a live GitHub reconnect can flip `attachment.status` from `"detached"` to attached while this exact component instance stays mounted (same `virtualMcpId` key). On that transition, a render that previously skipped `useSandboxLifecycle()` would now call it, changing the number/order of hooks called across renders — a React rules-of-hooks violation that throws ("Rendered more hooks than during the previous render") and crashes the surrounding tree instead of just the button.

**Fix:** moved the `useSandboxLifecycle()` call above both early returns. Pure reorder — the returned `previewUrl` is only read later in the render (passed to `PublishDialog`), so no behavior changes for either branch; the hook is just now called unconditionally like every other hook in this component.

**Verify:** `cd apps/web && bunx tsc --noEmit` is green; `bunx oxlint apps/web/src/components/thread/github/header-actions.tsx` is 0 warnings/errors. No dedicated test file exists for this component's render tree (it's deeply wired to sandbox/GitHub context providers), so this is a pure hook-order fix verified by typecheck + lint; full CI validates the rest.

**Checks run locally:** `bun run fmt` (no-op), `bunx tsc --noEmit` in apps/web, `bunx oxlint` on the one changed file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Calls `useSandboxLifecycle` unconditionally in `HeaderActions` to prevent a React hooks-order violation during live GitHub reconnects. Previously the hook ran only when renders passed two early returns; now it runs before them with no UI or logic change.

**Review notes**
- Moves the `useSandboxLifecycle()` call above early returns in `apps/web/src/components/thread/github/header-actions.tsx`; `previewUrl` usage remains unchanged.
- Validate by simulating a transition from `attachment.status="detached"` to attached while the component stays mounted; the hook-order error should no longer occur.
- No migration or config changes required; typecheck and lint are green.

<sup>Written for commit f01e9ef9e2991f239fcee57fe210b66b5387382e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

