### PR TITLE
fix(organization): persist an explicit empty description on ORGANIZATION_UPDATE

### DIFF
--- a/apps/api/src/tools/organization/update.test.ts
+++ b/apps/api/src/tools/organization/update.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, mock } from "bun:test";
+import { ORGANIZATION_UPDATE } from "./update";
+
+function makeCtx() {
+  const update = mock(
+    async (data: { organizationId: string; data: unknown }) => ({
+      id: data.organizationId,
+      name: "Acme",
+      slug: "acme",
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+    }),
+  );
+  return {
+    auth: { user: { id: "user-1" } },
+    access: { check: mock(async () => {}) },
+    boundAuth: { organization: { update } },
+    update,
+  } as unknown as Parameters<typeof ORGANIZATION_UPDATE.handler>[1] & {
+    update: typeof update;
+  };
+}
+
+describe("ORGANIZATION_UPDATE", () => {
+  it("persists an explicit empty description instead of dropping it", async () => {
+    const ctx = makeCtx();
+
+    await ORGANIZATION_UPDATE.handler({ id: "org-1", description: "" }, ctx);
+
+    expect(ctx.update).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      data: { metadata: { description: "" } },
+    });
+  });
+
+  it("still writes a non-empty description", async () => {
+    const ctx = makeCtx();
+
+    await ORGANIZATION_UPDATE.handler(
+      { id: "org-1", description: "hello" },
+      ctx,
+    );
+
+    expect(ctx.update).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      data: { metadata: { description: "hello" } },
+    });
+  });
+});

--- a/apps/api/src/tools/organization/update.ts
+++ b/apps/api/src/tools/organization/update.ts
@@ -45,7 +45,8 @@ export const ORGANIZATION_UPDATE = defineTool({
     // and renaming would silently invalidate every saved URL.
     const updateData: Record<string, unknown> = {};
     if (input.name) updateData.name = input.name;
-    if (input.description)
+    // !== undefined, not truthy: "" clears the description and must persist.
+    if (input.description !== undefined)
       updateData.metadata = { description: input.description };
 
     // Update organization via Better Auth


### PR DESCRIPTION
**Bug**: `ORGANIZATION_UPDATE`'s input schema allows `description: ""` (no `.min(1)`), but the handler built its update payload with `if (input.description) updateData.metadata = { description: input.description }` — a truthy check. Passing `""` to clear a previously-set description is silently dropped: the call resolves successfully but `metadata.description` keeps its stale value, with no error surfaced to the caller.

This is the same falsy-check-swallows-valid-empty-string trap already fixed elsewhere in this codebase (see settings-alias and pod-name empty-string fallbacks) — `metadata` here has no other field, so this is the only way to clear a description once set.

**Fix**: check `input.description !== undefined` instead of truthy, so an explicit empty string persists.

**Regression test**: `apps/api/src/tools/organization/update.test.ts` — asserts `description: ""` reaches `boundAuth.organization.update` as `{ metadata: { description: "" } }` (previously it wasn't called with metadata at all), plus a control case for a non-empty description.

To confirm: `bun test apps/api/src/tools/organization/update.test.ts`

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/tools/organization/update.test.ts`, `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists an explicitly empty organization description in `ORGANIZATION_UPDATE` instead of dropping it. Previously, passing `description: ""` succeeded but kept the old `metadata.description`; now `""` is written so callers can clear a description.

- Replaces the truthy check with `input.description !== undefined` when building `metadata`; `name` handling is unchanged.
- Adds tests in `apps/api/src/tools/organization/update.test.ts` covering both `""` and non-empty descriptions.
- No API changes or migrations; the handler now sends `metadata` when `description === ""`.

<sup>Written for commit cdd53865d98f09785c6002567abffa33cf997155. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

