### PR TITLE
refactor(threads): make harness the runtime authority

### DIFF
--- a/apps/api/src/api/routes/decopilot/routes.ts
+++ b/apps/api/src/api/routes/decopilot/routes.ts
@@ -630,7 +630,6 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
           // overwrite a runtime that became native after our preceding read.
           const claimed = await ctx.storage.threads.pinRuntimeIfUnset(taskId, {
             harnessId: pinnedHarness,
-            sandboxProviderKind: "agent-sandbox",
             branch,
             ...(pinV2 ? { messageStorageVersion: 2 } : {}),
           });

--- a/apps/api/src/api/watch.test.ts
+++ b/apps/api/src/api/watch.test.ts
@@ -138,7 +138,6 @@ function makeThread(overrides: Partial<Thread>): Thread {
     last_progress_at: overrides.last_progress_at ?? null,
     virtual_mcp_id: overrides.virtual_mcp_id ?? "",
     branch: overrides.branch ?? null,
-    sandbox_provider_kind: overrides.sandbox_provider_kind ?? null,
     harness_id: overrides.harness_id ?? null,
     metadata: overrides.metadata ?? {},
     created_at: overrides.created_at ?? "2026-01-01T00:00:00.000Z",

--- a/apps/api/src/harnesses/decopilot/background-tool-workflow.test.ts
+++ b/apps/api/src/harnesses/decopilot/background-tool-workflow.test.ts
@@ -11,7 +11,6 @@ describe("isHostedDecopilotThread", () => {
   test("ignores retired provider values", () => {
     const dirtyThread = {
       harness_id: "decopilot",
-      sandbox_provider_kind: "local-api",
     };
     expect(isHostedDecopilotThread(dirtyThread)).toBe(true);
   });

--- a/apps/api/src/storage/automations.ts
+++ b/apps/api/src/storage/automations.ts
@@ -597,7 +597,6 @@ class KyselyAutomationsStorage implements AutomationsStorage {
         trigger_id: triggerId,
         virtual_mcp_id: automation.virtual_mcp_id,
         harness_id: "decopilot",
-        sandbox_provider_kind: "agent-sandbox",
         // A headless agent run needs a pod, so it is a sandbox session whatever the project defaults to.
         metadata: JSON.stringify({ runtime: "sandbox" }),
         hidden: false,

--- a/apps/api/src/storage/ports.ts
+++ b/apps/api/src/storage/ports.ts
@@ -34,7 +34,7 @@ import type {
 import type { UserModelPreferences } from "@decocms/shared/organization/schema";
 import type { ThreadRuntime } from "@decocms/shared/thread/session-runtime";
 
-export type ThreadUpdateData = Partial<Thread> & {
+export type ThreadUpdateData = Omit<Partial<Thread>, "harness_id"> & {
   /**
    * Internal liveness heartbeat. Exposed only on updates so RUN_STARTED can
    * clear progress from an older turn in the same write that marks the new run
@@ -47,9 +47,10 @@ export type ThreadUpdateData = Partial<Thread> & {
   failure_kind?: string | null;
 };
 
+export type ThreadCreateData = Partial<Thread>;
+
 export interface ThreadRuntimePin {
   harnessId: string;
-  sandboxProviderKind: string | null;
   branch: string | null;
   messageStorageVersion?: number;
 }
@@ -63,7 +64,7 @@ export interface ThreadStoragePort {
   /** `isNew` is false when `data.id` collided with an existing row (the
    *  insert is `ON CONFLICT DO NOTHING`) — callers use it to skip
    *  create-only side effects (e.g. analytics) on a replayed/idempotent call. */
-  create(data: Partial<Thread>): Promise<Thread & { isNew: boolean }>;
+  create(data: ThreadCreateData): Promise<Thread & { isNew: boolean }>;
   get(id: string, organizationId: string): Promise<Thread | null>;
   update(
     id: string,

--- a/apps/api/src/storage/threads.integration.test.ts
+++ b/apps/api/src/storage/threads.integration.test.ts
@@ -181,18 +181,17 @@ describe("SqlThreadStorage", () => {
   });
 
   describe("runtime pin", () => {
-    it("stores explicit runtime pins during create", async () => {
+    it("stores the harness and branch during create", async () => {
       const thread = await storage.create({
         organization_id: "org_1",
         created_by: "user_1",
         branch: "main",
         harness_id: "decopilot",
-        sandbox_provider_kind: "agent-sandbox",
       });
 
       expect(thread.harness_id).toBe("decopilot");
-      expect(thread.sandbox_provider_kind).toBe("agent-sandbox");
       expect(thread.branch).toBe("main");
+      expect(thread).not.toHaveProperty("sandbox_provider_kind");
     });
 
     it("lets exactly one concurrent runtime claim win", async () => {
@@ -203,13 +202,11 @@ describe("SqlThreadStorage", () => {
       const pins = [
         {
           harnessId: "decopilot",
-          sandboxProviderKind: "agent-sandbox",
           branch: "hosted",
         },
         {
-          harnessId: "codex",
-          sandboxProviderKind: "user-desktop",
-          branch: "native",
+          harnessId: "claude-code",
+          branch: "other-hosted",
         },
       ] as const;
 
@@ -222,9 +219,6 @@ describe("SqlThreadStorage", () => {
       expect(winner).not.toBeNull();
       for (const result of results) {
         expect(result.thread?.harness_id).toBe(winner?.harness_id);
-        expect(result.thread?.sandbox_provider_kind).toBe(
-          winner?.sandbox_provider_kind,
-        );
         expect(result.thread?.branch).toBe(winner?.branch);
       }
     });
@@ -237,7 +231,6 @@ describe("SqlThreadStorage", () => {
       });
       const result = await storage.pinRuntimeIfUnset(thread.id, "org_1", {
         harnessId: "decopilot",
-        sandboxProviderKind: "agent-sandbox",
         branch: "stale-branch",
       });
 
@@ -245,23 +238,37 @@ describe("SqlThreadStorage", () => {
       expect(result.thread?.branch).toBe("already-selected");
     });
 
-    it("does not overwrite a conflicting partial runtime", async () => {
+    it("ignores and preserves a dirty legacy provider value", async () => {
       const thread = await storage.create({
         organization_id: "org_1",
         created_by: "user_1",
-        sandbox_provider_kind: "user-desktop",
         branch: "native-branch",
       });
+      await sql`UPDATE threads
+        SET sandbox_provider_kind = 'local-api'
+        WHERE id = ${thread.id}`.execute(database.db);
       const result = await storage.pinRuntimeIfUnset(thread.id, "org_1", {
         harnessId: "decopilot",
-        sandboxProviderKind: "agent-sandbox",
         branch: "hosted-branch",
       });
 
-      expect(result.claimed).toBe(false);
-      expect(result.thread?.harness_id).toBeNull();
-      expect(result.thread?.sandbox_provider_kind).toBe("user-desktop");
+      expect(result.claimed).toBe(true);
+      expect(result.thread?.harness_id).toBe("decopilot");
       expect(result.thread?.branch).toBe("native-branch");
+      expect(result.thread).not.toHaveProperty("sandbox_provider_kind");
+
+      const persisted = await sql<{
+        harness_id: string | null;
+        sandbox_provider_kind: string | null;
+      }>`SELECT harness_id, sandbox_provider_kind
+        FROM threads
+        WHERE id = ${thread.id}`.execute(database.db);
+      expect(persisted.rows).toEqual([
+        {
+          harness_id: "decopilot",
+          sandbox_provider_kind: "local-api",
+        },
+      ]);
     });
 
     it("returns no row for missing and cross-tenant targets", async () => {
@@ -271,7 +278,6 @@ describe("SqlThreadStorage", () => {
       });
       const pin = {
         harnessId: "decopilot",
-        sandboxProviderKind: "agent-sandbox",
         branch: "hosted",
       };
 

--- a/apps/api/src/storage/threads.ts
+++ b/apps/api/src/storage/threads.ts
@@ -10,6 +10,7 @@ import { generatePrefixedId } from "@decocms/shared/utils/generate-id";
 import type { ThreadRuntime } from "@decocms/shared/thread/session-runtime";
 import { DEFAULT_THREAD_TITLE } from "@/api/routes/decopilot/constants";
 import type {
+  ThreadCreateData,
   ThreadRuntimePin,
   ThreadRuntimePinResult,
   ThreadStoragePort,
@@ -81,7 +82,7 @@ export class OrgScopedThreadStorage {
     return this.organizationId;
   }
 
-  create(data: Partial<Thread>): Promise<Thread & { isNew: boolean }> {
+  create(data: ThreadCreateData): Promise<Thread & { isNew: boolean }> {
     const orgId = this.requireOrg();
     return this.inner.create({ ...data, organization_id: orgId });
   }
@@ -298,7 +299,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
   // Thread Operations
   // ==========================================================================
 
-  async create(data: Partial<Thread>): Promise<Thread & { isNew: boolean }> {
+  async create(data: ThreadCreateData): Promise<Thread & { isNew: boolean }> {
     const id = data.id ?? generatePrefixedId("thrd");
     const now = new Date().toISOString();
 
@@ -321,7 +322,6 @@ export class SqlThreadStorage implements ThreadStoragePort {
       trigger_id: data.trigger_id ?? null,
       virtual_mcp_id: data.virtual_mcp_id ?? "",
       branch: data.branch ?? null,
-      sandbox_provider_kind: data.sandbox_provider_kind ?? null,
       harness_id: data.harness_id ?? null,
       created_at: now,
       updated_at: now,
@@ -426,12 +426,6 @@ export class SqlThreadStorage implements ThreadStoragePort {
     if (data.virtual_mcp_id !== undefined) {
       updateData.virtual_mcp_id = data.virtual_mcp_id;
     }
-    if (data.sandbox_provider_kind !== undefined) {
-      updateData.sandbox_provider_kind = data.sandbox_provider_kind;
-    }
-    if (data.harness_id !== undefined) {
-      updateData.harness_id = data.harness_id;
-    }
     if (data.message_storage_version !== undefined) {
       updateData.message_storage_version = data.message_storage_version;
     }
@@ -459,9 +453,6 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .updateTable("threads")
       .set({
         harness_id: pin.harnessId,
-        sandbox_provider_kind: sql<string | null>`coalesce(${sql.ref(
-          "sandbox_provider_kind",
-        )}, ${pin.sandboxProviderKind})`,
         branch: sql<string | null>`coalesce(${sql.ref("branch")}, ${
           pin.branch
         })`,
@@ -473,14 +464,6 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .where("id", "=", id)
       .where("organization_id", "=", organizationId)
       .where("harness_id", "is", null)
-      .where((eb) =>
-        pin.sandboxProviderKind === null
-          ? eb("sandbox_provider_kind", "is", null)
-          : eb.or([
-              eb("sandbox_provider_kind", "is", null),
-              eb("sandbox_provider_kind", "=", pin.sandboxProviderKind),
-            ]),
-      )
       .returningAll()
       .executeTakeFirst();
 
@@ -1179,7 +1162,6 @@ export class SqlThreadStorage implements ThreadStoragePort {
     last_progress_at?: Date | string | null;
     virtual_mcp_id?: string | null;
     branch?: string | null;
-    sandbox_provider_kind?: string | null;
     harness_id?: string | null;
     metadata?: ThreadMetadata | string | null;
     created_at: Date | string;
@@ -1225,7 +1207,6 @@ export class SqlThreadStorage implements ThreadStoragePort {
         : null,
       virtual_mcp_id: row.virtual_mcp_id ?? "",
       branch: row.branch ?? null,
-      sandbox_provider_kind: row.sandbox_provider_kind ?? null,
       harness_id: row.harness_id ?? null,
       metadata,
       created_at: toIsoString(row.created_at),

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -953,7 +953,7 @@ export interface ThreadTable {
   virtual_mcp_id: string;
   /** Git branch this thread is pinned to (GitHub-linked virtualmcps only) */
   branch: string | null;
-  /** Sandbox provider kind pinned on first message (e.g. "agent-sandbox", "user-desktop") */
+  /** Dormant legacy column retained in the physical schema; runtime code ignores it. */
   sandbox_provider_kind: string | null;
   /** Harness id pinned on first message (e.g. "claude-code", "codex", "decopilot") */
   harness_id: string | null;
@@ -1040,8 +1040,6 @@ export interface Thread {
   virtual_mcp_id: string;
   /** Git branch this thread is pinned to (GitHub-linked virtualmcps only) */
   branch: string | null;
-  /** Sandbox provider kind pinned on first message (e.g. "agent-sandbox", "user-desktop") */
-  sandbox_provider_kind: string | null;
   /** Harness id pinned on first message (e.g. "claude-code", "codex", "decopilot") */
   harness_id: string | null;
   metadata: ThreadMetadata;

--- a/apps/api/src/tools/strip-server-managed-metadata.test.ts
+++ b/apps/api/src/tools/strip-server-managed-metadata.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { stripServerManagedMetadata } from "./strip-server-managed-metadata";
+
+describe("stripServerManagedMetadata", () => {
+  test("removes sandboxMap without mutating the caller's metadata", () => {
+    const metadata = {
+      instructions: "Keep me",
+      sandboxMap: { user: { branch: {} } },
+    };
+
+    expect(stripServerManagedMetadata(metadata)).toEqual({
+      instructions: "Keep me",
+    });
+    expect(metadata).toHaveProperty("sandboxMap");
+  });
+
+  test("preserves null and undefined", () => {
+    expect(stripServerManagedMetadata(null)).toBeNull();
+    expect(stripServerManagedMetadata(undefined)).toBeUndefined();
+  });
+});

--- a/apps/api/src/tools/strip-server-managed-metadata.ts
+++ b/apps/api/src/tools/strip-server-managed-metadata.ts
@@ -1,0 +1,8 @@
+export function stripServerManagedMetadata<T extends Record<string, unknown>>(
+  metadata: T | null | undefined,
+): Omit<T, "sandboxMap"> | null | undefined {
+  if (!metadata) return metadata;
+  const sanitized = { ...metadata };
+  delete sanitized.sandboxMap;
+  return sanitized;
+}

--- a/apps/api/src/tools/thread/create.ts
+++ b/apps/api/src/tools/thread/create.ts
@@ -51,6 +51,7 @@ import {
   branchUserLabel,
   generateBranchName,
 } from "@decocms/shared/branch-name";
+import { AGENT_SANDBOX_KIND } from "../sandbox/sandbox-map";
 
 const CreateInputSchema = z.object({
   data: ThreadCreateDataSchema.describe(
@@ -72,10 +73,8 @@ type SandboxMapMeta = {
 };
 
 /**
- * Pick the user's most-recently-touched branch from sandboxMap (3-level shape:
- * sandboxMap[userId][branch][sandboxProviderKind] → SandboxRecord). Returns
- * undefined when the user has no entries (caller falls back to
- * generateBranchName).
+ * Pick the user's most-recently-touched hosted branch from sandboxMap. Native
+ * desktop siblings are not routable by the API and cannot warm a hosted chat.
  */
 function pickWarmBranchFromSandboxMap(
   sandboxMap: SandboxMapMeta["sandboxMap"],
@@ -83,18 +82,13 @@ function pickWarmBranchFromSandboxMap(
 ): string | undefined {
   const branchMap = sandboxMap?.[userId];
   if (!branchMap) return undefined;
-  // For each branch, take the max createdAt across all sandboxProviderKind entries.
-  const sorted = Object.entries(branchMap).sort(([, aKinds], [, bKinds]) => {
-    const aMax = Math.max(
-      0,
-      ...Object.values(aKinds).map((e) => e.createdAt ?? 0),
+  const sorted = Object.entries(branchMap)
+    .filter(([, kinds]) => AGENT_SANDBOX_KIND in kinds)
+    .sort(
+      ([, aKinds], [, bKinds]) =>
+        (bKinds[AGENT_SANDBOX_KIND]?.createdAt ?? 0) -
+        (aKinds[AGENT_SANDBOX_KIND]?.createdAt ?? 0),
     );
-    const bMax = Math.max(
-      0,
-      ...Object.values(bKinds).map((e) => e.createdAt ?? 0),
-    );
-    return bMax - aMax;
-  });
   return sorted[0]?.[0];
 }
 

--- a/apps/api/src/tools/thread/helpers.test.ts
+++ b/apps/api/src/tools/thread/helpers.test.ts
@@ -25,7 +25,6 @@ const BASE_THREAD: Thread = {
   last_progress_at: null,
   virtual_mcp_id: "",
   branch: null,
-  sandbox_provider_kind: null,
   harness_id: null,
   metadata: {},
   message_storage_version: 1,

--- a/apps/api/src/tools/thread/helpers.ts
+++ b/apps/api/src/tools/thread/helpers.ts
@@ -120,7 +120,6 @@ export function normalizeThreadForResponse(
     virtual_mcp_id: thread.virtual_mcp_id || undefined,
     trigger_id: thread.trigger_id,
     branch: thread.branch,
-    sandbox_provider_kind: thread.sandbox_provider_kind,
     harness_id: thread.harness_id,
     metadata:
       thread.metadata && Object.keys(thread.metadata).length > 0

--- a/apps/api/src/tools/thread/update.integration.test.ts
+++ b/apps/api/src/tools/thread/update.integration.test.ts
@@ -151,6 +151,19 @@ describe("COLLECTION_THREADS_UPDATE", () => {
       env.ctx,
     );
     expect(created.item.metadata?.runtime).toBe("sandbox");
+    const sandboxMap = {
+      [env.userId]: {
+        main: {
+          "agent-sandbox": {
+            sandboxHandle: "sandbox-1",
+            previewUrl: null,
+          },
+        },
+      },
+    };
+    await env.ctx.storage.threads.update(created.item.id, {
+      metadata: { ...created.item.metadata, sandboxMap },
+    });
 
     const updated = await COLLECTION_THREADS_UPDATE.handler(
       {
@@ -160,6 +173,7 @@ describe("COLLECTION_THREADS_UPDATE", () => {
       env.ctx,
     );
     expect(updated.item.metadata?.runtime).toBe("sandbox");
+    expect(updated.item.metadata?.sandboxMap).toEqual(sandboxMap);
   });
 
   it("rejects a metadata write that would change the runtime stamp", async () => {

--- a/apps/api/src/tools/thread/update.ts
+++ b/apps/api/src/tools/thread/update.ts
@@ -22,6 +22,7 @@ import {
   ThreadUpdateDataSchema,
 } from "@decocms/shared/thread/schema";
 import { parseThreadRuntime } from "@decocms/shared/thread/session-runtime";
+import { stripServerManagedMetadata } from "../strip-server-managed-metadata";
 
 /**
  * Input schema for updating threads
@@ -105,11 +106,12 @@ export const COLLECTION_THREADS_UPDATE = defineTool({
 
     if (data.metadata !== undefined) {
       // `runtime` is stamped once at creation and immutable; `metadata` is a full-replacement write, so preserve it.
+      const incomingMetadata = stripServerManagedMetadata(data.metadata) ?? {};
       const existingRuntime = parseThreadRuntime(
         (existing.metadata as { runtime?: unknown } | null)?.runtime,
       );
       const incomingRuntime = parseThreadRuntime(
-        (data.metadata as { runtime?: unknown })?.runtime,
+        (incomingMetadata as { runtime?: unknown }).runtime,
       );
       if (
         existingRuntime &&
@@ -120,9 +122,16 @@ export const COLLECTION_THREADS_UPDATE = defineTool({
           `Cannot change a thread's runtime (${existingRuntime} → ${incomingRuntime}); it is stamped once at creation. Start a new chat instead.`,
         );
       }
-      updateData.metadata = existingRuntime
-        ? { ...data.metadata, runtime: existingRuntime }
-        : data.metadata;
+      const existingSandboxMap = (
+        existing.metadata as { sandboxMap?: unknown } | null
+      )?.sandboxMap;
+      updateData.metadata = {
+        ...incomingMetadata,
+        ...(existingRuntime ? { runtime: existingRuntime } : {}),
+        ...(existingSandboxMap !== undefined
+          ? { sandboxMap: existingSandboxMap }
+          : {}),
+      };
     }
 
     if (data.branch !== undefined) {

--- a/apps/api/src/tools/virtual/create.ts
+++ b/apps/api/src/tools/virtual/create.ts
@@ -17,6 +17,7 @@ import { VirtualMCPCreateDataSchema, VirtualMCPEntitySchema } from "./schema";
 import { requireOrgAdminForPinnedField } from "./require-org-admin-for-pin";
 import { requireConnectionsInOrganization } from "./require-connections-in-org";
 import { writeAgentPrompts } from "../../file-storage/agent-prompts";
+import { stripServerManagedMetadata } from "../strip-server-managed-metadata";
 /**
  * Random icon+color for new agents (server-side, no React deps).
  * Uses the same icon:// format as the client-side agent-icon module.
@@ -117,7 +118,8 @@ export const COLLECTION_VIRTUAL_MCP_CREATE = defineTool({
     }
 
     // `prompts` is seeded to org-fs after creation, not stored on the agent row.
-    const { prompts, ...createData } = input.data;
+    const { prompts, metadata: rawMetadata, ...createData } = input.data;
+    const metadata = stripServerManagedMetadata(rawMetadata);
 
     if (createData.connections.length > 0) {
       await requireConnectionsInOrganization(
@@ -132,6 +134,7 @@ export const COLLECTION_VIRTUAL_MCP_CREATE = defineTool({
     // Use a random icon+color if no icon is provided
     const dataWithIcon = {
       ...createData,
+      metadata,
       icon: createData.icon ?? pickRandomAgentIcon(),
     };
 

--- a/apps/api/src/tools/virtual/update.ts
+++ b/apps/api/src/tools/virtual/update.ts
@@ -16,6 +16,7 @@ import { VirtualMCPEntitySchema, VirtualMCPUpdateDataSchema } from "./schema";
 import { requireOrgAdminForPinnedField } from "./require-org-admin-for-pin";
 import { requireConnectionsInOrganization } from "./require-connections-in-org";
 import { pinnedSiteSlugOnRename } from "./pin-site-slug";
+import { stripServerManagedMetadata } from "../strip-server-managed-metadata";
 
 /**
  * Input schema for updating a virtual MCP
@@ -72,10 +73,17 @@ export const COLLECTION_VIRTUAL_MCP_UPDATE = defineTool({
 
     // `prompts` lives in org-fs, not on the agent row — pull it out before the
     // row update and re-seed separately below.
-    const { prompts, ...data } = input.data;
-    if (data.metadata && existing.metadata) {
-      data.metadata = { ...existing.metadata, ...data.metadata };
+    const { prompts, metadata: rawMetadata, ...updateData } = input.data;
+    let metadata = stripServerManagedMetadata(rawMetadata);
+    if (metadata && existing.metadata) {
+      metadata = { ...existing.metadata, ...metadata };
+    } else if (metadata === null && existing.metadata?.sandboxMap) {
+      metadata = { sandboxMap: existing.metadata.sandboxMap };
     }
+    const data = {
+      ...updateData,
+      ...(rawMetadata !== undefined ? { metadata } : {}),
+    };
 
     // A rename must not move the agent's asset tenancy.
     const pinnedSiteSlug = pinnedSiteSlugOnRename({

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -78,11 +78,9 @@ export interface StudioThread {
   last_progress_at: string | null;
   virtual_mcp_id: string;
   branch: string | null;
-  sandbox_provider_kind: string | null;
   harness_id: string | null;
   metadata: ThreadMetadata;
   message_storage_version: number;
-  link_transport: string | null;
 }
 
 export interface StudioThreadMessage {

--- a/packages/shared/src/thread/schema.test.ts
+++ b/packages/shared/src/thread/schema.test.ts
@@ -21,4 +21,11 @@ describe("ThreadUpdateDataSchema", () => {
     const result = ThreadUpdateDataSchema.safeParse({});
     expect(result.success).toBe(true);
   });
+
+  test("rejects the server-managed sandbox map", () => {
+    const result = ThreadUpdateDataSchema.safeParse({
+      metadata: { sandboxMap: {} },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/packages/shared/src/thread/schema.ts
+++ b/packages/shared/src/thread/schema.ts
@@ -99,13 +99,6 @@ export const ThreadEntitySchema = z.object({
     .nullable()
     .optional()
     .describe("Git branch this thread is pinned to (GitHub-linked vms only)"),
-  sandbox_provider_kind: z
-    .string()
-    .nullable()
-    .optional()
-    .describe(
-      "Pinned on first message; identifies which sandbox provider to dispatch to (e.g. 'agent-sandbox', 'user-desktop').",
-    ),
   harness_id: z
     .string()
     .nullable()
@@ -166,9 +159,17 @@ export const ThreadUpdateDataSchema = z.object({
     .describe(
       "New thread status (user-set override). 'expired' is a computed virtual status and cannot be set directly.",
     ),
-  metadata: ThreadMetadataSchema.optional().describe(
-    "Full replacement of the thread's metadata object",
-  ),
+  metadata: ThreadMetadataSchema.superRefine((metadata, ctx) => {
+    if ("sandboxMap" in metadata) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["sandboxMap"],
+        message: "sandboxMap is managed by the sandbox lifecycle",
+      });
+    }
+  })
+    .optional()
+    .describe("Full replacement of the thread's user-managed metadata"),
   branch: z
     .string()
     .min(1)


### PR DESCRIPTION
## Summary

- Uses the thread harness pin as the runtime authority.
- Stops persisting or consulting sandbox provider selection on thread operations.

## Testing

- Full workspace check and 18 focused thread tests
- No database migrations

Split from #6459. Supersedes #5638.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threads now use harness_id plus branch as the single runtime authority. The old sandbox_provider_kind is ignored and never returned; client-supplied server-managed metadata (like sandboxMap) is rejected/stripped, and existing runtime and sandboxMap are preserved on thread and agent updates.

**Refactors**
- Pins runtime with harness_id and branch; exactly one concurrent claim can win.
- Removes provider from runtime pinning and ignores the legacy DB column while leaving it intact.
- Drops sandbox_provider_kind from API and shared types; harness_id is immutable on updates.
- Seeds warm branches only from hosted sandboxes when available.

**Migration**
- Remove all reads/writes of sandbox_provider_kind and stop passing it to pins.
- Do not send metadata.sandboxMap; the shared schema rejects it and the server strips it.
- Do not attempt to update harness_id or change a thread’s runtime; start a new thread instead.
- No database migrations or config changes are required.

<sup>Written for commit fe998d7aad63963ee2eb62975d2945dc3bf865d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

