### PR TITLE
refactor(storage): extract parseJsonColumn helper in organization-settings

### DIFF
--- a/apps/api/src/storage/organization-settings.ts
+++ b/apps/api/src/storage/organization-settings.ts
@@ -2,6 +2,15 @@ import { sql, type Kysely } from "kysely";
 import type { Database, OrganizationSettings } from "./types";
 import type { OrganizationSettingsStoragePort } from "./ports";
 
+/**
+ * jsonb columns come back as an already-parsed object from some drivers and
+ * as a raw JSON string from others — normalize both to the parsed shape.
+ */
+function parseJsonColumn<T>(value: unknown): T | null {
+  if (!value) return null;
+  return (typeof value === "string" ? JSON.parse(value) : value) as T;
+}
+
 export class OrganizationSettingsStorage
   implements OrganizationSettingsStoragePort
 {
@@ -20,42 +29,26 @@ export class OrganizationSettingsStorage
 
     return {
       organizationId: record.organizationId,
-      sidebar_items: record.sidebar_items
-        ? typeof record.sidebar_items === "string"
-          ? JSON.parse(record.sidebar_items)
-          : record.sidebar_items
-        : null,
-      enabled_plugins: record.enabled_plugins
-        ? typeof record.enabled_plugins === "string"
-          ? JSON.parse(record.enabled_plugins)
-          : record.enabled_plugins
-        : null,
-      registry_config: record.registry_config
-        ? typeof record.registry_config === "string"
-          ? JSON.parse(record.registry_config)
-          : record.registry_config
-        : null,
-      simple_mode: record.simple_mode
-        ? typeof record.simple_mode === "string"
-          ? JSON.parse(record.simple_mode)
-          : record.simple_mode
-        : null,
-      default_home_agents: record.default_home_agents
-        ? typeof record.default_home_agents === "string"
-          ? JSON.parse(record.default_home_agents)
-          : record.default_home_agents
-        : null,
-      flags: record.flags
-        ? typeof record.flags === "string"
-          ? JSON.parse(record.flags)
-          : record.flags
-        : null,
+      sidebar_items: parseJsonColumn<OrganizationSettings["sidebar_items"]>(
+        record.sidebar_items,
+      ),
+      enabled_plugins: parseJsonColumn<OrganizationSettings["enabled_plugins"]>(
+        record.enabled_plugins,
+      ),
+      registry_config: parseJsonColumn<OrganizationSettings["registry_config"]>(
+        record.registry_config,
+      ),
+      simple_mode: parseJsonColumn<OrganizationSettings["simple_mode"]>(
+        record.simple_mode,
+      ),
+      default_home_agents: parseJsonColumn<
+        OrganizationSettings["default_home_agents"]
+      >(record.default_home_agents),
+      flags: parseJsonColumn<OrganizationSettings["flags"]>(record.flags),
       main_agent_id: record.main_agent_id ?? null,
-      sprint_config: record.sprint_config
-        ? typeof record.sprint_config === "string"
-          ? JSON.parse(record.sprint_config)
-          : record.sprint_config
-        : null,
+      sprint_config: parseJsonColumn<OrganizationSettings["sprint_config"]>(
+        record.sprint_config,
+      ),
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
     };


### PR DESCRIPTION
**Source:** C1 code-reduction, found while auditing the org-settings storage layer (`apps/api/src/storage/organization-settings.ts`) for the org-settings-persistence focus area. No related open PR touches this file — #6487/#6481/#6464/#6445 (recently merged/open) all touch `update.ts`/`delete.ts`/`member-list.ts`, not this file.

**What/why:** `OrganizationSettingsStorage.get()` inlined the same 'jsonb column may come back as a string or as an already-parsed value' ternary 7 times, once per settings field (`sidebar_items`, `enabled_plugins`, `registry_config`, `simple_mode`, `default_home_agents`, `flags`, `sprint_config`). Collapsed into one `parseJsonColumn<T>()` helper called per field. A maintainer gets one place to fix this normalization logic instead of seven.

**Net delta:** -35 / +28 lines in one file, no behavior change: same null-check, same `typeof === "string" ? JSON.parse(...) : value` logic, just factored out. Each call site passes an explicit type argument because Kysely's `ColumnType` select type doesn't infer cleanly through a bare generic parameter (confirmed via `tsc --noEmit` — inferring from the parameter directly produced a `T[][]` mismatch).

**How a reviewer confirms:** read the diff — `parseJsonColumn` is a straight extraction of the pre-existing ternary, and every field still round-trips through it. No integration test exists for this file that doesn't need real Postgres (this box has none available), so verification here is static: the change is a pure refactor with no schema/query changes.

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (green), `bunx oxlint apps/api/src/storage/organization-settings.ts` (0 warnings/errors). Full CI (including the Postgres-backed integration test for this file) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates JSON parsing for organization settings by extracting a `parseJsonColumn<T>()` helper. Behavior is unchanged: the previous per-field ternary becomes a single helper that normalizes string-or-object `jsonb` values with the same null check.

- No schema or query changes; only `get()` in `apps/api/src/storage/organization-settings.ts` is touched.
- Each call site passes an explicit generic due to `kysely` select type inference limits.
- To review: compare the helper to the prior ternary and confirm all JSON fields (`sidebar_items`, `enabled_plugins`, `registry_config`, `simple_mode`, `default_home_agents`, `flags`, `sprint_config`) route through it.

<sup>Written for commit 1bec1b48526ce62d62c12859a6fafcfec23953a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

