### PR TITLE
fix(sidebar): expose the active nav destination to assistive tech

### DIFF
--- a/apps/web/src/components/sidebar/nav-destinations.tsx
+++ b/apps/web/src/components/sidebar/nav-destinations.tsx
@@ -241,6 +241,7 @@ export function NavDestinationsContent({
       <SidebarMenuButton
         onClick={item.onSelect}
         isActive={item.isActive}
+        aria-current={item.isActive ? "page" : undefined}
         tooltip={showTooltip ? item.label : undefined}
       >
         {item.icon}


### PR DESCRIPTION
Accessibility gap in the sidebar's destination list (Home / Reports / Tasks / Library, plus coding-agent rows): the active item is only marked via a `data-active` attribute used for CSS styling — nothing tells assistive tech which destination is currently selected.

**Why it matters:** a screen-reader user navigating this list has no way to tell which destination (or coding agent) is currently open; sighted users get this for free from the active-state styling.

**Fix:** add `aria-current="page"` on the active `SidebarMenuButton`, mirroring `item.isActive` (already computed for both destinations and coding-agent rows, since `row()` is shared). `SidebarMenuButton` (`packages/ui`) spreads unknown props onto the underlying element, so no change to the shared component was needed.

**To confirm:** open the sidebar, select a destination, and inspect the corresponding `<button>` — it now carries `aria-current="page"`; inactive rows have no `aria-current` attribute.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), `bunx oxlint apps/web/src/components/sidebar/nav-destinations.tsx` (0 warnings/errors). No existing test covers this file (it's hook-heavy, not pure logic) — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the active sidebar destination with aria-current="page" so screen readers can announce the current page. Previously only a data-active attribute indicated the active item; now the active button exposes its state without changing visuals.

- Applies to both standard destinations and coding-agent rows by mirroring item.isActive.
- Implemented by passing aria-current to `SidebarMenuButton`; `packages/ui` already forwards unknown props, so no shared UI change.
- Review: select a destination and inspect the button; it has aria-current="page". Inactive items have no aria-current.

<sup>Written for commit 4250a8aa909061308e658112ae7b55067edfbd45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

