### PR TITLE
fix(organization): preserve existing metadata when archiving an org

### DIFF
--- a/apps/api/src/tools/organization/delete.test.ts
+++ b/apps/api/src/tools/organization/delete.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, mock } from "bun:test";
+import { ORGANIZATION_DELETE } from "./delete";
+
+function makeCtx(existingMetadata: unknown) {
+  const get = mock(async () => ({
+    id: "org-1",
+    name: "Acme",
+    slug: "acme",
+    metadata: existingMetadata,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+  }));
+  const update = mock(
+    async (data: { organizationId: string; data: unknown }) => ({
+      id: data.organizationId,
+    }),
+  );
+  return {
+    auth: { user: { id: "user-1" } },
+    access: { check: mock(async () => {}) },
+    boundAuth: { organization: { get, update } },
+    get,
+    update,
+  } as unknown as Parameters<typeof ORGANIZATION_DELETE.handler>[1] & {
+    get: typeof get;
+    update: typeof update;
+  };
+}
+
+describe("ORGANIZATION_DELETE", () => {
+  it("preserves existing metadata when archiving", async () => {
+    const ctx = makeCtx({ description: "an acme org" });
+
+    await ORGANIZATION_DELETE.handler({ id: "org-1" }, ctx);
+
+    const call = ctx.update.mock.calls[0]?.[0] as {
+      data: { metadata: Record<string, unknown> };
+    };
+    expect(call.data.metadata.description).toBe("an acme org");
+    expect(call.data.metadata.archived).toBe(true);
+    expect(typeof call.data.metadata.archivedAt).toBe("string");
+  });
+
+  it("archives fine when there's no prior metadata", async () => {
+    const ctx = makeCtx(undefined);
+
+    await ORGANIZATION_DELETE.handler({ id: "org-1" }, ctx);
+
+    const call = ctx.update.mock.calls[0]?.[0] as {
+      data: { metadata: Record<string, unknown> };
+    };
+    expect(call.data.metadata.archived).toBe(true);
+  });
+});

--- a/apps/api/src/tools/organization/delete.ts
+++ b/apps/api/src/tools/organization/delete.ts
@@ -32,10 +32,14 @@ export const ORGANIZATION_DELETE = defineTool({
     requireAuth(ctx);
     await ctx.access.check();
 
+    // Merge into existing metadata — organization.update replaces it wholesale.
+    const existing = await ctx.boundAuth.organization.get(input.id);
+
     await ctx.boundAuth.organization.update({
       organizationId: input.id,
       data: {
         metadata: {
+          ...existing?.metadata,
           archived: true,
           archivedAt: new Date().toISOString(),
         },


### PR DESCRIPTION
**Bug.** `ORGANIZATION_DELETE` (soft-delete/archive) replaced `organization.metadata` wholesale with just `{ archived: true, archivedAt }`. Better Auth's `organization.update` stores metadata as-is (`JSON.stringify(data.metadata)`, no merge — confirmed in the vendored `@decocms/better-auth` adapter), so archiving an org silently wiped out any existing metadata field (e.g. the `description` set via `ORGANIZATION_UPDATE`) with no error surfaced to the caller.

**Why it matters:** `ORGANIZATION_UPDATE` already had this exact bug pattern fixed for the `description`-drop case (#6464); this closes the same gap on the archive path, which is a one-way (no restore flow yet) but should still preserve org metadata rather than silently discard it. Also matters because the change is otherwise irreversible per the module's own doc comment about a future restore flow reading archived orgs.

**Fix:** fetch the org's current metadata via `ctx.boundAuth.organization.get(input.id)` and spread it before setting the `archived`/`archivedAt` flags.

**Regression test:** `apps/api/src/tools/organization/delete.test.ts` — asserts a pre-existing `description` survives the archive call, and that archiving still works with no prior metadata.

**Reviewer command:** `cd apps/api && bun test src/tools/organization/delete.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint` on both changed files (0 warnings/errors), targeted test above (2 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves organization metadata when archiving. Previously `ORGANIZATION_DELETE` overwrote `metadata` with `{ archived, archivedAt }`, erasing fields like `description`; now it merges the current `metadata` and sets the archive flags.

- Adds a regression test to verify `metadata.description` survives and archiving works with no prior metadata.
- No API changes or migrations. Run tests with: cd apps/api && bun test src/tools/organization/delete.test.ts

<sup>Written for commit fe348ed4d50389a7a1f20a3609fec9be9043058b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

