### PR TITLE
fix(sections-editor): unwrap object-valued multivariate image variants for array thumbnails

### DIFF
--- a/apps/web/src/components/sections-editor/array-item-display.test.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.test.ts
@@ -319,6 +319,31 @@ describe("getArrayItemImageSrc", () => {
     expect(getArrayItemImageSrc(item, schema)).toBeUndefined();
   });
 
+  test("unwraps a multivariate image whose variant value is an object", () => {
+    const item = {
+      matcher: ["/produtos/cheirinho"],
+      image: {
+        __resolveType: "site/flags/multivariate/desktopAndMobileImage.ts",
+        variants: [
+          {
+            rule: { __resolveType: "website/matchers/always.ts" },
+            value: {
+              desktop: "https://example.com/desktop.jpg",
+              mobile: "https://example.com/mobile.jpg",
+            },
+          },
+        ],
+      },
+    };
+    const schema: SchemaProperty = {
+      type: "object",
+      image: "{{{image.mobile}}}",
+    };
+    expect(getArrayItemImageSrc(item, schema)).toBe(
+      "https://example.com/mobile.jpg",
+    );
+  });
+
   test("defaults to image.mobile when image is a nested object", () => {
     const item = {
       image: {

--- a/apps/web/src/components/sections-editor/array-item-display.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.ts
@@ -6,7 +6,7 @@ import type { SchemaProperty } from "./resolve-schema";
 import { labelFromResolveType } from "./section-types";
 import { safeEditorImageUrl } from "./safe-editor-image-url";
 
-function resolveResolvable(obj: Record<string, unknown>): string | undefined {
+function resolveResolvable(obj: Record<string, unknown>): unknown {
   if (Array.isArray(obj.variants)) {
     const variants = obj.variants as Array<{
       rule?: { __resolveType?: string };
@@ -15,9 +15,9 @@ function resolveResolvable(obj: Record<string, unknown>): string | undefined {
     const always = variants.find((v) =>
       v.rule?.__resolveType?.includes("always"),
     );
-    if (typeof always?.value === "string") return always.value;
-    const first = variants.find((v) => typeof v.value === "string");
-    if (first) return first.value as string;
+    // Unwrap object-valued variants too (e.g. `{ desktop, mobile }`), not only strings.
+    const chosen = always ?? variants.find((v) => v.value != null);
+    if (chosen && chosen.value != null) return chosen.value;
   }
   if (typeof obj.src === "string") return obj.src;
   if (typeof obj.url === "string") return obj.url;
@@ -34,7 +34,9 @@ function resolveImageValue(value: unknown): unknown {
   }
   const obj = value as Record<string, unknown>;
   if (obj.__resolveType) {
-    return resolveResolvable(obj) ?? value;
+    // Recurse: an unwrapped variant value may itself be an object of URLs.
+    const unwrapped = resolveResolvable(obj);
+    return unwrapped === undefined ? value : resolveImageValue(unwrapped);
   }
   return resolveImageValues(obj);
 }


### PR DESCRIPTION
## Summary

In the Studio sections/content editor, an array field showed thumbnails on only **some** rows (e.g. farmrio "Category Banner 01" — the old deco admin showed all of them).

Array-item rows derive their thumbnail by rendering the item schema's `@image` template (`{{{image.mobile}}}`) against each item's value. The unwrapping helper `resolveResolvable` (`apps/web/src/components/sections-editor/array-item-display.ts`) only unwrapped a multivariate/resolvable variant when its `value` was a **string**.

farmrio's `image` prop is a multivariate flag `DesktopAndMobileImage`, so each item's stored `image` is a wrapper whose variant value is an **object**:

```json
"image": { "__resolveType": ".../desktopAndMobileImage.ts",
  "variants": [{ "rule": {…always}, "value": { "desktop": "…", "mobile": "…" } }] }
```

That object value stayed wrapped → `image.mobile` couldn't be traversed → no thumbnail. Items saved as a plain `{ desktop, mobile }` object (no wrapper) still resolved — hence "some show, some don't".

## Fix

`resolveResolvable` now returns the chosen variant's value even when it's an object (prefers the `always` rule, else first variant with a value), and `resolveImageValue` recurses on the unwrapped value so nested URLs resolve.

## Testing

- New unit test in `array-item-display.test.ts` covering the multivariate-object-variant case; full file green (29 pass).
- `bun run --cwd=apps/web check` and `bun run fmt` clean.
- Simulated the fixed logic over the real farmrio block: **36/36** banners now resolve a valid `https` mobile thumbnail (previously only the plain-object ones did).

## Affected areas

Sections/content editor array-item thumbnail rendering only. No schema/wire changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes array-item thumbnails in the sections editor when image is a multivariate wrapper with an object variant. Previously some rows showed no thumbnail because `image.mobile` could not traverse the wrapper; now it unwraps object-valued variants and resolves nested URLs.

- Updated resolve logic to return the chosen variant value even when it is an object (prefer the `always` rule, else the first with a value).
- Made image resolution recurse after unwrapping so nested URLs (e.g., `{ desktop, mobile }`) resolve.
- Added a unit test covering the multivariate object-variant case.
- Scope: editor thumbnail rendering only; no schema or wire changes.

<sup>Written for commit 68a09b02c6ada7edbe836bfde219ec651c552b1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

