### PR TITLE
fix(chat): ignore a stale voice recognizer's async callbacks after restart

### DIFF
--- a/apps/web/src/hooks/use-voice-input.test.ts
+++ b/apps/web/src/hooks/use-voice-input.test.ts
@@ -193,4 +193,80 @@ describe("useVoiceInput.startRecording", () => {
       configurable: true,
     });
   });
+
+  it("ignores a cancelled recognizer's late error once a newer one has started", async () => {
+    const instances: Array<{
+      onerror?: (event: { error: string }) => void;
+      onend?: () => void;
+    }> = [];
+    win.SpeechRecognition = function () {
+      const instance: {
+        start: () => void;
+        stop: () => void;
+        abort: () => void;
+        onerror?: (event: { error: string }) => void;
+        onend?: () => void;
+      } = { start() {}, stop() {}, abort() {} };
+      instances.push(instance);
+      return instance;
+    } as unknown as typeof SpeechRecognition;
+
+    const originalAudioContext = win.AudioContext;
+    win.AudioContext = function () {
+      return {
+        createMediaStreamSource: () => ({ connect: () => {} }),
+        createAnalyser: () => ({
+          fftSize: 0,
+          smoothingTimeConstant: 0,
+          frequencyBinCount: 0,
+          getByteFrequencyData: () => {},
+        }),
+        close: () => Promise.resolve(),
+      };
+    };
+
+    const track = { stop: () => {} };
+    const originalGetUserMedia = navigator.mediaDevices?.getUserMedia;
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: {
+        getUserMedia: () =>
+          Promise.resolve({
+            getTracks: () => [track],
+          } as unknown as MediaStream),
+      },
+      configurable: true,
+    });
+
+    const originalRaf = win.requestAnimationFrame;
+    const originalCaf = win.cancelAnimationFrame;
+    win.requestAnimationFrame = (() =>
+      1) as unknown as typeof win.requestAnimationFrame;
+    win.cancelAnimationFrame =
+      (() => {}) as unknown as typeof win.cancelAnimationFrame;
+
+    const { result } = renderHook(() => useVoiceInput());
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    act(() => result.current.cancelRecording());
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    expect(instances.length).toBe(2);
+    expect(result.current.status).toBe("recording");
+
+    // The cancelled recognizer's abort() resolves late as an "aborted" error.
+    act(() => instances[0]?.onerror?.({ error: "aborted" }));
+
+    expect(result.current.status).toBe("recording");
+
+    win.AudioContext = originalAudioContext;
+    win.requestAnimationFrame = originalRaf;
+    win.cancelAnimationFrame = originalCaf;
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia: originalGetUserMedia },
+      configurable: true,
+    });
+  });
 });

--- a/apps/web/src/hooks/use-voice-input.ts
+++ b/apps/web/src/hooks/use-voice-input.ts
@@ -143,6 +143,8 @@ export function useVoiceInput(): UseVoiceInputReturn {
     };
 
     recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      // Ignore a stale instance's async error once a newer one took over.
+      if (recognitionRef.current !== recognition) return;
       // "no-speech" is routine in continuous mode; onend restarts it below.
       if (event.error === "no-speech") return;
       // Fatal error (network/mic/permission) — stop, don't let onend restart it.
@@ -153,6 +155,7 @@ export function useVoiceInput(): UseVoiceInputReturn {
     };
 
     recognition.onend = () => {
+      if (recognitionRef.current !== recognition) return;
       if (isRecordingRef.current) {
         try {
           recognition.start();


### PR DESCRIPTION
Bug found while reading recently-touched `apps/web/src/hooks/use-voice-input.ts` (churned by #6451).

**Failure scenario:** `cancelRecording()` calls `recognitionRef.current?.abort()` but does not null out the ref, and `startRecording()` right after creates a *new* `SpeechRecognition` instance, reassigning `recognitionRef.current`. Browsers (Chrome) resolve `abort()` asynchronously as an `error` event with `error: "aborted"` — so the *old*, already-cancelled recognizer's `onerror` can fire after the new one is already recording. Its handler unconditionally does `isRecordingRef.current = false; recognitionRef.current = null; setStatus(...)`, which kills the ref to the live recognizer and flips the UI status back to `idle`/`permission-denied` mid-recording. The same stale-closure issue affects `onend`, which could restart a dead recognizer instance that no longer holds the mic session.

**Fix:** each handler now checks `recognitionRef.current !== recognition` and bails if the callback belongs to a superseded instance — the same pattern already used to distinguish the live session from historic ones.

**Regression test:** `use-voice-input.test.ts` — starts recording, cancels, restarts (second `SpeechRecognition` instance), then fires the *first* instance's `onerror({error: "aborted"})`. Before the fix this drops status to `idle` even though the second recognizer is still recording; after the fix status stays `recording`. Verified the test fails on the pre-fix code (`git stash` the source file, rerun) and passes after.

**To confirm:** `bun test apps/web/src/hooks/use-voice-input.test.ts`

**Checked locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (no new errors), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale `SpeechRecognition` callbacks from affecting the current session after a restart. Previously, a cancelled recognizer’s late `onerror("aborted")` or `onend` could null out the live `recognitionRef`, flip status from `recording`, or restart a dead instance; now those callbacks are ignored if they don’t belong to the current recognizer.

- Handlers in `use-voice-input.ts` early-return when `recognitionRef.current !== recognition`.
- Adds a regression test that cancels, restarts, then fires the old instance’s `onerror("aborted")`, asserting status remains `recording`.

<sup>Written for commit 52cec919c15a39b059e1d7163f1ac642e7e0f41b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

