### PR TITLE
refactor(sandbox): bind hosted lifecycle to agent sandbox

### DIFF
--- a/apps/api/src/api/routes/dev-connection.ts
+++ b/apps/api/src/api/routes/dev-connection.ts
@@ -27,6 +27,7 @@ import {
   getDevConnectionId,
   parseBranchMap,
   type SandboxMap,
+  type SandboxRecord,
 } from "@decocms/shared/sdk";
 import type { StudioContext } from "../../core/studio-context";
 import type { ConnectionEntity } from "../../tools/connection/schema";
@@ -35,11 +36,10 @@ import {
   SecretNotFoundError,
 } from "../../storage/secrets";
 import { readValidatedRuntimeEnv } from "../../tools/sandbox/helpers";
-import { readSandboxMap } from "../../tools/sandbox/sandbox-map";
 import {
-  type BranchMapEntryLike,
-  selectVmEntry,
-} from "@decocms/shared/sandbox/select-vm-entry";
+  AGENT_SANDBOX_KIND,
+  readSandboxMap,
+} from "../../tools/sandbox/sandbox-map";
 
 /** Env var the dev MCP app gates `/mcp` behind (matches the prod connection). */
 const MCP_AUTH_TOKEN_KEY = "MCP_AUTH_TOKEN";
