### PR TITLE
feat(claude-code): give a sandbox run every org MCP connection as its own server

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -61,6 +61,7 @@ import {
 } from "@/mcp-clients/virtual-mcp/mint-endpoint";
 import { orgFlagEnabled } from "@decocms/shared/organization/schema";
 import { WellKnownOrgMCPId } from "@decocms/shared/sdk";
+import { REVIEW_RUN_TOOL_NAMES } from "@/tools/task-board/task-run-context";
 import { getPublicUrl } from "@/core/server-constants";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
 import { getSettings } from "@/settings";
@@ -317,6 +318,19 @@ export class SandboxDispatchClient implements SandboxClient {
       `${this.harnessId}-run`,
       "task-run",
       threadId,
+      // Exactly the tools this run's surface exposes, not a wildcard. The
+      // reviewer superset covers both run kinds; which of them a given run can
+      // actually call is already decided by the server it talks to
+      // (`toolSubsetMCP`), so the key never widens that — it only stops being a
+      // full-access credential for every other management tool in Studio.
+      //
+      // `self` is the resource key management tools are checked under (see
+      // AccessControl's default `connectionId`). It does NOT gate the
+      // per-connection proxy the `orgMcps` entries dial: that route authorizes
+      // by ORG MEMBERSHIP and connection ownership, with no `access.check` at
+      // all, so a run reaches exactly the connections any member of the org
+      // reaches — no more, but also no less.
+      { self: [...REVIEW_RUN_TOOL_NAMES] },
     );
     const settings = await this.ctx.storage.organizationSettings.get(
       organization.id,

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -32,7 +32,10 @@
 import type { UIMessageChunk } from "ai";
 import { sleep } from "@decocms/shared/std";
 import type { SandboxClient } from "@decocms/sandbox/dispatch/sandbox-client";
-import { harnessRunResultSchema } from "@decocms/sandbox/dispatch/schemas";
+import {
+  harnessRunResultSchema,
+  type HarnessStreamInputWire,
+} from "@decocms/sandbox/dispatch/schemas";
 import {
   SANDBOX_GONE_TERMINAL_CODE,
   SANDBOX_UNREACHABLE_PREFIX,
@@ -52,7 +55,12 @@ import {
 import { mergeRunEnv, resolveOrgRunEnv } from "@/harnesses/org-run-env";
 import { withModelMetadata } from "@/harnesses/with-model-metadata";
 import type { StudioContext } from "../core/studio-context";
-import { mintMcpEndpoint } from "@/mcp-clients/virtual-mcp/mint-endpoint";
+import {
+  mintMcpEndpoint,
+  orgMcpServers,
+} from "@/mcp-clients/virtual-mcp/mint-endpoint";
+import { orgFlagEnabled } from "@decocms/shared/organization/schema";
+import { getPublicUrl } from "@/core/server-constants";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
 import { getSettings } from "@/settings";
 import { ensureSandbox } from "@/tools/sandbox/start";
@@ -283,6 +291,59 @@ export class SandboxDispatchClient implements SandboxClient {
     };
   }
 
+  /**
+   * The MCP surfaces one run gets: its own narrow Studio endpoint (`mcp`), plus
+   * — when the org opted in — every MCP connection in the org as its own server
+   * (`orgMcps`).
+   *
+   * Behind a flag because it is unbounded: each connection is one more server
+   * the harness connects to at session start and one more toolset in the
+   * model's context, and nothing here knows whether an org has three
+   * connections or thirty.
+   *
+   * One credential for all of them (see `orgMcpServers`), and a connection the
+   * proxy cannot reach is not this method's problem — the harness treats a
+   * broken org server as a missing toolset, not a failed run.
+   */
+  private async mcpForRun(
+    organization: { id: string; slug?: string; name?: string },
+    threadId: string,
+  ): Promise<Pick<HarnessStreamInputWire, "mcp" | "orgMcps">> {
+    const mcp = await mintMcpEndpoint(
+      this.ctx,
+      this.virtualMcpId,
+      organization,
+      `${this.harnessId}-run`,
+      "task-run",
+      threadId,
+    );
+    const settings = await this.ctx.storage.organizationSettings.get(
+      organization.id,
+    );
+    if (
+      !organization.slug ||
+      !orgFlagEnabled(settings?.flags, "coding_agent_org_mcps")
+    ) {
+      return { mcp };
+    }
+    // `list` excludes VIRTUAL connections (agents, not MCP servers) by default.
+    // Non-active ones are dropped here: a connection Studio already knows is
+    // erroring only costs the session a failed connect at startup.
+    const { items } = await this.ctx.storage.connections.list(organization.id);
+    const orgMcps = orgMcpServers({
+      publicUrl: getPublicUrl(),
+      organizationSlug: organization.slug,
+      headers: mcp.headers,
+      connections: items.filter((connection) => connection.status === "active"),
+    });
+    console.log(
+      `[${this.harnessId}] org mcps: ${
+        orgMcps.map((server) => server.name).join(" ") || "none"
+      }`,
+    );
+    return { mcp, orgMcps };
+  }
+
   private async *stream(
     input: HarnessStreamInput,
   ): AsyncIterable<UIMessageChunk> {
@@ -335,17 +396,9 @@ export class SandboxDispatchClient implements SandboxClient {
       // tools plus `TASK_ADD_REPO`. It used to be `/mcp/self` — every management
       // tool Studio has, ~200 of them, for the two this harness calls.
       //
-      // ponytail: one surface, not both — the agent's aggregated connections
-      // are not merged in. Add a second MCP server on the wire if a
-      // claude-code run ever needs an agent's own external tools.
-      mcp: await mintMcpEndpoint(
-        this.ctx,
-        this.virtualMcpId,
-        organization,
-        `${this.harnessId}-run`,
-        "task-run",
-        input.threadId,
-      ),
+      // The org's own MCP connections come alongside it (`orgMcps`), behind
+      // the `coding_agent_org_mcps` flag — see `mcpForRun`.
+      ...(await this.mcpForRun(organization, input.threadId)),
       // Hosted Decopilot mounts no working directory; this harness edits the
       // checkout the daemon prepared.
       workspace: await this.resolveWorkspace(input.threadId),

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -60,6 +60,7 @@ import {
   orgMcpServers,
 } from "@/mcp-clients/virtual-mcp/mint-endpoint";
 import { orgFlagEnabled } from "@decocms/shared/organization/schema";
+import { WellKnownOrgMCPId } from "@decocms/shared/sdk";
 import { getPublicUrl } from "@/core/server-constants";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
 import { getSettings } from "@/settings";
@@ -327,14 +328,18 @@ export class SandboxDispatchClient implements SandboxClient {
       return { mcp };
     }
     // `list` excludes VIRTUAL connections (agents, not MCP servers) by default.
-    // Non-active ones are dropped here: a connection Studio already knows is
-    // erroring only costs the session a failed connect at startup.
     const { items } = await this.ctx.storage.connections.list(organization.id);
     const orgMcps = orgMcpServers({
       publicUrl: getPublicUrl(),
       organizationSlug: organization.slug,
       headers: mcp.headers,
-      connections: items.filter((connection) => connection.status === "active"),
+      connections: items.filter(
+        (connection) =>
+          // A connection Studio already knows is erroring only costs the
+          // session a failed connect at startup.
+          connection.status === "active" &&
+          !isStudioOwnedConnection(organization.id, connection.id),
+      ),
     });
     console.log(
       `[${this.harnessId}] org mcps: ${
@@ -947,4 +952,24 @@ export async function* ndjsonLines(
     // leaves the request (and the daemon's run) hanging behind us.
     await reader.return?.().catch(() => {});
   }
+}
+
+/**
+ * Studio's own well-known connections, which every org has whether or not
+ * anyone configured an MCP: the management surface and the two store
+ * registries. Excluded from a run's `orgMcps` — `_self` alone is ~200
+ * management tools, which is exactly what the narrow task-run surface exists to
+ * avoid, and browsing the MCP store is not a coding agent's job. What the user
+ * actually connected is everything else.
+ */
+function isStudioOwnedConnection(
+  organizationId: string,
+  connectionId: string,
+): boolean {
+  return [
+    WellKnownOrgMCPId.SELF,
+    WellKnownOrgMCPId.REGISTRY,
+    WellKnownOrgMCPId.COMMUNITY_REGISTRY,
+    WellKnownOrgMCPId.DEV_ASSETS,
+  ].some((id) => id(organizationId) === connectionId);
 }

--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { MissingOrganizationSlugError, mcpEndpointUrl } from "./mint-endpoint";
+import {
+  MissingOrganizationSlugError,
+  mcpEndpointUrl,
+  orgMcpServers,
+} from "./mint-endpoint";
 
 const publicUrl = "https://studio.example.com";
 const organization = { id: "org_1", slug: "acme" };
@@ -80,5 +84,62 @@ describe("mcpEndpointUrl task-run", () => {
         target: "task-run",
       }),
     ).toThrow(/threadId is required/);
+  });
+});
+
+describe("orgMcpServers", () => {
+  const headers = { Authorization: "Bearer k" };
+  const servers = (
+    connections: { id: string; title?: string | null; slug?: string | null }[],
+  ) =>
+    orgMcpServers({
+      publicUrl,
+      organizationSlug: "acme",
+      headers,
+      connections,
+    });
+
+  it("points each connection at the org-scoped proxy, with the run's key", () => {
+    expect(servers([{ id: "conn_1", slug: "linear" }])).toEqual([
+      {
+        name: "linear",
+        url: "https://studio.example.com/api/acme/mcp/conn_1",
+        headers,
+      },
+    ]);
+  });
+
+  it("sanitizes a title into a name a client accepts", () => {
+    expect(servers([{ id: "c", title: "Google Drive!" }])[0]?.name).toBe(
+      "google-drive",
+    );
+  });
+
+  it("prefers the slug over the title", () => {
+    expect(
+      servers([{ id: "c", slug: "gdrive", title: "Drive" }])[0]?.name,
+    ).toBe("gdrive");
+  });
+
+  it("dedupes names so same-titled connections stay distinct servers", () => {
+    expect(
+      servers([
+        { id: "c1", title: "Notion" },
+        { id: "c2", title: "notion" },
+        { id: "c3", title: "NOTION" },
+      ]).map((server) => server.name),
+    ).toEqual(["notion", "notion-2", "notion-3"]);
+  });
+
+  it("falls back to a usable name when there is nothing to derive one from", () => {
+    expect(
+      servers([{ id: "c1", title: "///" }, { id: "c2" }]).map((s) => s.name),
+    ).toEqual(["mcp", "mcp-2"]);
+  });
+
+  it("url-encodes the connection id", () => {
+    expect(servers([{ id: "a/b", title: "x" }])[0]?.url).toBe(
+      "https://studio.example.com/api/acme/mcp/a%2Fb",
+    );
   });
 });

--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
@@ -90,6 +90,14 @@ export async function mintMcpEndpoint(
   target: McpEndpointTarget = "agent-tools",
   /** Required by `target: "task-run"`. */
   threadId?: string,
+  /**
+   * The key's allowlist. Defaults to full access, which is what a caller whose
+   * surface is the agent's own virtual MCP needs. A caller that knows exactly
+   * which tools its surface exposes should pass that instead — the key is a
+   * live credential handed to an autonomous run, and "every tool in Studio" is
+   * not a scope anyone chose, it is one nobody narrowed.
+   */
+  permissions: Record<string, string[]> = { "*": ["*"] },
 ): Promise<{
   url: string;
   headers: Record<string, string>;
@@ -107,12 +115,9 @@ export async function mintMcpEndpoint(
   const apiKey = await ctx.boundAuth.apiKey.create({
     name: apiKeyName,
     // The per-run key is the agent's own callback credential — it acts on
-    // behalf of the user, against `/mcp/virtual-mcp/<agentId>` (a `vir_*`
-    // resource) or the org's management MCP, for the duration of the run, so it
-    // needs full access. With no implicit default (auth/index.ts), the scope
-    // must be explicit; wildcard matches the prior behavior (full access via
-    // the admin bypass).
-    permissions: { "*": ["*"] },
+    // behalf of the user for the duration of the run. With no implicit default
+    // (auth/index.ts), the scope must be explicit; see the parameter.
+    permissions,
     expiresIn: MCP_KEY_TTL_SECONDS,
     metadata: {
       organization: {

--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
@@ -134,3 +134,51 @@ export async function mintMcpEndpoint(
     expiresAt: Date.now() + MCP_KEY_TTL_SECONDS * 1000,
   };
 }
+
+/**
+ * One MCP server entry per org connection, for a run that gets the org's
+ * connections on top of its own Studio surface (`orgMcps` on the wire).
+ *
+ * Every entry points at Studio's per-connection proxy and reuses the run's
+ * already-minted credential — the key is minted with full access, so it
+ * authorizes every connection in the org; a key per connection would be N live
+ * credentials nobody revokes for one run.
+ *
+ * Names are the client's tool namespace (`mcp__<name>__<tool>`), so they are
+ * sanitized to what an MCP client accepts and deduped — two connections with
+ * the same title must not collapse into one server. Pure: the unit test owns
+ * the naming.
+ */
+export function orgMcpServers(args: {
+  publicUrl: string;
+  organizationSlug: string;
+  headers: Record<string, string>;
+  connections: {
+    id: string;
+    title?: string | null;
+    slug?: string | null;
+  }[];
+}): { name: string; url: string; headers: Record<string, string> }[] {
+  const { publicUrl, organizationSlug, headers, connections } = args;
+  const taken = new Set<string>();
+  return connections.map((connection) => {
+    const base =
+      sanitizeServerName(connection.slug ?? connection.title ?? "") || "mcp";
+    let name = base;
+    for (let n = 2; taken.has(name); n++) name = `${base}-${n}`;
+    taken.add(name);
+    return {
+      name,
+      url: `${publicUrl}/api/${organizationSlug}/mcp/${encodeURIComponent(connection.id)}`,
+      headers,
+    };
+  });
+}
+
+/** Lowercase alphanumerics and hyphens — what an MCP client accepts as a name. */
+function sanitizeServerName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/apps/web/src/components/settings/review-settings.tsx
+++ b/apps/web/src/components/settings/review-settings.tsx
@@ -2,6 +2,7 @@ import { toast } from "sonner";
 import { Switch } from "@decocms/ui/components/switch.tsx";
 import {
   Coins01,
+  Cube01,
   FileSearch02,
   GitMerge,
   ShieldTick,
@@ -59,6 +60,30 @@ export function ReviewSettings() {
           icon={<UserSquare size={16} />}
           titleKey="settings.review.autoAssignReportTasksTitle"
           descriptionKey="settings.review.autoAssignReportTasksDescription"
+        />
+      </SettingsCard>
+    </SettingsSection>
+  );
+}
+
+/**
+ * What a coding-agent run (the Super Agent, the reviewers) can reach beyond its
+ * own checkout. Its own section, not part of the reviewer card above: this is
+ * about the tools a run holds, not about who reviews its work.
+ */
+export function AgentToolsSettings() {
+  const t = useT();
+  return (
+    <SettingsSection
+      title={t("settings.agentTools.title")}
+      description={t("settings.agentTools.description")}
+    >
+      <SettingsCard>
+        <FlagToggle
+          flag="coding_agent_org_mcps"
+          icon={<Cube01 size={16} />}
+          titleKey="settings.agentTools.orgMcpsTitle"
+          descriptionKey="settings.agentTools.orgMcpsDescription"
         />
       </SettingsCard>
     </SettingsSection>

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -479,6 +479,12 @@ export const settings = {
   "settings.review.autoAssignReportTasksDescription":
     "Tasks created from a report are delegated to the Super Agent automatically instead of landing unassigned.",
   "settings.review.updateError": "Couldn't update the setting",
+  "settings.agentTools.title": "Agent tools",
+  "settings.agentTools.description":
+    "What a coding-agent run reaches beyond the repository it is working in.",
+  "settings.agentTools.orgMcpsTitle": "Give runs this org's MCP connections",
+  "settings.agentTools.orgMcpsDescription":
+    "Every MCP you have connected becomes available to the Super Agent and the reviewers, on top of the task tools they always get. Tools load only when the agent looks for one, so connecting more does not crowd its context.",
   "settings.sprints.title": "Sprints",
   "settings.sprints.description":
     "Plan tasks into fixed-length sprints. Sprints are counted from a start day, so there is nothing to open or close.",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -498,6 +498,13 @@ export const settings = {
     "Tarefas criadas a partir de um relat\u00f3rio s\u00e3o delegadas ao Super Agent automaticamente, em vez de ficarem sem respons\u00e1vel.",
   "settings.review.updateError":
     "N\u00e3o foi poss\u00edvel atualizar a configura\u00e7\u00e3o",
+  "settings.agentTools.title": "Ferramentas do agente",
+  "settings.agentTools.description":
+    "O que um run de agente de c\u00f3digo alcan\u00e7a al\u00e9m do reposit\u00f3rio em que est\u00e1 trabalhando.",
+  "settings.agentTools.orgMcpsTitle":
+    "Dar aos runs as conex\u00f5es MCP desta organiza\u00e7\u00e3o",
+  "settings.agentTools.orgMcpsDescription":
+    "Cada MCP conectado fica dispon\u00edvel para o Super Agent e para os revisores, al\u00e9m das ferramentas de tarefa que eles sempre recebem. As ferramentas carregam s\u00f3 quando o agente procura por uma, ent\u00e3o conectar mais n\u00e3o ocupa o contexto dele.",
   "settings.sprints.title": "Sprints",
   "settings.sprints.description":
     "Planeje tarefas em sprints de dura\u00e7\u00e3o fixa. As sprints s\u00e3o contadas a partir de um dia inicial, ent\u00e3o n\u00e3o h\u00e1 nada para abrir ou fechar.",

--- a/apps/web/src/views/settings/jira.tsx
+++ b/apps/web/src/views/settings/jira.tsx
@@ -39,7 +39,10 @@ import {
 import { Page } from "@/components/page";
 import { JiraIcon } from "@/components/icons/jira-icon";
 import { SprintSettings } from "@/components/settings/sprint-settings";
-import { ReviewSettings } from "@/components/settings/review-settings";
+import {
+  AgentToolsSettings,
+  ReviewSettings,
+} from "@/components/settings/review-settings";
 import {
   SettingsCard,
   SettingsCardItem,
@@ -664,6 +667,7 @@ export function OrgTasksSettingsPage() {
             <Page.Title>{t("settings.nav.tasks")}</Page.Title>
             <ReviewSettings />
             <SprintSettings />
+            <AgentToolsSettings />
             <SettingsSection
               title={
                 <span className="flex items-center gap-2">

--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -3,6 +3,7 @@ import type { HarnessStreamInputWire } from "@decocms/sandbox/dispatch/schemas";
 import {
   brokenStudioMcp,
   buildOptions,
+  mcpServersFor,
   promptForRun,
   promptFromUserMessage,
 } from "./claude-code";
@@ -122,16 +123,30 @@ describe("brokenStudioMcp", () => {
     );
   });
 
-  test("reports every unusable server so the retry log says which", () => {
+  test("reports Studio's own server, not an org connection's", () => {
+    // An org MCP (`orgMcps`) riding along on the same session can be down,
+    // unauthorized or gone; that is a missing toolset, not a run to refuse.
     expect(
       brokenStudioMcp(
         [
           { name: "studio", status: "failed" },
-          { name: "other", status: "needs-auth" },
+          { name: "linear", status: "needs-auth" },
         ],
         url,
       ),
-    ).toBe("studio=failed other=needs-auth");
+    ).toBe("studio=failed");
+  });
+
+  test("a broken org connection alone leaves the run usable", () => {
+    expect(
+      brokenStudioMcp(
+        [
+          { name: "studio", status: "connected" },
+          { name: "linear", status: "failed" },
+        ],
+        url,
+      ),
+    ).toBe(null);
   });
 
   test("no MCP configured means nothing to wait for", () => {
@@ -264,5 +279,71 @@ describe("buildOptions", () => {
     // Decopilot's in-process runs carry `mcp.url === ""`; a server pointing at
     // an empty URL would fail the SDK's startup connect.
     expect(options().mcpServers).toBeUndefined();
+  });
+});
+
+describe("mcpServersFor", () => {
+  const studio = {
+    url: "https://studio.example/mcp/task-run/thrd_1",
+    headers: { Authorization: "Bearer k" },
+    expiresAt: 1,
+  };
+
+  test("mounts one server per org connection alongside Studio's", () => {
+    expect(
+      mcpServersFor(
+        input({
+          mcp: studio,
+          orgMcps: [
+            {
+              name: "linear",
+              url: "https://studio.example/api/acme/mcp/conn_1",
+              headers: { Authorization: "Bearer k" },
+            },
+          ],
+        }),
+      ),
+    ).toEqual({
+      linear: {
+        type: "http",
+        url: "https://studio.example/api/acme/mcp/conn_1",
+        headers: { Authorization: "Bearer k" },
+      },
+      studio: {
+        type: "http",
+        url: studio.url,
+        headers: studio.headers,
+      },
+    });
+  });
+
+  test("Studio's surface survives an org connection named `studio`", () => {
+    const servers = mcpServersFor(
+      input({
+        mcp: studio,
+        orgMcps: [
+          { name: "studio", url: "https://elsewhere.example/mcp", headers: {} },
+        ],
+      }),
+    );
+    expect(servers.studio).toEqual({
+      type: "http",
+      url: studio.url,
+      headers: studio.headers,
+    });
+  });
+
+  test("org connections still mount when Studio's url is the empty sentinel", () => {
+    expect(
+      Object.keys(
+        mcpServersFor(
+          input({
+            orgMcps: [
+              { name: "linear", url: "https://x.example/mcp", headers: {} },
+            ],
+          }),
+        ),
+      ),
+    ).toEqual(["linear"]);
   });
 });

--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -271,6 +271,7 @@ describe("buildOptions", () => {
         type: "http",
         url: "https://studio.example/mcp/virtual-mcp/agent_1",
         headers: { Authorization: "Bearer k", "x-org-id": "org_1" },
+        alwaysLoad: true,
       },
     });
   });
@@ -313,8 +314,25 @@ describe("mcpServersFor", () => {
         type: "http",
         url: studio.url,
         headers: studio.headers,
+        alwaysLoad: true,
       },
     });
+  });
+
+  test("org connections stay deferred; only Studio's own is always loaded", () => {
+    // The whole reason an org can hand a run thirty connections: their tools
+    // sit behind tool search instead of the turn-1 prompt. Studio's own cannot
+    // — the board tools are how the run reports what it did.
+    const servers = mcpServersFor(
+      input({
+        mcp: studio,
+        orgMcps: [
+          { name: "linear", url: "https://x.example/mcp", headers: {} },
+        ],
+      }),
+    );
+    expect(servers.linear).not.toHaveProperty("alwaysLoad");
+    expect(servers.studio).toHaveProperty("alwaysLoad", true);
   });
 
   test("Studio's surface survives an org connection named `studio`", () => {
@@ -330,6 +348,7 @@ describe("mcpServersFor", () => {
       type: "http",
       url: studio.url,
       headers: studio.headers,
+      alwaysLoad: true,
     });
   });
 

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -255,6 +255,27 @@ export function buildOptions(args: {
  * deduped there). The Studio entry wins a name clash — an org connection called
  * `studio` must not displace the surface the run reports its work through.
  *
+ * The two differ in ONE option, and it is the whole reason an org can hand a
+ * run thirty connections without drowning it: `alwaysLoad`.
+ *
+ * - Org connections are left at the default, which means their tools are
+ *   DEFERRED behind Claude Code's tool search — the model sees them only after
+ *   searching for one, so N connections cost the prompt nothing up front, and
+ *   their servers connect in the background instead of blocking the session.
+ * - Studio's own server is `alwaysLoad: true`. Its tools are how the run
+ *   reports what it did (the board), so they have to be in the turn-1 prompt
+ *   rather than behind a search the model may never run. It is also what makes
+ *   the `brokenStudioMcp` preflight mean anything: `alwaysLoad` blocks startup
+ *   until the server connects (capped at 5s), so `system/init` reports it as
+ *   connected or failed instead of the `pending` a deferred server shows.
+ *
+ * Deferral is Claude Code's own behavior, not something requested here, and it
+ * only applies when tool search is on — which it is NOT on a non-first-party
+ * `ANTHROPIC_BASE_URL` (our OpenRouter path) unless `ENABLE_TOOL_SEARCH` is set
+ * for that process. On those runs every org tool loads eagerly, so a big org is
+ * still a big prompt. Setting it there is a decision about whether the proxy
+ * forwards `tool_reference` blocks, which is not this file's to make.
+ *
  * Exported for the unit test, which owns the merge.
  */
 export function mcpServersFor(
@@ -276,6 +297,7 @@ export function mcpServersFor(
       type: "http" as const,
       url: input.mcp.url,
       headers: input.mcp.headers,
+      alwaysLoad: true,
     };
   }
   return servers;

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -8,10 +8,11 @@
  * assistant `messageId` derivable (the Anthropic message id of the turn, so a
  * re-delivered turn dedupes).
  *
- * Tools come from two places and neither needs configuring here: Claude Code's
- * built-ins operate on the checkout, and Studio's org tools arrive over MCP
- * from the endpoint minted for this run. Permissions are bypassed — the pod is
- * the isolation boundary, and there is no UI to answer a prompt.
+ * Tools come from three places and none needs configuring here: Claude Code's
+ * built-ins operate on the checkout, Studio's own tools arrive over MCP from the
+ * endpoint minted for this run, and the org's MCP connections arrive as one
+ * server each (`orgMcps`, when the org opted in). Permissions are bypassed —
+ * the pod is the isolation boundary, and there is no UI to answer a prompt.
  */
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
@@ -207,6 +208,7 @@ export function buildOptions(args: {
   const pluginDirs = (process.env[ENVS.PLUGIN_DIRS_ENV] ?? "")
     .split(":")
     .filter(Boolean);
+  const mcpServers = mcpServersFor(input);
   return {
     ...(cwd ? { cwd } : {}),
     ...(executable ? { pathToClaudeCodeExecutable: executable } : {}),
@@ -243,18 +245,40 @@ export function buildOptions(args: {
     // replaying it as prompt text. `sessionId` seeds a new one at the same id
     // so the next turn can resume it.
     ...(resume ? { resume: sessionId } : { sessionId }),
-    ...(input.mcp.url
-      ? {
-          mcpServers: {
-            [ENVS.STUDIO_MCP_SERVER_NAME]: {
-              type: "http" as const,
-              url: input.mcp.url,
-              headers: input.mcp.headers,
-            },
-          },
-        }
-      : {}),
+    ...(Object.keys(mcpServers).length ? { mcpServers } : {}),
   };
+}
+
+/**
+ * Every MCP server this run mounts: Studio's own surface under a fixed name,
+ * plus one per org connection Studio sent in `orgMcps` (each already named and
+ * deduped there). The Studio entry wins a name clash — an org connection called
+ * `studio` must not displace the surface the run reports its work through.
+ *
+ * Exported for the unit test, which owns the merge.
+ */
+export function mcpServersFor(
+  input: HarnessStreamInputWire,
+): NonNullable<Options["mcpServers"]> {
+  const servers: NonNullable<Options["mcpServers"]> = {};
+  for (const server of input.orgMcps ?? []) {
+    if (server.name === ENVS.STUDIO_MCP_SERVER_NAME) continue;
+    servers[server.name] = {
+      type: "http" as const,
+      url: server.url,
+      headers: server.headers,
+    };
+  }
+  // Decopilot's in-process runs carry the empty sentinel; a server pointing at
+  // an empty URL fails the SDK's startup connect.
+  if (input.mcp.url) {
+    servers[ENVS.STUDIO_MCP_SERVER_NAME] = {
+      type: "http" as const,
+      url: input.mcp.url,
+      headers: input.mcp.headers,
+    };
+  }
+  return servers;
 }
 
 /**
@@ -270,8 +294,14 @@ export function brokenStudioMcp(
   mcpUrl: string,
 ): string | null {
   if (!mcpUrl) return null;
-  const broken = servers.filter((server) =>
-    ["failed", "needs-auth", "disabled"].includes(server.status),
+  const broken = servers.filter(
+    (server) =>
+      // STUDIO's server only. The org's connections ride along on the same
+      // session (`orgMcps`) and any of them can be down, unauthorized, or just
+      // gone — that is a missing toolset, not a reason to refuse the run and
+      // burn the whole retry budget on it.
+      server.name === ENVS.STUDIO_MCP_SERVER_NAME &&
+      ["failed", "needs-auth", "disabled"].includes(server.status),
   );
   if (broken.length === 0) return null;
   return broken.map((server) => `${server.name}=${server.status}`).join(" ");

--- a/packages/sandbox/dispatch/schemas.ts
+++ b/packages/sandbox/dispatch/schemas.ts
@@ -129,6 +129,27 @@ export const harnessStreamInputSchema = z
         expiresAt: z.number().int().positive(),
       })
       .strict(),
+    /**
+     * Extra MCP servers this run mounts alongside `mcp` — one per org
+     * connection, each pointing at Studio's per-connection proxy
+     * (`/api/<slug>/mcp/<connectionId>`). Absent/empty = only `mcp`.
+     *
+     * A LIST of servers rather than tools merged into `mcp`: Studio's
+     * aggregator flattens tool names first-wins, so two connections exposing
+     * `SEARCH` would shadow each other. One server each keeps them namespaced
+     * by the client (`mcp__<name>__<tool>`).
+     */
+    orgMcps: z
+      .array(
+        z
+          .object({
+            name: z.string(),
+            url: z.string().url(),
+            headers: z.record(z.string(), z.string()),
+          })
+          .strict(),
+      )
+      .optional(),
     mode: z.enum(["default", "plan", "web-search", "gen-image"]),
     temperature: z.number(),
     toolApprovalLevel: z.enum(["auto", "readonly"]),

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -222,6 +222,12 @@ export const OrgFlagsSchema = z.object({
     .describe(
       "Run the QA Agent and Code Reviewer on a cheaper model than the Super Agent. A review reads a diff and reaches a verdict; it does not need the model that wrote the code. Off by default — turning it on trades some review depth for cost.",
     ),
+  coding_agent_org_mcps: z
+    .boolean()
+    .optional()
+    .describe(
+      "Give a coding-agent run (the claude-code harness in a sandbox) every MCP connection in the org as its own MCP server, on top of the narrow task-run surface it always gets. Off by default: each connection is one more server the agent connects to at session start, and all of their tools land in its context.",
+    ),
   auto_assign_report_tasks_to_super_agent: z
     .boolean()
     .optional()

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -126,6 +126,7 @@ export interface StudioToolIO {
             code_reviewer_enabled?: boolean | undefined;
             auto_merge?: boolean | undefined;
             cheap_reviewer_model?: boolean | undefined;
+            coding_agent_org_mcps?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
           }
         | null
@@ -198,6 +199,7 @@ export interface StudioToolIO {
             code_reviewer_enabled?: boolean | undefined;
             auto_merge?: boolean | undefined;
             cheap_reviewer_model?: boolean | undefined;
+            coding_agent_org_mcps?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
           }
         | undefined;
@@ -269,6 +271,7 @@ export interface StudioToolIO {
             code_reviewer_enabled?: boolean | undefined;
             auto_merge?: boolean | undefined;
             cheap_reviewer_model?: boolean | undefined;
+            coding_agent_org_mcps?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
           }
         | null


### PR DESCRIPTION
## Summary

A `claude-code` run in an agent-sandbox could reach exactly **one** MCP endpoint: the narrow task-run surface minted for it (`/api/<slug>/mcp/task-run/<threadId>`). The org's own MCP connections — the ones a user actually configured — were unreachable from inside the sandbox. The old code even said so:

> `ponytail: one surface, not both — the agent's aggregated connections are not merged in. Add a second MCP server on the wire if a claude-code run ever needs an agent's own external tools.`

This does that.

- **Studio** (`sandbox-dispatch-client.ts`) sends `orgMcps` on the dispatch wire: one entry per active, non-VIRTUAL, non-Studio-owned connection, each pointing at the org-scoped per-connection proxy (`/api/<slug>/mcp/<connectionId>`) and reusing the run's already-minted key.
- **The harness** (`packages/harness-runner/claude-code.ts`) mounts each as its own MCP server, so tools stay namespaced per connection (`mcp__<name>__<tool>`).

### Why a list of servers, not one aggregated endpoint

Studio's virtual-MCP aggregator flattens tool names first-wins, so two connections both exposing `SEARCH` would shadow each other. One server each keeps them namespaced by the client.

### Why `_self` and the registries are excluded

Every org has `_self`, `_registry` and `_community-registry` whether or not anyone configured an MCP. `_self` alone is ~200 management tools — exactly what the narrow task-run surface exists to avoid — and browsing the MCP store is not a coding agent's job. What the user actually connected is everything else.

### Lazy loading, not a bigger prompt

Claude Code already defers MCP tools behind its tool search: a server's tools reach the prompt only once the model searches for one, and the server connects in the background instead of blocking the session. That is the default, so N org connections cost the turn-1 prompt nothing. Studio's own server is the exception and now says so with `alwaysLoad: true` — the board tools are how a run reports what it did, so they belong in the prompt rather than behind a search the model may never run. That also makes the preflight below meaningful: `alwaysLoad` blocks startup until that server connects (capped at 5s), so `system/init` reports `connected`/`failed` instead of the `pending` a deferred server shows.

**Caveat:** tool search is off when `ANTHROPIC_BASE_URL` is not a first-party Anthropic host unless `ENABLE_TOOL_SEARCH` is set — that is our OpenRouter path. Those runs still load every org tool eagerly. Confirming whether OpenRouter forwards `tool_reference` blocks is what would let us turn it on there, and is also what would let the flag below be deleted.

### The run's key is no longer a wildcard

It was minted `{"*": ["*"]}` — a live 1h credential for every management tool in Studio, handed to an autonomous run that calls ten of them. It is now scoped to exactly the tools its surface exposes (`{ self: [...REVIEW_RUN_TOOL_NAMES] }`); `mintMcpEndpoint` takes the scope as a parameter and still defaults to the wildcard for its other caller.

This does **not** narrow which connections a run reaches, and cannot: `/api/:org/mcp/:connectionId` authorizes by org membership and connection ownership, with no `access.check` on that path at all. So a run reaches exactly the connections any member of the org reaches. If per-connection authorization is wanted, that is a change to the proxy route for every caller, not to this feature.

### Behind a flag, default off

`coding_agent_org_mcps` (org flag). The connection count is unbounded, and each one is another startup connect and another toolset in the model's context — so this is opt-in per org rather than a silent change to every run.

### One behavior inverted

`brokenStudioMcp` refused a run (and burned the whole MCP retry budget) when *any* configured MCP server came back `failed`/`needs-auth`/`disabled`. With org connections riding along that is wrong: a down or unauthorized org connection is a missing toolset, not a reason to fail the turn. It now keys on Studio's own server only. The test that encoded the old behavior is inverted, plus one for the new case.

## Testing

- `bun test packages/harness-runner apps/api/src/mcp-clients/virtual-mcp` — 75 pass. New unit tests cover the server-name sanitization/dedup (`orgMcpServers`), the merge and Studio-wins-a-name-clash (`mcpServersFor`), and the narrowed preflight.
- `bun run --cwd=apps/api check`, `bun run --cwd=packages/harness-runner check`, `bun run lint`, `knip`, `bun run fmt` all clean; tool contracts regenerated for the new flag.
- **Not yet exercised on a live cluster.** Both images are built and deployed on the decohouse k3s cluster (`studio-api:orgmcps1`, `studio-sandbox-go:orgmcps1`) with the flag on for `pedro-studio`, but no run was dispatched — triggering one needs a session/API key. The evidence to look for is the harness's own init line in the sandbox pod log: `[claude-code] mcp: studio=connected <conn>=connected ...`, plus `[claude-code] org mcps: ...` on the API pod.

## Notes

- The flag has a toggle: **Settings → Tasks → Agent tools**, its own section under the reviewer card (this is about what tools a run holds, not about who reviews its work). Strings are in the en + pt-br dictionaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts each org MCP connection as its own server for a claude-code sandbox run. Previously the run reached only the narrow Studio task‑run endpoint; now org connections ride alongside it, and only Studio’s server can block startup.

- Adds `orgMcps` on the dispatch wire: one entry per active non‑VIRTUAL org connection, each pointing at `/api/<slug>/mcp/<connectionId>` and reusing the run’s key. Excludes Studio-owned `_self`, `_registry`, `_community-registry`, and `_dev_assets`.
- The harness mounts one server per entry, keeping tools namespaced (`mcp__<name>__<tool>`). It sanitizes and dedupes server names; the Studio server keeps the `studio` name if an org connection collides. Org servers defer behind tool search; Studio’s is `alwaysLoad`.
- Narrows preflight: `brokenStudioMcp` only flags the Studio server. A failed or unauthorized org connection is treated as a missing toolset, not a run failure.
- Scopes the per‑run key to the task‑run tool allowlist instead of `{"*": ["*"]}`.
- Behind the `coding_agent_org_mcps` org flag (default off). Enable via the new Tasks > Agent tools toggle; the dispatch schema accepts optional `orgMcps` and existing callers remain compatible.

<sup>Written for commit 3f71fceffe149d7b16f1ed63f4642c15bae68d24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

