### PR TITLE
fix(thread): publish committed work while the dev server is still booting

### DIFF
--- a/apps/web/src/components/thread/github/panel-state.test.ts
+++ b/apps/web/src/components/thread/github/panel-state.test.ts
@@ -240,7 +240,7 @@ describe("selectHeaderButton", () => {
     expect(r.loading).toBe(true);
   });
 
-  // Setup phases hold the header; failure phases fall through to git/PR logic: git works even when the dev server can't run.
+  // Installing holds the header (working tree not in place). `starting` releases committed work — git works while the dev server boots — but a dirty-only tree stays held: workingTreeDirty may be boot noise until #6332's baseline arms (this is the #6314 false-"Review & Publish"-on-a-fresh-branch guard).
 
   test("lifecycle.installing + dirty branch → Installing packages… (not publishable yet)", () => {
     const r = selectHeaderButton(
@@ -256,7 +256,31 @@ describe("selectHeaderButton", () => {
     expect(r.menu).toEqual([]);
   });
 
-  test("lifecycle.starting + clean ready branch → Starting app…", () => {
+  test("lifecycle.starting + committed work → Review & Publish (git works while the dev server boots)", () => {
+    const r = selectHeaderButton(
+      happyInput({
+        lifecycle: { phase: "starting" },
+        branch: ready({ aheadOfBase: 2 }),
+      }),
+    );
+    expect(r.label).toBe("Review & Publish");
+    expect(r.action).toBe("publish");
+  });
+
+  test("lifecycle.starting + dirty-only tree (no commits) → Starting app… (boot dirt is not proof of work)", () => {
+    const r = selectHeaderButton(
+      happyInput({
+        lifecycle: { phase: "starting" },
+        branch: ready({ workingTreeDirty: true }),
+      }),
+    );
+    expect(r.label).toBe("Starting app…");
+    expect(r.disabled).toBe(true);
+    expect(r.loading).toBe(true);
+    expect(r.action).toBeUndefined();
+  });
+
+  test("lifecycle.starting + clean branch, no work → Starting app…", () => {
     const r = selectHeaderButton(
       happyInput({ lifecycle: { phase: "starting" } }),
     );

--- a/apps/web/src/components/thread/github/panel-state.ts
+++ b/apps/web/src/components/thread/github/panel-state.ts
@@ -230,7 +230,7 @@ export function selectHeaderButton(
     };
   }
 
-  // Setup phases gate the header; once the app has run (or failed to), git/PR copy below takes over.
+  // Setup phases gate the header until the checkout is in place; `starting` then releases committed work to the git/PR copy — publishing it needs the sandbox alive, not the dev server serving.
   switch (lifecycle.phase) {
     case "idle": {
       const label =
@@ -277,7 +277,7 @@ export function selectHeaderButton(
         }),
         menu: [],
       };
-    // Still booting: nothing runs yet, so nothing to review or publish. The failure phases fall through — pushing a fix is the point there.
+    // Working tree not in place yet: nothing to review or publish.
     case "installing":
       return {
         label: t("thread.headerActions.installingPackages"),
@@ -287,15 +287,19 @@ export function selectHeaderButton(
         tooltip: t("thread.headerActions.installingPackagesTooltip"),
         menu: [],
       };
+    // `starting`: committed work publishes now (git needs the checkout, not the dev server); a dirty-only tree waits, since workingTreeDirty may be boot noise until #6332's baseline arms.
     case "starting":
-      return {
-        label: t("thread.headerActions.startingApp"),
-        disabled: true,
-        loading: true,
-        variant: "outline",
-        tooltip: t("thread.headerActions.startingAppTooltip"),
-        menu: [],
-      };
+      if (!(branch.kind === "ready" && branch.aheadOfBase > 0)) {
+        return {
+          label: t("thread.headerActions.startingApp"),
+          disabled: true,
+          loading: true,
+          variant: "outline",
+          tooltip: t("thread.headerActions.startingAppTooltip"),
+          menu: [],
+        };
+      }
+      break;
     // running/*-failed/crashed: fall through to git/PR.
   }
 

--- a/apps/web/src/i18n/en/thread.ts
+++ b/apps/web/src/i18n/en/thread.ts
@@ -117,7 +117,7 @@ export const thread = {
     "Squash-merge PR #{prNumber} into {base}",
   "thread.headerActions.startingApp": "Starting app…",
   "thread.headerActions.startingAppTooltip":
-    "Starting the dev server — nothing to review or publish yet",
+    "Starting the dev server — no committed work to review or publish yet",
   "thread.headerActions.startingSandbox": "Preparing sandbox…",
   "thread.headerActions.submitForReview": "Submit for review",
   "thread.headerActions.switchingTo": "Switching to {branch}…",

--- a/apps/web/src/i18n/pt-br/thread.ts
+++ b/apps/web/src/i18n/pt-br/thread.ts
@@ -123,7 +123,7 @@ export const thread = {
     "Squash-merge do PR #{prNumber} em {base}",
   "thread.headerActions.startingApp": "Iniciando app…",
   "thread.headerActions.startingAppTooltip":
-    "Iniciando o servidor de desenvolvimento — ainda não há nada para revisar ou publicar",
+    "Iniciando o servidor de desenvolvimento — ainda não há trabalho commitado para revisar ou publicar",
   "thread.headerActions.startingSandbox": "Preparando sandbox…",
   "thread.headerActions.submitForReview": "Enviar para revisão",
   "thread.headerActions.switchingTo": "Mudando para {branch}…",


### PR DESCRIPTION
## Summary

The sandbox header gated the whole **Review & Publish** button on the `starting` lifecycle phase (added in #6314). A dev server still booting — or one that **never** reports `running` because the daemon's port-sniffer misses its bind-URL banner — held the button at "Starting app…" / "Iniciando app…" **forever**, even with committed work ready to publish.

Publishing committed work is a git operation: it needs the **sandbox alive** (a readable checkout), **not the dev server serving**.

## Why not just un-gate `starting`

Because #6314 was **not** cosmetic — it guarded a real false positive. On a fresh branch, during boot the dev server writes tracked files, so `workingTreeDirty` reads **true** before #6332's anti-boot-dirt baseline arms (the baseline only arms once the dev server *settles*). That flashed a false "Review & Publish" on a branch with no changes, which then cleared to "Up to date". Naively removing the gate reintroduces exactly that flash for the `starting` window.

## The fix (scoped by signal trust)

- `starting` **releases committed work** (`aheadOfBase > 0`) to the git/PR copy → **Review & Publish** appears without waiting on the dev server. `aheadOfBase` is never boot noise (nothing auto-commits), so it's safe to trust early.
- `starting` **still holds a dirty-only tree** — `workingTreeDirty` alone stays untrusted until the server settles, preserving #6314's fresh-branch guard.
- `installing`/`cloning`/`checking-out`/`idle` stay fully gated (working tree not in place yet).

## Testing

- `starting` + committed work → **Review & Publish** (the fix)
- `starting` + dirty-only tree (no commits) → **Starting app…** (boot-dirt guard, #6314 preserved)
- `starting` + clean branch → **Starting app…**
- `bun test panel-state.test.ts` → 46 pass. `tsc --noEmit` (web) and `bun run fmt` clean.

## Residual limitation

Genuine *uncommitted* edits made while the dev server is stuck `starting` still wait until it settles (running / *-failed / crashed) — the dirty flag can't be told apart from boot noise before the baseline arms. Committing surfaces the button immediately. The deeper fix for the never-settles case is the daemon-side port detection, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)