### PR TITLE
refactor(sections-editor): dedupe saved-block label resolution in parseSections

### DIFF
--- a/apps/web/src/components/sections-editor/parse-sections.ts
+++ b/apps/web/src/components/sections-editor/parse-sections.ts
@@ -18,6 +18,22 @@ export interface ParsedSection {
   isMultivariate?: boolean;
 }
 
+/** A saved block's own `name`, or its resolveType humanized, or a positional fallback. */
+function resolvedBlockLabel(
+  blockKey: string,
+  idx: number,
+  decofile: Record<string, unknown>,
+): string {
+  const resolvedBlock = decofile[blockKey] as
+    | Record<string, unknown>
+    | undefined;
+  return (
+    (typeof resolvedBlock?.name === "string" && resolvedBlock.name) ||
+    blockKey.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()) ||
+    `Section ${idx + 1}`
+  );
+}
+
 /**
  * Parse raw decofile sections into display-ready entries with
  * isLazy / isHidden / isSavedBlock / isMultivariate flags.
@@ -32,15 +48,10 @@ export function parseSections(
     const isLazy = isLazyResolveType(rt);
 
     if (!isLazy && rt !== "" && isSavedBlockResolveType(rt) && rt in decofile) {
-      const resolvedBlock = decofile[rt] as Record<string, unknown> | undefined;
-      const label =
-        (typeof resolvedBlock?.name === "string" && resolvedBlock.name) ||
-        rt.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()) ||
-        `Section ${idx + 1}`;
       return {
         index: idx,
         resolveType: rt,
-        label,
+        label: resolvedBlockLabel(rt, idx, decofile),
         isLazy: false,
         isSavedBlock: true,
       };
@@ -106,19 +117,10 @@ export function parseSections(
           isSavedBlockResolveType(innerRt) &&
           innerRt in decofile
         ) {
-          const resolvedBlock = decofile[innerRt] as
-            | Record<string, unknown>
-            | undefined;
-          const label =
-            (typeof resolvedBlock?.name === "string" && resolvedBlock.name) ||
-            innerRt
-              .replace(/[-_]/g, " ")
-              .replace(/\b\w/g, (c) => c.toUpperCase()) ||
-            `Section ${idx + 1}`;
           return {
             index: idx,
             resolveType: rt,
-            label,
+            label: resolvedBlockLabel(innerRt, idx, decofile),
             isHidden: true,
             isLazy: innerIsLazy,
             isSavedBlock: true,
@@ -156,19 +158,10 @@ export function parseSections(
       isSavedBlockResolveType(effectiveRt) &&
       effectiveRt in decofile
     ) {
-      const resolvedBlock = decofile[effectiveRt] as
-        | Record<string, unknown>
-        | undefined;
-      const label =
-        (typeof resolvedBlock?.name === "string" && resolvedBlock.name) ||
-        effectiveRt
-          .replace(/[-_]/g, " ")
-          .replace(/\b\w/g, (c) => c.toUpperCase()) ||
-        `Section ${idx + 1}`;
       return {
         index: idx,
         resolveType: rt,
-        label,
+        label: resolvedBlockLabel(effectiveRt, idx, decofile),
         isLazy: true,
         isSavedBlock: true,
       };


### PR DESCRIPTION
**Source:** reduction — `apps/web/src/components/sections-editor/parse-sections.ts` had the exact same saved-block label logic (own `name`, else humanized resolveType, else `Section N`) copy-pasted three times: for a top-level saved block, for a hidden (never-matcher) saved block, and for a lazy-wrapped saved block. #6508 added the third copy of this block last, making the duplication a clear pattern rather than a one-off.

**Payoff:** one canonical `resolvedBlockLabel()` helper instead of three near-identical inline blocks — any future fix to the label-fallback rule (e.g. adding a new fallback field) now only needs to change one place instead of three, and the diff shows the logic is provably identical across all three call sites.

**Change:** pure extraction, behavior-preserving — same inputs produce the same label at each of the three call sites (verified by the existing `parseSections` test suite, unchanged). Net: -26 / +19 lines.

**Verify:** `bun test apps/web/src/components/sections-editor/section-list.test.ts` (7/7 pass, unchanged).

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint apps/web/src/components/sections-editor/parse-sections.ts` (0 warnings/errors), targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates saved-block label resolution in `parseSections` by extracting a single `resolvedBlockLabel()` helper. Behavior unchanged: top-level, hidden, and lazy saved blocks still fall back in order to the block’s name, a humanized `resolveType`, then `Section N`.

<sup>Written for commit 417c800fdd5ce8575ea7f6a57545294fe985773e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

