### PR TITLE
fix(sections-editor): resolve a hidden saved-block section's own name and detach flag

### DIFF
--- a/apps/web/src/components/sections-editor/parse-sections.ts
+++ b/apps/web/src/components/sections-editor/parse-sections.ts
@@ -101,6 +101,30 @@ export function parseSections(
           };
         }
 
+        if (
+          innerRt !== "" &&
+          isSavedBlockResolveType(innerRt) &&
+          innerRt in decofile
+        ) {
+          const resolvedBlock = decofile[innerRt] as
+            | Record<string, unknown>
+            | undefined;
+          const label =
+            (typeof resolvedBlock?.name === "string" && resolvedBlock.name) ||
+            innerRt
+              .replace(/[-_]/g, " ")
+              .replace(/\b\w/g, (c) => c.toUpperCase()) ||
+            `Section ${idx + 1}`;
+          return {
+            index: idx,
+            resolveType: rt,
+            label,
+            isHidden: true,
+            isLazy: innerIsLazy,
+            isSavedBlock: true,
+          };
+        }
+
         return {
           index: idx,
           resolveType: rt,

--- a/apps/web/src/components/sections-editor/section-list.test.ts
+++ b/apps/web/src/components/sections-editor/section-list.test.ts
@@ -75,6 +75,31 @@ describe("parseSections", () => {
     expect(parsed[0]?.isHidden).toBe(true);
   });
 
+  it("resolves the saved block's own name and isSavedBlock when hidden", () => {
+    const parsed = parseSections(
+      [
+        {
+          __resolveType: "website/flags/multivariate/section.ts",
+          variants: [
+            {
+              value: { __resolveType: "Header" },
+              rule: { __resolveType: "website/matchers/never.ts" },
+            },
+          ],
+        },
+      ],
+      {
+        Header: {
+          __resolveType: "site/sections/Header/Header.tsx",
+          name: "Site Header",
+        },
+      },
+    );
+    expect(parsed[0]?.isHidden).toBe(true);
+    expect(parsed[0]?.isSavedBlock).toBe(true);
+    expect(parsed[0]?.label).toBe("Site Header");
+  });
+
   it("keeps the 'Variants of X' label when a variant section is hidden", () => {
     const parsed = parseSections(
       [

--- a/apps/web/src/components/sections-editor/unwrap-section.test.ts
+++ b/apps/web/src/components/sections-editor/unwrap-section.test.ts
@@ -109,6 +109,22 @@ describe("unwrapSection", () => {
     expect(unwrapSection(raw, parsed, {})).toBeNull();
   });
 
+  it("unwraps a hidden saved-block section to its resolved data", () => {
+    const raw = {
+      __resolveType: MV,
+      variants: [
+        { value: { __resolveType: "Header" }, rule: { __resolveType: NEVER } },
+      ],
+    };
+    const decofile = { Header: { __resolveType: HERO, title: "Site Header" } };
+    const parsed = parseSections([raw], decofile)[0]!;
+    expect(parsed.isSavedBlock).toBe(true);
+    expect(unwrapSection(raw, parsed, decofile)).toEqual({
+      data: { __resolveType: HERO, title: "Site Header" },
+      resolveType: HERO,
+    });
+  });
+
   it("unwrapBlockReference loads saved block data for site theme pointers", () => {
     const decofile = {
       Deco: {

--- a/apps/web/src/components/sections-editor/unwrap-section.ts
+++ b/apps/web/src/components/sections-editor/unwrap-section.ts
@@ -108,13 +108,14 @@ export function unwrapSection(
     return null;
   }
 
-  if (parsed.isSavedBlock) {
+  if (parsed.isSavedBlock && !parsed.isHidden) {
     const blockKey = parsed.isLazy
       ? ((raw.section?.__resolveType as string) ?? raw.__resolveType)
       : raw.__resolveType;
     return resolveSavedBlockData(blockKey, decofile);
   }
 
+  // Hidden checked before isSavedBlock: a hidden section's raw.__resolveType is the never-matcher wrapper, not the block key.
   if (parsed.isHidden) {
     const isLazy = isLazyResolveType(raw.__resolveType);
     const mvObj = isLazy ? (raw.section as RawSection | undefined) : raw;


### PR DESCRIPTION
Follows #6504 (the eye-toggle hide/show feature) — reactive hardening on the surrounding `parseSections`/`unwrapSection` logic.

A hidden saved-block section (eye toggled off) fell into `parseSections`' generic hidden branch, which never checked `isSavedBlockResolveType` against `decofile` the way the non-hidden branch already does. Two visible symptoms: the sidebar row showed a humanized resolveType key (e.g. "Header Abc") instead of the block's real name, and `isSavedBlock` stayed `undefined`, so the "Detach" menu item silently disappeared for a hidden reusable block (it only reappears once you un-hide the section).

**Failure scenario:** hide a page section that's a saved (reusable) block → its row loses its friendly name and its Detach option, with no way to fix that short of un-hiding first.

**Fix:** mirror the existing non-hidden saved-block resolution when the wrapped section is hidden, so it also resolves the block's name and sets `isSavedBlock: true`. That makes a hidden section able to be both `isHidden` and `isSavedBlock`, which `unwrapSection` never had to handle before — its `isSavedBlock` branch read `raw.__resolveType` directly, which for a hidden section is the never-matcher wrapper, not the block key. Reordered `unwrapSection` so `isHidden` is checked first; its existing `unwrapSectionValue` call already resolves a wrapped saved block correctly, so no new resolution logic was needed there.

Added regression tests: `parseSections` now asserts the label/isSavedBlock flag for a hidden saved block, and `unwrapSection` asserts it still returns the resolved block data (not null) for that same case.

**To verify:** `bun test apps/web/src/components/sections-editor/parse-sections.ts apps/web/src/components/sections-editor/unwrap-section.test.ts apps/web/src/components/sections-editor/section-list.test.ts apps/web/src/components/sections-editor/section-variants.test.ts apps/web/src/components/sections-editor/page-sections.test.ts` — all pass.

**Locally ran:** `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), `bunx oxlint` on the four touched files (0 warnings/errors), and the targeted test files above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hidden saved-block sections now resolve to their block name and keep Detach available. Previously, hidden saved blocks showed a humanized key and lost Detach; now they mirror saved-block resolution even when hidden and unwrap correctly.

- Mirror the non-hidden saved-block path in `parseSections` for hidden sections: resolve the name from `decofile` and set `isSavedBlock: true`.
- Reorder `unwrapSection` to check `isHidden` before `isSavedBlock`, since hidden sections wrap the block key; the hidden path already resolves the wrapped block data.
- Add regression tests for hidden saved-block labels and unwrap behavior. No migrations required.

<sup>Written for commit 5630596a911f4db6bb7afaa1661f5bc293504006. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

