### PR TITLE
refactor(reports): dedupe claim-error-code parsing into parseJsonResponse

### DIFF
--- a/apps/api/src/tools/reports/auth-client.ts
+++ b/apps/api/src/tools/reports/auth-client.ts
@@ -174,14 +174,10 @@ export class CommerceDiscoveryClaimError extends Error {
 async function parseClaimErrorCode(
   response: Response,
 ): Promise<CommerceDiscoveryClaimCode> {
-  const text = await response.text().catch(() => "");
-  if (!text) return "unknown";
-  try {
-    const parsed = JSON.parse(text) as { error?: unknown };
-    return isClaimCode(parsed.error) ? parsed.error : "unknown";
-  } catch {
-    return "unknown";
-  }
+  const parsed = (await parseJsonResponse(response)) as
+    | { error?: unknown }
+    | undefined;
+  return isClaimCode(parsed?.error) ? parsed.error : "unknown";
 }
 
 /**


### PR DESCRIPTION
Small reduction in `apps/api/src/tools/reports/auth-client.ts`: `parseClaimErrorCode` hand-rolled its own "read text, tolerate empty, JSON.parse, tolerate parse failure" logic — the exact same tolerant-parse shape `parseJsonResponse` already implements two functions below it (and is already used by every other response handler in this file, e.g. `fetchCommerceDiscoveryAuth`'s token check, `bindCommerceDiscoveryResource`, `fetchCommerceDiscoveryConnectionStatus`).

Why a maintainer wants it: one tolerant-parse implementation instead of two copies drifting apart — a future robustness fix (e.g. a body-size cap) only needs to land once.

Behavior preserved for every input:
- Empty/unparsable body -> `parseJsonResponse` returns `undefined` -> `parsed?.error` is `undefined` -> `isClaimCode(undefined)` is `false` -> `"unknown"` (same as before).
- Parsed JSON with a recognized `error` code -> unchanged.
- Parsed JSON with an unrecognized `error` (or missing `error`) -> `"unknown"` (same as before).

-9 / +5 lines, no behavior change, no new exports.

How I verified: `bun test apps/api/src/tools/reports/auth-client.test.ts` (26 pass, including the 403/409/400/non-JSON-body claim-error tests that exercise this exact function), `bunx tsc --noEmit` in `apps/api`, `bunx oxlint` on the touched file, `bun run fmt`. Full CI validates the rest.

Reviewer check: `bun test apps/api/src/tools/reports/auth-client.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates claim-error parsing in the reports auth client by routing `parseClaimErrorCode` through `parseJsonResponse`. This removes duplicate tolerant JSON parsing and preserves behavior for all responses.

**Review notes**
- `parseClaimErrorCode` now uses `parseJsonResponse`; empty or non-JSON bodies still return "unknown".
- Recognized `error` codes behave the same; unrecognized or missing values still return "unknown".
- No API or export changes; only `apps/api/src/tools/reports/auth-client.ts` is modified. Run `bun test apps/api/src/tools/reports/auth-client.test.ts` to verify the claim-error cases.

<sup>Written for commit 04ebd74626031aad24ed8d5814ac70166f32994e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

