### PR TITLE
fix(chat): give the tiptap chat composer an accessible name

### DIFF
--- a/apps/web/src/components/chat/tiptap/input.test.tsx
+++ b/apps/web/src/components/chat/tiptap/input.test.tsx
@@ -51,6 +51,23 @@ describe("TiptapProvider disabled", () => {
   });
 });
 
+describe("TiptapProvider accessible name", () => {
+  it("exposes the placeholder as the editable region's aria-label", () => {
+    const { container } = render(
+      <TiptapProvider
+        tiptapDoc={undefined}
+        setTiptapDoc={() => {}}
+        placeholder="Ask anything"
+      >
+        <EditableProbe />
+      </TiptapProvider>,
+    );
+    const editable = container.querySelector("[contenteditable]");
+    expect(editable?.getAttribute("role")).toBe("textbox");
+    expect(editable?.getAttribute("aria-label")).toBe("Ask anything");
+  });
+});
+
 describe("TiptapProvider enter-to-submit vs. an open suggestion dropdown", () => {
   // ProseMirror's own keydown listener runs before the @/ mention picker's
   // (it's registered at editor mount, well before the picker ever opens —

--- a/apps/web/src/components/chat/tiptap/input.tsx
+++ b/apps/web/src/components/chat/tiptap/input.tsx
@@ -89,6 +89,9 @@ export function TiptapProvider({
     editorProps: {
       attributes: {
         "data-chat-input": "true",
+        role: "textbox",
+        "aria-multiline": "true",
+        "aria-label": placeholder ?? "",
         class:
           "prose prose-sm max-w-none focus:outline-none w-full h-full text-[15px] p-[18px]",
       },


### PR DESCRIPTION
**Source:** accessibility gap found while hunting the chat-input area (no linked issue).

**Why:** the chat message composer is a ProseMirror `contenteditable` div with no `role` or `aria-label` — a screen-reader user tabbing into it hears nothing identifying it as the message input, only an empty editable region. This is the same editor used by both the chat composer (`apps/web/src/components/chat/input.tsx`) and the automation-detail Tiptap instance, both of which already pass a translated `placeholder` string that can double as the accessible name.

**Fix:** `TiptapProvider` (`apps/web/src/components/chat/tiptap/input.tsx`) now sets `role="textbox"`, `aria-multiline="true"`, and `aria-label` (from the existing `placeholder` prop) on the editor's DOM attributes, alongside the `data-chat-input` attribute already set there.

**Regression test:** added `apps/web/src/components/chat/tiptap/input.test.tsx` → `TiptapProvider accessible name` — renders the provider with a placeholder and asserts the editable node exposes `role="textbox"` and the matching `aria-label`.

**To verify:** `bun test apps/web/src/components/chat/tiptap/input.test.tsx`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/web workspace, clean), `bunx oxlint` on both touched files (0 warnings/errors), and the targeted test file above (7 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Tiptap-based chat composer announce itself as a multiline textbox to screen readers. Previously it was an unnamed editable region; now it sets role="textbox", aria-multiline="true", and an aria-label from the existing placeholder. No visual or typing behavior changes.

- Applied in TiptapProvider, affecting both the chat composer and the automation-detail editor; both pass a placeholder, so the aria-label is non-empty.
- Adds a unit test asserting role and aria-label; run: bun test apps/web/src/components/chat/tiptap/input.test.tsx

<sup>Written for commit 61b899882aab5b46c69126294d63c26a1ffb31a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

