### PR TITLE
fix(storage): surface a friendly error on a racing connection create

### DIFF
--- a/apps/api/src/storage/connection.integration.test.ts
+++ b/apps/api/src/storage/connection.integration.test.ts
@@ -85,6 +85,37 @@ describe("ConnectionStorage", () => {
         grantType: "authorization_code",
       });
     });
+
+    it("should surface a friendly error, not a raw driver error, when two concurrent creates race on the same id", async () => {
+      const id = "conn_racing_create";
+      const results = await Promise.allSettled([
+        storage.create({
+          id,
+          organization_id: "org_123",
+          created_by: "user_123",
+          title: "Racer A",
+          connection_type: "HTTP",
+          connection_url: "https://racer-a.invalid/mcp",
+        }),
+        storage.create({
+          id,
+          organization_id: "org_123",
+          created_by: "user_123",
+          title: "Racer B",
+          connection_type: "HTTP",
+          connection_url: "https://racer-b.invalid/mcp",
+        }),
+      ]);
+
+      const rejected = results.filter((r) => r.status === "rejected");
+      expect(rejected.length).toBeLessThanOrEqual(1);
+      for (const r of rejected) {
+        expect((r as PromiseRejectedResult).reason).toBeInstanceOf(Error);
+        expect((r as PromiseRejectedResult).reason.message).toBe(
+          "Connection ID already exists",
+        );
+      }
+    });
   });
 
   describe("createNew", () => {

--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -227,12 +227,25 @@ export class ConnectionStorage implements ConnectionStoragePort {
       created_at: now,
       updated_at: now,
     });
-    // returningAll() avoids a second round trip to re-fetch the inserted row.
-    const row = await this.db
-      .insertInto("connections")
-      .values(serialized as Insertable<Database["connections"]>)
-      .returningAll()
-      .executeTakeFirst();
+    let row: RawConnectionRow | undefined;
+    try {
+      // returningAll() avoids a second round trip to re-fetch the inserted row.
+      row = (await this.db
+        .insertInto("connections")
+        .values(serialized as Insertable<Database["connections"]>)
+        .returningAll()
+        .executeTakeFirst()) as RawConnectionRow | undefined;
+    } catch (error) {
+      // Race with a concurrent create() for the same id: match createNew()'s error.
+      if (
+        error instanceof Error &&
+        (error.message.includes("duplicate key") ||
+          error.message.includes("unique constraint"))
+      ) {
+        throw new Error("Connection ID already exists");
+      }
+      throw error;
+    }
     if (!row) {
       throw new Error(`Failed to create connection with id: ${id}`);
     }


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/storage/connection.ts` for races/error handling per the storage-layer focus area.

**Why a maintainer wants this:** `ConnectionStorage.create()` does a check-then-insert (select for an existing row, insert if none found) that is TOCTOU-racy — two concurrent `create()` calls for the same id can both pass the existence check, then both attempt the insert. The primary-key constraint on `connections.id` rejects the loser, but `create()` let that raw Postgres driver error (`duplicate key value violates unique constraint ...`) escape unhandled, instead of the friendly `"Connection ID already exists"` error that the sibling `createNew()` method already gives for the exact same race (see its existing test at line 90-115 of the integration test file). `create()` is a live path — `reports/setup.ts`, `monitor-run-start.ts`, `plugin-config-update.ts`, and `deco-sites.ts` all call it with a deterministic, org-scoped id — so a double-submit or a racing webhook hits this today and a caller gets an opaque driver error instead of a message it can branch on.

**Failure scenario:** two requests concurrently call `storage.connections.create({ id: "conn_x", ... })` for the same deterministic id (e.g. two overlapping calls to `reports/setup.ts` for the same org). Both pass the existence check, one insert wins, the other's insert throws a raw `duplicate key value violates unique constraint "connections_pkey"` error instead of `"Connection ID already exists"`.

**Fix:** wrap the insert in a try/catch and rethrow the same friendly error `createNew()` already uses for this exact race — one code path, no behavior change on the non-racing path (same insert, same returned row).

**Regression test:** added `apps/api/src/storage/connection.integration.test.ts` — fires two concurrent `create()` calls for the same id and asserts any rejection carries the friendly message, not a raw driver error.

**Command a reviewer runs to confirm:** `bun test apps/api/src/storage/connection.integration.test.ts` (needs Postgres — same as every other test in that file; not runnable in this bot's sandbox).

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors). The integration test itself needs a real Postgres instance, which isn't available in this sandbox — full CI validates it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces a friendly "Connection ID already exists" error when concurrent `ConnectionStorage.create()` calls race on the same id, instead of leaking the raw Postgres duplicate-key error. This matches `createNew()` and leaves non-racing behavior unchanged.

**Review notes**
- Wraps the `insert` in try/catch; maps duplicate-key/unique-constraint errors to the friendly message, otherwise rethrows the original error.
- Adds an integration test that runs two concurrent `create()` calls and asserts any rejection carries the friendly message.
- Improves error handling for current callers that use deterministic ids (double-submit/webhook races); no schema or API changes.

<sup>Written for commit c089212f1011accf79b8ea1caf68188b3e2946b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

