### PR TITLE
fix(chart): mount the Postgres CA in the migrate Job

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -147,6 +147,57 @@ jobs:
             --set database.url=postgresql://ci:ci@postgres.example.com:5432/studio \
             > /dev/null
 
+      - name: Render (migration Job mounts PostgreSQL CA)
+        run: |
+          set -euo pipefail
+          helm template deco-studio deploy/helm/studio \
+            --set database.url=postgresql://ci:ci@postgres.example.com:5432/studio \
+            --set-string database.caCert=test-ca \
+            --set-string configMap.meshConfig.NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-cert.pem \
+            > /tmp/studio-ca.yaml
+
+          python3 - <<'PY'
+          import sys, yaml
+
+          docs = [doc for doc in yaml.safe_load_all(open("/tmp/studio-ca.yaml")) if doc]
+          by_kind_name = {
+              (doc["kind"], doc["metadata"]["name"]): doc
+              for doc in docs
+          }
+          job = by_kind_name[("Job", "deco-studio-migrate")]
+          ca = by_kind_name[("ConfigMap", "deco-studio-ca-cert")]
+          pod = job["spec"]["template"]["spec"]
+          container = next(item for item in pod["containers"] if item["name"] == "migrate")
+          mount = next(
+              (item for item in container.get("volumeMounts", []) if item["name"] == "ca-cert"),
+              None,
+          )
+          volume = next(
+              (item for item in pod.get("volumes", []) if item["name"] == "ca-cert"),
+              None,
+          )
+          errors = []
+          if mount != {"name": "ca-cert", "mountPath": "/etc/ssl/certs", "readOnly": True}:
+              errors.append(f"wrong migration CA mount: {mount!r}")
+          expected_volume = {
+              "name": "ca-cert",
+              "configMap": {
+                  "name": "deco-studio-ca-cert",
+                  "items": [{"key": "ca-cert.pem", "path": "ca-cert.pem"}],
+              },
+          }
+          if volume != expected_volume:
+              errors.append(f"wrong migration CA volume: {volume!r}")
+          ca_wave = int(ca["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"])
+          job_wave = int(job["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"])
+          if ca_wave >= job_wave:
+              errors.append(f"CA ConfigMap wave {ca_wave} must precede migration Job wave {job_wave}")
+          if errors:
+              print("::error::" + "; ".join(errors))
+              sys.exit(1)
+          print(f"migration CA is mounted; ConfigMap wave {ca_wave} precedes Job wave {job_wave}")
+          PY
+
       # -n deco-studio matches the watchNamespaces pin in the example values;
       # the chart's namespace validation fails the render otherwise.
       - name: Render (in-cluster ClickHouse example)

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,6 +2,12 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
+# 0.15.1: the migration Job mounts the Postgres CA. 0.15.0 made the Job render
+# outside preview, but migrate-job.yaml declared no volumes while the
+# Deployments mount ca-cert at /etc/ssl/certs. NODE_EXTRA_CA_CERTS then names a
+# file that is not there and any privately-rooted Postgres — an RDS instance
+# endpoint, for one — fails with SELF_SIGNED_CERT_IN_CHAIN. The ca-cert
+# ConfigMap gets a sync-wave for the same reason 0.14.1 and 0.14.5 did.
 # 0.15.0: the single-writer migration Job now runs outside preview too
 # (migrateJob.enabled, default true). Every replica migrates the DBOS system
 # schema on boot and the SDK bumps its version with an UPDATE that has no
@@ -76,7 +82,7 @@ type: application
 # when disabled, so existing releases are unaffected.
 # 0.12.4: chart-managed API/worker dispatch roles now use
 # STUDIO_DISPATCH_ROLE; legacy overrides are rejected.
-version: 0.15.0
+version: 0.15.1
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/configmap-ca-cert.yaml
+++ b/deploy/helm/studio/templates/configmap-ca-cert.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ include "chart-deco-studio.fullname" . }}-ca-cert
   labels:
     {{- include "chart-deco-studio.labels" . | nindent 4 }}
+  annotations:
+    # Ahead of the migrate Job (-10) that now mounts this as a volume. A missing
+    # volume source leaves the container in CreateContainerConfigError, which
+    # stalls the whole sync on the hook with nothing on any object reporting a
+    # problem — the same shape as the ConfigMap at 0.14.1 and the ServiceAccount
+    # at 0.14.5. Only a real sync surfaces it; `helm template` cannot.
+    argocd.argoproj.io/sync-wave: "-30"
 data:
   ca-cert.pem: |
 {{ .Values.database.caCert | indent 4 }}

--- a/deploy/helm/studio/templates/migrate-job.yaml
+++ b/deploy/helm/studio/templates/migrate-job.yaml
@@ -105,4 +105,27 @@ spec:
               bun run node_modules/decocms/dist/server/migrate-dbos.js
           resources:
             {{- toYaml $jobResources | nindent 12 }}
