### PR TITLE
fix(chat): stop the voice-input recognizer from busy-looping on a fatal error

### DIFF
--- a/apps/web/src/hooks/use-voice-input.test.ts
+++ b/apps/web/src/hooks/use-voice-input.test.ts
@@ -114,4 +114,83 @@ describe("useVoiceInput.startRecording", () => {
       configurable: true,
     });
   });
+
+  it("stops recording instead of busy-looping restarts on a fatal recognition error", async () => {
+    let startCalls = 0;
+    let recognition: {
+      start: () => void;
+      stop: () => void;
+      abort: () => void;
+      onerror?: (event: { error: string }) => void;
+      onend?: () => void;
+    };
+    win.SpeechRecognition = function () {
+      recognition = {
+        start() {
+          startCalls++;
+        },
+        stop() {},
+        abort() {},
+      };
+      return recognition;
+    } as unknown as typeof SpeechRecognition;
+
+    const originalAudioContext = win.AudioContext;
+    win.AudioContext = function () {
+      return {
+        createMediaStreamSource: () => ({ connect: () => {} }),
+        createAnalyser: () => ({
+          fftSize: 0,
+          smoothingTimeConstant: 0,
+          frequencyBinCount: 0,
+          getByteFrequencyData: () => {},
+        }),
+        close: () => Promise.resolve(),
+      };
+    };
+
+    const track = { stop: () => {} };
+    const originalGetUserMedia = navigator.mediaDevices?.getUserMedia;
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: {
+        getUserMedia: () =>
+          Promise.resolve({
+            getTracks: () => [track],
+          } as unknown as MediaStream),
+      },
+      configurable: true,
+    });
+
+    // Stub the visualizer's rAF loop so it doesn't outlive the test.
+    const originalRaf = win.requestAnimationFrame;
+    const originalCaf = win.cancelAnimationFrame;
+    win.requestAnimationFrame = (() =>
+      1) as unknown as typeof win.requestAnimationFrame;
+    win.cancelAnimationFrame =
+      (() => {}) as unknown as typeof win.cancelAnimationFrame;
+
+    const { result } = renderHook(() => useVoiceInput());
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    expect(startCalls).toBe(1);
+
+    await act(async () => {
+      recognition.onerror?.({ error: "network" });
+      recognition.onend?.();
+    });
+
+    expect(result.current.status).toBe("idle");
+    // onend must not restart a recognizer that just fatally errored.
+    expect(startCalls).toBe(1);
+
+    win.AudioContext = originalAudioContext;
+    win.requestAnimationFrame = originalRaf;
+    win.cancelAnimationFrame = originalCaf;
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia: originalGetUserMedia },
+      configurable: true,
+    });
+  });
 });

--- a/apps/web/src/hooks/use-voice-input.ts
+++ b/apps/web/src/hooks/use-voice-input.ts
@@ -142,6 +142,16 @@ export function useVoiceInput(): UseVoiceInputReturn {
       setInterimTranscript(interim);
     };
 
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      // "no-speech" is routine in continuous mode; onend restarts it below.
+      if (event.error === "no-speech") return;
+      // Fatal error (network/mic/permission) — stop, don't let onend restart it.
+      isRecordingRef.current = false;
+      recognitionRef.current = null;
+      stopVisualizer();
+      setStatus(event.error === "not-allowed" ? "permission-denied" : "idle");
+    };
+
     recognition.onend = () => {
       if (isRecordingRef.current) {
         try {


### PR DESCRIPTION
Bug found while reviewing the chat input area for error resilience under network hiccups: `useVoiceInput` (used by the chat composer's mic button, `apps/web/src/components/chat/input.tsx`) never attached an `onerror` handler to the Web Speech `SpeechRecognition` instance.

`recognition.onend` restarts the recognizer whenever `isRecordingRef.current` is still true — that's needed so continuous dictation survives the routine gaps between phrases. But with no `onerror` handler, the same restart also fires after a *fatal* error: a dropped network connection (most `SpeechRecognition` implementations are cloud-backed), the mic being unplugged, or the OS revoking mic permission mid-recording. Each restart immediately re-fails with the identical error, so the hook busy-loops indefinitely and the UI is stuck showing "recording" with no way out short of a page reload.

Fix: add an `onerror` handler. `no-speech` is left alone (it's routine in continuous mode, `onend` already restarts it correctly). Any other error code stops the recognizer, tears down the visualizer, and returns `status` to `idle` (or `permission-denied` for `not-allowed`) instead of retrying forever.

Failure scenario: start voice input, then simulate a `network`/`audio-capture`/`not-allowed` error from the recognizer — before this fix `status` stays `recording` forever and `recognition.start()` gets called again on every `onend`; after the fix it settles to `idle` and stops restarting. Covered by the new test `stops recording instead of busy-looping restarts on a fatal recognition error` in `apps/web/src/hooks/use-voice-input.test.ts`.

Reviewer check: `bun test apps/web/src/hooks/use-voice-input.test.ts` (4 pass), `cd apps/web && bunx tsc --noEmit`, `bunx oxlint apps/web/src/hooks/use-voice-input.ts apps/web/src/hooks/use-voice-input.test.ts` — all green locally; full CI covers the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the chat mic’s voice input from busy-looping after a fatal Web Speech error by handling `SpeechRecognition.onerror`. Previously `onend` always restarted recognition and left status stuck at recording; now we ignore `no-speech`, stop on other errors, tear down the visualizer, and set status to idle or permission-denied.

- Add `recognition.onerror`: ignore `no-speech`; for other errors set `status` to `idle` or `permission-denied` (`not-allowed`), clear `recognitionRef`, stop the visualizer, and prevent `onend` from auto-restarting.
- Keep continuous dictation behavior: `onend` still restarts only when recording continues and no fatal error occurred.
- Add a unit test that reproduces fatal error scenarios and asserts no restart; see `apps/web/src/hooks/use-voice-input.test.ts`.

<sup>Written for commit 8e2e04b0877760fdbcb4fdbc77af9969799b8ddb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

