### PR TITLE
perf(task-board): add a partial index behind the archive/merged-tag sweeps

### DIFF
--- a/apps/api/migrations/176-task-board-done-sweep-index.ts
+++ b/apps/api/migrations/176-task-board-done-sweep-index.ts
@@ -1,0 +1,27 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Index behind the archive sweep (`listItemsAwaitingArchive`) and the
+ * merged-tag sweep (`listItemsAwaitingMergedTag`), both DBOS cron workflows
+ * that run cross-org, forever, filtering `status = 'done' AND dismissed_at
+ * IS NULL` — the exact same shape `idx_task_board_items_pending_review`
+ * (migration 165) fixed for the review sweeper. `task_board_items` only had
+ * an `organization_id` index, so both queries were a full scan of the table
+ * on every tick.
+ *
+ * Partial on the sweeps' shared predicate so the index stays tiny — it holds
+ * only Done, non-dismissed cards — and keyed on `updated_at`, the column both
+ * queries order and filter by (ASC for the archive sweep, DESC for the
+ * merged-tag sweep; a plain btree serves both directions).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE INDEX idx_task_board_items_done_sweep
+      ON task_board_items (updated_at)
+      WHERE status = 'done' AND dismissed_at IS NULL
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_task_board_items_done_sweep").execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -174,6 +174,7 @@ import * as migration172taskboarditemkeyseq from "./172-task-board-item-key-seq.
 import * as migration173threadgithubrepoconnectionindex from "./173-thread-github-repo-connection-index.ts";
 import * as migration174threadmessagepartspersistedat from "./174-thread-message-parts-persisted-at.ts";
 import * as migration175taskboardsprints from "./175-task-board-sprints.ts";
+import * as migration176taskboarddonesweepindex from "./176-task-board-done-sweep-index.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -379,6 +380,7 @@ const migrations: Record<string, Migration> = {
   "174-thread-message-parts-persisted-at":
     migration174threadmessagepartspersistedat,
   "175-task-board-sprints": migration175taskboardsprints,
+  "176-task-board-done-sweep-index": migration176taskboarddonesweepindex,
 };
 
 export default migrations;


### PR DESCRIPTION
**Source:** a missing-index gap in `apps/api/src/storage/task-board.ts`, the same shape as the incident migration 165 already fixed (`idx_task_board_items_pending_review`, GitHub rate-limit exhaustion from an unindexed cross-org sweeper scan).

**What:** `listItemsAwaitingArchive` (`dbos-archive-sweep.ts`) and `listItemsAwaitingMergedTag` (`dbos-tag-merged-sweep.ts`) are both DBOS cron workflows that run cross-org, forever, filtering `task_board_items` on `status = 'done' AND dismissed_at IS NULL`. `task_board_items` only carries an `organization_id` index (migration 126), so both queries are a full table scan on every tick, and the table grows unbounded (every task ever created, across every org). Migration 165's comment documents the exact same predicate-without-index shape for the review sweeper causing a measured production GitHub rate-limit incident from the resulting scan cost.

**Fix:** a partial btree index, `idx_task_board_items_done_sweep`, on `task_board_items(updated_at) WHERE status = 'done' AND dismissed_at IS NULL` — it stays tiny (only Done, non-dismissed cards) and covers both queries' filter + `ORDER BY updated_at` (one direction ASC, the other DESC; a plain btree serves both).

**Payoff:** turns two forever-running full-table-scans into index scans over a small partial index, cutting DB load on every tick regardless of how large the board grows — mirrors the exact fix already proven correct and worth doing for the sibling sweeper.

**Verify:** `EXPLAIN` the two queries against a task_board_items table with Done/non-Done rows before/after — the plan should switch from Seq Scan to Index Scan on `idx_task_board_items_done_sweep`.

**Checks run locally:** `bun run fmt`; `bunx tsc --noEmit` (apps/api workspace, clean); `bun test apps/api/migrations/index.test.ts` (guards every migration file is registered — passes); `bunx oxlint` on both changed files (0 warnings/errors). No Postgres available locally to run the migration itself — full CI validates that.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a partial index for Done, non-dismissed items in task_board_items to back the archive and merged‑tag sweepers. It replaces cross‑org full table scans with index scans and reduces DB load as boards grow.

- Creates idx_task_board_items_done_sweep: btree on updated_at WHERE status = 'done' AND dismissed_at IS NULL; covers both sweeps’ filter and ORDER BY (ASC/DESC).
- Migration: run "176-task-board-done-sweep-index"; it's registered in apps/api/migrations/index.ts.
- Verify: EXPLAIN the sweeper queries; plans should switch from Seq Scan to Index Scan on idx_task_board_items_done_sweep.

<sup>Written for commit b9e34db47a2d1c8bdfd95a9822306ceaa4b8a073. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