+          {{- if and (eq (lower (default "sqlite" .Values.database.engine)) "postgresql") .Values.database.caCert }}
+          # NODE_EXTRA_CA_CERTS points at /etc/ssl/certs/ca-cert.pem, so the Job
+          # needs the same mount the Deployments get. Without it the variable
+          # names a file that is not there, the extra CA is silently skipped,
+          # and a privately-rooted Postgres — an RDS instance endpoint, whose
+          # chain is not in the Node root store — fails the connection with
+          # SELF_SIGNED_CERT_IN_CHAIN seconds into the Job. Being a sync hook at
+          # wave -10, that aborts the operation and nothing in wave 0 is ever
+          # applied.
+          volumeMounts:
+            - name: ca-cert
+              mountPath: /etc/ssl/certs
+              readOnly: true
+          {{- end }}
+      {{- if and (eq (lower (default "sqlite" .Values.database.engine)) "postgresql") .Values.database.caCert }}
+      volumes:
+        - name: ca-cert
+          configMap:
+            name: {{ include "chart-deco-studio.fullname" . }}-ca-cert
+            items:
+              - key: ca-cert.pem
+                path: ca-cert.pem
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

The migrate Job cannot reach a Postgres whose certificate chain is not publicly rooted. On deco's staging that has blocked every sync since 2026-08-22; on a self-host it breaks the first deploy.

## Cause

0.15.0 (#6435) made the Job render outside preview. But `migrate-job.yaml` declares no `volumes`/`volumeMounts`, while `deployment.yaml` and `worker-deployment.yaml` both mount the `ca-cert` ConfigMap at `/etc/ssl/certs`.

`NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-cert.pem` therefore names a file that is not in the Job's container. Reproduced in-cluster with the Job's exact env:

```
Warning: Ignoring extra certs from `/etc/ssl/certs/ca-cert.pem`: No such file or directory
FAIL -> SELF_SIGNED_CERT_IN_CHAIN self signed certificate in certificate chain
```

Same pod, same query, `NODE_EXTRA_CA_CERTS` pointing at the real CA: `OK`.

`getSsl()` passes a plain boolean to the pool, so `DATABASE_PG_SSL=true` means `rejectUnauthorized: true`. An RDS **instance** endpoint chains to the Amazon RDS root, which is not in the Node root store — hence the ConfigMap. An RDS **Proxy** endpoint chains to a public root, which is why deco's production happened to survive this and staging did not.

The Job is a sync hook at wave **-10**, so the failure aborts the operation and nothing in wave 0 is applied.

## Fix

Mount `ca-cert` in the Job, guarded by the same `database.engine`/`database.caCert` condition the Deployments use.

The ca-cert ConfigMap also gains `sync-wave: "-30"`. It is now a volume source for a hook at -10, and a missing volume source leaves the container in `CreateContainerConfigError` while the sync stalls on the hook with nothing on any object reporting a problem — the same shape as the ConfigMap at 0.14.1 and the ServiceAccount at 0.14.5. Shipping the mount without the wave would have traded one first-install failure for another.

Chart 0.15.0 → 0.15.1.

## Testing

- `helm template` with `database.caCert` set: the Job renders the mount and the volume; the ConfigMap renders at wave -30.
- `helm template` without it: the Job is byte-identical to before, so preview and every SQLite install are unaffected.
- `helm lint` clean.
- Failure and fix both reproduced against a live RDS instance endpoint.

## Note for the reviewer

Outside this PR's scope, but adjacent: in `configmap.yaml`, `secret.yaml` and `externalsecret.yaml` the `sync-wave` annotation is gated on `preview.enabled`. The migrate Job consumes all three via `envFrom` in **every** mode, so on a non-preview first install they land at wave 0, after the hook at -10. Existing releases do not notice because the objects are already in the cluster. The CI wave assertion only reads the preview render, so it does not catch this. Worth a follow-up.

Refs: #6435, decocms/deco-apps-cd#359

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts the Postgres CA in the migrate Job and adds a sync-wave to the CA ConfigMap so the Job can connect to privately rooted Postgres. Previously `NODE_EXTRA_CA_CERTS` pointed to a non-existent file in the Job, triggering SELF_SIGNED_CERT_IN_CHAIN and aborting Argo CD sync.

- Mounts the `ca-cert` ConfigMap at `/etc/ssl/certs` in the migrate Job only when `database.engine=postgresql` and `.Values.database.caCert` is set.
- Ensures the CA ConfigMap has `argocd.argoproj.io/sync-wave: "-30"` so it exists before the `-10` migrate hook.
- Adds CI coverage in `.github/workflows/helm-test.yml` to assert the CA mount and that the ConfigMap wave precedes the Job wave.
- Bumps chart to 0.15.1; renders unchanged when `.Values.database.caCert` is unset, so previews and SQLite installs are unaffected.
- Migration action: none; for privately rooted Postgres, set `.Values.database.caCert` to the CA chain.

<sup>Written for commit 68a4efbd2ea2813b9985047e21d91d77d27bacdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

