### PR TITLE
[chore]: align Bun runtime to 1.4.0

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -10,7 +10,7 @@ description: >-
 inputs:
   bun-version:
     description: Bun version to install — single source of truth for CI.
-    default: "1.3.14"
+    default: "1.4.0"
 
 runs:
   using: composite

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -58,7 +58,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  BUN_VERSION: "1.3.14"
+  BUN_VERSION: "1.4.0"
 
 jobs:
   # Gate: skip each macOS job when a PR touches none of ITS inputs.

--- a/.github/workflows/release-native.yaml
+++ b/.github/workflows/release-native.yaml
@@ -138,7 +138,7 @@ permissions:
   actions: read
 
 env:
-  BUN_VERSION: "1.3.14"
+  BUN_VERSION: "1.4.0"
 
 jobs:
   # -------------------------------------------------------------------

--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
 
       - name: Find the merged pull request
         id: find_pr

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,6 +1,6 @@
 # Simplified Dockerfile - installs the locally-built decocms tarball (see below)
 # Uses debian-slim (not alpine) because @duckdb/node-bindings requires glibc
-FROM oven/bun:1-slim
+FROM oven/bun:1.4.0-slim
 
 # The package tarball is built once by CI (build-dist job) and dropped into the
 # build context as decocms.tgz. Installing that exact tarball keeps this image
@@ -8,7 +8,7 @@ FROM oven/bun:1-slim
 # round-trip (and propagation race) at image-build time.
 
 # Install runtime dependencies.
-# - ca-certificates: the oven/bun:1-slim base ships NO system CA bundle, but
+# - ca-certificates: the oven/bun:1.4.0-slim base ships NO system CA bundle, but
 #   DuckDB's native httpfs (OpenSSL) needs the OS trust store to verify TLS to
 #   storage.googleapis.com. Without it the GCS monitoring read fails with
 #   "Problem with the SSL CA cert (path? access rights?)". Bun/Node bundle their

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -85,7 +85,7 @@
     "@opentelemetry/sdk-metrics": "^2.2.0",
     "@opentelemetry/sdk-node": "^0.207.0",
     "@opentelemetry/sdk-trace-base": "^2.5.0",
-    "@types/bun": "^1.3.1",
+    "@types/bun": "1.4.0",
     "@types/google.maps": "^3.65.2",
     "@types/pg": "^8.15.6",
     "@types/react-syntax-highlighter": "^15.5.13",

--- a/apps/api/src/tools/registry/discover-tools.test.ts
+++ b/apps/api/src/tools/registry/discover-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { EventEmitter } from "node:events";
 import {
   createNoRedirectFetch,
   isPrivateUrl,
@@ -118,7 +119,11 @@ describe("withTimeout", () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
       expect(rejection).toBeUndefined();
     } finally {
-      process.off("unhandledRejection", onUnhandledRejection);
+      EventEmitter.prototype.off.call(
+        process,
+        "unhandledRejection",
+        onUnhandledRejection,
+      );
     }
   });
 

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -19,7 +19,7 @@
     "@decocms/shared": "workspace:*"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.1",
+    "@types/bun": "1.4.0",
     "typescript": "^5.9.3"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -95,7 +95,7 @@
     "@tailwindcss/vite": "^4.1.17",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/bun": "^1.3.1",
+    "@types/bun": "1.4.0",
     "@types/google.maps": "^3.65.2",
     "@types/mustache": "^4.2.5",
     "@types/react": "^19.2.14",

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@decocms/studio",
       "devDependencies": {
         "@biomejs/biome": "2.2.5",
-        "@types/bun": "^1.3.1",
+        "@types/bun": "1.4.0",
         "@types/node": "^24.9.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -72,7 +72,7 @@
         "@opentelemetry/sdk-metrics": "^2.2.0",
         "@opentelemetry/sdk-node": "^0.207.0",
         "@opentelemetry/sdk-trace-base": "^2.5.0",
-        "@types/bun": "^1.3.1",
+        "@types/bun": "1.4.0",
         "@types/google.maps": "^3.65.2",
         "@types/pg": "^8.15.6",
         "@types/react-syntax-highlighter": "^15.5.13",
@@ -119,7 +119,7 @@
         "@decocms/shared": "workspace:*",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.1",
+        "@types/bun": "1.4.0",
         "typescript": "^5.9.3",
       },
     },
@@ -204,7 +204,7 @@
         "@tailwindcss/vite": "^4.1.17",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/bun": "^1.3.1",
+        "@types/bun": "1.4.0",
         "@types/google.maps": "^3.65.2",
         "@types/mustache": "^4.2.5",
         "@types/react": "^19.2.14",
@@ -247,7 +247,7 @@
         "zod": "4.3.6",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.1",
+        "@types/bun": "1.4.0",
         "@types/pg": "^8.15.6",
         "typescript": "^7.0.2",
       },
@@ -263,7 +263,7 @@
       },
       "devDependencies": {
         "@decocms/sandbox": "workspace:*",
-        "@types/bun": "latest",
+        "@types/bun": "1.4.0",
         "ai": "^6.0.208",
         "typescript": "^7.0.2",
       },
