### PR TITLE
fix(virtual-mcp): url-encode the agent id in the agent-tools mint endpoint

### DIFF
--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts
@@ -48,6 +48,17 @@ describe("mcpEndpointUrl", () => {
     ).toThrow(MissingOrganizationSlugError);
   });
 
+  it("url-encodes the agent id so it can't break out of its path segment", () => {
+    expect(
+      mcpEndpointUrl({
+        publicUrl,
+        agentId: "vir 1/2",
+        organization,
+        target: "agent-tools",
+      }),
+    ).toBe("https://studio.example.com/mcp/virtual-mcp/vir%201%2F2");
+  });
+
   it("still resolves agent-tools without a slug — that path is not org-scoped", () => {
     expect(
       mcpEndpointUrl({

--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
@@ -66,7 +66,7 @@ export function mcpEndpointUrl(args: {
 }): string {
   const { publicUrl, agentId, organization, target, threadId } = args;
   if (target === "agent-tools") {
-    return `${publicUrl}/mcp/virtual-mcp/${agentId}`;
+    return `${publicUrl}/mcp/virtual-mcp/${encodeURIComponent(agentId)}`;
   }
   if (!organization.slug) {
     throw new MissingOrganizationSlugError(organization.id, target);


### PR DESCRIPTION
**Source:** bug found while sweeping `apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts` for input-validation gaps per this tick's focus area (virtual-mcp mint endpoint hardening).

**Why a maintainer wants it:** `mcpEndpointUrl` builds the MCP endpoint URL a sandbox-hosted harness dials, by interpolating an id into a URL path segment. It already `encodeURIComponent`s `threadId` (the `task-run` branch) and `connection.id` (`orgMcpServers`) before doing that — the file's own comments explain why: an unencoded identifier can break out of its path segment. The `agent-tools` branch (`${publicUrl}/mcp/virtual-mcp/${agentId}`) was the one path left unencoded, an inconsistency in the same file's own established pattern.

**Failure scenario:** if an agent/virtual-mcp id ever contains a `/` or other path-significant character, the un-encoded interpolation lets it break out of the `/mcp/virtual-mcp/<id>` path segment and change which route the minted URL actually points at, silently handing the live 1h key to the wrong endpoint. The regression test pins `agentId: "vir 1/2"` producing `.../mcp/virtual-mcp/vir%201%2F2`, matching the existing pattern used for `threadId` and `connection.id`.

**Confirm:** `cd apps/api && bun test src/mcp-clients/virtual-mcp/mint-endpoint.test.ts`

**Checked locally:** `bun run fmt`, `bunx oxlint` on both touched files, and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
URL-encodes agentId in the agent-tools branch of mcpEndpointUrl to prevent path-segment breakout and misrouting. Previously it interpolated the raw agentId; now it uses encodeURIComponent(agentId), consistent with threadId and connection.id.

- Update is a one-liner in apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts with a regression test asserting "vir 1/2" → "vir%201%2F2".
- No caller changes required; URLs still resolve, and the server decodes path params as before.

<sup>Written for commit 92726490335dae64b2d5b74f7c6e717ef5d95716. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

