### PR TITLE
refactor(sandbox): infer the daemon harness

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -1398,7 +1398,6 @@ async function prepareRun(
         const rawHarnessChunks = sandboxHosted
           ? new SandboxDispatchClient({
               ctx,
-              harnessId,
               virtualMcpId: effectiveVirtualMcp.id,
               // Tell the harness it is picking up an interrupted turn: its own
               // context is gone, but the work is in the checkout and in git.

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -42,7 +42,7 @@ import {
 import type { PodTermination } from "@decocms/sandbox/provider";
 import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
 import { isTransientStreamError } from "@/harnesses/decopilot/built-in-tools/subtask";
-import type { HarnessId, HarnessStreamInput } from "@/harnesses/lib/types";
+import type { HarnessStreamInput } from "@/harnesses/lib/types";
 import {
   claudeCodeEnvFromCredential,
   modelClassFromMetadata,
@@ -86,8 +86,8 @@ import {
  */
 const SANDBOX_REPO_CWD = "/repo";
 
-/** Harnesses this client can dispatch. Decopilot is in-process, never here. */
-const SANDBOX_HOSTED_HARNESSES = new Set<HarnessId>(["claude-code"]);
+/** The one harness this client dispatches. Decopilot runs in-process. */
+const SANDBOX_HOSTED_HARNESS = "claude-code";
 
 /**
  * Dispatches per run WITHOUT PROGRESS: the first, plus ONE continuation after
@@ -204,20 +204,14 @@ export function isUnreachableStatus(status: number): boolean {
   return status === 404 || status === 410 || status >= 500;
 }
 
-/**
- * Widened past `HarnessId` so callers holding a raw `threads.harness_id` can ask
- * without an `as`-cast — a cast there would hide a renamed harness until
- * runtime. A Set lookup is total over strings, so nothing is lost.
- */
 export function harnessRunsInSandbox(
   harnessId: string | null | undefined,
 ): boolean {
-  return SANDBOX_HOSTED_HARNESSES.has(harnessId as HarnessId);
+  return harnessId === SANDBOX_HOSTED_HARNESS;
 }
 
 export class SandboxDispatchClient {
   private readonly ctx: StudioContext;
-  private readonly harnessId: HarnessId;
   private readonly virtualMcpId: string;
   private readonly branch: string;
   private readonly credential: ClaudeCodeCredential | null;
@@ -225,7 +219,6 @@ export class SandboxDispatchClient {
 
   constructor(args: {
     ctx: StudioContext;
-    harnessId: HarnessId;
     virtualMcpId: string;
     branch: string;
     /** Resolved thinking-slot credential; becomes the sandbox's model env. */
@@ -238,13 +231,7 @@ export class SandboxDispatchClient {
      */
     resume?: { reason: string };
   }) {
-    if (!harnessRunsInSandbox(args.harnessId)) {
-      throw new Error(
-        `SandboxDispatchClient runs sandbox-hosted harnesses only; got "${args.harnessId}"`,
-      );
-    }
     this.ctx = args.ctx;
-    this.harnessId = args.harnessId;
     this.virtualMcpId = args.virtualMcpId;
     this.branch = args.branch;
     this.credential = args.credential;
@@ -333,7 +320,7 @@ export class SandboxDispatchClient {
       this.ctx,
       this.virtualMcpId,
       organization,
-      `${this.harnessId}-run`,
+      `${SANDBOX_HOSTED_HARNESS}-run`,
       "task-run",
       threadId,
       // Exactly what this run mounts, never a wildcard: the tools its own
@@ -355,7 +342,7 @@ export class SandboxDispatchClient {
       connections,
     });
     console.log(
-      `[${this.harnessId}] org mcps: ${
+      `[${SANDBOX_HOSTED_HARNESS}] org mcps: ${
         orgMcps.map((server) => server.name).join(" ") || "none"
       }${
         candidates.length === connections.length
@@ -435,7 +422,7 @@ export class SandboxDispatchClient {
   ): AsyncIterable<UIMessageChunk> {
     if (!this.credential) {
       throw new Error(
-        `the ${this.harnessId} harness needs a resolved model credential; ` +
+        `the ${SANDBOX_HOSTED_HARNESS} harness needs a resolved model credential; ` +
           `this run has none (check the agent's thinking model)`,
       );
     }
@@ -450,7 +437,7 @@ export class SandboxDispatchClient {
     const organization = this.ctx.organization;
     if (!organization) {
       throw new Error(
-        `the ${this.harnessId} harness needs an organization on the context ` +
+        `the ${SANDBOX_HOSTED_HARNESS} harness needs an organization on the context ` +
           `to mint its MCP endpoint; this run has none`,
       );
     }
@@ -492,7 +479,7 @@ export class SandboxDispatchClient {
     // rather than a second agent in the same checkout (see the daemon's
     // `Registry.claim`).
     const runId = input.threadId;
-    const { ctx, harnessId, virtualMcpId, branch } = this;
+    const { ctx, virtualMcpId, branch } = this;
     const credentialProviderId = this.credential.providerId;
 
     // Provisioning is re-done per attempt on purpose. On the continuation path
@@ -526,7 +513,6 @@ export class SandboxDispatchClient {
           dispatchToDaemon({
             provider,
             handle: sandbox.sandboxHandle,
-            harnessId,
             input: resume ? { ...wireInput, resume } : wireInput,
             runId,
             signal: input.signal,
@@ -802,7 +788,6 @@ function renewWhileStreaming(
 async function* dispatchToDaemon(args: {
   provider: Pick<AgentSandboxProvider, "proxyDaemonRequest" | "renewTtl">;
   handle: string;
-  harnessId: HarnessId;
   runId: string;
   input: HarnessStreamInput;
   signal?: AbortSignal;
@@ -811,22 +796,37 @@ async function* dispatchToDaemon(args: {
   // "operation timed out" with no run, no handle and no duration on it, which is
   // indistinguishable from a model error until you go read pod logs.
   const startedAt = Date.now();
+  const wireInput = toWireInput(args.input);
+  const request = (legacyHarnessId = false) =>
+    args.provider.proxyDaemonRequest(args.handle, "/_sandbox/dispatch", {
+      method: "POST",
+      headers: new Headers({ "content-type": "application/json" }),
+      body: JSON.stringify({
+        ...(legacyHarnessId ? { harnessId: SANDBOX_HOSTED_HARNESS } : {}),
+        runId: args.runId,
+        input: wireInput,
+      }),
+      ...(args.signal ? { signal: args.signal } : {}),
+    });
   let res: Response;
   try {
-    res = await args.provider.proxyDaemonRequest(
-      args.handle,
-      "/_sandbox/dispatch",
-      {
-        method: "POST",
-        headers: new Headers({ "content-type": "application/json" }),
-        body: JSON.stringify({
-          harnessId: args.harnessId,
-          runId: args.runId,
-          input: toWireInput(args.input),
-        }),
-        ...(args.signal ? { signal: args.signal } : {}),
-      },
-    );
+    res = await request();
+    if (res.status === 400) {
+      const errorBody: unknown = await res
+        .clone()
+        .json()
+        .catch(() => null);
+      if (
+        typeof errorBody === "object" &&
+        errorBody !== null &&
+        "error" in errorBody &&
+        errorBody.error === "missing_harness_id"
+      ) {
+        // Old pods can outlive an API rollout; their rejection happens before
+        // the run is claimed, so this compatibility retry is side-effect-free.
+        res = await request(true);
+      }
+    }
   } catch (err) {
     // The proxy could not reach the pod at all (port-forward gone, TLS to a
     // dead node, ECONNRESET). Nothing ran, so this is always safe to continue

--- a/packages/harness-runner/README.md
+++ b/packages/harness-runner/README.md
@@ -11,19 +11,18 @@ Runs coding-agent harnesses inside a sandbox pod, one process per run.
 
 ## Overview
 
-The Go daemon execs this process for each dispatched run, writes a
-`{harnessId, input}` envelope to stdin, and reads NDJSON frames
-(`{chunks, error}`) off stdout as they are produced. stderr is the pod's log.
-The daemon adds the run's terminal `done` frame itself — this process only emits
-what the harness produced.
+The Go daemon execs this process for each dispatched run, writes `{input}` to
+stdin, and reads NDJSON frames (`{chunks, error}`) off stdout as they are
+produced. stderr is the pod's log. The daemon adds the run's terminal `done`
+frame itself — this process only emits what the harness produced.
 
 The wire is defined by `daemon-go/internal/dispatch/runner.go`; the frame shape
-is `harnessRunResultSchema` in `packages/sandbox/dispatch/schemas.ts`. One
-harness is implemented today, `claude-code`, driven by the Claude Agent SDK.
+is `harnessRunResultSchema` in `packages/sandbox/dispatch/schemas.ts`. The runner
+is hard-coded to `claude-code`, driven by the Claude Agent SDK.
 
 ## Responsibilities
 
-- Read the dispatch envelope off stdin and dispatch it to a harness.
+- Read and validate the fixed dispatch envelope from stdin.
 - Run the harness against the checkout the daemon already prepared.
 - Translate SDK messages into AI SDK `UIMessageChunk`s so nothing downstream of
   the daemon needs new part types.
@@ -41,7 +40,7 @@ harness is implemented today, `claude-code`, driven by the Claude Agent SDK.
 Not imported by Studio. The daemon spawns it through `HARNESS_RUNNER_CMD`:
 
 ```bash
-echo '{"harnessId":"claude-code","input":{ ... }}' | bun packages/harness-runner/main.ts
+echo '{"input":{ ... }}' | bun packages/harness-runner/main.ts
 ```
 
 Model access is configured entirely by environment, pushed down as sandbox env

--- a/packages/harness-runner/main.test.ts
+++ b/packages/harness-runner/main.test.ts
@@ -26,15 +26,6 @@ async function run(body: string): Promise<Record<string, unknown>> {
 }
 
 describe("harness-runner wire", () => {
-  test("an unknown harness is a result with an error, not a crash", async () => {
-    expect(
-      await run(JSON.stringify({ harnessId: "codex", input: {} })),
-    ).toEqual({
-      chunks: [],
-      error: { code: "unknown_harness", message: expect.any(String) },
-    });
-  });
-
   test("malformed stdin is bad_input", async () => {
     const result = await run("{not json");
     expect(result.chunks).toEqual([]);
@@ -42,7 +33,7 @@ describe("harness-runner wire", () => {
   });
 
   test("a missing input is bad_input", async () => {
-    const result = await run(JSON.stringify({ harnessId: "claude-code" }));
+    const result = await run("{}");
     expect(result.error).toMatchObject({ code: "bad_input" });
   });
 });

--- a/packages/harness-runner/main.ts
+++ b/packages/harness-runner/main.ts
@@ -3,7 +3,7 @@
  * The harness-runner: the TS half of the Go daemon's `/dispatch` path.
  *
  * One process per run. The daemon execs the argv in `HARNESS_RUNNER_CMD`, writes
- * `{harnessId, input}` to stdin, and reads a stream of `HarnessRunResult` frames
+ * `{input}` to stdin, and reads a stream of `HarnessRunResult` frames
  * back off stdout — one JSON line each, forwarded to Studio as they arrive so a
  * long turn persists as it goes. The wire is
  * `daemon-go/internal/dispatch/runner.go`. stderr is the pod's log.
@@ -27,17 +27,11 @@ function fail(code: string, message: string): never {
 }
 
 const raw = await Bun.stdin.text();
-let body: { harnessId?: unknown; input?: unknown };
+let body: { input?: unknown };
 try {
   body = JSON.parse(raw);
 } catch {
   fail("bad_input", "stdin is not JSON");
-}
-if (body.harnessId !== "claude-code") {
-  fail(
-    "unknown_harness",
-    `harness-runner does not implement ${JSON.stringify(body.harnessId)}`,
-  );
 }
 if (typeof body.input !== "object" || body.input === null) {
   fail("bad_input", "input is missing");

--- a/packages/sandbox/daemon-e2e/daemon.dispatch.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.dispatch.e2e.test.ts
@@ -94,7 +94,7 @@ describe("daemon e2e: dispatch", () => {
     const res = await fetch(url(d, "/_sandbox/dispatch"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: toBody({ harnessId: "x", input: {} }),
+      body: toBody({ input: {} }),
     });
     expect(res.status).toBe(401);
   });
@@ -109,23 +109,11 @@ describe("daemon e2e: dispatch", () => {
     expect(((await res.json()) as { error: string }).error).toBe("bad_json");
   });
 
-  it("POST /dispatch with a non-string harnessId → 400 missing_harness_id", async () => {
-    const res = await fetch(url(d, "/_sandbox/dispatch"), {
-      method: "POST",
-      headers: jsonAuthHeaders(),
-      body: toBody({ harnessId: 123, input: {} }),
-    });
-    expect(res.status).toBe(400);
-    expect(((await res.json()) as { error: string }).error).toBe(
-      "missing_harness_id",
-    );
-  });
-
   it("POST /dispatch without runId → 400 missing_run_id", async () => {
     const res = await fetch(url(d, "/_sandbox/dispatch"), {
       method: "POST",
       headers: jsonAuthHeaders(),
-      body: toBody({ harnessId: "claude-code", input: {} }),
+      body: toBody({ input: {} }),
     });
     expect(res.status).toBe(400);
     expect(((await res.json()) as { error: string }).error).toBe(
@@ -139,7 +127,6 @@ describe("daemon e2e: dispatch", () => {
       headers: jsonAuthHeaders(),
       body: toBody({
         runId: "run-bad-input",
-        harnessId: "claude-code",
         input: {},
       }),
     });
@@ -147,7 +134,7 @@ describe("daemon e2e: dispatch", () => {
     expect(((await res.json()) as { error: string }).error).toBe("bad_input");
   });
 
-  it("POST /dispatch with no harness configured → 200 with an error result", async () => {
+  it("POST /dispatch with no runner configured → 200 with an error result", async () => {
     // The gates above answer with a status code; once the envelope is valid the
     // route always answers 200 with a HarnessRunResult, so a run that produced
     // nothing is still `{chunks, error}` and not an HTTP failure.
@@ -155,13 +142,30 @@ describe("daemon e2e: dispatch", () => {
       method: "POST",
       headers: jsonAuthHeaders(),
       body: toBody({
-        runId: "run-no-harness",
-        harnessId: "claude-code",
+        runId: "run-no-runner",
         input: VALID_INPUT,
       }),
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("application/json");
+    expect(await res.json()).toEqual({
+      chunks: [],
+      done: true,
+      error: { code: "unknown_harness", message: expect.any(String) },
+    });
+  });
+
+  it("accepts the legacy harnessId envelope during a rolling upgrade", async () => {
+    const res = await fetch(url(d, "/_sandbox/dispatch"), {
+      method: "POST",
+      headers: jsonAuthHeaders(),
+      body: toBody({
+        harnessId: "claude-code",
+        runId: "run-legacy-envelope",
+        input: VALID_INPUT,
+      }),
+    });
+    expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       chunks: [],
       done: true,
@@ -224,7 +228,6 @@ describe("daemon e2e: dispatch runs a harness", () => {
       headers: jsonAuthHeaders(),
       body: toBody({
         runId,
-        harnessId: "claude-code",
         input: { ...VALID_INPUT, harness: { stubMode: mode } },
       }),
     });
@@ -269,13 +272,12 @@ describe("daemon e2e: dispatch runs a harness", () => {
       const echoed = JSON.parse(
         (body.chunks[0] as { delta: string }).delta,
       ) as Record<string, unknown>;
-      expect(echoed.harnessId).toBe("claude-code");
       expect(echoed.threadId).toBe("thrd_e2e");
       // `/repo` is rebased onto the pod's app root before the harness sees it.
       expect(echoed.cwd).toMatch(/\/repo$/);
       expect(echoed.cwd).not.toBe("/repo");
       // The model credential reaches the harness as its spawn env.
-      expect(echoed.apiKey).toBe("sk-e2e");
+      expect(echoed.hasExpectedApiKey).toBe(true);
     },
     HOOK_TIMEOUT_MS,
   );

--- a/packages/sandbox/daemon-e2e/daemon.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.e2e.test.ts
@@ -912,7 +912,7 @@ describe("daemon e2e: auth on mutating routes", () => {
     {
       name: "dispatch",
       path: "/_sandbox/dispatch",
-      body: toBody({ harnessId: "x", input: {} }),
+      body: toBody({ input: {} }),
     },
   ];
 

--- a/packages/sandbox/daemon-e2e/stub-harness.mjs
+++ b/packages/sandbox/daemon-e2e/stub-harness.mjs
@@ -1,7 +1,7 @@
 /**
  * A stub harness for the dispatch conformance tests.
  *
- * Speaks the real harness wire — `{harnessId, input}` as JSON on stdin,
+ * Speaks the real harness wire — `{input}` as JSON on stdin,
  * newline-delimited `{chunks, error}` frames on stdout — without Bun, the Claude
  * Agent SDK or a model provider. `input.harness.stubMode` picks the behaviour
  * under test, so one daemon serves every case:
@@ -45,13 +45,12 @@ if (mode === "hang") {
         {
           type: "text-delta",
           id: "1",
-          // Echoed so the test can prove the envelope and the run env reached
-          // the harness, and that `/repo` was rebased onto the pod's app root.
+          // Echoed so the test can prove the input and run env reached the
+          // harness, and that `/repo` was rebased onto the pod's app root.
           delta: JSON.stringify({
-            harnessId: body.harnessId,
             threadId: body.input?.threadId,
             cwd: body.input?.workspace?.cwd ?? null,
-            apiKey: process.env.ANTHROPIC_API_KEY ?? null,
+            hasExpectedApiKey: process.env.ANTHROPIC_API_KEY === "sk-e2e",
           }),
         },
       ],

--- a/packages/sandbox/daemon-go/README.md
+++ b/packages/sandbox/daemon-go/README.md
@@ -21,11 +21,13 @@ Studio can tell a live sandbox from a dead one.
 
 ### Dispatch is single-writer per run
 
-One run id, one harness. A dispatch for a run that is already in flight is a
-TAKEOVER: the daemon cancels the run it displaces, waits for that process group
-to die, and only then execs the replacement. Studio sends exactly that when the
-pod driving a run was replaced and another picked the work up, and the invariant
-it buys is that two `claude` processes never share one checkout.
+One run id, one active runner process. The dispatch endpoint always invokes the
+installed Claude Code runner; callers send only the run id and input. A dispatch
+for a run that is already in flight is a TAKEOVER: the daemon cancels the run it
+displaces, waits for that process group to die, and only then execs the
+replacement. Studio sends exactly that when the pod driving a run was replaced
+and another picked the work up, and the invariant it buys is that two `claude`
+processes never share one checkout.
 
 Two properties the consumer depends on, both asserted in `daemon-e2e/`:
 
@@ -43,7 +45,7 @@ Two properties the consumer depends on, both asserted in `daemon-e2e/`:
 | `main.go` | Env contract, wiring, HTTP server, shutdown |
 | `internal/routes/` | HTTP surface: `/health`, `/_sandbox/*`, fs, git, bash, exec, tasks, tools, events |
 | `internal/setup/` | Clone, install, golden cache, dep metrics, orchestration |
-| `internal/dispatch/` | Direct agent run dispatch and harness runner |
+| `internal/dispatch/` | Agent run dispatch and harness runner |
 | `internal/gitx/` | Git: checkout, rebase, publish, branch status, protected-branch guard |
 | `internal/proc/` | PTY spawn, task manager, log tee, ring buffer, port sniffer |
 | `internal/config/` | Tenant config store: classify, merge, validate, persist |
@@ -51,7 +53,7 @@ Two properties the consumer depends on, both asserted in `daemon-e2e/`:
 | `internal/orgfs/` | Links half of org-fs (the privileged mounter is the sidecar in `../orgfs/`) |
 | `internal/proxy/` | Preview HTTP + WebSocket proxy |
 | `internal/probe/`, `internal/lifecycle/` | Health probe and lifecycle state |
-| `internal/auth/`, `internal/urlallow/` | Bearer-token auth and the URL-transfer allowlist |
+| `internal/auth/`, `internal/urlallow/` | Bearer-token auth and the remote file-transfer allowlist |
 | `internal/telemetry/` | OTLP metrics export |
 | `internal/worktree/` | Worktree lock |
 
@@ -65,7 +67,7 @@ Set by the sandbox template, not by the daemon:
 | `DAEMON_BOOT_ID` | Boot identity echoed by `/health`; how Studio detects a restart |
 | `APP_ROOT` (or `WORKDIR`) | Workspace root — `repo/` checkout, daemon state, log tees |
 | `PROXY_PORT` (or `DAEMON_PORT`) | Listen port |
-| `OFFLOAD_ALLOWED_HOSTS` | Allowlist for URL-transfer routes; empty fails closed |
+| `OFFLOAD_ALLOWED_HOSTS` | Allowlist for remote file upload/download URLs; empty fails closed |
 | `ORGFS_SIDECAR_CONFIG_PATH` / `ORGFS_SIDECAR_STATUS_PATH` | Org-fs relay to the mounter sidecar; org-fs is inert without them |
 
 `/health` is unauthenticated on purpose: Studio polls it and marks the sandbox

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
@@ -19,6 +19,9 @@ import (
 
 const tombstoneTTL = 60 * time.Second
 
+// The dispatch endpoint always runs the sandbox's installed Claude Code runner.
+const sandboxHarnessID = "claude-code"
+
 // maxDispatchBodyBytes stops an unbounded request body from parking the pod's
 // memory. Current dispatch always sends the complete input inline.
 const maxDispatchBodyBytes = 32 * 1024 * 1024
@@ -299,11 +302,7 @@ func (reg *Registry) HandleDispatch(w http.ResponseWriter, r *http.Request, deps
 		jsonError(w, 400, map[string]string{"error": "bad_json"})
 		return
 	}
-	var harnessId, runId string
-	if raw, ok := frame["harnessId"]; !ok || json.Unmarshal(raw, &harnessId) != nil {
-		jsonError(w, 400, map[string]string{"error": "missing_harness_id"})
-		return
-	}
+	var runId string
 	if raw, ok := frame["runId"]; !ok || json.Unmarshal(raw, &runId) != nil {
 		jsonError(w, 400, map[string]string{"error": "missing_run_id"})
 		return
@@ -326,10 +325,10 @@ func (reg *Registry) HandleDispatch(w http.ResponseWriter, r *http.Request, deps
 
 	ctx, cancel := context.WithCancel(r.Context())
 	entry, awaitTakeover := reg.claim(runId, cancel)
-	slog.Info("dispatch received", "harness", harnessId, "run_id", runId)
+	slog.Info("dispatch received", "harness", sandboxHarnessID, "run_id", runId)
 	awaitTakeover()
 
-	reg.runHarness(ctx, w, deps, harnessId, runId, entry, rebaseInput(input, deps.AppRoot))
+	reg.runHarness(ctx, w, deps, runId, entry, rebaseInput(input, deps.AppRoot))
 }
 
 // runHarness runs the harness for one run and streams its frames as this
@@ -346,7 +345,7 @@ func (reg *Registry) runHarness(
 	ctx context.Context,
 	w http.ResponseWriter,
 	deps Deps,
-	harnessId, runId string,
+	runId string,
 	entry *activeRun,
 	input json.RawMessage,
 ) {
@@ -364,7 +363,7 @@ func (reg *Registry) runHarness(
 	writeResultHeaders(w)
 	body := newBodyWriter(w)
 	startedAt := time.Now()
-	stopKeepalive := startKeepalive(ctx, body, harnessId, runId)
+	stopKeepalive := startKeepalive(ctx, body, runId)
 	defer stopKeepalive()
 
 	// Per-run workspace state, before the harness can touch the workspace.
@@ -372,8 +371,8 @@ func (reg *Registry) runHarness(
 		deps.BeforeRun(runInfoOf(input))
 	}
 	// Deferred, not placed after RunHarness: every terminal path below returns
-	// early (crash, cancel, unknown harness), and the run that crashed halfway is
-	// exactly the one whose stray output must still be rescued.
+	// early (crash, cancel, unavailable runner), and the run that crashed
+	// halfway is exactly the one whose stray output must still be rescued.
 	//
 	// Registered AFTER the keepalive's defer, so it runs BEFORE it: `AfterRun`
 	// copies a skill tree and a session transcript over org-fs, and Studio is
@@ -400,7 +399,7 @@ func (reg *Registry) runHarness(
 	// identical in the pod log (both are silence until "dispatch done"), which is
 	// exactly the question you ask this log to answer.
 	seq := 0
-	frames, err := RunHarness(ctx, deps.HarnessRunnerCmd, harnessId, input, runEnv,
+	frames, err := RunHarness(ctx, deps.HarnessRunnerCmd, input, runEnv,
 		func(frame []byte) bool {
 			seq++
 			// A streaming run is working, so it counts as activity: the idle
@@ -408,7 +407,7 @@ func (reg *Registry) runHarness(
 			// longer than the idle TTL reports as untouched since the dispatch
 			// request arrived and gets its pod evicted mid-turn.
 			activity.Bump()
-			slog.Info("dispatch frame", "harness", harnessId, "run_id", runId,
+			slog.Info("dispatch frame", "harness", sandboxHarnessID, "run_id", runId,
 				"seq", seq, "bytes", len(frame),
 				"elapsed_s", int(time.Since(startedAt).Seconds()))
 			return body.write(append(frame, '\n'))
@@ -433,7 +432,7 @@ func (reg *Registry) runHarness(
 		// and forth. `superseded` says "stop, someone else has this."
 		if reg.displaced(runId, entry) {
 			slog.Info("dispatch superseded by takeover",
-				"harness", harnessId, "run_id", runId, "elapsed_s", elapsed)
+				"harness", sandboxHarnessID, "run_id", runId, "elapsed_s", elapsed)
 			body.write(terminalFrame("superseded",
 				"a newer dispatch took over this run"))
 			return
@@ -443,7 +442,7 @@ func (reg *Registry) runHarness(
 		// ASKED FOR. Studio spends no retry on it, which is right: a human said
 		// stop.
 		if reg.tombstoned(runId) {
-			slog.Info("dispatch cancelled", "harness", harnessId, "run_id", runId, "elapsed_s", elapsed)
+			slog.Info("dispatch cancelled", "harness", sandboxHarnessID, "run_id", runId, "elapsed_s", elapsed)
 			body.write(terminalFrame("cancelled", "run cancelled"))
 			return
 		}
@@ -455,18 +454,18 @@ func (reg *Registry) runHarness(
 		// mid-edit. `sandbox_gone` says the pod could not finish, not that the
 		// run should not: the checkout is intact, the shutdown publish pushes it
 		// to the branch, and a replacement pod can pick the turn up.
-		slog.Info("dispatch sandbox gone", "harness", harnessId, "run_id", runId, "elapsed_s", elapsed)
+		slog.Info("dispatch sandbox gone", "harness", sandboxHarnessID, "run_id", runId, "elapsed_s", elapsed)
 		body.write(terminalFrame(sandboxGoneCode,
 			"the sandbox stopped mid-run (pod shutting down or connection dropped)"))
 		return
 	}
 	if err != nil {
-		slog.Error("harness crashed", "harness", harnessId, "run_id", runId,
+		slog.Error("harness crashed", "harness", sandboxHarnessID, "run_id", runId,
 			"elapsed_s", elapsed, "err", err)
 		body.write(terminalFrame("harness_crashed", err.Error()))
 		return
 	}
-	slog.Info("dispatch done", "harness", harnessId, "run_id", runId,
+	slog.Info("dispatch done", "harness", sandboxHarnessID, "run_id", runId,
 		"elapsed_s", elapsed, "frames", frames)
 	body.write(terminalFrame("", ""))
 }
@@ -482,7 +481,7 @@ func (reg *Registry) runHarness(
 func startKeepalive(
 	ctx context.Context,
 	body *bodyWriter,
-	harnessId, runId string,
+	runId string,
 ) func() {
 	ctx, cancel := context.WithCancel(ctx)
 	stopped := make(chan struct{})
@@ -502,7 +501,7 @@ func startKeepalive(
 				// A quiet run is still a live run — see the frame callback's
 				// note on the idle reaper.
 				activity.Bump()
-				slog.Info("dispatch waiting", "harness", harnessId, "run_id", runId,
+				slog.Info("dispatch waiting", "harness", sandboxHarnessID, "run_id", runId,
 					"elapsed_s", int(time.Since(startedAt).Seconds()))
 			}
 		}

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
@@ -24,7 +24,7 @@ func TestKeepaliveWritesWhitespaceWhileQuiet(t *testing.T) {
 	dispatchHeartbeat = 5 * time.Millisecond
 	defer func() { dispatchHeartbeat = restore }()
 
-	stop := startKeepalive(context.Background(), body, "claude-code", "run-1")
+	stop := startKeepalive(context.Background(), body, "run-1")
 	time.Sleep(60 * time.Millisecond)
 	stop()
 	body.write(terminalFrame("harness_crashed", "boom"))
@@ -147,7 +147,6 @@ func TestRebaseWorkspaceCwd(t *testing.T) {
 func TestDispatchIgnoresRetiredMessagesRef(t *testing.T) {
 	const token = "tkn"
 	body := `{
-		"harnessId": "claude-code",
 		"runId": "run-legacy-ref",
 		"messagesRef": {
 			"url": "https://not-allowed.invalid/messages",
@@ -328,7 +327,7 @@ func TestKeepaliveCountsAsActivity(t *testing.T) {
 	defer func() { dispatchHeartbeat = restore }()
 
 	activity.Bump()
-	stop := startKeepalive(context.Background(), newBodyWriter(httptest.NewRecorder()), "claude-code", "run-1")
+	stop := startKeepalive(context.Background(), newBodyWriter(httptest.NewRecorder()), "run-1")
 	time.Sleep(200 * time.Millisecond)
 	stop()
 

--- a/packages/sandbox/daemon-go/internal/dispatch/runner.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/runner.go
@@ -5,7 +5,7 @@ package dispatch
 // keep the two in step:
 //
 //	spawn   argv from HARNESS_RUNNER_CMD, in its own process group
-//	input   {harnessId, input} as JSON on stdin
+//	input   {input} as JSON on stdin
 //	output  a stream of HarnessRunResult frames on stdout, one JSON line each;
 //	        stderr is the pod's log
 //	cancel  cancel ctx — the process group is killed, the CLI with it
@@ -40,12 +40,11 @@ import (
 func RunHarness(
 	ctx context.Context,
 	argv []string,
-	harnessId string,
 	input json.RawMessage,
 	env map[string]string,
 	emit func([]byte) bool,
 ) (int, error) {
-	payload, err := json.Marshal(map[string]any{"harnessId": harnessId, "input": input})
+	payload, err := json.Marshal(map[string]any{"input": input})
 	if err != nil {
 		return 0, err
 	}

--- a/packages/sandbox/daemon-go/internal/dispatch/runner_test.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/runner_test.go
@@ -58,8 +58,7 @@ func runFakeHarness(mode string) {
 	}
 	raw, _ := io.ReadAll(os.Stdin)
 	var body struct {
-		HarnessId string         `json:"harnessId"`
-		Input     map[string]any `json:"input"`
+		Input map[string]any `json:"input"`
 	}
 	json.Unmarshal(raw, &body)
 	if mode == fakeRunnerNoisy {
@@ -74,8 +73,7 @@ func runFakeHarness(mode string) {
 	}
 	result, _ := json.Marshal(map[string]any{
 		"chunks": []any{map[string]any{
-			"harnessId": body.HarnessId,
-			"threadId":  body.Input["threadId"],
+			"threadId": body.Input["threadId"],
 			// Echoed so a test can prove the run env crossed the wire. A real
 			// harness never emits it — this one carries no real credential.
 			"apiKey": os.Getenv("ANTHROPIC_API_KEY"),
@@ -105,7 +103,7 @@ func runFakeTimed(
 	t.Setenv(fakeRunnerEnv, mode)
 	var frames [][]byte
 	var at []time.Time
-	_, err := RunHarness(ctx, fakeHarnessArgv(), "claude-code",
+	_, err := RunHarness(ctx, fakeHarnessArgv(),
 		json.RawMessage(`{"threadId":"t-1"}`), env, func(frame []byte) bool {
 			frames = append(frames, append([]byte(nil), frame...))
 			at = append(at, time.Now())
@@ -192,7 +190,7 @@ func TestRunHarnessEmitsEachFrameAsItArrives(t *testing.T) {
 func TestRunHarnessStopsWhenTheClientIsGone(t *testing.T) {
 	t.Setenv(fakeRunnerEnv, fakeRunnerMulti)
 	seen := 0
-	frames, err := RunHarness(context.Background(), fakeHarnessArgv(), "claude-code",
+	frames, err := RunHarness(context.Background(), fakeHarnessArgv(),
 		json.RawMessage(`{"threadId":"t-1"}`), nil, func([]byte) bool {
 			seen++
 			return false
@@ -230,7 +228,7 @@ func TestRunHarnessCancellationKillsTheChild(t *testing.T) {
 func TestRunHarnessRejectsAMissingBinary(t *testing.T) {
 	_, err := RunHarness(context.Background(),
 		[]string{"/nonexistent/harness-runner-" + strconv.Itoa(os.Getpid())},
-		"claude-code", json.RawMessage(`{"threadId":"t-1"}`), nil,
+		json.RawMessage(`{"threadId":"t-1"}`), nil,
 		func([]byte) bool { return true })
 	if err == nil {
 		t.Fatal("spawning a missing harness binary reported success")

--- a/packages/sandbox/dispatch/schemas.test.ts
+++ b/packages/sandbox/dispatch/schemas.test.ts
@@ -8,7 +8,6 @@ import { FIXTURE_MINIMAL_INPUT } from "./fixtures";
 describe("harnessStreamInputSchema (v3)", () => {
   test("accepts v3 single-message harness input", () => {
     const result = harnessStreamInputSchema.safeParse({
-      harnessId: "claude-code",
       threadId: "thread-1",
       userMessage: {
         id: "msg-1",
@@ -55,10 +54,7 @@ describe("harnessStreamInputSchema (v3)", () => {
     ],
     ["projectSlug", "legacy"],
     ["virtualMcp", { id: "agent-1" }],
-    ["organizationSlug", "acme"],
-    ["triggerId", "trigger-1"],
-    ["traceparent", "00-trace-parent"],
-    ["runFenceToken", "fence-1"],
+    ["harnessId", "claude-code"],
   ] as const)("rejects removed shared harness field %s", (field, value) => {
     const result = harnessStreamInputSchema.safeParse({
       ...FIXTURE_MINIMAL_INPUT,
@@ -129,10 +125,9 @@ describe("harnessStreamInputSchema (v3)", () => {
     expect(harnessStreamInputSchema.safeParse(v1Input).success).toBe(false);
   });
 
-  it("round-trips all five model slots with per-slot credentialId and harnessId", () => {
+  it("round-trips all five model slots with per-slot credentialId", () => {
     const result = harnessStreamInputSchema.safeParse({
       ...minimalV3,
-      harnessId: "decopilot",
       models: {
         thinking: {
           id: "anthropic/claude-sonnet",
@@ -170,7 +165,6 @@ describe("harnessStreamInputSchema (v3)", () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.harnessId).toBe("decopilot");
       expect(result.data.models).toEqual({
         thinking: {
           id: "anthropic/claude-sonnet",
@@ -301,15 +295,6 @@ describe("harnessStreamInputSchema (v3)", () => {
         branch: "main",
       });
     }
-  });
-
-  it("rejects unknown harness ids", () => {
-    const result = harnessStreamInputSchema.safeParse({
-      ...minimalV3,
-      harnessId: "made-up",
-    });
-
-    expect(result.success).toBe(false);
   });
 
   it("rejects unknown harness modes", () => {

--- a/packages/sandbox/dispatch/schemas.ts
+++ b/packages/sandbox/dispatch/schemas.ts
@@ -86,7 +86,6 @@ const harnessWorkspaceSchema = z.discriminatedUnion("cwd", [
 
 export const harnessStreamInputSchema = z
   .object({
-    harnessId: z.enum(["decopilot", "claude-code", "codex"]).optional(),
     threadId: z.string(),
     userMessage: chatMessageSchema,
     harness: z.object({ sessionId: z.string().optional() }).strict(),


### PR DESCRIPTION
## Summary

- Removes harnessId from the Studio to daemon dispatch envelope and harness stdin.
- Fixes the daemon runner to Claude Code while tolerating the legacy envelope field during rollout.

## Testing

- API and sandbox typechecks, 29 schema tests, Go race tests, and 130 daemon black-box tests
- No database migrations

Split from #6459. Supersedes #5652.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Infers the sandbox harness in the daemon and fixes it to Claude Code, removing `harnessId` from the API→daemon wire and from the harness-runner stdin. Old behavior required clients to send `harnessId`; new behavior always runs the configured Claude Code runner with `{ runId, input }`, with a compatibility path for rolling upgrades.

Refactors
- `apps/api` uses a single sandbox-hosted harness and `SandboxDispatchClient` retries with a legacy `harnessId` only if an old pod returns `missing_harness_id`.
- `packages/sandbox/daemon-go` ignores any legacy `harnessId`, logs the inferred harness, updates keepalive/takeover logs, and runs the installed runner with `{input}` only.
- `packages/harness-runner` reads `{input}` from stdin and drops harness-id checks; docs and tests updated.
- `packages/sandbox/dispatch` schemas and e2e tests remove `harnessId` and cover legacy-envelope acceptance.
- No database migrations.

Migration
- Callers of `/_sandbox/dispatch` must send `{ runId, input }` and omit `harnessId`.
- Custom runners invoked via `HARNESS_RUNNER_CMD` must read `{input}` from stdin and remove any harness-id gating.

<sup>Written for commit 823879c9c6dc2cf3bd89f51c80defaa154f602f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