@@ -296,7 +296,7 @@
         "zod": "4.3.6",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.5",
+        "@types/bun": "1.4.0",
         "@types/mime-db": "^1.43.6",
         "ai": "^6.0.208",
         "ts-json-schema-generator": "^2.4.0",
@@ -318,7 +318,7 @@
       "devDependencies": {
         "@nats-io/jetstream": "3.4.0",
         "@nats-io/nats-core": "3.4.0",
-        "@types/bun": "latest",
+        "@types/bun": "1.4.0",
         "typescript": "^7.0.2",
       },
     },
@@ -345,7 +345,7 @@
         "prettier": "^3.6.2",
       },
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "1.4.0",
         "@types/node": "^24.6.2",
         "tsup": "^8.5.0",
         "tsx": "^4.7.1",
@@ -1801,7 +1801,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -2075,7 +2075,7 @@
 
     "buffer": ["buffer@5.6.0", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4" } }, "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -3867,27 +3867,13 @@
 
     "@decocms/better-auth/better-call": ["better-call@1.1.5", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.7.10", "set-cookie-parser": "^2.7.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-nQJ3S87v6wApbDwbZ++FrQiSiVxWvZdjaO+2v6lZJAG2WWggkB2CziUDjPciz3eAt9TqfRursIQMZIcpkBnvlw=="],
 
-    "@decocms/e2e/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
-    "@decocms/harness-runner/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
-    "@decocms/native/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
     "@decocms/native/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "@decocms/runtime/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
-    "@decocms/sandbox/@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
-
     "@decocms/studio-web/@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
-
-    "@decocms/studio-web/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@decocms/studio-web/lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
 
     "@decocms/studio-web/tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
-
-    "@decocms/typegen/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@decocms/typegen/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -4229,8 +4215,6 @@
 
     "decocms/@better-auth/sso": ["@better-auth/sso@1.4.1", "", { "dependencies": { "@better-fetch/fetch": "1.1.18", "fast-xml-parser": "^5.2.5", "jose": "^6.1.0", "samlify": "^2.10.1", "zod": "^4.1.12" }, "peerDependencies": { "better-auth": "1.4.1" } }, "sha512-EG3P6uxieSFQvOR4Xxs210YrIrLGGlUDluvPxKx1qMgVxfbt3S8ziQ3wnLScTJKe3WjzsCX8JdN6hLhbO76YAA=="],
 
-    "decocms/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
     "decode-named-character-reference/character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
@@ -4541,23 +4525,9 @@
 
     "@decocms/better-auth/better-call/set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
-    "@decocms/e2e/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
-    "@decocms/harness-runner/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
-    "@decocms/native/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
-    "@decocms/runtime/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
-    "@decocms/sandbox/@types/bun/bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
-
     "@decocms/studio-web/@tailwindcss/vite/@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
 
     "@decocms/studio-web/@tailwindcss/vite/@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.3", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.3", "@tailwindcss/oxide-darwin-arm64": "4.3.3", "@tailwindcss/oxide-darwin-x64": "4.3.3", "@tailwindcss/oxide-freebsd-x64": "4.3.3", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3", "@tailwindcss/oxide-linux-arm64-musl": "4.3.3", "@tailwindcss/oxide-linux-x64-gnu": "4.3.3", "@tailwindcss/oxide-linux-x64-musl": "4.3.3", "@tailwindcss/oxide-wasm32-wasi": "4.3.3", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3", "@tailwindcss/oxide-win32-x64-msvc": "4.3.3" } }, "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA=="],
-
-    "@decocms/studio-web/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
-    "@decocms/typegen/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@decocms/ui/@tailwindcss/vite/@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
 
@@ -4770,8 +4740,6 @@
     "decocms/@better-auth/sso/better-auth": ["better-auth@1.4.5", "", { "dependencies": { "@better-auth/core": "1.4.5", "@better-auth/telemetry": "1.4.5", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.18", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "better-call": "1.1.4", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "ms": "4.0.0-nightly.202508271359", "nanostores": "^1.0.1", "zod": "^4.1.12" }, "peerDependencies": { "@lynx-js/react": "*", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@sveltejs/kit", "@tanstack/react-start", "next", "react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-pHV2YE0OogRHvoA6pndHXCei4pcep/mjY7psSaHVrRgjBtumVI68SV1g9U9XPRZ4KkoGca9jfwuv+bB2UILiFw=="],
 
     "decocms/@better-auth/sso/samlify": ["samlify@2.12.0", "", { "dependencies": { "@authenio/xml-encryption": "^2.0.2", "@xmldom/xmldom": "^0.8.11", "node-rsa": "^1.1.1", "xml": "^1.0.1", "xml-crypto": "^6.1.2", "xml-escape": "^1.1.0", "xpath": "^0.0.34" } }, "sha512-ewGsHyY4kInDH0BfprlAZ1rHpH1jBmbqYiXDbuI3t1Y8h71gqEt4Z7jdCFyPHFR8jItJkbdckTijUZGg14CDlg=="],
-
-    "decocms/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 

--- a/deploy/helm/sandbox-env/orgfs-sidecar/Dockerfile
+++ b/deploy/helm/sandbox-env/orgfs-sidecar/Dockerfile
@@ -5,7 +5,7 @@
 # Build context is the REPO ROOT (the bundle pulls TS from packages/):
 # docker build -f deploy/helm/sandbox-env/orgfs-sidecar/Dockerfile .
 
-FROM oven/bun:1.3.14-debian AS build
+FROM oven/bun:1.4.0-debian AS build
 WORKDIR /repo
 # Only the sidecar's import graph — no full workspace install.
 # @decocms/shared/std is a zero-dependency workspace export; a hand-made
@@ -17,7 +17,7 @@ RUN mkdir -p node_modules/@decocms \
   && bun build packages/sandbox/orgfs/sidecar-main.ts \
     --target bun --outfile /out/sidecar.js
 
-FROM oven/bun:1.3.14-debian
+FROM oven/bun:1.4.0-debian
 LABEL org.opencontainers.image.source="https://github.com/decocms/studio"
 # rclone does the FUSE mounting; user_allow_other lets the unprivileged main
 # container (different uid) read the mounts after propagation.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@decocms/studio",
   "devDependencies": {
     "@biomejs/biome": "2.2.5",
-    "@types/bun": "^1.3.1",
+    "@types/bun": "1.4.0",
     "@types/node": "^24.9.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -17,7 +17,7 @@
     "zod": "4.3.6"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.1",
+    "@types/bun": "1.4.0",
     "@types/pg": "^8.15.6",
     "typescript": "^7.0.2"
   }

--- a/packages/harness-runner/package.json
+++ b/packages/harness-runner/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@decocms/sandbox": "workspace:*",
-    "@types/bun": "latest",
+    "@types/bun": "1.4.0",
     "ai": "^6.0.208",
     "typescript": "^7.0.2"
   }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -29,7 +29,7 @@
     "ai": ">=6.0.0"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.5",
+    "@types/bun": "1.4.0",
     "@types/mime-db": "^1.43.6",
     "ai": "^6.0.208",
     "ts-json-schema-generator": "^2.4.0"

--- a/packages/sandbox/image/Dockerfile
+++ b/packages/sandbox/image/Dockerfile
@@ -24,7 +24,7 @@ COPY daemon-go/ ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" \
       go build -trimpath -ldflags="-s -w" -o /out/daemon-go .
 
-FROM oven/bun:1.3.14-debian AS runtime-base
+FROM oven/bun:1.4.0-debian AS runtime-base
 
 ARG COREPACK_VERSION=0.35.0
 ARG DENO_VERSION=v1.46.3

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@nats-io/jetstream": "3.4.0",
     "@nats-io/nats-core": "3.4.0",
-    "@types/bun": "latest",
+    "@types/bun": "1.4.0",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/typegen/package.json
+++ b/packages/typegen/package.json
@@ -24,7 +24,7 @@
     "prettier": "^3.6.2"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "1.4.0",
     "@types/node": "^24.6.2",
     "tsup": "^8.5.0",
     "tsx": "^4.7.1",

--- a/tests/multi-pod/mock-ai/Dockerfile
+++ b/tests/multi-pod/mock-ai/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1-alpine
+FROM oven/bun:1.4.0-alpine
 
 WORKDIR /app
 COPY server.ts /app/server.ts

--- a/tests/resilience/Dockerfile.studio
+++ b/tests/resilience/Dockerfile.studio
@@ -1,4 +1,4 @@
-FROM oven/bun:1-slim
+FROM oven/bun:1.4.0-slim
 
 # unzip + bash are runtime dependencies.
 RUN apt-get update && \

--- a/tests/resilience/everything-server/Dockerfile
+++ b/tests/resilience/everything-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1-slim
+FROM oven/bun:1.4.0-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## What is this contribution about?

Bottom layer of the Bun 1.4 adoption stack.

- Pins repository-controlled CI, release workflows, native jobs, sandbox/API/test images, and all direct `@types/bun` declarations to Bun 1.4.0.
- Deduplicates the Bun type resolution in `bun.lock`.
- Adapts one process-event cleanup call to Bun 1.4's narrower `Process.off` typing without changing runtime behavior.

Next in stack: #6476

## How did you verify your code works?

- `bun install --frozen-lockfile --lockfile-only`
- `bun run fmt`
- `bun run check` — all 14 workspaces passed
- `bun run lint` — 0 errors
- `bun run test` — 7,557 tests across 752 files
- Targeted discover-tools tests — 20 passed
- Verified the referenced 1.4.0 slim, Debian, and Alpine Docker manifests for amd64 and arm64

## Screenshots/Demonstration

Not applicable; no UI changes.

## How to Test

1. Run `bun install --frozen-lockfile`.
2. Run `bun run check && bun run lint && bun run test`.
3. Confirm workflows and Docker builds resolve exact Bun 1.4.0 tags.

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is unchanged because no user-facing contract changed
- [x] No database migration or breaking application API change