### PR TITLE
fix(oauth-proxy): guard origin-metadata endpoint URLs against SSRF

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -99,6 +99,7 @@ import {
 import { createDecoAppsRoutes } from "./routes/deco-apps";
 import { createVirtualMcpRoutes } from "./routes/virtual-mcp";
 import {
+  assertOriginEndpointIsSafe,
   createLegacyWellKnownProtectedResourceRoutes,
   createWellKnownAuthServerRoutes,
   fetchAuthorizationServerMetadata,
@@ -520,6 +521,9 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
   if (!originEndpointUrl) {
     return c.json({ error: `Unknown OAuth endpoint: ${endpoint}` }, 404);
   }
+
+  const endpointGuardError = assertOriginEndpointIsSafe(originEndpointUrl);
+  if (endpointGuardError) return endpointGuardError;
 
   // Build URL with query string
   const targetUrl = new URL(originEndpointUrl);

--- a/apps/api/src/api/routes/oauth-proxy-ssrf.test.ts
+++ b/apps/api/src/api/routes/oauth-proxy-ssrf.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { fetchAuthorizationServerMetadata } from "./oauth-proxy";
+import {
+  assertOriginEndpointIsSafe,
+  fetchAuthorizationServerMetadata,
+} from "./oauth-proxy";
 
 /**
  * `authServerUrl` comes from the origin's own protected-resource-metadata
@@ -22,5 +25,33 @@ describe("fetchAuthorizationServerMetadata SSRF guard", () => {
       "http://localhost:9999/",
     );
     expect(response.status).toBe(502);
+  });
+});
+
+/**
+ * `authorization_endpoint` / `token_endpoint` / `registration_endpoint`
+ * come from the same origin-controlled auth-server metadata document — a
+ * malicious/compromised MCP server can point one of these at an internal
+ * address and get the proxy to fetch or redirect there server-side,
+ * forwarding the caller's Authorization header along with it.
+ */
+describe("assertOriginEndpointIsSafe SSRF guard", () => {
+  test("refuses a private/internal endpoint URL", () => {
+    const response = assertOriginEndpointIsSafe(
+      "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+    );
+    expect(response?.status).toBe(502);
+  });
+
+  test("refuses localhost", () => {
+    const response = assertOriginEndpointIsSafe("http://localhost:9999/token");
+    expect(response?.status).toBe(502);
+  });
+
+  test("allows a public endpoint URL", () => {
+    const response = assertOriginEndpointIsSafe(
+      "https://auth.example.com/token",
+    );
+    expect(response).toBeNull();
   });
 });

--- a/apps/api/src/api/routes/oauth-proxy.ts
+++ b/apps/api/src/api/routes/oauth-proxy.ts
@@ -705,6 +705,22 @@ async function fetchMetadataWithRetry(
   }
 }
 
+/**
+ * Validates an OAuth endpoint URL taken from origin-controlled auth-server
+ * metadata (authorization/token/registration_endpoint) before the proxy
+ * fetches or redirects to it server-side — same guard as `authServerUrl`
+ * above, applied one hop further downstream.
+ */
+export function assertOriginEndpointIsSafe(url: string): Response | null {
+  if (!isPrivateUrl(url)) return null;
+  return new Response(
+    JSON.stringify({
+      error: "URLs targeting private networks are not allowed",
+    }),
+    { status: 502, headers: { "Content-Type": "application/json" } },
+  );
+}
+
 export async function fetchAuthorizationServerMetadata(
   authServerUrl: string,
 ): Promise<Response> {


### PR DESCRIPTION
**Source:** SSRF hardening on the OAuth proxy (this tick's focus area), extending the guard already applied to `authServerUrl` in `fetchAuthorizationServerMetadata` (see `oauth-proxy-ssrf.test.ts`).

**The gap:** `oauthProxyHandler` in `apps/api/src/api/app.ts` resolves `originEndpointUrl` (the `authorization_endpoint` / `token_endpoint` / `registration_endpoint`) straight from the origin MCP server's own auth-server metadata document — not from the connection's vetted `connection_url`. It then does a server-side `fetch(targetUrl, { headers: { Authorization: ... }, ... })` for the token/register endpoints (and a 302 redirect for authorize). A malicious or compromised MCP server can return metadata whose `token_endpoint`/`registration_endpoint` points at an internal address (e.g. the cloud metadata IP `169.254.169.254`, or any private-network host) and get Studio's backend to make that request server-side, forwarding whatever `Authorization` header the caller sent — an SSRF into the deployment's internal network, with credential leakage.

`authServerUrl` itself was already guarded with `isPrivateUrl` in `fetchAuthorizationServerMetadata` for exactly this reason; this closes the same class of gap one hop further downstream, on the endpoint URLs *read out of* that metadata.

**Fix:** extracted the check into an exported pure function `assertOriginEndpointIsSafe` in `oauth-proxy.ts` (reusing the already-tested `isPrivateUrl`), called from `app.ts` right after `originEndpointUrl` is resolved and before it's fetched/redirected to.

**Regression test:** added to the existing `oauth-proxy-ssrf.test.ts` (same file/pattern as the `authServerUrl` guard) — asserts the new function refuses a metadata-endpoint URL pointing at the cloud metadata IP and at localhost, and allows a normal public endpoint.

**To verify:** `bun test apps/api/src/api/routes/oauth-proxy-ssrf.test.ts`

**Locally ran:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on the three touched files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards OAuth proxy endpoint URLs from origin auth-server metadata against SSRF. Previously the proxy used `authorization_endpoint`, `token_endpoint`, and `registration_endpoint` as-is for server-side fetch/redirect; now it validates these and returns 502 for unsafe targets to prevent internal-network access and credential forwarding.

- Introduces `assertOriginEndpointIsSafe` and calls it before building the target URL in the proxy.
- Adds regression tests covering cloud metadata IP, localhost, and a valid public endpoint.

<sup>Written for commit 402f8a3493d97fd94f52adf0bc35d215d43a5f75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

