### PR TITLE
fix(cms): header publish button follows the popover's change count

### DIFF
--- a/apps/web/src/components/thread/github/cms-header-actions.tsx
+++ b/apps/web/src/components/thread/github/cms-header-actions.tsx
@@ -52,6 +52,7 @@ import {
   CmsPublishPopover,
   type CmsPublishMode,
 } from "./cms-publish-popover.tsx";
+import { summarizePublishManifest } from "./publish-change-summary.ts";
 import {
   isCmsStateSettling,
   selectCmsHeaderButton,
@@ -159,6 +160,18 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
         headSha: status.headSha ?? "",
       }
     : { kind: "unknown" };
+
+  /**
+   * The publishable change count, derived from the SAME manifest summarizer the
+   * popover uses (the count ignores `lookup`/`diff`, so the manifest alone is
+   * enough here), so the header button and the popover can never disagree on
+   * whether there is anything to publish — auto-generated artifacts are excluded
+   * in both. `null` when the manifest is absent (sandbox daemon); the state
+   * machine then falls back to the branch's `aheadOfBase` commit count.
+   */
+  const publishableChangeCount = status?.changedFiles
+    ? summarizePublishManifest({ files: status.changedFiles }).count
+    : null;
 
   const githubHeadBranch =
     (branchMeta.kind === "ready" ? branchMeta.branch : null) ?? branch ?? null;
@@ -359,6 +372,7 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
           ? String(statusQuery.error)
           : null,
     loading: Boolean(settling),
+    publishableChangeCount,
     t,
   });
 

--- a/apps/web/src/components/thread/github/cms-header-actions.tsx
+++ b/apps/web/src/components/thread/github/cms-header-actions.tsx
@@ -164,10 +164,11 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
   /**
    * The publishable change count, derived from the SAME manifest summarizer the
    * popover uses (the count ignores `lookup`/`diff`, so the manifest alone is
-   * enough here), so the header button and the popover can never disagree on
+   * enough here), so with a manifest the header button and the popover agree on
    * whether there is anything to publish — auto-generated artifacts are excluded
    * in both. `null` when the manifest is absent (sandbox daemon); the state
-   * machine then falls back to the branch's `aheadOfBase` commit count.
+   * machine then falls back to the branch's `aheadOfBase` commit count, which
+   * the popover doesn't, so the two can drift apart in that window alone.
    */
   const publishableChangeCount = status?.changedFiles
     ? summarizePublishManifest({ files: status.changedFiles }).count

--- a/apps/web/src/components/thread/github/cms-panel-state.test.ts
+++ b/apps/web/src/components/thread/github/cms-panel-state.test.ts
@@ -56,6 +56,8 @@ function input(
     statusError: null,
     syncing: false,
     statusRetrying: false,
+    // Manifest-less fallback by default; manifest cases opt in explicitly.
+    publishableChangeCount: null,
     t: mockT,
     ...over,
   };
