### PR TITLE
fix(signup): cap the length of the attribution ref/src cookie values

### DIFF
--- a/apps/web/src/lib/signup-attribution.test.ts
+++ b/apps/web/src/lib/signup-attribution.test.ts
@@ -42,4 +42,9 @@ describe("captureSignupAttribution", () => {
     expect(document.cookie).toContain("studio_signup_ref=first");
     expect(document.cookie).not.toContain("second");
   });
+
+  test("drops an oversized ref/src instead of ballooning the cookie", () => {
+    captureSignupAttribution({ ref: "a".repeat(129), src: "b".repeat(129) });
+    expect(document.cookie).toBe("");
+  });
 });

--- a/apps/web/src/lib/signup-attribution.ts
+++ b/apps/web/src/lib/signup-attribution.ts
@@ -1,6 +1,8 @@
 const REF_COOKIE = "studio_signup_ref";
 const SRC_COOKIE = "studio_signup_src";
 const MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+// Untrusted query params echoed into a cookie sent on every request — bound them.
+const MAX_VALUE_LENGTH = 128;
 
 function getCookie(name: string): string | null {
   const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
@@ -22,10 +24,18 @@ export function captureSignupAttribution(search: {
   ref?: string;
   src?: string;
 }) {
-  if (search.ref && !getCookie(REF_COOKIE)) {
+  if (
+    search.ref &&
+    search.ref.length <= MAX_VALUE_LENGTH &&
+    !getCookie(REF_COOKIE)
+  ) {
     setCookie(REF_COOKIE, search.ref);
   }
-  if (search.src && !getCookie(SRC_COOKIE)) {
+  if (
+    search.src &&
+    search.src.length <= MAX_VALUE_LENGTH &&
+    !getCookie(SRC_COOKIE)
+  ) {
     setCookie(SRC_COOKIE, search.src);
   }
 }


### PR DESCRIPTION
Follows #5405 (the WhatsApp Concierge signup-attribution capture, part of issue #3747's attribution pipeline).

`captureSignupAttribution` reads the `ref`/`src` query params straight off the `/login` URL — validated only as `z.string().optional()`, with no length bound — and writes them verbatim into a first-party cookie with a 30-day max-age. That cookie then rides every subsequent request to the server. An attacker-crafted signup link with a multi-KB `ref`/`src` value would balloon every request header from that browser for a month, and the value later gets echoed into the `user_signed_up` PostHog event server-side (`apps/api/src/auth/index.ts`).

This caps `ref`/`src` at 128 chars (plenty for a lead id/channel tag) and fails closed: an oversized value is dropped rather than truncated-and-stored, so a bad value never partially persists.

Failure scenario: visit `/login?ref=<10000 chars>` — before this fix, a 10KB cookie is set and sent on every request from that browser for 30 days; after, nothing is stored.

Reviewer check: `bun test apps/web/src/lib/signup-attribution.test.ts` — added `drops an oversized ref/src instead of ballooning the cookie`, inverting the missing-bound behavior.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web), the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the signup attribution `ref`/`src` cookie values at 128 chars and drops oversized inputs to prevent multi‑KB cookies and noisy server events. Previously, any length was stored for 30 days; now we set the cookie only when the value exists, is ≤128 chars, and the cookie is not already present.

- Review: Check the new `MAX_VALUE_LENGTH` guard in `captureSignupAttribution` and the added test that asserts oversized values are ignored.
- Rollout: No migration. This change does not clear any preexisting oversized `studio_signup_ref`/`studio_signup_src` cookies; clear them manually if needed during testing.

<sup>Written for commit a0828dcf2845e398da18a3542486923bcb10f8fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

