### PR TITLE
fix(settings): roll back the optimistic Jira column mapping on a failed save

### DIFF
--- a/apps/web/src/views/settings/jira.tsx
+++ b/apps/web/src/views/settings/jira.tsx
@@ -231,6 +231,7 @@ function ColumnMappingRows({ integration }: { integration: JiraIntegration }) {
 
   // The mapping is keyed by STATUS name; one row writes every status its column groups.
   function setColumnMapping(statuses: string[], value: string) {
+    const previous = mapping;
     const next = { ...mapping };
     for (const status of statuses) {
       if (value === DONT_SYNC) {
@@ -243,8 +244,11 @@ function ColumnMappingRows({ integration }: { integration: JiraIntegration }) {
     upsert.mutate(
       { statusMapping: next },
       {
-        onError: (err) =>
-          toast.error(errorMessage(err, t("settings.jira.saveFailed"))),
+        onError: (err) => {
+          // Roll back — a refetch matching the pre-mutation value can keep the same object reference and never resync this row otherwise.
+          setMapping(previous);
+          toast.error(errorMessage(err, t("settings.jira.saveFailed")));
+        },
       },
     );
   }


### PR DESCRIPTION
Follows #6450, which added an optimistic local `mapping` state to `ColumnMappingRows` so two quick edits don't stomp each other while the save round-trips. That commit never rolls the optimistic value back on `onError` — it only toasts.

Failure scenario: the row's local sync effect (`if (syncedWith !== integration) { ... }`) only resets `mapping` when the `integration` prop's *reference* changes. `useUpsertJiraIntegration`'s `onSettled` always invalidates and refetches on failure, but TanStack Query's default structural sharing preserves the old object reference when the refetched data is deep-equal to what's already cached — which it is here, since the server rejected the write and the underlying `statusMapping` is unchanged. So after a failed save, the row keeps showing the edit the user just made as if it had saved, even though a toast said it failed, until some unrelated prop change (e.g. `lastSyncedAt`) happens to force a new `integration` reference.

Fix: capture the pre-mutation mapping and restore it in `onError`, so a failed save always reverts the visible dropdown to the last known-good value regardless of query structural sharing.

Reviewer check: `cd apps/web && bunx tsc --noEmit` (clean) and read the diff — `setMapping(previous)` runs before the toast in the same `onError` callback.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), `bunx oxlint apps/web/src/views/settings/jira.tsx` (0 warnings/errors). No existing unit test covers this component (it's UI-state logic requiring RTL, outside this bot's targeted-check budget); full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolls back the optimistic Jira column mapping after a failed save. Previously, a failed save left the dropdown showing the edited value until some unrelated prop change; now it immediately restores the last known-good mapping and shows the error toast.

- Review notes: In `ColumnMappingRows.setColumnMapping`, we capture `previous` before mutating and call `setMapping(previous)` inside `onError` before the toast.
- Context: Query refetch after a failure can keep the same object reference when data is unchanged, so the row’s local sync effect wouldn’t run; this change avoids relying on that.

<sup>Written for commit 5c7eebafc1acd6042d9fb4d8707783f74b270276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

