### PR TITLE
fix(sections-editor): dedupe listAvailableSections by resolveType

### DIFF
--- a/apps/web/src/components/sections-editor/section-catalog.test.ts
+++ b/apps/web/src/components/sections-editor/section-catalog.test.ts
@@ -302,6 +302,29 @@ describe("section-catalog", () => {
     ).toBeTruthy();
   });
 
+  it("listAvailableSections dedupes a resolveType listed under multiple sections block groups", () => {
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          sections: {
+            "site/sections/Hero.tsx": { $ref: "#/definitions/Hero" },
+          },
+          "website/sections": {
+            "site/sections/Hero.tsx": { $ref: "#/definitions/Hero" },
+          },
+        },
+      },
+      schema: { definitions: {} },
+    };
+
+    const available = listAvailableSections(meta);
+    const matches = available.filter(
+      (entry) => entry.resolveType === "site/sections/Hero.tsx",
+    );
+
+    expect(matches).toHaveLength(1);
+  });
+
   it("extractSectionCatalog excludes Theme sections", () => {
     const meta: LiveMeta = {
       manifest: {

--- a/apps/web/src/components/sections-editor/section-catalog.ts
+++ b/apps/web/src/components/sections-editor/section-catalog.ts
@@ -110,17 +110,26 @@ export function listAvailableSections(
   meta: LiveMeta,
 ): Array<{ resolveType: string; title: string }> {
   const blocks = meta.manifest?.blocks ?? {};
-  const entries: Array<{ resolveType: string; title: string }> = [];
+  const byResolveType = new Map<
+    string,
+    { resolveType: string; title: string }
+  >();
 
   for (const [blockType, blockMap] of Object.entries(blocks)) {
     if (!blockType.includes("sections")) continue;
     for (const resolveType of Object.keys(blockMap)) {
       if (shouldSkipSectionResolveType(resolveType)) continue;
-      entries.push({ resolveType, title: labelFromResolveType(resolveType) });
+      if (byResolveType.has(resolveType)) continue;
+      byResolveType.set(resolveType, {
+        resolveType,
+        title: labelFromResolveType(resolveType),
+      });
     }
   }
 
-  return entries.sort((a, b) => a.title.localeCompare(b.title));
+  return [...byResolveType.values()].sort((a, b) =>
+    a.title.localeCompare(b.title),
+  );
 }
 
 /**


### PR DESCRIPTION
**Source:** bug found while auditing `apps/web/src/components/sections-editor/section-catalog.ts` (this tick's focus area).

**Why a maintainer wants this:** `listAvailableSections` — the cheap, schema-free lister used by the sandbox Content tab's "Available sections" list — pushes one entry per manifest blockType group without deduping by `resolveType`. Its sibling `extractSectionCatalog` already guards against exactly this with a `Map` keyed by `resolveType`, so the gap here looks like an oversight from when the cheap lister was split out for performance.

**Failure scenario:** if the same section `resolveType` is registered under more than one `sections`-named block group in the manifest (e.g. both `sections` and `website/sections`), `listAvailableSections` returns two entries with the identical `resolveType`. `content-browser.tsx` renders this list keyed by `section.resolveType` (`apps/web/src/components/sandbox/content/content-browser.tsx:1897`), so React sees a duplicate key — one of the two rows silently fails to render/update correctly.

**Fix:** dedupe with a `Map<resolveType, entry>`, mirroring `extractSectionCatalog`'s existing pattern. Added a regression test (`listAvailableSections dedupes a resolveType listed under multiple sections block groups`) that fails on the old code (2 matches) and passes now (1 match).

**To verify:** `cd apps/web && bun test src/components/sections-editor/section-catalog.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), `bunx oxlint` on both touched files (0 warnings/errors), and the targeted test file above (12 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dedupes `listAvailableSections` by `resolveType` to prevent duplicate rows when the same section is registered in multiple "sections"-named block groups. Previously it emitted one entry per group; now it emits one per `resolveType`, avoiding React key collisions in the Content browser.

- Mirrors `extractSectionCatalog` by using a Map keyed by `resolveType`.
- Preserves label generation and alphabetical sort.
- Adds a regression test for the multi-group scenario.
- No migration required; callers now receive a unique list.

<sup>Written for commit 57cd46a8c3d68a80e28a9d3886517e773b20b1df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

