### PR TITLE
fix(chat): ignore a stale voice recognizer's late onresult callback

### DIFF
--- a/apps/web/src/hooks/use-voice-input.test.ts
+++ b/apps/web/src/hooks/use-voice-input.test.ts
@@ -269,4 +269,84 @@ describe("useVoiceInput.startRecording", () => {
       configurable: true,
     });
   });
+
+  it("ignores a stale recognizer's late result once a newer one has started", async () => {
+    const instances: Array<{
+      onresult?: (event: unknown) => void;
+    }> = [];
+    win.SpeechRecognition = function () {
+      const instance: {
+        start: () => void;
+        stop: () => void;
+        abort: () => void;
+        onresult?: (event: unknown) => void;
+      } = { start() {}, stop() {}, abort() {} };
+      instances.push(instance);
+      return instance;
+    } as unknown as typeof SpeechRecognition;
+
+    const originalAudioContext = win.AudioContext;
+    win.AudioContext = function () {
+      return {
+        createMediaStreamSource: () => ({ connect: () => {} }),
+        createAnalyser: () => ({
+          fftSize: 0,
+          smoothingTimeConstant: 0,
+          frequencyBinCount: 0,
+          getByteFrequencyData: () => {},
+        }),
+        close: () => Promise.resolve(),
+      };
+    };
+
+    const track = { stop: () => {} };
+    const originalGetUserMedia = navigator.mediaDevices?.getUserMedia;
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: {
+        getUserMedia: () =>
+          Promise.resolve({
+            getTracks: () => [track],
+          } as unknown as MediaStream),
+      },
+      configurable: true,
+    });
+
+    const originalRaf = win.requestAnimationFrame;
+    const originalCaf = win.cancelAnimationFrame;
+    win.requestAnimationFrame = (() =>
+      1) as unknown as typeof win.requestAnimationFrame;
+    win.cancelAnimationFrame =
+      (() => {}) as unknown as typeof win.cancelAnimationFrame;
+
+    const { result } = renderHook(() => useVoiceInput());
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    act(() => result.current.cancelRecording());
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    expect(instances.length).toBe(2);
+
+    // The stale (cancelled) recognizer's result arrives after the new one started.
+    act(() =>
+      instances[0]?.onresult?.({
+        resultIndex: 0,
+        results: [
+          Object.assign([{ transcript: "stale words" }], { isFinal: true }),
+        ],
+      }),
+    );
+
+    expect(result.current.transcript).toBe("");
+
+    win.AudioContext = originalAudioContext;
+    win.requestAnimationFrame = originalRaf;
+    win.cancelAnimationFrame = originalCaf;
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia: originalGetUserMedia },
+      configurable: true,
+    });
+  });
 });

--- a/apps/web/src/hooks/use-voice-input.ts
+++ b/apps/web/src/hooks/use-voice-input.ts
@@ -123,6 +123,8 @@ export function useVoiceInput(): UseVoiceInputReturn {
     recognition.lang = navigator.language || "en-US";
 
     recognition.onresult = (event: SpeechRecognitionEvent) => {
+      // Ignore a stale instance's async result once a newer one took over.
+      if (recognitionRef.current !== recognition) return;
       let interim = "";
       let newFinal = "";
       for (let i = event.resultIndex; i < event.results.length; i++) {


### PR DESCRIPTION
Follows #6494, which guarded `onerror`/`onend` in `use-voice-input.ts` against a stale `SpeechRecognition` instance firing async callbacks after a restart — but missed `onresult`.

**Payoff:** `finalTranscriptRef`/`interimTranscriptRef` are shared across recognizer instances. If a user stops/cancels and quickly restarts recording, the old (stale) recognizer can still fire a late `onresult` with a final transcript, which splices into the new session's transcript even though the old recognizer was supposed to be discarded — the exact same bug class #6494 fixed for `onerror`/`onend`, just on the one callback that was missed.

**Fix:** add the same `recognitionRef.current !== recognition` guard to `onresult`.

**Regression test:** `use-voice-input.test.ts` — starts recording, cancels, restarts (two instances), fires `onresult` on the stale first instance with a final transcript, and asserts the new session's `transcript` stays empty (previously it would have picked up the stale words).

**Verify:** `bun test apps/web/src/hooks/use-voice-input.test.ts` (6 pass).

Locally ran: `bun test apps/web/src/hooks/use-voice-input.test.ts`, `bunx oxlint apps/web/src/hooks/use-voice-input.ts apps/web/src/hooks/use-voice-input.test.ts`, `bun run fmt`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore late onresult from a stale `SpeechRecognition` instance after a restart to prevent stale text from splicing into the new session. Previously, a cancelled recognizer could append a final transcript to the new session; now the hook drops those events.

- Add `recognitionRef.current !== recognition` guard to `onresult`, matching existing `onerror`/`onend` guards.
- Add a regression test that starts, cancels, restarts, then fires the stale instance’s `onresult` and asserts the new session’s `transcript` stays empty.
- No API changes; only stale results are ignored.

<sup>Written for commit 3d583282416fd05ca8bf941b4d23d4bedd2c79f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

