### PR TITLE
feat(sections-editor): allow hiding variant sections via the eye toggle

### DIFF
--- a/apps/web/src/components/sections-editor/parse-sections.ts
+++ b/apps/web/src/components/sections-editor/parse-sections.ts
@@ -69,12 +69,38 @@ export function parseSections(
         >;
         let innerRt = (innerValue.__resolveType as string) ?? "";
         const innerIsLazy = isLazyResolveType(innerRt);
+        let mvInner: Record<string, unknown> = innerValue;
         if (innerIsLazy) {
           const nested = innerValue.section as
             | Record<string, unknown>
             | undefined;
           innerRt = (nested?.__resolveType as string) ?? innerRt;
+          if (nested) mvInner = nested;
         }
+
+        // Hidden variant section: keep the "Variants of X" label from the wrapped multivariate block.
+        if (
+          innerRt === PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE ||
+          innerRt === SECTION_MULTIVARIATE_RESOLVE_TYPE
+        ) {
+          const innerVariants = Array.isArray(mvInner.variants)
+            ? (mvInner.variants as Array<Record<string, unknown>>)
+            : [];
+          const firstValueRt = (
+            innerVariants[0]?.value as Record<string, unknown> | undefined
+          )?.__resolveType as string | undefined;
+          const sectionLabel = firstValueRt
+            ? labelFromResolveType(firstValueRt)
+            : "Section";
+          return {
+            index: idx,
+            resolveType: rt,
+            label: `Variants of ${sectionLabel}`,
+            isHidden: true,
+            isLazy: innerIsLazy,
+          };
+        }
+
         return {
           index: idx,
           resolveType: rt,

--- a/apps/web/src/components/sections-editor/section-list.test.ts
+++ b/apps/web/src/components/sections-editor/section-list.test.ts
@@ -74,4 +74,41 @@ describe("parseSections", () => {
     );
     expect(parsed[0]?.isHidden).toBe(true);
   });
+
+  it("keeps the 'Variants of X' label when a variant section is hidden", () => {
+    const parsed = parseSections(
+      [
+        {
+          __resolveType: "website/flags/multivariate/section.ts",
+          variants: [
+            {
+              value: {
+                __resolveType: "website/flags/multivariate/section.ts",
+                variants: [
+                  {
+                    value: {
+                      __resolveType: "site/sections/Category/CategoryShelf.tsx",
+                    },
+                    rule: { __resolveType: "website/matchers/always.ts" },
+                  },
+                  {
+                    value: {
+                      __resolveType: "site/sections/Category/CategoryShelf.tsx",
+                    },
+                    rule: { __resolveType: "website/matchers/device.ts" },
+                  },
+                ],
+              },
+              rule: { __resolveType: "website/matchers/never.ts" },
+            },
+          ],
+        },
+      ],
+      {},
+    );
+    expect(parsed[0]?.isHidden).toBe(true);
+    // Hidden variant sections are edited via un-hide, not as a single section.
+    expect(parsed[0]?.isMultivariate).toBeUndefined();
+    expect(parsed[0]?.label).toBe("Variants of CategoryShelf");
+  });
 });

--- a/apps/web/src/components/sections-editor/section-list.tsx
+++ b/apps/web/src/components/sections-editor/section-list.tsx
@@ -325,41 +325,39 @@ function SortableSectionItem({
         </Tooltip>
       )}
 
