### PR TITLE
ci(dependabot): add monthly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # JavaScript/TypeScript dependencies (Bun workspaces, root manifest)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "[chore]"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "[chore]"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
Add Dependabot config for monthly dependency updates.

- **npm** ecosystem (`/`) — Bun workspaces auto-detected from root `package.json`; grouped into one PR per run.
- **github-actions** ecosystem — bumps action versions across `.github/workflows/*`; grouped.
- Both: `monthly` schedule, `open-pull-requests-limit: 10`, commit prefix `[chore]` matching repo convention.

## Testing
Config-only change. YAML validated against Dependabot v2 schema. No code paths affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Dependabot` to automate monthly dependency updates, replacing manual bumps. Old behavior: no automation; new behavior: grouped monthly PRs for `npm` (Bun workspaces) and `github-actions`.

**Dependencies**
- Runs from the repo root to cover all workspaces.
- Caps open Dependabot PRs at 10.
- Uses `[chore]` commit message prefix.
- Config-only change with no code or workflow behavior changes.

<sup>Written for commit 0dcabafb1da5f4d0d81bada4fb9a72bd5f8f3399. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

