### PR TITLE
fix(oauth): don't discard a successfully minted GitHub token on a persist failure

### DIFF
--- a/apps/api/src/oauth/github-mint.ts
+++ b/apps/api/src/oauth/github-mint.ts
@@ -140,16 +140,24 @@ async function mintAndStore(
   const mintStartedAt = Date.now();
   const minted = await mintRepoToken(ctx, recipe);
   const expiresAt = resolveGhsExpiry(minted.expiresAt, mintStartedAt);
-  await tokenStorage.upsert({
-    connectionId,
-    accessToken: minted.accessToken,
-    refreshToken: null,
-    scope: null,
-    expiresAt,
-    clientId: null,
-    clientSecret: null,
-    tokenEndpoint: null,
-  });
+  try {
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: minted.accessToken,
+      refreshToken: null,
+      scope: null,
+      expiresAt,
+      clientId: null,
+      clientSecret: null,
+      tokenEndpoint: null,
+    });
+  } catch (error) {
+    // A cache miss, not a failure — the minted token is already valid on GitHub's side.
+    console.warn("[GithubMint] failed to persist minted token", {
+      connectionId,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
   return minted.accessToken;
 }
 


### PR DESCRIPTION
Bug found while hunting the OAuth token-refresh area, in `github-mint.ts`'s `mintAndStore` — the sibling code path to `refreshAndStoreOnce` in `token-refresh.ts`, which was just hardened in #6507 ("don't throw from refreshAndStore when persisting a token fails") to return `null` instead of rejecting on a storage blip. `mintAndStore` had the identical shape (mint, then `await tokenStorage.upsert(...)` unguarded) but was never given the same treatment.

**Failure scenario:** `MINT_REPO_TOKEN` succeeds and hands back a valid ~1h GitHub App installation token, but the subsequent `tokenStorage.upsert` throws (a transient Postgres blip). Since `ensureRepoScopedToken`'s return type is `Promise<string>` (non-nullable), the whole call rejects and the caller (github-clone-info, org-repo-sync, the GraphQL client, decofile's client-for-repo, MCP proxy headers) sees a hard failure — even though a perfectly good, already-minted token exists in hand. Unlike a refresh, a mint's validity doesn't depend on being cached: GitHub already issued it, it works for its lifetime regardless of whether we manage to persist it locally.

**Fix:** wrap the persist in try/catch, warn-log on failure, and still return the minted token — the only cost of a persist miss is a cache miss (one extra re-mint on the next call), not a failed tool call.

**Verify:** `cd apps/api && bunx tsc --noEmit` (clean); `bun test apps/api/src/oauth/github-mint.test.ts` (5 pass); `bunx oxlint apps/api/src/oauth/github-mint.ts` (0 warnings/errors). No new test added — exercising `mintAndStore`'s persist-failure path requires a stubbed `StudioContext` + mocked `clientFromConnection`, which per this repo's testing tiers belongs in e2e, not a unit test; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids discarding a valid GitHub App installation token when persistence fails. Previously, `mintAndStore` rejected if `tokenStorage.upsert` threw; now it returns the minted token and logs a warning, preventing hard failures for callers.

- Wraps the persist step in try/catch and warns on failure.
- Callers receive the minted token; the only side effect is a possible cache miss and re-mint on the next call.
- Aligns mint behavior with the hardened refresh path; no configuration or migration changes.

<sup>Written for commit 9dceb08b7071b70a1ecbbc20d2720ed03d3cfe32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

