### PR TITLE
fix(organization): preserve existing metadata when updating organization description

### DIFF
--- a/apps/api/src/tools/organization/update.test.ts
+++ b/apps/api/src/tools/organization/update.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it, mock } from "bun:test";
 import { ORGANIZATION_UPDATE } from "./update";
 
 function makeCtx() {
+  const get = mock(async () => ({
+    id: "org-1",
+    slug: "acme",
+    name: "Acme",
+    metadata: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+  }));
   const update = mock(
     async (data: { organizationId: string; data: unknown }) => ({
       id: data.organizationId,
@@ -13,7 +20,7 @@ function makeCtx() {
   return {
     auth: { user: { id: "user-1" } },
     access: { check: mock(async () => {}) },
-    boundAuth: { organization: { update } },
+    boundAuth: { organization: { get, update } },
     update,
   } as unknown as Parameters<typeof ORGANIZATION_UPDATE.handler>[1] & {
     update: typeof update;
@@ -43,6 +50,49 @@ describe("ORGANIZATION_UPDATE", () => {
     expect(ctx.update).toHaveBeenCalledWith({
       organizationId: "org-1",
       data: { metadata: { description: "hello" } },
+    });
+  });
+
+  it("merges description into existing metadata instead of replacing it", async () => {
+    const get = mock(async () => ({
+      id: "org-1",
+      slug: "acme",
+      name: "Acme",
+      metadata: {
+        archived: true,
+        archivedAt: "2026-01-01T00:00:00Z",
+      },
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+    }));
+    const update = mock(
+      async (data: { organizationId: string; data: unknown }) => ({
+        id: data.organizationId,
+        name: "Acme",
+        slug: "acme",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      }),
+    );
+    const ctx = {
+      auth: { user: { id: "user-1" } },
+      access: { check: mock(async () => {}) },
+      organization: { id: "org-1" },
+      boundAuth: { organization: { get, update } },
+    } as unknown as Parameters<typeof ORGANIZATION_UPDATE.handler>[1];
+
+    await ORGANIZATION_UPDATE.handler(
+      { id: "org-1", description: "new desc" },
+      ctx,
+    );
+
+    expect(update).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      data: {
+        metadata: {
+          archived: true,
+          archivedAt: "2026-01-01T00:00:00Z",
+          description: "new desc",
+        },
+      },
     });
   });
 });

--- a/apps/api/src/tools/organization/update.ts
+++ b/apps/api/src/tools/organization/update.ts
@@ -46,8 +46,13 @@ export const ORGANIZATION_UPDATE = defineTool({
     const updateData: Record<string, unknown> = {};
     if (input.name) updateData.name = input.name;
     // !== undefined, not truthy: "" clears the description and must persist.
-    if (input.description !== undefined)
-      updateData.metadata = { description: input.description };
+    if (input.description !== undefined) {
+      const org = await ctx.boundAuth.organization.get(input.id);
+      updateData.metadata = {
+        ...(org?.metadata ?? {}),
+        description: input.description,
+      };
+    }
 
     // Update organization via Better Auth
     const result = await ctx.boundAuth.organization.update({


### PR DESCRIPTION
## Source
Inspecting the organization tools cleanup area, found that `ORGANIZATION_UPDATE` overwrites the entire organization metadata object instead of merging the new description field into it. This causes other metadata fields (e.g., `archived`, `archivedAt`) to be silently lost when updating just the description.

## Impact
When calling `ORGANIZATION_UPDATE` with a new description on an organization that already has metadata, all existing metadata fields except `description` are dropped from the metadata object. This can cause data loss of any fields stored in organization metadata.

## Solution
Fetch the existing organization metadata before updating, then merge the new description field into it instead of replacing the entire object. This ensures all existing metadata fields are preserved.

## Regression Test
Added test `merges description into existing metadata instead of replacing it` that verifies:
- When an organization has existing metadata (`{ archived: true, archivedAt: "..." }`)
- And `ORGANIZATION_UPDATE` is called with a new description
- The resulting update preserves the `archived` and `archivedAt` fields
- While adding the new `description` field

## Verification
- `bun test apps/api/src/tools/organization/update.test.ts` — all 3 tests pass (2 existing + 1 regression)
- `bunx tsc --noEmit` in apps/api — no type errors
- `bun run fmt` — no formatting changes needed
- Unit test confirms behavior-preserving: existing tests still pass, new test enforces metadata merging

## Line Delta
-3 / +58 in two files (update.ts: core fix, update.test.ts: regression test + test setup)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves existing organization metadata when updating the description to prevent data loss. Previously, ORGANIZATION_UPDATE replaced metadata with { description }, dropping fields like archived and archivedAt; now it merges description into existing metadata.

- Fetches current organization metadata via ctx.boundAuth.organization.get and merges it with the new description (null/empty string still clears description).
- Adds a regression test that verifies archived and archivedAt are preserved.
- Introduces one extra read per update call.
- No API changes and no migration required.

<sup>Written for commit 8f81be878d4bcaf3a451765c7759049f78728de2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

