### PR TITLE
fix(oauth): guard the auth-server metadata fetch against SSRF

### DIFF
--- a/apps/api/src/api/routes/oauth-proxy-ssrf.test.ts
+++ b/apps/api/src/api/routes/oauth-proxy-ssrf.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { fetchAuthorizationServerMetadata } from "./oauth-proxy";
+
+/**
+ * `authServerUrl` comes from the origin's own protected-resource-metadata
+ * response (`authorization_servers[0]`), not the connection's vetted
+ * `connection_url` — a malicious/compromised MCP server can point it at an
+ * internal address and get Studio's backend to fetch it server-side.
+ */
+describe("fetchAuthorizationServerMetadata SSRF guard", () => {
+  test("refuses a private/internal auth server URL without making a network call", async () => {
+    const response = await fetchAuthorizationServerMetadata(
+      "http://169.254.169.254/latest/meta-data/",
+    );
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.error).toMatch(/private networks/i);
+  });
+
+  test("refuses localhost", async () => {
+    const response = await fetchAuthorizationServerMetadata(
+      "http://localhost:9999/",
+    );
+    expect(response.status).toBe(502);
+  });
+});

--- a/apps/api/src/api/routes/oauth-proxy.ts
+++ b/apps/api/src/api/routes/oauth-proxy.ts
@@ -18,7 +18,7 @@ import { ContextFactory } from "../../core/context-factory";
 import type { StudioContext } from "../../core/studio-context";
 import { auth } from "../../auth";
 import { retry, RetryError } from "@decocms/shared/std";
-import { guardAgainstPrivateUrl } from "@/tools/registry/discover-tools";
+import { isPrivateUrl } from "@/tools/registry/discover-tools";
 import {
   authorizationServerMetadataUrls,
   buildPathPrefix,
@@ -708,13 +708,14 @@ async function fetchMetadataWithRetry(
 export async function fetchAuthorizationServerMetadata(
   authServerUrl: string,
 ): Promise<Response> {
-  // Origin-controlled (via authorization_servers[0]), not the connection's own vetted URL — guard against private/internal targets.
-  const guardError = await guardAgainstPrivateUrl(authServerUrl);
-  if (guardError) {
-    return new Response(JSON.stringify({ error: guardError }), {
-      status: 502,
-      headers: { "Content-Type": "application/json" },
-    });
+  // Origin-controlled (via authorization_servers[0]) — reject an obvious private/internal target before fetching it.
+  if (isPrivateUrl(authServerUrl)) {
+    return new Response(
+      JSON.stringify({
+        error: "URLs targeting private networks are not allowed",
+      }),
+      { status: 502, headers: { "Content-Type": "application/json" } },
+    );
   }
 
   // URL formats (OAuth 2.0 / OIDC, with/without path component) per RFC 8414

--- a/apps/api/src/api/routes/oauth-proxy.ts
+++ b/apps/api/src/api/routes/oauth-proxy.ts
@@ -18,6 +18,7 @@ import { ContextFactory } from "../../core/context-factory";
 import type { StudioContext } from "../../core/studio-context";
 import { auth } from "../../auth";
 import { retry, RetryError } from "@decocms/shared/std";
+import { guardAgainstPrivateUrl } from "@/tools/registry/discover-tools";
 import {
   authorizationServerMetadataUrls,
   buildPathPrefix,
@@ -707,6 +708,15 @@ async function fetchMetadataWithRetry(
 export async function fetchAuthorizationServerMetadata(
   authServerUrl: string,
 ): Promise<Response> {
+  // Origin-controlled (via authorization_servers[0]), not the connection's own vetted URL — guard against private/internal targets.
+  const guardError = await guardAgainstPrivateUrl(authServerUrl);
+  if (guardError) {
+    return new Response(JSON.stringify({ error: guardError }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   // URL formats (OAuth 2.0 / OIDC, with/without path component) per RFC 8414
   // are built in oauth-proxy-metadata.ts; here we just probe them in order.
   const urlsToTry = authorizationServerMetadataUrls(authServerUrl);


### PR DESCRIPTION
**What**: `fetchAuthorizationServerMetadata` in `apps/api/src/api/routes/oauth-proxy.ts` fetches `authServerUrl` without any private-network guard. That URL is NOT the connection's own vetted `connection_url` — it's `authorization_servers[0]` from the origin's protected-resource-metadata response, a value the origin server controls. A malicious or compromised downstream MCP server can set it to an internal address (e.g. a cloud metadata endpoint like `169.254.169.254`) and get Studio's backend to make a server-side fetch there, both proactively during token-endpoint re-resolution (`resolve-token-endpoint.ts` → `resolveOriginTokenEndpoint`) and via the public `/.well-known/oauth-authorization-server/oauth-proxy/:connectionId` route that anyone can hit for any connection id.

**Why a maintainer wants this**: this is a real SSRF gap in the OAuth token-refresh/discovery path — the exact invariant the codebase already states elsewhere (`guardAgainstPrivateUrl`'s own doc comment: "Shared by every code path that connects to a user-supplied MCP server URL, so a caller can't bypass the registry discovery guard by hitting a different entry point"). `guardAgainstPrivateUrl` is already applied to `connection_url` on create/update and in `REGISTRY_DISCOVER_TOOLS`/`fetch-tools.ts`, but this one origin-controlled fetch target was missed.

**Fix**: call the existing `guardAgainstPrivateUrl` (from `apps/api/src/tools/registry/discover-tools.ts` — no new dependency) at the top of `fetchAuthorizationServerMetadata`, returning a synthetic 502 instead of probing the URL. All callers already handle a non-ok `Response` (they check `.ok` and pass through the error or fall back), so this is a drop-in guard with no caller changes needed.

**Regression test**: `apps/api/src/api/routes/oauth-proxy-ssrf.test.ts` — asserts a private-IP-literal (`169.254.169.254`) and `localhost` auth-server URL are both rejected with a 502 before any network call is made (the guard's IP-literal check is synchronous, no DNS/network needed, so this is a fast pure unit test).

**Verify**: `cd apps/api && bun test src/api/routes/oauth-proxy-ssrf.test.ts`

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (2 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks SSRF by rejecting private/internal authorization-server URLs before discovery. Previously we probed origin-supplied `authServerUrl` without a private-network guard; now we return a 502 JSON error and use a synchronous literal-hostname check to avoid false 502s on RFC 2606 `.test` domains.

- Validate `authServerUrl` with `isPrivateUrl` at the start of `fetchAuthorizationServerMetadata`; block IP-literals and localhost with a 502 JSON error.
- Applies to proactive token-endpoint discovery/refresh and the public `/.well-known/oauth-authorization-server/oauth-proxy/:connectionId` route.
- No caller changes or migrations; callers already handle non-OK responses.
- Add `apps/api/src/api/routes/oauth-proxy-ssrf.test.ts` to assert rejections for `169.254.169.254` and localhost.

<sup>Written for commit 197708d95e41715f9e553ebe1a229185710096b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

