### PR TITLE
fix(chat): dispose the orphaned thread manager on HMR teardown

### DIFF
--- a/apps/web/src/components/chat/store/thread-manager-store.ts
+++ b/apps/web/src/components/chat/store/thread-manager-store.ts
@@ -641,6 +641,14 @@ export class ThreadManagerStore {
 
 let current: ThreadManagerStore | null = null;
 
+// A hot-replaced module instance starts with `current: null`, orphaning the old instance's live `/watch` subscription — dispose it on HMR teardown.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    current?.dispose();
+    current = null;
+  });
+}
+
 /** Idempotent: same key → same instance. Different key → dispose + reopen. */
 export function getOrOpenManager(
   orgSlug: string,


### PR DESCRIPTION
Follows #6095, which fixed the identical bug in `thread-connection.ts` but left its sibling module-scoped registry in `thread-manager-store.ts` unpatched.

**The bug:** `ThreadManagerStore`'s module-scoped `current` singleton (thread-manager-store.ts) owns a live `/watch` SSE subscription plus an in-flight `loadInitialPage()` call, but the module has no `import.meta.hot.dispose` handler. When Vite hot-replaces this module during a decopilot run (any edit that touches this file or something it imports), the new module instance starts with `current: null` and `getOrOpenManager` mints a second `ThreadManagerStore` for the same org — subscribing to the shared SSE pool again. The old instance's subscription is now orphaned: it keeps running, so every subsequent thread-list event gets applied twice (once per instance), and the old instance is never disposed. `thread-connection.ts` hit and fixed this exact failure mode for its own singleton in #6095; this PR applies the same one-line pattern to `thread-manager-store.ts`.

**Fix:** register an `import.meta.hot.dispose` hook that disposes the current `ThreadManagerStore` (unsubscribing its `/watch` listener) and clears the slot before the module is replaced, so the next `getOrOpenManager` call creates a clean instance instead of a duplicate.

No test: #6095 (the sibling fix for `thread-connection.ts`) shipped without one for the same reason — `import.meta.hot` is a Vite-only hook not exercised under `bun test`, so there is no way to assert on it in the existing unit-test harness without faking Vite's HMR runtime.

**Reviewer check:** `cd apps/web && bunx tsc --noEmit` (clean) and `bun test apps/web/src/components/chat/store/thread-manager-store.test.ts` (41 pass, unaffected — confirms the registry's existing behavior is untouched).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web), `bun test apps/web/src/components/chat/store/thread-manager-store.test.ts`, `bunx oxlint` on the changed file — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disposes the module-scoped `ThreadManagerStore` during Vite HMR to prevent orphaned `/watch` subscriptions and double-applied thread-list events. Previously, HMR replaced the module without disposal, leaving the old instance running and creating a second manager for the same org.

**Notes for reviewers**
- Adds an `import.meta.hot.dispose` hook that calls `current?.dispose()` and clears the singleton; this runs only under HMR and has no production impact.
- No test added because `import.meta.hot` is Vite-only and not exercised by `bun test`.

<sup>Written for commit 749e1be712e71fe4f90c4b6ea70a8c55c5aacdc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

