### PR TITLE
fix(native): quiesce setup before reclaiming worktree

### DIFF
--- a/apps/native/crates/local-api/src/sandbox/manager.rs
+++ b/apps/native/crates/local-api/src/sandbox/manager.rs
@@ -773,7 +773,20 @@ impl SandboxManager {
         let handle_lock = self.handle_lock(handle);
         let _permit = handle_lock.lock().await;
 
+        let sandbox = self.get(handle);
         let killed = self.stop_locked(handle).await?;
+        if let Some(sandbox) = sandbox {
+            let worker_stopped = sandbox
+                .setup
+                .join_closed_worker(TASK_KILL_REAP_DEADLINE)
+                .await;
+            if !worker_stopped {
+                tracing::warn!(
+                    handle,
+                    "aborted a setup worker before reclaiming its worktree"
+                );
+            }
+        }
 
         let root = crate::sandbox::worktree_root(&self.app_root, handle);
         match tokio::fs::remove_dir_all(&root).await {
@@ -2274,6 +2287,70 @@ mod tests {
         assert!(
             !worktree.exists(),
             "reclaim proceeds once the git op releases the lock"
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_registered_joins_the_setup_worker_before_deleting_its_worktree() {
+        let (_root, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = Arc::new(SandboxManager::new(app_root.path().to_path_buf()));
+        let cfg = GitSandboxConfig {
+            virtual_mcp_id: "vmcp-worker-reclaim".to_string(),
+            clone_url,
+            branch: Some("work".to_string()),
+            ..Default::default()
+        };
+
+        let sandbox = manager.ensure(&cfg).await.expect("ensure succeeds");
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let settled = sandbox.setup.lifecycle_snapshot()["phase"] == "start-failed"
+                    && !sandbox.setup.is_running()
+                    && sandbox.setup.pending_count() == 0;
+                if settled {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the initial setup pipeline settles");
+
+        std::fs::write(sandbox.workdir.join("package-lock.json"), "{}\n").unwrap();
+        let (append_entered, release_append) = sandbox.tasks.logs().block_next_append();
+        assert!(sandbox.setup.resume_from(Step::Install));
+        let entered = tokio::time::timeout(Duration::from_secs(5), append_entered.acquire())
+            .await
+            .expect("runtime detection reaches its log append")
+            .expect("append gate stays open");
+        entered.forget();
+
+        let handle = sandbox.handle.clone();
+        let worktree = crate::sandbox::worktree_root(app_root.path(), &handle);
+        drop(sandbox);
+        let reclaim = tokio::spawn({
+            let manager = manager.clone();
+            let handle = handle.clone();
+            async move { manager.remove_registered(&handle).await }
+        });
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !reclaim.is_finished(),
+            "reclaim must join a setup worker that can still write below the worktree root"
+        );
+
+        release_append.add_permits(1);
+        reclaim
+            .await
+            .expect("reclaim task doesn't panic")
+            .expect("reclaim succeeds")
+            .expect("a registered handle is not unknown");
+        assert!(
+            !worktree.exists(),
+            "the joined setup worker cannot recreate the reclaimed root"
         );
     }
 

--- a/apps/native/crates/local-api/src/setup/mod.rs
+++ b/apps/native/crates/local-api/src/setup/mod.rs
@@ -348,10 +348,21 @@ impl SetupOrchestrator {
     ) -> SetupShutdownResult {
         self.close();
         let tasks = self.tasks.kill_all_and_wait(term_grace, kill_grace).await;
+        let worker_stopped = self.join_closed_worker(kill_grace).await;
+        SetupShutdownResult {
+            worker_stopped,
+            tasks,
+        }
+    }
 
+    /// Joins the worker after admission has been closed and its process tasks
+    /// have been reaped. A timed-out worker is aborted and still fully joined,
+    /// so callers may safely remove the directories it owns after this returns.
+    pub(crate) async fn join_closed_worker(&self, timeout: Duration) -> bool {
+        debug_assert!(self.is_closed());
         let worker = self.lock_worker().take();
         let worker_stopped = match worker {
-            Some(mut worker) => match tokio::time::timeout(kill_grace, &mut worker).await {
+            Some(mut worker) => match tokio::time::timeout(timeout, &mut worker).await {
                 Ok(_) => true,
                 Err(_) => {
                     worker.abort();
@@ -363,10 +374,7 @@ impl SetupOrchestrator {
         };
         self.running.store(false, Ordering::SeqCst);
         self.pending.store(0, Ordering::SeqCst);
-        SetupShutdownResult {
-            worker_stopped,
-            tasks,
-        }
+        worker_stopped
     }
 
     /// `true` while a step is actively being applied. Surfaced on


### PR DESCRIPTION
## Summary

- closes and joins the setup worker before deleting a native sandbox worktree
- preserves the existing task-family stop semantics while preventing a late setup log write from recreating the reclaimed root
- adds a deterministic regression test for the worker/write race observed in macOS CI

## Testing

- `cargo fmt --check`
- `cargo clippy -p local-api --lib -- -D warnings`
- `cargo test -p local-api --lib` (878 passed)
- focused reclaim tests (4 passed)
- full repository format, typecheck, lint, and knip checks

No database migrations or backfills.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a race where a setup worker could recreate a deleted sandbox root by appending a late log. Reclaim now waits for the setup worker to exit (or aborts on timeout) before deleting the worktree; previously we deleted after stopping tasks without joining the worker.

- Adds `join_closed_worker(timeout)` to the setup orchestrator and calls it from `remove_registered` with `TASK_KILL_REAP_DEADLINE`.
- Aborts and warns if the worker doesn’t stop in time; removal continues safely.
- Keeps task stop behavior unchanged; only reclaim may block up to the timeout.
- Adds a deterministic test that proves reclaim joins the worker before deleting its worktree.
- No migrations or rollout steps.

<sup>Written for commit 580c59a50626df79484249855626133f6f04bb19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

