### PR TITLE
fix(sandbox): reject a packageManager.path that escapes the repo root

### DIFF
--- a/packages/sandbox/daemon-go/internal/config/validate.go
+++ b/packages/sandbox/daemon-go/internal/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -94,8 +95,10 @@ func validateApplication(app *Application) string {
 		if app.PackageManager.Name != nil && !validPms[*app.PackageManager.Name] {
 			return fmt.Sprintf("packageManager invalid: %s", *app.PackageManager.Name)
 		}
-		if app.PackageManager.Path != nil && *app.PackageManager.Path == "" {
-			return "packageManager.path must be non-empty"
+		if app.PackageManager.Path != nil {
+			if reason := validatePmPath(*app.PackageManager.Path); reason != "" {
+				return reason
+			}
 		}
 	}
 	if app.Port != nil {
@@ -103,6 +106,22 @@ func validateApplication(app *Application) string {
 		if p != float64(int(p)) || p <= 0 || p > 65535 {
 			return fmt.Sprintf("port invalid: %v", p)
 		}
+	}
+	return ""
+}
+
+// validatePmPath rejects a packageManager.path that would let
+// paths.ResolvePmRoot (internal/paths/paths.go) run install/dev commands
+// outside the repo checkout: an absolute path is used verbatim, and a
+// relative path is joined onto the repo dir without a containment check, so
+// "../.." segments walk out of it.
+func validatePmPath(p string) string {
+	if p == "" {
+		return "packageManager.path must be non-empty"
+	}
+	clean := filepath.Clean(p)
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return fmt.Sprintf("packageManager.path must be a relative path within the repo: %s", p)
 	}
 	return ""
 }

--- a/packages/sandbox/daemon-go/internal/config/validate_test.go
+++ b/packages/sandbox/daemon-go/internal/config/validate_test.go
@@ -1,0 +1,39 @@
+package config
+
+import "testing"
+
+func TestValidatePmPathRejectsEscapeFromRepoRoot(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"relative within repo", "apps/web", false},
+		{"dot-relative within repo", "./apps/web", false},
+		{"absolute path", "/etc", true},
+		{"parent traversal", "../etc", true},
+		{"nested parent traversal", "apps/../../etc", true},
+		{"bare parent", "..", true},
+		{"empty", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := validatePmPath(c.path)
+			if c.wantErr && got == "" {
+				t.Fatalf("validatePmPath(%q) = %q, want a rejection reason", c.path, got)
+			}
+			if !c.wantErr && got != "" {
+				t.Fatalf("validatePmPath(%q) = %q, want no error", c.path, got)
+			}
+		})
+	}
+}
+
+func TestValidateApplicationRejectsEscapingPmPath(t *testing.T) {
+	app := &Application{
+		PackageManager: &PackageManagerConfig{Path: Str("../../etc")},
+	}
+	if reason := validateApplication(app); reason == "" {
+		t.Fatal("validateApplication accepted a packageManager.path that escapes the repo root")
+	}
+}


### PR DESCRIPTION
**Bug**: `validateApplication` in `packages/sandbox/daemon-go/internal/config/validate.go` only checked that `packageManager.path` was non-empty. That value flows straight into `paths.ResolvePmRoot` (`internal/paths/paths.go`), which returns an absolute path verbatim and otherwise joins it onto the repo dir with no containment check — so a config with `packageManager.path: "/etc"` or `"../../etc"` makes every install/dev-server command in the orchestrator (`internal/setup/orchestrator.go`, 5 call sites) run with that directory as `cwd`, outside the sandbox's repo checkout.

**Fix**: reject absolute paths and any path that `filepath.Clean` resolves to `".."` or starting with `"../"`, mirroring the existing defensive checks in the same file (branch/host/runtime allowlists).

**Regression test**: `internal/config/validate_test.go` — table test over relative/absolute/traversal paths, plus one `validateApplication`-level case with a `../../etc` path.

**Reviewer check**: `cd packages/sandbox/daemon-go && go test ./internal/config/...`

**Locally verified**: `gofmt -l .` (clean), `go vet ./internal/config/...`, `go test ./internal/config/...` — all green. Full CI runs the rest of the daemon-go suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects `packageManager.path` values that escape the repo root to prevent orchestrator commands from running outside the sandbox. Previously validation only checked non-empty; absolute or parent-traversal paths were accepted. Now only relative, in-repo paths pass.

- Validation: `validateApplication` calls `validatePmPath` to reject empty, absolute, `".."`, or `"../"`-prefixed paths after `filepath.Clean`.
- Tests: Added table tests and an integration case in `packages/sandbox/daemon-go/internal/config/validate_test.go`.
- Migration: Configs must set `packageManager.path` to a relative path within the repo (e.g., `apps/web`). Absolute or traversal paths will fail validation.
- Review: `cd packages/sandbox/daemon-go && go test ./internal/config/...`

<sup>Written for commit d4ed845f4e3bfac052ee03c0cfd8d76fc299aedd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

