### PR TITLE
fix(org): bound limit/offset on ORGANIZATION_MEMBER_LIST

### DIFF
--- a/apps/api/src/tools/organization/member-list.test.ts
+++ b/apps/api/src/tools/organization/member-list.test.ts
@@ -37,4 +37,23 @@ describe("ORGANIZATION_MEMBER_LIST", () => {
       createdAt: "2026-01-01T00:00:00.000Z",
     });
   });
+
+  it("rejects an unbounded, negative, or non-integer limit/offset", () => {
+    // Regression: limit/offset used to be a plain z.number() with no bounds.
+    expect(() =>
+      ORGANIZATION_MEMBER_LIST.inputSchema.parse({ limit: 1_000_000 }),
+    ).toThrow();
+    expect(() =>
+      ORGANIZATION_MEMBER_LIST.inputSchema.parse({ limit: -1 }),
+    ).toThrow();
+    expect(() =>
+      ORGANIZATION_MEMBER_LIST.inputSchema.parse({ offset: -1 }),
+    ).toThrow();
+    expect(() =>
+      ORGANIZATION_MEMBER_LIST.inputSchema.parse({ limit: 1.5 }),
+    ).toThrow();
+    expect(
+      ORGANIZATION_MEMBER_LIST.inputSchema.parse({ limit: 1000, offset: 0 }),
+    ).toEqual({ limit: 1000, offset: 0 });
+  });
 });

--- a/apps/api/src/tools/organization/member-list.ts
+++ b/apps/api/src/tools/organization/member-list.ts
@@ -19,8 +19,8 @@ export const ORGANIZATION_MEMBER_LIST = defineTool({
     openWorldHint: false,
   },
   inputSchema: z.object({
-    limit: z.number().optional(),
-    offset: z.number().optional(),
+    limit: z.number().int().min(1).max(1000).optional(),
+    offset: z.number().int().min(0).optional(),
   }),
 
   outputSchema: z.object({


### PR DESCRIPTION
**Source:** bug found while hardening `apps/api/src/tools/organization/member-list.ts` (this tick's focus area).

**Why:** `ORGANIZATION_MEMBER_LIST`'s `limit`/`offset` input fields were a plain `z.number().optional()` with no bounds — every other paginated tool in the repo constrains these (e.g. `CollectionListInputSchema` in `packages/bindings/src/well-known/collections.ts` caps `limit` at `1-1000` and requires `offset >= 0`, both as integers). A caller could pass an unbounded (`limit: 1_000_000`), negative, or fractional value straight through to Better Auth's `listMembers`, with no validation catching it at the tool boundary.

**Failure scenario:** `ORGANIZATION_MEMBER_LIST({ limit: 1_000_000 })` or `{ limit: -1 }` or `{ limit: 1.5 }` all passed Zod validation before this fix and were forwarded verbatim to `ctx.boundAuth.organization.listMembers`.

**Fix:** `limit: z.number().int().min(1).max(1000).optional()`, `offset: z.number().int().min(0).optional()` — matching the existing repo-wide pagination convention.

**Regression test:** added a case in `member-list.test.ts` asserting the schema rejects an over-cap, negative, and fractional `limit`/`offset`, and still accepts a valid bounded value.

**To verify:** `cd apps/api && bun test src/tools/organization/member-list.test.ts`

**Checked locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds pagination inputs for `ORGANIZATION_MEMBER_LIST` to integers: limit 1–1000 and offset >= 0, matching repo pagination conventions. Previously any number was accepted; now invalid values fail validation, preventing unbounded, negative, or fractional inputs from reaching the auth backend.

- Client requirements: pass an integer limit within 1–1000 and an integer offset >= 0; out-of-range or non-integer values will throw at the tool boundary.

<sup>Written for commit 98d8e7ac727d8b399dd3785170adbe52e50bb228. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

