### PR TITLE
docs(pt-br): sync the subtask tool description with connection-scoped subagents

### DIFF
--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/decopilot/tools.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/decopilot/tools.mdx
@@ -20,7 +20,7 @@ Essas são as tools que o agent Decopilot usa internamente para gerenciar o pró
 
 | Tool | Disponível em subtasks | O que faz |
 |---|:---:|---|
-| `subtask` | Não | Inicia uma subtask, opcionalmente com um agent específico |
+| `subtask` | Não | Inicia uma subtask com um agent clonado, outro agent, ou um agent efêmero restrito a uma connection MCP específica |
 | `user_ask` | Não | Pergunta a você quando precisa de input |
 | `enable_tool` | Sim | Ativa uma scope tool para que ela possa ser chamada no próximo passo |
 | `read_resource` | Sim | Lê documentação ou diretrizes do escopo atual |


### PR DESCRIPTION
PR #4589 ("feat(decopilot): support connection-scoped subagents") updated the English `subtask` tool row in `studio/decopilot/tools.mdx` to describe the three subtask kinds — a cloned agent, another agent, or an ephemeral agent scoped to a concrete MCP connection — but the Portuguese translation was never updated and still describes the old, pre-#4589 behavior ("Inicia uma subtask, opcionalmente com um agent específico"), which omits the connection-scoped-subagent capability entirely.

A maintainer wants pt-br readers to see the same tool contract as en readers, since the docs are the spec for how Decopilot's `subtask` tool actually works.

Change: one line in `apps/docs/client/src/content/deco-studio/pt-br/studio/decopilot/tools.mdx`, translating the current English row verbatim: "Inicia uma subtask com um agent clonado, outro agent, ou um agent efêmero restrito a uma connection MCP específica".

To confirm: diff the `subtask` row in `apps/docs/client/src/content/deco-studio/en/studio/decopilot/tools.mdx` against the pt-br file — they now describe the same three subtask kinds.

This is a docs-content-only change (no code, no build step to verify); I diffed the en/pt-br pair line-by-line, which is what the docs i18n review is for.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the pt-br `subtask` tool description to include connection-scoped subagents, matching the current English spec. Previously: “Inicia uma subtask, opcionalmente com um agent específico.” Now: “Inicia uma subtask com um agent clonado, outro agent, ou um agent efêmero restrito a uma connection MCP específica.”

**Review notes**
- One-line change in `apps/docs/client/src/content/deco-studio/pt-br/studio/decopilot/tools.mdx`; no code or build impact.
- Compare the `subtask` row with `apps/docs/client/src/content/deco-studio/en/studio/decopilot/tools.mdx`; both should list the same three subtask kinds.
- Terminology mirrors en: “agent clonado”, “outro agent”, and “agent efêmero … connection MCP específica.”

<sup>Written for commit 70313879fa97b65cd68ff1046fd5ac366eccd99c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

