### PR TITLE
fix(decopilot): cap persisted error part text

### DIFF
--- a/apps/api/src/api/routes/decopilot/part-row-builder.test.ts
+++ b/apps/api/src/api/routes/decopilot/part-row-builder.test.ts
@@ -201,6 +201,21 @@ describe("PartRowBuilder", () => {
     ]);
   });
 
+  it("truncates an oversized error text", () => {
+    const builder = new PartRowBuilder({
+      orgId: "org_1",
+      threadId: "thread_1",
+      runId: "thread_1",
+      baseTimeMs: 1_700_000_000_000,
+    });
+
+    const rows = builder.emitError("error_msg", "x".repeat(2_000_000));
+    const text = (rows[0]?.payload as { text: string }).text;
+
+    expect(text.length).toBeLessThan(8_200);
+    expect(text).toEndWith("… [truncated 1992000 characters]");
+  });
+
   it("does not freeze streaming text", () => {
     expect(isFinalPart({ type: "text", state: "streaming", text: "he" })).toBe(
       false,

--- a/apps/api/src/api/routes/decopilot/part-row-builder.ts
+++ b/apps/api/src/api/routes/decopilot/part-row-builder.ts
@@ -357,11 +357,25 @@ export class PartRowBuilder {
       const seq = this.seqFor(key);
       const row = this.row(messageId, "assistant", seq, "error", {
         type: "text",
-        text: `Error: ${errorText}`,
+        text: `Error: ${truncateErrorText(errorText)}`,
       });
       this.partKeyByRowId.set(row.id, key);
       rows.push(row);
     }
     return [...rows, ...this.markFinished(messageId, "assistant")];
   }
+}
+
+/**
+ * Cap on persisted error text. Some errors quote their whole input back — an AI
+ * SDK `Type validation failed` embeds the entire message array — and the part is
+ * replayed into the next request, so an untruncated one grows on every retry
+ * until the thread is unloadable and the provider rejects the prompt.
+ */
+const MAX_ERROR_TEXT_LENGTH = 8_000;
+
+function truncateErrorText(errorText: string): string {
+  if (errorText.length <= MAX_ERROR_TEXT_LENGTH) return errorText;
+  const dropped = errorText.length - MAX_ERROR_TEXT_LENGTH;
+  return `${errorText.slice(0, MAX_ERROR_TEXT_LENGTH)}… [truncated ${dropped} characters]`;
 }


### PR DESCRIPTION
## Problem

Thread `eba78149-9253-44ee-bd5d-3f4cbfd97828` (org `demo-storefront`) is unopenable — the page dies on load. It holds **4.3 MB of parts**, 3.3 MB of which are two `error` parts.

Chain:

1. `TASK_BOARD_ITEM_LIST` returned a **820 KB** `tool_result` in one call.
2. A later run failed AI SDK validation: `Type validation failed … Invalid string: must start with "data-"`.
3. That error's `.message` **embeds the entire serialized message array**, and it was persisted verbatim as an `error` part → **1.07 MB** row.
4. The part is replayed into the next request's history, so the next failure embedded the previous one → **2.23 MB** row. Exactly double. Self-amplifying.
5. Final run died with `failure_kind: overloaded` — a multi-MB prompt.

Not isolated: 4 prod threads have `error` parts over 100 KB, the largest **3.82 MB** (from 2026-07-24), so the pattern has been live for a month.

## Fix

One guard at the single place the value is persisted — `PartRowBuilder.emitError` — capping the text at 8 000 chars with an explicit `[truncated N characters]` suffix. That breaks the amplification loop, which is what makes a thread unrecoverable.

## Not in this PR

- The part type that actually fails validation (a `tool-<name>` not declared in the UIMessage schema, so Zod reports the last union branch, `data-${string}`). Without it the error still fires — just small and harmless now.
- Paginating / size-capping `TASK_BOARD_ITEM_LIST`; 820 KB in one tool result is its own context problem.

## Testing

`bun test apps/api/src/api/routes/decopilot/part-row-builder.test.ts` — 12 pass, including a new case asserting a 2 MB error text is truncated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps persisted error part text at 8,000 characters to prevent runaway payload growth that made some threads unloadable and caused provider prompt rejections. Previously we stored the full error message; now we truncate and mark the omission.

- Truncates error text in `PartRowBuilder.emitError` and appends "… [truncated N characters]".
- Scope: only affects persisted `error` parts; other part types are unchanged.
- Adds a test asserting a 2 MB error is truncated.

<sup>Written for commit a615717317602335fd9856be2a05530185323507. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

