### PR TITLE
fix(sandbox): cap the Go daemon's inline dispatch request body size

### DIFF
--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
@@ -3,6 +3,7 @@ package dispatch
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -17,6 +18,12 @@ import (
 )
 
 const tombstoneTTL = 60 * time.Second
+
+// maxDispatchBodyBytes bounds the inline `/dispatch` request body. Matches
+// maxOffloadBytes: a run whose messages are actually this large is expected to
+// come in via messagesRef, not inline, so this cap just stops an unbounded
+// read from parking the pod's memory on one request.
+const maxDispatchBodyBytes = maxOffloadBytes
 
 // Terminal code for a run this pod could not finish (shutdown / dropped
 // connection) as opposed to one that was cancelled on purpose. Studio maps it
@@ -282,8 +289,13 @@ func (reg *Registry) HandleDispatch(w http.ResponseWriter, r *http.Request, deps
 		jsonError(w, 401, map[string]string{"error": "unauthorized"})
 		return
 	}
-	body, err := io.ReadAll(r.Body)
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxDispatchBodyBytes))
 	if err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			jsonError(w, 413, map[string]string{"error": "body_too_large"})
+			return
+		}
 		jsonError(w, 400, map[string]string{"error": "bad_json"})
 		return
 	}

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
@@ -354,3 +354,18 @@ func TestUnauthorizedCancelLeavesNoTombstone(t *testing.T) {
 		t.Fatal("a rejected cancel must not tombstone the run")
 	}
 }
+
+// An oversized inline dispatch body must be rejected before it is buffered in
+// full — the offload path already caps at this size, and the inline path had
+// no cap at all.
+func TestDispatchRejectsOversizedBody(t *testing.T) {
+	const token = "tkn"
+	body := strings.NewReader(strings.Repeat("a", maxDispatchBodyBytes+1))
+	req := httptest.NewRequest("POST", "/dispatch", body)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	NewRegistry().HandleDispatch(rec, req, Deps{DaemonToken: func() string { return token }})
+	if rec.Code != 413 {
+		t.Fatalf("dispatch with oversized body returned %d, want 413", rec.Code)
+	}
+}


### PR DESCRIPTION
**Source**: bounded resource fix (C3), same DoS-bound category as the already-merged #6215/#6039 fs caps and the open #6252 config-body cap — this is the `/dispatch` entry point, which none of those touch.

**The gap**: `HandleDispatch` in `packages/sandbox/daemon-go/internal/dispatch/dispatch.go` read the request body with a plain `io.ReadAll(r.Body)` — no size limit. Its sibling path, `handleOffloadDispatch` → `FetchOffloadedMessages` (`offload.go`), already caps external message fetches at `maxOffloadBytes` (32MB) with a `Content-Length`/read-limit check specifically because a large payload is expected to go through that offload path, not inline. The inline path had no equivalent bound, so one oversized POST to `/dispatch` could buffer arbitrarily large bytes into the pod's memory before validation even runs.

**Fix**: wrap the read in `http.MaxBytesReader(w, r.Body, maxDispatchBodyBytes)` (aliased to the existing `maxOffloadBytes` constant, so the two caps stay in sync) and answer `413 body_too_large` via `errors.As` on `*http.MaxBytesError` instead of buffering past the cap.

**Verification**: `TestDispatchRejectsOversizedBody` sends a `maxDispatchBodyBytes+1`-byte body through `HandleDispatch` and asserts a 413. Ran `go build ./...`, `go vet ./internal/dispatch/...`, `gofmt -l` (clean), and `go test ./internal/dispatch/...` (full package, all green) locally — CI runs the rest.

A reviewer can confirm with: `cd packages/sandbox/daemon-go && go test ./internal/dispatch/... -run TestDispatchRejectsOversizedBody -v`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the Go sandbox daemon’s inline `/dispatch` request body to prevent unbounded memory use. Previously `io.ReadAll` buffered the full body; now the read is limited to `maxOffloadBytes` (32MB) and oversized bodies return 413.

- Uses `http.MaxBytesReader` in `HandleDispatch`; on overflow returns 413 `body_too_large` before buffering. Other read/JSON errors still return 400 `bad_json`.
- Aligns the inline path with the offload path by aliasing the cap to `maxOffloadBytes`.
- Adds `TestDispatchRejectsOversizedBody` to assert the 413 response.

<sup>Written for commit 15725912c8b5f616e6b54f9f9d8cc9ff9edc82c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

