### PR TITLE
fix(virtual-mcp): report the actual target in MissingOrganizationSlugError

### DIFF
--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts
@@ -86,6 +86,18 @@ describe("mcpEndpointUrl task-run", () => {
       }),
     ).toThrow(/threadId is required/);
   });
+
+  it("a task-run endpoint with no slug reports its own target, not 'management'", () => {
+    expect(() =>
+      mcpEndpointUrl({
+        publicUrl,
+        agentId: "vir_1",
+        organization: { id: "org_1" },
+        target: "task-run",
+        threadId: "thrd_1",
+      }),
+    ).toThrow(/"task-run" MCP endpoint/);
+  });
 });
 
 describe("orgMcpServers", () => {

--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
@@ -39,10 +39,10 @@ const MCP_KEY_TTL_SECONDS = 3600;
 export type McpEndpointTarget = "agent-tools" | "management" | "task-run";
 
 export class MissingOrganizationSlugError extends Error {
-  constructor(organizationId: string) {
+  constructor(organizationId: string, target: McpEndpointTarget) {
     super(
-      `cannot mint a management MCP endpoint for organization "${organizationId}": ` +
-        `the org-scoped path /api/<slug>/mcp/self needs the org slug, which was not loaded.`,
+      `cannot mint a "${target}" MCP endpoint for organization "${organizationId}": ` +
+        `the org-scoped path needs the org slug, which was not loaded.`,
     );
     this.name = "MissingOrganizationSlugError";
   }
@@ -69,7 +69,7 @@ export function mcpEndpointUrl(args: {
     return `${publicUrl}/mcp/virtual-mcp/${agentId}`;
   }
   if (!organization.slug) {
-    throw new MissingOrganizationSlugError(organization.id);
+    throw new MissingOrganizationSlugError(organization.id, target);
   }
   if (target === "task-run") {
     if (!threadId) {


### PR DESCRIPTION
Found while reviewing the recently-changed virtual-MCP mint endpoint (`apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts`) for correctness/error-handling.

`MissingOrganizationSlugError`'s message hardcoded "management MCP endpoint" wording, but `mcpEndpointUrl` throws it for **both** the `management` and `task-run` targets — both require `organization.slug`. Minting a `task-run` endpoint with no loaded slug (a real path — sandbox-hosted task runs mint this via `SandboxDispatchClient`) surfaced an error claiming a "management" endpoint was being minted, which misleads whoever debugs the failure into looking at the wrong surface.

Fix: `MissingOrganizationSlugError` now takes the `target` and reports it in the message instead of a hardcoded string.

Regression test added: `mcpEndpointUrl` with `target: "task-run"` and no slug now asserts the thrown message names `"task-run"`, not `"management"` — this would have failed before the fix.

Reviewer check: `bun test apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts`

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file (16 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports the requested MCP endpoint target in `MissingOrganizationSlugError` so missing-slug failures name the correct target. Previously the error always said "management MCP endpoint," which misled debugging for `task-run` minting.

- `mcpEndpointUrl` now passes `target` to `MissingOrganizationSlugError`; the message includes "agent-tools", "management", or "task-run".
- Update any code or tests that match the old "management MCP endpoint" text.
- Adds a regression test ensuring a `task-run` endpoint without a slug mentions `"task-run"`. Run: `bun test apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts`.

<sup>Written for commit 8a6fd7e322ae33174156fb54ad4d089943086a20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

