### PR TITLE
fix(decopilot): cap a persisted tool part's errorText, not just the run-level error text

### DIFF
--- a/apps/api/src/api/routes/decopilot/part-row-builder.test.ts
+++ b/apps/api/src/api/routes/decopilot/part-row-builder.test.ts
@@ -216,6 +216,33 @@ describe("PartRowBuilder", () => {
     expect(text).toEndWith("… [truncated 1992000 characters]");
   });
 
+  it("truncates an oversized tool output-error errorText", () => {
+    const builder = new PartRowBuilder({
+      orgId: "org_1",
+      threadId: "thread_1",
+      runId: "thread_1",
+      baseTimeMs: 1_700_000_000_000,
+    });
+
+    const rows = builder.emitFinal({
+      id: "assistant_1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-search",
+          state: "output-error",
+          toolCallId: "tc_1",
+          input: {},
+          errorText: "x".repeat(2_000_000),
+        },
+      ],
+    });
+
+    const payload = rows[0]?.payload as { errorText: string };
+    expect(payload.errorText.length).toBeLessThan(8_200);
+    expect(payload.errorText).toEndWith("… [truncated 1992000 characters]");
+  });
+
   it("does not freeze streaming text", () => {
     expect(isFinalPart({ type: "text", state: "streaming", text: "he" })).toBe(
       false,

--- a/apps/api/src/api/routes/decopilot/part-row-builder.ts
+++ b/apps/api/src/api/routes/decopilot/part-row-builder.ts
@@ -161,7 +161,7 @@ export class PartRowBuilder {
         message.role,
         seq,
         kindForPart(part),
-        part,
+        capPartErrorText(part),
       );
       this.partKeyByRowId.set(row.id, key);
       rows.push(row);
@@ -187,7 +187,7 @@ export class PartRowBuilder {
         message.role,
         seq,
         kindForPart(part),
-        part,
+        capPartErrorText(part),
       );
       this.partKeyByRowId.set(row.id, key);
       rows.push(row);
@@ -321,7 +321,7 @@ export class PartRowBuilder {
         message.role,
         seq,
         kindForPart(part),
-        part,
+        capPartErrorText(part),
       );
       this.partKeyByRowId.set(row.id, key);
       rows.push(row);
@@ -378,4 +378,23 @@ function truncateErrorText(errorText: string): string {
   if (errorText.length <= MAX_ERROR_TEXT_LENGTH) return errorText;
   const dropped = errorText.length - MAX_ERROR_TEXT_LENGTH;
   return `${errorText.slice(0, MAX_ERROR_TEXT_LENGTH)}… [truncated ${dropped} characters]`;
+}
+
+/**
+ * Same growth mechanism as {@link truncateErrorText}, on a different part
+ * shape: a tool part's `input-error`/`output-error` state carries its own
+ * `errorText` (often quoting the tool's own oversized input back, e.g. a
+ * schema-validation failure on a large write). It is stored raw and replayed
+ * into every later request the same way an assistant error part is, so an
+ * uncapped one grows the thread on every retry exactly like the case above.
+ */
+function capPartErrorText(part: AnyPart): AnyPart {
+  const errorText = (part as { errorText?: unknown }).errorText;
+  if (
+    typeof errorText !== "string" ||
+    errorText.length <= MAX_ERROR_TEXT_LENGTH
+  ) {
+    return part;
+  }
+  return { ...part, errorText: truncateErrorText(errorText) };
 }


### PR DESCRIPTION
Follows #6462, which capped `PartRowBuilder.emitError`'s run-level error text at 8,000 chars because some errors quote their whole input back (an AI SDK `Type validation failed` embeds the entire message array) and the persisted part is replayed into the next request — so an untruncated one grows on every retry until the thread is unloadable.

The same growth mechanism exists on a different, uncapped part shape: a tool part's `input-error`/`output-error` state carries its own `errorText` field (per the AI SDK's `ToolUIPart` types), often quoting the tool's own oversized input back (e.g. a schema-validation failure on a large write, or a tool that echoes a huge arg on failure). `emitMessageParts`/`emitRequestMessageParts`/`emitFinalSnapshot` all persisted the raw `part` object verbatim, with no cap on `errorText` — so a single oversized tool failure grows the thread's stored history exactly like the case #6462 fixed, just via a different field.

This reuses the existing `truncateErrorText` helper via a new `capPartErrorText(part)`, applied at the three sites that persist a raw part payload. Non-string or under-cap `errorText` (or none at all) passes through unchanged — every other part shape and field is untouched.

Failure scenario: a tool call fails with a multi-MB `errorText` (e.g. it echoes back a huge file write or a giant tool-arg validation error). That tool part gets persisted uncapped, then replayed into every subsequent request in the thread, growing the payload further on each retry until the thread becomes unloadable/unsendable — same failure mode #6462 fixed for the run-level error, one field over.

To confirm: `cd apps/api && bun test src/api/routes/decopilot/part-row-builder.test.ts` — includes a new regression test asserting a 2,000,000-char tool `errorText` is truncated to under 8,200 chars with a `[truncated N characters]` suffix, mirroring the existing `emitError` truncation test.

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (no errors in the touched file), the targeted test file above, and `bunx oxlint` on both changed files (one pre-existing warning in the test file, not introduced by this change). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps persisted tool part errorText to 8,000 characters to prevent unbounded thread growth from replayed failures. Old behavior stored tool errorText verbatim; new behavior truncates it with the same “[truncated N characters]” suffix as run-level errors, leaving other fields unchanged.

- Applies the cap at all three persistence sites for raw parts (message parts, request message parts, and final emission).
- Reuses the existing truncateErrorText via a new capPartErrorText(part); only affects string errorText over the limit.
- Adds a regression test that truncates a 2,000,000‑char tool errorText to under 8,200 characters with the expected suffix.

<sup>Written for commit fbae03ed862c4eb1daf91522ab8fdfd7f4e9858d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

