### PR TITLE
fix(oauth): don't throw from refreshAndStore when persisting a token fails

### DIFF
--- a/apps/api/src/oauth/token-refresh-persist-failure.test.ts
+++ b/apps/api/src/oauth/token-refresh-persist-failure.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, mock, beforeEach } from "bun:test";
+import type { TokenRefreshResult } from "./refresh-access-token";
+import type { DownstreamToken } from "../storage/types";
+import type { DownstreamTokenStorage } from "../storage/downstream-token";
+
+// Narrow justified mock per TESTING.md: refreshAccessToken makes a real HTTP call.
+const mockRefreshAccessToken =
+  vi.fn<(...args: unknown[]) => Promise<TokenRefreshResult>>();
+mock.module("./refresh-access-token", () => ({
+  refreshAccessToken: mockRefreshAccessToken,
+}));
+
+const { refreshAndStore, clearRefreshBackoff } = await import(
+  "./token-refresh"
+);
+
+const baseToken: DownstreamToken = {
+  id: "dtok_1",
+  connectionId: "conn_persist_fail",
+  accessToken: "old-access",
+  refreshToken: "refresh-1",
+  scope: null,
+  expiresAt: null,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+  clientId: "client-1",
+  clientSecret: null,
+  tokenEndpoint: "https://idp.example.com/token",
+};
+
+function fakeStorage(overrides: Partial<DownstreamTokenStorage>) {
+  return {
+    get: vi.fn(),
+    upsert: vi.fn(),
+    delete: vi.fn(),
+    isExpired: vi.fn(),
+    ...overrides,
+  } as unknown as DownstreamTokenStorage;
+}
+
+beforeEach(() => {
+  mockRefreshAccessToken.mockReset();
+  clearRefreshBackoff();
+});
+
+describe("refreshAndStore — storage failures don't throw", () => {
+  it("returns null instead of rejecting when persisting a fresh token fails", async () => {
+    mockRefreshAccessToken.mockResolvedValue({
+      success: true,
+      accessToken: "new-access",
+      expiresIn: 3600,
+    });
+    const storage = fakeStorage({
+      upsert: vi.fn().mockRejectedValue(new Error("db unavailable")),
+    });
+
+    await expect(refreshAndStore(baseToken, storage)).resolves.toBeNull();
+  });
+
+  it("returns null instead of rejecting when deleting a dead token fails", async () => {
+    mockRefreshAccessToken.mockResolvedValue({
+      success: false,
+      permanent: true,
+      error: "invalid_grant",
+    });
+    const storage = fakeStorage({
+      delete: vi.fn().mockRejectedValue(new Error("db unavailable")),
+    });
+
+    await expect(refreshAndStore(baseToken, storage)).resolves.toBeNull();
+  });
+});

--- a/apps/api/src/oauth/token-refresh.ts
+++ b/apps/api/src/oauth/token-refresh.ts
@@ -99,23 +99,38 @@ async function refreshAndStoreOnce(
     // must not nuke the user's auth — that turns every blip in the upstream
     // OAuth server into a forced manual reconnect.
     if (result.permanent === true) {
-      await tokenStorage.delete(token.connectionId);
+      // Don't let a storage blip surface as an uncaught rejection to callers.
+      await tokenStorage.delete(token.connectionId).catch((error) => {
+        console.warn("[TokenRefresh] failed to delete dead token row", {
+          connectionId: token.connectionId,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      });
     }
     return { accessToken: null, permanent: result.permanent === true };
   }
-  await tokenStorage.upsert({
-    connectionId: token.connectionId,
-    accessToken: result.accessToken,
-    refreshToken: result.refreshToken ?? token.refreshToken,
-    scope: result.scope ?? token.scope,
-    expiresAt:
-      result.expiresIn === undefined
-        ? null
-        : new Date(Date.now() + result.expiresIn * 1000),
-    clientId: token.clientId,
-    clientSecret: token.clientSecret,
-    tokenEndpoint: token.tokenEndpoint,
-  });
+  try {
+    await tokenStorage.upsert({
+      connectionId: token.connectionId,
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken ?? token.refreshToken,
+      scope: result.scope ?? token.scope,
+      expiresAt:
+        result.expiresIn === undefined
+          ? null
+          : new Date(Date.now() + result.expiresIn * 1000),
+      clientId: token.clientId,
+      clientSecret: token.clientSecret,
+      tokenEndpoint: token.tokenEndpoint,
+    });
+  } catch (error) {
+    // Persisting the refreshed token failed — report a transient failure.
+    console.warn("[TokenRefresh] failed to persist refreshed token", {
+      connectionId: token.connectionId,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return { accessToken: null, permanent: false };
+  }
   return { accessToken: result.accessToken, permanent: false };
 }
 


### PR DESCRIPTION
**What**: `refreshAndStoreOnce` in `apps/api/src/oauth/token-refresh.ts` called `tokenStorage.upsert(...)` (on a successful refresh) and `tokenStorage.delete(...)` (on a permanent failure) with no error handling. A transient DB write failure during either call rejected the promise returned by the exported `refreshAndStore`, propagating an uncaught exception up through `getValidDownstreamAccessToken`.

**Why a maintainer wants this**: the module's own docs promise the opposite behavior — "transient failures... must not nuke the user's auth" and callers are expected to get a typed failure state to gracefully fall back on. The hottest caller, `apps/api/src/mcp-clients/outbound/headers.ts`, calls `getValidDownstreamAccessToken` with no try/catch and falls back to the connection's static token only when `tokenResult.accessToken` is falsy — a thrown exception here skips that fallback and fails the whole outbound request instead of degrading gracefully, turning a DB blip into a hard proxy failure.

**Failure scenario**: refresh succeeds against the upstream IdP, but the subsequent `tokenStorage.upsert` throws (transient Postgres error). Before this fix, that exception bubbles out of `refreshAndStore` uncaught; after, it's caught, logged, and reported as a normal `{accessToken: null, permanent: false}` transient failure — the caller falls back to the connection token as designed, and the in-flight/backoff bookkeeping in `refreshAndStore` still runs correctly.

**Regression test**: `apps/api/src/oauth/token-refresh-persist-failure.test.ts` — a fake in-memory `DownstreamTokenStorage` whose `upsert`/`delete` reject, asserting `refreshAndStore` resolves to `null` instead of rejecting, for both the success-then-persist-fails and permanent-failure-then-delete-fails paths.

**Verify**: `cd apps/api && bun test src/oauth/token-refresh-persist-failure.test.ts` (also ran the existing `src/oauth/token-refresh.test.ts` to confirm no regression).

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), both targeted test files (6 pass total), and `bunx oxlint` on the two changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `refreshAndStore` from throwing when token persistence fails, so callers degrade gracefully during transient storage outages. Before: a failed `upsert`/`delete` rejected the promise and skipped fallbacks; now: we catch and log storage errors and return a typed result (`{accessToken: null, permanent: false|true}`).

- Implements try/catch around `upsert`; returns `{accessToken: null, permanent: false}` on persist errors and logs a warn.
- Wraps `delete` with `.catch(...)`; still returns `{accessToken: null, permanent: true}` on permanent failures even if the delete fails.
- Adds `apps/api/src/oauth/token-refresh-persist-failure.test.ts` covering both paths; existing refresh tests still pass.

<sup>Written for commit 5453a92a37635d561bc283602257085553f5b494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

