### PR TITLE
fix(chat): fall back the composer's aria-label to the default placeholder

### DIFF
--- a/apps/web/src/components/chat/tiptap/input.test.tsx
+++ b/apps/web/src/components/chat/tiptap/input.test.tsx
@@ -66,6 +66,17 @@ describe("TiptapProvider accessible name", () => {
     expect(editable?.getAttribute("role")).toBe("textbox");
     expect(editable?.getAttribute("aria-label")).toBe("Ask anything");
   });
+
+  it("falls back to the default placeholder text when none is given", () => {
+    const { container } = render(
+      <TiptapProvider tiptapDoc={undefined} setTiptapDoc={() => {}}>
+        <EditableProbe />
+      </TiptapProvider>,
+    );
+    const editable = container.querySelector("[contenteditable]");
+    expect(editable?.getAttribute("aria-label")).not.toBe("");
+    expect(editable?.getAttribute("aria-label")).toContain("Ask anything");
+  });
 });
 
 describe("TiptapProvider enter-to-submit vs. an open suggestion dropdown", () => {

--- a/apps/web/src/components/chat/tiptap/input.tsx
+++ b/apps/web/src/components/chat/tiptap/input.tsx
@@ -17,6 +17,9 @@ import { AtMention } from "./mention-at.tsx";
 import { SlashMention } from "./mention-slash.tsx";
 import { AiProviderModel } from "@/hooks/collections/use-ai-providers.ts";
 
+const DEFAULT_PLACEHOLDER =
+  "Ask anything, / for prompts & skills, @ for agents & resources...";
+
 function buildExtensions(placeholderRef: React.RefObject<string | undefined>) {
   return [
     StarterKit.configure({
@@ -27,9 +30,7 @@ function buildExtensions(placeholderRef: React.RefObject<string | undefined>) {
       dropcursor: false,
     }),
     Placeholder.configure({
-      placeholder: () =>
-        placeholderRef.current ??
-        "Ask anything, / for prompts & skills, @ for agents & resources...",
+      placeholder: () => placeholderRef.current ?? DEFAULT_PLACEHOLDER,
       showOnlyWhenEditable: false,
     }),
     MentionNode,
@@ -91,7 +92,7 @@ export function TiptapProvider({
         "data-chat-input": "true",
         role: "textbox",
         "aria-multiline": "true",
-        "aria-label": placeholder ?? "",
+        "aria-label": placeholder ?? DEFAULT_PLACEHOLDER,
         class:
           "prose prose-sm max-w-none focus:outline-none w-full h-full text-[15px] p-[18px]",
       },


### PR DESCRIPTION
Follows #6468, which gave the tiptap chat composer's contenteditable region an `aria-label` sourced from the `placeholder` prop.

That fix set `"aria-label": placeholder ?? ""` — when a future caller omits `placeholder`, the composer still renders the Placeholder extension's own hardcoded default text ("Ask anything, / for prompts & skills, @ for agents & resources...") visibly, but the accessible name becomes an *explicit empty string*, which is worse for assistive tech than having no `aria-label` at all (it suppresses the accessible-name computation instead of falling through to other sources). Every current call site (`chat/input.tsx`, `automation-detail.tsx`) does pass `placeholder`, so this is dormant today, but it reintroduces the exact bug class #6468 just fixed for the next caller that doesn't.

Fix: extracted the Placeholder extension's default text into a shared `DEFAULT_PLACEHOLDER` constant and used it as the `aria-label` fallback too, so the accessible name always matches what's visibly shown.

Failure scenario: any new `TiptapProvider` usage without a `placeholder` prop renders visible placeholder text with an empty accessible name — a screen reader announces the field as unlabeled.

Reviewer check: `cd apps/web && bun test src/components/chat/tiptap/input.test.tsx` — added a test asserting the fallback aria-label is non-empty and contains the default text.

Locally ran: `bun run fmt`, the targeted test file above (8/8 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat composer’s accessible name by falling back `aria-label` to the default placeholder when `placeholder` is omitted. Previously it set an explicit empty `aria-label`, which hid the accessible name and resulted in an unlabeled field for screen readers.

- Extracts the default placeholder text to `DEFAULT_PLACEHOLDER` and uses it for both the Placeholder extension and the `aria-label`.
- Adds a test ensuring `aria-label` is non-empty and includes the default text when no `placeholder` is provided.
- Scope: only affects `TiptapProvider` without a `placeholder`; existing call sites remain unchanged.

<sup>Written for commit 03ff2e1d98100c6e33396dc193fa41515ac0c85a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

