### PR TITLE
fix(task-board): decide TASK_BOARD_ITEM_PRS_GET's merge->done reconcile per repo

### DIFF
--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -10,6 +10,7 @@ import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import { retry, RetryError } from "@decocms/shared/std";
 import { InMemoryMcpReadCache } from "@/mcp-clients/mcp-read-cache";
 import { TaskBoardItemPrSchema } from "./schema";
+import { cardWorkLanded } from "./archive-merged";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
@@ -1248,7 +1249,7 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
     // only advances the card to Done when someone opens this modal. Upgrade path:
     // a `pull_request` webhook calling the same forward move. Best-effort; a
     // failure must never break the read. Forward-only: never un-does Done or Archived.
-    if (prs.some((p) => p.merged)) {
+    if (cardWorkLanded(prs)) {
       try {
         if (
           item &&


### PR DESCRIPTION
PR #6544 replaced the naive "every/any PR merged" rule with `cardWorkLanded` (group a card's PRs by repo, require one merged and none still in play) at three call sites — `archive-merged.ts`, `tag-merged.ts`, `reconcile-merged.ts` — but missed a fourth: the "reconcile-on-view" block inside `TASK_BOARD_ITEM_PRS_GET`'s handler in `prs-get.ts`, which still used `prs.some((p) => p.merged)`.

**Failure scenario:** a task board card links PRs across two repos (a real, supported case — the PR description for #6544 explicitly calls out "a card touching two repos genuinely does need both to land"). The moment the FIRST repo's PR merges, this reconcile fires and moves the card straight to Done, even though the second repo's PR is still open and unmerged — the exact per-PR-vs-per-repo bug #6544 fixed everywhere else, just missed at this one call site (it runs every time someone opens the task's PR modal, since it's driven by the 10s poll).

**Fix:** use the same `cardWorkLanded(prs)` helper the other three sweeps already share, instead of `prs.some((p) => p.merged)`. `prs` here already carries `repoOwner`/`repoName`/`state`/`merged` per PR (from `fetchPrLiveState`), so it's a drop-in call.

No behavior change for the common single-repo case; only changes the (previously-wrong) multi-repo case to match the invariant the other three sweeps now enforce.

**To verify:** `cd apps/api && bunx tsc --noEmit` (clean — confirms no circular-import issue from importing `cardWorkLanded` out of `archive-merged.ts`), `bun test apps/api/src/tools/task-board/archive-merged.test.ts` (the `cardWorkLanded` unit tests, unchanged and still green), `bunx oxlint apps/api/src/tools/task-board/prs-get.ts` (clean). No existing test exercised this specific reconcile block, so nothing needed inverting; full CI covers the rest.