### PR TITLE
fix(thread/github): use headerActions namespace for header aria-label

### DIFF
--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -538,7 +538,7 @@ function HeaderButtonRenderer(props: {
         {...(action && !loading ? { icon: actionIcon(action) } : {})}
         {...(tooltip ? { tooltip } : {})}
         items={items}
-        menuAriaLabel={t("thread.cmsActions.moreActionsAriaLabel")}
+        menuAriaLabel={t("thread.headerActions.moreActionsAriaLabel")}
         onClick={action ? () => onAction(action) : undefined}
       />
     </span>

--- a/apps/web/src/i18n/en/thread.ts
+++ b/apps/web/src/i18n/en/thread.ts
@@ -100,6 +100,7 @@ export const thread = {
   "thread.headerActions.markReady": "Mark ready",
   "thread.headerActions.markDraftReadyTooltip":
     "Mark draft PR ready for review",
+  "thread.headerActions.moreActionsAriaLabel": "More actions",
   "thread.headerActions.openNewPrTooltip":
     "Open a new PR with the latest commits",
   "thread.headerActions.prMergedTooltip": "PR #{prNumber} merged into {base}",

--- a/apps/web/src/i18n/pt-br/thread.ts
+++ b/apps/web/src/i18n/pt-br/thread.ts
@@ -106,6 +106,7 @@ export const thread = {
   "thread.headerActions.markReady": "Marcar como pronto",
   "thread.headerActions.markDraftReadyTooltip":
     "Marcar PR rascunho como pronto para revisão",
+  "thread.headerActions.moreActionsAriaLabel": "Mais ações",
   "thread.headerActions.openNewPrTooltip":
     "Abrir um novo PR com os últimos commits",
   "thread.headerActions.prMergedTooltip": "PR #{prNumber} mesclado em {base}",


### PR DESCRIPTION
## Summary
Aligns the split button's aria-label i18n key with the HeaderActions component's namespace.

## Why
The HeaderActions component for GitHub thread header was using `thread.cmsActions.moreActionsAriaLabel`, but it's a thread/GitHub-specific component and should use `thread.headerActions.moreActionsAriaLabel` for consistency. This improves accessibility by ensuring aria-labels use the correct component domain and makes the i18n structure predictable.

## Changes
- Add `thread.headerActions.moreActionsAriaLabel` to English and Portuguese i18n files
- Update header-actions.tsx to use the correct i18n key for the split button menu

## Verification
- ✅ `bun run fmt` passes (3573 files formatted, no changes)
- ✅ `bunx tsc --noEmit` in apps/web passes (no type errors)
- ✅ `bun test apps/web/src/components/thread/github/panel-state.test.ts` passes (46 tests)
- ✅ `bunx oxlint` passes on modified files (0 warnings, 0 errors)

Review: confirm aria-label namespace is now consistent with other headerActions keys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the GitHub thread HeaderActions menu aria-label with the correct i18n namespace. Previously it used `thread.cmsActions.moreActionsAriaLabel`; now it uses `thread.headerActions.moreActionsAriaLabel` for consistency and predictable i18n.

- Updated `menuAriaLabel` in `apps/web/src/components/thread/github/header-actions.tsx` to `t("thread.headerActions.moreActionsAriaLabel")`.
- Added `thread.headerActions.moreActionsAriaLabel` to `en` and `pt-br` locale files; add this key to other locales if your deployment requires them.
- Behavior is unchanged aside from the i18n key path; the accessible label text remains "More actions".

<sup>Written for commit 95d5d8149a1d4046573a119b40fba402273669fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

