### PR TITLE
fix(helm): publish agent sandbox chart changes

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,6 +2,10 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
+# 0.16.0: removes the public NATS link tunnel and moves the retained internal
+# cluster credentials mount from tunnel.nats.clusterCreds to nats.clusterCreds.
+# Hosted execution is now enabled explicitly with
+# STUDIO_AGENT_SANDBOX_ENABLED; the provider and runner selectors are gone.
 # 0.15.0: the single-writer migration Job now runs outside preview too
 # (migrateJob.enabled, default true). Every replica migrates the DBOS system
 # schema on boot and the SDK bumps its version with an UPDATE that has no
@@ -76,7 +80,7 @@ type: application
 # when disabled, so existing releases are unaffected.
 # 0.12.4: chart-managed API/worker dispatch roles now use
 # STUDIO_DISPATCH_ROLE; legacy overrides are rejected.
-version: 0.15.0
+version: 0.16.0
 appVersion: "latest"
 
 dependencies:


### PR DESCRIPTION
## Summary

- publish chart 0.16.0 for the hosted AgentSandbox simplification
- publish the removal of the retired public NATS link tunnel

## Review shape

This is the one-file top of Studio Stack #6542. The implementation from the original large diff is split into 18 focused PRs below it, rooted at #6515.

The PostgreSQL CA fix #6509 and native reclaim race fix #6534 are independent PRs based directly on `main`; neither is part of this stack.

## Testing

- formatting, full workspace typecheck, lint with 0 errors, and knip
- Helm lint and default renders
- Go vet, race tests, and daemon build
- focused TypeScript, Rust, Go, daemon black-box, Helm, Compose, and multi-pod suites across the stack
- no database migrations

## Related work

- follow-up task-board availability gate: #6502
- deployment cleanup: decocms/deco-apps-cd#361

Top of Stack #6542; depends directly on #6531.
