### PR TITLE
feat(claude-code): scope a run's org MCPs to the dispatcher's own grants

### DIFF
--- a/apps/api/src/harnesses/org-mcp-grants.test.ts
+++ b/apps/api/src/harnesses/org-mcp-grants.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import { connectionGrantsFor, rolesOf } from "./org-mcp-grants";
+
+describe("connectionGrantsFor", () => {
+  const ids = ["conn_a", "conn_b"];
+
+  it("gives an owner every candidate connection — they bypass the check anyway", () => {
+    expect(
+      connectionGrantsFor({
+        role: "owner",
+        roleStatements: [],
+        connectionIds: ids,
+      }),
+    ).toEqual({ conn_a: ["*"], conn_b: ["*"] });
+  });
+
+  it("gives an admin the same, including through a comma-joined role", () => {
+    expect(
+      connectionGrantsFor({
+        role: "billing-manager,admin",
+        roleStatements: [],
+        connectionIds: ids,
+      }),
+    ).toEqual({ conn_a: ["*"], conn_b: ["*"] });
+  });
+
+  it("gives a member nothing when no role grants a connection — as the proxy would", () => {
+    expect(
+      connectionGrantsFor({
+        role: "user",
+        roleStatements: [],
+        connectionIds: ids,
+      }),
+    ).toEqual({});
+  });
+
+  it("keeps a partial grant partial", () => {
+    expect(
+      connectionGrantsFor({
+        role: "support",
+        roleStatements: [{ conn_a: ["VTEX_LIST_BRANDS", "VTEX_LIST_SKUS"] }],
+        connectionIds: ids,
+      }),
+    ).toEqual({ conn_a: ["VTEX_LIST_BRANDS", "VTEX_LIST_SKUS"] });
+  });
+
+  it("unions across roles, and a wildcard subsumes named tools", () => {
+    expect(
+      connectionGrantsFor({
+        role: "support,analyst",
+        roleStatements: [{ conn_a: ["VTEX_LIST_BRANDS"] }, { conn_a: ["*"] }],
+        connectionIds: ids,
+      }),
+    ).toEqual({ conn_a: ["*"] });
+  });
+
+  it("ignores grants for connections the run is not mounting", () => {
+    expect(
+      connectionGrantsFor({
+        role: "support",
+        roleStatements: [{ conn_elsewhere: ["*"], self: ["*"] }],
+        connectionIds: ids,
+      }),
+    ).toEqual({});
+  });
+});
+
+describe("rolesOf", () => {
+  it("splits Better Auth's comma-joined multi-role value", () => {
+    expect(rolesOf("admin, billing-manager")).toEqual([
+      "admin",
+      "billing-manager",
+    ]);
+  });
+
+  it("is empty for a member with no role", () => {
+    expect(rolesOf(undefined)).toEqual([]);
+    expect(rolesOf("")).toEqual([]);
+  });
+});

