### PR TITLE
fix(organization): reject deleting an org other than the authenticated one

### DIFF
--- a/apps/api/src/tools/organization/delete.test.ts
+++ b/apps/api/src/tools/organization/delete.test.ts
@@ -17,6 +17,7 @@ function makeCtx(existingMetadata: unknown) {
   return {
     auth: { user: { id: "user-1" } },
     access: { check: mock(async () => {}) },
+    organization: { id: "org-1", slug: "acme", name: "Acme" },
     boundAuth: { organization: { get, update } },
     get,
     update,
@@ -49,5 +50,16 @@ describe("ORGANIZATION_DELETE", () => {
       data: { metadata: Record<string, unknown> };
     };
     expect(call.data.metadata.archived).toBe(true);
+  });
+
+  it("rejects deleting an organization other than the authenticated one", async () => {
+    const ctx = makeCtx({ description: "an acme org" });
+
+    await expect(
+      ORGANIZATION_DELETE.handler({ id: "org-2" }, ctx),
+    ).rejects.toThrow(
+      "Organization ID does not match authenticated organization",
+    );
+    expect(ctx.update.mock.calls.length).toBe(0);
   });
 });

--- a/apps/api/src/tools/organization/delete.ts
+++ b/apps/api/src/tools/organization/delete.ts
@@ -32,6 +32,13 @@ export const ORGANIZATION_DELETE = defineTool({
     requireAuth(ctx);
     await ctx.access.check();
 
+    // Reject a target org the caller isn't authenticated against (see member-remove.ts).
+    if (input.id !== ctx.organization?.id) {
+      throw new Error(
+        "Organization ID does not match authenticated organization",
+      );
+    }
+
     // Merge into existing metadata — organization.update replaces it wholesale.
     const existing = await ctx.boundAuth.organization.get(input.id);
 


### PR DESCRIPTION
ORGANIZATION_DELETE takes `id` as the org to archive but never checked it against `ctx.organization?.id` (the path-resolved, membership-verified org from `resolveOrgFromPath`). A caller authenticated against org A could pass `input.id` for org B and reach `boundAuth.organization.update` with an org they may have zero membership in. Better Auth's own `updateOrganization` endpoint does independently re-check membership+permission for the target `organizationId`, so this wasn't a live bypass today, but it left the tool one vendored-dependency behavior away from one, and it's inconsistent with the sibling tools in the same directory (`member-add.ts`, `member-remove.ts`) which already guard against exactly this cross-org mismatch.

This adds the same defense-in-depth guard used in `member-remove.ts`: reject when `input.id !== ctx.organization?.id`, failing before any Better Auth call is made, plus a regression test (`rejects deleting an organization other than the authenticated one`) asserting the update call never fires when ids mismatch.

Trust-boundary justification (per the C4/R4 gate): this parses/validates an id used to select which organization's data gets mutated (archived) — a destructive, cross-tenant-scoped operation — so it clears the trust-boundary bar directly.

To verify: `bun test apps/api/src/tools/organization/delete.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects cross-org deletes in `ORGANIZATION_DELETE` by requiring the target `id` to match the authenticated organization. This prevents accidental or malicious cross-tenant deletes and aligns delete with member add/remove guards.

- Old: any `id` could be passed; downstream Better Auth checks typically blocked unauthorized updates. New: the handler throws "Organization ID does not match authenticated organization" before calling `organization.update`.
- Adds a regression test ensuring `update` is not called when IDs mismatch.
- No migration required; same-org deletes are unchanged.

<sup>Written for commit 0997805abadd67c09abfe408cb1660e185d961af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

