### PR TITLE
fix(task-board): give the assignee/tag picker search inputs an accessible name

### DIFF
--- a/apps/web/src/layouts/task-board/assignee-picker.tsx
+++ b/apps/web/src/layouts/task-board/assignee-picker.tsx
@@ -25,6 +25,7 @@ export function AssigneePickerContent({
     <Command>
       <CommandInput
         placeholder={t("taskBoard.taskDialog.assignToPlaceholder")}
+        aria-label={t("taskBoard.taskDialog.assignToPlaceholder")}
         className="h-9"
       />
       <CommandList>

--- a/apps/web/src/layouts/task-board/tag-picker.tsx
+++ b/apps/web/src/layouts/task-board/tag-picker.tsx
@@ -56,6 +56,7 @@ export function TagPickerContent({
         value={search}
         onValueChange={setSearch}
         placeholder={t("taskBoard.taskDialog.tagFilterPlaceholder")}
+        aria-label={t("taskBoard.taskDialog.tagFilterPlaceholder")}
         className="h-9"
       />
       <CommandList>


### PR DESCRIPTION
Every `CommandInput` search box in the task-board filter bar (`task-filters.tsx`) sets an `aria-label` mirroring its placeholder, but the two identical search boxes used inside the task dialog's assignee and tag pickers (`assignee-picker.tsx`, `tag-picker.tsx`) were missed — a screen reader announces them as an unlabeled combobox, since cmdk's `Command.Input` renders a bare `<input>` with no implicit accessible name from a placeholder alone.

This adds `aria-label` to both, using the same translation key already used for their `placeholder`, matching the pattern every other `CommandInput` in this directory already follows.

Behavior-preserving: `aria-label` is just passed through cmdk's `CommandPrimitive.Input` props (`React.ComponentProps<typeof CommandPrimitive.Input>` already allows it), no visual or logic change.

A reviewer can confirm by opening a task card's assignee or tag picker and inspecting the accessibility tree (e.g. Chrome DevTools "Accessibility" pane) on the search input — it now reports the placeholder text as its name instead of blank.

Checks run locally: `bun run fmt`, `bunx oxlint` on both changed files (0 warnings/errors). No test added — this is a two-line attribute addition to presentational components, not new logic; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Label the assignee and tag picker search inputs with an aria-label so screen readers announce a name. Previously these inputs were an unlabeled combobox; now they use the same translated text as their placeholders. No visual or logic changes.

- Adds aria-label to the two `CommandInput` instances in assignee-picker.tsx and tag-picker.tsx (1 line each); `cmdk` forwards it to the underlying input.
- To review: open a task dialog, open the Assignee or Tag picker, inspect the search input in the Accessibility pane; its name should equal the placeholder.

<sup>Written for commit 49ce8605cc08a667d3cf7957c1102c4708e82cc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

