### PR TITLE
fix(organization): reject updating an org other than the authenticated one

### DIFF
--- a/apps/api/src/tools/organization/update.test.ts
+++ b/apps/api/src/tools/organization/update.test.ts
@@ -13,6 +13,7 @@ function makeCtx() {
   return {
     auth: { user: { id: "user-1" } },
     access: { check: mock(async () => {}) },
+    organization: { id: "org-1", slug: "acme", name: "Acme" },
     boundAuth: { organization: { update } },
     update,
   } as unknown as Parameters<typeof ORGANIZATION_UPDATE.handler>[1] & {
@@ -44,5 +45,16 @@ describe("ORGANIZATION_UPDATE", () => {
       organizationId: "org-1",
       data: { metadata: { description: "hello" } },
     });
+  });
+
+  it("rejects updating an organization other than the authenticated one", async () => {
+    const ctx = makeCtx();
+
+    await expect(
+      ORGANIZATION_UPDATE.handler({ id: "org-2", name: "Evil" }, ctx),
+    ).rejects.toThrow(
+      "Organization ID does not match authenticated organization",
+    );
+    expect(ctx.update.mock.calls.length).toBe(0);
   });
 });

--- a/apps/api/src/tools/organization/update.ts
+++ b/apps/api/src/tools/organization/update.ts
@@ -40,6 +40,13 @@ export const ORGANIZATION_UPDATE = defineTool({
     // Check authorization
     await ctx.access.check();
 
+    // Reject a target org the caller isn't authenticated against (see member-remove.ts).
+    if (input.id !== ctx.organization?.id) {
+      throw new Error(
+        "Organization ID does not match authenticated organization",
+      );
+    }
+
     // Build update data
     // Slug is intentionally NOT updatable: it anchors org URLs (/api/:org/...)
     // and renaming would silently invalidate every saved URL.


### PR DESCRIPTION
ORGANIZATION_UPDATE was missing the org-scope guard that ORGANIZATION_DELETE (#6501) and ORGANIZATION_MEMBER_REMOVE already have. `ctx.access.check()` only verifies the caller's role in `ctx.organization` (the path-resolved org) — it never checks that `input.id` matches. Without the guard, an authenticated member of org A could call ORGANIZATION_UPDATE with `id: <org-B>` and rewrite org B's name/description despite having no membership there.

**Failure scenario:** caller authenticated against `org-1` calls `ORGANIZATION_UPDATE({ id: "org-2", name: "Evil" })` — `access.check()` passes (checks the caller's role in org-1), and the update lands on org-2's Better Auth record. The regression test `rejects updating an organization other than the authenticated one` in `update.test.ts` asserts this now throws and the update call never fires.

Fix mirrors the exact guard already in `delete.ts`/`member-remove.ts`: reject when `input.id !== ctx.organization?.id`.

Reviewer command: `bun test apps/api/src/tools/organization/update.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/tools/organization/update.test.ts` (3 pass), `bunx oxlint` on both changed files (0 errors/warnings). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks updating any organization other than the one the caller is authenticated against. Previously `ORGANIZATION_UPDATE` only checked role on the path org, so a user from org A could update org B by passing its id; now it throws "Organization ID does not match authenticated organization" when `input.id` differs from `ctx.organization.id`.

- Bug Fixes
  - Adds the same org-scope guard used in delete and member-remove.
  - Adds a regression test that ensures no update occurs on mismatched ids.

<sup>Written for commit 1af3c366f9e9a0a9b9c3b38fa8d64821bdbec15e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

