### PR TITLE
fix(sections-editor): unwrap hidden items within lazy-wrapped sections for correct labeling

### DIFF
--- a/apps/web/src/components/sections-editor/array-item-display.test.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.test.ts
@@ -96,6 +96,47 @@ describe("getArrayItemLabel", () => {
     );
   });
 
+  test("labels a lazy-wrapped item containing a hidden section by the section name", () => {
+    // Real scenario: lazy wrapper around a multivariate flag (hidden item) containing a section
+    const item = {
+      __resolveType: "website/sections/Rendering/Lazy.tsx",
+      section: {
+        __resolveType: "website/flags/multivariate.ts",
+        variants: [
+          {
+            value: {
+              __resolveType:
+                "site/sections/Content/BannerCarrouselDepartment.tsx",
+            },
+            rule: { __resolveType: "website/matchers/never.ts" },
+          },
+        ],
+      },
+    };
+    expect(getArrayItemLabel(item, 0, undefined)).toBe(
+      "BannerCarrouselDepartment",
+    );
+  });
+
+  test("labels a lazy-wrapped item containing a hidden object by its fields", () => {
+    // Lazy wrapper around a hidden item with a title field
+    const item = {
+      __resolveType: "website/sections/Rendering/Lazy.tsx",
+      section: {
+        __resolveType: "website/flags/multivariate.ts",
+        variants: [
+          {
+            value: {
+              title: "Hidden Banner Title",
+            },
+            rule: { __resolveType: "website/matchers/never.ts" },
+          },
+        ],
+      },
+    };
+    expect(getArrayItemLabel(item, 0, undefined)).toBe("Hidden Banner Title");
+  });
+
   test("labels a date matcher item by its configured range", () => {
     // Real farmrio data: a Multi rule's `matchers` child.
     const item = {

--- a/apps/web/src/components/sections-editor/array-item-display.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.ts
@@ -141,6 +141,8 @@ function baseArrayItemLabel(
     const inner = lazyWrappedInner(obj);
     if (inner) {
       obj = inner;
+      // Unwrap again in case the lazy wrapper contains a hidden item.
+      obj = arrayItemDisplayValue(obj) as Record<string, unknown>;
     }
     if (itemSchema?.titleBy) {
       const fromTitleBy = readTitleByValue(obj, itemSchema.titleBy);


### PR DESCRIPTION
## Problem

When a lazy-wrapped section contains a hidden item (multivariate flag wrapper), the array item label incorrectly displayed the wrapper's type ("Multivariate") instead of the hidden value's actual name. This manifested as a subtle UI glitch where some array items showed meaningless labels.

## Root Cause

The `baseArrayItemLabel` function unwraps lazy-wrapped items to extract their inner section, but did not recursively unwrap hidden items within those sections. If the lazy wrapper's `section` was itself a hidden item (multivariate flag), the function would try to extract a label from the wrapper metadata rather than the hidden value.

## Solution

After unwrapping a lazy-wrapped item, apply `arrayItemDisplayValue` again to unwrap any hidden items nested within. This ensures the labeling logic operates on the actual content, not the wrapper layers.

## Test Coverage

Added two regression tests:
1. Lazy-wrapped item containing a hidden section - verifies the section name is extracted correctly
2. Lazy-wrapped item containing a hidden object with fields - verifies field extraction works through nested wrappers

All 35 existing and new tests pass. No type errors or lint warnings.

## Verification

Run with: `bun test apps/web/src/components/sections-editor/array-item-display.test.ts`

Changes verified with:
- `bunx tsc --noEmit` (no errors)
- `bunx oxlint` (no issues)
- `bun run fmt` (formatting compliant)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes array item labels in the sections editor when a lazy-wrapped section contains a hidden item. Previously labels showed the wrapper type (e.g., "Multivariate"); now they show the inner section name or field value. Only affects lazy-wrapped items with hidden inner content.

- Update `baseArrayItemLabel`: after unwrapping a lazy wrapper, call `arrayItemDisplayValue` to unwrap hidden items before deriving the label.
- Add two regression tests covering lazy + hidden section and lazy + hidden object cases. No migrations or schema changes.

<sup>Written for commit ed7b1416bb4293751649c0f70e1eca1567b1aea2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

