### PR TITLE
fix(sandbox): cap the Go daemon's /tools/sync request body

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/tools.go
+++ b/packages/sandbox/daemon-go/internal/routes/tools.go
@@ -20,6 +20,13 @@ type toolsSyncBody struct {
 	ExpiresAt *float64          `json:"expiresAt"`
 }
 
+// maxToolsSyncBodyBytes bounds the /tools/sync request body: a URL plus a
+// handful of headers, never a file transfer, so 1MB is generous headroom.
+// Without a limit, json.Decoder streams an unbounded body into memory and
+// could crash the daemon, tearing down the sandbox pod on the next missed
+// health probe.
+const maxToolsSyncBodyBytes = 1024 * 1024
+
 // ToolsSync handles POST /_sandbox/tools/sync — body `{ url, headers,
 // expiresAt? }` (the run's Virtual MCP endpoint). Writes the endpoint file,
 // then lists the endpoint's tools and writes a JSON Schema catalog under
@@ -29,7 +36,7 @@ type toolsSyncBody struct {
 func ToolsSync(deps ToolsDeps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var body toolsSyncBody
-		raw := json.NewDecoder(r.Body)
+		raw := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxToolsSyncBodyBytes))
 		if err := raw.Decode(&body); err != nil {
 			httpx.Error(w, 400, "invalid JSON body")
 			return

--- a/packages/sandbox/daemon-go/internal/routes/tools_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/tools_test.go
@@ -1,0 +1,35 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Without a cap, ToolsSync's json.Decoder would stream an unbounded request
+// body into memory and could crash the daemon, tearing down the sandbox pod
+// on the next missed health probe.
+func TestToolsSyncRejectsOversizedBody(t *testing.T) {
+	oversized := `{"url":"https://example.com","headers":{"pad":"` +
+		strings.Repeat("a", maxToolsSyncBodyBytes) + `"}}`
+	req := httptest.NewRequest(http.MethodPost, "/_sandbox/tools/sync", strings.NewReader(oversized))
+	rec := httptest.NewRecorder()
+
+	ToolsSync(ToolsDeps{})(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestToolsSyncRejectsMissingURL(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/_sandbox/tools/sync", strings.NewReader(`{"headers":{}}`))
+	rec := httptest.NewRecorder()
+
+	ToolsSync(ToolsDeps{})(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
The other three obvious daemon body-size gaps in this area (`/read`, `/edit`, config-update) are already covered by open PRs #6215, #6039, and #6252 — this fixes a fourth, uncovered one: `ToolsSync` (`POST /_sandbox/tools/sync`) decodes the request body with a bare `json.NewDecoder(r.Body)`, with no size limit at all (not even the daemon's general 500MB transfer cap that the fs routes get via `decodeBody`).

Why it matters: a misbehaving or malicious caller can stream an unbounded body at this route and the daemon buffers it into memory while decoding, which can OOM the process — the daemon's health probe treats a single miss as dead and Studio tears the sandbox pod down mid-session.

Fix: wrap `r.Body` in `http.MaxBytesReader` capped at 1MB before decoding — the payload is just a URL plus a handful of headers, never a file transfer, so 1MB is generous headroom, matching the same pattern already used for `/dispatch` (`maxDispatchBodyBytes`) and the `ConfigUpdate`/`OrgFsConfig` routes in the open #6252 PR.

Regression test: `TestToolsSyncRejectsOversizedBody` sends a body over the cap and asserts a 400 instead of the decoder buffering it unbounded; `TestToolsSyncRejectsMissingURL` is an existing-behavior sanity check alongside it.

How to verify: `cd packages/sandbox/daemon-go && go test ./internal/routes/... -run TestToolsSync -v`

Locally ran: `go build ./...`, `go vet ./internal/routes/...`, `gofmt -l` (clean), and the full `go test ./internal/routes/...` package (all green). CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the Go daemon’s ToolsSync (POST /_sandbox/tools/sync) request body at 1MB to prevent unbounded memory use. Previously the handler decoded the body without a limit; oversized bodies could be buffered into memory and OOM the process.

- Wraps the request body with `http.MaxBytesReader` (1MB) before `json.Decoder`, aligning with caps used by dispatch/config routes.
- Behavior change: bodies over 1MB now return 400 Bad Request; normal payloads are unaffected.
- Adds tests: TestToolsSyncRejectsOversizedBody and TestToolsSyncRejectsMissingURL.

<sup>Written for commit 2050053d8affd21361b13fba6f769b592f92f71b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

