### PR TITLE
fix(sandbox): bound sandbox handle slugification

### DIFF
--- a/packages/sandbox/server/provider/shared/handle.test.ts
+++ b/packages/sandbox/server/provider/shared/handle.test.ts
@@ -10,6 +10,10 @@ const idFor = (projectRef: string, userId = "u_1"): SandboxId => ({
 const ID = idFor("agent:org:vmcp:deco/mellow-flint");
 
 describe("computeHandle", () => {
+  it("preserves the stable SHA-256 routing hash", () => {
+    expect(hashSandboxId(ID)).toBe("96371d07c69454ac");
+  });
+
   it("strips the prefix before the last `/` from the branch slug", () => {
     expect(computeHandle(ID)).toMatch(/^mellow-flint-[0-9a-f]{16}$/);
   });
@@ -41,6 +45,33 @@ describe("computeHandle", () => {
     expect(match).not.toBeNull();
     expect(match![1]!.length).toBeLessThanOrEqual(24);
     expect(match![1]!.endsWith("-")).toBe(false);
+  });
+
+  it("uses the 24th character when a separator and character both fit", () => {
+    const prefix = "a".repeat(22);
+    expect(computeHandle(idFor(`agent:org:vmcp:${prefix}-b`))).toMatch(
+      new RegExp(`^${prefix}-b-[0-9a-f]{16}$`),
+    );
+  });
+
+  it("drops a separator truncated into the 24th position", () => {
+    const prefix = "a".repeat(23);
+    expect(computeHandle(idFor(`agent:org:vmcp:${prefix}-b`))).toMatch(
+      new RegExp(`^${prefix}-[0-9a-f]{16}$`),
+    );
+  });
+
+  it("handles long separator runs without regex backtracking", () => {
+    const separators = "-".repeat(100_000);
+    expect(
+      computeHandle(idFor(`agent:org:vmcp:${separators}safe${separators}`)),
+    ).toMatch(/^safe-[0-9a-f]{16}$/);
+  });
+
+  it("treats non-ASCII characters as separators", () => {
+    expect(computeHandle(idFor("agent:org:vmcp:Fóó--Bär"))).toMatch(
+      /^f-b-r-[0-9a-f]{16}$/,
+    );
   });
 
   it("keeps the connection id as the slug for a thread-scoped branch", () => {

--- a/packages/sandbox/server/provider/shared/handle.ts
+++ b/packages/sandbox/server/provider/shared/handle.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { hash } from "node:crypto";
 import { refSlugSource } from "../sandbox-ref";
 import { sandboxIdKey, type SandboxId } from "../types";
 
@@ -6,10 +6,7 @@ const SLUG_MAX = 24;
 
 /** Stable short hash of a SandboxId. Length in hex chars (default 16). */
 export function hashSandboxId(id: SandboxId, length = 16): string {
-  return createHash("sha256")
-    .update(sandboxIdKey(id))
-    .digest("hex")
-    .slice(0, length);
+  return hash("sha256", sandboxIdKey(id), "hex").slice(0, length);
 }
 
 /**
@@ -41,10 +38,26 @@ export function computeHandle(id: SandboxId): string {
 function slugifyBranch(branch: string | null | undefined): string {
   if (!branch) return "";
   const lastSegment = branch.split("/").pop() ?? "";
-  return lastSegment
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, SLUG_MAX)
-    .replace(/-+$/g, "");
+  let slug = "";
+  let separatorPending = false;
+
+  for (const char of lastSegment.toLowerCase()) {
+    const code = char.charCodeAt(0);
+    const isAsciiLetter = code >= 97 && code <= 122;
+    const isDigit = code >= 48 && code <= 57;
+    if (!isAsciiLetter && !isDigit) {
+      separatorPending ||= slug.length > 0;
+      continue;
+    }
+
+    if (separatorPending) {
+      if (slug.length + 1 >= SLUG_MAX) break;
+      slug += "-";
+      separatorPending = false;
+    }
+    slug += char;
+    if (slug.length === SLUG_MAX) break;
+  }
+
+  return slug;
 }


### PR DESCRIPTION
## Summary

- Replaces regex slugification with a bounded single-pass implementation.
- Preserves the stable SHA-256 routing hash and covers long separator input.

## Testing

- Sandbox typecheck and 17 focused handle tests
- No database migrations

Split from #6459.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces regex-based sandbox handle slugification with a bounded single-pass algorithm to avoid backtracking and make outputs predictable. Slugs are capped at 24 characters without trailing hyphens, and the 16-character SHA‑256 routing hash suffix remains unchanged.

- Uses only the last path segment of the branch as the slug source.
- Treats non-ASCII and other non-alphanumeric characters as separators and collapses runs.
- Emits a dash only when both the dash and next character fit; drops a dash that would land at position 24.
- Switches the routing hash implementation to `node:crypto` `hash()` with identical output.

<sup>Written for commit 7f0c0b0905cb974eaa3a2130f59db8d5dacc25c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

