### PR TITLE
fix(sandbox): stop the Go daemon's grep route hanging on an oversized match line

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/fs.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs.go
@@ -561,6 +561,14 @@ func Grep(deps FsDeps) http.HandlerFunc {
 			}
 			lines = append(lines, line)
 		}
+		if reader.Err() != nil && !truncated {
+			// A line over the scanner's buffer cap (e.g. a minified/lockfile
+			// match) leaves rg still writing to a pipe nobody drains; without
+			// killing it here, cmd.Wait() below blocks forever once the pipe
+			// buffer fills, hanging the request and the daemon's health probe.
+			truncated = true
+			cmd.Process.Kill()
+		}
 		err = cmd.Wait()
 		code := 0
 		if err != nil {

--- a/packages/sandbox/daemon-go/internal/routes/fs_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // seedBlocks lays a repo with two `.deco/blocks/*.json` sources but NO merged
@@ -94,6 +95,49 @@ func TestGrepCapsCallerSuppliedLimit(t *testing.T) {
 	}
 	if out.MatchCount > grepMaxResultLimit {
 		t.Fatalf("expected matchCount capped at %d, got %d", grepMaxResultLimit, out.MatchCount)
+	}
+}
+
+// A match line longer than the scanner's 4MB buffer used to hang the request
+// forever: Scan() gave up on the oversized line but rg kept writing to a pipe
+// nobody was draining, so cmd.Wait() blocked once the pipe buffer filled.
+func TestGrepOversizedLineDoesNotHang(t *testing.T) {
+	if _, err := exec.LookPath("rg"); err != nil {
+		t.Skip("ripgrep not installed")
+	}
+	repoDir := t.TempDir()
+	var content strings.Builder
+	content.WriteString("needle ")
+	for content.Len() < 5*1024*1024 {
+		content.WriteString("padding ")
+	}
+	content.WriteString("\n")
+	for i := 0; i < 2000; i++ {
+		content.WriteString("needle\n")
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "haystack.txt"), []byte(content.String()), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	deps := FsDeps{AppRoot: repoDir, RepoDir: repoDir}
+	body, _ := json.Marshal(map[string]any{
+		"pattern":     "needle",
+		"output_mode": "content",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grep", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		Grep(deps)(rec, req)
+		close(done)
+	}()
+	select {
+	case <-done:
+		if rec.Code != 200 {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Grep hung on an oversized match line")
 	}
 }
 


### PR DESCRIPTION
**Source**: bug found while reviewing the Go daemon's fs routes (`packages/sandbox/daemon-go/internal/routes/fs.go`) for edge-case handling and error-reporting consistency, per this tick's focus area.

**Why a maintainer wants it**: the daemon's health probe is unforgiving — a single missed probe tears the sandbox pod down mid-session — so a request path that can hang forever is a real reliability bug, not just a slow response.

**Failure scenario**: `/grep` in content mode spawns `rg` and scans its stdout with `bufio.Scanner` capped at a 4MB buffer (`bufioScanner` in `util.go`). If a matched line is longer than that (a minified bundle, a lockfile, a generated file — all plausible in a real repo), `Scan()` returns `false` on the oversized-token error, and the loop exits. Nothing else reads from the `stdout` pipe after that. If `rg` still has more output queued, it blocks on the next pipe write once the OS pipe buffer fills, and `cmd.Wait()` right after the loop blocks forever waiting for a process that will never exit — hanging the request (and eventually the daemon itself).

**Fix**: mirror the existing result-limit truncation path — when the scanner stops with an error, kill the `rg` process before calling `cmd.Wait()`, and report the results gathered so far as truncated instead of hanging.

**Regression test**: `TestGrepOversizedLineDoesNotHang` in `fs_test.go` writes a haystack with one >5MB line plus normal matches, calls `Grep` on a goroutine, and fails if it doesn't complete within 10s (before the fix this reproduces the hang). Skips locally without ripgrep installed, same as the existing `TestGrepCapsCallerSuppliedLimit`.

**To confirm**: `cd packages/sandbox/daemon-go && go test ./internal/routes/ -run TestGrep -v` (needs `rg` on PATH; CI has it).

**Locally verified**: `go build ./...`, `go vet ./internal/routes/...`, `gofmt -l` (clean) — ripgrep isn't installed in this sandbox so the two `TestGrep*` tests skip here exactly as they do for any environment without it; full CI runs them for real.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `/grep` in content mode from hanging when ripgrep outputs a match line larger than the scanner buffer. Previously the handler stopped reading and `rg` blocked on stdout, causing the request to hang; now we kill `rg` on a scanner error and return partial results as truncated.

- Mirrors the existing truncation path: on `bufio.Scanner` error, set truncated and call `cmd.Process.Kill()` before `cmd.Wait()`.
- Response behavior is unchanged otherwise; requests complete with 200 and indicate truncation when hit.
- Adds `TestGrepOversizedLineDoesNotHang` in `packages/sandbox/daemon-go/internal/routes/fs_test.go`; skips without `rg` on PATH, CI runs it.

<sup>Written for commit 272c0778f34512999bf14290ccd51238532e7287. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

