### PR TITLE
fix(cli): don't crash the dev CLI on a child stdout/stderr pipe error

### DIFF
--- a/apps/api/src/cli/commands/dev.test.ts
+++ b/apps/api/src/cli/commands/dev.test.ts
@@ -1,0 +1,25 @@
+import { expect, it } from "bun:test";
+import { getCliState, resetCliStateForTests } from "../cli-store";
+import { pipeToLogStore } from "./dev";
+
+it("pipeToLogStore keeps lines read before the stream errors, without crashing", () => {
+  resetCliStateForTests();
+
+  let pulls = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      pulls++;
+      if (pulls === 1) {
+        controller.enqueue(new TextEncoder().encode("[0] hello\n"));
+        return;
+      }
+      controller.error(new Error("pipe broke"));
+    },
+  });
+
+  pipeToLogStore(stream);
+
+  return new Promise((resolve) => setTimeout(resolve, 10)).then(() => {
+    expect(getCliState().logs.map((l) => l.rawLine)).toEqual(["hello"]);
+  });
+});

--- a/apps/api/src/cli/commands/dev.ts
+++ b/apps/api/src/cli/commands/dev.ts
@@ -30,7 +30,7 @@ export interface DevOptions {
  * Pipe a readable stream line-by-line into the CLI store log entries.
  * Lines are stripped of ANSI codes and concurrently prefixes like "[0] " / "[1] ".
  */
-function pipeToLogStore(stream: ReadableStream<Uint8Array>) {
+export function pipeToLogStore(stream: ReadableStream<Uint8Array>) {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
@@ -55,11 +55,15 @@ function pipeToLogStore(stream: ReadableStream<Uint8Array>) {
   }
 
   (async () => {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      processLines();
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        processLines();
+      }
+    } catch {
+      // A pipe read error shouldn't crash the whole dev CLI.
     }
     if (buffer.trim()) {
       const stripped = Bun.stripANSI(buffer)


### PR DESCRIPTION
Follows #6476 (the recent `Bun.stripANSI` migration in `dev.ts`/`serve.ts`) — while hardening that surface I found `pipeToLogStore` in `apps/api/src/cli/commands/dev.ts` has no error handling around its stream-reading loop.

`startDevServer` pipes the spawned dev-servers child's stdout/stderr through `pipeToLogStore` into an unawaited async IIFE. If that pipe errors (the child is killed abruptly, an EPIPE, etc.), `reader.read()` rejects and, since nothing awaits or catches the IIFE, it surfaces as an unhandled promise rejection — which crashes the whole `bun run dev` CLI (losing the TUI and any already-running services) instead of just dropping the rest of that one stream's log lines.

Failure scenario: run `bun run dev`, then have the spawned `dev:servers` child die in a way that errors its stdio pipe (e.g. OOM-killed) — the parent CLI process itself crashes rather than degrading gracefully.

Fix: wrap the read loop in try/catch so a pipe error just stops that stream's log ingestion instead of taking down the process. Also exported `pipeToLogStore` (previously module-private) so it's directly testable, matching the existing pattern for `interceptConsoleForTui` in `serve.ts`.

Regression test (`apps/api/src/cli/commands/dev.test.ts`): feeds a `ReadableStream` that emits one line then errors on the next pull, and asserts the line read before the error is still recorded and the call doesn't throw/reject. Verified this test fails (with an unhandled-rejection-style module error) against the pre-fix code and passes after the fix.

Command a reviewer runs to confirm: `bun test apps/api/src/cli/commands/dev.test.ts`

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/cli/commands/dev.test.ts`, `bunx oxlint apps/api/src/cli/commands/dev.ts apps/api/src/cli/commands/dev.test.ts` (all green). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the dev CLI from crashing when a child stdout/stderr pipe errors. Before: a `reader.read()` rejection surfaced as an unhandled promise rejection and killed `bun run dev`. Now: a pipe error stops only that stream’s log ingestion, retains lines read before the error, and keeps the TUI and other services running.

- Wraps `pipeToLogStore`’s read loop in try/catch and flushes any buffered tail (stripped via `Bun.stripANSI`).
- Exports `pipeToLogStore` from `apps/api/src/cli/commands/dev.ts` to enable direct tests.
- Adds a regression test at `apps/api/src/cli/commands/dev.test.ts`; run `bun test apps/api/src/cli/commands/dev.test.ts`.

<sup>Written for commit a8df1412a8943a597efabe7ad879f10f525f9efa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

