### PR TITLE
fix(sandbox): exclude the Commerce Discovery connection from a run's org MCPs

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { UIMessageChunk } from "ai";
 import { harnessRunResultSchema } from "@decocms/sandbox/dispatch/schemas";
+import { WellKnownOrgMCPId } from "@decocms/shared/sdk";
 import { withModelMetadata } from "./with-model-metadata";
 import {
   describeTermination,
@@ -8,6 +9,7 @@ import {
   errorForTerminal,
   harnessRunsInSandbox,
   isRunSuperseded,
+  isStudioOwnedConnection,
   isUnreachableStatus,
   ndjsonLines,
   pushSandboxEnv,
@@ -39,6 +41,24 @@ const collect = async (it: AsyncIterable<UIMessageChunk>) => {
   for await (const c of it) out.push(c);
   return out;
 };
+
+describe("isStudioOwnedConnection", () => {
+  const orgId = "org_1";
+
+  test.each([
+    ["self", WellKnownOrgMCPId.SELF],
+    ["registry", WellKnownOrgMCPId.REGISTRY],
+    ["community registry", WellKnownOrgMCPId.COMMUNITY_REGISTRY],
+    ["dev assets", WellKnownOrgMCPId.DEV_ASSETS],
+    ["commerce discovery", WellKnownOrgMCPId.COMMERCE_DISCOVERY],
+  ])("excludes the %s connection", (_name, wellKnownId) => {
+    expect(isStudioOwnedConnection(orgId, wellKnownId(orgId))).toBe(true);
+  });
+
+  test("does not exclude a real user-configured connection", () => {
+    expect(isStudioOwnedConnection(orgId, "conn_abc123")).toBe(false);
+  });
+});
 
 describe("harnessRunsInSandbox", () => {
   test("claude-code is sandbox-hosted", () => {

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -1039,14 +1039,16 @@ export async function* ndjsonLines(
 }
 
 /**
- * Studio's own well-known connections, which every org has whether or not
- * anyone configured an MCP: the management surface and the two store
- * registries. Excluded from a run's `orgMcps` — `_self` alone is ~200
- * management tools, which is exactly what the narrow task-run surface exists to
- * avoid, and browsing the MCP store is not a coding agent's job. What the user
- * actually connected is everything else.
+ * Studio's own well-known connections — the management surface, the two store
+ * registries, and (for orgs that ran commerce onboarding) the Commerce
+ * Discovery report connection. Excluded from a run's `orgMcps` — `_self`
+ * alone is ~200 management tools, which is exactly what the narrow task-run
+ * surface exists to avoid, browsing the MCP store is not a coding agent's
+ * job, and the report connection is a diagnostics tool for the commerce UI,
+ * not something a coding agent should be handed. What the user actually
+ * connected is everything else.
  */
-function isStudioOwnedConnection(
+export function isStudioOwnedConnection(
   organizationId: string,
   connectionId: string,
 ): boolean {
@@ -1055,5 +1057,6 @@ function isStudioOwnedConnection(
     WellKnownOrgMCPId.REGISTRY,
     WellKnownOrgMCPId.COMMUNITY_REGISTRY,
     WellKnownOrgMCPId.DEV_ASSETS,
+    WellKnownOrgMCPId.COMMERCE_DISCOVERY,
   ].some((id) => id(organizationId) === connectionId);
 }


### PR DESCRIPTION
**Source**: bug found while auditing `apps/api/src/harnesses/sandbox-dispatch-client.ts` (recently touched by #6466/#6473/#6474, which added the `coding_agent_org_mcps` org-MCPs feature).

**Payoff**: `isStudioOwnedConnection` exists specifically to keep Studio's own internal connections out of a sandbox-hosted coding-agent run's mounted org MCPs — it already excludes `self`, the two store registries, and dev-assets. It was missing `WellKnownOrgMCPId.COMMERCE_DISCOVERY`, which is also a real per-org connection: `COMMERCE_DISCOVERY_SETUP` (apps/api/src/tools/reports/setup.ts) creates it as a normal `HTTP` connection row carrying its own `connection_token`, used by the commerce-report/diagnostics UI. With `coding_agent_org_mcps` enabled, any org that ran commerce onboarding would get this internal reporting connection silently mounted as a generic MCP server on every Claude Code sandbox run — exposing an internal service credential/tool surface to a coding agent that has no business calling it, alongside whatever the org actually connected.

**Fix**: add `WellKnownOrgMCPId.COMMERCE_DISCOVERY` to the exclusion list in `isStudioOwnedConnection`, and export the function (it was private) so the exclusion set is pinned by a unit test.

**Regression test**: `apps/api/src/harnesses/sandbox-dispatch-client.test.ts` — new `describe("isStudioOwnedConnection", ...)` block asserts every well-known org connection id (self/registry/community-registry/dev-assets/commerce-discovery) is excluded, and a real user connection id is not.

**To verify**: `cd apps/api && bunx tsc --noEmit` and `bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts` (50/50 pass).

**Checks run locally**: `bun run fmt`, targeted `tsc --noEmit` on `apps/api`, the single test file above, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the Commerce Discovery org connection from sandbox-hosted coding-agent runs to avoid exposing an internal reporting credential. Previously, with `coding_agent_org_mcps` enabled, the Commerce Discovery connection was mounted as a generic MCP server; now it is excluded like `self`, registries, and dev-assets.

- Add Commerce Discovery to the `isStudioOwnedConnection` exclusion list.
- Export `isStudioOwnedConnection` and add unit tests covering all well-known IDs and a non-excluded user connection.
- Scope: only affects `orgMcps` construction for sandbox-hosted Claude Code runs; no impact on commerce diagnostics UI or connection creation.
- Rollout: no migrations or config changes. Effective only when `coding_agent_org_mcps` mounts org MCPs.

<sup>Written for commit 5f1146abf1c0ab91a525cebe0039923ab4b5fefa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

