### PR TITLE
fix(sections-editor): match the always-matcher variant by exact resolveType, not substring

### DIFF
--- a/apps/web/src/components/sections-editor/array-item-display.test.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.test.ts
@@ -416,6 +416,58 @@ describe("getArrayItemImageSrc", () => {
     );
   });
 
+  test("prefers the always variant over an earlier targeted-rule variant", () => {
+    const item = {
+      matcher: ["/produtos/cheirinho"],
+      image: {
+        __resolveType: "site/flags/multivariate/desktopAndMobileImage.ts",
+        variants: [
+          {
+            rule: { __resolveType: "website/matchers/device.ts" },
+            value: { desktop: "https://example.com/targeted.jpg" },
+          },
+          {
+            rule: { __resolveType: "website/matchers/always.ts" },
+            value: { desktop: "https://example.com/default.jpg" },
+          },
+        ],
+      },
+    };
+    const schema: SchemaProperty = {
+      type: "object",
+      image: "{{{image.desktop}}}",
+    };
+    expect(getArrayItemImageSrc(item, schema)).toBe(
+      "https://example.com/default.jpg",
+    );
+  });
+
+  test("recognizes the legacy $live always matcher as the default variant", () => {
+    const item = {
+      matcher: ["/produtos/cheirinho"],
+      image: {
+        __resolveType: "site/flags/multivariate/desktopAndMobileImage.ts",
+        variants: [
+          {
+            rule: { __resolveType: "website/matchers/device.ts" },
+            value: { desktop: "https://example.com/targeted.jpg" },
+          },
+          {
+            rule: { __resolveType: "$live/matchers/MatchAlways.ts" },
+            value: { desktop: "https://example.com/default.jpg" },
+          },
+        ],
+      },
+    };
+    const schema: SchemaProperty = {
+      type: "object",
+      image: "{{{image.desktop}}}",
+    };
+    expect(getArrayItemImageSrc(item, schema)).toBe(
+      "https://example.com/default.jpg",
+    );
+  });
+
   test("defaults to image.mobile when image is a nested object", () => {
     const item = {
       image: {

--- a/apps/web/src/components/sections-editor/array-item-display.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.ts
@@ -4,8 +4,14 @@ import { extractUrl } from "./fields/extract-url";
 import { formatMatcher } from "./format-matcher";
 import { inferInlineUnionIndex } from "./fields/inline-union-value";
 import type { SchemaProperty } from "./resolve-schema";
-import { labelFromResolveType } from "./section-types";
+import {
+  ALWAYS_MATCHER_RESOLVE_TYPE,
+  labelFromResolveType,
+} from "./section-types";
 import { safeEditorImageUrl } from "./safe-editor-image-url";
+
+// Legacy $live path for the same "always" matcher (see format-matcher.ts's alwaysTypes).
+const LEGACY_ALWAYS_MATCHER_RESOLVE_TYPE = "$live/matchers/MatchAlways.ts";
 
 function resolveResolvable(obj: Record<string, unknown>): unknown {
   if (Array.isArray(obj.variants)) {
@@ -13,8 +19,10 @@ function resolveResolvable(obj: Record<string, unknown>): unknown {
       rule?: { __resolveType?: string };
       value?: unknown;
     }>;
-    const always = variants.find((v) =>
-      v.rule?.__resolveType?.includes("always"),
+    const always = variants.find(
+      (v) =>
+        v.rule?.__resolveType === ALWAYS_MATCHER_RESOLVE_TYPE ||
+        v.rule?.__resolveType === LEGACY_ALWAYS_MATCHER_RESOLVE_TYPE,
     );
     // Unwrap object-valued variants too (e.g. `{ desktop, mobile }`), not only strings.
     const chosen = always ?? variants.find((v) => v.value != null);


### PR DESCRIPTION
**Bug found while auditing `apps/web/src/components/sections-editor/array-item-display.ts`.**

`resolveResolvable()` picks the "always" (default) variant of a multivariate array-item field with `v.rule?.__resolveType?.includes("always")` — a loose, case-sensitive substring check. `format-matcher.ts` already special-cases a legacy resolveType for the same matcher, `$live/matchers/MatchAlways.ts` (capitalized `Always`), which the substring check misses. When it misses, `resolveResolvable` falls back to `variants.find(v => v.value != null)` — the *first* variant with a value — instead of the default one.

**Failure scenario:** an array item's image/link field is a multivariate value whose variants array has a targeted-rule variant (e.g. device) *before* a legacy-always variant. The section list/preview then shows the targeted variant's value as if it were the default, silently displaying the wrong image or label for that item.

**Fix:** match exactly against `ALWAYS_MATCHER_RESOLVE_TYPE` (the existing shared constant, previously unused in this file) and the same legacy path `format-matcher.ts` already recognizes, instead of a substring check.

**Regression test** in `array-item-display.test.ts`: confirmed it fails against the old code (picks `targeted.jpg` instead of `default.jpg`) and passes with the fix.

**To verify:** `bun test apps/web/src/components/sections-editor/array-item-display.test.ts`

**Locally ran:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI covers the rest.