### PR TITLE
fix(sandbox): stop the dirty-baseline swallowing an edit made mid-boot

### DIFF
--- a/packages/sandbox/daemon-go/internal/gitx/branchstatus.go
+++ b/packages/sandbox/daemon-go/internal/gitx/branchstatus.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,6 +27,12 @@ type BranchStatusMonitor struct {
 	last        events.BranchMeta
 	baseline    map[string]string
 	hasBaseline bool
+	// userTouched is the set of repo-relative paths written through the daemon's
+	// own fs routes — the user's work. Boot dirt is written by the dev server
+	// process directly and never lands here, so it is exactly the separator the
+	// time-based baseline can't provide: a path the user edited is never folded
+	// into the baseline. Copy-on-write so `compute` can read a snapshot lock-free.
+	userTouched map[string]struct{}
 	pollStop    chan struct{}
 	pollStarted bool
 	stopped     bool
@@ -79,6 +86,41 @@ func (m *BranchStatusMonitor) ArmBaseline() {
 	m.baseline = baseline
 	m.mu.Unlock()
 	m.Refresh()
+}
+
+// MarkUserTouched records a path the user wrote through the fs routes so the
+// baseline never counts it as boot dirt. An edit made while the sandbox is still
+// `starting` — before the baseline arms — would otherwise be snapshotted into the
+// baseline and silently swallowed; this keeps it publishable. Refreshing is the
+// caller's (the fs route already does).
+func (m *BranchStatusMonitor) MarkUserTouched(path string) {
+	rel := m.toRepoRel(path)
+	if rel == "" {
+		return
+	}
+	m.mu.Lock()
+	next := make(map[string]struct{}, len(m.userTouched)+1)
+	for p := range m.userTouched {
+		next[p] = struct{}{}
+	}
+	next[rel] = struct{}{}
+	m.userTouched = next
+	m.mu.Unlock()
+}
+
+// toRepoRel normalizes a fs-route path to the slash-separated, repo-relative form
+// `git status` emits (relative paths resolve against repoDir, matching SafePath).
+// Anything outside the repo returns "" and is ignored.
+func (m *BranchStatusMonitor) toRepoRel(path string) string {
+	abs := path
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(m.repoDir, path)
+	}
+	rel, err := filepath.Rel(m.repoDir, filepath.Clean(abs))
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return ""
+	}
+	return filepath.ToSlash(rel)
 }
 
 func (m *BranchStatusMonitor) Refresh() {
@@ -180,12 +222,19 @@ func (m *BranchStatusMonitor) compute() *events.BranchMeta {
 	m.mu.Lock()
 	hasBaseline := m.hasBaseline
 	baseline := m.baseline
+	userTouched := m.userTouched
 	m.mu.Unlock()
 	// Un-armed means boot has not settled (ArmBaseline runs at every boot
 	// outcome), so everything dirty here is boot dirt — reporting it as the
 	// user's work armed "Review & Publish" on an untouched, empty thread.
 	if len(dirtyPaths) > 0 && hasBaseline {
 		for p := range dirtyPaths {
+			// A path the user wrote is their work regardless of the baseline — this
+			// is what stops an edit made before arming from being swallowed by it.
+			if _, touched := userTouched[p]; touched {
+				dirty = true
+				break
+			}
 			baseHash, ok := baseline[p]
 			if !ok || m.hashWorktreeFile(p) != baseHash {
 				dirty = true

--- a/packages/sandbox/daemon-go/internal/gitx/branchstatus_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/branchstatus_test.go
@@ -2,6 +2,7 @@ package gitx
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -12,8 +13,22 @@ func (nopBroadcaster) Emit(string, any) {}
 
 func write(t *testing.T, repo, name, content string) {
 	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(repo, name)), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func commitAll(t *testing.T, repo string) {
+	t.Helper()
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-q", "-m", "snapshot"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
 	}
 }
 
@@ -53,6 +68,33 @@ func TestBaselineSeparatesBootDirtFromUserWork(t *testing.T) {
 	m.ArmBaseline()
 	if !dirty(t, m) {
 		t.Fatal("first arm wins: a later arm must not swallow the edit")
+	}
+}
+
+// The reported bug: a CMS edit made while the sandbox is still `starting` — before
+// the baseline arms — was snapshotted into the baseline as boot dirt and silently
+// swallowed, so the header read "Up to date" over a real change. A path written
+// through the fs routes (MarkUserTouched) must survive the arm regardless of order.
+func TestUserTouchedEditSurvivesLaterBaselineArm(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature")
+	m := NewBranchStatusMonitor(repo, nopBroadcaster{}, nil)
+
+	// The storefront ships committed blocks, so editing one shows as a modified
+	// tracked path — the shape the header actually sees.
+	write(t, repo, ".deco/blocks/pages-Home.json", `{"__resolveType":"x"}`)
+	commitAll(t, repo)
+
+	// Both made while `starting`, before the baseline arms: boot dirt the dev
+	// server emits directly, and a CMS block edit that came through the fs route.
+	write(t, repo, "boot.gen.json", "{}\n")
+	write(t, repo, ".deco/blocks/pages-Home.json", `{"__resolveType":"y"}`)
+	m.MarkUserTouched(".deco/blocks/pages-Home.json")
+
+	// Arms only once the dev server settles — after both writes above.
+	m.ArmBaseline()
+
+	if !dirty(t, m) {
+		t.Fatal("an edit made before arming must not be swallowed by the baseline")
 	}
 }
 

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -1035,6 +1035,7 @@ func main() {
 		AppRoot: appRoot,
 		RepoDir: repoDir,
 		OnWorkingTreeWrite: func(path string) {
+			d.branchStatus.MarkUserTouched(path)
 			d.branchStatus.Refresh()
 			d.emitFileChanged(path)
 		},


### PR DESCRIPTION
## Symptom

Edit content (e.g. reorder sections) while the sandbox is still **`starting`**; after boot finishes, the header reads **"Atualizado" / "Up to date"** even though there's a real, unpublished change. The edit is silently dropped from "has work to publish."

## Root cause

The anti-boot-dirt baseline (`branchstatus.go`) snapshots *"what is dirty right now"* as **not the user's work**, and arms only once the dev server **settles** — 3s after `running`, or on a boot failure (#6332). An edit made during `starting` is a CMS block write through the fs routes; it's already dirty on disk when the baseline finally arms, so `ArmBaseline` folds it into the baseline at its **edited** hash. `compute()` then sees `current == baseline` → `WorkingTreeDirty: false` → the header renders "Atualizado". **The edit is swallowed.**

The baseline separated boot dirt from user work by **time**, which can't work — the user's edit lands in the same pre-arm window as the boot dirt.

## Fix — separate by *source*, not time

Boot dirt is written by the dev server process directly; user edits come through the daemon's fs routes, which already fire `OnWorkingTreeWrite`. So:

- Track paths written through the fs routes (`MarkUserTouched`, normalized to the repo-relative form `git status` emits).
- In `compute()`, a **dirty user-touched path is the user's work regardless of the baseline** — so an edit is never swallowed, whatever order it and the arm happen in. Boot dirt (never routed) still baselines and stays out of the dirty signal.

Copy-on-write set so `compute()` reads a lock-free snapshot (health-probe path — no lock held across the git/hash I/O).

## Testing

- New `TestUserTouchedEditSurvivesLaterBaselineArm` reproduces the exact bug: commit a block, then edit it + boot-dirt during `starting`, arm the baseline after → asserts `WorkingTreeDirty` stays `true`.
- Existing baseline tests (boot dirt still swallowed; content-hash edit detection; first-arm-wins) still pass — the boot-dirt guard is preserved.
- `go test ./...`, `go vet`, `go test -race ./internal/gitx/`, `gofmt` all clean.

## Known narrow gap

Exact-path match covers the real case (editing a **committed** block → a modified tracked path). A brand-new *first* block created inside a still-untracked `.deco/blocks/` collapses to a directory entry in `git status --porcelain` and isn't matched — left for a follow-up (would need prefix-matching against collapsed untracked dirs).

## Relation to #6490

Independent. #6490 is the front (`panel-state.ts`) — it stops the publish button being *held* on the dev server booting. This is the daemon (`branchstatus.go`) — it stops an edit made *during* that boot from being *swallowed*. Different layer, different failure mode; either can merge without the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops edits made while the sandbox is starting from being absorbed into the dirty-baseline. Previously, an edit during startup was folded into the baseline and the header showed “Up to date”; now, any dirty path written via the daemon’s fs routes is always treated as user work.

- Introduces `userTouched` and `MarkUserTouched` in `packages/sandbox/daemon-go/internal/gitx/branchstatus.go` (repo-relative, slash-normalized paths; copy-on-write snapshot); `compute()` marks dirty if a touched path is dirty before consulting the baseline.
- Wires `OnWorkingTreeWrite` to `MarkUserTouched` in `packages/sandbox/daemon-go/main.go`.
- Adds `TestUserTouchedEditSurvivesLaterBaselineArm`; existing baseline tests still pass.
- Known gap: brand-new files only visible as collapsed untracked dirs aren’t matched; follow-up will require prefix matching.

<sup>Written for commit 776d0627dafd3f9704aeea673c5b11aba94341af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

