### PR TITLE
fix(sections-editor): translate the autosave failure toast

### DIFF
--- a/apps/web/src/components/sections-editor/use-save-block.ts
+++ b/apps/web/src/components/sections-editor/use-save-block.ts
@@ -14,6 +14,7 @@ import {
 import { sandboxGitStatusQueryKey } from "../thread/github/sandbox-git-api";
 import { useOptionalChatTask } from "@/components/chat/chat-context";
 import { KEYS } from "@/lib/query-keys";
+import { useT } from "@/i18n/use-t";
 
 /** Debounce window for form-driven block autosaves (ms). */
 export const AUTOSAVE_DELAY = 700;
@@ -156,6 +157,7 @@ export function useDebouncedSaveBlock(
   opts?: { onSaved?: () => void },
 ) {
   const saveBlock = useSaveBlock(params);
+  const t = useT();
   const pendingRef = useRef<Map<string, SaveData>>(new Map());
   const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
     new Map(),
@@ -171,7 +173,12 @@ export function useDebouncedSaveBlock(
       { blockKey, data: resolved },
       {
         onSuccess: () => opts?.onSaved?.(),
-        onError: (err) => toast.error(`Save failed: ${err.message}`),
+        onError: (err) =>
+          toast.error(
+            t("sectionsEditor.sectionsEditor.saveFailed", {
+              error: err.message,
+            }),
+          ),
       },
     );
   };


### PR DESCRIPTION
`useDebouncedSaveBlock` (used by every form-driven block editor — section forms, the SEO editor, SEO sheets) showed a hardcoded English "Save failed: {error}" toast on autosave failure, while every other save-failure toast in this same feature (see `sections-editor.tsx`, 9+ call sites) goes through `t("sectionsEditor.sectionsEditor.saveFailed", { error })`, which already has both an `en` and `pt-br` translation. A pt-br user editing a section form and hitting a save error would see this one toast in English while every other error toast in the same screen is localized.

Fix: route the same error through the existing `useT()` + `sectionsEditor.sectionsEditor.saveFailed` key instead of a template literal. No new translation keys needed — this key already exists and is already used for the identical message elsewhere in the same directory.

Checks run locally:
- `bun run fmt`
- `cd apps/web && bunx tsc --noEmit` — clean
- `bunx oxlint apps/web/src/components/sections-editor/use-save-block.ts` — 0 warnings/errors

No existing test covers this hook's toast wiring (it's UI copy, not a trust boundary), so no test was added per the repo's no-coverage-PR rule. Full CI validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the autosave failure toast in `useDebouncedSaveBlock`. Previously it showed a hardcoded English "Save failed: {error}"; now it uses `t("sectionsEditor.sectionsEditor.saveFailed", { error })` so pt-br users see the translated message.

- Affects all form-driven block editors using `useDebouncedSaveBlock` (section forms, SEO editor, SEO sheets).
- Reuses existing i18n key; no new translation keys or copy changes.
- No migration or config changes.

<sup>Written for commit 1f8e5e4df785eee791b7bf8d132d4596d19a6695. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

