### PR TITLE
refactor(deploy): use explicit agent sandbox enablement

### DIFF
--- a/.github/workflows/preview-build.yaml
+++ b/.github/workflows/preview-build.yaml
@@ -291,9 +291,8 @@ jobs:
             <details><summary>What does <b>not</b> work in a preview</summary>
 
             - **Agent tool execution against a hosted sandbox** — previews run
-              `STUDIO_SANDBOX_PROVIDER=user-desktop` with no daemon attached, so
-              dispatch returns `409 link_offline`. Sandbox previews and the
-              sandbox lifecycle UI are equally out.
+              with `STUDIO_AGENT_SANDBOX_ENABLED=false`. Sandbox previews and
+              the sandbox lifecycle UI are out of scope.
             - **AI features** until you add your own provider key in org settings.
               Previews ship no key, so preview LLM spend is zero by construction.
             - **Google / GitHub sign-in** — OAuth callbacks cannot be registered

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -34,7 +34,7 @@ complete product from one artifact.
   `StudioContext`.
 - Proxy downstream MCP connections and enforce credentials and permissions.
 - Coordinate DBOS workflows, automations, event delivery, NATS messaging, and
-  sandbox providers.
+  the hosted AgentSandbox provider.
 - Emit OpenTelemetry traces, metrics, and logs and query monitoring backends.
 - Package the production server, migration runner, CLI, and staged web assets.
 
@@ -117,7 +117,7 @@ Key paths:
 | `src/dbos/` and `src/dispatch-queue/` | Durable workflows and queue coordination |
 | `src/event-bus/` and `src/nats/` | Event delivery and NATS integration |
 | `src/encryption/` and `src/vault/` | Credential encryption and secure token access |
-| `src/sandbox/` and `src/link-daemon/` | Sandbox lifecycle and desktop-link coordination |
+| `src/sandbox/` | Hosted agent-sandbox lifecycle and preview routing |
 | `src/observability/` and `src/monitoring/` | Telemetry export and monitoring queries |
 | `migrations/` | Ordered Kysely migrations |
 | `scripts/` | Bundle, contract-generation, migration, and smoke-test utilities |
@@ -188,7 +188,7 @@ Core settings include:
 | `ENCRYPTION_KEY` | Stable credential-vault key | Set explicitly in production |
 | `CONFIG_PATH` | Theme, logo, and monitoring JSON configuration | `./config.json` |
 | `STUDIO_DISPATCH_ROLE` | Queue role: `all`, `api`, or `worker` | `all` |