--- a/apps/api/src/harnesses/org-mcp-grants.ts
+++ b/apps/api/src/harnesses/org-mcp-grants.ts
@@ -1,0 +1,79 @@
+/**
+ * Which of the org's MCP connections a run may use, and with which tools.
+ *
+ * A sandbox run acts on behalf of the person who dispatched it, so it must not
+ * reach a connection that person cannot reach. That is not a policy invented
+ * here — it is the same decision Studio makes on every proxied tool call
+ * (`mcp-clients/outbound/transports/auth.ts` checks
+ * `{ <connectionId>: [<toolName>] }`), reproduced at dispatch time so the run's
+ * key carries exactly that authority and no more.
+ *
+ * Reproduced rather than probed: the alternative is one `hasPermission` round
+ * trip per (connection, tool) at dispatch, and a probe keyed on `"*"` would
+ * throw away a partial grant — a role that may call two tools on a connection
+ * would read as "no access" and lose the connection entirely.
+ */
+
+import { hasAdminRole } from "@decocms/shared/auth/roles";
+import type { Permission } from "@/storage/types";
+
+/**
+ * The connection entries for a run's key: `{ <connectionId>: [tools] }`, only
+ * for connections the dispatcher can actually use.
+ *
+ * - **admin/owner** bypass every permission check in `AccessControl`, so their
+ *   runs get every candidate connection at `"*"`. Anything narrower would be a
+ *   restriction the dispatcher does not have.
+ * - **everyone else** gets the union of their roles' own statements, verbatim:
+ *   a role granting two tools on a connection yields those two tools, and a
+ *   connection no role names is absent — which is what the proxy would answer
+ *   anyway.
+ *
+ * A member whose roles grant no connection therefore gets none. That is the
+ * honest result, not a bug: today the same person calling that connection
+ * through Studio is denied.
+ *
+ * Pure — the unit test owns this, because the shape of this map is what decides
+ * whether a run can call anything at all.
+ */
+export function connectionGrantsFor(args: {
+  /** The dispatcher's `member.role`, possibly Better Auth's comma-joined form. */
+  role: string | null | undefined;
+  /**
+   * Statements for the dispatcher's non-built-in roles, in any order. Built-in
+   * roles contribute nothing here: `user` has no per-connection grant (its
+   * statement is keyed on `self`), and admin/owner never reach this path.
+   */
+  roleStatements: readonly Permission[];
+  /** Connections the run would otherwise mount. */
+  connectionIds: readonly string[];
+}): Record<string, string[]> {
+  const { role, roleStatements, connectionIds } = args;
+  if (hasAdminRole(role ?? undefined)) {
+    return Object.fromEntries(connectionIds.map((id) => [id, ["*"]]));
+  }
+  const grants: Record<string, string[]> = {};
+  for (const id of connectionIds) {
+    const tools = new Set<string>();
+    for (const statement of roleStatements) {
+      for (const tool of statement[id] ?? []) tools.add(tool);
+    }
+    if (tools.size === 0) continue;
+    // A `"*"` anywhere in the union subsumes the named tools next to it.
+    grants[id] = tools.has("*") ? ["*"] : [...tools];
+  }
+  return grants;
+}
+
+/**
+ * The individual roles in a `member.role` value. Better Auth stores multiple
+ * roles comma-joined (`"admin,billing-manager"`), and a caller that treats that
+ * string as one role name finds no statement for it and silently grants
+ * nothing.
+ */
+export function rolesOf(role: string | null | undefined): string[] {
+  return (role ?? "")
+    .split(",")
+    .map((one) => one.trim())
+    .filter(Boolean);
+}

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -63,6 +63,10 @@ import {
 import { orgFlagEnabled } from "@decocms/shared/organization/schema";
 import { WellKnownOrgMCPId } from "@decocms/shared/sdk";
 import type { ConnectionEntity } from "@/tools/connection/schema";
+import { hasAdminRole } from "@decocms/shared/auth/roles";
+import { fetchRolePermissions } from "@/core/context-factory";
+import type { Permission } from "@/storage/types";
+import { connectionGrantsFor, rolesOf } from "@/harnesses/org-mcp-grants";
 import { REVIEW_RUN_TOOL_NAMES } from "@/tools/task-board/task-run-context";
 import { getPublicUrl } from "@/core/server-constants";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
@@ -317,8 +321,17 @@ export class SandboxDispatchClient implements SandboxClient {
   private async mcpForRun(
     organization: { id: string; slug?: string; name?: string },
     threadId: string,
+    dispatcherUserId: string,
   ): Promise<Pick<HarnessStreamInputWire, "mcp" | "orgMcps">> {
-    const connections = await this.orgMcpConnections(organization);
+    const candidates = await this.orgMcpConnections(organization);
+    const grants = await this.dispatcherConnectionGrants(
+      organization.id,
+      dispatcherUserId,
+      candidates.map((connection) => connection.id),
+    );
+    const connections = candidates.filter(
+      (connection) => connection.id in grants,
+    );
     const mcp = await mintMcpEndpoint(
       this.ctx,
       this.virtualMcpId,
@@ -335,10 +348,7 @@ export class SandboxDispatchClient implements SandboxClient {
       // already decided by the server it talks to (`toolSubsetMCP`). Each
       // connection is its own resource key, `"*"` because a run that was given
       // a connection was given the whole connection.
-      runKeyPermissions({
-        toolNames: REVIEW_RUN_TOOL_NAMES,
-        connectionIds: connections.map((connection) => connection.id),
-      }),
+      runKeyPermissions({ toolNames: REVIEW_RUN_TOOL_NAMES, grants }),
     );
     if (connections.length === 0 || !organization.slug) return { mcp };
     const orgMcps = orgMcpServers({
@@ -350,9 +360,53 @@ export class SandboxDispatchClient implements SandboxClient {
     console.log(
       `[${this.harnessId}] org mcps: ${
         orgMcps.map((server) => server.name).join(" ") || "none"
+      }${
+        candidates.length === connections.length
+          ? ""
+          : ` (${candidates.length - connections.length} withheld — the ` +
+            `dispatching user has no grant for them)`
       }`,
     );
     return { mcp, orgMcps };
+  }
+
+  /**
+   * The dispatching user's own per-connection authority, as
+   * `{ <connectionId>: [tools] }` — the scope the run's key gets, and the
+   * filter on which connections it mounts at all.
+   *
+   * The role is read from the member row rather than taken off the context: a
+   * dispatch can arrive from the board or a worker, where the context was not
+   * built from that user's session, and a missing role would silently strip
+   * every connection.
+   */
+  private async dispatcherConnectionGrants(
+    organizationId: string,
+    dispatcherUserId: string,
+    connectionIds: string[],
+  ): Promise<Record<string, string[]>> {
+    if (connectionIds.length === 0) return {};
+    const member = await this.ctx.db
+      .selectFrom("member")
+      .select(["role"])
+      .where("organizationId", "=", organizationId)
+      .where("userId", "=", dispatcherUserId)
+      .executeTakeFirst();
+    const role = member?.role;
+    const statements = hasAdminRole(role ?? undefined)
+      ? []
+      : (
+          await Promise.all(
+            rolesOf(role).map((one) =>
+              fetchRolePermissions(this.ctx.db, organizationId, one),
+            ),
+          )
+        ).filter((statement): statement is Permission => Boolean(statement));
+    return connectionGrantsFor({
+      role,
+      roleStatements: statements,
+      connectionIds,
+    });
   }
 
   /**
@@ -433,7 +487,7 @@ export class SandboxDispatchClient implements SandboxClient {
       //
       // The org's own MCP connections come alongside it (`orgMcps`), behind
       // the `coding_agent_org_mcps` flag — see `mcpForRun`.
-      ...(await this.mcpForRun(organization, input.threadId)),
+      ...(await this.mcpForRun(organization, input.threadId, input.user.id)),
       // Hosted Decopilot mounts no working directory; this harness edits the
       // checkout the daemon prepared.
       workspace: await this.resolveWorkspace(input.threadId),

--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts
@@ -146,25 +146,25 @@ describe("orgMcpServers", () => {
 });
 
 describe("runKeyPermissions", () => {
-  const permissions = (connectionIds: string[]) =>
-    runKeyPermissions({ toolNames: ["TASK_BOARD_ITEM_UPDATE"], connectionIds });
+  const permissions = (grants: Record<string, string[]>) =>
+    runKeyPermissions({ toolNames: ["TASK_BOARD_ITEM_UPDATE"], grants });
 
   it("names every mounted connection as its own resource", () => {
     // The regression this pins: a proxied call is authorized as
     // `{ <connectionId>: [<toolName>] }`, so a key that names only `self`
     // denies every org-MCP tool the run has.
-    expect(permissions(["conn_1", "conn_2"])).toEqual({
+    expect(permissions({ conn_1: ["*"], conn_2: ["READ"] })).toEqual({
       self: ["TASK_BOARD_ITEM_UPDATE"],
       conn_1: ["*"],
-      conn_2: ["*"],
+      conn_2: ["READ"],
     });
   });
 
   it("grants no wildcard resource — the key is not full access", () => {
-    expect(permissions(["conn_1"])["*"]).toBeUndefined();
+    expect(permissions({ conn_1: ["*"] })["*"]).toBeUndefined();
   });
 
   it("is just the tool scope when the run mounts no connections", () => {
-    expect(permissions([])).toEqual({ self: ["TASK_BOARD_ITEM_UPDATE"] });
+    expect(permissions({})).toEqual({ self: ["TASK_BOARD_ITEM_UPDATE"] });
   });
 });

--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
@@ -201,12 +201,12 @@ function sanitizeServerName(raw: string): string {
 export function runKeyPermissions(args: {
   /** Management tools the run's own surface exposes (checked under `self`). */
   toolNames: readonly string[];
-  /** Connections the run mounts; each becomes its own resource key. */
-  connectionIds: readonly string[];
+  /**
+   * Per-connection grants for the run, `{ <connectionId>: [tools] }` — see
+   * `connectionGrantsFor`, which derives them from the dispatching user's own
+   * authority rather than from the org's connection list.
+   */
+  grants: Record<string, string[]>;
 }): Record<string, string[]> {
-  return {
-    self: [...args.toolNames],
-    // `"*"`: a run that was given a connection was given the whole connection.
-    ...Object.fromEntries(args.connectionIds.map((id) => [id, ["*"]])),
-  };
+  return { self: [...args.toolNames], ...args.grants };
 }


### PR DESCRIPTION
Follow-up to #6473, now merged — this PR targets `main` and carries one commit.

## What

A sandbox run acts on behalf of whoever dispatched it, so it should not reach a connection that person cannot reach. Today the run's key names **every active connection in the org**, regardless of who pressed the button.

It now names what the dispatcher's own roles name.

## How

`connectionGrantsFor` reproduces the decision Studio makes on every proxied call — `AccessControl` with the connection as the resource, checking `{ <connectionId>: [<toolName>] }` — at dispatch time:

- **admin/owner** bypass every permission check, so their runs get every candidate connection at `"*"`. Anything narrower would be a restriction the dispatcher does not have.
- **everyone else** gets the union of their roles' statements, **verbatim** — a role granting two tools on a connection yields exactly those two.
- a connection no role names is **not mounted at all**. Mounting a server whose every call is denied is the failure #6473 just fixed.

Reproduced rather than probed on purpose: probing would cost one `hasPermission` round trip per (connection, tool) at dispatch, and a probe keyed on `"*"` would throw away a partial grant — "may call two tools here" would read as no access and lose the connection.

The role is read from the `member` row rather than taken off the context: a dispatch can arrive from the board or a worker, whose context was not built from that user's session, and a missing role would silently strip every connection.

## What this changes in practice

Role distribution in production today:

| role | memberships | effect |
|---|---|---|
| owner | 807 | unchanged — bypasses |
| admin | 521 | unchanged — bypasses |
| user | 171 | **no org MCPs** unless a custom role grants one |
| member | 63 | same |
| custom (11 roles, 7 carrying `conn_` grants) | — | gets exactly what the role grants |

So ~85% of dispatchers are unaffected, and the rest get the honest answer: today that same person calling that connection through Studio is denied, so their run is too. The dispatch log says how many were withheld and why, because "the agent didn't use my MCP" otherwise looks identical to a broken server.

## Testing

- `org-mcp-grants.test.ts` — owner/admin (including the comma-joined multi-role form), member with no grants, partial grant preserved, union across roles with `"*"` subsuming named tools, and grants for connections the run isn't mounting being ignored.
- `runKeyPermissions` updated to take the grant map; its tests keep pinning that no `"*"` resource is ever produced.
- `bun run --cwd=apps/api check`, `lint`, `knip`, `fmt` clean. (One pre-existing local failure, `web_search async-research e2e`, needs a local Postgres.)
- Not exercised on a live run.

## Open question

`BASIC_USAGE_TOOLS` are granted to any member on **any** resource, so strictly a member could call a downstream tool whose name collides with one (`ORG_FS_READ`, the basic-usage management tools). Those names never appear on a real downstream MCP, so this does not model it. Worth revisiting if a connection ever ships a tool by one of those names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes a run’s org MCP connections and tool access to the dispatching user’s own grants. Previously the run key named every active org connection; now it names only the connections and tools the dispatcher’s roles permit. Admin/owner behavior is unchanged; non-admin runs may mount fewer or no connections.

- Adds `connectionGrantsFor` (plus `rolesOf`) to derive `{ <connectionId>: [tools] }` from the dispatcher’s roles, preserving partial grants and union across roles; connections with no grant are not mounted.
- Filters mounted connections in `sandbox-dispatch-client` to those in the grants, passes those grants to the key, and reads the dispatcher’s role from the `member` row; logs how many candidate connections were withheld.
- Changes `runKeyPermissions` to accept `grants: Record<string, string[]>` instead of `connectionIds` and to preserve partial tool grants. Required: update callers to `runKeyPermissions({ toolNames, grants })`.
- Tests cover admin/owner bypass, empty and partial grants, wildcard subsuming named tools, multi-role parsing, and ignoring grants for non-mounted connections.

<sup>Written for commit 237d5ece4335e7ef5acb16b464637fc8e63285a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