@@ -179,10 +179,8 @@ export async function resolveDevConnection(
 function pickEntryForBranch(
   userMap: SandboxMap[string],
   branch: string,
-): { branch: string; entry: BranchMapEntryLike } | null {
-  const entry = selectVmEntry(
-    parseBranchMap(userMap[branch]) as Record<string, BranchMapEntryLike>,
-  );
+): { branch: string; entry: SandboxRecord } | null {
+  const entry = parseBranchMap(userMap[branch])[AGENT_SANDBOX_KIND] ?? null;
   return entry ? { branch, entry } : null;
 }
 
@@ -193,12 +191,10 @@ function pickEntryForBranch(
  */
 function pickMostRecentEntry(
   userMap: SandboxMap[string],
-): { branch: string; entry: BranchMapEntryLike } | null {
-  let best: { branch: string; entry: BranchMapEntryLike } | null = null;
+): { branch: string; entry: SandboxRecord } | null {
+  let best: { branch: string; entry: SandboxRecord } | null = null;
   for (const [branch, raw] of Object.entries(userMap)) {
-    const entry = selectVmEntry(
-      parseBranchMap(raw) as Record<string, BranchMapEntryLike>,
-    );
+    const entry = parseBranchMap(raw)[AGENT_SANDBOX_KIND] ?? null;
     if (!entry) continue;
     if (!best || (entry.createdAt ?? 0) > (best.entry.createdAt ?? 0)) {
       best = { branch, entry };

--- a/apps/api/src/api/routes/public-config.test.ts
+++ b/apps/api/src/api/routes/public-config.test.ts
@@ -93,11 +93,11 @@ describe("GET /api/config", () => {
     expect(body.config.googleMapsApiKey).toBeNull();
   });
 
-  it("reports agent-sandbox runtime availability when agent-sandbox provider is configured", async () => {
+  it("reports agent-sandbox runtime availability when enabled", async () => {
     setGlobalSettings({
       ...originalSettings,
       localMode: false,
-      sandboxProviderKind: "agent-sandbox",
+      agentSandboxEnabled: true,
     });
 
     const res = await publicConfigRoutes.request("/");
@@ -106,11 +106,11 @@ describe("GET /api/config", () => {
     expect(body.config.runtime).toEqual({ agentSandbox: true });
   });
 
-  it("does not report agent-sandbox runtime availability for user-desktop provider", async () => {
+  it("does not report agent-sandbox runtime availability when disabled", async () => {
     setGlobalSettings({
       ...originalSettings,
       localMode: false,
-      sandboxProviderKind: "user-desktop",
+      agentSandboxEnabled: false,
     });
 
     const res = await publicConfigRoutes.request("/");
@@ -119,11 +119,11 @@ describe("GET /api/config", () => {
     expect(body.config.runtime).toEqual({ agentSandbox: false });
   });
 
-  it("does not report agent-sandbox in local mode even with the agent-sandbox provider", async () => {
+  it("does not report agent-sandbox in local mode even when enabled", async () => {
     setGlobalSettings({
       ...originalSettings,
       localMode: true,
-      sandboxProviderKind: "agent-sandbox",
+      agentSandboxEnabled: true,
     });
 
     const res = await publicConfigRoutes.request("/");

--- a/apps/api/src/api/routes/public-config.ts
+++ b/apps/api/src/api/routes/public-config.ts
@@ -58,8 +58,7 @@ app.get("/", (c) => {
     runtime: {
       // Local/dev mode has no cloud agent-sandbox cluster, so cloud Decopilot
       // can't run there — report it unavailable to drop it from the picker.
-      agentSandbox:
-        !isLocalMode() && getSettings().sandboxProviderKind === "agent-sandbox",
+      agentSandbox: !isLocalMode() && !!getSettings().agentSandboxEnabled,
     },
   };
 

--- a/apps/api/src/api/routes/sandbox-events-handler.ts
+++ b/apps/api/src/api/routes/sandbox-events-handler.ts
@@ -9,16 +9,13 @@
 
 import type { Context } from "hono";
 import { streamSSE } from "hono/streaming";
-import {
-  resolveSandboxProviderKindFromEnv,
-  type SandboxProviderKind,
-  type SandboxProvider,
-} from "@decocms/sandbox/provider";
+import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
 import { delay, exponentialBackoffWithJitter } from "@decocms/shared/std";
 import { subscribeLifecycle } from "../../sandbox/lifecycle";
 import type { StudioContext } from "../../core/studio-context";
 import { KyselySandboxProviderStateStore } from "../../storage/sandbox-runner-state";
 import {
+  AGENT_SANDBOX_KIND,
   readSandboxMap,
   removeSandboxMapEntry,
   resolveVm,
@@ -81,7 +78,7 @@ const PROXY_BACKOFF_CAP_MS = 10_000;
 export interface VmEventsHandlerArgs {
   ctx: StudioContext;
   claimName: string;
-  runner: SandboxProvider;
+  runner: AgentSandboxProvider;
   virtualMcpId: string;
   branch: string;
   userId: string;
@@ -100,8 +97,6 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
     projectRef,
     virtualMcpMetadata,
   } = args;
-  const providerKind = resolveSandboxProviderKindFromEnv();
-
   // The agent row is a no-op sandbox store for the synthetic Decopilot agent —
   // its records live on the THREAD (see `setThreadSandboxMapEntry`). Resolve the
   // thread id from the branch so the stale-handle check below covers thread-
@@ -121,7 +116,7 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
     }, HEARTBEAT_MS);
     // Renew immediately as well as on the interval: a stream that reconnects
     // onto a long-lived sandbox is adopting a TTL that is already part-spent.
-    const renew = () => void runner.renewTtl?.(claimName);
+    const renew = () => void runner.renewTtl(claimName);
     renew();
     const ttlRenew = setInterval(renew, TTL_RENEW_MS);
     stream.onAbort(() => {
@@ -137,7 +132,6 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
         readSandboxMap(virtualMcpMetadata),
         userId,
         branch,
-        providerKind,
       );
       let fromThread = false;
       if (!vmEntry && threadId) {
@@ -145,12 +139,9 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
           await getThreadSandboxMap(ctx, threadId),
           userId,
           branch,
-          providerKind,
         );
         fromThread = !!vmEntry;
       }
-      const existingProviderKind: SandboxProviderKind | null =
-        vmEntry?.sandboxProviderKind ?? null;
 
       if (vmEntry?.sandboxHandle === claimName) {
         const stale = await isStaleHandle(runner, claimName);
@@ -163,7 +154,6 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
             branch,
             userId,
             projectRef,
-            sandboxProviderKind: existingProviderKind ?? providerKind,
             threadId: fromThread ? threadId : null,
           });
           await stream.writeSSE({ event: "gone", data: "" }).catch(() => {});
@@ -225,7 +215,7 @@ const HEAD_REF_RESPONSE_MAX_BYTES = 256 * 1024;
  */
 async function recordDaemonHeadRef(args: {
   ctx: StudioContext;
-  runner: SandboxProvider;
+  runner: AgentSandboxProvider;
   claimName: string;
   branch: string;
   threadId: string | null;
@@ -265,7 +255,7 @@ async function recordDaemonHeadRef(args: {
 }
 
 async function isStaleHandle(
-  runner: SandboxProvider,
+  runner: AgentSandboxProvider,
   claimName: string,
 ): Promise<boolean> {
   try {
@@ -283,13 +273,12 @@ async function isStaleHandle(
 
 async function cleanupStaleEntry(args: {
   ctx: StudioContext;
-  runner: SandboxProvider;
+  runner: AgentSandboxProvider;
   claimName: string;
   virtualMcpId: string;
   branch: string;
   userId: string;
   projectRef: string;
-  sandboxProviderKind: SandboxProviderKind;
   /** Set when the stale entry was found on the thread (synthetic agent) — clear
    *  it there instead of / in addition to the agent row. */
   threadId: string | null;
@@ -302,7 +291,6 @@ async function cleanupStaleEntry(args: {
     branch,
     userId,
     projectRef,
-    sandboxProviderKind,
     threadId,
   } = args;
   // Drop the thread's sandboxMap entry first. A dangling `sandboxHandle` left
@@ -311,16 +299,10 @@ async function cleanupStaleEntry(args: {
   // that only stops when the tab closes.
   if (threadId) {
     try {
-      await removeThreadSandboxMapEntry(
-        ctx,
-        threadId,
-        userId,
-        branch,
-        sandboxProviderKind,
-      );
+      await removeThreadSandboxMapEntry(ctx, threadId, userId, branch);
     } catch (err) {
       console.warn(
-        `[vm-events] thread sandboxMap cleanup failed for ${threadId}/${branch}/${sandboxProviderKind}: ${
+        `[vm-events] thread sandboxMap cleanup failed for ${threadId}/${branch}/${AGENT_SANDBOX_KIND}: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
@@ -335,12 +317,11 @@ async function cleanupStaleEntry(args: {
         userId,
         userId,
         branch,
-        sandboxProviderKind,
       );
     }
   } catch (err) {
     console.warn(
-      `[vm-events] sandboxMap cleanup failed for ${virtualMcpId}/${branch}/${sandboxProviderKind}: ${
+      `[vm-events] sandboxMap cleanup failed for ${virtualMcpId}/${branch}/${AGENT_SANDBOX_KIND}: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
@@ -356,10 +337,10 @@ async function cleanupStaleEntry(args: {
   }
   try {
     const stateStore = new KyselySandboxProviderStateStore(ctx.db);
-    await stateStore.delete({ userId, projectRef }, sandboxProviderKind);
+    await stateStore.delete({ userId, projectRef }, AGENT_SANDBOX_KIND);
   } catch (err) {
     console.warn(
-      `[vm-events] sandbox_runner_state delete failed for ${userId}/${projectRef}/${sandboxProviderKind}: ${
+      `[vm-events] sandbox_runner_state delete failed for ${userId}/${projectRef}/${AGENT_SANDBOX_KIND}: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
@@ -369,7 +350,7 @@ async function cleanupStaleEntry(args: {
 async function emitLifecycle(args: {
   stream: import("hono/streaming").SSEStreamingApi;
   claimName: string;
-  runner: SandboxProvider;
+  runner: AgentSandboxProvider;
   signal: AbortSignal;
 }): Promise<boolean> {
   const { stream, claimName, runner, signal } = args;
@@ -413,7 +394,7 @@ async function emitLifecycle(args: {
 
 async function proxyDaemonEvents(args: {
   stream: import("hono/streaming").SSEStreamingApi;
-  runner: SandboxProvider;
+  runner: AgentSandboxProvider;
   claimName: string;
   signal: AbortSignal;
 }): Promise<void> {
@@ -440,10 +421,10 @@ async function proxyDaemonEvents(args: {
       }
       // Daemon unreachable past the budget. Don't emit a terminal failure —
       // end the stream so the client's EventSource reconnects (it will pick
-      // up logs / `gone` once the link is back). Latching here froze the
-      // preview across a `deco link` relink. Log once (per ~60s SSE attempt)
-      // so an operator can tell an expected `deco link` outage from a
-      // misconfig/crash without the client seeing a terminal failure.
+      // up logs / `gone` once the daemon is reachable again). Latching here
+      // froze previews across transient daemon restarts. Log once (per ~60s
+      // SSE attempt) so an operator can distinguish an outage from a
+      // misconfiguration/crash without the client seeing a terminal failure.
       console.warn(
         `[vm-events] daemon unreachable past budget for ${claimName}: ${
           err instanceof Error ? err.message : String(err)

--- a/apps/api/src/api/routes/sandbox-proxy.test.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
 import { delay } from "@decocms/shared/std";
-import type { SandboxProvider } from "@decocms/sandbox/provider";
 import {
   readBoundedText,
   UpstreamPayloadTooLargeError,
@@ -98,17 +97,11 @@ describe("withClaimGitLock", () => {
   });
 });
 
-function fakeRunner(response: Response): SandboxProvider {
+function fakeRunner(response: Response): Parameters<typeof fetchDaemonJson>[0] {
   return {
-    kind: "agent-sandbox",
-    ensure: async () => {
-      throw new Error("unused");
-    },
-    delete: async () => {},
-    alive: async () => true,
-    getPreviewUrl: async () => null,
     proxyDaemonRequest: async () => response,
-  } as unknown as SandboxProvider;
+    adoptLiveClaim: async () => false,
+  };
 }
 
 describe("fetchDaemonJson", () => {
@@ -130,7 +123,7 @@ describe("fetchDaemonJson", () => {
     ).rejects.toThrow("Daemon error (502)");
   });
 
-  it("throws SANDBOX_GONE on a 404 with no adoptLiveClaim to retry", async () => {
+  it("throws SANDBOX_GONE when a 404 cannot be adopted", async () => {
     const runner = fakeRunner(new Response("not found", { status: 404 }));
     await expect(
       fetchDaemonJson(runner, "claim-a", "/_sandbox/git/status"),

--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -16,8 +16,10 @@ import { bodyLimit } from "hono/body-limit";
 import { streamSSE } from "hono/streaming";
 import { createMiddleware } from "hono/factory";
 import { composeSandboxRef } from "@decocms/sandbox/provider";
-import type { SandboxProvider } from "@decocms/sandbox/provider";
-import type { ClaimPhase } from "@decocms/sandbox/provider/agent-sandbox";
+import type {
+  AgentSandboxProvider,
+  ClaimPhase,
+} from "@decocms/sandbox/provider/agent-sandbox";
 import { computeClaimHandle } from "../../sandbox/claim-handle";
 import {
   loadBranchThread,
@@ -32,7 +34,7 @@ import {
 } from "@decocms/shared/thread/session-runtime";
 import { liveSandboxForBranch } from "../../tools/sandbox/live-sandbox-for-branch";
 import { stampRuntimeIfAbsent } from "../../tools/thread/stamp-runtime-if-absent";
-import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
+import { getAgentSandboxProvider } from "../../sandbox/lifecycle";
 import {
   getUserId,
   requireAuth,
@@ -65,7 +67,6 @@ import {
   buildLoaderInvokeUrl,
   parseLoaderInvokeRequest,
 } from "../../lib/loader-invoke";
-import { loopbackPreviewTarget } from "../../lib/loopback-preview";
 import {
   GitPushAuthError,
   parseGithubRepoFromMetadata,
@@ -82,7 +83,7 @@ interface VmClaim {
   callerUserId: string;
   /** Null when no sandbox runner is configured on this studio instance — or
    *  when the session is sandbox-less (`runtime` below). */
-  runner: SandboxProvider | null;
+  runner: AgentSandboxProvider | null;
   virtualMcpId: string;
   branch: string;
   userId: string;
@@ -129,14 +130,10 @@ const PREVIEW_INVOKE_MAX_BODY_BYTES = 64 * 1024;
 
 /**
  * Quick interactive file ops (read/write/mkdir/unlink/rename/glob) must fail
- * FAST when the daemon link is partitioned. Without an explicit bound they
- * inherit the tunnel dispatch's 30s first-frame timeout (see
- * `links/tunnel-dispatch.ts`), so a read against a severed link hangs ~30s
- * before erroring. These ops answer in well under a second on a healthy link,
- * so a 10s ceiling never trips when the daemon is reachable but turns a
- * partition into a prompt 502 instead of a 30s stall. Streaming/long ops
- * (exec, events, git/*) are intentionally NOT bounded here - the daemon itself
- * allows up to 60s for upstream headers (see `daemon/proxy.ts`).
+ * fast when the hosted daemon is unreachable. These ops answer in well under
+ * a second on a healthy sandbox, so a 10s ceiling turns a broken pod/network
+ * path into a prompt 502. Streaming/long ops (exec, events, git/*) retain their
+ * operation-specific lifetimes.
  */
 const QUICK_FILE_OP_TIMEOUT_MS = 10_000;
 const GIT_STATUS_TIMEOUT_MS = 2_000;
@@ -214,18 +211,6 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
   const virtualMcpMetadata =
     (virtualMcp.metadata as Record<string, unknown>) ?? null;
 
-  // Source of truth: sandboxMap. If an entry exists for (user, branch) we use
-  // that recorded kind — a sandbox provisioned via `desktop` must
-  // remain addressable via `desktop` even on a cluster whose env kind
-  // is `agent-sandbox` / `docker`. Pre-provision callers fall through to
-  // the link-or-env default policy inside `resolveSandboxProvider`.
-  //
-  // On failure (e.g. the recorded kind is `desktop` but the user's
-  // link daemon is offline) we surface `null` rather than falling back
-  // to the env singleton: rebinding a `desktop`-provisioned VM onto
-  // a different provider kind (say `agent-sandbox`) would forward traffic
-  // to a sandbox that doesn't host this VM. The events handler streams a
-  // `failed` phase from null; other handlers 503 via `requireRunner`.
   // Sandbox-less Fast Preview: there is no runner by design. Claim the route
   // with runner:null + the flag so the `/git/*` handlers serve their
   // GitHub-backed equivalents; daemon-backed routes 503 via requireRunner.
@@ -255,14 +240,9 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
     return next();
   }
 
-  let runner: SandboxProvider | null;
+  let runner: AgentSandboxProvider | null;
   try {
-    const resolved = await resolveSandboxProvider(ctx, {
-      userId: sandboxUserId,
-      branch,
-      virtualMcpMetadata,
-    });
-    runner = resolved.provider;
+    runner = await getAgentSandboxProvider(ctx);
   } catch {
     runner = null;
   }
@@ -334,9 +314,6 @@ async function resolveClaimRuntime(
     projectDefault === "cms"
       ? await liveSandboxForBranch(ctx, {
           claimName: claim.claimName,
-          userId: claim.sandboxUserId,
-          branch: claim.branch,
-          virtualMcpMetadata: claim.virtualMcpMetadata,
         })
       : "alive";
   const runtime: ThreadRuntime =
@@ -373,23 +350,18 @@ async function resolveClaimRuntime(
  */
 async function resolveBranchRunner(
   c: Context<VmEnv>,
-): Promise<SandboxProvider | null> {
+): Promise<AgentSandboxProvider | null> {
   const claim = c.get("vmClaim");
   if (claim.runner) return claim.runner;
   try {
-    const { provider } = await resolveSandboxProvider(c.var.studioContext, {
-      userId: claim.userId,
-      branch: claim.branch,
-      virtualMcpMetadata: claim.virtualMcpMetadata,
-    });
-    return provider;
+    return await getAgentSandboxProvider(c.var.studioContext);
   } catch {
     return null;
   }
 }
 
 /** Guard for routes that need a non-null runner. Returns the runner or a 503. */
-function requireRunner(c: Context<VmEnv>): SandboxProvider | Response {
+function requireRunner(c: Context<VmEnv>): AgentSandboxProvider | Response {
   const { runner } = c.get("vmClaim");
   if (!runner) {
     return c.json({ error: "No sandbox runner configured" }, 503);
@@ -537,18 +509,10 @@ async function proxyDaemon(
     signal?: AbortSignal;
     /** Map 404 to 410 (sandbox needs re-provision). */
     map404to410?: boolean;
-    /**
-     * Null out `repoDir` in the JSON response unless the resolved runner is
-     * `user-desktop`. Every daemon reports `repoDir` as its own
-     * container-internal path (`/app/repo` on agent-sandbox); only a desktop
-     * link daemon's path exists on the user's machine. The frontend uses this
-     * to build `vscode://file<repoDir>` deep links — surfacing a container path
-     * pops a "Path does not exist" error. Authoritative because it keys off the
-     * resolved runner, immune to a stale/racing frontend provider-kind.
-     */
-    redactRepoDirUnlessDesktop?: boolean;
+    /** Null out the hosted daemon's container-internal `repoDir`. */
+    redactRepoDir?: boolean;
     /** Pod-addressed route: act on this runner whatever the session's runtime is. */
-    runner?: SandboxProvider;
+    runner?: AgentSandboxProvider;
   },
 ) {
   // Sandbox-less Fast Preview: daemon-backed routes have no daemon, ever.
@@ -609,7 +573,7 @@ async function proxyDaemon(
       } catch {
         /* ignore */
       }
-      const adopted = await runner.adoptLiveClaim?.(
+      const adopted = await runner.adoptLiveClaim(
         { userId, projectRef },
         claimName,
       );
@@ -643,10 +607,7 @@ async function proxyDaemon(
     }
 
     const rawText = await upstream.text();
-    const text =
-      opts?.redactRepoDirUnlessDesktop && runner.kind !== "user-desktop"
-        ? redactRepoDir(rawText)
-        : rawText;
+    const text = opts?.redactRepoDir ? redactRepoDir(rawText) : rawText;
     const contentType =
       upstream.headers.get("content-type") ?? "application/json";
     return new Response(text, {
@@ -709,7 +670,10 @@ export function redactRepoDir(text: string): string {
 }
 
 export async function fetchDaemonJson<T>(
-  runner: SandboxProvider,
+  runner: {
+    proxyDaemonRequest: AgentSandboxProvider["proxyDaemonRequest"];
+    adoptLiveClaim: AgentSandboxProvider["adoptLiveClaim"];
+  },
   claimName: string,
   daemonPath: string,
   method: "GET" | "POST" = "GET",
@@ -727,7 +691,7 @@ export async function fetchDaemonJson<T>(
     } catch {
       /* ignore */
     }
-    const adopted = await runner.adoptLiveClaim?.(sandboxId, claimName);
+    const adopted = await runner.adoptLiveClaim(sandboxId, claimName);
     if (adopted) {
       upstream = await runner.proxyDaemonRequest(claimName, daemonPath, {
         method,
@@ -840,9 +804,8 @@ export const createSandboxRoutes = () => {
     proxyDaemon(c, "/_sandbox/config", {
       method: "GET",
       map404to410: true,
-      // A container path (`/app/repo`) is never openable on the user's
-      // machine — only surface `repoDir` for the desktop link daemon.
-      redactRepoDirUnlessDesktop: true,
+      // A hosted container path (`/app/repo`) is never openable locally.
+      redactRepoDir: true,
     }),
   );
   app.put("/:virtualMcpId/:branch/config", (c) =>
@@ -850,7 +813,7 @@ export const createSandboxRoutes = () => {
       method: "PUT",
       forwardJsonBody: true,
       map404to410: true,
-      // No `redactRepoDirUnlessDesktop` here: the PUT response echoes the
+      // No `redactRepoDir` here: the PUT response echoes the
       // written TenantConfig (git/operator/application), which carries no
       // `repoDir` — only the GET read handler surfaces it.
     }),
@@ -871,17 +834,13 @@ export const createSandboxRoutes = () => {
         400,
       );
     }
-    // Pod-addressed means a pod that EXISTS. `resolveSandboxProvider` hands
-    // back the env-default provider for any caller, so without the liveness
+    // Pod-addressed means a pod that EXISTS. Without the liveness
     // check a sandbox-less session would proxy to a daemon that was never
     // provisioned and get a 410 where it used to get a clean 404.
     const claim = c.get("vmClaim");
     const podRunner =
       (await liveSandboxForBranch(c.var.studioContext, {
         claimName: claim.claimName,
-        userId: claim.userId,
-        branch: claim.branch,
-        virtualMcpMetadata: claim.virtualMcpMetadata,
       })) === "gone"
         ? null
         : await resolveBranchRunner(c);
@@ -1149,7 +1108,7 @@ export const createSandboxRoutes = () => {
       const claim = c.get("vmClaim");
       // runner === null ⇔ sandbox-less Fast Preview (the claim middleware
       // only admits a null runner for that mode).
-      let runner: SandboxProvider | null = null;
+      let runner: AgentSandboxProvider | null = null;
       if (claim.runtime !== "cms") {
         const required = requireRunner(c);
         if (required instanceof Response) return required;
@@ -1239,7 +1198,7 @@ export const createSandboxRoutes = () => {
     async (c) => {
       const claim = c.get("vmClaim");
       // runner === null ⇔ sandbox-less Fast Preview (see suggest-commit).
-      let runner: SandboxProvider | null = null;
+      let runner: AgentSandboxProvider | null = null;
       if (claim.runtime !== "cms") {
         const required = requireRunner(c);
         if (required instanceof Response) return required;
@@ -1354,10 +1313,7 @@ export const createSandboxRoutes = () => {
     }
 
     const base = previewUrl.replace(/\/+$/, "");
-    const loopback = loopbackPreviewTarget(`${base}${path}`);
-    return proxyPreviewUpstream(c, loopback?.url ?? `${base}${path}`, {
-      ...(loopback ? { headers: { host: loopback.hostHeader } } : {}),
-    });
+    return proxyPreviewUpstream(c, `${base}${path}`);
   });
 
   // -- Preview invoke (loader/action resolution) ------------------------------
@@ -1399,12 +1355,10 @@ export const createSandboxRoutes = () => {
       }
 
       const invokeUrl = buildLoaderInvokeUrl(previewUrl, invoke.resolveType);
-      const loopback = loopbackPreviewTarget(invokeUrl);
-      return proxyPreviewUpstream(c, loopback?.url ?? invokeUrl, {
+      return proxyPreviewUpstream(c, invokeUrl, {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          ...(loopback ? { host: loopback.hostHeader } : {}),
         },
         body: JSON.stringify(invoke.payload),
         signal: AbortSignal.timeout(30_000),

--- a/apps/api/src/file-storage/mount/provisioning.ts
+++ b/apps/api/src/file-storage/mount/provisioning.ts
@@ -1,7 +1,6 @@
 /**
- * Builds the `ORGFS_CONFIG` payload the studio pushes to a sandbox daemon (as a
- * boot env var) to turn on org-fs mounting. The daemon's `parseOrgFsConfig`
- * (packages/sandbox/orgfs/config.ts) validates this shape.
+ * Builds the org-fs payload Studio posts to a sandbox daemon. The daemon
+ * validates and relays this shape to its mounter sidecar.
  *
  * The mounted set is hardcoded for now (per the team decision); later this
  * becomes per-agent configurable. Three volumes (org skills are deliberately
@@ -33,8 +32,8 @@ import {
   publicVolumeForSet,
 } from "../public-sets";
 
-/** Shape the daemon parses from ORGFS_CONFIG (mirrors OrgFsMountConfig). */
-export interface OrgFsProvisionConfig {
+/** Shape the daemon relays to the sidecar (mirrors OrgFsMountConfig). */
+interface OrgFsProvisionConfig {
   baseUrl: string;
   orgSlug: string;
   token: string;
@@ -101,16 +100,16 @@ export function buildOrgFsConfig(opts: {
   };
 }
 
-/** API-key lifetime for the org-fs token baked into a sandbox's ORGFS_CONFIG.
+/** API-key lifetime for the org-fs token relayed to a sandbox.
  *  Sandboxes are ephemeral and re-provisioned (re-minting) on restart, so a
  *  generous fixed TTL is fine for now; tie to the sandbox lifecycle later. */
 const ORG_FS_KEY_TTL_SECONDS = 60 * 60 * 24 * 7;
 
 /**
- * Mint an org-fs API key for the caller and return the JSON `ORGFS_CONFIG` the
- * daemon mounts from — or `undefined` if minting fails (mounting is then simply
- * skipped; never breaks sandbox provisioning). Used by both sandbox-ensure
- * paths (SANDBOX_START + dispatch), desktop-only.
+ * Mint an org-fs API key for the caller and return the JSON config the daemon
+ * relays to its sidecar — or `undefined` if minting fails (mounting is then
+ * skipped; never breaks sandbox provisioning). Used by both hosted
+ * sandbox-ensure paths (SANDBOX_START + dispatch).
  */
 export async function mintOrgFsConfigJson(
   ctx: {

--- a/apps/api/src/harnesses/cross-tree-guard.test.ts
+++ b/apps/api/src/harnesses/cross-tree-guard.test.ts
@@ -8,20 +8,13 @@ import { Glob } from "bun";
 // ../../api/routes/decopilot/*, ../../ai-providers/*, or ../../shared/*").
 //
 // `core`/`storage`/`tools` are intentionally NOT in the pattern: the
-// cluster-side DI assemblers (`in-process-sandbox-client.ts`,
-// `decopilot/harness-deps.ts`, `decopilot/index.ts`) legitimately keep
-// `StudioContext`/`HarnessContext` type reaches (`../core/studio-context`,
-// `../../core/harness-context`) — that DI surface is rewritten to
-// harness-lib specifiers when the package moved, and stays that way.
+// cluster-side DI assembler (`decopilot/harness-deps.ts`) legitimately keeps
+// its `StudioContext` reach. That cluster file is outside the portable lib
+// subtree guarded by the lint rule.
 //
 // Excludes:
 //  - *.integration.test.ts (DB-backed; stays studio-side, not packaged)
-//  - local-dispatch.ts / index.ts (studio-only, folded into InProcessSandboxClient)
-const EXCLUDED = new Set([
-  "local-dispatch.ts",
-  "local-dispatch.test.ts",
-  "index.ts", // top-level studio barrel
-]);
+//  - index.ts (the top-level Studio barrel)
 const CROSS_TREE =
   /from\s+["'](?:\.\.\/)+(?:api\/routes\/decopilot|ai-providers|shared)\//;
 
@@ -32,7 +25,7 @@ describe("harness tree is cross-tree-free", () => {
     for await (const rel of new Glob("**/*.ts").scan(root)) {
       if (rel.endsWith(".integration.test.ts")) continue;
       const base = rel.split("/").pop()!;
-      if (rel === base && EXCLUDED.has(base)) continue;
+      if (rel === base && base === "index.ts") continue;
       const src = await Bun.file(root + rel).text();
       if (CROSS_TREE.test(src)) offenders.push(rel);
     }
@@ -46,20 +39,14 @@ describe("harness tree is cross-tree-free", () => {
 // `@decocms/sandbox` in the package DAG, so a `@decocms/sandbox` import here is
 // not a layering violation — but we still keep that surface explicit and small.
 // Only the dispatch/fs glue modules may bridge into sandbox:
-//  - `in-process-sandbox-client.ts` implements the `SandboxClient` dispatch
-//    contract (`@decocms/sandbox/dispatch`) for in-process cluster dispatch.
-//  - `sandbox-dispatch-client.ts` implements the SAME contract for harnesses
-//    that run inside the sandbox (claude-code): it needs the provider to
-//    provision the pod and proxy the daemon request. Its sibling by design —
-//    one `SandboxClient` impl per execution location.
-//  - `cluster-sandbox-fs.ts` constructs the cluster `SandboxProvider` + fs hooks.
+//  - `sandbox-dispatch-client.ts` runs claude-code inside the sandbox and needs
+//    the provider to provision the pod and proxy the daemon request.
+//  - `agent-sandbox-fs.ts` constructs the hosted provider + fs hooks.
 // Every other production file consumes the harness-owned flat `SandboxFsHooks`
-// via DI and stays sandbox-free. (`desktop-sandbox-fs.ts` relocated into
-// `@decocms/sandbox/dispatch` with the desktop subtree in the package-move slice.)
+// via DI and stays sandbox-free.
 const SANDBOX_GLUE = new Set([
-  "in-process-sandbox-client.ts",
   "sandbox-dispatch-client.ts",
-  "decopilot/built-in-tools/cluster-sandbox-fs.ts",
+  "decopilot/built-in-tools/agent-sandbox-fs.ts",
 ]);
 const SANDBOX_IMPORT = /from\s+["']@decocms\/sandbox/;
 

--- a/apps/api/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/api/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -24,7 +24,7 @@ import {
   type CodingWorkspacePromptInput,
 } from "@/harnesses/lib/coding-workspace-prompt";
 import { buildOrgFilesystemPrompt } from "@/api/routes/decopilot/constants";
-import { sandboxIsDecoSite } from "./built-in-tools/cluster-sandbox-fs";
+import { sandboxIsDecoSite } from "./built-in-tools/agent-sandbox-fs";
 import type { GithubRepo } from "@decocms/shared/sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {

--- a/apps/api/src/harnesses/decopilot/built-in-tools/agent-sandbox-fs.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/agent-sandbox-fs.ts
@@ -1,26 +1,23 @@
 /**
- * CLUSTER sandbox-fs glue (option-b sandbox decoupling).
+ * Hosted AgentSandbox filesystem glue.
  *
- * Isolates the `@decocms/sandbox` builder + the cluster sandbox-provisioning
+ * Isolates the `@decocms/sandbox` builder + hosted sandbox-provisioning
  * `@/` imports that the portable built-in tools must NOT carry. The harness VM
- * tools consume the flat `SandboxFsHooks` returned here and never see
- * `SandboxProvider` (spec §4.3).
+ * tools consume the flat `SandboxFsHooks` returned here and never depend on
+ * the hosted provider implementation (spec §4.3).
  *
  * ASSEMBLER-GLUE: this module stays `@/`- and `@decocms/sandbox`-coupled and is
- * slated to relocate into the cluster assembler (`harness-deps.ts`) in the
+ * slated to relocate into the hosted assembler (`harness-deps.ts`) in the
  * package-move phase (spec Phase 5). The portable consumer
  * (`built-in-tools/index.ts`) imports only this relative module — no
  * `@decocms/sandbox`.
  */
 
-import {
-  createSandboxFsHooks,
-  type SandboxProvider,
-  type SandboxProviderKind,
-} from "@decocms/sandbox/provider";
+import { createSandboxFsHooks } from "@decocms/sandbox/provider";
+import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
 import type { StudioContext } from "@/core/studio-context";
 import { mintMcpEndpoint } from "@/mcp-clients/virtual-mcp/mint-endpoint";
-import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
+import { getAgentSandboxProvider } from "@/sandbox/lifecycle";
 import { ensureSandbox } from "@/tools/sandbox/start";
 import { removeSandboxMapEntry } from "@/tools/sandbox/sandbox-map";
 import type { SandboxFsHooks } from "@/harnesses/lib/decopilot/built-in-tools/vm-tools/sandbox-fs-hooks-types";
@@ -38,9 +35,9 @@ import type { SandboxFsHooks } from "@/harnesses/lib/decopilot/built-in-tools/vm
  */
 async function syncToolsCatalog(
   ctx: StudioContext,
-  runner: SandboxProvider,
+  runner: AgentSandboxProvider,
   handle: string,
-  vm: { virtualMcpId: string; providerKind: SandboxProviderKind },
+  vm: { virtualMcpId: string },
 ): Promise<void> {
   try {
     const organization = ctx.organization;
@@ -62,28 +59,27 @@ async function syncToolsCatalog(
     );
     if (!res.ok) {
       console.warn(
-        "[cluster-sandbox-fs] tools/sync failed",
+        "[agent-sandbox-fs] tools/sync failed",
         res.status,
         await res.text().catch(() => ""),
       );
     }
   } catch (err) {
-    console.warn("[cluster-sandbox-fs] tools/sync failed", err);
+    console.warn("[agent-sandbox-fs] tools/sync failed", err);
   }
 }
 
 /**
- * Build the cluster flat fs hooks for a (virtualMcp, branch, user) tuple.
+ * Build hosted AgentSandbox fs hooks for a (virtualMcp, branch, user) tuple.
  *
  * Behavior-identical to the block formerly inline in `buildAllTools`: the
- * provider is resolved eagerly (it short-circuits on `ctx.sandboxPreference`
- * populated by dispatch-run, so no DB hit), while the
+ * provider is resolved eagerly, while the
  * sandbox PROVISIONING stays lazy behind the memoized `ensureHandle` closure —
  * `ensureSandbox` only runs on the first VM-tool invocation. The
  * handle-resolution + auto-restart retry layer lives inside
- * `createSandboxFsHooks`, so the VM tools never touch `SandboxProvider`.
+ * `createSandboxFsHooks`, so the VM tools never touch `AgentSandboxProvider`.
  */
-export async function buildClusterSandboxFs(
+export async function buildAgentSandboxFs(
   ctx: StudioContext,
   vm: {
     virtualMcpId: string;
@@ -97,28 +93,12 @@ export async function buildClusterSandboxFs(
     threadId?: string;
   },
 ): Promise<SandboxFsHooks> {
-  // `dispatch-run` already populated `ctx.sandboxPreference` from the resolved
-  // `DispatchTarget`, so the resolver short-circuits on that ctx hint without
-  // reading sandboxMap — no DB hit on the decopilot hot path. The same `kind`
-  // flows into `ensureSandbox` below so `runner` and the provisioned handle come
-  // from the same provider.
-  const { provider: runner, kind: providerKind } = await resolveSandboxProvider(
-    ctx,
-    {
-      userId: vm.userId,
-      branch: vm.branch,
-      virtualMcpMetadata: null,
-    },
-  );
+  const runner = await getAgentSandboxProvider(ctx);
   let cached: Promise<string> | null = null;
   const ensureHandle = () => {
     if (!cached) {
       cached = ensureSandbox(
-        {
-          virtualMcpId: vm.virtualMcpId,
-          branch: vm.branch,
-          sandboxProviderKind: providerKind,
-        },
+        { virtualMcpId: vm.virtualMcpId, branch: vm.branch },
         ctx,
       ).then((entry) => entry.sandboxHandle);
       // Reset on failure so the next tool call retries instead of
@@ -135,7 +115,6 @@ export async function buildClusterSandboxFs(
           .then((handle) =>
             syncToolsCatalog(ctx, runner, handle, {
               virtualMcpId: vm.virtualMcpId,
-              providerKind,
             }),
           )
           .catch(() => {});
@@ -144,16 +123,9 @@ export async function buildClusterSandboxFs(
     return cached;
   };
   // Ephemeral agents have no restart button, so the call layer auto-restarts on
-  // proxy failure. user-desktop sandboxes also auto-restart: the local daemon
-  // can drop/relink under the user at any time, and the iframe + ingress
-  // already render the reconnecting state, so a dead-daemon proxy error should
-  // reap + respawn rather than surface a sticky failure.
-  const canAutoRestart =
-    vm.branch === "ephemeral" || providerKind === "user-desktop";
+  // proxy failure.
+  const canAutoRestart = vm.branch === "ephemeral";
   const invalidateHandle = async (opts?: { force?: boolean }) => {
-    // Capture before clearing — we need the dead handle to flush the captured
-    // runner's cache below.
-    const lastHandlePromise = cached;
     cached = null;
     // `force` (set by the retry layer when the daemon reported the sandbox is
     // provably GONE — 404) reaps + respawns even for non-auto-restart branches:
@@ -169,22 +141,9 @@ export async function buildClusterSandboxFs(
         vm.userId,
         vm.userId,
         vm.branch,
-        providerKind,
       );
     } catch (err) {
-      console.warn("[cluster-sandbox-fs] failed to reap vmMap entry", err);
-    }
-    // Flush the captured runner's in-process cache + state-store row.
-    // `ensureSandbox` constructs its own provider instance for the respawn, so
-    // without this the captured `runner` (used for proxy calls) would keep
-    // serving the dead URL out of its records map on the retry.
-    if (lastHandlePromise && typeof runner.forgetHandle === "function") {
-      try {
-        const lastHandle = await lastHandlePromise;
-        await runner.forgetHandle(lastHandle);
-      } catch (err) {
-        console.warn("[cluster-sandbox-fs] forgetHandle failed", err);
-      }
+      console.warn("[agent-sandbox-fs] failed to reap vmMap entry", err);
     }
   };
   return createSandboxFsHooks(runner, {
@@ -202,7 +161,7 @@ export async function buildClusterSandboxFs(
  * don't carry it as dead weight.
  *
  * Runs `test -d .deco` from the daemon's default bash cwd (the repo root). It
- * reuses `buildClusterSandboxFs`, so the sandbox `ensureSandbox` resolution is
+ * reuses `buildAgentSandboxFs`, so the sandbox `ensureSandbox` resolution is
  * memoized: on an already-running sandbox (the common case for an active coding
  * thread) this is a cheap proxied bash call; on the first turn it provisions
  * the same sandbox the VM file tools will use moments later.
@@ -216,12 +175,12 @@ export async function sandboxIsDecoSite(
   vm: { virtualMcpId: string; branch: string; userId: string },
 ): Promise<boolean> {
   try {
-    const fs = await buildClusterSandboxFs(ctx, vm);
+    const fs = await buildAgentSandboxFs(ctx, vm);
     const { stdout } = await fs.onBash("test -d .deco && echo __DECO_SITE__");
     return stdout.includes("__DECO_SITE__");
   } catch (err) {
     console.warn(
-      "[cluster-sandbox-fs] .deco probe failed; assuming deco site",
+      "[agent-sandbox-fs] .deco probe failed; assuming deco site",
       err,
     );
     return true;

--- a/apps/api/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/index.ts
@@ -47,7 +47,7 @@ import { createReadToolOutputTool } from "@/harnesses/lib/decopilot/built-in-too
 import { type VirtualClient } from "@/harnesses/lib/decopilot/built-in-tools/sandbox";
 import { createVmTools } from "@/harnesses/lib/decopilot/built-in-tools/vm-tools/index";
 import type { HtmlArtifactBuffer } from "@/harnesses/lib/decopilot/built-in-tools/vm-tools/types";
-import { buildClusterSandboxFs } from "./cluster-sandbox-fs";
+import { buildAgentSandboxFs } from "./agent-sandbox-fs";
 import { createSwappableFs } from "./swappable-fs";
 import { createLoadRepoTool } from "./load-repo";
 import { createSubtaskTool, SubtaskInputSchema } from "./subtask";
@@ -205,7 +205,7 @@ async function buildAllTools(
     objectStorage: ctx.objectStorage,
   });
   if (userId) {
-    // Cluster `interests.write` hook: closes over ctx/storage and forwards the
+    // Hosted `interests.write` hook: closes over ctx/storage and forwards the
     // org/agent/user carried in the InterestsWrite payload. The tool itself no
     // longer touches StudioContext (HarnessDeps conversion).
     tools.update_interests = createUpdateInterestsTool({
@@ -232,8 +232,8 @@ async function buildAllTools(
   // VM file tools — six LLM-visible tools (read/write/edit/grep/glob/bash)
   // always registered when a vmContext is provided. The handle is resolved
   // lazily on the first tool invocation: `ensureSandbox` either reuses
-  // the existing sandboxMap entry (fast path) or provisions a new sandbox via
-  // the env-selected runner. The promise is memoized on the closure so
+  // the existing sandboxMap entry (fast path) or provisions a new hosted
+  // sandbox. The promise is memoized on the closure so
   // parallel first calls (e.g. the model emitting bash + read in one step)
   // share a single provisioning round-trip.
   const vmNeedsApproval =
@@ -243,10 +243,10 @@ async function buildAllTools(
   let vmTools: ToolSet | undefined;
   if (vmContext) {
     // The flat fs hooks (provider resolution + lazy handle + auto-restart retry
-    // layer) are built by the cluster glue so the portable tools never import
+    // layer) are built by the AgentSandbox glue so the portable tools never import
     // `@decocms/sandbox` (spec §4.3). Provisioning stays lazy inside the hooks —
     // `ensureSandbox` runs on the first VM-tool call, not here.
-    const initialFs = await buildClusterSandboxFs(ctx, {
+    const initialFs = await buildAgentSandboxFs(ctx, {
       virtualMcpId: vmContext.virtualMcpId,
       branch: vmContext.branch,
       userId: vmContext.userId,
@@ -285,7 +285,7 @@ async function buildAllTools(
       // tool catalog. Provisioning stays lazy — the next VM-tool call ensures it.
       rebindFs: async (branch) => {
         swappableFs.swap(
-          await buildClusterSandboxFs(ctx, {
+          await buildAgentSandboxFs(ctx, {
             virtualMcpId: vmContext.virtualMcpId,
             branch,
             userId: vmContext.userId,

--- a/apps/api/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -22,14 +22,13 @@
  * loops on an empty `/app/repo`. The returned root listing lets the model
  * confirm the repo without a same-turn `bash`.
  *
- * CLUSTER-GLUE: `@/`-coupled, same tier as `cluster-sandbox-fs.ts`.
+ * HOSTED-GLUE: `@/`-coupled, same tier as `agent-sandbox-fs.ts`.
  */
 
 import { sleep } from "@decocms/shared/std";
 import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
 import type { StudioContext } from "@/core/studio-context";
-import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
 import { getRepoScope } from "@decocms/shared/github-repo-scope";
 import { isDecopilot } from "@decocms/shared/sdk";
 import {
@@ -38,7 +37,7 @@ import {
 } from "@/tools/sandbox/sandbox-map";
 import { ensureSandbox } from "@/tools/sandbox/start";
 import { threadBranch } from "@/tools/sandbox/thread-repo";
-import { buildClusterSandboxFs } from "./cluster-sandbox-fs";
+import { buildAgentSandboxFs } from "./agent-sandbox-fs";
 
 type RepoOption = {
   connectionId: string;
@@ -207,17 +206,8 @@ export async function createLoadRepoTool(opts: {
 
       // 2. Eagerly provision the repo sandbox on the repo-specific branch.
       //    `ensureSandbox` reads the thread repo we just wrote (it prefers
-      //    thread over agent). Resolve the kind so the frontend + fs tools bind
-      //    to the same sandbox.
-      const { kind } = await resolveSandboxProvider(ctx, {
-        userId,
-        branch,
-        virtualMcpMetadata: null,
-      });
-      const entry = await ensureSandbox(
-        { virtualMcpId, branch, sandboxProviderKind: kind },
-        ctx,
-      );
+      //    thread over agent).
+      const entry = await ensureSandbox({ virtualMcpId, branch }, ctx);
 
       // 3. `ensureSandbox` already persisted the sandbox record on the thread
       //    (provisionSandbox → setThreadSandboxMapEntry — the single writer), so
@@ -232,7 +222,6 @@ export async function createLoadRepoTool(opts: {
         readSandboxMap(thread?.metadata),
         userId,
         branch,
-        kind,
         entry,
       );
       // Open the Preview panel + patch the client's local thread row (branch +
@@ -246,14 +235,13 @@ export async function createLoadRepoTool(opts: {
           branch,
           githubRepo,
           sandboxMap,
-          sandboxProviderKind: kind,
         },
       } as Parameters<UIMessageStreamWriter["write"]>[0]);
 
       // 4. Poll until the checkout is present, only to enrich the return
       //    message/listing. Provisioning starts the clone async in the daemon,
       //    so `ensureSandbox` returning isn't proof the files are there.
-      const fs = await buildClusterSandboxFs(ctx, {
+      const fs = await buildAgentSandboxFs(ctx, {
         virtualMcpId,
         branch,
         userId,

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -461,7 +461,7 @@ export class SandboxDispatchClient implements SandboxClient {
     // Resolved before the pod exists; model credential wins — see `mergeRunEnv`.
     const runEnv = mergeRunEnv(await resolveOrgRunEnv(this.ctx), modelEnv);
 
-    const { provider, kind } = await resolveSandboxProvider(this.ctx, {
+    const { provider } = await resolveSandboxProvider(this.ctx, {
       userId: input.user.id,
       branch: this.branch,
       virtualMcpMetadata: null,
@@ -520,7 +520,6 @@ export class SandboxDispatchClient implements SandboxClient {
           {
             virtualMcpId,
             branch,
-            sandboxProviderKind: kind,
             // One agent loop, no preview, and a memory ceiling of its own.
             purpose: "harness-run",
           },

--- a/apps/api/src/sandbox/lifecycle.test.ts
+++ b/apps/api/src/sandbox/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "bun:test";
-import type { ClaimPhase, SandboxProvider } from "@decocms/sandbox/provider";
+import type { ClaimPhase } from "@decocms/sandbox/provider/agent-sandbox";
 import {
   __resetSharedLifecyclesForTesting,
   subscribeLifecycle,
@@ -10,7 +10,7 @@ import {
 // ---------------------------------------------------------------------------
 
 interface FakeWatchableHandle {
-  runner: SandboxProvider;
+  runner: Parameters<typeof subscribeLifecycle>[0];
   /** How many times the source generator has been started. */
   starts: () => number;
   /** Push a phase to the active source generator. */
@@ -20,10 +20,8 @@ interface FakeWatchableHandle {
 }
 
 /**
- * Synthesize a `SandboxProvider` whose `watchClaimLifecycle` is an async
- * generator we can drive frame-by-frame from the test. The other interface
- * methods are no-ops; only the watcher is exercised here. Tracks how many
- * times the generator has been instantiated (so we can prove dedup).
+ * Synthesize a lifecycle watcher we can drive frame-by-frame. Tracks how many
+ * times its async generator has been instantiated (so we can prove dedup).
  */
 function makeFakeWatchable(): FakeWatchableHandle {
   let starts = 0;
@@ -54,13 +52,7 @@ function makeFakeWatchable(): FakeWatchableHandle {
     }
   }
 
-  const runner: SandboxProvider = {
-    kind: "agent-sandbox",
-    ensure: async () => ({ handle: "h", workdir: "/app", previewUrl: null }),
-    delete: async () => {},
-    alive: async () => true,
-    getPreviewUrl: async () => null,
-    proxyDaemonRequest: async () => new Response(null, { status: 204 }),
+  const runner: Parameters<typeof subscribeLifecycle>[0] = {
     watchClaimLifecycle: gen,
   };
 

--- a/apps/api/src/sandbox/lifecycle.ts
+++ b/apps/api/src/sandbox/lifecycle.ts
@@ -1,19 +1,14 @@
-/**
- * Provider singletons, one per kind. SANDBOX_DELETE dispatches on the entry's
- * recorded sandboxProviderKind (not env), so a pod that flipped STUDIO_SANDBOX_PROVIDER
- * between start and stop still tears down the right kind of sandbox.
- */
+/** Hosted AgentSandboxProvider lifecycle. */
 
 import type { StudioContext } from "@/core/studio-context";
-import {
-  resolveSandboxProviderKindFromEnv,
-  type SandboxProviderKind,
-  type SandboxProvider,
-} from "@decocms/sandbox/provider";
 import type {
   ClaimPhase,
   AgentSandboxProvider,
 } from "@decocms/sandbox/provider/agent-sandbox";
+import type {
+  SandboxProvider,
+  SandboxProviderKind,
+} from "@decocms/sandbox/provider";
 import { getDb } from "@/database";
 import type { Kysely } from "kysely";
 import { meter } from "@/observability";
@@ -33,45 +28,39 @@ import { getPublicUrl } from "@/core/server-constants";
 // into the long-lived `Bun.serve` handlers, whose closures capture
 // `getOrInitSharedRunner` from whichever instance of this module was active
 // at boot. Without the global anchor, post-reload preview requests would look
-// up runners in a stale module's empty map and re-provision needlessly.
+// up a runner in a stale module's empty cache and re-provision needlessly.
 // Symbol.for keeps the same key across module instances.
-const RUNNERS_KEY = Symbol.for("decocms.sandbox.lifecycle.runners");
-const INFLIGHT_KEY = Symbol.for("decocms.sandbox.lifecycle.inflight");
+const RUNNER_KEY = Symbol.for("decocms.sandbox.lifecycle.agent-sandbox-runner");
+const INFLIGHT_KEY = Symbol.for(
+  "decocms.sandbox.lifecycle.agent-sandbox-inflight",
+);
 type LifecycleGlobal = {
-  [RUNNERS_KEY]?: Partial<Record<SandboxProviderKind, SandboxProvider>>;
-  [INFLIGHT_KEY]?: Partial<
-    Record<SandboxProviderKind, Promise<SandboxProvider>>
-  >;
+  [RUNNER_KEY]?: AgentSandboxProvider;
+  [INFLIGHT_KEY]?: Promise<AgentSandboxProvider>;
 };
 const lifecycleGlobal = globalThis as unknown as LifecycleGlobal;
 
-const runners: Partial<Record<SandboxProviderKind, SandboxProvider>> =
-  (lifecycleGlobal[RUNNERS_KEY] ??= {});
-// In-flight instantiate() promises, memoized per kind. Two concurrent
+// An in-flight instantiate() promise is memoized globally. Two concurrent
 // callers on a cold studio would otherwise both miss the resolved-runner
 // cache and both call instantiate(); memoizing the promise (and only
-// promoting to `runners` once it resolves) collapses them to a single
+// promoting it to the runner slot once it resolves) collapses them to a single
 // build. Cleared on failure so a retry can take a fresh swing.
-const inflight: Partial<Record<SandboxProviderKind, Promise<SandboxProvider>>> =
-  (lifecycleGlobal[INFLIGHT_KEY] ??= {});
-
 function resolveOnce(
-  kind: SandboxProviderKind,
-  build: () => Promise<SandboxProvider>,
-): Promise<SandboxProvider> {
-  const cached = runners[kind];
+  build: () => Promise<AgentSandboxProvider>,
+): Promise<AgentSandboxProvider> {
+  const cached = lifecycleGlobal[RUNNER_KEY];
   if (cached) return Promise.resolve(cached);
-  const pending = inflight[kind];
+  const pending = lifecycleGlobal[INFLIGHT_KEY];
   if (pending) return pending;
   const promise = build()
     .then((runner) => {
-      runners[kind] = runner;
+      lifecycleGlobal[RUNNER_KEY] = runner;
       return runner;
     })
     .finally(() => {
-      delete inflight[kind];
+      delete lifecycleGlobal[INFLIGHT_KEY];
     });
-  inflight[kind] = promise;
+  lifecycleGlobal[INFLIGHT_KEY] = promise;
   return promise;
 }
 
@@ -141,135 +130,122 @@ function readPreviewGateway(): { name: string; namespace: string } | undefined {
 }
 
 async function instantiate(
-  kind: SandboxProviderKind,
   db: Kysely<DatabaseSchema>,
-): Promise<SandboxProvider> {
+): Promise<AgentSandboxProvider> {
   const stateStore = new KyselySandboxProviderStateStore(db);
   const previewUrlPattern = readPreviewUrlPattern();
-  switch (kind) {
-    case "agent-sandbox": {
-      // Dynamic import — @kubernetes/client-node is heavy and only needed
-      // when STUDIO_SANDBOX_PROVIDER=agent-sandbox. Deploys that never select
-      // the hosted provider don't load it.
-      const { AgentSandboxProvider, parseTenantPools } = await import(
-        "@decocms/sandbox/provider/agent-sandbox"
+  // Dynamic import — @kubernetes/client-node is heavy and only needed when
+  // hosted agent sandboxes are enabled.
+  const { AgentSandboxProvider, parseTenantPools } = await import(
+    "@decocms/sandbox/provider/agent-sandbox"
+  );
+  // `meter` is reassigned by initObservability() after sdk.start(); read
+  // it at provider construction (post-init) so we get the real instruments
+  // not the no-op evaluated at module load.
+  // Ambient vault (encryption key only, no request ctx) so the runner can
+  // re-mint a fresh clone credential on autonomous recovery instead of
+  // replaying the expired token baked into the persisted cloneUrl.
+  const vault = new CredentialVault(getSettings().encryptionKey);
+  return new AgentSandboxProvider({
+    stateStore,
+    previewUrlPattern,
+    sandboxTemplateName: readSandboxTemplateName(),
+    envName: readEnvName(),
+    previewGateway: readPreviewGateway(),
+    sentinelToken: readSandboxSentinelToken(),
+    // JSON array of tenant warm pools (see the provider's
+    // `tenant-pools.ts`). Unset — the default — means no pool is ever
+    // resolved and no reconciler runs. Throws on malformed config: a pool
+    // that silently fails to parse costs N pods and serves nobody.
+    tenantPools: parseTenantPools(process.env.STUDIO_SANDBOX_TENANT_POOLS),
+    meter,
+    mintCloneUrl: async (repo, mintOpts) => {
+      // Only connection-backed clones can be re-minted; buildCloneInfo
+      // refreshes standard OAuth GitHub connections from db + vault alone.
+      // Legacy repo-scoped tokens throw here (need an org-scoped ctx) and
+      // the runner falls back to the persisted URL.
+      if (!repo.connectionId) return null;
+      const parsed = parseGithubOwnerRepo(repo.cloneUrl);
+      if (!parsed) return null;
+      const { cloneUrl } = await buildCloneInfo(
+        repo.connectionId,
+        parsed.owner,
+        parsed.name,
+        db,
+        vault,
+        { bufferMs: mintOpts?.bufferMs },
       );
-      // `meter` is reassigned by initObservability() after sdk.start(); read
-      // it at provider construction (post-init) so we get the real instruments
-      // not the no-op evaluated at module load.
-      // Ambient vault (encryption key only, no request ctx) so the runner can
-      // re-mint a fresh clone credential on autonomous recovery instead of
-      // replaying the expired token baked into the persisted cloneUrl.
-      const vault = new CredentialVault(getSettings().encryptionKey);
-      return new AgentSandboxProvider({
-        stateStore,
-        previewUrlPattern,
-        sandboxTemplateName: readSandboxTemplateName(),
-        envName: readEnvName(),
-        previewGateway: readPreviewGateway(),
-        sentinelToken: readSandboxSentinelToken(),
-        // JSON array of tenant warm pools (see the provider's
-        // `tenant-pools.ts`). Unset — the default — means no pool is ever
-        // resolved and no reconciler runs. Throws on malformed config: a pool
-        // that silently fails to parse costs N pods and serves nobody.
-        tenantPools: parseTenantPools(process.env.STUDIO_SANDBOX_TENANT_POOLS),
-        meter,
-        mintCloneUrl: async (repo, mintOpts) => {
-          // Only connection-backed clones can be re-minted; buildCloneInfo
-          // refreshes standard OAuth GitHub connections from db + vault alone.
-          // Legacy repo-scoped tokens throw here (need an org-scoped ctx) and
-          // the runner falls back to the persisted URL.
-          if (!repo.connectionId) return null;
-          const parsed = parseGithubOwnerRepo(repo.cloneUrl);
-          if (!parsed) return null;
-          const { cloneUrl } = await buildCloneInfo(
-            repo.connectionId,
-            parsed.owner,
-            parsed.name,
-            db,
-            vault,
-            { bufferMs: mintOpts?.bufferMs },
-          );
-          return cloneUrl;
-        },
-        // Same lifetime problem as mintCloneUrl; see mintOrgFsConfig's docs.
-        mintOrgFsConfig: async (tenant) => {
-          if (!tenant.orgSlug) return null;
-          const json = await mintOrgFsConfigJson(
-            {
-              boundAuth: {
-                apiKey: {
-                  create: (data) =>
-                    auth.api.createApiKey({
-                      body: { ...data, userId: tenant.userId },
-                    }),
-                },
-              },
-              storage: { orgRepoSyncs: new OrgRepoSyncStorage(db) },
+      return cloneUrl;
+    },
+    // Same lifetime problem as mintCloneUrl; see mintOrgFsConfig's docs.
+    mintOrgFsConfig: async (tenant) => {
+      if (!tenant.orgSlug) return null;
+      const json = await mintOrgFsConfigJson(
+        {
+          boundAuth: {
+            apiKey: {
+              create: (data) =>
+                auth.api.createApiKey({
+                  body: { ...data, userId: tenant.userId },
+                }),
             },
-            {
-              orgSlug: tenant.orgSlug,
-              orgId: tenant.orgId,
-              baseUrl: getPublicUrl(),
-            },
-          );
-          return json ?? null;
+          },
+          storage: { orgRepoSyncs: new OrgRepoSyncStorage(db) },
         },
-      });
-    }
-    case "user-desktop": {
-      // user-desktop is never the ambient hosted default — there is no
-      // ambient link claim to bind to here. It is constructed per-run by
-      // `resolveSandboxProvider` (sandbox/resolve-provider.ts) from
-      // either the per-run ctx hint or the recorded sandboxMap kind, both of
-      // which carry the user's link. Hitting this branch means SANDBOX_DELETE
-      // was called for a `user-desktop` row without a live link context,
-      // which today should not happen (the user-desktop provider doesn't
-      // write to `sandbox_runner_state`).
-      throw new Error(
-        "user-desktop provider cannot be instantiated without a per-run link claim — call resolveSandboxProvider, which binds the link before constructing the provider.",
+        {
+          orgSlug: tenant.orgSlug,
+          orgId: tenant.orgId,
+          baseUrl: getPublicUrl(),
+        },
       );
-    }
-    default: {
-      const exhaustive: never = kind;
-      throw new Error(`Unknown sandbox provider kind: ${String(exhaustive)}`);
-    }
-  }
+      return json ?? null;
+    },
+  });
 }
 
-/** SANDBOX_DELETE uses this so teardown follows the entry's recorded sandboxProviderKind. */
+/** Resolve the hosted provider for enabled user-facing operations. */
+export function getAgentSandboxProvider(
+  ctx: StudioContext,
+): Promise<AgentSandboxProvider> {
+  if (!getSettings().agentSandboxEnabled) {
+    throw new Error(
+      "Agent sandbox is disabled. Set STUDIO_AGENT_SANDBOX_ENABLED=true to enable it.",
+    );
+  }
+  return resolveOnce(() => instantiate(ctx.db));
+}
+
+/**
+ * Resolve the hosted provider for teardown even after it has been disabled.
+ * This shares the exact singleton used by enabled user-facing operations.
+ */
+export function getAgentSandboxProviderForTeardown(
+  ctx: StudioContext,
+): Promise<AgentSandboxProvider> {
+  return resolveOnce(() => instantiate(ctx.db));
+}
+
+/**
+ * Compatibility bridge for callers migrated later in this stack. Every kind
+ * now resolves to the one hosted provider; the generic resolver is removed
+ * once those callers are gone.
+ */
 export function getSandboxProviderByKind(
   ctx: StudioContext,
-  kind: SandboxProviderKind,
+  _kind: SandboxProviderKind,
 ): Promise<SandboxProvider> {
-  return resolveOnce(kind, () => instantiate(kind, ctx.db));
+  return getAgentSandboxProvider(ctx);
 }
 
 /**
  * Eager provider accessor for paths that need the provider before any user
  * request — preview-host proxying at the Bun.serve layer is the only caller
- * today. Reads the provider kind from env and constructs without a
- * StudioContext (the state store only needs a Kysely instance). Returns null
- * when no provider kind is configured.
- *
- * `instantiate()` only ever yields the hosted `AgentSandboxProvider` (the
- * sole env-instantiable provider — `user-desktop` is built per-run and
- * throws here), so the resolved provider is always an `AgentSandboxProvider`.
- * Typing it as such lets the preview proxy skip a redundant kind check + cast.
+ * today. Constructs without a StudioContext (the state store only needs a
+ * Kysely instance) and returns null when hosted agent sandboxes are disabled.
  */
 export async function getOrInitSharedRunner(): Promise<AgentSandboxProvider | null> {
-  let kind: SandboxProviderKind;
-  try {
-    kind = resolveSandboxProviderKindFromEnv();
-  } catch (err) {
-    console.warn(
-      "[lifecycle] cannot resolve sandbox runner:",
-      err instanceof Error ? err.message : String(err),
-    );
-    return null;
-  }
-  const runner = await resolveOnce(kind, () => instantiate(kind, getDb().db));
-  return runner as AgentSandboxProvider;
+  if (!getSettings().agentSandboxEnabled) return null;
+  return resolveOnce(() => instantiate(getDb().db));
 }
 
 // ---------------------------------------------------------------------------
@@ -287,9 +263,6 @@ export async function getOrInitSharedRunner(): Promise<AgentSandboxProvider | nu
 // synchronously so they don't appear stuck on `claiming` while waiting for
 // the next watch event.
 //
-// For user-desktop the source generator yields a single `ready` and
-// returns; the dedup machinery still works (each subscriber gets the phase
-// replayed) at near-zero cost.
 // ---------------------------------------------------------------------------
 
 interface SharedLifecycleEntry {
@@ -303,7 +276,7 @@ interface SharedLifecycleEntry {
   abort: AbortController;
 }
 
-// Same `--hot` reload concern as `runners`/`inflight` above: an in-flight
+// Same `--hot` reload concern as the runner/inflight slots above: an in-flight
 // lifecycle subscription must not be orphaned when the module re-evaluates,
 // or two SSE clients on the same claim would each open their own watch.
 const SHARED_LIFECYCLES_KEY = Symbol.for(
@@ -322,6 +295,8 @@ export interface LifecycleHandle {
   unsubscribe(): void;
 }
 
+type LifecycleWatcher = Pick<AgentSandboxProvider, "watchClaimLifecycle">;
+
 /**
  * Subscribe to a SandboxClaim's lifecycle phase stream. Multiple subscribers
  * for the same `claimName` share one underlying watcher; `onPhase` is called
@@ -333,7 +308,7 @@ export interface LifecycleHandle {
  * observed (whichever comes first).
  */
 export function subscribeLifecycle(
-  runner: SandboxProvider,
+  runner: LifecycleWatcher,
   claimName: string,
   onPhase: (phase: ClaimPhase) => void,
 ): LifecycleHandle {
@@ -407,7 +382,7 @@ function makeUnsubscribeHandle(
 }
 
 async function pumpLifecycleSource(
-  runner: SandboxProvider,
+  runner: LifecycleWatcher,
   claimName: string,
   entry: SharedLifecycleEntry,
 ): Promise<void> {

--- a/apps/api/src/sandbox/preview-proxy.test.ts
+++ b/apps/api/src/sandbox/preview-proxy.test.ts
@@ -384,24 +384,6 @@ describe("tryUpgradePreviewWs", () => {
     expect((res as Response).status).toBe(404);
   });
 
-  it("rejects legacy /_decopilot_vm/* paths even on WS (dual-serve compat)", async () => {
-    const fakeRunner = {
-      resolvePreviewUpstreamUrl: async () => "http://x:9000",
-    };
-    const req = wsRequest("/_decopilot_vm/bash");
-    const res = await tryUpgradePreviewWs(
-      req,
-      { upgrade: () => true },
-      {
-        baseDomain,
-        // biome-ignore lint/suspicious/noExplicitAny: structural duck-type
-        getRunner: async () => fakeRunner as any,
-      },
-    );
-    expect(res).not.toBeNull();
-    expect((res as Response).status).toBe(404);
-  });
-
   it("calls server.upgrade and returns undefined when upgrade succeeds", async () => {
     const fakeRunner = {
       resolvePreviewUpstreamUrl: async () => "http://upstream:9000",

--- a/apps/api/src/sandbox/preview-proxy.ts
+++ b/apps/api/src/sandbox/preview-proxy.ts
@@ -12,10 +12,9 @@
  * Routing browsers straight at the dev port breaks SSE + iframe embedding.
  *
  * Auth model: preview URLs are open-by-handle, the same way Vercel preview
- * URLs are. The handle is the secret. /_sandbox/* (and the legacy
- * /_decopilot_vm/* prefix the daemon dual-serves) are rejected here
- * (defense-in-depth — the daemon's bearer-token check rejects it too) so
- * the admin surface stays uncallable from preview hosts.
+ * URLs are. The handle is the secret. /_sandbox/* is rejected here
+ * (defense-in-depth — the daemon's bearer-token check rejects it too) so the
+ * admin surface stays uncallable from preview hosts.
  */
 
 import {
@@ -31,7 +30,6 @@ import {
  */
 const MAX_PENDING_FRAMES = 256;
 
-// Keep in sync with apps/api/src/link-daemon/local-ingress.ts CONNECTING_HTML.
 const CONNECTING_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Connecting…</title><style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#fafafa;color:#555}div{text-align:center;max-width:420px;padding:24px}h3{margin:0 0 8px}p{margin:0;font-size:14px;color:#999;line-height:1.5}</style></head><body><div><h3>Connecting to sandbox…</h3><p>Waiting for the sandbox to come online. This page refreshes automatically.</p></div><script>setTimeout(function(){window.location.reload()},1500)</script></body></html>`;
 
 /** A top-level document navigation (the iframe loading a page) — as opposed to
@@ -150,7 +148,7 @@ export async function tryHandlePreviewHttp(
   const response = await runner.proxyPreviewRequest(handle, request);
   // Unspawned / unreachable sandbox: serve an auto-reloading "connecting" page
   // for top-level document navigations so the iframe shows a friendly reloading
-  // page (mirrors the desktop local-ingress) instead of raw JSON. The app's own
+  // page instead of raw JSON. The app's own
   // fetches (non-document) keep the JSON error so they can handle/retry it.
   if (
     response.headers.get(PREVIEW_NOT_READY_HEADER) &&
@@ -237,10 +235,7 @@ export async function tryUpgradePreviewWs(
   }
 
   const reqUrl = new URL(request.url);
-  if (
-    reqUrl.pathname.startsWith("/_sandbox") ||
-    reqUrl.pathname.startsWith("/_decopilot_vm")
-  ) {
+  if (reqUrl.pathname.startsWith("/_sandbox")) {
     return errorResponse(404, "not found");
   }
 

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -399,6 +399,9 @@ export function resolveConfig(
         envVars.MESH_DISPATCH_ROLE,
       ),
     ),
+    agentSandboxEnabled:
+      envVars.STUDIO_AGENT_SANDBOX_ENABLED === "true" ||
+      envVars.STUDIO_AGENT_SANDBOX_ENABLED === "1",
     sandboxProviderKind: resolveSandboxProviderKind(
       envVars.STUDIO_SANDBOX_PROVIDER,
     ),

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -173,6 +173,9 @@ export interface Settings {
   podName: string;
   /** Which DBOS run queues this pod dequeues (pod dispatch-role split). */
   dispatchRole: DispatchRole;
+  /** Whether hosted agent sandboxes are available. Optional during the
+   * rollout so older settings producers remain compatible. */
+  agentSandboxEnabled?: boolean;
   sandboxProviderKind: "agent-sandbox" | "user-desktop";
   /** Sticky HEAD ref for thread-scoped sandboxes (SANDBOX_STICKY_HEAD_REF).
    *  Off by default — see `sandbox/head-ref.ts` for the boot-path change this

--- a/apps/api/src/tools/sandbox/delete.test.ts
+++ b/apps/api/src/tools/sandbox/delete.test.ts
@@ -1,40 +1,38 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 import type { SandboxMap, SandboxRecord } from "@decocms/shared/sdk";
 import type { StudioContext } from "../../core/studio-context";
-import type {
-  SandboxProvider,
-  SandboxProviderKind,
-} from "@decocms/sandbox/provider";
+import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
 
-// Mock per-kind runner lookup BEFORE importing SANDBOX_DELETE.
+// Mock the hosted teardown runner before importing SANDBOX_DELETE.
 const mockDelete = mock(async (_handle: string): Promise<void> => {});
-const lastRequestedKind: { value: string | null } = { value: null };
 
 async function* readyOnly() {
   yield { kind: "ready" as const };
 }
 
-function makeMockRunner(kind: SandboxProviderKind): SandboxProvider {
-  return {
-    kind,
-    ensure: async () => ({
-      handle: "_unused",
-      workdir: "/app",
-      previewUrl: null,
-    }),
-    delete: (h) => mockDelete(h),
-    alive: async () => true,
-    getPreviewUrl: async () => null,
-    proxyDaemonRequest: async () => new Response(null, { status: 204 }),
-    watchClaimLifecycle: () => readyOnly(),
-  };
-}
+const mockRunner: Pick<
+  AgentSandboxProvider,
+  | "alive"
+  | "delete"
+  | "ensure"
+  | "getPreviewUrl"
+  | "proxyDaemonRequest"
+  | "watchClaimLifecycle"
+> = {
+  ensure: async () => ({
+    handle: "_unused",
+    workdir: "/app",
+    previewUrl: null,
+  }),
+  delete: (h) => mockDelete(h),
+  alive: async () => true,
+  getPreviewUrl: async () => null,
+  proxyDaemonRequest: async () => new Response(null, { status: 204 }),
+  watchClaimLifecycle: () => readyOnly(),
+};
 
 mock.module("../../sandbox/lifecycle", () => ({
-  getSandboxProviderByKind: (_ctx: unknown, kind: SandboxProviderKind) => {
-    lastRequestedKind.value = kind;
-    return makeMockRunner(kind);
-  },
+  getAgentSandboxProviderForTeardown: async () => mockRunner,
 }));
 
 const { SANDBOX_DELETE } = await import("./delete");
@@ -44,13 +42,11 @@ const BRANCH = "feat/example";
 const HOSTED_ENTRY: SandboxRecord = {
   sandboxHandle: "f9e2fadeb813e08eb00eef6f962be2b2",
   previewUrl: "https://f9e2fadeb813e08eb00eef6f962be2b2.sandboxes.example.com/",
-  sandboxProviderKind: "agent-sandbox",
 };
 
 const DESKTOP_ENTRY: SandboxRecord = {
   sandboxHandle: "desktop-handle",
   previewUrl: "http://desktop-handle.localhost:5174/",
-  sandboxProviderKind: "user-desktop",
 };
 
 /**
@@ -62,7 +58,7 @@ const DESKTOP_ENTRY: SandboxRecord = {
 function makeSandboxMap(
   userId: string,
   branch: string,
-  kind: SandboxProviderKind,
+  kind: "agent-sandbox" | "local-api",
   entry: SandboxRecord,
 ): SandboxMap {
   return {
@@ -158,7 +154,6 @@ describe("SANDBOX_DELETE", () => {
   beforeEach(() => {
     mockDelete.mockReset();
     mockDelete.mockImplementation(async () => {});
-    lastRequestedKind.value = null;
   });
 
   it("calls runner.delete with the entry's handle and removes sandboxMap entry", async () => {
@@ -178,7 +173,6 @@ describe("SANDBOX_DELETE", () => {
       {
         virtualMcpId: "vmcp_1",
         branch: BRANCH,
-        sandboxProviderKind: "agent-sandbox",
         removeWorktree: false,
       },
       ctx,
@@ -187,7 +181,6 @@ describe("SANDBOX_DELETE", () => {
     expect(result).toEqual({ success: true });
     expect(mockDelete).toHaveBeenCalledTimes(1);
     expect(mockDelete).toHaveBeenCalledWith(HOSTED_ENTRY.sandboxHandle);
-    expect(lastRequestedKind.value).toBe("agent-sandbox");
 
     expect(updateSpy).toHaveBeenCalledTimes(1);
     const updateCall = (updateSpy.mock.calls as unknown[][])[0]!;
@@ -197,40 +190,9 @@ describe("SANDBOX_DELETE", () => {
     expect(updated.sandboxMap["user-1"]).toBeUndefined();
   });
 
-  it("dispatches to the agent-sandbox runner when input.sandboxProviderKind is 'agent-sandbox'", async () => {
+  it("does not route a native desktop entry through the hosted provider", async () => {
     const metadata: Metadata = {
-      sandboxMap: makeSandboxMap(
-        "user-1",
-        BRANCH,
-        "agent-sandbox",
-        HOSTED_ENTRY,
-      ),
-    };
-    const virtualMcp = makeVirtualMcp("org_1", metadata);
-    const ctx = makeCtx({ virtualMcp });
-
-    await SANDBOX_DELETE.handler(
-      {
-        virtualMcpId: "vmcp_1",
-        branch: BRANCH,
-        sandboxProviderKind: "agent-sandbox",
-        removeWorktree: false,
-      },
-      ctx,
-    );
-
-    expect(mockDelete).toHaveBeenCalledWith(HOSTED_ENTRY.sandboxHandle);
-    expect(lastRequestedKind.value).toBe("agent-sandbox");
-  });
-
-  it("tears down a legacy user-desktop entry through the hosted provider", async () => {
-    const metadata: Metadata = {
-      sandboxMap: makeSandboxMap(
-        "user-1",
-        BRANCH,
-        "user-desktop",
-        DESKTOP_ENTRY,
-      ),
+      sandboxMap: makeSandboxMap("user-1", BRANCH, "local-api", DESKTOP_ENTRY),
     };
     const virtualMcp = makeVirtualMcp("org_1", metadata);
     const updateSpy = mock(async () => {});
@@ -240,32 +202,26 @@ describe("SANDBOX_DELETE", () => {
       {
         virtualMcpId: "vmcp_1",
         branch: BRANCH,
-        sandboxProviderKind: "user-desktop",
         removeWorktree: false,
       },
       ctx,
     );
 
     expect(result).toEqual({ success: true });
-    // `user-desktop` no longer has a provider; the resolver serves it from the
-    // hosted one so old sandboxMap rows stay deletable.
-    expect(lastRequestedKind.value).toBe("agent-sandbox");
-    expect(mockDelete).toHaveBeenCalledWith(DESKTOP_ENTRY.sandboxHandle);
-    expect(updateSpy).toHaveBeenCalledTimes(1);
-    const updateCall = (updateSpy.mock.calls as unknown[][])[0]!;
-    const updated = (updateCall[2] as { metadata: { sandboxMap: SandboxMap } })
-      .metadata;
-    expect(updated.sandboxMap["user-1"]).toBeUndefined();
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(updateSpy).not.toHaveBeenCalled();
   });
 
-  it("normalizes legacy cluster input before lookup and provider dispatch", async () => {
+  it("preserves a native desktop sibling when deleting the hosted entry", async () => {
     const metadata: Metadata = {
-      sandboxMap: makeSandboxMap(
-        "user-1",
-        BRANCH,
-        "agent-sandbox",
-        HOSTED_ENTRY,
-      ),
+      sandboxMap: {
+        "user-1": {
+          [BRANCH]: {
+            "agent-sandbox": HOSTED_ENTRY,
+            "local-api": DESKTOP_ENTRY,
+          },
+        },
+      },
     };
     const virtualMcp = makeVirtualMcp("org_1", metadata);
     const updateSpy = mock(async () => {});
@@ -275,54 +231,22 @@ describe("SANDBOX_DELETE", () => {
       {
         virtualMcpId: "vmcp_1",
         branch: BRANCH,
-        sandboxProviderKind: "cluster",
-      } as unknown as Parameters<typeof SANDBOX_DELETE.handler>[0],
+        removeWorktree: false,
+      },
       ctx,
     );
 
     expect(mockDelete).toHaveBeenCalledWith(HOSTED_ENTRY.sandboxHandle);
-    expect(lastRequestedKind.value).toBe("agent-sandbox");
     expect(updateSpy).toHaveBeenCalledTimes(1);
+    const updateCall = (updateSpy.mock.calls as unknown[][])[0]!;
+    const updated = (updateCall[2] as { metadata: { sandboxMap: SandboxMap } })
+      .metadata;
+    expect(updated.sandboxMap["user-1"]?.[BRANCH]).toEqual({
+      "local-api": DESKTOP_ENTRY,
+    });
   });
 
-  // Regression guard: a pod that flipped STUDIO_SANDBOX_PROVIDER between start
-  // and stop must still tear down the runner the entry was created against.
-  // The kind is now caller-supplied, so the env value is irrelevant.
-  it("dispatches on input.sandboxProviderKind even when STUDIO_SANDBOX_PROVIDER env disagrees", async () => {
-    const original = process.env.STUDIO_SANDBOX_PROVIDER;
-    // Env says user-desktop, but the entry was created against agent-sandbox.
-    process.env.STUDIO_SANDBOX_PROVIDER = "user-desktop";
-    try {
-      const metadata: Metadata = {
-        sandboxMap: makeSandboxMap(
-          "user-1",
-          BRANCH,
-          "agent-sandbox",
-          HOSTED_ENTRY,
-        ),
-      };
-      const virtualMcp = makeVirtualMcp("org_1", metadata);
-      const ctx = makeCtx({ virtualMcp });
-
-      await SANDBOX_DELETE.handler(
-        {
-          virtualMcpId: "vmcp_1",
-          branch: BRANCH,
-          sandboxProviderKind: "agent-sandbox",
-          removeWorktree: false,
-        },
-        ctx,
-      );
-
-      expect(mockDelete).toHaveBeenCalledWith(HOSTED_ENTRY.sandboxHandle);
-      expect(lastRequestedKind.value).toBe("agent-sandbox");
-    } finally {
-      if (original === undefined) delete process.env.STUDIO_SANDBOX_PROVIDER;
-      else process.env.STUDIO_SANDBOX_PROVIDER = original;
-    }
-  });
-
-  it("skips runner.delete and DB update when no sandboxMap entry for (user, branch, kind)", async () => {
+  it("skips runner.delete and DB update when no hosted entry exists", async () => {
     // Entry exists for a different user — this user has no entry.
     const metadata: Metadata = {
       sandboxMap: makeSandboxMap(
@@ -340,7 +264,6 @@ describe("SANDBOX_DELETE", () => {
       {
         virtualMcpId: "vmcp_1",
         branch: BRANCH,
-        sandboxProviderKind: "agent-sandbox",
         removeWorktree: false,
       },
       ctx,
@@ -358,7 +281,6 @@ describe("SANDBOX_DELETE", () => {
       {
         virtualMcpId: "vmcp_missing",
         branch: BRANCH,
-        sandboxProviderKind: "agent-sandbox",
         removeWorktree: false,
       },
       ctx,
@@ -381,7 +303,6 @@ describe("SANDBOX_DELETE", () => {
         {
           virtualMcpId: "vmcp_1",
           branch: BRANCH,
-          sandboxProviderKind: "agent-sandbox",
           removeWorktree: false,
         },
         ctx,

--- a/apps/api/src/tools/sandbox/delete.ts
+++ b/apps/api/src/tools/sandbox/delete.ts
@@ -1,21 +1,8 @@
-/**
- * SANDBOX_DELETE. Dispatches on the caller-supplied `sandboxProviderKind` (not
- * env), so a pod that flipped STUDIO_SANDBOX_PROVIDER between start and stop
- * still tears down the right kind of sandbox.
- */
-
 import { z } from "zod";
-import { normalizeSandboxProviderKind } from "@decocms/sandbox/provider";
 import { defineTool } from "../../core/define-tool";
+import { getAgentSandboxProviderForTeardown } from "../../sandbox/lifecycle";
 import { requireVmEntry } from "./helpers";
-import { removeSandboxMapEntry } from "./sandbox-map";
-import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
-
-const sandboxProviderKindInputSchema = z.enum([
-  "agent-sandbox",
-  "user-desktop",
-  "cluster",
-]);
+import { AGENT_SANDBOX_KIND, removeSandboxMapEntry } from "./sandbox-map";
 
 export const SANDBOX_DELETE = defineTool({
   name: "SANDBOX_DELETE",
@@ -36,15 +23,12 @@ export const SANDBOX_DELETE = defineTool({
       .describe(
         "Branch whose vm should be deleted (sandboxMap[userId][branch])",
       ),
-    sandboxProviderKind: sandboxProviderKindInputSchema.describe(
-      "Kind of sandbox provider the VM was started with. Hosted provider is `agent-sandbox`; legacy `cluster` input is accepted only for compatibility and normalized to `agent-sandbox`. Used to locate the correct 3-level sandboxMap entry.",
-    ),
     removeWorktree: z
       .boolean()
       .optional()
       .default(false)
       .describe(
-        "Also reclaim the sandbox's workspace (local worktree + disk). Ignored by providers whose teardown already destroys the filesystem.",
+        "Also reclaim the sandbox's workspace (local worktree + disk). Ignored by hosted teardown, whose filesystem is already destroyed.",
       ),
   }),
   outputSchema: z.object({
@@ -52,16 +36,9 @@ export const SANDBOX_DELETE = defineTool({
   }),
 
   handler: async (input, ctx) => {
-    // Normalize here too because direct unit tests call handler() without
-    // going through schema parsing.
-    const kind = normalizeSandboxProviderKind(input.sandboxProviderKind);
-
     let vmEntry: Awaited<ReturnType<typeof requireVmEntry>>;
     try {
-      vmEntry = await requireVmEntry(
-        { ...input, sandboxProviderKind: kind },
-        ctx,
-      );
+      vmEntry = await requireVmEntry(input, ctx);
     } catch (err) {
       if (err instanceof Error && err.message === "Virtual MCP not found") {
         return { success: true };
@@ -77,12 +54,7 @@ export const SANDBOX_DELETE = defineTool({
       return { success: true };
     }
 
-    const { provider: runner } = await resolveSandboxProvider(ctx, {
-      userId: sandboxUserId,
-      branch: input.branch,
-      virtualMcpMetadata: vmEntry.metadata,
-      explicitKind: kind,
-    });
+    const runner = await getAgentSandboxProviderForTeardown(ctx);
 
     // Clear first so the UI returns to idle regardless of teardown outcome.
     await removeSandboxMapEntry(
@@ -91,14 +63,13 @@ export const SANDBOX_DELETE = defineTool({
       userId,
       sandboxUserId,
       input.branch,
-      kind,
     );
 
     await runner
       .delete(entry.sandboxHandle)
       .catch((err) =>
         console.error(
-          `[SANDBOX_DELETE] ${kind} ${entry.sandboxHandle}: ${
+          `[SANDBOX_DELETE] ${AGENT_SANDBOX_KIND} ${entry.sandboxHandle}: ${
             err instanceof Error ? err.message : String(err)
           }`,
         ),

--- a/apps/api/src/tools/sandbox/helpers.ts
+++ b/apps/api/src/tools/sandbox/helpers.ts
@@ -12,7 +12,6 @@ import {
   type SandboxRecord,
   type SubmoduleCredential,
 } from "@decocms/shared/sdk";
-import type { SandboxProviderKind } from "@decocms/sandbox/provider";
 
 import {
   requireAuth,
@@ -109,7 +108,7 @@ export function readValidatedSubmoduleCredentials(
  * Extracts common auth + lookup boilerplate shared by all VM tools.
  * Validates auth, checks access, fetches and validates the Virtual MCP,
  * and returns the metadata and sandboxMap entry for the sandbox's OWNER on the
- * specified branch + kind. `entry` is null when no vm is registered for that triple.
+ * specified branch. `entry` is null when no hosted sandbox is registered.
  *
  * `userId` is the caller (audit); `sandboxUserId` is who the sandbox is keyed by
  * — the same resolution SANDBOX_START uses, so a teammate's thread resolves that
@@ -119,7 +118,6 @@ export async function requireVmEntry(
   input: {
     virtualMcpId: string;
     branch: string;
-    sandboxProviderKind: SandboxProviderKind;
   },
   ctx: StudioContext,
 ) {
@@ -139,7 +137,6 @@ export async function requireVmEntry(
     sandboxMap,
     sandboxUserId,
     input.branch,
-    input.sandboxProviderKind,
   );
   return { virtualMcp, metadata, userId, sandboxUserId, entry, organization };
 }

--- a/apps/api/src/tools/sandbox/live-sandbox-for-branch.ts
+++ b/apps/api/src/tools/sandbox/live-sandbox-for-branch.ts
@@ -1,6 +1,6 @@
 import type { StudioContext } from "../../core/studio-context";
 import { sleep } from "@decocms/shared/std";
-import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
+import { getAgentSandboxProvider } from "../../sandbox/lifecycle";
 
 /** The claim decision cannot wait on a slow control plane. */
 const ALIVE_PROBE_TIMEOUT_MS = 2_000;
@@ -20,26 +20,17 @@ export type SandboxLiveness = "alive" | "gone" | "unknown";
  *
  * Liveness, never presence: a `sandboxMap` cell records that a sandbox was
  * once started and survives long after the pod is gone (nothing removes it but
- * SANDBOX_DELETE), which is exactly how a dead 2026-07 `user-desktop` record
+ * SANDBOX_DELETE), which is exactly how a dead 2026-07 `local-api` record
  * kept routing a brand-new CMS session to a daemon that cannot exist. `alive()`
  * asks the runner instead — the same probe `sandbox-events-handler` already
  * makes on this request path.
  */
 export async function liveSandboxForBranch(
   ctx: StudioContext,
-  claim: {
-    claimName: string;
-    userId: string;
-    branch: string;
-    virtualMcpMetadata: Record<string, unknown> | null;
-  },
+  claim: { claimName: string },
 ): Promise<SandboxLiveness> {
   try {
-    const { provider } = await resolveSandboxProvider(ctx, {
-      userId: claim.userId,
-      branch: claim.branch,
-      virtualMcpMetadata: claim.virtualMcpMetadata,
-    });
+    const provider = await getAgentSandboxProvider(ctx);
     return await probeAlive(provider, claim.claimName);
   } catch {
     return "unknown";

--- a/apps/api/src/tools/sandbox/patch-sandbox-operator.ts
+++ b/apps/api/src/tools/sandbox/patch-sandbox-operator.ts
@@ -1,4 +1,4 @@
-import type { SandboxProvider } from "@decocms/sandbox/provider";
+import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
 import { coAuthorFromStudioContext } from "../../lib/co-author-identity";
 import { readBoundedText } from "../../lib/bounded-text";
 import type { StudioContext } from "../../core/studio-context";
@@ -9,7 +9,7 @@ const CONFIG_RESPONSE_MAX_BYTES = 10 * 1024 * 1024;
 /** Sync the authenticated Studio user into daemon tenant config for co-author. */
 export async function patchSandboxOperator(
   ctx: StudioContext,
-  runner: SandboxProvider,
+  runner: Pick<AgentSandboxProvider, "proxyDaemonRequest">,
   handle: string,
 ): Promise<void> {
   const operator = coAuthorFromStudioContext(ctx);

--- a/apps/api/src/tools/sandbox/resolve-env.ts
+++ b/apps/api/src/tools/sandbox/resolve-env.ts
@@ -1,5 +1,5 @@
 import type { RuntimeEnvEntry } from "@decocms/shared/sdk";
-import type { SandboxProvider } from "@decocms/sandbox/provider";
+import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
 import {
   SecretAccessDeniedError,
   SecretNotFoundError,
@@ -12,7 +12,7 @@ const CONFIG_RESPONSE_MAX_BYTES = 10 * 1024 * 1024;
 
 interface ResolveAndPushParams {
   ctx: StudioContext;
-  runner: SandboxProvider;
+  runner: Pick<AgentSandboxProvider, "proxyDaemonRequest">;
   handle: string;
   orgId: string;
   userId: string;

--- a/apps/api/src/tools/sandbox/sandbox-map.test.ts
+++ b/apps/api/src/tools/sandbox/sandbox-map.test.ts
@@ -51,7 +51,6 @@ describe("readSandboxMap canonical reads", () => {
       sandboxHandle: "h1",
       previewUrl: null,
       createdAt: 1,
-      sandboxProviderKind: "agent-sandbox",
     };
     const meta = {
       sandboxMap: { user1: { main: { "agent-sandbox": inner } } },
@@ -64,7 +63,6 @@ describe("readSandboxMap canonical reads", () => {
       sandboxHandle: "h1",
       previewUrl: null,
       createdAt: 1,
-      sandboxProviderKind: "agent-sandbox",
     };
     const meta = { vmMap: { user1: { main: { "agent-sandbox": inner } } } };
     expect(readSandboxMap(meta)).toEqual({});
@@ -73,26 +71,22 @@ describe("readSandboxMap canonical reads", () => {
 
 describe("resolveVm", () => {
   test("returns null when user is absent", () => {
-    expect(resolveVm({}, "user-1", "main", "agent-sandbox")).toBeNull();
+    expect(resolveVm({}, "user-1", "main")).toBeNull();
   });
 
   test("returns null when branch is absent for that user", () => {
     const sandboxMap = { "user-1": { main: { "agent-sandbox": ENTRY_A } } };
-    expect(
-      resolveVm(sandboxMap, "user-1", "feat/x", "agent-sandbox"),
-    ).toBeNull();
+    expect(resolveVm(sandboxMap, "user-1", "feat/x")).toBeNull();
   });
 
-  test("returns the entry when userId, branch, and kind are all present", () => {
+  test("returns the hosted entry when userId and branch are present", () => {
     const sandboxMap = {
       "user-1": {
         main: { "agent-sandbox": ENTRY_A },
         "feat/x": { "agent-sandbox": ENTRY_B },
       },
     };
-    expect(resolveVm(sandboxMap, "user-1", "feat/x", "agent-sandbox")).toEqual(
-      ENTRY_B,
-    );
+    expect(resolveVm(sandboxMap, "user-1", "feat/x")).toEqual(ENTRY_B);
   });
 
   test("isolates users from each other", () => {
@@ -100,32 +94,23 @@ describe("resolveVm", () => {
       "user-1": { main: { "agent-sandbox": ENTRY_A } },
       "user-2": { main: { "agent-sandbox": ENTRY_B } },
     };
-    expect(resolveVm(sandboxMap, "user-1", "main", "agent-sandbox")).toEqual(
-      ENTRY_A,
-    );
-    expect(resolveVm(sandboxMap, "user-2", "main", "agent-sandbox")).toEqual(
-      ENTRY_B,
-    );
+    expect(resolveVm(sandboxMap, "user-1", "main")).toEqual(ENTRY_A);
+    expect(resolveVm(sandboxMap, "user-2", "main")).toEqual(ENTRY_B);
   });
 
   test("returns null when the kind is absent but another kind exists", () => {
     const sandboxMap = {
-      "user-1": { main: { "user-desktop": ENTRY_A } },
+      "user-1": { main: { "local-api": ENTRY_A } },
     };
-    // looking up "agent-sandbox" when only "user-desktop" exists → null
-    expect(resolveVm(sandboxMap, "user-1", "main", "agent-sandbox")).toBeNull();
+    // looking up "agent-sandbox" when only "local-api" exists → null
+    expect(resolveVm(sandboxMap, "user-1", "main")).toBeNull();
   });
 
-  test("returns the entry for the requested kind when multiple kinds coexist", () => {
+  test("returns the hosted entry when a local sibling coexists", () => {
     const sandboxMap = {
-      "user-1": { main: { "user-desktop": ENTRY_A, "agent-sandbox": ENTRY_B } },
+      "user-1": { main: { "local-api": ENTRY_A, "agent-sandbox": ENTRY_B } },
     };
-    expect(resolveVm(sandboxMap, "user-1", "main", "user-desktop")).toEqual(
-      ENTRY_A,
-    );
-    expect(resolveVm(sandboxMap, "user-1", "main", "agent-sandbox")).toEqual(
-      ENTRY_B,
-    );
+    expect(resolveVm(sandboxMap, "user-1", "main")).toEqual(ENTRY_B);
   });
 });
 
@@ -136,84 +121,62 @@ describe("mergeSandboxMapEntry", () => {
     const current = {
       u: { "thread:t/conn_a": { "agent-sandbox": ENTRY_A } },
     };
-    const next = mergeSandboxMapEntry(
-      current,
-      "u",
-      "thread:t/conn_b",
-      "agent-sandbox",
-      ENTRY_B,
-    );
-    expect(resolveVm(next, "u", "thread:t/conn_a", "agent-sandbox")).toEqual(
-      ENTRY_A,
-    );
-    expect(resolveVm(next, "u", "thread:t/conn_b", "agent-sandbox")).toEqual(
-      ENTRY_B,
-    );
+    const next = mergeSandboxMapEntry(current, "u", "thread:t/conn_b", ENTRY_B);
+    expect(resolveVm(next, "u", "thread:t/conn_a")).toEqual(ENTRY_A);
+    expect(resolveVm(next, "u", "thread:t/conn_b")).toEqual(ENTRY_B);
   });
 
   test("preserves sibling kinds on the same branch", () => {
-    const current = { u: { b: { "user-desktop": ENTRY_A } } };
-    const next = mergeSandboxMapEntry(
-      current,
-      "u",
-      "b",
-      "agent-sandbox",
-      ENTRY_B,
-    );
-    expect(resolveVm(next, "u", "b", "user-desktop")).toEqual(ENTRY_A);
-    expect(resolveVm(next, "u", "b", "agent-sandbox")).toEqual(ENTRY_B);
+    const current = { u: { b: { "local-api": ENTRY_A } } };
+    const next = mergeSandboxMapEntry(current, "u", "b", ENTRY_B);
+    expect(next.u?.b?.["local-api"]).toEqual(ENTRY_A);
+    expect(resolveVm(next, "u", "b")).toEqual(ENTRY_B);
   });
 
   test("does not mutate the input map", () => {
     const current = { u: { b: { "agent-sandbox": ENTRY_A } } };
     const snapshot = JSON.stringify(current);
-    mergeSandboxMapEntry(current, "u", "b", "user-desktop", ENTRY_B);
+    mergeSandboxMapEntry(current, "u", "b", ENTRY_B);
     expect(JSON.stringify(current)).toBe(snapshot);
   });
 
-  test("normalizes a legacy stringified branch cell instead of corrupting it", () => {
+  test("normalizes a malformed stringified branch cell instead of corrupting it", () => {
     // parseBranchMap treats a non-object (stringified) cell as empty, so the
     // merge drops the unreadable cell rather than a raw spread exploding it into
     // character-indexed keys ("0","1",...).
     const current = {
       u: { b: JSON.stringify({ "agent-sandbox": ENTRY_A }) },
     } as unknown as Parameters<typeof mergeSandboxMapEntry>[0];
-    const next = mergeSandboxMapEntry(
-      current,
-      "u",
-      "b",
-      "user-desktop",
-      ENTRY_B,
-    );
-    expect(resolveVm(next, "u", "b", "user-desktop")).toEqual(ENTRY_B);
+    const next = mergeSandboxMapEntry(current, "u", "b", ENTRY_B);
+    expect(resolveVm(next, "u", "b")).toEqual(ENTRY_B);
     expect(next.u?.b).not.toHaveProperty("0");
   });
 });
 
 describe("deleteSandboxMapEntry", () => {
   test("returns null when the entry is absent (no-op write)", () => {
-    expect(deleteSandboxMapEntry({}, "u", "b", "agent-sandbox")).toBeNull();
-    const other = { u: { b: { "user-desktop": ENTRY_A } } };
-    expect(deleteSandboxMapEntry(other, "u", "b", "agent-sandbox")).toBeNull();
+    expect(deleteSandboxMapEntry({}, "u", "b")).toBeNull();
+    const other = { u: { b: { "local-api": ENTRY_A } } };
+    expect(deleteSandboxMapEntry(other, "u", "b")).toBeNull();
   });
 
   test("removes the entry and prunes empty branch + user buckets", () => {
     const current = { u: { b: { "agent-sandbox": ENTRY_A } } };
-    const next = deleteSandboxMapEntry(current, "u", "b", "agent-sandbox");
+    const next = deleteSandboxMapEntry(current, "u", "b");
     expect(next).toEqual({});
   });
 
   test("keeps sibling kinds and sibling branches", () => {
     const current = {
       u: {
-        b: { "agent-sandbox": ENTRY_A, "user-desktop": ENTRY_B },
+        b: { "agent-sandbox": ENTRY_A, "local-api": ENTRY_B },
         other: { "agent-sandbox": ENTRY_A },
       },
     };
-    const next = deleteSandboxMapEntry(current, "u", "b", "agent-sandbox");
-    expect(resolveVm(next!, "u", "b", "user-desktop")).toEqual(ENTRY_B);
-    expect(resolveVm(next!, "u", "other", "agent-sandbox")).toEqual(ENTRY_A);
-    expect(resolveVm(next!, "u", "b", "agent-sandbox")).toBeNull();
+    const next = deleteSandboxMapEntry(current, "u", "b");
+    expect(next?.u?.b?.["local-api"]).toEqual(ENTRY_B);
+    expect(resolveVm(next!, "u", "other")).toEqual(ENTRY_A);
+    expect(resolveVm(next!, "u", "b")).toBeNull();
   });
 });
 
@@ -243,7 +206,6 @@ describe("setSandboxMapEntry", () => {
       sandboxHandle: "new",
       previewUrl: null,
       createdAt: 2,
-      sandboxProviderKind: "agent-sandbox",
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -253,7 +215,6 @@ describe("setSandboxMapEntry", () => {
       "u",
       "u",
       "b",
-      "agent-sandbox",
       newEntry,
     );
 

--- a/apps/api/src/tools/sandbox/sandbox-map.ts
+++ b/apps/api/src/tools/sandbox/sandbox-map.ts
@@ -1,22 +1,24 @@
 /**
- * sandboxMap helpers — per-(user, branch, sandboxProviderKind) sandbox registry.
+ * Hosted sandbox-map helpers.
  *
  * Lookup: sandboxMap[userId][branch][sandboxProviderKind] -> SandboxRecord
  *
- * Stored in the virtualmcp's metadata JSON column. Threads sharing the same
- * (user, branch, kind) triple share one sandbox.
+ * Stored in the virtualmcp's metadata JSON column. Hosted threads sharing the
+ * same (user, branch) pair share one `agent-sandbox` entry. Native `local-api`
+ * entries may coexist in the same branch cell and are preserved by writes.
  *
  * NOTE: read-modify-write is NOT atomic across pods — two concurrent SANDBOX_START
- * calls for the same (sandbox, user, branch, kind) can race. Accepted for v1. A
+ * calls for the same (sandbox, user, branch) can race. Accepted for v1. A
  * proper fix requires a Postgres advisory lock or a dedicated sandbox_sessions table.
  */
 
 import { parseBranchMap } from "@decocms/shared/sdk";
 import type { SandboxMap, SandboxRecord } from "@decocms/shared/sdk";
-import type { SandboxProviderKind } from "@decocms/sandbox/provider";
 
 import type { VirtualMCPStoragePort } from "../../storage/ports";
 import type { VirtualMCPUpdateData } from "../virtual/schema";
+
+export const AGENT_SANDBOX_KIND = "agent-sandbox" as const;
 
 export function readSandboxMap(
   metadata: Record<string, unknown> | null | undefined,
@@ -31,19 +33,18 @@ export function resolveVm(
   sandboxMap: SandboxMap,
   userId: string,
   branch: string,
-  sandboxProviderKind: SandboxProviderKind,
 ): SandboxRecord | null {
   const raw = sandboxMap[userId]?.[branch];
   if (!raw) return null;
   const parsed = parseBranchMap(raw);
-  return parsed[sandboxProviderKind] ?? null;
+  return parsed[AGENT_SANDBOX_KIND] ?? null;
 }
 
 /**
- * Pure merge: returns a copy of `current` with sandboxMap[userId][branch][kind]
- * set to `entry`. Creates intermediate buckets as needed and preserves any
- * sibling users, branches, and kinds. Normalizes the target branch cell through
- * `parseBranchMap` so a legacy stringified cell can't corrupt the spread. The
+ * Pure merge: returns a copy of `current` with the hosted entry set. Creates
+ * intermediate buckets as needed and preserves sibling users, branches, and
+ * native entries. Normalizes the target branch cell through `parseBranchMap`
+ * so a malformed stringified cell can't corrupt the spread. The
  * single source of truth for both the agent-scoped (`setSandboxMapEntry`) and
  * thread-scoped (`setThreadSandboxMapEntry`) writers.
  */
@@ -51,13 +52,12 @@ export function mergeSandboxMapEntry(
   current: SandboxMap,
   targetUserId: string,
   branch: string,
-  sandboxProviderKind: SandboxProviderKind,
   entry: SandboxRecord,
 ): SandboxMap {
   const currentBranchMap = parseBranchMap(current[targetUserId]?.[branch]);
   const nextBranchMap = {
     ...currentBranchMap,
-    [sandboxProviderKind]: entry,
+    [AGENT_SANDBOX_KIND]: entry,
   };
   return {
     ...current,
@@ -69,9 +69,8 @@ export function mergeSandboxMapEntry(
 }
 
 /**
- * Read-modify-write: sets sandboxMap[userId][branch][kind] = entry on the
- * virtualmcp. Creates intermediate buckets as needed. Preserves any
- * sibling-kind entries already present at sandboxMap[userId][branch][*].
+ * Read-modify-write: sets the hosted entry on the virtualmcp. Creates
+ * intermediate buckets as needed and preserves a native sibling entry.
  */
 export async function setSandboxMapEntry(
   storage: VirtualMCPStoragePort,
@@ -79,7 +78,6 @@ export async function setSandboxMapEntry(
   actingUserId: string,
   targetUserId: string,
   branch: string,
-  sandboxProviderKind: SandboxProviderKind,
   entry: SandboxRecord,
 ): Promise<void> {
   const virtualMcp = await storage.findById(virtualMcpId);
@@ -90,7 +88,6 @@ export async function setSandboxMapEntry(
     readSandboxMap(meta),
     targetUserId,
     branch,
-    sandboxProviderKind,
     entry,
   );
 
@@ -113,13 +110,12 @@ export function deleteSandboxMapEntry(
   current: SandboxMap,
   targetUserId: string,
   branch: string,
-  sandboxProviderKind: SandboxProviderKind,
 ): SandboxMap | null {
   const branchMap = parseBranchMap(current[targetUserId]?.[branch]);
-  if (!branchMap[sandboxProviderKind]) return null;
+  if (!branchMap[AGENT_SANDBOX_KIND]) return null;
 
   const nextBranchMap = { ...branchMap };
-  delete nextBranchMap[sandboxProviderKind];
+  delete nextBranchMap[AGENT_SANDBOX_KIND];
 
   const userMap = { ...(current[targetUserId] ?? {}) };
   if (Object.keys(nextBranchMap).length === 0) {
@@ -148,7 +144,6 @@ export async function removeSandboxMapEntry(
   actingUserId: string,
   targetUserId: string,
   branch: string,
-  sandboxProviderKind: SandboxProviderKind,
 ): Promise<void> {
   const virtualMcp = await storage.findById(virtualMcpId);
   if (!virtualMcp) return;
@@ -158,7 +153,6 @@ export async function removeSandboxMapEntry(
     readSandboxMap(meta),
     targetUserId,
     branch,
-    sandboxProviderKind,
   );
   if (!next) return;
 

--- a/apps/api/src/tools/sandbox/start.test.ts
+++ b/apps/api/src/tools/sandbox/start.test.ts
@@ -6,15 +6,11 @@ import type {
   EnsureOptions,
   Sandbox,
   SandboxId,
-  SandboxProvider,
 } from "@decocms/sandbox/provider";
 import { composeSandboxRef } from "@decocms/sandbox/provider";
+import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
 
-// Pin provider kind — the dev env flips STUDIO_SANDBOX_PROVIDER and SANDBOX_START
-// reads it at handler time.
-process.env.STUDIO_SANDBOX_PROVIDER = "agent-sandbox";
-
-// Mock runner BEFORE importing SANDBOX_START — handler is runner-agnostic.
+// Mock the hosted runner before importing SANDBOX_START.
 
 const mockEnsure = mock(
   async (_id: SandboxId, _opts?: EnsureOptions): Promise<Sandbox> => ({
@@ -24,48 +20,35 @@ const mockEnsure = mock(
   }),
 );
 
-const mockClusterDelete = mock(async (_handle: string) => {});
-const mockAgentSandboxDelete = mock(async (_handle: string) => {});
+const mockDelete = mock(async (_handle: string) => {});
 
 async function* readyOnly() {
   yield { kind: "ready" as const };
 }
 
-const mockClusterRunner: SandboxProvider = {
-  kind: "agent-sandbox",
+const mockRunner: Pick<
+  AgentSandboxProvider,
+  | "alive"
+  | "delete"
+  | "ensure"
+  | "getPreviewUrl"
+  | "hasSchedulableCapacity"
+  | "proxyDaemonRequest"
+  | "watchClaimLifecycle"
+> = {
   ensure: (id, opts) => mockEnsure(id, opts),
-  delete: (handle) => mockClusterDelete(handle),
+  delete: (handle) => mockDelete(handle),
   alive: async () => true,
   getPreviewUrl: async () => "https://stub.preview/",
-  proxyDaemonRequest: async () => new Response(null, { status: 204 }),
-  watchClaimLifecycle: () => readyOnly(),
-};
-
-const mockDesktopDelete = mock(async (_handle: string) => {});
-
-const mockDesktopRunner: SandboxProvider = {
-  kind: "user-desktop",
-  ensure: (id, opts) => mockEnsure(id, opts),
-  delete: (handle) => mockDesktopDelete(handle),
-  alive: async () => true,
-  getPreviewUrl: async () => "https://stub.preview/",
+  hasSchedulableCapacity: async () => true,
   proxyDaemonRequest: async () => new Response(null, { status: 204 }),
   watchClaimLifecycle: () => readyOnly(),
 };
 
 mock.module("../../sandbox/lifecycle", () => ({
-  // Only ever invoked for the agent-sandbox kind — the desktop path goes through
-  // `buildDesktopProvider` (below); user-desktop is never instantiated here.
-  getSandboxProviderByKind: (
-    _ctx: unknown,
-    _kind: "agent-sandbox" | "user-desktop",
-  ) => mockClusterRunner,
-  // The unified resolver in `resolve-provider.ts` calls
-  // `buildDesktopProvider` directly (no ctx side-effects), so a mock
-  // is needed for SANDBOX_START's desktop path to construct the expected
-  // runner under test.
-  buildDesktopProvider: async () => mockDesktopRunner,
-  getOrInitSharedRunner: async () => mockClusterRunner,
+  getAgentSandboxProvider: async () => mockRunner,
+  getAgentSandboxProviderForTeardown: async () => mockRunner,
+  getOrInitSharedRunner: async () => mockRunner,
   // Bun's mock.module persists across test files in the same shard. Other
   // tests in the shard (e.g. oauth-proxy.e2e.test.ts) load app.ts which
   // imports subscribeLifecycle from this module — keep the export shape
@@ -74,8 +57,15 @@ mock.module("../../sandbox/lifecycle", () => ({
   __resetSharedLifecyclesForTesting: () => {},
 }));
 
+let mockSettings: Record<string, unknown> = { nodeEnv: "test" };
 mock.module("../../settings", () => ({
-  getSettings: () => ({ nodeEnv: "test" }),
+  getSettings: () => mockSettings,
+  // Bun keeps module mocks alive across test files in one shard. Preserve the
+  // real module's complete runtime surface so later settings-backed tests can
+  // replace and restore their configuration normally.
+  setGlobalSettings: (settings: Record<string, unknown>) => {
+    mockSettings = settings;
+  },
 }));
 
 const { DownstreamTokenStorage: RealDownstreamTokenStorage } = await import(
@@ -316,12 +306,8 @@ describe("SANDBOX_START", () => {
       async () => new Response("{}", { status: 404 }),
     ) as unknown as typeof fetch;
     mockEnsure.mockReset();
-    mockClusterDelete.mockReset();
-    mockAgentSandboxDelete.mockReset();
-    mockDesktopDelete.mockReset();
-    mockClusterDelete.mockImplementation(async () => {});
-    mockAgentSandboxDelete.mockImplementation(async () => {});
-    mockDesktopDelete.mockImplementation(async () => {});
+    mockDelete.mockReset();
+    mockDelete.mockImplementation(async () => {});
     mockTokenGet.mockReset();
     mockEnsure.mockImplementation(async () => ({
       handle: "vm_xyz",
@@ -436,7 +422,7 @@ describe("SANDBOX_START", () => {
     expect(Object.keys(updated.metadata.sandboxMap)).toEqual([USER_ID]);
   });
 
-  it("persists sandboxMap entry with handle + previewUrl + sandboxProviderKind", async () => {
+  it("persists the hosted sandbox under the fixed map key", async () => {
     mockEnsure.mockImplementation(async () => ({
       handle: "vm_xyz",
       workdir: "/app",
@@ -455,7 +441,6 @@ describe("SANDBOX_START", () => {
     expect(result.previewUrl).toBe("https://stub.preview/");
     expect(result.branch).toBe(BRANCH);
     expect(result.isNewVm).toBe(true);
-    expect(result.sandboxProviderKind).toBe("agent-sandbox");
 
     expect(updateSpy).toHaveBeenCalledTimes(1);
     const updateCall = (updateSpy.mock.calls as unknown[][])[0]!;
@@ -468,7 +453,6 @@ describe("SANDBOX_START", () => {
     expect(stored).toMatchObject({
       sandboxHandle: "vm_xyz",
       previewUrl: "https://stub.preview/",
-      sandboxProviderKind: "agent-sandbox",
     });
     // Server-stamped; assert recency, not exact value.
     expect(typeof (stored as SandboxRecord)?.createdAt).toBe("number");
@@ -762,54 +746,10 @@ describe("SANDBOX_START", () => {
     expect(opts.repo?.cloneUrl).not.toContain("ghu_stale_token");
   });
 
-  it("an explicit user-desktop reuses the agent-sandbox entry instead of provisioning a second VM", async () => {
-    // `user-desktop` is legacy: the desktop link daemon that implemented it is
-    // gone, so the resolver normalizes it to `agent-sandbox` — provider AND
-    // kind. An explicit legacy override therefore looks up the hosted entry it
-    // will actually run on, rather than recording a sibling row under a kind
-    // with no runner (which would leave the handle and the runner mismatched).
+  it("reuses an existing hosted sandbox entry", async () => {
     const agentSandboxEntry: SandboxRecord = {
       sandboxHandle: "vm_agent-sandbox_existing",
       previewUrl: "https://agent-sandbox.preview/",
-      sandboxProviderKind: "agent-sandbox",
-      createdAt: 123,
-    };
-    mockEnsure.mockImplementation(async () => ({
-      handle: agentSandboxEntry.sandboxHandle,
-      workdir: "/app",
-      previewUrl: agentSandboxEntry.previewUrl,
-    }));
-    const metadata: Metadata = {
-      ...BASE_METADATA,
-      // 3-level: agent-sandbox entry lives under its own key
-      sandboxMap: {
-        [USER_ID]: {
-          [BRANCH]: { "agent-sandbox": agentSandboxEntry },
-        },
-      },
-    };
-    const virtualMcp = makeVirtualMcp(ORG_ID, metadata);
-    const ctx = makeCtx({ virtualMcp });
-
-    const result = await SANDBOX_START.handler(
-      {
-        virtualMcpId: VMCP_ID,
-        branch: BRANCH,
-        sandboxProviderKind: "user-desktop",
-      },
-      ctx,
-    );
-
-    expect(mockClusterDelete).not.toHaveBeenCalled();
-    expect(result.sandboxProviderKind).toBe("agent-sandbox");
-    expect(result.isNewVm).toBe(false);
-  });
-
-  it("SANDBOX_START with no sandboxProviderKind honors an existing recorded kind", async () => {
-    const agentSandboxEntry: SandboxRecord = {
-      sandboxHandle: "vm_agent-sandbox_existing",
-      previewUrl: "https://agent-sandbox.preview/",
-      sandboxProviderKind: "agent-sandbox",
       createdAt: 123,
     };
     mockEnsure.mockImplementation(async () => ({
@@ -834,9 +774,7 @@ describe("SANDBOX_START", () => {
       ctx,
     );
 
-    expect(result.sandboxProviderKind).toBe("agent-sandbox");
     expect(result.isNewVm).toBe(false);
-    expect(mockDesktopDelete).not.toHaveBeenCalled();
     const sandboxMapCall = (updateSpy.mock.calls as unknown[][]).find(
       (call) => {
         const meta = (call[2] as { metadata?: { sandboxMap?: SandboxMap } })
@@ -853,16 +791,14 @@ describe("SANDBOX_START", () => {
       | undefined;
     expect(branchMap?.["agent-sandbox"]).toMatchObject({
       sandboxHandle: agentSandboxEntry.sandboxHandle,
-      sandboxProviderKind: "agent-sandbox",
     });
-    expect(branchMap?.["user-desktop"]).toBeUndefined();
+    expect(branchMap?.["local-api"]).toBeUndefined();
   });
 
   it("does not tear down anything when the existing entry is on the same runner", async () => {
     const sameRunnerEntry: SandboxRecord = {
       sandboxHandle: "vm_agent-sandbox_existing",
       previewUrl: "https://agent-sandbox.preview/",
-      sandboxProviderKind: "agent-sandbox",
     };
     const metadata: Metadata = {
       ...BASE_METADATA,
@@ -877,85 +813,7 @@ describe("SANDBOX_START", () => {
 
     await SANDBOX_START.handler({ virtualMcpId: VMCP_ID, branch: BRANCH }, ctx);
 
-    expect(mockAgentSandboxDelete).not.toHaveBeenCalled();
-    expect(mockClusterDelete).not.toHaveBeenCalled();
-  });
-
-  // -----------------------------------------------------------------------
-  // sandboxProviderKind default-resolution tests
-  // -----------------------------------------------------------------------
-
-  it("SANDBOX_START with no sandboxProviderKind picks the env kind (default policy is env-only)", async () => {
-    // Optimistic presence: the default no longer consults link liveness.
-    // STUDIO_SANDBOX_PROVIDER is "agent-sandbox" at module load time (top of
-    // file), so a fresh (user, branch) with no recorded kind resolves to it.
-    const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
-    const updateSpy = mock(async () => {});
-    const ctx = makeCtx({ virtualMcp, updateSpy });
-
-    const result = await SANDBOX_START.handler(
-      { virtualMcpId: VMCP_ID, branch: BRANCH },
-      ctx,
-    );
-
-    expect(result.sandboxProviderKind).toBe("agent-sandbox");
-    const updateCall = (updateSpy.mock.calls as unknown[][])[0]!;
-    const updated = (updateCall[2] as { metadata: { sandboxMap: SandboxMap } })
-      .metadata;
-    // 3-level key: sandboxMap[userId][branch][kind]
-    const stored = (
-      updated.sandboxMap[USER_ID]?.[BRANCH] as Record<string, unknown>
-    )?.["agent-sandbox"] as SandboxRecord | undefined;
-    expect(stored?.sandboxProviderKind).toBe("agent-sandbox");
-  });
-
-  it("SANDBOX_START with explicit sandboxProviderKind ignores defaults", async () => {
-    const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
-    const updateSpy = mock(async () => {});
-    const ctx = makeCtx({ virtualMcp, updateSpy });
-
-    const result = await SANDBOX_START.handler(
-      {
-        virtualMcpId: VMCP_ID,
-        branch: BRANCH,
-        sandboxProviderKind: "agent-sandbox",
-      },
-      ctx,
-    );
-
-    expect(result.sandboxProviderKind).toBe("agent-sandbox");
-    const updateCall = (updateSpy.mock.calls as unknown[][])[0]!;
-    const updated = (updateCall[2] as { metadata: { sandboxMap: SandboxMap } })
-      .metadata;
-    // 3-level key: sandboxMap[userId][branch][kind]
-    const stored = (
-      updated.sandboxMap[USER_ID]?.[BRANCH] as Record<string, unknown>
-    )?.["agent-sandbox"] as SandboxRecord | undefined;
-    expect(stored?.sandboxProviderKind).toBe("agent-sandbox");
-  });
-
-  it("normalizes legacy cluster input to agent-sandbox", async () => {
-    const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
-    const updateSpy = mock(async () => {});
-    const ctx = makeCtx({ virtualMcp, updateSpy });
-
-    const result = await SANDBOX_START.handler(
-      {
-        virtualMcpId: VMCP_ID,
-        branch: BRANCH,
-        sandboxProviderKind: "cluster",
-      } as unknown as Parameters<typeof SANDBOX_START.handler>[0],
-      ctx,
-    );
-
-    expect(result.sandboxProviderKind).toBe("agent-sandbox");
-    const updateCall = (updateSpy.mock.calls as unknown[][])[0]!;
-    const updated = (updateCall[2] as { metadata: { sandboxMap: SandboxMap } })
-      .metadata;
-    const stored = (
-      updated.sandboxMap[USER_ID]?.[BRANCH] as Record<string, unknown>
-    )?.["agent-sandbox"] as SandboxRecord | undefined;
-    expect(stored?.sandboxProviderKind).toBe("agent-sandbox");
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   it("throws RECONNECT_ERROR when refreshing an expired token fails", async () => {

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -1,28 +1,22 @@
 /**
- * SANDBOX_START. Keyed by (userId, branch, sandboxProviderKind) in the Virtual
+ * SANDBOX_START. Keyed by (userId, branch, "agent-sandbox") in the Virtual
  * MCP's `sandboxMap`, where `userId` is the sandbox's OWNER — the thread's
  * creator on a thread-scoped branch, so a member opening a teammate's thread
  * resumes that thread's single sandbox instead of booting a private copy of the
  * same git branch (see `resolveSandboxUserId`).
- * Provider-agnostic — dispatches through the active `SandboxProvider`; this
- * handler only does `sandboxMap` bookkeeping. Branch is minted from the caller's
+ * Branch is minted from the caller's
  * slug + a timestamp (`generateBranchName`) when omitted — a fresh identity, so
  * callers that have a branch must pass it or they get a second sandbox.
- *
- * Different sandbox provider kinds coexist as siblings under the same
- * (user, branch) key — no stale-sandbox teardown is needed on kind change.
  */
 
 import { z } from "zod";
 import type { SandboxRecord } from "@decocms/shared/sdk";
 import {
   composeSandboxRef,
-  normalizeSandboxProviderKind,
-  type SandboxProvider,
-  type SandboxProviderKind,
   type SandboxPurpose,
   type Workload,
 } from "@decocms/sandbox/provider";
+import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
 import { sleep } from "@decocms/shared/std";
 import { defineTool } from "../../core/define-tool";
 import {
@@ -62,7 +56,7 @@ import {
   generateBranchName,
 } from "@decocms/shared/branch-name";
 import { PACKAGE_MANAGER_CONFIG } from "@decocms/shared/runtime-defaults";
-import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
+import { getAgentSandboxProvider } from "../../sandbox/lifecycle";
 import { stampRuntimeIfAbsent } from "../thread/stamp-runtime-if-absent";
 import { parseThreadRuntime } from "@decocms/shared/thread/session-runtime";
 import {
@@ -74,7 +68,6 @@ import {
   threadIdFromBranch,
 } from "./thread-repo";
 import { pickGitBranch } from "../../sandbox/head-ref";
-import { deriveOffloadAllowlist } from "../../object-storage/offload-allowlist";
 import { getSettings } from "../../settings";
 import { getPublicUrl } from "../../core/server-constants";
 import { mintOrgFsConfigJson } from "../../file-storage/mount/provisioning";
@@ -90,12 +83,6 @@ type GithubRepo = {
 type GithubRepoMeta = {
   githubRepo?: GithubRepo | null;
 };
-
-const sandboxProviderKindInputSchema = z.enum([
-  "agent-sandbox",
-  "user-desktop",
-  "cluster",
-]);
 
 export const SANDBOX_START = defineTool({
   name: "SANDBOX_START",
@@ -117,11 +104,6 @@ export const SANDBOX_START = defineTool({
       .describe(
         "Git branch to check out. Pass the thread's branch whenever the caller has one: when omitted the handler mints a fresh `<user-slug>-<timestamp>` name, which becomes a SEPARATE sandbox from the one the thread's own branch resolves to. The resolved branch is returned in the response so callers can persist it.",
       ),
-    sandboxProviderKind: sandboxProviderKindInputSchema
-      .optional()
-      .describe(
-        "Explicit runtime choice. Hosted provider is `agent-sandbox`; legacy `cluster` input is accepted only for compatibility and normalized to `agent-sandbox`. When omitted, defaults to `user-desktop` if the acting user's link daemon is online, else the env kind.",
-      ),
     threadId: z
       .string()
       .optional()
@@ -134,7 +116,6 @@ export const SANDBOX_START = defineTool({
     sandboxHandle: z.string(),
     branch: z.string(),
     isNewVm: z.boolean(),
-    sandboxProviderKind: z.enum(["agent-sandbox", "user-desktop"]),
   }),
 
   handler: async (input, ctx) => {
@@ -165,8 +146,6 @@ export const SANDBOX_START = defineTool({
       }
     }
 
-    // Resolve kind after loading metadata so recorded sandboxMap entries can
-    // pin the provider when the caller did not pass an explicit kind.
     const userId = getUserId(ctx);
     if (!userId) throw new Error("User ID required");
 
@@ -189,28 +168,12 @@ export const SANDBOX_START = defineTool({
     }
     const metadata = (virtualMcp.metadata ?? {}) as Record<string, unknown>;
 
-    // Resolve the runner once. `resolveSandboxProvider` returns the
-    // existing kind when sandboxMap already has an entry for (user, branch),
-    // honors `input.sandboxProviderKind` as a caller override, and
-    // otherwise applies the link-or-env default policy. We bind the
-    // provider here so the kind we record in sandboxMap matches the runner
-    // that actually `ensure`d the sandbox.
-    const explicitKind = input.sandboxProviderKind
-      ? normalizeSandboxProviderKind(input.sandboxProviderKind)
-      : undefined;
-    const { provider: runner, kind: providerKind } =
-      await resolveSandboxProvider(ctx, {
-        userId: sandboxUserId,
-        branch: resolvedBranch,
-        virtualMcpMetadata: metadata,
-        explicitKind,
-      });
+    const runner = await getAgentSandboxProvider(ctx);
 
     const existing: SandboxRecord | null = resolveVm(
       readSandboxMap(metadata),
       sandboxUserId,
       resolvedBranch,
-      providerKind,
     );
 
     // Thread-scoped repo (bound by `load_repo`) wins over the agent's repo — the
@@ -236,7 +199,6 @@ export const SANDBOX_START = defineTool({
       metadata,
       githubRepo,
       existing,
-      providerKind,
       runner,
     });
     // A pod means a coding session. This is the web's path — `ensureSandbox`'s
@@ -248,7 +210,6 @@ export const SANDBOX_START = defineTool({
       ...entry,
       branch: resolvedBranch,
       isNewVm,
-      sandboxProviderKind: providerKind,
     };
   },
 });
@@ -257,17 +218,13 @@ export const SANDBOX_START = defineTool({
  * Lazy provisioner for the always-on sandbox tools path. Mirrors SANDBOX_START's
  * flow but: (a) tolerates a missing GitHub repo (boots a blank sandbox),
  * and (b) takes a fast path when the existing sandboxMap entry already
- * matches the requested kind — avoiding a full `provider.ensure` round-trip
+ * matches — avoiding a full `provider.ensure` round-trip
  * on every fresh stream when the sandbox is already registered.
- *
- * Unlike SANDBOX_START, `sandboxProviderKind` is required — callers (e.g. POST
- * /messages) must resolve the kind before calling this function.
  */
 export async function ensureSandbox(
   input: {
     virtualMcpId: string;
     branch: string;
-    sandboxProviderKind: SandboxProviderKind;
     /**
      * What the sandbox is for. `harness-run` — one headless agent loop, no
      * preview — drops the application workload (install + dev server) from the
@@ -298,26 +255,13 @@ export async function ensureSandbox(
     readSandboxMap(metadata),
     sandboxUserId,
     input.branch,
-    input.sandboxProviderKind,
   );
 
-  const providerKind = input.sandboxProviderKind;
-
-  // Resolve the runner up front: for user-desktop we must verify the cached
-  // entry against the live daemon before trusting it (the daemon may have
-  // restarted via `deco link` relink, leaving the sandboxMap pointing at a
-  // dead handle). resolveSandboxProvider is cheap and idempotent.
-  const { provider: runner } = await resolveSandboxProvider(ctx, {
-    userId: sandboxUserId,
-    branch: input.branch,
-    virtualMcpMetadata: metadata,
-    explicitKind: providerKind,
-  });
+  const runner = await getAgentSandboxProvider(ctx);
 
   // A recorded entry is trusted only if a pod actually answers at it. Nothing
-  // but SANDBOX_DELETE removes a cell, so an evicted pod (or a `user-desktop`
-  // record from a daemon that no longer exists) leaves one behind forever;
-  // probing every kind is what makes that self-healing rather than sticky.
+  // but SANDBOX_DELETE removes a cell, so an evicted pod leaves one behind
+  // forever; probing it is what makes that self-healing rather than sticky.
   if (existing) {
     // A probe that ERRORS is not evidence the pod is gone — treat it as alive,
     // the same way the events handler does. Reaping on a throttled control-plane
@@ -330,7 +274,6 @@ export async function ensureSandbox(
       userId,
       sandboxUserId,
       input.branch,
-      providerKind,
     ).catch((err) => {
       console.warn("[ensureSandbox] failed to reap stale entry", err);
     });
@@ -361,7 +304,6 @@ export async function ensureSandbox(
     metadata,
     githubRepo,
     existing: null,
-    providerKind,
     runner,
     ...(input.purpose ? { purpose: input.purpose } : {}),
   });
@@ -383,8 +325,7 @@ type StartParams = {
   metadata: Record<string, unknown>;
   githubRepo: GithubRepo | null;
   existing: SandboxRecord | null;
-  providerKind: SandboxProviderKind;
-  runner: SandboxProvider;
+  runner: AgentSandboxProvider;
   /** See `ensureSandbox`'s `purpose`. `harness-run` implies checkout-only. */
   purpose?: SandboxPurpose;
 };
@@ -557,11 +498,8 @@ async function provisionSandbox(
     };
   }
 
-  // Missing workload = clone-only; the runner picks its default.
-  // `devPort` is omitted unless the user explicitly pinned one — leaves
-  // runners free to assign a unique dynamic port (user-desktop needs this;
-  // multiple sandboxes on the user's machine share the host network and
-  // can't all bind 3000).
+  // Missing workload = clone-only; the runner picks its default. `devPort` is
+  // omitted unless the user explicitly pinned one.
   const workload: Workload | undefined =
     runtime && packageManager && !cloneOnly
       ? {
@@ -578,33 +516,17 @@ async function provisionSandbox(
     branch,
   });
 
-  // Message-offload SSRF allowlist. The user-desktop daemon fails closed
-  // (empty allowlist) unless the control plane pushes the object-storage host
-  // it mints presigned offload URLs against. Derive it from the control
-  // plane's OWN trusted S3 config (never a request frame) and pass it through
-  // the ensure control channel so it lands in the spawned daemon's boot env.
-  // Only relevant for `user-desktop`; hosted execution reads its own S3 env.
-  const offload =
-    runner.kind === "user-desktop"
-      ? await deriveOffloadAllowlist(ctx.objectStorage, {
-          isProduction: getSettings().nodeEnv === "production",
-        })
-      : null;
-
-  // Org-fs mounts: mint an fs-scoped token + build the daemon's ORGFS_CONFIG.
-  // org-fs is the universal substrate now — both desktop links and hosted
-  // pods always mount (hosted relies on the privileged org-fs sidecar
-  // shipping in the default deploy). Guarded inside the helper: a mint
-  // failure → undefined → no mounting, never breaks provisioning.
+  // Org-fs mounts: mint an fs-scoped token and build the daemon config payload.
+  // Hosted pods mount through the privileged org-fs sidecar shipped in the
+  // default deployment. Guarded inside the helper: a mint failure → undefined
+  // → no mounting, never breaks provisioning.
   //
   // DISABLE_ORGFS_MOUNTS is a debug escape hatch (opt-out, default off): it
   // skips provisioning the mount so a sandbox boots without org-fs, for
   // low-level mount debugging. NOT a supported "org-fs-off" product mode —
   // the prompt/tools still assume org-fs, so the agent's `org/` paths just
   // won't exist while it's set.
-  const wantsOrgFs =
-    (runner.kind === "user-desktop" || runner.kind === "agent-sandbox") &&
-    !getSettings().orgFsMountsDisabled;
+  const wantsOrgFs = !getSettings().orgFsMountsDisabled;
   // ctx.organization is unset on the decopilot vm-tools dispatch path (the
   // org travels as the `orgId` param there) — resolve the slug from the row
   // so chat-ephemeral sandboxes get mounts too.
@@ -635,7 +557,7 @@ async function provisionSandbox(
   // here turns over-admission into a queue. Bounded well under the readiness
   // timeout this call already tolerates, so it adds no new liveness risk; past
   // the bound the error is phrased for the task-board retry to recognize as
-  // infrastructure. No-op for a provider that can't answer.
+  // infrastructure.
   await waitForSchedulableCapacity(runner);
 
   const sandbox = await runner.ensure(
@@ -662,12 +584,6 @@ async function provisionSandbox(
         ...(ctx.auth.user?.email ? { userEmail: ctx.auth.user.email } : {}),
         ...(ctx.auth.user?.name ? { userName: ctx.auth.user.name } : {}),
       },
-      ...(offload
-        ? {
-            offloadAllowedHosts: offload.hosts,
-            offloadAllowSameHostDev: offload.allowSameHostDev,
-          }
-        : {}),
       ...(orgFsConfigJson ? { orgFsConfigJson } : {}),
     },
   );
@@ -699,8 +615,6 @@ async function provisionSandbox(
   const entry: SandboxRecord = {
     sandboxHandle: sandbox.handle,
     previewUrl: sandbox.previewUrl,
-    sandboxApiUrl: sandbox.previewUrl, // for desktop the two are equal
-    sandboxProviderKind: runner.kind,
     createdAt,
     startedWith: {
       packageManager: runtimeSelected,
@@ -715,7 +629,6 @@ async function provisionSandbox(
     userId,
     sandboxUserId,
     branch,
-    params.providerKind,
     entry,
   );
   // Thread-scoped branch: the agent write above is a no-op for the synthetic
@@ -725,14 +638,7 @@ async function provisionSandbox(
   // ctx fallback: a `pinnedRef` run is keyed by a real git ref, not `thread:<id>`.
   const threadId = threadIdFromBranch(branch) ?? ctx.metadata?.threadId;
   if (threadId) {
-    await setThreadSandboxMapEntry(
-      ctx,
-      threadId,
-      sandboxUserId,
-      branch,
-      params.providerKind,
-      entry,
-    );
+    await setThreadSandboxMapEntry(ctx, threadId, sandboxUserId, branch, entry);
   }
 
   // Different handle = new sandbox (stale entry / orphan recovery / state miss).
@@ -863,9 +769,8 @@ const CAPACITY_POLL_MS = 5_000;
  * instead of every run in the burst.
  */
 async function waitForSchedulableCapacity(
-  runner: SandboxProvider,
+  runner: AgentSandboxProvider,
 ): Promise<void> {
-  if (!runner.hasSchedulableCapacity) return;
   const deadline = Date.now() + CAPACITY_WAIT_MS;
   let logged = false;
   while (!(await runner.hasSchedulableCapacity())) {

--- a/apps/api/src/tools/sandbox/sync-git-credentials.test.ts
+++ b/apps/api/src/tools/sandbox/sync-git-credentials.test.ts
@@ -4,7 +4,6 @@ import {
   SANDBOX_START_ERROR_CODES,
 } from "@decocms/shared/sandbox-start-errors";
 import type { StudioContext } from "../../core/studio-context";
-import type { SandboxProvider } from "@decocms/sandbox/provider";
 
 mock.module("../../shared/github-clone-info", () => ({
   buildCloneInfo: mock(async () => {
@@ -84,7 +83,7 @@ describe("refreshSandboxGitCredentials", () => {
       db: {},
       vault: {},
     } as unknown as StudioContext;
-    const runner = {} as SandboxProvider;
+    const runner = {} as Parameters<typeof refreshSandboxGitCredentials>[1];
 
     await expect(
       refreshSandboxGitCredentials(ctx, runner, "handle_1", {

--- a/apps/api/src/tools/sandbox/sync-git-credentials.ts
+++ b/apps/api/src/tools/sandbox/sync-git-credentials.ts
@@ -1,5 +1,5 @@
 import type { GithubRepo } from "@decocms/shared/sdk/types";
-import type { SandboxProvider } from "@decocms/sandbox/provider";
+import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
 import type { StudioContext } from "../../core/studio-context";
 import { RECONNECT_ERROR } from "../../oauth/token-refresh";
 import { coAuthorFromStudioContext } from "../../lib/co-author-identity";
@@ -38,7 +38,7 @@ export function parseGithubRepoFromMetadata(
  */
 export async function refreshSandboxGitCredentials(
   ctx: StudioContext,
-  runner: SandboxProvider,
+  runner: Pick<AgentSandboxProvider, "proxyDaemonRequest">,
   handle: string,
   githubRepo: GithubRepo,
 ): Promise<void> {

--- a/apps/api/src/tools/sandbox/thread-repo.ts
+++ b/apps/api/src/tools/sandbox/thread-repo.ts
@@ -17,7 +17,6 @@ import type {
   SandboxMap,
   SandboxRecord,
 } from "@decocms/shared/sdk";
-import type { SandboxProviderKind } from "@decocms/sandbox/provider";
 import {
   findReusableRepoConnection,
   getRepoScope,
@@ -347,7 +346,8 @@ export async function resolveSandboxBranchForThread(
 
 /**
  * Persist a sandbox record on the THREAD's `metadata.sandboxMap`
- * ([userId][branch][kind]) via the shared {@link mergeSandboxMapEntry}. The
+ * ([userId][branch][agent-sandbox]) via the shared
+ * {@link mergeSandboxMapEntry}. The
  * synthetic Decopilot agent's sandboxMap write is a no-op, so for thread-scoped
  * branches this is the only place the frontend reads the live `previewUrl`/
  * handle from. Called from `provisionSandbox` so every provisioning path
@@ -359,7 +359,6 @@ export async function setThreadSandboxMapEntry(
   threadId: string,
   userId: string,
   branch: string,
-  kind: SandboxProviderKind,
   entry: SandboxRecord,
 ): Promise<void> {
   const meta = await getThreadMeta(ctx, threadId);
@@ -368,7 +367,6 @@ export async function setThreadSandboxMapEntry(
     readSandboxMap(meta),
     userId,
     branch,
-    kind,
     entry,
   );
   await ctx.storage.threads
@@ -389,7 +387,7 @@ export async function getThreadSandboxMap(
   return readSandboxMap(await getThreadMeta(ctx, threadId));
 }
 
-/** Remove sandboxMap[userId][branch][kind] from the thread via the shared
+/** Remove sandboxMap[userId][branch][agent-sandbox] from the thread via the shared
  *  {@link deleteSandboxMapEntry}. No-op when the thread or entry is absent.
  *  Never throws. Mirrors the agent-scoped `removeSandboxMapEntry`. */
 export async function removeThreadSandboxMapEntry(
@@ -397,16 +395,10 @@ export async function removeThreadSandboxMapEntry(
   threadId: string,
   userId: string,
   branch: string,
-  kind: SandboxProviderKind,
 ): Promise<void> {
   const meta = await getThreadMeta(ctx, threadId);
   if (!meta) return;
-  const next = deleteSandboxMapEntry(
-    readSandboxMap(meta),
-    userId,
-    branch,
-    kind,
-  );
+  const next = deleteSandboxMapEntry(readSandboxMap(meta), userId, branch);
   if (!next) return;
   await ctx.storage.threads
     .update(threadId, { metadata: { ...meta, sandboxMap: next } })

--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -30,7 +30,7 @@ import {
 } from "@/core/studio-context";
 import { selectLoadableRepos } from "@/harnesses/decopilot/built-in-tools/load-repo";
 import { pickGitBranch } from "@/sandbox/head-ref";
-import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
+import { getAgentSandboxProvider } from "@/sandbox/lifecycle";
 import {
   buildCloneInfo,
   ensureGithubCloneToken,
@@ -43,7 +43,7 @@ import {
   syntheticBranchToGitRef,
 } from "@/tools/sandbox/thread-repo";
 import { retry, sleep } from "@decocms/shared/std";
-import type { SandboxProvider } from "@decocms/sandbox/provider";
+import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
 import { requireTaskRunContext } from "./task-run-context";
 
 /**
@@ -82,7 +82,6 @@ async function waitForSandboxRecord(
   threadId: string,
   sandboxUserId: string,
   branch: string,
-  kind: Parameters<typeof resolveVm>[3],
 ): Promise<ReturnType<typeof resolveVm>> {
   return retry(
     async () => {
@@ -90,7 +89,6 @@ async function waitForSandboxRecord(
         await getThreadSandboxMap(ctx, threadId),
         sandboxUserId,
         branch,
-        kind,
       );
       if (!record) throw new Error("sandbox record not written yet");
       return record;
@@ -112,7 +110,7 @@ const CLONE_MAX_CONSECUTIVE_FAILURES = 5;
 
 /** One bash command in the run's pod. Throws on a non-2xx from the daemon. */
 async function podBash(
-  provider: SandboxProvider,
+  provider: AgentSandboxProvider,
   handle: string,
   threadId: string,
   command: string,
@@ -269,17 +267,12 @@ export const TASK_ADD_REPO = defineTool({
       runBranch: thread.branch,
     });
     const sandboxUserId = await resolveSandboxUserId(ctx, branch, userId);
-    const { provider, kind } = await resolveSandboxProvider(ctx, {
-      userId: sandboxUserId,
-      branch,
-      virtualMcpMetadata: null,
-    });
+    const provider = await getAgentSandboxProvider(ctx);
     const record = await waitForSandboxRecord(
       ctx,
       threadId,
       sandboxUserId,
       branch,
-      kind,
     );
     if (!record) {
       throw new Error(

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -349,6 +349,7 @@ export type GithubRepo = z.infer<typeof GithubRepoSchema>;
 /** The active sandbox provider kinds. */
 export type SandboxProviderKind = "agent-sandbox" | "user-desktop";
 export type LegacySandboxProviderKind = SandboxProviderKind | "cluster";
+type SandboxMapOwnerKind = SandboxProviderKind | "local-api";
 
 const sandboxProviderKindSchema = z.enum(["agent-sandbox", "user-desktop"]);
 const legacySandboxProviderKindSchema = z.enum([
@@ -456,17 +457,23 @@ export function parseSandboxRecord(raw: unknown): SandboxRecord {
  */
 export function parseBranchMap(
   raw: unknown,
-): Partial<Record<SandboxProviderKind, SandboxRecord>> {
+): Partial<Record<SandboxMapOwnerKind, SandboxRecord>> {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
   const obj = raw as Record<string, unknown>;
 
-  const out: Partial<Record<SandboxProviderKind, SandboxRecord>> = {};
+  const out: Partial<Record<SandboxMapOwnerKind, SandboxRecord>> = {};
   for (const [k, v] of Object.entries(obj)) {
     if (!v || typeof v !== "object") continue;
-    if (k !== "cluster" && k !== "agent-sandbox" && k !== "user-desktop") {
+    if (
+      k !== "cluster" &&
+      k !== "agent-sandbox" &&
+      k !== "local-api" &&
+      k !== "user-desktop"
+    ) {
       continue;
     }
-    const kind = normalizeSandboxProviderKind(k);
+    const kind: SandboxMapOwnerKind =
+      k === "local-api" ? k : normalizeSandboxProviderKind(k);
     try {
       if (k === "cluster" && out[kind]) {
         continue;

--- a/tests/multi-pod/docker-compose.yml
+++ b/tests/multi-pod/docker-compose.yml
@@ -124,6 +124,7 @@ services:
       # no sandbox is actually provisioned because ensureSandbox is lazy
       # (built-in-tools/index.ts) and the mock-ai test never emits tool calls.
       STUDIO_SANDBOX_PROVIDER: agent-sandbox
+      STUDIO_AGENT_SANDBOX_ENABLED: "true"
     ports:
       - "127.0.0.1:13001:3000"
     # POD_NAME makes `run_owner_pod` match the compose service name


### PR DESCRIPTION
## Summary

- Binds hosted lifecycle operations directly to AgentSandbox.
- Deletes provider-resolution branches that no longer have another implementation.

## Testing

- Full workspace check and 79 focused lifecycle tests
- Multi-pod fixture enables STUDIO_AGENT_SANDBOX_ENABLED in this lifecycle slice
- No database migrations

Part of Studio Stack #6542; depends on #6520. Split from #6459 and supersedes #5641.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds the hosted sandbox lifecycle directly to the `agent-sandbox` provider and drops multi-provider switching. Hosted flows now always run `agent-sandbox`; `/api/config` exposes availability via a new `agentSandboxEnabled` flag.

- Refactors
  - Replaces generic provider resolution with `getAgentSandboxProvider` and narrows types to `AgentSandboxProvider`.
  - Collapses the sandbox map to a per-(user, branch) `agent-sandbox` entry and preserves any `local-api` siblings.
  - Pins `SANDBOX_START`/`SANDBOX_DELETE` to `agent-sandbox` and removes provider-kind inputs/resolvers.
  - Sets `runtime.agentSandbox` from `agentSandboxEnabled` (read from `STUDIO_AGENT_SANDBOX_ENABLED`).
  - Removes legacy `/_decopilot_vm/*` preview handling; the preview proxy now rejects only `/_sandbox/*`.
  - Renames cluster-sandbox-fs to agent-sandbox-fs and limits built-in tools to `proxyDaemonRequest` where possible.

- Migration
  - Set `STUDIO_AGENT_SANDBOX_ENABLED=true` (clients read it from `/api/config`).
  - Remove callers passing `sandboxProviderKind` to `SANDBOX_START`/`SANDBOX_DELETE`.
  - No database migrations.

<sup>Written for commit bd30aef6d3dc3139e52ea04749b5097c488edb84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