@@ -798,6 +800,79 @@ describe("uncommitted work", () => {
       input({
         branch: ready({ headSha: "merged-sha", workingTreeDirty: true }),
         pr: pr({ state: "closed", merged: true, headSha: "merged-sha" }),
+      }),
+    );
+    expect(r.label).toBe(threadEn["thread.cmsActions.reviewAndPublish"]);
+    expect(r.action).toBe("publish");
+  });
+});
+
+describe("publish manifest gates the draft state", () => {
+  /** The bug: commits ahead of base whose only diff is regenerated artifacts
+   *  the popover drops. The header must agree with the popover's empty list. */
+  test("ahead of base but zero publishable changes → Up to date", () => {
+    const r = selectCmsHeaderButton(
+      input({
+        branch: ready({ aheadOfBase: 2 }),
+        publishableChangeCount: 0,
+      }),
+    );
+    expect(r.label).toBe(threadEn["thread.headerActions.upToDate"]);
+    expect(r.disabled).toBe(true);
+    expect(r.action).toBeUndefined();
+  });
+
+  test("a positive manifest count → Review & Publish", () => {
+    const r = selectCmsHeaderButton(
+      input({
+        branch: ready({ aheadOfBase: 2 }),
+        publishableChangeCount: 3,
+      }),
+    );
+    expect(r.label).toBe(threadEn["thread.cmsActions.reviewAndPublish"]);
+    expect(r.action).toBe("publish");
+  });
+
+  /** An uncommitted edit is publishable even when the base…head manifest is
+   *  empty — the backend that leaves each save in the working tree. */
+  test("a dirty tree publishes even at manifest count 0", () => {
+    const r = selectCmsHeaderButton(
+      input({
+        branch: ready({ aheadOfBase: 0, workingTreeDirty: true }),
+        publishableChangeCount: 0,
+      }),
+    );
+    expect(r.label).toBe(threadEn["thread.cmsActions.reviewAndPublish"]);
+    expect(r.action).toBe("publish");
+  });
+
+  /** No manifest (sandbox daemon): the coarse commit count is all there is. */
+  test("null count falls back to aheadOfBase", () => {
+    const publishable = selectCmsHeaderButton(
+      input({
+        branch: ready({ aheadOfBase: 2 }),
+        publishableChangeCount: null,
+      }),
+    );
+    expect(publishable.action).toBe("publish");
+    const clean = selectCmsHeaderButton(
+      input({
+        branch: ready({ aheadOfBase: 0 }),
+        publishableChangeCount: null,
+      }),
+    );
+    expect(clean.label).toBe(threadEn["thread.headerActions.upToDate"]);
+  });
+
+  /** An open PR is publishable on its own terms; the draft-state count gate
+   *  never runs for it. */
+  test("an open PR still publishes at manifest count 0", () => {
+    const r = selectCmsHeaderButton(
+      input({
+        branch: ready({ aheadOfBase: 2 }),
+        pr: pr(),
+        reviews: reviews(),
+        publishableChangeCount: 0,
       }),
     );
     expect(r.label).toBe(threadEn["thread.cmsActions.reviewAndPublish"]);

--- a/apps/web/src/components/thread/github/cms-panel-state.ts
+++ b/apps/web/src/components/thread/github/cms-panel-state.ts
@@ -73,10 +73,11 @@ export interface SelectCmsHeaderButtonInput {
   /**
    * Publishable changed-file count from the base…head manifest, auto-generated
    * artifacts (`*.gen.json`, tailwind output) already excluded — the SAME
-   * number the publish popover renders, so the header button and the popover can
-   * never disagree on whether there is anything to publish. `null` when no
-   * manifest is available (the sandbox daemon has none), where the coarse
-   * `aheadOfBase` commit count is the only signal.
+   * number the publish popover renders, so the header button and the popover
+   * agree on whether there is anything to publish. `null` when no manifest is
+   * available (the sandbox daemon has none); then this falls back to the coarse
+   * `aheadOfBase` commit count while the popover falls back to its own diff
+   * count, so the two can drift apart in that manifest-less window alone.
    */
   publishableChangeCount: number | null;
   t: TFunction;
@@ -208,13 +209,15 @@ export function isCmsStateSettling(input: {
  * Not live yet: one `/git/status` backend commits each save, the other doesn't.
  *
  * Prefers the publish manifest's own count — the exact set the popover lists,
- * auto-generated artifacts already excluded — so the header can never advertise
- * "Review & publish" over a branch whose only drift is regenerated `*.gen.json`
- * or tailwind output that the popover drops (which would open the popover onto
- * "Everything published" with a disabled Publish). Falls back to the raw
- * `aheadOfBase` commit count only when no manifest is available. The
- * `workingTreeDirty` term is already artifact-filtered (`hasPublishableLocalWork`)
- * and carries the backend that leaves each save uncommitted, so it stands alone.
+ * auto-generated artifacts already excluded — so with a manifest the header
+ * won't advertise "Review & publish" over a branch whose only drift is
+ * regenerated `*.gen.json` or tailwind output that the popover drops (which
+ * would open the popover onto "Everything published" with a disabled Publish).
+ * Falls back to the raw `aheadOfBase` commit count only when no manifest is
+ * available — where the popover falls back to its own diff count, so the two
+ * can still diverge in that window. The `workingTreeDirty` term is already
+ * artifact-filtered (`hasPublishableLocalWork`) and carries the backend that
+ * leaves each save uncommitted, so it stands alone.
  */
 function hasUnpublishedWork(
   branch: Extract<BranchMeta, { kind: "ready" }>,

--- a/apps/web/src/components/thread/github/cms-panel-state.ts
+++ b/apps/web/src/components/thread/github/cms-panel-state.ts
@@ -70,6 +70,15 @@ export interface SelectCmsHeaderButtonInput {
   loading: boolean;
   /** Why the branch status could not be read, if it could not. */
   statusError: string | null;
+  /**
+   * Publishable changed-file count from the base…head manifest, auto-generated
+   * artifacts (`*.gen.json`, tailwind output) already excluded — the SAME
+   * number the publish popover renders, so the header button and the popover can
+   * never disagree on whether there is anything to publish. `null` when no
+   * manifest is available (the sandbox daemon has none), where the coarse
+   * `aheadOfBase` commit count is the only signal.
+   */
+  publishableChangeCount: number | null;
   t: TFunction;
 }
 
@@ -195,18 +204,42 @@ export function isCmsStateSettling(input: {
   );
 }
 
-/** Not live yet: one `/git/status` backend commits each save, the other doesn't. */
+/**
+ * Not live yet: one `/git/status` backend commits each save, the other doesn't.
+ *
+ * Prefers the publish manifest's own count — the exact set the popover lists,
+ * auto-generated artifacts already excluded — so the header can never advertise
+ * "Review & publish" over a branch whose only drift is regenerated `*.gen.json`
+ * or tailwind output that the popover drops (which would open the popover onto
+ * "Everything published" with a disabled Publish). Falls back to the raw
+ * `aheadOfBase` commit count only when no manifest is available. The
+ * `workingTreeDirty` term is already artifact-filtered (`hasPublishableLocalWork`)
+ * and carries the backend that leaves each save uncommitted, so it stands alone.
+ */
 function hasUnpublishedWork(
   branch: Extract<BranchMeta, { kind: "ready" }>,
+  publishableChangeCount: number | null,
 ): boolean {
-  return branch.aheadOfBase > 0 || branch.workingTreeDirty;
+  if (branch.workingTreeDirty) return true;
+  if (publishableChangeCount !== null) return publishableChangeCount > 0;
+  return branch.aheadOfBase > 0;
 }
 
 /** Picks the Fast Preview header button; first match wins, so order is behavior. */
 export function selectCmsHeaderButton(
   input: SelectCmsHeaderButtonInput,
 ): CmsHeaderButton {
-  const { branch, pr, checks, reviews, publishing, saving, loading, t } = input;
+  const {
+    branch,
+    pr,
+    checks,
+    reviews,
+    publishing,
+    saving,
+    loading,
+    publishableChangeCount,
+    t,
+  } = input;
 
   // A failed status read is not a slow one; spinning on it never resolves.
   if (branch.kind !== "ready" && input.statusError) {
@@ -329,7 +362,7 @@ export function selectCmsHeaderButton(
     };
   }
 
-  if (hasUnpublishedWork(branch)) {
+  if (hasUnpublishedWork(branch, publishableChangeCount)) {
     return {
       label: t("thread.cmsActions.reviewAndPublish"),
       action: "publish",


### PR DESCRIPTION
## Summary

The Fast Preview header enabled the green **"Revisar e publicar"** button whenever a branch was ahead of base, while the popover it opens showed **"Tudo publicado"** with a disabled Publish. Two sources of truth for the same state:

- **Header** — `hasUnpublishedWork` gated on `aheadOfBase > 0`, a raw commit count with **no filter**.
- **Popover** — `summary.count` from `summarizePublishManifest`, which **excludes auto-generated artifacts** (`*.gen.json`, `tailwind.css`, `generate.digests.json`).

So a branch ahead of base only by regenerated files (or commits whose net diff vs base is empty) advertised an enabled publish button over an empty popover.

## Fix

Derive the header's publishable count from the **same** `summarizePublishManifest` the popover uses, so the two can never disagree — auto-generated artifacts are excluded in both. The manifest rides free on the already-shared `/git/status` query (the count ignores `lookup`/`diff`, so no extra request). Fall back to `aheadOfBase` only when no manifest is available (sandbox daemon). `workingTreeDirty` (already artifact-filtered via `hasPublishableLocalWork`) stays its own term for the backend that leaves each save uncommitted.

- `cms-header-actions.tsx` — compute `publishableChangeCount`, pass it to the state machine.
- `cms-panel-state.ts` — `hasUnpublishedWork` prefers the count; `aheadOfBase` is now the fallback only.

## Testing

- New suite in `cms-panel-state.test.ts` covering the bug (ahead of base + count 0 → "Up to date"), the positive path, dirty-tree at count 0, the manifest-less fallback, and the open-PR case that bypasses the gate.
- `bun test` on `apps/web/src/components/thread/github/`: **314 pass / 0 fail**.
- `tsc --noEmit`, `bun run fmt`, `bun run lint` (0 errors) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a mismatch where the Fast Preview header enabled “Review & Publish” on raw commit count while the popover showed “Everything published.” The header now keys off the popover’s manifest-based publishable change count when present and falls back to `aheadOfBase` only if the manifest is absent.

**Bug Fixes**
- Uses the popover’s manifest summary (excluding auto-generated artifacts) to compute the header count.
- Falls back to `aheadOfBase` only when no manifest is available (sandbox), so header and popover can still diverge there.
- Preserves `workingTreeDirty` as an independent publish trigger.
- Reuses `/git/status`; no extra network requests.
- Adds unit tests and clarifies comments to scope agreement to manifest-backed flows.

<sup>Written for commit c5a39486af9b3100808ba5100f9c3f2925098b0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