-| `STUDIO_SANDBOX_PROVIDER` | Sandbox provider: `user-desktop` or `agent-sandbox` | `user-desktop` |
+| `STUDIO_AGENT_SANDBOX_ENABLED` | Enable hosted AgentSandbox provisioning | `false` |
 | `CLICKHOUSE_URL` | Optional ClickHouse monitoring endpoint | Local monitoring backend |
 
 Authentication providers use `AUTH_*` variables. The validated list lives in

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
@@ -18,7 +18,7 @@ Chart sources:
   **Easiest path:** for a one-command install with bundled dependencies (local or a POC cluster), use the [umbrella chart](https://github.com/decocms/studio/tree/main/selfhost/examples/k8s-local) or `selfhost/scripts/local-k8s.sh` (see [Quickstart](/en/studio/self-hosting/quickstart)). There's also a **guide for coding agents** ([`SKILL.md`](https://github.com/decocms/studio/blob/main/selfhost/skills/self-host-studio/SKILL.md)) that interviews you and writes a reusable install directory — an umbrella chart with pinned OCI dependencies plus your values. This page is the **chart reference** for installing directly and for production — the full dependency guide (managed vs in-cluster Postgres/S3/ClickHouse, secrets with/without ESO, ingress, sandbox) lives in [`selfhost/production`](https://github.com/decocms/studio/tree/main/selfhost/production).
 </Callout>
 
-For the runtime architecture (web/API/worker split, Postgres, NATS, and sandbox providers), see [Architecture](/en/studio/architecture).
+For the runtime architecture (web/API/worker split, Postgres, NATS, and AgentSandbox), see [Architecture](/en/studio/architecture).
 
 ## Deployment model
 
@@ -121,7 +121,7 @@ configMap:
   meshConfig:
     BETTER_AUTH_URL: "https://studio.example.com"
     BASE_URL: "https://studio.example.com"
-    STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
+    STUDIO_AGENT_SANDBOX_ENABLED: "true"
     STUDIO_ENV: "production"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-production"
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
@@ -18,7 +18,7 @@ Código-fonte dos charts:
   **Caminho mais fácil:** para uma instalação de um comando com dependências embutidas (local ou cluster de POC), use o [umbrella chart](https://github.com/decocms/studio/tree/main/selfhost/examples/k8s-local) ou `selfhost/scripts/local-k8s.sh` (veja o [Quickstart](/pt-br/studio/self-hosting/quickstart)). Há também um **guia para agentes de código** ([`SKILL.md`](https://github.com/decocms/studio/blob/main/selfhost/skills/self-host-studio/SKILL.md)) que entrevista você e escreve um diretório de instalação reutilizável — um umbrella chart com dependências OCI fixadas mais os seus values. Esta página é a **referência do chart** para instalar direto e para produção — o guia completo de dependências (Postgres/S3/ClickHouse managed ou in-cluster, secrets com/sem ESO, ingress, sandbox) está em [`selfhost/production`](https://github.com/decocms/studio/tree/main/selfhost/production).
 </Callout>
 
-Para entender a arquitetura em runtime (separação web/API/worker, Postgres, NATS e providers de sandbox), veja [Arquitetura](/pt-br/studio/architecture).
+Para entender a arquitetura em runtime (separação web/API/worker, Postgres, NATS e AgentSandbox), veja [Arquitetura](/pt-br/studio/architecture).
 
 ## Modelo de deployment
 
@@ -121,7 +121,7 @@ configMap:
   meshConfig:
     BETTER_AUTH_URL: "https://studio.example.com"
     BASE_URL: "https://studio.example.com"
-    STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
+    STUDIO_AGENT_SANDBOX_ENABLED: "true"
     STUDIO_ENV: "production"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-production"
 

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -35,8 +35,8 @@ installed (it ships the CRDs + controller).
   match `mesh.namespace` and `mesh.serviceAccountName`; this chart grants that
   identity the runner permissions in `agent-sandbox-system`.
 - The Studio release must explicitly set
-  `STUDIO_SANDBOX_PROVIDER=agent-sandbox`. The default provider is the user's
-  linked desktop and is not a production cluster configuration.
+  `STUDIO_AGENT_SANDBOX_ENABLED=true`. Hosted sandbox provisioning is disabled
+  by default.
 - The Studio release for THIS environment must point its runner at
   the env-suffixed SandboxTemplate by setting
   `STUDIO_SANDBOX_TEMPLATE_NAME=studio-sandbox-<envName>` in the studio
@@ -119,7 +119,7 @@ serviceAccount:
 
 configMap:
   meshConfig:
-    STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
+    STUDIO_AGENT_SANDBOX_ENABLED: "true"
     STUDIO_ENV: "staging"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-staging"
     # The next three values are required only when previewGateway.enabled=true.

--- a/deploy/helm/studio/values-preview.yaml
+++ b/deploy/helm/studio/values-preview.yaml
@@ -233,16 +233,15 @@ configMap:
     AUTH_EMAIL_PASSWORD_ENABLED: "true"
     # Several reviewers behind one office IP trip the auth limiter otherwise.
     DISABLE_RATE_LIMIT: "true"
-    # No hosted sandboxes by default. Agent dispatch returns 409 link_offline
-    # with no local daemon attached — a documented limitation, not a bug.
+    # No hosted sandboxes by default. Hosted agent execution and its sandbox
+    # lifecycle UI are unavailable in a standard preview.
     #
     # To test agent behaviour in a preview, set preview.sandbox.enabled=true
     # (see values.yaml — it grants reach over a shared production namespace) and
     # replace this block with the settings below, pointed at an existing
     # environment whose templates and warm pool the preview borrows:
     #
-    #   STUDIO_SANDBOX_PROVIDER: "cluster"
-    #   STUDIO_SANDBOX_RUNNER: "agent-sandbox"
+    #   STUDIO_AGENT_SANDBOX_ENABLED: "true"
     #   STUDIO_SANDBOX_TEMPLATE_NAME: "<existing template, e.g. studio-sandbox-stg>"
     #   STUDIO_ENV: "<matching env suffix, e.g. stg>"
     #   STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME: "<that env's sandbox gateway>"
@@ -252,7 +251,7 @@ configMap:
     # Without STUDIO_SANDBOX_SENTINEL_TOKEN the claim takes the cold-start path
     # instead of the warm pool — slower per sandbox, and it borrows no capacity
     # from the environment being shared.
-    STUDIO_SANDBOX_PROVIDER: "user-desktop"
+    STUDIO_AGENT_SANDBOX_ENABLED: "false"
     DISABLE_ORGFS_MOUNTS: "true"
     # Never let a preview provision real gateway keys. STUDIO_PROVISION_SECRET_KEY
     # is deliberately left unset, which is the other half of this gate.

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -178,9 +178,10 @@ preview:
   # with production sandboxes — see templates/preview-sandbox-rbac.yaml for why
   # that cannot currently be narrowed, and what would remove the need.
   #
-  # The application also needs the matching STUDIO_SANDBOX_* configuration
-  # (provider, runner, template name, preview gateway) pointed at an existing
-  # environment; enabling this alone grants permission but changes no behaviour.
+  # The application also needs STUDIO_AGENT_SANDBOX_ENABLED plus matching
+  # environment, template, sentinel/pool and preview-routing configuration
+  # pointed at an existing environment; enabling this alone grants permission
+  # but changes no behaviour.
   sandbox:
     enabled: false
     # Namespace holding the SandboxTemplates, warm pools and claims.

--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -27,7 +27,7 @@ the clock.
 
 | Not supported | Reason |
 |---|---|
-| Agent execution against a hosted sandbox | `STUDIO_SANDBOX_PROVIDER=user-desktop`, no daemon attached → `409 link_offline`. A hosted-sandbox preview class needs the `sandbox-env` chart and is out of scope. |
+| Agent execution against a hosted sandbox | `STUDIO_AGENT_SANDBOX_ENABLED=false`; a hosted-sandbox preview class needs the `sandbox-env` chart and is out of scope. |
 | AI features out of the box | No provider key is seeded, so preview LLM spend is zero by construction. Add your own key in org settings. |
 | Google / GitHub sign-in | OAuth callbacks cannot be registered for a per-PR hostname. Email/password only. |
 | Monitoring dashboard, billing, outbound email | No ClickHouse, no Stripe, no mail provider. |

--- a/selfhost/README.md
+++ b/selfhost/README.md
@@ -69,7 +69,7 @@ namespace guard is opted out for this case via `sandbox-operator.allowForeignNam
 
 - **Required:** PostgreSQL (DB + DBOS workflow engine); `BETTER_AUTH_SECRET`;
   `ENCRYPTION_KEY` (credential vault).
-- **Bundled by the chart:** NATS (event-bus wake-ups + CLI link tunnel).
+- **Bundled by the chart:** NATS (event-bus wake-ups + run streaming).
 - **Required for a faithful run:** an S3-compatible object store (assets /
   buckets / org-fs). Locally = MinIO; in prod = managed S3.
 - **Optional:** ClickHouse + OTel collector (monitoring dashboard), sandbox
@@ -119,7 +119,7 @@ removed values key won't error — `helm template` after big `deploy/` changes).
 
 The sandbox is a separate layer — the `sandbox-operator` (agent-sandbox operator
 + CRDs) and `sandbox-env` charts under [`deploy/helm`](../deploy/helm), plus
-Studio wiring (`STUDIO_SANDBOX_PROVIDER=agent-sandbox`). Core Studio (agents,
+Studio wiring (`STUDIO_AGENT_SANDBOX_ENABLED=true`). Core Studio (agents,
 connections, MCP proxy) runs fine without it; enable it for the *full* install.
 
 The umbrella installs the sandbox layer as part of the one `helm install`: the

--- a/selfhost/examples/dev-hybrid/.env.example
+++ b/selfhost/examples/dev-hybrid/.env.example
@@ -20,7 +20,7 @@ S3_FORCE_PATH_STYLE=true
 # ── Sandbox (driven in the cluster via your kubeconfig) ──────────────────────
 # The token MUST equal the umbrella's sandbox-env.sentinel.token so Studio runs in
 # warm-pool mode (otherwise claims are rejected — see the skill's troubleshooting).
-STUDIO_SANDBOX_PROVIDER=agent-sandbox
+STUDIO_AGENT_SANDBOX_ENABLED=true
 STUDIO_ENV=local
 STUDIO_SANDBOX_TEMPLATE_NAME=studio-sandbox-local
 STUDIO_SANDBOX_SENTINEL_TOKEN=local-dev-sandbox-sentinel-token-change-me

--- a/selfhost/examples/k8s-local/values.yaml
+++ b/selfhost/examples/k8s-local/values.yaml
@@ -40,7 +40,7 @@ chart-deco-studio:
       S3_SECRET_ACCESS_KEY: "minioadmin"
       S3_FORCE_PATH_STYLE: "true"
       # Sandbox: server-side (agent-sandbox), wired to sandbox-env's template.
-      STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
+      STUDIO_AGENT_SANDBOX_ENABLED: "true"
       STUDIO_ENV: "local"
       STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-local"
       # Shared sentinel token — MUST equal sandbox-env.sentinel.token below.

--- a/selfhost/production/README.md
+++ b/selfhost/production/README.md
@@ -154,7 +154,7 @@ helm install sandbox-env-prod deploy/helm/sandbox-env \
   -n agent-sandbox-system -f selfhost/production/values-sandbox-env-prod.yaml
 ```
 
-Then wire Studio: `STUDIO_SANDBOX_PROVIDER=agent-sandbox`, `STUDIO_ENV=<env>`,
+Then wire Studio: `STUDIO_AGENT_SANDBOX_ENABLED=true`, `STUDIO_ENV=<env>`,
 `STUDIO_SANDBOX_TEMPLATE_NAME=studio-sandbox-<env>`, and the preview URL pattern
 pointing at your wildcard domain.
 

--- a/selfhost/production/values-sandbox-env-prod.yaml
+++ b/selfhost/production/values-sandbox-env-prod.yaml
@@ -88,7 +88,7 @@ previewGateway:
 # Then wire the Studio release (chart-deco-studio values):
 #   configMap:
 #     meshConfig:
-#       STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
+#       STUDIO_AGENT_SANDBOX_ENABLED: "true"
 #       STUDIO_ENV: "prod"
 #       STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-prod"
 #       STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.preview.example.com"

--- a/selfhost/production/values-studio-prod.yaml
+++ b/selfhost/production/values-studio-prod.yaml
@@ -85,7 +85,7 @@ configMap:
     # the SHARED bearer — deliver it via the ExternalSecret with the SAME value as
     # sandbox-env's sentinel.token, or the daemon handshake fails and claims never
     # go Ready ("environment variable override is not allowed ... DAEMON_TOKEN").
-    STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
+    STUDIO_AGENT_SANDBOX_ENABLED: "true"
     STUDIO_ENV: "<env>"                                   # e.g. prod
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-<env>"  # = studio-sandbox-<STUDIO_ENV>
     # STUDIO_SANDBOX_SENTINEL_TOKEN → via ExternalSecret (== sandbox-env.sentinel.token)

--- a/selfhost/skills/self-host-studio/SKILL.md
+++ b/selfhost/skills/self-host-studio/SKILL.md
@@ -106,7 +106,7 @@ detected environment, then walk these. Record answers into a values file you'll
    - a **shared sentinel token**: the SAME value in `sandbox-env.sentinel.token`
      and Studio's `STUDIO_SANDBOX_SENTINEL_TOKEN` (generate one: `openssl rand -hex 32`).
      Missing → Studio cold-provisions and the template rejects `DAEMON_TOKEN`.
-   - `STUDIO_SANDBOX_PROVIDER=agent-sandbox`, `STUDIO_ENV=<env>`,
+   - `STUDIO_AGENT_SANDBOX_ENABLED=true`, `STUDIO_ENV=<env>`,
      `STUDIO_SANDBOX_TEMPLATE_NAME=studio-sandbox-<env>`.
    All three live in ONE artifact, so the values file is the only place the
    handshake has to be right.
@@ -289,7 +289,7 @@ For a standalone/prod install, wire Studio with:
 ```yaml
 configMap:
   meshConfig:
-    STUDIO_SANDBOX_PROVIDER: "agent-sandbox"          # or "user-desktop" (laptop via NATS link)
+    STUDIO_AGENT_SANDBOX_ENABLED: "true"
     STUDIO_ENV: "<envName>"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-<envName>"
 ```

--- a/tests/multi-pod/docker-compose.yml
+++ b/tests/multi-pod/docker-compose.yml
@@ -117,13 +117,9 @@ services:
       S3_BUCKET: studio-dev
       S3_ACCESS_KEY_ID: minioadmin
       S3_SECRET_ACCESS_KEY: minioadmin
-      # Pin the sandbox provider so POST /decopilot/messages doesn't default
-      # to "user-desktop" — there's no link daemon in this cluster, and
-      # resolveDispatchTarget would 409 with link_offline. "agent-sandbox"
-      # makes resolveDispatchTarget short-circuit to hosted execution;
-      # no sandbox is actually provisioned because ensureSandbox is lazy
+      # Enable hosted execution for POST /decopilot/messages. No sandbox is
+      # actually provisioned because ensureSandbox is lazy
       # (built-in-tools/index.ts) and the mock-ai test never emits tool calls.
-      STUDIO_SANDBOX_PROVIDER: agent-sandbox
       STUDIO_AGENT_SANDBOX_ENABLED: "true"
     ports:
       - "127.0.0.1:13001:3000"

--- a/tests/resilience/docker-compose.yml
+++ b/tests/resilience/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       BETTER_AUTH_URL: http://localhost:3000
       BASE_URL: http://localhost:3000
       DECOCMS_LOCAL_MODE: "true"
-      STUDIO_SANDBOX_PROVIDER: user-desktop
+      STUDIO_AGENT_SANDBOX_ENABLED: "false"
       ENCRYPTION_KEY: test-encryption-key-32chars-long!
       # org-fs mounts can't work in these containers (no FUSE / rclone mount
       # fails), and this suite exercises API/NATS resilience, not org-fs. With

--- a/tests/resilience/scenarios/decopilot-nats-restart-selfheal.README.md
+++ b/tests/resilience/scenarios/decopilot-nats-restart-selfheal.README.md
@@ -25,14 +25,14 @@ A v2 streaming turn requires the full decopilot dispatch pipeline:
 |---|-----|-------|-----|
 | 1 | **No model provider.** `streamText` and tier resolution need an OpenAI-compatible endpoint. The resilience `docker-compose.yml` has no `mock-ai` service. | `tests/resilience/docker-compose.yml` | Port the `mock-ai` service from `tests/multi-pod/docker-compose.yml` (build context `./mock-ai`, copy `tests/multi-pod/mock-ai/`). It already supports `slow:<n>x<ms>` hints, which is exactly what this scenario needs to keep a stream open while NATS is severed. |
 | 2 | **v2 is off.** No `STREAM_OF_RECORD_V2_PERCENT`, so every new thread stays `message_storage_version=1` and **no parts are ever written**. | `studio` service env in the compose | Add `STREAM_OF_RECORD_V2_PERCENT: "100"` so the new thread is pinned v2 at its first-message site (see `apps/api/src/api/routes/decopilot/v2-canary.ts`). |
-| 3 | **Dispatch 409s.** `studio` runs `STUDIO_SANDBOX_PROVIDER=user-desktop` and the `link-daemon` is behind a compose profile (not started by `up --wait`). With no link claim, `resolveDispatchTarget` returns `user_desktop_link_offline` → `POST /messages` 409s before dispatch. | `studio` service env in the compose | Run the turn with `STUDIO_SANDBOX_PROVIDER=agent-sandbox` (as multi-pod does) so dispatch short-circuits to hosted execution. The mock-ai stream never emits tool calls, so no sandbox is provisioned (`ensureSandbox` is lazy). |
+| 3 | **Hosted sandbox is disabled.** `studio` runs `STUDIO_AGENT_SANDBOX_ENABLED=false`, so hosted execution cannot provision its runtime. | `studio` service env in the compose | Run the turn with `STUDIO_AGENT_SANDBOX_ENABLED=true` (as multi-pod does). The mock-ai stream never emits tool calls, so no sandbox is provisioned (`ensureSandbox` is lazy). |
 
 > ⚠️ Changing the shared `studio` service env (#2, #3) would alter behaviour for
 > **every** resilience scenario in the suite (they all reuse the one `studio`
 > container via `registerTestHooks`). Two clean options:
 >
 > - **Dedicated service.** Add a second studio service (e.g. `studio-v2`) with
->   `STREAM_OF_RECORD_V2_PERCENT=100` + `STUDIO_SANDBOX_PROVIDER=agent-sandbox` + the
+>   `STREAM_OF_RECORD_V2_PERCENT=100` + `STUDIO_AGENT_SANDBOX_ENABLED=true` + the
 >   `mock-ai` dependency, on its own host port, and point this scenario at it.
 >   Keeps the existing scenarios byte-for-byte unchanged. **Preferred.**
 > - **Flip the shared env.** Set the two vars on the shared `studio` service and

--- a/tests/resilience/scenarios/decopilot-nats-restart-selfheal.test.ts
+++ b/tests/resilience/scenarios/decopilot-nats-restart-selfheal.test.ts
@@ -44,13 +44,11 @@
  *   2. **No v2 env.** The `studio` service has no `STREAM_OF_RECORD_V2_PERCENT`,
  *      so every new thread stays `message_storage_version=1` and NO parts are
  *      ever written. The turn must run with `STREAM_OF_RECORD_V2_PERCENT=100`.
- *   3. **Dispatch 409s.** `studio` runs with `STUDIO_SANDBOX_PROVIDER=user-desktop`
- *      and the `link-daemon` is behind a compose profile (not started by
- *      `up --wait`). With no link claim, `resolveDispatchTarget` returns
- *      `user_desktop_link_offline` and `POST /messages` 409s before any
- *      dispatch. The turn must run with `STUDIO_SANDBOX_PROVIDER=agent-sandbox`
- *      (as the multi-pod suite does) so dispatch short-circuits to hosted
- *      execution and the mock-ai stream runs without a sandbox.
+ *   3. **Hosted sandbox is disabled.** `studio` runs with
+ *      `STUDIO_AGENT_SANDBOX_ENABLED=false`, so the hosted runtime cannot be
+ *      provisioned. The turn must run with `STUDIO_AGENT_SANDBOX_ENABLED=true`
+ *      (as the multi-pod suite does); the mock-ai stream emits no tool calls,
+ *      so the run still provisions no sandbox.
  *
  * The toxiproxy / poll / Postgres-query wiring below is REAL and runnable —
  * `dbQuery` shells into the compose `postgres` service exactly like
@@ -62,10 +60,8 @@
  */
 
 import { describe, expect, test } from "bun:test";
-// Relative import (NOT the `@/` alias): the `@/` path is defined only inside
-// the apps/api workspace tsconfig, and these resilience scenarios live
-// outside it. The headless link-daemon entrypoint reaches into app code the
-// same way (see ../link-daemon-entrypoint.ts).
+// Relative import (NOT the `@/` alias): that path is defined only inside the
+// apps/api workspace tsconfig, while resilience scenarios live outside it.
 import {
   foldParts,
   type ThreadMessagePart,
@@ -169,14 +165,14 @@ describe("decopilot — stream-of-record self-heal across NATS restart", () => {
   // The actual self-heal proof. SKIPPED until the harness can drive a v2
   // streaming chat turn (see file header + README for the three missing
   // pieces). The body is intentionally complete so that un-skipping it — once
-  // `mock-ai` + `STREAM_OF_RECORD_V2_PERCENT=100` + `STUDIO_SANDBOX_PROVIDER=agent-sandbox`
+  // `mock-ai` + `STREAM_OF_RECORD_V2_PERCENT=100` + `STUDIO_AGENT_SANDBOX_ENABLED=true`
   // are wired — runs the real assertion with no further edits beyond
   // implementing `driveV2Turn` (outlined in the README).
   // ────────────────────────────────────────────────────────────────────────
   test.skip("NATS drops mid-stream → result survives in thread_message_parts → reconnect renders COMPLETE message", async () => {
     // TODO(task-10-harness): requires (a) a `mock-ai` service in
     // tests/resilience/docker-compose.yml, (b) `STREAM_OF_RECORD_V2_PERCENT=100`
-    // and `STUDIO_SANDBOX_PROVIDER=agent-sandbox` on the `studio` service, and
+    // and `STUDIO_AGENT_SANDBOX_ENABLED=true` on the `studio` service, and
     // (c) a `driveV2Turn` helper that bootstraps a provider/agent/thread and
     // POSTs a streaming message. See the README for the full port plan and
     // the `driveV2Turn` signature.


### PR DESCRIPTION
## Summary

- Replaces provider-selection deployment values with STUDIO_AGENT_SANDBOX_ENABLED.
- Updates Helm, Compose, self-host, preview, and resilience examples together.

## Testing

- Full check, Helm lint and renders, Compose validation, and resilience test bundling
- No database migrations

Split from #6459.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches sandbox configuration from provider selection to an explicit flag for hosted AgentSandbox. Old: `STUDIO_SANDBOX_PROVIDER` defaulted to `user-desktop`, causing 409s without a desktop link; new: `STUDIO_AGENT_SANDBOX_ENABLED` gates hosted execution and defaults to false so previews and installs are stable by default. Updates Helm values, preview config, `sandbox-env` docs, self-host guides/examples, and test compose files to the new flag.

**Migration**
- Replace `STUDIO_SANDBOX_PROVIDER=agent-sandbox` with `STUDIO_AGENT_SANDBOX_ENABLED=true` in Helm values, Compose, and `.env` files.
- For previews that need hosted sandboxes, enable `preview.sandbox.enabled` and set `STUDIO_AGENT_SANDBOX_ENABLED=true` plus `STUDIO_ENV`, `STUDIO_SANDBOX_TEMPLATE_NAME`, and `STUDIO_SANDBOX_SENTINEL_TOKEN`.

<sup>Written for commit 3499240169ee21810244cf87eaa02846dfd5c1a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

