### PR TITLE
refactor(services): use Bun.Archive for NATS

### DIFF
--- a/apps/api/src/services/ensure-services.test.ts
+++ b/apps/api/src/services/ensure-services.test.ts
@@ -1,5 +1,137 @@
 import { describe, expect, it } from "bun:test";
-import { minioArtifactName, minioDownloadUrl } from "./ensure-services";
+import {
+  minioArtifactName,
+  minioDownloadUrl,
+  natsArtifactName,
+  natsBinaryTempPath,
+  readNatsBinaryFromTarGzip,
+  shouldInstallExtractedNatsBinary,
+} from "./ensure-services";
+
+async function makeNatsTarGzip(
+  artifact: string,
+  contents: string,
+): Promise<Uint8Array> {
+  const archiveRoot = artifact.slice(0, -".tar.gz".length);
+  return new Bun.Archive(
+    {
+      [`${archiveRoot}/LICENSE`]: "license",
+      [`${archiveRoot}/nats-server`]: contents,
+    },
+    { compress: "gzip" },
+  ).bytes();
+}
+
+describe("natsArtifactName", () => {
+  it("uses tar.gz for unix artifacts", () => {
+    expect(natsArtifactName("darwin", "arm64")).toBe(
+      "nats-server-v2.14.2-darwin-arm64.tar.gz",
+    );
+    expect(natsArtifactName("linux", "x64")).toBe(
+      "nats-server-v2.14.2-linux-amd64.tar.gz",
+    );
+  });
+
+  it("keeps the Windows ZIP artifact", () => {
+    expect(natsArtifactName("win32", "x64")).toBe(
+      "nats-server-v2.14.2-windows-amd64.zip",
+    );
+  });
+
+  it("throws on an unsupported platform", () => {
+    expect(() => natsArtifactName("sunos", "sparc")).toThrow(
+      /Unsupported platform/,
+    );
+  });
+});
+
+describe("readNatsBinaryFromTarGzip", () => {
+  it("reads the executable from a gzipped NATS release archive", async () => {
+    const artifact = "nats-server-v2.14.2-linux-amd64.tar.gz";
+    const archive = await makeNatsTarGzip(artifact, "nats executable");
+
+    const binary = await readNatsBinaryFromTarGzip(archive, artifact);
+
+    expect(binary.name).toBe("nats-server-v2.14.2-linux-amd64/nats-server");
+    expect(await binary.text()).toBe("nats executable");
+  });
+
+  it("supports archive roots longer than the legacy tar name field", async () => {
+    const artifact = `nats-server-v2.14.2-${"long-".repeat(30)}linux-amd64.tar.gz`;
+    const archive = await makeNatsTarGzip(artifact, "long path executable");
+
+    const binary = await readNatsBinaryFromTarGzip(archive, artifact);
+
+    expect(binary.name.length).toBeGreaterThan(100);
+    expect(await binary.text()).toBe("long path executable");
+  });
+
+  it("propagates corrupt archive errors", async () => {
+    await expect(
+      readNatsBinaryFromTarGzip(
+        new TextEncoder().encode("not a tar archive"),
+        "nats-server-v2.14.2-linux-amd64.tar.gz",
+      ),
+    ).rejects.toThrow(/archive format/);
+  });
+
+  it("propagates truncated gzip errors", async () => {
+    const artifact = "nats-server-v2.14.2-linux-amd64.tar.gz";
+    const archive = await makeNatsTarGzip(artifact, "nats executable");
+
+    await expect(
+      readNatsBinaryFromTarGzip(archive.subarray(0, 32), artifact),
+    ).rejects.toThrow(/truncated gzip input/);
+  });
+
+  it("rejects an archive without the expected executable", async () => {
+    const artifact = "nats-server-v2.14.2-linux-amd64.tar.gz";
+    const archive = await new Bun.Archive(
+      { "unexpected/nats-server": "wrong binary" },
+      { compress: "gzip" },
+    ).bytes();
+
+    await expect(readNatsBinaryFromTarGzip(archive, artifact)).rejects.toThrow(
+      /NATS binary not found/,
+    );
+  });
+
+  it("rejects the Windows archive format before parsing", async () => {
+    await expect(
+      readNatsBinaryFromTarGzip(
+        new Uint8Array(),
+        "nats-server-v2.14.2-windows-amd64.zip",
+      ),
+    ).rejects.toThrow(/Expected a \.tar\.gz NATS artifact/);
+  });
+});
+
+describe("natsBinaryTempPath", () => {
+  it("creates an adjacent path from explicit process and nonce inputs", () => {
+    expect(natsBinaryTempPath("/srv/bin/nats-server", 42, "nonce-a")).toBe(
+      "/srv/bin/nats-server.download-42-nonce-a",
+    );
+  });
+
+  it("does not share a path between invocations in one process", () => {
+    const first = natsBinaryTempPath("/srv/bin/nats-server", 42, "nonce-a");
+    const second = natsBinaryTempPath("/srv/bin/nats-server", 42, "nonce-b");
+
+    expect(first).not.toBe(second);
+  });
+});
+
+describe("shouldInstallExtractedNatsBinary", () => {
+  it("never replaces an already-installed Windows binary", () => {
+    expect(shouldInstallExtractedNatsBinary(true, true)).toBe(false);
+    expect(shouldInstallExtractedNatsBinary(true, false)).toBe(false);
+  });
+
+  it("moves only an available extracted binary into an empty destination", () => {
+    expect(shouldInstallExtractedNatsBinary(false, true)).toBe(true);
+    expect(shouldInstallExtractedNatsBinary(false, false)).toBe(false);
+  });
+});
 
 describe("minioArtifactName", () => {
   it("returns the bare executable on unix platforms", () => {

--- a/apps/api/src/services/ensure-services.ts
+++ b/apps/api/src/services/ensure-services.ts
@@ -526,10 +526,10 @@ async function stopPostgres(home: string): Promise<void> {
 // NATS (auto-downloaded binary)
 // ---------------------------------------------------------------------------
 
-function natsArtifactName(): string {
-  const p = platform();
-  const a = arch();
-
+export function natsArtifactName(
+  p: string = platform(),
+  a: string = arch(),
+): string {
   const osMap: Record<string, string> = {
     darwin: "darwin",
     linux: "linux",
@@ -554,6 +554,75 @@ function natsArtifactName(): string {
   return `nats-server-${NATS_VERSION}-${osName}-${archName}.${ext}`;
 }
 
+/**
+ * Read the NATS executable from its Unix release archive without extracting
+ * archive-controlled paths to disk. Bun.Archive detects gzip automatically.
+ */
+export async function readNatsBinaryFromTarGzip(
+  archiveBytes: Uint8Array,
+  artifact: string,
+): Promise<File> {
+  if (!artifact.endsWith(".tar.gz")) {
+    throw new Error(`Expected a .tar.gz NATS artifact, received ${artifact}`);
+  }
+
+  const archiveRoot = artifact.slice(0, -".tar.gz".length);
+  const binaryEntry = `${archiveRoot}/nats-server`;
+  const files = await new Bun.Archive(archiveBytes).files(binaryEntry);
+  const binary = files.get(binaryEntry);
+
+  if (!binary) {
+    throw new Error(
+      `NATS binary not found at ${binaryEntry} in archive ${artifact}`,
+    );
+  }
+
+  return binary;
+}
+
+export function natsBinaryTempPath(
+  binPath: string,
+  pid: number,
+  nonce: string,
+): string {
+  return `${binPath}.download-${pid}-${nonce}`;
+}
+
+export function shouldInstallExtractedNatsBinary(
+  binPathExists: boolean,
+  extractedBinExists: boolean,
+): boolean {
+  return !binPathExists && extractedBinExists;
+}
+
+async function installNatsBinaryFromTarGzip(
+  archiveBytes: Uint8Array,
+  artifact: string,
+  binPath: string,
+): Promise<void> {
+  const binary = await readNatsBinaryFromTarGzip(archiveBytes, artifact);
+  // Prepare beside the destination so rename remains atomic on one filesystem.
+  const tmpPath = natsBinaryTempPath(binPath, process.pid, crypto.randomUUID());
+
+  try {
+    await Bun.write(tmpPath, binary);
+    await chmod(tmpPath, 0o755);
+    renameSync(tmpPath, binPath);
+  } catch (error) {
+    try {
+      await unlink(tmpPath);
+    } catch (cleanupError) {
+      if ((cleanupError as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw new AggregateError(
+          [error, cleanupError],
+          `Failed to install NATS and clean up ${tmpPath}`,
+        );
+      }
+    }
+    throw error;
+  }
+}
+
 function natsBinaryPath(home: string): string {
   return join(servicesDir(home), "nats", "bin", `nats-server${EXE_EXT}`);
 }
@@ -574,42 +643,51 @@ async function downloadNats(home: string): Promise<string> {
     );
   }
 
-  const archivePath = join(binDir, artifact);
   const arrayBuffer = await response.arrayBuffer();
-  writeFileSync(archivePath, Buffer.from(arrayBuffer));
-
-  // Both the Windows `.zip` and the unix `.tar.gz` contain a single versioned
-  // top-level directory (e.g. nats-server-v2.14.2-linux-amd64/nats-server).
-  // Extract the whole archive, then move the binary up to binDir and drop the
-  // versioned directory so binPath resolves regardless of platform packaging.
-  const extractedDir = join(binDir, artifact.replace(/\.(zip|tar\.gz)$/, ""));
 
   if (IS_WINDOWS) {
-    const proc = Bun.spawn([
-      "powershell",
-      "-Command",
-      `Expand-Archive -Path '${archivePath}' -DestinationPath '${binDir}' -Force`,
-    ]);
-    await proc.exited;
-  } else {
-    // `tar` (with gzip via -z) is universally present on macOS/Linux, unlike
-    // `unzip`. Unix releases ship only `.tar.gz` since the 2.11 line.
-    const proc = Bun.spawn(["tar", "-xzf", archivePath, "-C", binDir]);
-    await proc.exited;
-  }
+    const stagingDir = join(
+      binDir,
+      `.nats-download-${process.pid}-${crypto.randomUUID()}`,
+    );
+    const archivePath = join(stagingDir, artifact);
+    const extractedDir = join(stagingDir, artifact.replace(/\.zip$/, ""));
 
-  if (!existsSync(binPath)) {
-    const extractedBin = join(extractedDir, `nats-server${EXE_EXT}`);
-    if (existsSync(extractedBin)) {
-      renameSync(extractedBin, binPath);
+    try {
+      ensureDir(stagingDir);
+      writeFileSync(archivePath, Buffer.from(arrayBuffer));
+
+      const proc = Bun.spawn([
+        "powershell",
+        "-Command",
+        `Expand-Archive -Path '${archivePath}' -DestinationPath '${stagingDir}' -Force`,
+      ]);
+      const exitCode = await proc.exited;
+      if (exitCode !== 0) {
+        throw new Error(
+          `Failed to extract NATS ZIP: PowerShell exited with code ${exitCode}`,
+        );
+      }
+
+      const extractedBin = join(extractedDir, `nats-server${EXE_EXT}`);
+      if (
+        shouldInstallExtractedNatsBinary(
+          existsSync(binPath),
+          existsSync(extractedBin),
+        )
+      ) {
+        renameSync(extractedBin, binPath);
+      }
+    } finally {
+      // Own the archive and extracted directory under one per-call staging dir.
+      rmSync(stagingDir, { recursive: true, force: true });
     }
-  }
-  rmSync(extractedDir, { recursive: true, force: true });
-
-  await unlink(archivePath).catch(() => {});
-
-  if (!IS_WINDOWS) {
-    await chmod(binPath, 0o755);
+  } else {
+    await installNatsBinaryFromTarGzip(
+      new Uint8Array(arrayBuffer),
+      artifact,
+      binPath,
+    );
   }
 
   if (!existsSync(binPath)) {


### PR DESCRIPTION
## What is this contribution about?

Top layer of the Bun 1.4 adoption stack. Base: #6477.

- Replaces Unix system-`tar` extraction with selective `Bun.Archive.files()` parsing.
- Writes only the expected `nats-server` entry to an application-controlled path.
- Uses unique adjacent staging paths, applies mode 0755, then atomically renames.
- Preserves Windows ZIP behavior while adding unique staging, PowerShell exit validation, no-clobber behavior, and guaranteed cleanup.
- Keeps all committed tests pure and in-memory.

## How did you verify your code works?

- Focused archive/platform tests — 19 passed
- Manual 100-way same-process install stress: every install succeeded, final content and mode were correct, and no staging files leaked
- Manual corrupt/forced-rename failure probes preserved the destination and cleaned staging
- API typecheck, targeted oxlint, formatting, knip, and production API/CLI bundle passed
- `bun run test` — 7,570 tests across 752 files on this layer
- Integrated stack verification — 7,572 tests across 753 files

## Screenshots/Demonstration

Not applicable; backend development-service bootstrap only.

## How to Test

1. Run `bun test apps/api/src/services/ensure-services.test.ts`.
2. Run `bun run --cwd=apps/api check`.
3. Remove the local development NATS binary and start Studio development services.
4. Confirm the versioned NATS artifact installs and launches without requiring system `tar`.

## Migration Notes

No database migration. The trusted GitHub release archive remains buffered in memory; the selected executable adds approximately one uncompressed binary allocation.

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Corrupt, truncated, missing-entry, long-path, platform, and collision behavior is covered
- [x] Archive-controlled paths are never extracted to disk
- [x] No UI or database change