### PR TITLE
perf(task-board): parallelize the item-list and github-connections queries

### DIFF
--- a/apps/api/src/tools/task-board/list.ts
+++ b/apps/api/src/tools/task-board/list.ts
@@ -35,11 +35,10 @@ export const TASK_BOARD_ITEM_LIST = defineTool({
       );
     }
 
-    const items = await ctx.storage.taskBoard.list(organizationId);
-    const { items: githubConnections } = await ctx.storage.connections.list(
-      organizationId,
-      { slug: "mcp-github" },
-    );
+    const [items, { items: githubConnections }] = await Promise.all([
+      ctx.storage.taskBoard.list(organizationId),
+      ctx.storage.connections.list(organizationId, { slug: "mcp-github" }),
+    ]);
     const repos = listRepoScopeLabels(githubConnections);
 
     // Opening the board is the stall-recovery trigger: re-run the thread-finish


### PR DESCRIPTION
**Source:** DB-latency investigation on task-board storage paths (this tick's focus area).

**Payoff:** `TASK_BOARD_ITEM_LIST` fires on every task-board open/refresh and was awaiting two independent queries sequentially: `taskBoard.list()` (already a heavily-optimized batched query joining threads/tags) and `connections.list()` for the GitHub repo picker. Neither reads the other's result, and each goes through Kysely's connection pool independently (not a shared transaction), so there's no correctness reason to serialize them. Running them with `Promise.all` overlaps their round-trip time instead of adding it, shaving the tool's wall-clock latency on every board load.

**Change:** `apps/api/src/tools/task-board/list.ts` — replaced two sequential `await`s with a single `Promise.all`. Behavior-preserving: same two calls, same inputs/outputs, `repos` still derived from `githubConnections` after both resolve.

**Verify:**
- `cd apps/api && bunx tsc --noEmit` — green.
- `bunx oxlint apps/api/src/tools/task-board/list.ts` — 0 warnings/errors.
- `bun run fmt` — no changes.
- No existing unit test covers this tool (it's a thin storage-composition handler needing a real DB per repo testing policy); full CI's integration/e2e suite validates the DB-backed behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelizes task-board item fetch and GitHub connections fetch to reduce board load latency. Previously awaited `taskBoard.list()` then `connections.list()`; now runs both with `Promise.all` with the same response and repo derivation.

**Review notes**
- Replaces two sequential awaits with `Promise.all` in `apps/api/src/tools/task-board/list.ts`.
- The queries are independent; no shared transaction or data dependency.
- Behavior unchanged: same inputs/outputs; `repos` still computed from GitHub connections after both resolve.

<sup>Written for commit a9c44cb087e47700d42b73706215de844585527f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

