### PR TITLE
fix(sandbox): free the publish header from the dev-server lifecycle

### DIFF
--- a/apps/web/src/components/thread/github/panel-state.test.ts
+++ b/apps/web/src/components/thread/github/panel-state.test.ts
@@ -289,13 +289,25 @@ describe("selectHeaderButton", () => {
     expect(r.action).toBe("publish");
   });
 
-  test("lifecycle.starting + clean branch, no work → Starting app…", () => {
+  test("lifecycle.starting + clean branch, git status still resolving → Starting app…", () => {
     const r = selectHeaderButton(
       happyInput({ lifecycle: { phase: "starting" } }),
     );
     expect(r.label).toBe("Starting app…");
     expect(r.disabled).toBe(true);
     expect(r.loading).toBe(true);
+  });
+
+  test("lifecycle.starting + clean branch, git status resolved empty → Up to date (not the boot pill)", () => {
+    const r = selectHeaderButton(
+      happyInput({
+        lifecycle: { phase: "starting" },
+        noReviewableDiff: true,
+      }),
+    );
+    expect(r.label).toBe("Up to date");
+    expect(r.disabled).toBe(true);
+    expect(r.action).toBeUndefined();
   });
 
   test("lifecycle.install-failed + dirty branch → Review & Publish (commit fixes)", () => {

--- a/apps/web/src/components/thread/github/panel-state.test.ts
+++ b/apps/web/src/components/thread/github/panel-state.test.ts
@@ -240,7 +240,7 @@ describe("selectHeaderButton", () => {
     expect(r.loading).toBe(true);
   });
 
-  // Installing holds the header (working tree not in place). `starting` releases committed work — git works while the dev server boots — but a dirty-only tree stays held: workingTreeDirty may be boot noise until #6332's baseline arms (this is the #6314 false-"Review & Publish"-on-a-fresh-branch guard).
+  // Installing holds the header (working tree not in place). `starting` releases any real work — publishing is git, which needs the checkout, not the dev server. workingTreeDirty is trustworthy here: the daemon reports it only for user-written paths (BranchStatusMonitor.userTouched), so boot dirt no longer masquerades as work and the #6314 fresh-branch guard is preserved without gating on the lifecycle.
 
   test("lifecycle.installing + dirty branch → Installing packages… (not publishable yet)", () => {
     const r = selectHeaderButton(
@@ -267,17 +267,26 @@ describe("selectHeaderButton", () => {
     expect(r.action).toBe("publish");
   });
 
-  test("lifecycle.starting + dirty-only tree (no commits) → Starting app… (boot dirt is not proof of work)", () => {
+  test("lifecycle.starting + dirty-only tree (no commits) → Review & Publish (daemon reports dirty only for user-written paths, not boot dirt)", () => {
     const r = selectHeaderButton(
       happyInput({
         lifecycle: { phase: "starting" },
         branch: ready({ workingTreeDirty: true }),
       }),
     );
-    expect(r.label).toBe("Starting app…");
-    expect(r.disabled).toBe(true);
-    expect(r.loading).toBe(true);
-    expect(r.action).toBeUndefined();
+    expect(r.label).toBe("Review & Publish");
+    expect(r.action).toBe("publish");
+  });
+
+  test("lifecycle.starting + unpushed commits → Review & Publish (git works while the dev server boots)", () => {
+    const r = selectHeaderButton(
+      happyInput({
+        lifecycle: { phase: "starting" },
+        branch: ready({ aheadOfBase: 1, unpushed: 1 }),
+      }),
+    );
+    expect(r.label).toBe("Review & Publish");
+    expect(r.action).toBe("publish");
   });
 
   test("lifecycle.starting + clean branch, no work → Starting app…", () => {

--- a/apps/web/src/components/thread/github/panel-state.ts
+++ b/apps/web/src/components/thread/github/panel-state.ts
@@ -287,16 +287,14 @@ export function selectHeaderButton(
         tooltip: t("thread.headerActions.installingPackagesTooltip"),
         menu: [],
       };
-    // `starting`: any real work publishes now (git needs the checkout, not the dev server); workingTreeDirty is trustworthy mid-boot since the daemon reports it only for user-written paths (BranchStatusMonitor.userTouched), not boot dirt.
-    case "starting":
-      if (
-        !(
-          branch.kind === "ready" &&
-          (branch.workingTreeDirty ||
-            branch.aheadOfBase > 0 ||
-            branch.unpushed > 0)
-        )
-      ) {
+    // `starting` never gates the verdict — publishing is git (needs the checkout, not the dev server). Fall through the moment either signal resolves: real work (workingTreeDirty is user-written-only mid-boot, commits are never boot noise) → git/PR copy, or an authoritative-empty /git/status → "Up to date". Hold the boot pill only while both are still undecided.
+    case "starting": {
+      const hasWork =
+        branch.kind === "ready" &&
+        (branch.workingTreeDirty ||
+          branch.aheadOfBase > 0 ||
+          branch.unpushed > 0);
+      if (!hasWork && !input.noReviewableDiff) {
         return {
           label: t("thread.headerActions.startingApp"),
           disabled: true,
@@ -307,6 +305,7 @@ export function selectHeaderButton(
         };
       }
       break;
+    }
     // running/*-failed/crashed: fall through to git/PR.
   }
 

--- a/apps/web/src/components/thread/github/panel-state.ts
+++ b/apps/web/src/components/thread/github/panel-state.ts
@@ -287,9 +287,16 @@ export function selectHeaderButton(
         tooltip: t("thread.headerActions.installingPackagesTooltip"),
         menu: [],
       };
-    // `starting`: committed work publishes now (git needs the checkout, not the dev server); a dirty-only tree waits, since workingTreeDirty may be boot noise until #6332's baseline arms.
+    // `starting`: any real work publishes now (git needs the checkout, not the dev server); workingTreeDirty is trustworthy mid-boot since the daemon reports it only for user-written paths (BranchStatusMonitor.userTouched), not boot dirt.
     case "starting":
-      if (!(branch.kind === "ready" && branch.aheadOfBase > 0)) {
+      if (
+        !(
+          branch.kind === "ready" &&
+          (branch.workingTreeDirty ||
+            branch.aheadOfBase > 0 ||
+            branch.unpushed > 0)
+        )
+      ) {
         return {
           label: t("thread.headerActions.startingApp"),
           disabled: true,

--- a/packages/sandbox/daemon-go/internal/gitx/branchstatus.go
+++ b/packages/sandbox/daemon-go/internal/gitx/branchstatus.go
@@ -224,16 +224,25 @@ func (m *BranchStatusMonitor) compute() *events.BranchMeta {
 	baseline := m.baseline
 	userTouched := m.userTouched
 	m.mu.Unlock()
-	// Un-armed means boot has not settled (ArmBaseline runs at every boot
-	// outcome), so everything dirty here is boot dirt — reporting it as the
-	// user's work armed "Review & Publish" on an untouched, empty thread.
-	if len(dirtyPaths) > 0 && hasBaseline {
+	// A path the user wrote through the fs routes is their work regardless of the
+	// baseline OR whether the dev server has settled — boot dirt is written by the
+	// dev server directly and never comes through those routes. Reporting it dirty
+	// before the baseline arms is what frees the header from the dev-server
+	// lifecycle: an edit made while the sandbox is still `starting` is publishable
+	// immediately, instead of waiting on a probe that may never fire.
+	//
+	// For every other dirty path we still need the baseline: un-armed means boot
+	// has not settled (ArmBaseline runs at every boot outcome), so a non-user
+	// path here is boot dirt — reporting it as the user's work armed
+	// "Review & Publish" on an untouched, empty thread.
+	if len(dirtyPaths) > 0 {
 		for p := range dirtyPaths {
-			// A path the user wrote is their work regardless of the baseline — this
-			// is what stops an edit made before arming from being swallowed by it.
 			if _, touched := userTouched[p]; touched {
 				dirty = true
 				break
+			}
+			if !hasBaseline {
+				continue
 			}
 			baseHash, ok := baseline[p]
 			if !ok || m.hashWorktreeFile(p) != baseHash {

--- a/packages/sandbox/daemon-go/internal/gitx/branchstatus_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/branchstatus_test.go
@@ -98,6 +98,32 @@ func TestUserTouchedEditSurvivesLaterBaselineArm(t *testing.T) {
 	}
 }
 
+// The dev server may never settle — a port-sniffer miss leaves the sandbox stuck
+// in `starting`, so ArmBaseline never runs. A CMS edit made in that window must
+// still read as the user's work: the header (publishing is git, not the dev
+// server) can only free itself from the lifecycle if the daemon reports the edit
+// dirty without waiting on a baseline that isn't coming.
+func TestUserTouchedEditDirtyBeforeBaselineArms(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature")
+	m := NewBranchStatusMonitor(repo, nopBroadcaster{}, nil)
+
+	write(t, repo, ".deco/blocks/pages-Home.json", `{"__resolveType":"x"}`)
+	commitAll(t, repo)
+
+	// Boot dirt alone, still `starting`, baseline never armed: nothing to publish.
+	write(t, repo, "boot.gen.json", "{}\n")
+	if dirty(t, m) {
+		t.Fatal("un-armed boot dirt must not read as the user's work")
+	}
+
+	// A CMS block edit through the fs route, still before any arm.
+	write(t, repo, ".deco/blocks/pages-Home.json", `{"__resolveType":"y"}`)
+	m.MarkUserTouched(".deco/blocks/pages-Home.json")
+	if !dirty(t, m) {
+		t.Fatal("a user edit must be publishable even while the dev server never settles")
+	}
+}
+
 // The baseline pins content, not just paths: editing a file that was dirty at
 // boot is still the user's work.
 func TestBaselineDetectsEditToBaselinedPath(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #6490. That PR released **committed** work from the `starting` gate, but explicitly left a *residual limitation*: a genuine **uncommitted** edit made while the dev server is still booting still waited for the lifecycle to settle. And when the daemon's port-sniffer misses the dev server's bind banner, the phase **never leaves `starting`** — so that edit was unpublishable *forever*, even though publishing is a pure git operation that needs only the checkout.

This finishes the decoupling: **the publish header no longer depends on the dev server in any case.** `starting` never gates the verdict — it falls through to the git/PR copy the moment either signal resolves: real work, or an authoritative-empty `/git/status`.

## Root cause (daemon-side)

#6492 added `userTouched` — paths written through the daemon's fs routes, i.e. the user's actual work — but only consulted it **inside** the `hasBaseline` guard in `compute()`. The boot-dirt baseline (`ArmBaseline`) only arms once the dev server *settles* (running / `*-failed` / crashed). So while the sandbox is still `starting`, `hasBaseline` is false, the `userTouched` check is skipped, and a real user edit is reported **clean** over SSE. The frontend, seeing no dirty flag it could trust, held `"Starting app…"`.

## The fix

- **daemon** (`branchstatus.go`): a user-touched path is reported dirty **regardless of the baseline**. Boot dirt is written by the dev server process directly and never comes through the fs routes, so this frees `WorkingTreeDirty` from the dev-server lifecycle *without* reintroducing the #6314 false-`"Review & Publish"`-on-a-fresh-branch flash — non-user boot dirt is still ignored until the baseline arms.
- **web** (`panel-state.ts`): the `starting` case no longer gates the verdict. It releases to the git/PR copy on any real work — `workingTreeDirty || aheadOfBase > 0 || unpushed > 0`, all trustworthy mid-boot — and to `"Up to date"` when the deepened `/git/status` (`noReviewableDiff`, which resolves independently of the dev server) confirms nothing to publish. The `"Starting app…"` pill holds only while both signals are still undecided.

## Behavior — lifecycle `starting` + …

| state | before | after |
| --- | --- | --- |
| committed work (`aheadOfBase > 0`) | Review & Publish (#6490) | Review & Publish |
| **uncommitted user edit** (`workingTreeDirty`) | **Starting app… (stuck)** | **Review & Publish** |
| unpushed commits | Starting app… | Review & Publish |
| **clean, `/git/status` resolved empty** | **Starting app…** | **Up to date** |
| clean, status still resolving / boot dirt only | Starting app… | Starting app… *(guard preserved)* |

## Testing

- daemon: `TestUserTouchedEditDirtyBeforeBaselineArms` — a user edit is dirty before the baseline ever arms (dev server never settles), while boot dirt alone stays clean.
- web: **inverted** the `panel-state` test that encoded the old dirty-only-holds behavior; added `unpushed`-during-`starting` and clean-resolved-empty-during-`starting` cases.
- `go test ./internal/gitx`, `bun test panel-state.test.ts` (48 pass), `tsc --noEmit` (web), `bun run fmt` — all clean.

## Note

This is the frontend/`WorkingTreeDirty`-path decoupling. The daemon still never promoting `starting → running` when the port-sniffer misses a non-standard bind banner (the reason the pill was stuck in the first place) is a separate daemon-side port-detection fix, tracked separately — this PR makes the **publish** flow immune to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)