### PR TITLE
fix(mcp-clients): strip __binding recursively from configuration state before JWT embed

### DIFF
--- a/apps/api/src/mcp-clients/outbound/headers.test.ts
+++ b/apps/api/src/mcp-clients/outbound/headers.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { stripBindingMetadata } from "./headers";
+
+describe("stripBindingMetadata", () => {
+  test("strips __binding from a top-level object value", () => {
+    const input = {
+      connection: {
+        __type: "@deco/database",
+        value: "conn_1",
+        __binding: [{ name: "QUERY" }],
+      },
+    };
+    expect(stripBindingMetadata(input)).toEqual({
+      connection: { __type: "@deco/database", value: "conn_1" },
+    });
+  });
+
+  test("strips __binding from array items", () => {
+    const input = {
+      connections: [
+        {
+          __type: "@deco/database",
+          value: "conn_1",
+          __binding: [{ name: "QUERY" }],
+        },
+        {
+          __type: "@deco/database",
+          value: "conn_2",
+          __binding: [{ name: "QUERY" }],
+        },
+      ],
+    };
+    expect(stripBindingMetadata(input)).toEqual({
+      connections: [
+        { __type: "@deco/database", value: "conn_1" },
+        { __type: "@deco/database", value: "conn_2" },
+      ],
+    });
+  });
+
+  test("strips __binding nested inside a grouped object", () => {
+    const input = {
+      group: {
+        connection: {
+          __type: "@deco/llm",
+          value: "conn_3",
+          __binding: [{ name: "CHAT" }],
+        },
+      },
+    };
+    expect(stripBindingMetadata(input)).toEqual({
+      group: {
+        connection: { __type: "@deco/llm", value: "conn_3" },
+      },
+    });
+  });
+
+  test("leaves values without __binding unchanged", () => {
+    const input = { foo: "bar", nested: { baz: 1 } };
+    expect(stripBindingMetadata(input)).toEqual(input);
+  });
+
+  test("passes through non-object values", () => {
+    expect(stripBindingMetadata(null)).toBeNull();
+    expect(stripBindingMetadata(undefined)).toBeUndefined();
+    expect(stripBindingMetadata("x")).toBe("x");
+  });
+});

--- a/apps/api/src/mcp-clients/outbound/headers.ts
+++ b/apps/api/src/mcp-clients/outbound/headers.ts
@@ -20,26 +20,24 @@ import { writeStudioHeader } from "@/core/studio-headers";
  * Strip `__binding` from configuration state values before embedding in JWTs.
  * `__binding` contains tool schemas used only by the UI for connection filtering —
  * it can be very large and causes 431 (header too large) errors when included.
+ *
+ * Recurses into arrays and nested objects: a downstream MCP's config schema is
+ * arbitrary (Studio doesn't control it), so a binding field can legitimately sit
+ * inside a multi-value array or a grouped/nested object, not just at the top level.
  */
-function stripBindingMetadata(
-  state: Record<string, unknown> | null | undefined,
-): Record<string, unknown> | undefined {
-  if (!state) return undefined;
-  const cleaned: Record<string, unknown> = {};
-  for (const [key, val] of Object.entries(state)) {
-    if (
-      val &&
-      typeof val === "object" &&
-      !Array.isArray(val) &&
-      "__binding" in val
-    ) {
-      const { __binding, ...rest } = val as Record<string, unknown>;
-      cleaned[key] = rest;
-    } else {
-      cleaned[key] = val;
-    }
+export function stripBindingMetadata(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripBindingMetadata);
   }
-  return cleaned;
+  if (value && typeof value === "object") {
+    const { __binding, ...rest } = value as Record<string, unknown>;
+    const cleaned: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(rest)) {
+      cleaned[key] = stripBindingMetadata(val);
+    }
+    return cleaned;
+  }
+  return value;
 }
 
 /**
@@ -118,9 +116,12 @@ async function _buildRequestHeaders(
           role: ctxUser?.role,
         },
         metadata: {
-          state: stripBindingMetadata(
-            connection.configuration_state as Record<string, unknown> | null,
-          ),
+          state: connection.configuration_state
+            ? (stripBindingMetadata(connection.configuration_state) as Record<
+                string,
+                unknown
+              >)
+            : undefined,
           studioUrl: ctx.baseUrl,
           meshUrl: ctx.baseUrl,
           connectionId,


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/mcp-clients/outbound/headers.ts` (MCP outbound transport robustness focus area).

**Why:** `stripBindingMetadata` exists specifically to prevent 431 (header-too-large) errors by stripping the `__binding` key — which embeds full tool schemas — from `configuration_state` before it's put in the JWT sent to downstream MCP servers. It only checked one level deep: a top-level state key whose *direct* object value carried `__binding`. Since Studio doesn't control a downstream MCP's config schema, a binding field can legitimately live inside an array (a multi-value connection selector) or a nested/grouped object — neither shape got stripped, silently reopening the exact 431 failure the function was written to prevent.

**Fix:** made the strip recursive over both arrays and nested objects, instead of a single shallow pass over top-level keys. Behavior for the existing shape (top-level object value with `__binding`) is unchanged — this only widens coverage to shapes it previously missed.

**Verify:** `bun test apps/api/src/mcp-clients/outbound/headers.test.ts` — new pure-logic unit test covering top-level, array, and nested-object `__binding` stripping, plus the untouched-passthrough cases.

**Checked locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test above (5 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents 431 header-too-large errors by recursively stripping `__binding` from `configuration_state` before embedding it in the JWT. Previously only top-level object values had `__binding` removed; now arrays and nested objects are covered.

- Recurses through arrays and nested objects and removes `__binding` at any depth; preserves existing top-level behavior.
- Only affects the JWT metadata payload; does not mutate input or stored state.
- Broadens `stripBindingMetadata` to accept `unknown`; call site now guards null/undefined.
- Adds unit tests covering top-level, array, nested-object stripping, and passthrough cases.

<sup>Written for commit 94cc8b38a963b6185823dd0362d75152eef9688e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

