### PR TITLE
fix(sections-editor): group multivariate saved sections by their real component type

### DIFF
--- a/apps/web/src/components/sections-editor/page-list.test.ts
+++ b/apps/web/src/components/sections-editor/page-list.test.ts
@@ -201,6 +201,39 @@ describe("page-list", () => {
     });
   });
 
+  it("extractGlobalSections resolves the underlying component type for a multivariate-wrapped section", () => {
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          sections: {
+            "site/sections/Content/Alert.tsx": { $ref: "#/definitions/Alert" },
+          },
+        },
+      },
+      schema: {},
+    };
+    const decofile = {
+      Alerta: {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          {
+            value: { __resolveType: "site/sections/Content/Alert.tsx" },
+            rule: { __resolveType: "website/matchers/always.ts" },
+          },
+        ],
+      },
+    };
+
+    const sections = extractGlobalSections(decofile, meta);
+    expect(sections).toEqual([
+      {
+        key: "Alerta",
+        name: "Alerta",
+        resolveType: "site/sections/Content/Alert.tsx",
+      },
+    ]);
+  });
+
   it("hasEditableDecoContent is true when pages exist", () => {
     expect(
       hasEditableDecoContent(

--- a/apps/web/src/components/sections-editor/page-list.tsx
+++ b/apps/web/src/components/sections-editor/page-list.tsx
@@ -5,7 +5,10 @@ import {
   type LiveMeta,
 } from "./resolve-schema";
 import { normalizePagePath } from "./page-path-utils";
-import { listSavedSectionBlocks } from "./section-catalog";
+import {
+  listSavedSectionBlocks,
+  underlyingSectionResolveType,
+} from "./section-catalog";
 import { extractRedirects } from "@/components/sandbox/content/redirect-data";
 
 export interface PageEntry {
@@ -288,8 +291,7 @@ export function extractGlobalSections(
   return listSavedSectionBlocks(meta, decofile)
     .map((entry) => {
       const block = decofile[entry.resolveType] as Record<string, unknown>;
-      const resolveType =
-        typeof block.__resolveType === "string" ? block.__resolveType : "";
+      const resolveType = underlyingSectionResolveType(meta, block);
       return {
         key: entry.resolveType,
         name: entry.description ?? globalSectionLabel(entry.resolveType, block),

--- a/apps/web/src/components/sections-editor/section-catalog.ts
+++ b/apps/web/src/components/sections-editor/section-catalog.ts
@@ -124,18 +124,23 @@ export function listAvailableSections(
 }
 
 /**
- * A saved block whose top-level resolveType is the multivariate section flag
- * (`website/flags/multivariate/section.ts`) is still an insertable section — it
- * wraps a real section under `variants[].value` (with A/B variants + matcher
- * rules). Confirm at least one variant resolves to a manifest section so a dead
- * flag isn't offered. Mirrors how the runtime resolves the block ref.
+ * For a saved block wrapped in the multivariate section flag
+ * (`website/flags/multivariate/section.ts`), the underlying component's
+ * resolveType — read from the first variant that resolves to a manifest
+ * section (with A/B variants + matcher rules). Mirrors how the runtime
+ * resolves the block ref. Non-multivariate blocks (or a flag with no
+ * resolvable variant) just return their own resolveType unchanged.
  */
-function multivariateWrapsManifestSection(
+export function underlyingSectionResolveType(
   meta: LiveMeta,
   block: Record<string, unknown>,
-): boolean {
+): string {
+  const rt = block.__resolveType;
+  if (typeof rt !== "string") return "";
+  if (rt !== SECTION_MULTIVARIATE_RESOLVE_TYPE) return rt;
+
   const variants = block.variants;
-  if (!Array.isArray(variants)) return false;
+  if (!Array.isArray(variants)) return rt;
 
   for (const variant of variants) {
     const value = (variant as Record<string, unknown>)?.value as
@@ -144,17 +149,32 @@ function multivariateWrapsManifestSection(
     if (!value) continue;
 
     // Lazy-wrapped section values nest the real section under `.section`.
-    let rt = value.__resolveType;
-    if (typeof rt === "string" && isLazyResolveType(rt)) {
+    let variantRt = value.__resolveType;
+    if (typeof variantRt === "string" && isLazyResolveType(variantRt)) {
       const inner = value.section as Record<string, unknown> | undefined;
-      rt = inner?.__resolveType ?? rt;
+      variantRt = inner?.__resolveType ?? variantRt;
     }
-    if (typeof rt === "string" && isManifestSectionResolveType(meta, rt)) {
-      return true;
+    if (
+      typeof variantRt === "string" &&
+      isManifestSectionResolveType(meta, variantRt)
+    ) {
+      return variantRt;
     }
   }
 
-  return false;
+  return rt;
+}
+
+/**
+ * A saved block whose top-level resolveType is the multivariate section flag
+ * is still an insertable section — confirm at least one variant resolves to a
+ * manifest section so a dead flag isn't offered.
+ */
+function multivariateWrapsManifestSection(
+  meta: LiveMeta,
+  block: Record<string, unknown>,
+): boolean {
+  return underlyingSectionResolveType(meta, block) !== block.__resolveType;
 }
 
 export function listSavedSectionBlocks(


### PR DESCRIPTION
Follows #6455, which made `listSavedSectionBlocks`/`extractSectionCatalog` recognize saved sections wrapped in the `website/flags/multivariate/section.ts` A/B-test flag as insertable sections.

`extractGlobalSections` (page-list.tsx), used by the content browser's saved-sections list and grouping (`groupSavedSectionsByResolveType` in section-group-header.tsx), sets each entry's `resolveType` straight from the saved block's own `__resolveType`. For any multivariate-wrapped section that is now `website/flags/multivariate/section.ts` for every single A/B-tested section regardless of which component it actually wraps (Alert, Banner, …), so `sectionTypeLabel` (which takes the last path segment, e.g. "Alert") collapses every A/B-tested section into one generic "Section" group in the sidebar instead of grouping by its real component type — a real regression newly exposed by #6455's own change, since multivariate blocks weren't in this list before.

Fix: added `underlyingSectionResolveType(meta, block)` in section-catalog.ts (extracted from the existing multivariate-unwrap logic used by `listSavedSectionBlocks`) and use it in `extractGlobalSections` so a multivariate-wrapped block's `resolveType` reflects the underlying component, not the flag wrapper. Non-multivariate blocks are unaffected (returns their own resolveType, matching the existing test at page-list.test.ts:169).

Regression test: `page-list.test.ts` — "extractGlobalSections resolves the underlying component type for a multivariate-wrapped section", asserting `resolveType` is the wrapped `site/sections/Content/Alert.tsx`, not the flag path.

To confirm: `cd apps/web && bun test src/components/sections-editor/page-list.test.ts src/components/sections-editor/section-catalog.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), the targeted test file above (30 pass), and `bunx oxlint` on the three touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups multivariate saved sections in the sections editor by the underlying component type instead of the `website/flags/multivariate/section.ts` wrapper. Previously all A/B-tested sections collapsed into a single "Section" group; now they group by their actual components (e.g., Alert, Banner).

- Introduces `underlyingSectionResolveType` in `section-catalog.ts` to resolve the real component from multivariate variants, falling back to the block’s own resolveType when needed.
- Uses this resolver in `extractGlobalSections` so `resolveType` reflects the underlying section; non-multivariate blocks are unchanged.
- Aligns `multivariateWrapsManifestSection` with the new resolver for consistent insertability checks.
- Adds a regression test confirming a multivariate-wrapped section resolves to its `site/sections/...` type.

<sup>Written for commit 9d8aa365a474132cd3024d8af164317283aee768. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

