### PR TITLE
fix(sections-editor): list saved multivariate section blocks in picker

### DIFF
--- a/apps/web/src/components/sections-editor/section-catalog.test.ts
+++ b/apps/web/src/components/sections-editor/section-catalog.test.ts
@@ -181,6 +181,50 @@ describe("section-catalog", () => {
     expect(resolveTypes).not.toContain("Preview /sections/Footer.tsx");
   });
 
+  it("extractSectionCatalog includes saved multivariate section blocks", () => {
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          pages: {
+            "website/pages/Page.tsx": { $ref: "#/definitions/Page" },
+          },
+          sections: {
+            "site/sections/Content/Alert.tsx": { $ref: "#/definitions/Alert" },
+          },
+        },
+      },
+      schema: { definitions: { Page: {}, Alert: {} } },
+    };
+
+    const decofile = {
+      Alerta: {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          {
+            value: { __resolveType: "site/sections/Content/Alert.tsx" },
+            rule: { __resolveType: "website/matchers/always.ts" },
+          },
+        ],
+      },
+      // Non-section variants must not be offered as an insertable section.
+      "Loader Flag": {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          { value: { __resolveType: "vtex/loaders/legacy/productList.ts" } },
+        ],
+      },
+    };
+
+    const catalog = extractSectionCatalog(meta, decofile);
+    const resolveTypes = catalog.map((entry) => entry.resolveType);
+
+    expect(resolveTypes).toContain("Alerta");
+    expect(resolveTypes).not.toContain("Loader Flag");
+    expect(catalog.find((e) => e.resolveType === "Alerta")?.isSavedBlock).toBe(
+      true,
+    );
+  });
+
   it("extractSectionCatalog includes manifest sections even when page anyOf is populated", () => {
     const meta: LiveMeta = {
       manifest: {

--- a/apps/web/src/components/sections-editor/section-catalog.ts
+++ b/apps/web/src/components/sections-editor/section-catalog.ts
@@ -10,7 +10,10 @@ import {
   type LiveMeta,
   type SchemaProperty,
 } from "./resolve-schema";
-import { labelFromResolveType } from "./section-types";
+import {
+  labelFromResolveType,
+  SECTION_MULTIVARIATE_RESOLVE_TYPE,
+} from "./section-types";
 
 export interface SectionCatalogEntry {
   resolveType: string;
@@ -120,6 +123,40 @@ export function listAvailableSections(
   return entries.sort((a, b) => a.title.localeCompare(b.title));
 }
 
+/**
+ * A saved block whose top-level resolveType is the multivariate section flag
+ * (`website/flags/multivariate/section.ts`) is still an insertable section — it
+ * wraps a real section under `variants[].value` (with A/B variants + matcher
+ * rules). Confirm at least one variant resolves to a manifest section so a dead
+ * flag isn't offered. Mirrors how the runtime resolves the block ref.
+ */
+function multivariateWrapsManifestSection(
+  meta: LiveMeta,
+  block: Record<string, unknown>,
+): boolean {
+  const variants = block.variants;
+  if (!Array.isArray(variants)) return false;
+
+  for (const variant of variants) {
+    const value = (variant as Record<string, unknown>)?.value as
+      | Record<string, unknown>
+      | undefined;
+    if (!value) continue;
+
+    // Lazy-wrapped section values nest the real section under `.section`.
+    let rt = value.__resolveType;
+    if (typeof rt === "string" && isLazyResolveType(rt)) {
+      const inner = value.section as Record<string, unknown> | undefined;
+      rt = inner?.__resolveType ?? rt;
+    }
+    if (typeof rt === "string" && isManifestSectionResolveType(meta, rt)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function listSavedSectionBlocks(
   meta: LiveMeta,
   decofile: Record<string, unknown>,
@@ -137,7 +174,12 @@ export function listSavedSectionBlocks(
     if (PAGE_BLOCK_RESOLVE_TYPES.has(rt)) continue;
     if (typeof obj.path === "string") continue;
     if (shouldSkipSectionResolveType(rt)) continue;
-    if (!isManifestSectionResolveType(meta, rt)) continue;
+
+    const isSectionBlock =
+      isManifestSectionResolveType(meta, rt) ||
+      (rt === SECTION_MULTIVARIATE_RESOLVE_TYPE &&
+        multivariateWrapsManifestSection(meta, obj));
+    if (!isSectionBlock) continue;
 
     entries.push({
       resolveType: key,


### PR DESCRIPTION
## Summary

The **Add Section** picker's search couldn't find saved blocks that are **multivariate section flags** (e.g. farmrio's `Alerta` — the A/B tipbar with variants "ETC Segment", "By date", "Default").

Root cause: `listSavedSectionBlocks` (`section-catalog.ts`) only accepted a saved block when its **top-level** `__resolveType` was a manifest section (`site/sections/*`). A multivariate section flag wraps the real section under `variants[].value`, so its top-level resolveType is `website/flags/multivariate/section.ts` — which isn't in the manifest as a section — and the block was silently dropped from the catalog (and therefore from search), even though it renders fine on live pages.

On farmrio this hid 3 reusable blocks: `Alerta`, `benefícios app versão att`, `carrossel quadrado vestidos - home farm verão 27`.

## Change

`listSavedSectionBlocks` now also accepts blocks whose top-level resolveType is the multivariate section flag, gated by a new `multivariateWrapsManifestSection` helper that confirms at least one variant resolves to a manifest section (unwrapping a lazy wrapper first). This keeps dead flags — or flags wrapping a loader — out of the picker.

The resulting catalog entry is **identical in shape** to a direct-section saved block (block-id `resolveType`, `previewBlock` = block key, `isSavedBlock: true`), so preview and insertion follow the existing saved-block path unchanged.

## Testing

- New test in `section-catalog.test.ts`: a multivariate section block (`Alerta` → `Content/Alert.tsx`) is included; a multivariate flag wrapping a loader is **not**.
- `bun test` sections-editor: **701 pass / 0 fail**
- `tsc --noEmit`: clean
- `bun run fmt` / lint: clean on changed files

## Affected areas

Sections editor "Add Section" picker only. No schema, runtime, or storage changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Add Section picker now lists saved multivariate section blocks that wrap real sections, restoring hidden reusable blocks (e.g., farmrio’s “Alerta”). Previously it only showed saved blocks whose top-level `__resolveType` was a manifest section; now it also accepts `website/flags/multivariate/section.ts` when at least one variant resolves to a manifest section.

**Review notes**
- Adds `multivariateWrapsManifestSection` and gates on `SECTION_MULTIVARIATE_RESOLVE_TYPE`, unwrapping lazy variants before checking `isManifestSectionResolveType`.
- Keeps catalog entries identical to direct-section saved blocks (`isSavedBlock: true`), so preview and insertion paths are unchanged.
- Tests ensure a multivariate section block is included and a loader-wrapped flag is excluded; typecheck and lint are clean.
- Scope: sections editor “Add Section” picker only; no schema, runtime, or storage changes.

<sup>Written for commit b50fd56a11f0f026a739fc798450fb30b87b71e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

