### PR TITLE
fix(settings): stop concurrent Jira column-mapping edits from stomping each other

### DIFF
--- a/apps/web/src/views/settings/jira.tsx
+++ b/apps/web/src/views/settings/jira.tsx
@@ -209,6 +209,14 @@ function ColumnMappingRows({ integration }: { integration: JiraIntegration }) {
   const upsert = useUpsertJiraIntegration();
   const columns = useJiraBoardColumns(integration.boardId);
 
+  // Optimistic local copy so two quick edits don't race the save round-trip and stomp each other.
+  const [mapping, setMapping] = useState(integration.statusMapping);
+  const [syncedWith, setSyncedWith] = useState(integration);
+  if (syncedWith !== integration) {
+    setSyncedWith(integration);
+    setMapping(integration.statusMapping);
+  }
+
   if (columns.isPending) return <Skeleton className="h-24 w-full mt-3" />;
   if (columns.isError) {
     return (
@@ -220,7 +228,7 @@ function ColumnMappingRows({ integration }: { integration: JiraIntegration }) {
 
   // The mapping is keyed by STATUS name; one row writes every status its column groups.
   function setColumnMapping(statuses: string[], value: string) {
-    const next = { ...integration.statusMapping };
+    const next = { ...mapping };
     for (const status of statuses) {
       if (value === DONT_SYNC) {
         delete next[status];
@@ -228,6 +236,7 @@ function ColumnMappingRows({ integration }: { integration: JiraIntegration }) {
         next[status] = value as BoardStatus;
       }
     }
+    setMapping(next);
     upsert.mutate(
       { statusMapping: next },
       {
@@ -255,9 +264,7 @@ function ColumnMappingRows({ integration }: { integration: JiraIntegration }) {
           </div>
           <Select
             value={
-              (column.statuses[0] &&
-                integration.statusMapping[column.statuses[0]]) ??
-              DONT_SYNC
+              (column.statuses[0] && mapping[column.statuses[0]]) ?? DONT_SYNC
             }
             onValueChange={(value) => setColumnMapping(column.statuses, value)}
           >


### PR DESCRIPTION
**What:** `ColumnMappingRows` (Settings → Board → Jira integration) built each save's `statusMapping` patch from the `integration` prop, which only reflects a save after its mutation round-trips and the query cache is invalidated (`onSettled`).

**The bug:** map column A, then quickly map column B before A's save has settled. B's patch is computed as `{ ...integration.statusMapping }` — still the pre-A snapshot — plus B's change, and is sent as a full replacement (the server's `JIRA_INTEGRATION_UPSERT` takes `statusMapping` as-is, no merge). A's edit is silently lost on the next save, with no error surfaced to the user. This is exactly the kind of lost-update race the repo's checklist calls out ("trace what happens to A's output... under concurrency").

**The fix:** keep a local optimistic copy of the mapping (`mapping` state), update it synchronously on every edit before firing the mutation, and read/write against it instead of the stale prop. The copy resets to the server value whenever a fresh `integration` object arrives (a real refetch — including after a failed save, so a rejected mutation self-heals the UI back to the last-known-good server state). This is the standard React "adjust state during render when a prop changes" pattern, no `useEffect` involved.

**How to confirm:** in Settings → Board → Jira, with two or more board columns, open the column-status dropdowns and quickly change two different columns' mappings before the toast for the first one would normally land — reload the page and both changes should be persisted (previously the first one would revert).

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint apps/web/src/views/settings/jira.tsx` (0 warnings/errors). No existing test covers this view (a settings page wired to network mutations isn't a pure-logic unit per `TESTING.md`); full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents concurrent Jira column-mapping edits in Settings → Board from overwriting each other. Before: each save used the stale `integration.statusMapping`, so a quick second edit could drop the first because the server replaces the mapping. Now: we keep an optimistic local `mapping`, update it immediately on every change, submit from it, and resync when a fresh `integration` arrives (including after failed saves).

- How to review/QA: In Settings → Board → Jira, quickly change two different columns before the first toast appears; reload and both mappings persist (previously the first reverted).

<sup>Written for commit cc19aab8fe0ade46cf6555589081f149365eadb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