-      {!section.isMultivariate && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label={
-                isHidden
-                  ? t("sectionsEditor.sectionList.showSection")
-                  : t("sectionsEditor.sectionList.hideSection")
-              }
-              className={cn(
-                actionButtonVisibilityClass(reserveActionButtonSpace, isHidden),
-              )}
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleHidden();
-              }}
-              onPointerDown={(e) => e.stopPropagation()}
-            >
-              {isHidden ? (
-                <EyeOff className="h-3.5 w-3.5" />
-              ) : (
-                <Eye className="h-3.5 w-3.5" />
-              )}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            {isHidden
-              ? t("sectionsEditor.sectionList.showSection")
-              : t("sectionsEditor.sectionList.hideSection")}
-          </TooltipContent>
-        </Tooltip>
-      )}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={
+              isHidden
+                ? t("sectionsEditor.sectionList.showSection")
+                : t("sectionsEditor.sectionList.hideSection")
+            }
+            className={cn(
+              actionButtonVisibilityClass(reserveActionButtonSpace, isHidden),
+            )}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleHidden();
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            {isHidden ? (
+              <EyeOff className="h-3.5 w-3.5" />
+            ) : (
+              <Eye className="h-3.5 w-3.5" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {isHidden
+            ? t("sectionsEditor.sectionList.showSection")
+            : t("sectionsEditor.sectionList.hideSection")}
+        </TooltipContent>
+      </Tooltip>
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/apps/web/src/components/sections-editor/section-variants.test.ts
+++ b/apps/web/src/components/sections-editor/section-variants.test.ts
@@ -294,6 +294,26 @@ describe("section-variants", () => {
     }
   });
 
+  it("hideSection/showSection round-trips a whole multivariate (variant) section", () => {
+    const mvSection = {
+      __resolveType: "website/flags/multivariate/section.ts",
+      variants: [
+        {
+          rule: { __resolveType: "website/matchers/always.ts" },
+          value: { __resolveType: "site/sections/Hero.tsx", title: "A" },
+        },
+        {
+          rule: { __resolveType: "website/matchers/device.ts", mobile: true },
+          value: { __resolveType: "site/sections/Hero.tsx", title: "B" },
+        },
+      ],
+    };
+
+    const hidden = hideSection(mvSection as never);
+    expect(parseSections([hidden], {})[0]?.isHidden).toBe(true);
+    expect(showSection(hidden as never)).toEqual(mvSection as never);
+  });
+
   it("hideSection on lazy sections stores the core section, not the lazy wrapper", () => {
     const lazy = {
       __resolveType: "website/sections/Rendering/Lazy.tsx",

--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -984,14 +984,12 @@ export function SectionsEditor({
     savePageSections(updatedSections);
   };
 
-  // Hide/show a section via the multivariate+never wrapper (see hideSection /
-  // showSection). Round-trips normal, lazy, and saved-block sections.
-  // Multivariate sections (real variants) are managed through the variant UI.
+  // Hide/show any section via the multivariate+never wrapper (see hideSection / showSection).
   const handleToggleHidden = (index: number) => {
     if (!activePageKey) return;
     const rawSection = rawSections[index];
     const parsed = parsedSections[index];
-    if (!rawSection || !parsed || parsed.isMultivariate) return;
+    if (!rawSection || !parsed) return;
 
     const next = parsed.isHidden
       ? showSection(rawSection)

--- a/apps/web/src/components/sections-editor/unwrap-section.test.ts
+++ b/apps/web/src/components/sections-editor/unwrap-section.test.ts
@@ -127,6 +127,33 @@ describe("unwrapSection", () => {
     });
   });
 
+  it("returns null for a hidden variant section (would flatten the variants)", () => {
+    const raw = {
+      __resolveType: MV,
+      variants: [
+        {
+          value: {
+            __resolveType: MV,
+            variants: [
+              {
+                value: { __resolveType: HERO, title: "A" },
+                rule: { __resolveType: "website/matchers/always.ts" },
+              },
+              {
+                value: { __resolveType: HERO, title: "B" },
+                rule: { __resolveType: "website/matchers/device.ts" },
+              },
+            ],
+          },
+          rule: { __resolveType: NEVER },
+        },
+      ],
+    };
+    const parsed = parseSections([raw], {})[0]!;
+    expect(parsed.isHidden).toBe(true);
+    expect(unwrapSection(raw, parsed, {})).toBeNull();
+  });
+
   it("returns null for multivariate sections", () => {
     const raw = {
       __resolveType: MV,

--- a/apps/web/src/components/sections-editor/unwrap-section.ts
+++ b/apps/web/src/components/sections-editor/unwrap-section.ts
@@ -121,6 +121,15 @@ export function unwrapSection(
     const innerValue =
       (mvObj?.variants?.[0]?.value as Record<string, unknown>) ??
       (raw as Record<string, unknown>);
+    const innerRt = (innerValue.__resolveType as string) ?? "";
+    const effectiveInnerRt = isLazyResolveType(innerRt)
+      ? (((innerValue.section as Record<string, unknown> | undefined)
+          ?.__resolveType as string) ?? innerRt)
+      : innerRt;
+    // Hidden variant section wraps a multivariate block; editing it as one section would flatten the variants.
+    if (isMultivariateResolveType(effectiveInnerRt)) {
+      return null;
+    }
     return unwrapSectionValue(innerValue, decofile);
   }
 


### PR DESCRIPTION
## Summary

Variant sections — the green **"Variants of X"** rows in the sections editor — had no eye 👁 toggle to hide/show them, unlike every other section row. The visibility toggle was gated behind `!section.isMultivariate`, and variant rows are multivariate, so the button never rendered.

This enables the eye toggle for variant sections while keeping their multivariate structure intact through the hide/show round-trip.

## Changes

- **`section-list.tsx`** — drop the `!section.isMultivariate` gate on the eye/visibility button so it renders for every row (the async-render/⚡ toggle stays gated as before). It's hover-revealed on visible rows, just like normal sections.
- **`sections-editor.tsx`** — `handleToggleHidden` no longer early-returns for multivariate rows. Hiding wraps a section in a `multivariate + never-matcher` block; since a variant section is already multivariate, this double-wraps it, and `showSection` restores **every** variant unchanged.
- **`parse-sections.ts`** — when a variant section is hidden, keep the **"Variants of X"** label (read from the wrapped multivariate's first variant) instead of falling back to the generic multivariate resolve-type name ("Section").
- **`unwrap-section.ts`** — a hidden variant section returns `null` on select, so it won't open in the single-section editor where saving would **flatten** its variants. Un-hide it to manage variants.

## Testing

- New unit coverage:
  - `hideSection`/`showSection` round-trips a whole multivariate section.
  - a hidden variant section parses as `isHidden` with the `Variants of X` label (and not `isMultivariate`).
  - `unwrapSection` returns `null` for a hidden variant section.
- `bun test apps/web/src/components/sections-editor/` → **710 pass / 0 fail**
- `tsc --noEmit` (apps/web) clean; `bun run lint` no new warnings; `bun run fmt` applied.

## Affected areas

Sections editor left-panel tree only. No storage/wire format changes — the hide mechanism reuses the existing `website/flags/multivariate/section.ts` + `website/matchers/never.ts` wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable hiding variant sections via the eye toggle. Previously variant rows (multivariate) had no toggle; now all rows can be hidden, and unhide restores the full variants unchanged.

- The eye toggle renders for every row in `section-list.tsx`; the async-render/Zap toggle remains gated.
- `handleToggleHidden` now runs for multivariate rows. Hiding wraps with multivariate+never; showing unwraps and restores all variants.
- `parse-sections` preserves the "Variants of X" label for hidden variants.
- `unwrap-section` returns null for hidden variant rows to avoid flattening; unhide to edit variants.
- Scope: sections editor left panel only. No storage/wire format changes.

<sup>Written for commit 52f0a0b91cd6da6926f94fc1d4348c55c970383e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

