### PR TITLE
fix(fast-preview): read committed meta.gen.json via GitHub API in sandbox-less mode

### DIFF
--- a/apps/api/src/api/routes/decofile.ts
+++ b/apps/api/src/api/routes/decofile.ts
@@ -248,6 +248,37 @@ export function createDecofileRoutes() {
     }
   });
 
+  app.get("/:virtualMcpId/:branch/meta", async (c) => {
+    const scope = c.get("decofileScope");
+    const metaPath = scope.packagePath
+      ? `${scope.packagePath}/.deco/meta.gen.json`
+      : ".deco/meta.gen.json";
+    try {
+      const client = await gitDataClientForScope(c);
+      /** The thread branch may not be materialized on GitHub yet (it forks
+       *  from default at first CMS touch), so fall back to the default branch —
+       *  meta.gen.json is a code artifact the CMS never edits, so the default's
+       *  copy is the schema the forked branch would carry anyway. */
+      let text = await client.getFileTextAtRef(scope.branch, metaPath);
+      if (text === null) {
+        const defaultBranch = await client.getDefaultBranch();
+        if (defaultBranch !== scope.branch) {
+          text = await client.getFileTextAtRef(defaultBranch, metaPath);
+        }
+      }
+      if (text === null) {
+        return c.json({ error: "meta.gen.json not committed" }, 404);
+      }
+      return c.body(text, 200, {
+        "content-type": "application/json",
+        "Cache-Control": "no-store",
+        "Access-Control-Allow-Origin": "*",
+      });
+    } catch (err) {
+      return errorResponse(c, err);
+    }
+  });
+
   app.patch("/:virtualMcpId/:branch", async (c) => {
     const scope = c.get("decofileScope");
     const ctx = c.var.studioContext;

--- a/apps/api/src/decofile/github-git-data.ts
+++ b/apps/api/src/decofile/github-git-data.ts
@@ -331,6 +331,24 @@ export function createGitDataClient(params: {
     return { status: res.status, json };
   }
 
+  /** Blob text by sha via the Blob API (base64, up to 100MB). Shared by
+   * `getBlobText` and by `getFileTextAtRef`'s large-file fallback. */
+  async function blobText(blobSha: string): Promise<string> {
+    const { json } = await call<{ content: string; encoding: string }>(
+      "GET",
+      `${repoBase}/git/blobs/${blobSha}`,
+    );
+    if (json.encoding !== "base64") {
+      throw new GitHubApiError(
+        502,
+        "GET",
+        `${repoBase}/git/blobs/${blobSha}`,
+        `unexpected blob encoding ${json.encoding}`,
+      );
+    }
+    return Buffer.from(json.content, "base64").toString("utf-8");
+  }
+
   return {
     owner,
     repo,
@@ -406,26 +424,15 @@ export function createGitDataClient(params: {
       return json.tree;
     },
 
-    async getBlobText(blobSha) {
-      const { json } = await call<{ content: string; encoding: string }>(
-        "GET",
-        `${repoBase}/git/blobs/${blobSha}`,
-      );
-      if (json.encoding !== "base64") {
-        throw new GitHubApiError(
-          502,
-          "GET",
-          `${repoBase}/git/blobs/${blobSha}`,
-          `unexpected blob encoding ${json.encoding}`,
-        );
-      }
-      return Buffer.from(json.content, "base64").toString("utf-8");
+    getBlobText(blobSha) {
+      return blobText(blobSha);
     },
 
     async getFileTextAtRef(ref, filePath) {
       const { status, json } = await call<{
         content?: string;
         encoding?: string;
+        sha?: string;
       }>(
         "GET",
         `${repoBase}/contents/${encodeRefPath(filePath)}?ref=${encodeURIComponent(ref)}`,
@@ -433,6 +440,13 @@ export function createGitDataClient(params: {
         { allow: [404] },
       );
       if (status === 404 || json?.content === undefined) return null;
+      /** Files over the Contents API's 1MB limit come back with
+       * `encoding: "none"` and empty content, but the blob sha is still there —
+       * fetch the blob directly (the Blob API serves up to 100MB). A large
+       * `.deco/meta.gen.json` routinely crosses that line. */
+      if (json.encoding === "none" && json.sha) {
+        return blobText(json.sha);
+      }
       if (json.encoding !== "base64") {
         throw new GitHubApiError(
           502,

--- a/apps/web/src/components/sections-editor/read-committed-file.ts
+++ b/apps/web/src/components/sections-editor/read-committed-file.ts
@@ -72,3 +72,36 @@ export async function readCommittedJson<T>(
     return { kind: "unavailable" };
   }
 }
+
+/**
+ * Read the committed `.deco/meta.gen.json` from the branch via the sandbox-less
+ * decofile API (`/api/:org/decofile/:vmId/:branch/meta`), which resolves it
+ * through the GitHub API — no dev server, no daemon. This is the Fast Preview
+ * equivalent of `readCommittedJson`: the schema source that answers before (and
+ * without) a running runtime, so the CMS isn't stuck on a cross-origin
+ * `/live/_meta` fetch that CORS blocks.
+ *
+ * 404 = the artifact isn't committed on this branch → `absent` (fall through to
+ * production). Other non-ok statuses throw so the caller's query retries.
+ */
+export async function readCommittedMetaViaGit<T>(params: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+}): Promise<CommittedRead<T>> {
+  const url = `/api/${params.orgSlug}/decofile/${encodeURIComponent(
+    params.virtualMcpId,
+  )}/${encodeURIComponent(params.branch)}/meta`;
+  const res = await fetch(url, { cache: "no-store" });
+  if (res.status === 404) return { kind: "absent" };
+  if (!res.ok) {
+    const err = new Error(`Failed to read committed meta: ${res.status}`);
+    (err as { status?: number }).status = res.status;
+    throw err;
+  }
+  try {
+    return { kind: "data", data: (await res.json()) as T };
+  } catch {
+    return { kind: "unavailable" };
+  }
+}

--- a/apps/web/src/components/sections-editor/use-live-meta.test.ts
+++ b/apps/web/src/components/sections-editor/use-live-meta.test.ts
@@ -76,7 +76,7 @@ describe("metaSourceOrder", () => {
     expect(committedIdx).toBeLessThan(productionIdx);
   });
 
-  it("fast preview: production only — no dev server, no daemon to read", () => {
+  it("fast preview: committed (via git) → production, never live", () => {
     expect(
       metaSourceOrder({
         fetchEnabled: true,
@@ -84,6 +84,17 @@ describe("metaSourceOrder", () => {
         productionUrl: PROD,
         fastPreviewActive: true,
       }),
-    ).toEqual([{ kind: "production", baseUrl: PROD }]);
+    ).toEqual([{ kind: "committed" }, { kind: "production", baseUrl: PROD }]);
+  });
+
+  it("fast preview, no production: committed is the only source", () => {
+    expect(
+      metaSourceOrder({
+        fetchEnabled: true,
+        previewUrl: PREVIEW,
+        productionUrl: null,
+        fastPreviewActive: true,
+      }),
+    ).toEqual([{ kind: "committed" }]);
   });
 });

--- a/apps/web/src/components/sections-editor/use-live-meta.ts
+++ b/apps/web/src/components/sections-editor/use-live-meta.ts
@@ -2,7 +2,10 @@ import { type Query, useQuery } from "@tanstack/react-query";
 import { exponentialBackoffWithJitter } from "@decocms/shared/std";
 import { KEYS } from "@/lib/query-keys";
 import { decoRepoPath } from "./deco-repo-path";
-import { readCommittedJson } from "./read-committed-file";
+import {
+  readCommittedJson,
+  readCommittedMetaViaGit,
+} from "./read-committed-file";
 import { useSessionRuntime } from "@/hooks/use-session-runtime";
 import { usePackagePath } from "./use-package-path";
 import type { LiveMeta } from "./resolve-schema";
@@ -35,9 +38,8 @@ export type MetaSource =
  * last resort — it only matters for sites with no committed `meta.gen.json`
  * (e.g. Fresh/Deco sites), unblocking the CMS before the runtime boots.
  *
- * Sandbox-less Fast Preview drops both sandbox-backed sources: there is no dev
- * server, and no daemon to read the working tree through, so production is the
- * only source that can answer.
+ * Sandbox-less Fast Preview reads `committed` from the branch via the GitHub
+ * API (`readCommittedMetaViaGit`), not a dev server/daemon.
  */
 export function metaSourceOrder(input: {
   fetchEnabled: boolean;
@@ -46,7 +48,9 @@ export function metaSourceOrder(input: {
   fastPreviewActive: boolean;
 }): MetaSource[] {
   const sources: MetaSource[] = [];
-  if (!input.fastPreviewActive) {
+  if (input.fastPreviewActive) {
+    sources.push({ kind: "committed" });
+  } else {
     if (input.fetchEnabled && input.previewUrl) {
       sources.push({ kind: "live", baseUrl: input.previewUrl });
     }
@@ -108,10 +112,12 @@ export function useLiveMeta(
         }
       };
       const readCommitted = () =>
-        readCommittedJson<LiveMeta>(
-          params!,
-          decoRepoPath(packagePath, ".deco/meta.gen.json"),
-        );
+        fastPreviewActive
+          ? readCommittedMetaViaGit<LiveMeta>(params!)
+          : readCommittedJson<LiveMeta>(
+              params!,
+              decoRepoPath(packagePath, ".deco/meta.gen.json"),
+            );
 
       // Walk the sources in priority order; first hit wins. Falling all the way
       // through means neither a live/production runtime nor a committed snapshot

--- a/packages/e2e/tests/decofile-api.spec.ts
+++ b/packages/e2e/tests/decofile-api.spec.ts
@@ -939,4 +939,66 @@ test.describe("decofile API", () => {
       await ctx.dispose();
     }
   });
+
+  test("GET /meta serves committed meta.gen.json, falls back to default branch, 404 when absent", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    try {
+      const user = await signUpViaApi(ctx);
+      const owner = uniqueOwner();
+      const project = await createFastPreviewProject(ctx, user.orgSlug, {
+        owner,
+        repo: "site",
+      });
+      const meta = { schema: { root: "site/mod.ts" } };
+      await seedStubRepo(ctx, {
+        owner,
+        repo: "site",
+        defaultBranch: "main",
+        branches: {
+          // Default branch commits the artifact; a feature branch does not.
+          main: {
+            files: { ".deco/meta.gen.json": `${JSON.stringify(meta)}\n` },
+          },
+          feature: { files: { ".deco/blocks/Hero.json": '{"n":1}\n' } },
+        },
+      });
+
+      const metaUrl = (branch: string) =>
+        `/api/${project.org}/decofile/${project.vmcpId}/${branch}/meta`;
+
+      // Branch that commits it: served straight back, parsed as JSON.
+      const onMain = await ctx.get(metaUrl("main"));
+      expect(onMain.status()).toBe(200);
+      expect(onMain.headers()["content-type"]).toContain("application/json");
+      expect(await onMain.json()).toEqual(meta);
+
+      // A branch without it falls back to the default branch's committed copy.
+      const onFeature = await ctx.get(metaUrl("feature"));
+      expect(onFeature.status()).toBe(200);
+      expect(await onFeature.json()).toEqual(meta);
+
+      // Neither branch nor default commits it: 404 (client falls to production).
+      const bare = uniqueOwner();
+      const bareProject = await createFastPreviewProject(ctx, user.orgSlug, {
+        owner: bare,
+        repo: "site",
+      });
+      await seedStubRepo(ctx, {
+        owner: bare,
+        repo: "site",
+        defaultBranch: "main",
+        branches: {
+          main: { files: { ".deco/blocks/Hero.json": '{"n":1}\n' } },
+        },
+      });
+      const missing = await ctx.get(
+        `/api/${bareProject.org}/decofile/${bareProject.vmcpId}/main/meta`,
+      );
+      expect(missing.status()).toBe(404);
+    } finally {
+      await ctx.dispose();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Sandbox-less Fast Preview (`runtime === "cms"`) has no dev server and no sandbox daemon, so `useLiveMeta` dropped both sandbox-backed schema sources (`live`, `committed`) and fell straight to a **cross-origin** `fetch(<site>/live/_meta)`. On VTEX (`*.vtex.app`) that CORS-fails (`net::ERR_FAILED`) → the CMS gets stuck on a terminal error and never loads the section schema.

This reads the committed `.deco/meta.gen.json` **from the branch via the GitHub API** instead — the exact mechanism the sandbox-less decofile route already uses for `.deco/blocks/*.json`, so it needs no dev server and no daemon.

## Changes

**Backend**
- New route `GET /api/:org/decofile/:vmId/:branch/meta` (`apps/api/src/api/routes/decofile.ts`) → `GitDataClient.getFileTextAtRef(branch, ".deco/meta.gen.json")`, falling back to the default branch (thread branches fork from it, and `meta.gen.json` is a code artifact the CMS never edits, so the default's copy is the schema the forked branch would carry).
- `getFileTextAtRef` now handles files over the Contents API's 1MB limit: GitHub returns `encoding:"none"` + the blob sha, so it fetches the blob directly via the Blob API (up to 100MB). A large storefront's `meta.gen.json` routinely crosses that line. Extracted the blob-fetch into a shared helper.

**Frontend**
- `readCommittedMetaViaGit` (`read-committed-file.ts`): same-origin GET, so no CORS; 404 → `absent` (falls through to production).
- `metaSourceOrder` (`use-live-meta.ts`): the fast-preview branch now emits `committed` (via git) → `production` instead of production-only. `readCommitted` routes to the git endpoint when fast preview is active.
- The daemon `/read` proxy still serves the **non**-fast-preview (sandbox) path unchanged.

## Condition

Only resolves when `.deco/meta.gen.json` is **committed** to the branch. It's a generated artifact — if the repo `.gitignore`s it, the git read 404s and falls back to production `/live/_meta` (still CORS-blocked on VTEX). Committed `meta.gen.json` is already what Studio pickers rely on.

## Testing

- ✅ `bun run check` (api, web, e2e) — typecheck clean
- ✅ `bun run lint` — 0 errors
- ✅ `bun run fmt` — no changes
- ✅ unit: `use-live-meta.test.ts` (inverted the "fast preview: production only" case) + `apps/api/src/decofile/`
- ✅ e2e added: `GET /meta` serves committed meta, falls back to default branch, 404 when absent (not run locally — needs Postgres; runs in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Fast Preview schema loading by reading committed `.deco/meta.gen.json` via the GitHub API instead of cross-origin `/live/_meta`. Previously, Fast Preview fetched production only and CORS-failed on VTEX; now it tries committed meta first, then production, avoiding CORS and unblocking the CMS.

- Backend: adds `GET /api/:org/decofile/:vmId/:branch/meta` to return the branch’s committed `.deco/meta.gen.json`, falling back to the default branch if missing. Returns 404 when absent. Handles >1MB files by using the Blob API when the Contents API responds with `encoding: "none"`.
- Frontend: Fast Preview source order becomes `committed → production`. Implements `readCommittedMetaViaGit` and routes `readCommitted` to the new API when Fast Preview is active. Non–Fast Preview path via the daemon remains unchanged.
- Tests: updates unit tests for the new source order and adds e2e covering serve, default-branch fallback, and 404.
- Migration: to benefit, ensure `.deco/meta.gen.json` is committed. If not committed, the client falls back to production (which may still be CORS-blocked on VTEX). No config changes required.

<sup>Written for commit fa4a25b6dbd123d8cdf2a4004664c869eeedc20c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

