### PR TITLE
fix(claude-code): put the mounted connections on the run's key

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -58,9 +58,11 @@ import type { StudioContext } from "../core/studio-context";
 import {
   mintMcpEndpoint,
   orgMcpServers,
+  runKeyPermissions,
 } from "@/mcp-clients/virtual-mcp/mint-endpoint";
 import { orgFlagEnabled } from "@decocms/shared/organization/schema";
 import { WellKnownOrgMCPId } from "@decocms/shared/sdk";
+import type { ConnectionEntity } from "@/tools/connection/schema";
 import { REVIEW_RUN_TOOL_NAMES } from "@/tools/task-board/task-run-context";
 import { getPublicUrl } from "@/core/server-constants";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
@@ -299,18 +301,24 @@ export class SandboxDispatchClient implements SandboxClient {
    * (`orgMcps`).
    *
    * Behind a flag because it is unbounded: each connection is one more server
-   * the harness connects to at session start and one more toolset in the
-   * model's context, and nothing here knows whether an org has three
+   * the harness connects to, and nothing here knows whether an org has three
    * connections or thirty.
    *
-   * One credential for all of them (see `orgMcpServers`), and a connection the
-   * proxy cannot reach is not this method's problem — the harness treats a
-   * broken org server as a missing toolset, not a failed run.
+   * The connections are resolved BEFORE the key is minted, because they are
+   * part of its scope: every proxied tool call is authorized as
+   * `{ <connectionId>: [<toolName>] }` (see the outbound transport's
+   * `AccessControl`), so a key that does not name a connection cannot call
+   * anything on it. One credential for all of them — a key per connection would
+   * be N live credentials nobody revokes for one run.
+   *
+   * A connection the proxy cannot reach is still not this method's problem: the
+   * harness treats a broken org server as a missing toolset, not a failed run.
    */
   private async mcpForRun(
     organization: { id: string; slug?: string; name?: string },
     threadId: string,
   ): Promise<Pick<HarnessStreamInputWire, "mcp" | "orgMcps">> {
+    const connections = await this.orgMcpConnections(organization);
     const mcp = await mintMcpEndpoint(
       this.ctx,
       this.virtualMcpId,
@@ -318,42 +326,26 @@ export class SandboxDispatchClient implements SandboxClient {
       `${this.harnessId}-run`,
       "task-run",
       threadId,
-      // Exactly the tools this run's surface exposes, not a wildcard. The
-      // reviewer superset covers both run kinds; which of them a given run can
-      // actually call is already decided by the server it talks to
-      // (`toolSubsetMCP`), so the key never widens that — it only stops being a
-      // full-access credential for every other management tool in Studio.
+      // Exactly what this run mounts, never a wildcard: the tools its own
+      // Studio surface exposes, plus the connections it was given.
       //
       // `self` is the resource key management tools are checked under (see
-      // AccessControl's default `connectionId`). It does NOT gate the
-      // per-connection proxy the `orgMcps` entries dial: that route authorizes
-      // by ORG MEMBERSHIP and connection ownership, with no `access.check` at
-      // all, so a run reaches exactly the connections any member of the org
-      // reaches — no more, but also no less.
-      { self: [...REVIEW_RUN_TOOL_NAMES] },
+      // AccessControl's default `connectionId`); the reviewer superset covers
+      // both run kinds, and which of them a given run can actually call is
+      // already decided by the server it talks to (`toolSubsetMCP`). Each
+      // connection is its own resource key, `"*"` because a run that was given
+      // a connection was given the whole connection.
+      runKeyPermissions({
+        toolNames: REVIEW_RUN_TOOL_NAMES,
+        connectionIds: connections.map((connection) => connection.id),
+      }),
     );
-    const settings = await this.ctx.storage.organizationSettings.get(
-      organization.id,
-    );
-    if (
-      !organization.slug ||
-      !orgFlagEnabled(settings?.flags, "coding_agent_org_mcps")
-    ) {
-      return { mcp };
-    }
-    // `list` excludes VIRTUAL connections (agents, not MCP servers) by default.
-    const { items } = await this.ctx.storage.connections.list(organization.id);
+    if (connections.length === 0 || !organization.slug) return { mcp };
     const orgMcps = orgMcpServers({
       publicUrl: getPublicUrl(),
       organizationSlug: organization.slug,
       headers: mcp.headers,
-      connections: items.filter(
-        (connection) =>
-          // A connection Studio already knows is erroring only costs the
-          // session a failed connect at startup.
-          connection.status === "active" &&
-          !isStudioOwnedConnection(organization.id, connection.id),
-      ),
+      connections,
     });
     console.log(
       `[${this.harnessId}] org mcps: ${
@@ -361,6 +353,30 @@ export class SandboxDispatchClient implements SandboxClient {
       }`,
     );
     return { mcp, orgMcps };
+  }
+
+  /**
+   * The org connections this run mounts, or none when the org has not opted in
+   * (or has no slug, without which the per-connection URL cannot be built).
+   */
+  private async orgMcpConnections(organization: {
+    id: string;
+    slug?: string;
+  }): Promise<ConnectionEntity[]> {
+    if (!organization.slug) return [];
+    const settings = await this.ctx.storage.organizationSettings.get(
+      organization.id,
+    );
+    if (!orgFlagEnabled(settings?.flags, "coding_agent_org_mcps")) return [];
+    // `list` excludes VIRTUAL connections (agents, not MCP servers) by default.
+    const { items } = await this.ctx.storage.connections.list(organization.id);
+    return items.filter(
+      (connection) =>
+        // A connection Studio already knows is erroring only costs the session
+        // a failed connect at startup.
+        connection.status === "active" &&
+        !isStudioOwnedConnection(organization.id, connection.id),
+    );
   }
 
   private async *stream(

--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts
@@ -3,6 +3,7 @@ import {
   MissingOrganizationSlugError,
   mcpEndpointUrl,
   orgMcpServers,
+  runKeyPermissions,
 } from "./mint-endpoint";
 
 const publicUrl = "https://studio.example.com";
@@ -141,5 +142,29 @@ describe("orgMcpServers", () => {
     expect(servers([{ id: "a/b", title: "x" }])[0]?.url).toBe(
       "https://studio.example.com/api/acme/mcp/a%2Fb",
     );
+  });
+});
+
+describe("runKeyPermissions", () => {
+  const permissions = (connectionIds: string[]) =>
+    runKeyPermissions({ toolNames: ["TASK_BOARD_ITEM_UPDATE"], connectionIds });
+
+  it("names every mounted connection as its own resource", () => {
+    // The regression this pins: a proxied call is authorized as
+    // `{ <connectionId>: [<toolName>] }`, so a key that names only `self`
+    // denies every org-MCP tool the run has.
+    expect(permissions(["conn_1", "conn_2"])).toEqual({
+      self: ["TASK_BOARD_ITEM_UPDATE"],
+      conn_1: ["*"],
+      conn_2: ["*"],
+    });
+  });
+
+  it("grants no wildcard resource — the key is not full access", () => {
+    expect(permissions(["conn_1"])["*"]).toBeUndefined();
+  });
+
+  it("is just the tool scope when the run mounts no connections", () => {
+    expect(permissions([])).toEqual({ self: ["TASK_BOARD_ITEM_UPDATE"] });
   });
 });

--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
@@ -187,3 +187,26 @@ function sanitizeServerName(raw: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
 }
+
+/**
+ * The allowlist for a run's key: the tools its own Studio surface exposes,
+ * under `self`, plus one entry per connection it mounts.
+ *
+ * Both halves are load-bearing and the connection half was missed once, which
+ * denied every org-MCP call a run made (`Access denied to: VTEX_LIST_BRANDS`).
+ * A proxied tool call is authorized as `{ <connectionId>: [<toolName>] }` — the
+ * connection is the RESOURCE, not the tool — so a key that names only `self`
+ * can call nothing on any connection. Pure, so that stays pinned.
+ */
+export function runKeyPermissions(args: {
+  /** Management tools the run's own surface exposes (checked under `self`). */
+  toolNames: readonly string[];
+  /** Connections the run mounts; each becomes its own resource key. */
+  connectionIds: readonly string[];
+}): Record<string, string[]> {
+  return {
+    self: [...args.toolNames],
+    // `"*"`: a run that was given a connection was given the whole connection.
+    ...Object.fromEntries(args.connectionIds.map((id) => [id, ["*"]])),
+  };
+}


### PR DESCRIPTION
Follow-up to #6466. Every org-MCP tool call a run makes is denied.

## What happens

On a Super Agent run with `coding_agent_org_mcps` on ([thread](https://studio.decocms.com/deco/thrd_l3DqvRaCHOIr1pnl0rfBX?virtualmcpid=decopilot_Mxt5kTw54XWnyDZse5iI9sHFhfnQzQBM&main=board)):

```
tool-mcp__vtex__VTEX_LIST_BRANDS            → MCP error -32603: Access denied to: VTEX_LIST_BRANDS
tool-mcp__exa-search-mcp__web_search_exa    → MCP error -32603: Access denied to: web_search_exa
tool-mcp__docsdecocx-mcp__SEARCH_DOCS       → MCP error -32603: Access denied to: SEARCH_DOCS
tool-mcp__studio__TASK_BOARD_COMMENT_LIST   → {"comments":[]}
```

The servers mount, tool search finds their tools (`mcp__vtex__VTEX_LIST_PRODUCTS`, …), and every call bounces. Studio's own server works.

## Why

#6466 narrowed the run's key from `{"*": ["*"]}` to `{ self: [...REVIEW_RUN_TOOL_NAMES] }`, on the stated claim that the per-connection proxy authorizes by org membership and connection ownership with no `access.check` on that path.

That claim was wrong. `apps/api/src/mcp-clients/outbound/transports/auth.ts` builds an `AccessControl` for **every proxied tool call**, with the **connection** as the resource key:

```ts
const connectionAccessControl = new AccessControl(
  …,
  toolName,
  ctx.boundAuth,
  …,
  connection.id,   // ← resource key
  …,
);
await connectionAccessControl.check(toolName);
```

For an API-key principal that resolves to `checkApiKeyPermission(granted, { [connection.id]: [toolName] })`. A key naming only `self` has no entry for that connection and no `"*"` resource to fall back on, so it fails closed. The gate did its job; the scope was wrong.

## The fix

The key names exactly what the run mounts — `self` for its own surface, plus each mounted connection at `"*"` (a run that was given a connection was given the whole connection). The connections are therefore resolved **before** the key is minted, so `mcpForRun` does the lookup first and a new `orgMcpConnections` owns it.

No wildcard resource is restored: with the flag off the key is still just `{ self: [...] }`, and with it on it names N connections and nothing else.

## Testing

- `runKeyPermissions` extracted as a pure function and unit-tested — connections appear as their own resource keys, no `"*"` resource, and the connection-less case is just the tool scope. This is the second time the shape of that map decided whether the feature works, so it is pinned now.
- `bun test packages/harness-runner apps/api/src/mcp-clients` — 189 pass. `check`, `lint`, `knip`, `fmt` clean.
- Not yet re-run on a live thread; the run above is the reproduction.

## Note

This also settles the open question from #6466: the run's connection reach **is** key-gated, so per-connection scoping is real and available. Making that scope mirror the dispatching user's own per-connection grants (rather than every active connection in the org) is the natural next step, and now has a working mechanism to hang off.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes org-MCP authorization by putting mounted connections on the run key. Previously the key named only `self`, so proxied calls authorized as `{ <connectionId>: [<toolName>] }` failed with “Access denied”. Now the key includes `self` tool scope and each mounted connection as its own resource.

- Old: run key = `{ self: [tools] }` → org-MCP tool calls denied.
- New: run key = `{ self: [tools], <connectionId>: ["*"], ... }` → org-MCP tool calls allowed.
- No wildcard resource is restored; behavior is unchanged when the org flag is off.

**Details for review**
- Resolve connections before minting the key: `mcpForRun` calls `orgMcpConnections`, then passes IDs to `runKeyPermissions`.
- Add `runKeyPermissions` (pure) with tests that pin the key shape and deny any implicit `"*"` resource.
- `orgMcpConnections` filters to active, non-Studio-owned connections; if no slug or flag off, mount none.
- Rollout: no migration needed. Orgs without `coding_agent_org_mcps` stay on `self`-only scope.

<sup>Written for commit b7b657a4f532c15d7b2ee8e6ae061cf970a4597c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

