### PR TITLE
fix(thread/github): wire the head-moved guard into the coding session's publish dialog

### DIFF
--- a/apps/web/src/components/thread/github/publish-dialog.tsx
+++ b/apps/web/src/components/thread/github/publish-dialog.tsx
@@ -349,6 +349,7 @@ function PublishDialogBody({
     headBranch: githubHeadBranch,
     coAuthor,
     existingOpenPr,
+    expectedHeadSha: headSha ?? undefined,
   };
 
   const messageParts = () =>


### PR DESCRIPTION
`publish-flow.ts`'s `runPublishFlow`/`runSubmitForReviewFlow` were built (#6325) to check `PublishTarget.expectedHeadSha` against the branch's live head before mutating anything, throwing `PublishHeadMovedError` if someone else's commit (a teammate, the coding agent, or the author's own autosave in another tab) landed after the change list was shown. `cms-publish-popover.tsx` (Fast Preview) wires this correctly with `expectedHeadSha: headSha ?? undefined`, but `publish-dialog.tsx` — the coding-session's own PublishDialog, the one surface where a live coding agent is most likely to keep committing while the dialog is open — never set it on its `publishTarget`, even though it already receives the confirmed `headSha` prop (used elsewhere in the same file for the base…head diff) and `header-actions.tsx` passes it the same `effectiveBranchMeta.headSha` the CMS surface uses. The guard was silently a no-op for this dialog since it shipped.

**Failure scenario:** open the publish dialog on a sandbox branch, let the coding agent (or a teammate) push another commit while the dialog is still open, then click Publish/Submit for review — the flow proceeds on the stale change list instead of throwing `PublishHeadMovedError` and asking the author to re-read the diff.

**Fix:** pass `expectedHeadSha: headSha ?? undefined` into `publishTarget`, matching `cms-publish-popover.tsx`'s existing wiring — a one-line, behavior-only-tightening change (turns a previously-silent no-op guard into a live one; nothing else changes).

How to confirm: `cd apps/web && bunx tsc --noEmit` (clean) and `bunx oxlint apps/web/src/components/thread/github/publish-dialog.tsx` (0 warnings/errors). No existing test covers `runPublishFlow`'s head-check path against this specific dialog (it needs a full MCP-client + sandbox mock to exercise), so this was verified by tracing the exact prop wiring against the working `cms-publish-popover.tsx` sibling and confirming the type/lint checks stay green; full CI runs the rest.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web), `bunx oxlint` on the changed file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the head-moved guard in the coding-session Publish dialog. Previously it published from a stale change list if new commits arrived after opening; now it supplies the current head SHA and throws PublishHeadMovedError when the branch head has moved.

- Matches the existing Fast Preview popover by passing expectedHeadSha from the dialog’s headSha prop.
- No UI or API changes; only blocks Publish/Submit when the live head differs.
- If headSha is unavailable, the guard remains a no-op (unchanged behavior).

<sup>Written for commit 06a339517523cacc28e1ce7537d71536eccc6e69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

