### PR TITLE
fix(task-board): decide a card has landed per repo, not per PR

### DIFF
--- a/apps/api/src/tools/task-board/archive-merged.integration.test.ts
+++ b/apps/api/src/tools/task-board/archive-merged.integration.test.ts
@@ -113,7 +113,10 @@ describe("auto-archive sweep", () => {
   it("archives a merged card, logs it, and won't archive it twice", async () => {
     const id = await seed("done", new Date(Date.now() - 3 * DAY_MS), true);
 
-    const first = await archiveMergedForOrg(ctx, ORG, [id], async () => true);
+    const first = await archiveMergedForOrg(ctx, ORG, [id], async () => ({
+      state: "closed" as const,
+      merged: true,
+    }));
     expect(first.archived).toBe(1);
     expect((await taskBoard.getById(id, ORG))?.status).toBe("archived");
 
@@ -131,8 +134,52 @@ describe("auto-archive sweep", () => {
     );
 
     // No longer Done, so a second sweep must leave it alone.
-    const second = await archiveMergedForOrg(ctx, ORG, [id], async () => true);
+    const second = await archiveMergedForOrg(ctx, ORG, [id], async () => ({
+      state: "closed" as const,
+      merged: true,
+    }));
     expect(second.archived).toBe(0);
+  });
+
+  it("archives past an abandoned PR, and waits on a second repo", async () => {
+    const settled = new Date(Date.now() - 3 * DAY_MS);
+    const link = (id: string, prNumber: number, repoName: string) =>
+      taskBoard.linkPr({
+        taskBoardItemId: id,
+        organizationId: ORG,
+        url: `https://github.com/acme/${repoName}/pull/${prNumber}`,
+        prNumber,
+        repoOwner: "acme",
+        repoName,
+      });
+
+    const bounced = await seed("done", settled, false);
+    await link(bounced, 1, "repo");
+    await link(bounced, 2, "repo");
+
+    const twoRepos = await seed("done", settled, false);
+    await link(twoRepos, 3, "repo");
+    await link(twoRepos, 4, "repo-us");
+
+    // PR 1 is the branch a reviewer bounce walked away from; 4 is the second
+    // repo's, still open.
+    const reader = async (
+      _ctx: StudioContext,
+      _orgId: string,
+      pr: { number: number },
+    ) =>
+      pr.number === 1
+        ? { state: "closed" as const, merged: false }
+        : pr.number === 4
+          ? { state: "open" as const, merged: false }
+          : { state: "closed" as const, merged: true };
+
+    expect(
+      (await archiveMergedForOrg(ctx, ORG, [bounced, twoRepos], reader))
+        .archived,
+    ).toBe(1);
+    expect((await taskBoard.getById(bounced, ORG))?.status).toBe("archived");
+    expect((await taskBoard.getById(twoRepos, ORG))?.status).toBe("done");
   });
 
   it("leaves a card alone when GitHub can't confirm the merge", async () => {
@@ -140,11 +187,20 @@ describe("auto-archive sweep", () => {
     const open = await seed("done", new Date(Date.now() - 3 * DAY_MS), true);
 
     expect(
-      (await archiveMergedForOrg(ctx, ORG, [unknown], async () => null))
-        .archived,
+      (
+        await archiveMergedForOrg(ctx, ORG, [unknown], async () => ({
+          state: null,
+          merged: null,
+        }))
+      ).archived,
     ).toBe(0);
     expect(
-      (await archiveMergedForOrg(ctx, ORG, [open], async () => false)).archived,
+      (
+        await archiveMergedForOrg(ctx, ORG, [open], async () => ({
+          state: "open" as const,
+          merged: false,
+        }))
+      ).archived,
     ).toBe(0);
     expect((await taskBoard.getById(unknown, ORG))?.status).toBe("done");
     expect((await taskBoard.getById(open, ORG))?.status).toBe("done");

--- a/apps/api/src/tools/task-board/archive-merged.test.ts
+++ b/apps/api/src/tools/task-board/archive-merged.test.ts
@@ -1,17 +1,75 @@
 import { describe, expect, it } from "bun:test";
-import { allPrsMerged, groupByOrg } from "./archive-merged";
+import { cardWorkLanded, groupByOrg, type PrLanding } from "./archive-merged";
 
-describe("allPrsMerged", () => {
-  it("archives only when every linked PR is merged", () => {
-    expect(allPrsMerged([true])).toBe(true);
-    expect(allPrsMerged([true, true])).toBe(true);
-    expect(allPrsMerged([true, false])).toBe(false);
+const BR = { repoOwner: "acme", repoName: "storefront" };
+const US = { repoOwner: "acme", repoName: "storefront-us" };
+
+const merged = (repo: typeof BR): PrLanding => ({
+  ...repo,
+  state: "closed",
+  merged: true,
+});
+const open = (repo: typeof BR): PrLanding => ({
+  ...repo,
+  state: "open",
+  merged: false,
+});
+const abandoned = (repo: typeof BR): PrLanding => ({
+  ...repo,
+  state: "closed",
+  merged: false,
+});
+const unreadable = (repo: typeof BR): PrLanding => ({
+  ...repo,
+  state: null,
+  merged: null,
+});
+
+describe("cardWorkLanded", () => {
+  it("lands a single merged PR", () => {
+    expect(cardWorkLanded([merged(BR)])).toBe(true);
   });
 
-  it("never archives on no PRs or an unreachable GitHub", () => {
-    expect(allPrsMerged([])).toBe(false);
-    expect(allPrsMerged([null])).toBe(false);
-    expect(allPrsMerged([true, null])).toBe(false);
+  it("needs every repo the card touches, not every PR", () => {
+    expect(cardWorkLanded([merged(BR), merged(US)])).toBe(true);
+    expect(cardWorkLanded([merged(BR), open(US)])).toBe(false);
+  });
+
+  // Inverts `allPrsMerged`, which stranded a bounced card forever.
+  it("ignores a PR the reviewer bounce abandoned in the same repo", () => {
+    expect(cardWorkLanded([abandoned(BR), merged(BR)])).toBe(true);
+  });
+
+  it("holds while a repo still has an open PR, merged sibling or not", () => {
+    expect(cardWorkLanded([merged(BR), open(BR)])).toBe(false);
+    expect(cardWorkLanded([open(BR), open(BR)])).toBe(false);
+  });
+
+  it("never lands a repo whose PRs all closed unmerged", () => {
+    expect(cardWorkLanded([abandoned(BR)])).toBe(false);
+  });
+
+  it("defers on an unreachable GitHub rather than landing on a guess", () => {
+    expect(cardWorkLanded([unreadable(BR)])).toBe(false);
+    expect(cardWorkLanded([merged(BR), unreadable(BR)])).toBe(false);
+    expect(cardWorkLanded([merged(BR), unreadable(US)])).toBe(false);
+  });
+
+  it("accepts a merge reported without a state", () => {
+    expect(cardWorkLanded([{ ...BR, state: null, merged: true }])).toBe(true);
+  });
+
+  it("groups repos case-insensitively, as GitHub does", () => {
+    expect(
+      cardWorkLanded([
+        merged(BR),
+        { ...BR, repoName: "StoreFront", state: "open", merged: false },
+      ]),
+    ).toBe(false);
+  });
+
+  it("never lands a card with no PRs at all", () => {
+    expect(cardWorkLanded([])).toBe(false);
   });
 });
 

--- a/apps/api/src/tools/task-board/archive-merged.ts
+++ b/apps/api/src/tools/task-board/archive-merged.ts
@@ -17,26 +17,72 @@
 import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItemPrRef } from "@/storage/types";
 import { recordTaskActivity } from "./activity";
-import { fetchPrMerged } from "./prs-get";
+import { fetchPrLanding } from "./prs-get";
 import { emitTaskBoardUpdated } from "./run-reactions";
 
-/** How the sweep asks GitHub whether a PR merged — a parameter only so a
- *  local/CI harness can drive the archive path without a GitHub connection. */
-type PrMergedReader = (
+/** What {@link cardWorkLanded} needs to know about one linked PR: the repo it
+ *  targets, and whether it is still in play. */
+export interface PrLanding {
+  repoOwner: string;
+  repoName: string;
+  state: "open" | "closed" | null;
+  merged: boolean | null;
+}
+
+/** How a sweep asks GitHub where a PR stands — a parameter only so a local/CI
+ *  harness can drive the path without a GitHub connection. Shared with the
+ *  merged-tag sweep, which gates on the same question. */
+export type PrLandingReader = (
   ctx: StudioContext,
   orgId: string,
   pr: TaskBoardItemPrRef,
-) => Promise<boolean | null>;
+) => Promise<Pick<PrLanding, "state" | "merged">>;
 
 /**
- * Is this Done card's work landed? Every linked PR merged, and at least one
- * linked. No PRs means there's nothing to verify — a design/research task is
- * left in Done for a human to archive. `null` (GitHub unreachable) is never read
- * as merged, so a bad fetch defers the archive to the next sweep instead of
- * archiving on a guess.
+ * Has this card's work landed?
+ *
+ * Per REPOSITORY, not per PR. A card carries several PRs for two unrelated
+ * reasons and the old "every linked PR merged" rule conflated them. A reviewer
+ * bounce that opens a fresh PR instead of pushing to the reviewed branch leaves
+ * the abandoned one closed-and-unmerged forever, so `every(merged)` could never
+ * be satisfied and the card was stranded out of the archive, the merged tag and
+ * the reconcile permanently — while `pickActivePr`, asking the neighbouring
+ * question, reads exactly the same list as a retry history. A card touching two
+ * repos, meanwhile, genuinely does need both to land.
+ *
+ * So each repo the card has PRs in needs one merged and none still in play.
+ * Note this cannot be answered from `merged` alone: closed-unmerged and still
+ * open both report `merged: false`, and only the first is settled.
+ *
+ * "In play" is deliberately generous — an unreadable PR (`state: null`) counts
+ * as outstanding, so a GitHub blip defers rather than landing a card on a
+ * guess. Same conservative direction the previous rule took with `merged: null`.
+ *
+ * No PRs at all means there is nothing to verify: a design or research task is
+ * left for a human, never landed automatically.
  */
-export function allPrsMerged(merged: (boolean | null)[]): boolean {
-  return merged.length > 0 && merged.every((m) => m === true);
+export function cardWorkLanded(prs: PrLanding[]): boolean {
+  if (prs.length === 0) return false;
+  const byRepo = new Map<string, PrLanding[]>();
+  for (const pr of prs) {
+    // GitHub treats owner/name case-insensitively, and the two spellings can
+    // reach us from different places (a parsed URL vs a connection's scope).
+    const key = `${pr.repoOwner}/${pr.repoName}`.toLowerCase();
+    const group = byRepo.get(key);
+    if (group) group.push(pr);
+    else byRepo.set(key, [pr]);
+  }
+  return [...byRepo.values()].every(repoLanded);
+}
+
+/** One repo's PRs on a card: one of them merged, and none left in play.
+ *  `merged === true` also passes the second test on its own, for the partial
+ *  read that reports a merge without a state. */
+function repoLanded(prs: PrLanding[]): boolean {
+  return (
+    prs.some((pr) => pr.merged === true) &&
+    prs.every((pr) => pr.merged === true || pr.state === "closed")
+  );
 }
 
 /**
@@ -50,16 +96,19 @@ async function archiveIfMerged(
   ctx: StudioContext,
   organizationId: string,
   itemId: string,
-  prMerged: PrMergedReader,
+  prLanding: PrLandingReader,
 ): Promise<boolean> {
   const item = await ctx.storage.taskBoard.getById(itemId, organizationId);
   if (!item || item.status !== "done") return false;
 
   const prs = await ctx.storage.taskBoard.listPrs(itemId, organizationId);
-  const merged = await Promise.all(
-    prs.map((pr) => prMerged(ctx, organizationId, pr)),
+  const landings = await Promise.all(
+    prs.map(async (pr) => ({
+      ...pr,
+      ...(await prLanding(ctx, organizationId, pr)),
+    })),
   );
-  if (!allPrsMerged(merged)) return false;
+  if (!cardWorkLanded(landings)) return false;
 
   const updated = await ctx.storage.taskBoard.update(
     itemId,
@@ -88,12 +137,12 @@ export async function archiveMergedForOrg(
   ctx: StudioContext,
   organizationId: string,
   itemIds: string[],
-  prMerged: PrMergedReader = fetchPrMerged,
+  prLanding: PrLandingReader = fetchPrLanding,
 ): Promise<{ archived: number }> {
   let archived = 0;
   for (const itemId of itemIds) {
     try {
-      if (await archiveIfMerged(ctx, organizationId, itemId, prMerged)) {
+      if (await archiveIfMerged(ctx, organizationId, itemId, prLanding)) {
         archived += 1;
       }
     } catch (err) {

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -1018,13 +1018,24 @@ async function fetchPrGet(
 }
 
 /** Just "is this PR merged?", for the archive sweep. */
-export async function fetchPrMerged(
+export async function fetchPrLanding(
   ctx: StudioContext,
   orgId: string,
   pr: TaskBoardItemPrRef,
-): Promise<boolean | null> {
-  const obj = await fetchPrGet(ctx, orgId, pr, "merged");
-  return typeof obj?.merged === "boolean" ? obj.merged : null;
+): Promise<{ state: "open" | "closed" | null; merged: boolean | null }> {
+  const obj = await fetchPrGet(ctx, orgId, pr, "landing");
+  return {
+    // `merged` alone cannot answer `cardWorkLanded`: a closed-unmerged PR and an
+    // open one both report false, and only the first is settled. Both fields
+    // come off the one `get` this already pays for.
+    state:
+      obj?.state === "closed"
+        ? "closed"
+        : obj?.state === "open"
+          ? "open"
+          : null,
+    merged: typeof obj?.merged === "boolean" ? obj.merged : null,
+  };
 }
 
 /**

--- a/apps/api/src/tools/task-board/reconcile-merged.test.ts
+++ b/apps/api/src/tools/task-board/reconcile-merged.test.ts
@@ -4,14 +4,27 @@
  * consulted. Storage is a fake — the contract under test is the gate, the
  * status write and the timeline entry, none of which need Postgres.
  *
- * The merged flags arrive from the sweeper's own throttled PR read, so there is
- * no GitHub reader to stub here (see `advanceToDoneIfMerged`'s doc comment).
+ * The live PR states arrive from the sweeper's own throttled PR read, so there
+ * is no GitHub reader to stub here (see `advanceToDoneIfMerged`'s doc comment).
  */
 
 import { describe, expect, it } from "bun:test";
 import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItem } from "@/storage/types";
+import type { PrLanding } from "./archive-merged";
 import { advanceToDoneIfMerged } from "./reconcile-merged";
+
+const REPO = { repoOwner: "acme", repoName: "storefront" };
+const merged: PrLanding = { ...REPO, state: "closed", merged: true };
+const openPr: PrLanding = { ...REPO, state: "open", merged: false };
+const abandoned: PrLanding = { ...REPO, state: "closed", merged: false };
+const unreadable: PrLanding = { ...REPO, state: null, merged: null };
+const otherRepoOpen: PrLanding = {
+  repoOwner: "acme",
+  repoName: "storefront-us",
+  state: "open",
+  merged: false,
+};
 
 const item = (over: Partial<TaskBoardItem> = {}): TaskBoardItem =>
   ({
@@ -49,7 +62,7 @@ function fakeCtx(over: { humanRejectedDone?: boolean } = {}) {
 describe("advanceToDoneIfMerged", () => {
   it("moves a card whose PR landed outside Studio, and says why", async () => {
     const { ctx, updates, activity } = fakeCtx();
-    expect(await advanceToDoneIfMerged(ctx, item(), [true])).toBe(true);
+    expect(await advanceToDoneIfMerged(ctx, item(), [merged])).toBe(true);
     expect(updates).toEqual([{ status: "done" }]);
     expect(activity).toEqual([
       {
@@ -63,7 +76,7 @@ describe("advanceToDoneIfMerged", () => {
 
   it("leaves an unmerged card alone", async () => {
     const { ctx, updates } = fakeCtx();
-    expect(await advanceToDoneIfMerged(ctx, item(), [false])).toBe(false);
+    expect(await advanceToDoneIfMerged(ctx, item(), [openPr])).toBe(false);
     expect(updates).toEqual([]);
   });
 
@@ -71,12 +84,23 @@ describe("advanceToDoneIfMerged", () => {
   // shipped. This is also what an unregistered/timed-out throttled read yields.
   it("defers to the next sweep when GitHub does not answer", async () => {
     const { ctx } = fakeCtx();
-    expect(await advanceToDoneIfMerged(ctx, item(), [null])).toBe(false);
+    expect(await advanceToDoneIfMerged(ctx, item(), [unreadable])).toBe(false);
   });
 
-  it("needs every linked PR merged, not just one", async () => {
+  it("needs every repo the card touches to have landed", async () => {
     const { ctx } = fakeCtx();
-    expect(await advanceToDoneIfMerged(ctx, item(), [true, false])).toBe(false);
+    expect(
+      await advanceToDoneIfMerged(ctx, item(), [merged, otherRepoOpen]),
+    ).toBe(false);
+  });
+
+  // Inverts the old every-PR rule, which stranded a bounced card in review.
+  it("moves past a PR the bounce abandoned in the same repo", async () => {
+    const { ctx, updates } = fakeCtx();
+    expect(await advanceToDoneIfMerged(ctx, item(), [abandoned, merged])).toBe(
+      true,
+    );
+    expect(updates).toEqual([{ status: "done" }]);
   });
 
   it("does nothing for a card with no linked PR", async () => {
@@ -87,14 +111,16 @@ describe("advanceToDoneIfMerged", () => {
   it("only ever moves a card that is still In Review", async () => {
     const { ctx } = fakeCtx();
     expect(
-      await advanceToDoneIfMerged(ctx, item({ status: "in_progress" }), [true]),
+      await advanceToDoneIfMerged(ctx, item({ status: "in_progress" }), [
+        merged,
+      ]),
     ).toBe(false);
   });
 
   // A person who pulled the card back out of Done outranks a merged PR.
   it("honors a human's rejection of Done", async () => {
     const { ctx, updates } = fakeCtx({ humanRejectedDone: true });
-    expect(await advanceToDoneIfMerged(ctx, item(), [true])).toBe(false);
+    expect(await advanceToDoneIfMerged(ctx, item(), [merged])).toBe(false);
     expect(updates).toEqual([]);
   });
 });

--- a/apps/api/src/tools/task-board/reconcile-merged.ts
+++ b/apps/api/src/tools/task-board/reconcile-merged.ts
@@ -21,19 +21,20 @@
 import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItem } from "@/storage/types";
 import { recordTaskActivity } from "./activity";
-import { allPrsMerged } from "./archive-merged";
+import { cardWorkLanded, type PrLanding } from "./archive-merged";
 import { emitTaskBoardUpdated } from "./run-reactions";
 
 /**
- * Move `item` to Done if every linked PR is merged on GitHub. Returns whether
- * it moved.
+ * Move `item` to Done if its work landed on GitHub (see {@link cardWorkLanded}
+ * for what "landed" means once a card carries more than one PR). Returns
+ * whether it moved.
  *
- * Takes the merged flags rather than reading GitHub itself: its one caller, the
- * sweeper, already reads every linked PR through the rate-limited queue
- * (`readPrStateThrottled`), and `merged` comes back on that same `get`. Reading
- * again here would put the sweep's real network call OUTSIDE the queue that
- * exists to keep it from exhausting the shared `github-mcp` budget — see
- * `dbos-github-read.ts`.
+ * Takes the live PR states rather than reading GitHub itself: its one caller,
+ * the sweeper, already reads every linked PR through the rate-limited queue
+ * (`readPrStateThrottled`), and both `state` and `merged` come back on that
+ * same `get`. Reading again here would put the sweep's real network call
+ * OUTSIDE the queue that exists to keep it from exhausting the shared
+ * `github-mcp` budget — see `dbos-github-read.ts`.
  *
  * Deliberately NOT gated on `auto_merge`, on who merged, or on the reviewers'
  * verdicts: the PR is already in the base branch, so the work shipped and the
@@ -41,17 +42,17 @@ import { emitTaskBoardUpdated } from "./run-reactions";
  * `hasHumanRejectedDone` — a person who pulled this card back out of Done meant
  * it, and a merged PR is not a reason to overrule them.
  *
- * `null` (GitHub unreachable) is never read as merged, so a bad fetch defers to
- * the next sweep rather than shipping a card on a guess.
+ * An unreadable PR is never read as landed, so a bad fetch defers to the next
+ * sweep rather than shipping a card on a guess.
  */
 export async function advanceToDoneIfMerged(
   ctx: StudioContext,
   item: TaskBoardItem,
-  merged: (boolean | null)[],
+  prs: PrLanding[],
 ): Promise<boolean> {
   const orgId = item.organizationId;
   if (item.status !== "in_review") return false;
-  if (!allPrsMerged(merged)) return false;
+  if (!cardWorkLanded(prs)) return false;
   if (await ctx.storage.taskBoard.hasHumanRejectedDone(item.id, orgId)) {
     return false;
   }

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -523,13 +523,7 @@ export class TaskBoardReviewSweeper {
     // A PR merged outside Studio moves no card on its own — see
     // `reconcile-merged.ts`. Runs before the merge retry and before the `owned`
     // gate: a handed-off card whose PR a human merged is exactly the stuck case.
-    if (
-      await advanceToDoneIfMerged(
-        ctx,
-        item,
-        live.map((pr) => pr.merged),
-      )
-    ) {
+    if (await advanceToDoneIfMerged(ctx, item, live)) {
       return true;
     }
 

--- a/apps/api/src/tools/task-board/tag-merged.integration.test.ts
+++ b/apps/api/src/tools/task-board/tag-merged.integration.test.ts
@@ -99,7 +99,10 @@ describe("merged-tag sweep", () => {
   it("tags a merged card, logs it, and drops it from the work list", async () => {
     const id = await seed("done", true);
 
-    const first = await tagMergedForOrg(ctx, ORG, [id], async () => true);
+    const first = await tagMergedForOrg(ctx, ORG, [id], async () => ({
+      state: "closed" as const,
+      merged: true,
+    }));
     expect(first.tagged).toBe(1);
     expect(
       (await taskBoard.getById(id, ORG))?.tags.map((t) => t.name),
@@ -122,7 +125,10 @@ describe("merged-tag sweep", () => {
     const a = await seed("done", true);
     const b = await seed("done", true);
 
-    await tagMergedForOrg(ctx, ORG, [a, b], async () => true);
+    await tagMergedForOrg(ctx, ORG, [a, b], async () => ({
+      state: "closed" as const,
+      merged: true,
+    }));
 
     const merged = (await tags.listOrgTags(ORG)).filter(
       (t) => t.name.toLowerCase() === MERGED_TAG_NAME,
@@ -135,10 +141,20 @@ describe("merged-tag sweep", () => {
     const open = await seed("done", true);
 
     expect(
-      (await tagMergedForOrg(ctx, ORG, [unknown], async () => null)).tagged,
+      (
+        await tagMergedForOrg(ctx, ORG, [unknown], async () => ({
+          state: null,
+          merged: null,
+        }))
+      ).tagged,
     ).toBe(0);
     expect(
-      (await tagMergedForOrg(ctx, ORG, [open], async () => false)).tagged,
+      (
+        await tagMergedForOrg(ctx, ORG, [open], async () => ({
+          state: "open" as const,
+          merged: false,
+        }))
+      ).tagged,
     ).toBe(0);
     expect((await taskBoard.getById(unknown, ORG))?.tags).toEqual([]);
     expect((await taskBoard.getById(open, ORG))?.tags).toEqual([]);
@@ -164,7 +180,10 @@ describe("merged-tag sweep", () => {
       by: USER,
     });
 
-    await tagMergedForOrg(ctx, otherOrg, [item.id], async () => false);
+    await tagMergedForOrg(ctx, otherOrg, [item.id], async () => ({
+      state: "open" as const,
+      merged: false,
+    }));
 
     expect(await tags.listOrgTags(otherOrg)).toEqual([]);
   });

--- a/apps/api/src/tools/task-board/tag-merged.ts
+++ b/apps/api/src/tools/task-board/tag-merged.ts
@@ -3,8 +3,8 @@
  * `merged` tag, so "done" and "actually shipped" are told apart on the board
  * without opening every card's PR link.
  *
- * Same shape and the same gate as `archive-merged.ts` (it reuses `allPrsMerged`
- * and `groupByOrg`), but no settle window: the tag is a statement about the PR,
+ * Same shape and the same gate as `archive-merged.ts` (it reuses
+ * `cardWorkLanded` and `groupByOrg`), but no settle window: the tag is a statement about the PR,
  * not about the card being finished with. It runs unattended on the hourly
  * `taskBoardMergedTagSweepWorkflow` (see `dbos-tag-merged-sweep.ts`) — nothing
  * about it is a decision a human makes per task.
@@ -17,23 +17,14 @@
 
 import { nextTagColor } from "@decocms/shared/task-board";
 import type { StudioContext } from "@/core/studio-context";
-import type { TaskBoardItemPrRef } from "@/storage/types";
 import { recordTaskActivity } from "./activity";
-import { allPrsMerged } from "./archive-merged";
-import { fetchPrMerged } from "./prs-get";
+import { cardWorkLanded, type PrLandingReader } from "./archive-merged";
+import { fetchPrLanding } from "./prs-get";
 import { emitTaskBoardUpdated } from "./run-reactions";
 
 /** Lowercase — org tags are matched case-insensitively, so an existing
  *  "Merged" is reused rather than forked into a second tag. */
 export const MERGED_TAG_NAME = "merged";
-
-/** How the sweep asks GitHub whether a PR merged — a parameter only so a
- *  local/CI harness can drive the tag path without a GitHub connection. */
-type PrMergedReader = (
-  ctx: StudioContext,
-  orgId: string,
-  pr: TaskBoardItemPrRef,
-) => Promise<boolean | null>;
 
 /**
  * The org's `merged` tag id, created on first use. Resolved lazily — only once
@@ -71,16 +62,19 @@ async function tagIfMerged(
   organizationId: string,
   itemId: string,
   tagId: () => Promise<string>,
-  prMerged: PrMergedReader,
+  prLanding: PrLandingReader,
 ): Promise<boolean> {
   const item = await ctx.storage.taskBoard.getById(itemId, organizationId);
   if (!item || item.status !== "done") return false;
 
   const prs = await ctx.storage.taskBoard.listPrs(itemId, organizationId);
-  const merged = await Promise.all(
-    prs.map((pr) => prMerged(ctx, organizationId, pr)),
+  const landings = await Promise.all(
+    prs.map(async (pr) => ({
+      ...pr,
+      ...(await prLanding(ctx, organizationId, pr)),
+    })),
   );
-  if (!allPrsMerged(merged)) return false;
+  if (!cardWorkLanded(landings)) return false;
 
   await ctx.storage.taskBoard.addItemTags(itemId, [await tagId()], "system");
   const updated = await ctx.storage.taskBoard.getById(itemId, organizationId);
@@ -107,7 +101,7 @@ export async function tagMergedForOrg(
   ctx: StudioContext,
   organizationId: string,
   itemIds: string[],
-  prMerged: PrMergedReader = fetchPrMerged,
+  prLanding: PrLandingReader = fetchPrLanding,
 ): Promise<{ tagged: number }> {
   let cached: Promise<string> | null = null;
   const tagId = () => (cached ??= resolveMergedTagId(ctx, organizationId));
@@ -115,7 +109,7 @@ export async function tagMergedForOrg(
   let tagged = 0;
   for (const itemId of itemIds) {
     try {
-      if (await tagIfMerged(ctx, organizationId, itemId, tagId, prMerged)) {
+      if (await tagIfMerged(ctx, organizationId, itemId, tagId, prLanding)) {
         tagged += 1;
       }
     } catch (err) {


### PR DESCRIPTION
## What is this contribution about?

`allPrsMerged` demanded that **every** linked PR be merged, while `pickActivePr` — asking the neighbouring question over the same list — reads it as a **retry history** ("the newest one not definitively closed"). The two rules contradict each other, and the contradiction strands cards:

- A reviewer bounce that opens a fresh PR instead of pushing to the reviewed branch leaves the abandoned one closed-and-unmerged **forever**. `every(merged)` can then never be satisfied, so the card is permanently invisible to the archive sweep, the `merged` tag sweep and the In Review reconcile — while still costing one GitHub read per PR per sweep tick, for good.
- Meanwhile a card that legitimately touches two repositories genuinely does need both to land, and "newest wins" would ship it on one.

This replaces the rule with `cardWorkLanded`: **group a card's PRs by repository, and require each repo to have one merged and none still in play.** A bounce reads as a retry; two repositories read as two things that must both land.

That question cannot be answered from `merged` alone — a closed-unmerged PR and a still-open one both report `false`, and only the first is settled. So `fetchPrMerged` becomes `fetchPrLanding` and returns `state` alongside `merged`. Both fields already come off the single `get` it was paying for, so there is **no additional GitHub call**. For the same reason the review sweeper now hands `advanceToDoneIfMerged` its live PR states instead of mapping them down to merged flags — it already had them.

An unreadable PR (`state: null`) still counts as outstanding, so a GitHub blip defers the decision rather than landing a card on a guess. That is the same conservative direction the old rule took with `merged: null`.

## How did you verify your code works?

**New/inverted unit coverage** in `archive-merged.test.ts` (11 tests): one merged PR lands; two repos need both; **inverted** the old every-PR rule with an explicit "ignores a PR the reviewer bounce abandoned in the same repo" case; a repo with an open PR holds even when a sibling merged; a repo whose PRs all closed unmerged never lands; unreadable PRs defer; a merge reported without a state still counts; repo grouping is case-insensitive; no PRs never lands.

Per the repo's inversion rule I **inverted rather than appended** in `reconcile-merged.test.ts` too: `"needs every linked PR merged, not just one"` (which encoded the bug) became `"needs every repo the card touches to have landed"` plus a new `"moves past a PR the bounce abandoned in the same repo"`.

**Real-Postgres coverage** added to `archive-merged.integration.test.ts`: one card with an abandoned + a merged PR in the same repo, one card with a merged PR in repo A and an open PR in repo B, swept together — exactly one archives, and the right one. The existing integration readers in both `archive-merged` and `tag-merged` were updated to the new reader shape.

Against real Postgres (`DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres`), `bun test src/tools/task-board/ src/storage/` is **670 pass / 0 fail** (68 files). `bun run check` reports 0 type errors, `bun run lint` 18 warnings identical to baseline, `bun run knip` clean, `bun run fmt` applied.

**Flagging honestly:** `bun test src` across the whole workspace shows 53 failures, all in areas this PR does not touch (S3, MCP proxy, credential vault, `/api/config`) and all of which **pass standalone** — order-dependent interference in the shared suite, the same class already present on `main`. No e2e run.

## Screenshots/Demonstration

Not applicable — no UI change.

## How to Test

1. Create a Done card with a linked PR and confirm the archive sweep still archives it once every PR is merged (unchanged behaviour).
2. Link a **second** PR in the **same** repo to a card, with the first closed-unmerged and the second merged. Before: the card never archived, never got the `merged` tag, and never advanced out of In Review. After: it does.
3. Link PRs in **two different** repos to one card with only one merged. Expected: the card does **not** advance until both land.
4. Make the GitHub read fail (or return an unreadable PR). Expected: no card moves — the sweep defers to the next tick.

## Migration Notes

None. No schema change, no new configuration, no flag.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decides whether a card has “landed” per repository, not per PR, so reviewer bounces don’t strand cards and multi-repo work only ships when all repos land. Previously we required every linked PR to be merged; now we require at least one merged PR per repo and no PRs in that repo still open or unreadable.

- Bug Fixes
  - Treats closed-unmerged PRs in the same repo as abandoned; a merged sibling still lands the repo.
  - Requires each touched repo to have one merged PR and none still open; unreadable PRs defer decisions.
  - Prevents cards from getting stuck out of archive/merged-tag/In Review reconcile and avoids ongoing sweep reads on them.

- Refactors
  - Replaces `allPrsMerged` with `cardWorkLanded`.
  - Renames `fetchPrMerged` to `fetchPrLanding`, returning `{ state, merged }` from the same GitHub GET (no extra calls).
  - `advanceToDoneIfMerged` now accepts live PR states; the review sweeper passes them through.
  - No schema or config changes; no migration needed.

<sup>Written for commit 70a0febae27820ab0d4b4ff2c557232aa2a27103. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

