### PR TITLE
fix(jira): pick the push target from an ordered mapping, not from jsonb key order

### DIFF
--- a/apps/api/migrations/178-jira-status-mapping-array.ts
+++ b/apps/api/migrations/178-jira-status-mapping-array.ts
@@ -1,0 +1,58 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Invert `org_jira_integrations.status_mapping` from `{ "<jira status>":
+ * "<lane>" }` to `{ "<lane>": ["<jira status>", …] }`.
+ *
+ * Several Jira statuses sharing one lane is the normal case, so the push has to
+ * pick one. Under the old shape it picked by iterating `Object.entries` over
+ * jsonb, which Postgres orders by key length and then bytes — the Jira column a
+ * card landed in was decided by how many characters its status name had. An
+ * array makes the choice explicit: position 0 is the lane's leftmost board
+ * column, and the settings UI writes it in board order.
+ *
+ * The old shape cannot say which status came first, so a lane that collapsed
+ * several keeps them in jsonb key order here. That is no worse than the
+ * behaviour being replaced, and re-picking the columns in settings rewrites it
+ * in board order.
+ *
+ * Readers go through `normalizeStatusMapping`, which still accepts the old
+ * shape, so a rolling deploy keeps syncing on either side of this.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    UPDATE org_jira_integrations
+       SET status_mapping = (
+             SELECT COALESCE(jsonb_object_agg(lane, statuses), '{}'::jsonb)
+               FROM (
+                 SELECT value AS lane, jsonb_agg(key ORDER BY key) AS statuses
+                   FROM jsonb_each_text(status_mapping)
+                  GROUP BY value
+               ) AS grouped
+           )
+     WHERE jsonb_typeof(status_mapping) = 'object'
+       AND NOT EXISTS (
+             SELECT 1 FROM jsonb_each(status_mapping)
+              WHERE jsonb_typeof(value) = 'array'
+           )
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    UPDATE org_jira_integrations
+       SET status_mapping = (
+             SELECT COALESCE(jsonb_object_agg(status, lane), '{}'::jsonb)
+               FROM (
+                 SELECT jsonb_array_elements_text(value) AS status, key AS lane
+                   FROM jsonb_each(status_mapping)
+                  WHERE jsonb_typeof(value) = 'array'
+               ) AS flattened
+           )
+     WHERE jsonb_typeof(status_mapping) = 'object'
+       AND EXISTS (
+             SELECT 1 FROM jsonb_each(status_mapping)
+              WHERE jsonb_typeof(value) = 'array'
+           )
+  `.execute(db);
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -176,6 +176,7 @@ import * as migration174threadmessagepartspersistedat from "./174-thread-message
 import * as migration175taskboardsprints from "./175-task-board-sprints.ts";
 import * as migration176taskboarddonesweepindex from "./176-task-board-done-sweep-index.ts";
 import * as migration177notifications from "./177-notifications.ts";
+import * as migration178jirastatusmappingarray from "./178-jira-status-mapping-array.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -383,6 +384,7 @@ const migrations: Record<string, Migration> = {
   "175-task-board-sprints": migration175taskboardsprints,
   "176-task-board-done-sweep-index": migration176taskboarddonesweepindex,
   "177-notifications": migration177notifications,
+  "178-jira-status-mapping-array": migration178jirastatusmappingarray,
 };
 
 export default migrations;

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -6,7 +6,7 @@
   "file-storage/dbos-org-repo-sync.ts": "32c606976916fde2be7abe3084f7388744bdb610c178e9c2a07a8080f764904e",
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",
   "harnesses/decopilot/background-tool-workflow.ts": "1ae73b5a614ae6439942c1e52de52deeb3e18d1bb7e528be820720b592cfe833",
-  "jira/dbos-jira-sync.ts": "f0b69aea436e5fbd6b7486665bad910a6a27cbc1588c94508edffa3d932ce3ff",
+  "jira/dbos-jira-sync.ts": "4befebae160cf7cb88b8b8f1412d1f68fbcb55edc58c890193bc3175da1387d9",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
   "notifications/dbos-digest.ts": "673bc164593266704d2918a0bcaaf838a2480dfb46d1d19c02bdb38c73ecc370",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",

--- a/apps/api/src/jira/dbos-jira-sync.ts
+++ b/apps/api/src/jira/dbos-jira-sync.ts
@@ -19,6 +19,10 @@ import { TaskBoardStorage } from "@/storage/task-board";
 import { CredentialVault } from "@/encryption/credential-vault";
 import type { StudioContext } from "@/core/studio-context";
 import { JIRA_PUSH_QUEUE } from "@/dispatch-queue/queue-names";
+import {
+  planStatusPush,
+  statusPushNoop,
+} from "@decocms/shared/jira-status-mapping";
 import { JiraClient } from "./client";
 import {
   attachImage,
@@ -317,7 +321,9 @@ interface StatusTransitionPlan {
 /** Step 1: plan the transition. Null = nothing to do — integration off, card
  *  unlinked, no Jira status mapped to this lane, already there, or the
  *  issue's workflow offers no transition to it (logged, not an error: the
- *  tenant's Jira workflow is theirs to shape). */
+ *  tenant's Jira workflow is theirs to shape). Which of a lane's statuses the
+ *  card lands in is {@link planStatusPush}'s call, and the reason the mapping
+ *  is ordered. */
 async function resolveStatusTransition(
   params: JiraStatusPushParams,
 ): Promise<StatusTransitionPlan | null> {
@@ -338,31 +344,40 @@ async function resolveStatusTransition(
     params.organizationId,
   );
   if (!item) return null;
-  const targets = Object.entries(integration.statusMapping)
-    .filter(([, lane]) => lane === item.status)
-    .map(([name]) => name);
-  if (targets.length === 0) return null;
-  if (link.jiraStatus && targets.includes(link.jiraStatus)) return null;
+  // Settles the common cases without paying for a `listTransitions` call.
+  if (statusPushNoop(integration.statusMapping, item.status, link.jiraStatus)) {
+    return null;
+  }
+
   const client = new JiraClient(
     integration.siteUrl,
     integration.email,
     integration.apiToken,
   );
   const transitions = await client.listTransitions(link.jiraIssueId);
-  for (const target of targets) {
-    const transition = transitions.find((t) => t.to.name === target);
-    if (transition) {
-      return {
-        jiraIssueId: link.jiraIssueId,
-        transitionId: transition.id,
-        targetName: target,
-      };
+  const plan = planStatusPush({
+    mapping: integration.statusMapping,
+    lane: item.status,
+    currentJiraStatus: link.jiraStatus,
+    availableTransitions: transitions.map((t) => t.to.name),
+  });
+  if (plan.kind !== "transition") {
+    if (plan.kind === "unreachable") {
+      console.warn(
+        `[jira] ${link.jiraIssueKey} is ${item.status} on the board, but its ` +
+          `workflow offers no transition to ${plan.targets.join(" / ")} — ` +
+          `the card will not move on the Jira board`,
+      );
     }
+    return null;
   }
-  console.warn(
-    `[jira] no transition to ${targets.join("/")} available for ${link.jiraIssueKey}`,
-  );
-  return null;
+  const transition = transitions.find((t) => t.to.name === plan.targetName);
+  if (!transition) return null;
+  return {
+    jiraIssueId: link.jiraIssueId,
+    transitionId: transition.id,
+    targetName: plan.targetName,
+  };
 }
 
 /** Step 2: execute it. Re-checks the link first so a retry after a

--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -21,6 +21,7 @@ import type {
 } from "@/storage/types";
 import { reactToSuperAgentDelegation } from "@/tools/task-board/enqueue-super-agent";
 import { emitTaskBoardUpdated } from "@/tools/task-board/run-reactions";
+import { laneIndex } from "@decocms/shared/jira-status-mapping";
 import {
   collectMentionAccountIds,
   jiraBodyToText,
@@ -246,8 +247,9 @@ async function runSync(
   if (!boardId) {
     throw new Error("No Jira board selected");
   }
-  const mapping = integration.statusMapping;
-  if (Object.keys(mapping).length === 0) {
+  // One reverse index for the whole sync rather than a scan per issue.
+  const laneOf = laneIndex(integration.statusMapping);
+  if (laneOf.size === 0) {
     throw new Error("No status mapping configured");
   }
 
@@ -303,8 +305,9 @@ async function runSync(
         throw new Error(`Unparseable updated on ${issue.key}`);
       }
 
-      const status: TaskBoardItemStatus | undefined =
-        mapping[issue.fields.status.name];
+      const status = laneOf.get(issue.fields.status.name) as
+        | TaskBoardItemStatus
+        | undefined;
       if (!status || !isCardIssue(issue) || backlogIds.has(issue.id)) {
         counts.skipped++;
         watermark = issueUpdated;

--- a/apps/api/src/storage/jira-integrations.integration.test.ts
+++ b/apps/api/src/storage/jira-integrations.integration.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Real-Postgres coverage for `status_mapping`, which is jsonb and therefore
+ * the one part of this row an in-memory fake cannot tell you the truth about:
+ * Postgres orders jsonb object keys by length and then bytes, and it is exactly
+ * that ordering the old status → lane shape leaned on to pick a push target.
+ *
+ * Two properties are pinned here. A mapping written in the array shape reads
+ * back with each lane's statuses in the order they were written, because the
+ * push sends a card entering a lane to position 0 — note "QA" precedes "Code
+ * Review" in jsonb key order, so a reader leaning on that would hand back the
+ * wrong target. And a row still holding the pre-array shape reads back
+ * normalized, which keeps a rolling deploy syncing while migration 178 lands.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import { CredentialVault } from "../encryption/credential-vault";
+import { JiraIntegrationStorage } from "./jira-integrations";
+
+const ORG = "org_jira_map_1";
+const USER = "user_jm1";
+
+describe("jira integration status mapping", () => {
+  let database: StudioDatabase;
+  let storage: JiraIntegrationStorage;
+
+  const write = (statusMapping: Record<string, string[]>) =>
+    storage.upsert({
+      organizationId: ORG,
+      siteUrl: "https://example.atlassian.net",
+      email: "sync@example.test",
+      apiToken: "token",
+      boardId: "1",
+      boardName: "Board",
+      statusMapping,
+      jqlFilter: null,
+      autoDelegate: false,
+      enabled: false,
+      createdBy: USER,
+    });
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values({ id: ORG, name: ORG, slug: "org-jira-map-1", createdAt: now })
+      .execute();
+    // Raw SQL: real Postgres has a BOOLEAN emailVerified the typed shape disagrees with.
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"jm1@map.test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    storage = new JiraIntegrationStorage(
+      database.db,
+      new CredentialVault("0".repeat(64)),
+    );
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("round-trips a lane's statuses in the order they were written", async () => {
+    const mapping = {
+      triage: ["Backlog"],
+      in_review: ["Code Review", "QA"],
+      done: ["Released", "Closed"],
+    };
+    const written = await write(mapping);
+    expect(written.statusMapping).toEqual(mapping);
+
+    const read = await storage.getByOrg(ORG);
+    expect(read?.statusMapping.in_review).toEqual(["Code Review", "QA"]);
+    expect(read?.statusMapping.done).toEqual(["Released", "Closed"]);
+  });
+
+  it("normalizes a pre-array row, without inventing an order it cannot know", async () => {
+    await write({ triage: ["Backlog"] });
+    await sql`
+      UPDATE org_jira_integrations
+         SET status_mapping = ${sql.lit(
+           JSON.stringify({
+             Backlog: "triage",
+             "Code Review": "in_review",
+             QA: "in_review",
+           }),
+         )}::jsonb
+       WHERE organization_id = ${ORG}
+    `.execute(database.db);
+
+    const read = await storage.getByOrg(ORG);
+    expect(Object.keys(read?.statusMapping ?? {}).sort()).toEqual([
+      "in_review",
+      "triage",
+    ]);
+    expect(read?.statusMapping.triage).toEqual(["Backlog"]);
+    expect([...(read?.statusMapping.in_review ?? [])].sort()).toEqual([
+      "Code Review",
+      "QA",
+    ]);
+  });
+
+  it("reads an empty mapping as empty rather than throwing", async () => {
+    await write({});
+    expect((await storage.getByOrg(ORG))?.statusMapping).toEqual({});
+  });
+});

--- a/apps/api/src/storage/jira-integrations.ts
+++ b/apps/api/src/storage/jira-integrations.ts
@@ -1,10 +1,10 @@
 import type { Kysely } from "kysely";
 import type { CredentialVault } from "../encryption/credential-vault";
-import type {
-  Database,
-  OrgJiraIntegration,
-  TaskBoardItemStatus,
-} from "./types";
+import {
+  type JiraStatusMapping,
+  normalizeStatusMapping,
+} from "@decocms/shared/jira-status-mapping";
+import type { Database, OrgJiraIntegration } from "./types";
 
 /**
  * Per-org Jira Cloud integration configs (see migration 171). One row per
@@ -26,7 +26,7 @@ type Row = {
   api_token: string;
   board_id: string | null;
   board_name: string | null;
-  status_mapping: Record<string, TaskBoardItemStatus> | string;
+  status_mapping: unknown;
   jql_filter: string | null;
   auto_delegate: boolean;
   webhook_secret: string;
@@ -62,10 +62,13 @@ export class JiraIntegrationStorage {
       boardId: row.board_id,
       boardName: row.board_name,
       // Defensive parse — driver jsonb handling varies (see organization-settings.ts).
-      statusMapping:
+      // Normalized on the way out, so every reader gets lane → statuses and
+      // a row still in the legacy status → lane shape keeps syncing.
+      statusMapping: normalizeStatusMapping(
         typeof row.status_mapping === "string"
           ? JSON.parse(row.status_mapping)
           : row.status_mapping,
+      ),
       jqlFilter: row.jql_filter,
       autoDelegate: row.auto_delegate,
       webhookSecret: row.webhook_secret,
@@ -95,7 +98,7 @@ export class JiraIntegrationStorage {
     apiToken: string;
     boardId: string | null;
     boardName: string | null;
-    statusMapping: Record<string, TaskBoardItemStatus>;
+    statusMapping: JiraStatusMapping;
     jqlFilter: string | null;
     autoDelegate: boolean;
     enabled: boolean;

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -24,6 +24,7 @@ import type {
 } from "@decocms/shared/organization/schema";
 import type { ThreadMetadata } from "@decocms/shared/entities";
 import type { PrivateRegistryDatabase } from "./registry/types";
+import type { JiraStatusMapping } from "@decocms/shared/jira-status-mapping";
 
 export type {
   OrgSsoConfigPublic,
@@ -1948,13 +1949,11 @@ export interface OrgJiraIntegrationTable {
   /** Agile board the sync mirrors (its columns minus its Backlog tab). */
   board_id: string | null;
   board_name: string | null;
-  /** { "<jira status name>": "<board status>" } — the per-tenant mapping.
-   *  Issues whose Jira status is not a key here are skipped by the sync. */
-  status_mapping: ColumnType<
-    Record<string, TaskBoardItemStatus>,
-    string | undefined,
-    string
-  >;
+  /** { "<board status>": ["<jira status name>", …] } — the per-tenant mapping,
+   *  each lane's Jira statuses in board order. Issues whose Jira status names
+   *  no lane are skipped by the sync. Read through `normalizeStatusMapping`,
+   *  which also accepts the pre-array shape (migration 205). */
+  status_mapping: ColumnType<JiraStatusMapping, string | undefined, string>;
   /** Optional extra JQL ANDed into the pull (labels, sprints, …) — the
    *  tenant's way to match their board's saved filter. */
   jql_filter: ColumnType<
@@ -1987,7 +1986,7 @@ export interface OrgJiraIntegration {
   apiToken: string;
   boardId: string | null;
   boardName: string | null;
-  statusMapping: Record<string, TaskBoardItemStatus>;
+  statusMapping: JiraStatusMapping;
   jqlFilter: string | null;
   autoDelegate: boolean;
   webhookSecret: string;

--- a/apps/api/src/tools/jira/index.ts
+++ b/apps/api/src/tools/jira/index.ts
@@ -20,10 +20,14 @@ import { syncJiraIntegrationSafe } from "@/jira/sync";
 import type { OrgJiraIntegration } from "@/storage/types";
 import { TaskBoardItemStatusSchema } from "../task-board/schema";
 
+// `partialRecord`, not `record`: a `z.record` over an enum demands EVERY lane
+// be present, so an org mapping three of its columns would fail validation.
 const statusMappingSchema = z
-  .record(z.string(), TaskBoardItemStatusSchema)
+  .partialRecord(TaskBoardItemStatusSchema, z.array(z.string()))
   .describe(
-    "Jira status name → board status. Issues in unmapped Jira statuses are not synced.",
+    "Board status → its Jira status names, in board order. Several Jira " +
+      "statuses may share a lane; the first is where a card entering that lane " +
+      "is pushed. Issues whose Jira status names no lane are not synced.",
   );
 
 /** The API token never leaves the server — outputs carry the rest.

--- a/apps/web/src/views/settings/jira.tsx
+++ b/apps/web/src/views/settings/jira.tsx
@@ -67,7 +67,24 @@ import {
 } from "@/hooks/use-jira-integration";
 import { timeAgo } from "@/layouts/library/cards";
 
-type BoardStatus = JiraIntegration["statusMapping"][string];
+type BoardStatus = keyof JiraIntegration["statusMapping"];
+type StatusMapping = JiraIntegration["statusMapping"];
+
+/** One column of the org's Jira board, as `JIRA_BOARD_COLUMNS_LIST` returns it. */
+type BoardColumn = { name: string; statuses: string[] };
+
+/** The lane a board column currently maps to, found through any one of the
+ *  statuses it groups. */
+function laneOfColumn(
+  mapping: StatusMapping,
+  column: BoardColumn,
+): BoardStatus | undefined {
+  const first = column.statuses[0];
+  if (!first) return undefined;
+  return Object.entries(mapping).find(([, names]) =>
+    (names as string[]).includes(first),
+  )?.[0] as BoardStatus | undefined;
+}
 
 const BOARD_STATUS_OPTIONS: Array<{
   value: BoardStatus;
@@ -229,16 +246,24 @@ function ColumnMappingRows({ integration }: { integration: JiraIntegration }) {
     );
   }
 
-  // The mapping is keyed by STATUS name; one row writes every status its column groups.
-  function setColumnMapping(statuses: string[], value: string) {
+  /**
+   * Rewrite the whole mapping from the column list rather than patching one
+   * entry, so each lane's statuses come out in BOARD ORDER. That order is not
+   * cosmetic: the push sends a card entering a lane to position 0, so the
+   * leftmost Jira column of a lane is where it lands.
+   */
+  function setColumnMapping(changed: BoardColumn, value: string) {
     const previous = mapping;
-    const next = { ...mapping };
-    for (const status of statuses) {
-      if (value === DONT_SYNC) {
-        delete next[status];
-      } else {
-        next[status] = value as BoardStatus;
-      }
+    const next: StatusMapping = {};
+    for (const column of columns.data ?? []) {
+      const lane =
+        column.name === changed.name
+          ? value === DONT_SYNC
+            ? undefined
+            : (value as BoardStatus)
+          : laneOfColumn(mapping, column);
+      if (!lane) continue;
+      next[lane] = [...(next[lane] ?? []), ...column.statuses];
     }
     setMapping(next);
     upsert.mutate(
@@ -270,10 +295,8 @@ function ColumnMappingRows({ integration }: { integration: JiraIntegration }) {
             )}
           </div>
           <Select
-            value={
-              (column.statuses[0] && mapping[column.statuses[0]]) ?? DONT_SYNC
-            }
-            onValueChange={(value) => setColumnMapping(column.statuses, value)}
+            value={laneOfColumn(mapping, column) ?? DONT_SYNC}
+            onValueChange={(value) => setColumnMapping(column, value)}
           >
             <SelectTrigger className="w-44 shrink-0">
               <SelectValue />

--- a/packages/shared/src/jira-status-mapping.test.ts
+++ b/packages/shared/src/jira-status-mapping.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+import {
+  jiraStatusesForLane,
+  laneIndex,
+  normalizeStatusMapping,
+  planStatusPush,
+} from "./jira-status-mapping.ts";
+
+/** Two Jira columns collapsing into In Review — the case the push has to
+ *  choose within, and the reason order is part of the shape. */
+const MAPPING = {
+  triage: ["Backlog"],
+  in_progress: ["Doing"],
+  in_review: ["Code Review", "QA"],
+  done: ["Released", "Closed"],
+};
+
+describe("normalizeStatusMapping", () => {
+  it("keeps a well-formed mapping, order intact", () => {
+    expect(normalizeStatusMapping(MAPPING)).toEqual(MAPPING);
+  });
+
+  it("reads the legacy status → lane shape so a rolling deploy keeps syncing", () => {
+    expect(
+      normalizeStatusMapping({
+        Backlog: "triage",
+        "Code Review": "in_review",
+        QA: "in_review",
+      }),
+    ).toEqual({ triage: ["Backlog"], in_review: ["Code Review", "QA"] });
+  });
+
+  it("gives a status to the first lane that claims it, never to two", () => {
+    expect(
+      normalizeStatusMapping({
+        in_review: ["QA"],
+        done: ["QA", "Closed"],
+      }),
+    ).toEqual({ in_review: ["QA"], done: ["Closed"] });
+  });
+
+  it("drops malformed entries instead of trusting stored jsonb", () => {
+    expect(
+      normalizeStatusMapping({
+        in_review: ["QA", "", 7, null],
+        done: "Closed",
+        todo: [],
+      }),
+    ).toEqual({ in_review: ["QA"] });
+  });
+
+  it("reads a missing or non-object mapping as empty", () => {
+    expect(normalizeStatusMapping(null)).toEqual({});
+    expect(normalizeStatusMapping(undefined)).toEqual({});
+    expect(normalizeStatusMapping([])).toEqual({});
+    expect(normalizeStatusMapping("nope")).toEqual({});
+  });
+});
+
+describe("laneIndex", () => {
+  it("answers the pull for every status a lane groups", () => {
+    const index = laneIndex(MAPPING);
+    expect(index.get("Code Review")).toBe("in_review");
+    expect(index.get("QA")).toBe("in_review");
+    expect(index.get("Backlog")).toBe("triage");
+    expect(index.get("Nothing")).toBeUndefined();
+  });
+});
+
+describe("jiraStatusesForLane", () => {
+  it("returns a lane's statuses leftmost-first, or nothing", () => {
+    expect(jiraStatusesForLane(MAPPING, "in_review")).toEqual([
+      "Code Review",
+      "QA",
+    ]);
+    expect(jiraStatusesForLane(MAPPING, "archived")).toEqual([]);
+  });
+});
+
+describe("planStatusPush", () => {
+  const plan = (over: {
+    lane: string;
+    currentJiraStatus?: string | null;
+    availableTransitions?: string[];
+  }) =>
+    planStatusPush({
+      mapping: MAPPING,
+      lane: over.lane,
+      currentJiraStatus: over.currentJiraStatus ?? null,
+      availableTransitions: over.availableTransitions ?? [
+        "Backlog",
+        "Doing",
+        "Code Review",
+        "QA",
+        "Released",
+        "Closed",
+      ],
+    });
+
+  it("enters a lane at its leftmost column, not at whichever key sorted first", () => {
+    expect(plan({ lane: "in_review" })).toEqual({
+      kind: "transition",
+      targetName: "Code Review",
+    });
+    expect(plan({ lane: "done" })).toEqual({
+      kind: "transition",
+      targetName: "Released",
+    });
+  });
+
+  it("leaves a card already somewhere in the lane where it is", () => {
+    expect(plan({ lane: "in_review", currentJiraStatus: "QA" })).toEqual({
+      kind: "noop",
+      reason: "already-in-lane",
+    });
+    expect(
+      plan({ lane: "in_review", currentJiraStatus: "Code Review" }),
+    ).toEqual({ kind: "noop", reason: "already-in-lane" });
+  });
+
+  it("moves a card whose current status belongs to another lane", () => {
+    expect(plan({ lane: "in_review", currentJiraStatus: "Doing" })).toEqual({
+      kind: "transition",
+      targetName: "Code Review",
+    });
+  });
+
+  it("skips to the next column when the leftmost is unreachable", () => {
+    expect(
+      plan({ lane: "in_review", availableTransitions: ["QA", "Closed"] }),
+    ).toEqual({ kind: "transition", targetName: "QA" });
+  });
+
+  it("reports an unreachable lane instead of silently doing nothing", () => {
+    expect(
+      plan({ lane: "in_review", availableTransitions: ["Backlog"] }),
+    ).toEqual({ kind: "unreachable", targets: ["Code Review", "QA"] });
+  });
+
+  it("does nothing for a lane the org never mapped", () => {
+    expect(plan({ lane: "archived" })).toEqual({
+      kind: "noop",
+      reason: "unmapped",
+    });
+  });
+});

--- a/packages/shared/src/jira-status-mapping.ts
+++ b/packages/shared/src/jira-status-mapping.ts
@@ -1,0 +1,149 @@
+/**
+ * The Jira ↔ board status mapping, and the three questions asked of it.
+ *
+ * The shape is lane → the Jira statuses that mean it, IN BOARD ORDER. Several
+ * Jira statuses collapsing into one lane is the normal case: a team with
+ * separate "Code Review" and "QA" columns runs both as In Review. So the
+ * mapping is many-to-one on the pull, and has to CHOOSE on the push. Order is
+ * what makes that choice deterministic and meaningful — position 0 is the
+ * lane's leftmost Jira column, which is where a card entering the lane belongs.
+ *
+ * The legacy shape was the inverse, status → lane, which left the push
+ * iterating `Object.entries`: jsonb orders keys by length and then bytes, so
+ * the Jira column a card landed in was decided by how many characters its
+ * status name happened to have. {@link normalizeStatusMapping} still accepts
+ * that shape so a rolling deploy keeps syncing, but nothing writes it.
+ *
+ * Lanes are plain strings here. Each side narrows at its own boundary (Zod on
+ * the server, the tool-IO type on the web) — the questions below are the same
+ * whatever the lane vocabulary is.
+ */
+
+/** Lane → its Jira statuses, leftmost board column first. */
+export type JiraStatusMapping = Record<string, string[]>;
+
+/** The pre-array shape: Jira status name → lane. */
+type LegacyJiraStatusMapping = Record<string, string>;
+
+function isLegacyShape(
+  raw: Record<string, unknown>,
+): raw is LegacyJiraStatusMapping {
+  return Object.values(raw).every((v) => typeof v === "string");
+}
+
+/**
+ * Read a stored mapping in either shape, dropping anything malformed.
+ *
+ * A Jira status may name only one lane — the settings UI cannot produce a
+ * status in two, and honouring one would make the pull's answer depend on
+ * iteration order, which is the whole defect this shape exists to remove. The
+ * first lane claiming a status keeps it.
+ *
+ * A legacy row comes back in whatever order Postgres hands its jsonb keys back
+ * in, because the old shape never recorded one. That preserves today's
+ * arbitrary push target for the length of a rolling deploy rather than fixing
+ * it; migration 178 is what fixes it, per row, for good.
+ */
+export function normalizeStatusMapping(raw: unknown): JiraStatusMapping {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const entries = raw as Record<string, unknown>;
+
+  if (isLegacyShape(entries)) {
+    const out: JiraStatusMapping = {};
+    for (const [statusName, lane] of Object.entries(entries)) {
+      if (!statusName || !lane) continue;
+      (out[lane] ??= []).push(statusName);
+    }
+    return out;
+  }
+
+  const out: JiraStatusMapping = {};
+  const claimed = new Set<string>();
+  for (const [lane, statuses] of Object.entries(entries)) {
+    if (!lane || !Array.isArray(statuses)) continue;
+    const kept = statuses.filter(
+      (s): s is string =>
+        typeof s === "string" && s.length > 0 && !claimed.has(s),
+    );
+    for (const s of kept) claimed.add(s);
+    if (kept.length > 0) out[lane] = kept;
+  }
+  return out;
+}
+
+/** Jira status name → lane, for the pull. Built once per sync, not per issue. */
+export function laneIndex(mapping: JiraStatusMapping): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const [lane, statuses] of Object.entries(mapping)) {
+    for (const status of statuses) {
+      if (!index.has(status)) index.set(status, lane);
+    }
+  }
+  return index;
+}
+
+/** A lane's Jira statuses, leftmost board column first. */
+export function jiraStatusesForLane(
+  mapping: JiraStatusMapping,
+  lane: string,
+): string[] {
+  return mapping[lane] ?? [];
+}
+
+/**
+ * What the push should do with a card that just entered `lane`.
+ *
+ * `already-in-lane` is the load-bearing no-op: the issue is somewhere in this
+ * lane's own statuses, so whoever put it there — a person on the Jira board, or
+ * a later sub-stage move — owns its position within the lane, and dragging it
+ * back to position 0 would fight them every tick.
+ *
+ * `unreachable` is separated from the no-ops so the caller can say so. A lane
+ * mapped to a status the issue's workflow will not transition to is a silent
+ * dead end otherwise: the card moves on the Studio board and never on Jira's.
+ */
+export type StatusPushPlan =
+  | { kind: "transition"; targetName: string }
+  | { kind: "noop"; reason: "unmapped" | "already-in-lane" }
+  | { kind: "unreachable"; targets: string[] };
+
+/**
+ * The half of the plan that needs nothing from Jira, so a caller can settle the
+ * common cases before paying for a `listTransitions` round-trip. Both no-ops
+ * are common: most board writes are on lanes the org never mapped, and a card
+ * moving within its lane's own statuses hits `already-in-lane` every tick.
+ */
+export function statusPushNoop(
+  mapping: JiraStatusMapping,
+  lane: string,
+  currentJiraStatus: string | null,
+): "unmapped" | "already-in-lane" | null {
+  const targets = jiraStatusesForLane(mapping, lane);
+  if (targets.length === 0) return "unmapped";
+  if (currentJiraStatus && targets.includes(currentJiraStatus)) {
+    return "already-in-lane";
+  }
+  return null;
+}
+
+export function planStatusPush(args: {
+  mapping: JiraStatusMapping;
+  lane: string;
+  /** Where the linked issue was last known to be. */
+  currentJiraStatus: string | null;
+  /** Status names the issue can transition to right now. */
+  availableTransitions: string[];
+}): StatusPushPlan {
+  const reason = statusPushNoop(
+    args.mapping,
+    args.lane,
+    args.currentJiraStatus,
+  );
+  if (reason) return { kind: "noop", reason };
+  const targets = jiraStatusesForLane(args.mapping, args.lane);
+  const reachable = new Set(args.availableTransitions);
+  const targetName = targets.find((t) => reachable.has(t));
+  return targetName
+    ? { kind: "transition", targetName }
+    : { kind: "unreachable", targets };
+}

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -4863,9 +4863,16 @@ export interface StudioToolIO {
         email: string;
         boardId: string | null;
         boardName: string | null;
-        statusMapping: Record<
-          string,
-          "done" | "triage" | "todo" | "in_progress" | "in_review" | "archived"
+        statusMapping: Partial<
+          Record<
+            | "done"
+            | "triage"
+            | "todo"
+            | "in_progress"
+            | "in_review"
+            | "archived",
+            string[]
+          >
         >;
         jqlFilter: string | null;
         autoDelegate: boolean;
@@ -4885,14 +4892,16 @@ export interface StudioToolIO {
       boardId?: string | null | undefined;
       boardName?: string | null | undefined;
       statusMapping?:
-        | Record<
-            string,
-            | "done"
-            | "triage"
-            | "todo"
-            | "in_progress"
-            | "in_review"
-            | "archived"
+        | Partial<
+            Record<
+              | "done"
+              | "triage"
+              | "todo"
+              | "in_progress"
+              | "in_review"
+              | "archived",
+              string[]
+            >
           >
         | undefined;
       jqlFilter?: string | null | undefined;
@@ -4906,9 +4915,16 @@ export interface StudioToolIO {
         email: string;
         boardId: string | null;
         boardName: string | null;
-        statusMapping: Record<
-          string,
-          "done" | "triage" | "todo" | "in_progress" | "in_review" | "archived"
+        statusMapping: Partial<
+          Record<
+            | "done"
+            | "triage"
+            | "todo"
+            | "in_progress"
+            | "in_review"
+            | "archived",
+            string[]
+          >
         >;
         jqlFilter: string | null;
         autoDelegate: boolean;


### PR DESCRIPTION
## What is this contribution about?

Several Jira statuses collapsing into one board lane is the normal case — a team with separate "Code Review" and "QA" columns runs both as In Review. The **pull** already handled that. The **push** has to *choose*, and chose like this (`dbos-jira-sync.ts`):

```ts
const targets = Object.entries(integration.statusMapping)
  .filter(([, lane]) => lane === item.status)
  .map(([name]) => name);
```

`status_mapping` is jsonb, and Postgres orders jsonb object keys **by length, then bytes**. So the Jira column an agent's card landed in was decided by how many characters its status name happened to have. With several statuses sharing a lane that isn't a tie-break, it's the entire decision — and it gets worse as more lanes are mapped many-to-one.

**The fix is to invert the mapping** from `{ "<jira status>": "<lane>" }` to `{ "<lane>": ["<jira status>", …] }`, ordered. Position 0 is the lane's leftmost Jira column, which is where a card entering that lane belongs. The settings UI rewrites the whole mapping from the board's column list on every edit instead of patching one key, so board order holds by construction and can't drift.

Three things fall out:

- **The decision is now pure and tested.** `planStatusPush` lives in `@decocms/shared`. `sync.ts` and `dbos-jira-sync.ts` had **no tests at all**; this is the part worth having them for.
- **`unreachable` is separated from the two no-ops.** A lane mapped to a status the tenant's workflow won't transition to used to be a silent dead end: the card moved on the Studio board and never on Jira's. It now says so in the log. `statusPushNoop` is split out so the two common cases (unmapped lane, card already inside the lane) still settle without paying for a `listTransitions` round-trip.
- **`z.partialRecord`, not `z.record`.** A `z.record` over an enum demands **every** lane key be present, so an org mapping three of its columns would have failed validation outright. Verified against zod 4.3.6 before committing.

Readers go through `normalizeStatusMapping`, which still accepts the old shape, so a rolling deploy keeps syncing on either side of migration 178. A legacy row comes back in jsonb key order because the old shape never recorded one — that preserves today's arbitrary target for the length of the deploy rather than fixing it, and the migration is what fixes it, per row, for good.

## How did you verify your code works?

**New pure unit suite** `packages/shared/src/jira-status-mapping.test.ts` (13 tests): entering a lane targets its leftmost column and not whichever key sorted first; a card already anywhere in the lane is left alone; the next column is used when the leftmost is unreachable; an unreachable lane reports rather than no-ops; an unmapped lane no-ops; the legacy shape is read; a status claimed by two lanes goes to one; malformed stored jsonb is dropped rather than trusted.

**New real-Postgres suite** `apps/api/src/storage/jira-integrations.integration.test.ts` (3 tests) — jsonb is precisely what an in-memory fake cannot tell the truth about here. It pins that a written array round-trips **in order** (note `"QA"` precedes `"Code Review"` in jsonb key order, so a reader leaning on that order fails this test), that a pre-array row reads back normalized, and that an empty mapping doesn't throw. The order assertion on the legacy path deliberately asserts membership, not order: the old shape never recorded one, and I removed a first draft of that test that asserted a guarantee which does not exist.

**Migration 178 exercised against real Postgres** with the exact shape currently in production (two statuses collapsing into one lane): `up` converts it, running `up` again is a no-op, `down` round-trips back to the original object byte-for-byte, and `up` after `down` reproduces the converted form. After rebasing onto `main` I re-ran the full ledger from scratch to confirm `177-notifications` and `178-jira-status-mapping-array` both apply, in order.

`bun test src/jira src/storage src/tools/task-board src/tools/jira migrations` against real Postgres: **839 pass / 0 fail** (83 files). `bun run check` 0 errors, `bun run knip` clean, `bun run fmt:check` clean. `bun run lint` reports 19 warnings; none are in a file this PR touches.

Grepped both tiers for the changed wire/storage contract: no `packages/e2e` test references Jira, and no consumer of `statusMapping` exists outside the files changed here.

## Screenshots/Demonstration

Settings → Jira → column mapping is unchanged to look at: still one row per board column with a lane picker. Only what it serializes changed.

## How to Test

1. On an org with a Jira board connected, map **two** board columns to the **same** lane (e.g. both to In Review).
2. Move a card into that lane from Studio. Expected: the Jira issue transitions to the **leftmost** of the two columns, every time. Before this change, which one it picked depended on the character length of the status names.
3. Move the Jira issue by hand to the **second** of the two columns. Expected: Studio leaves it there and does not drag it back to the first.
4. Map a lane to a column the issue's Jira workflow can't transition to. Expected: a `[jira] … offers no transition to …` warning naming the issue and the targets, instead of silence.
5. Re-pick a column's lane in settings. Expected: the mapping is rewritten in board order.

## Migration Notes

**Migration 178** (`178-jira-status-mapping-array.ts`) inverts `org_jira_integrations.status_mapping` in place. It is idempotent, reversible, and skips rows already in the array shape.

The old shape cannot say which of a lane's statuses came first, so a lane that collapsed several keeps them in a stable but arbitrary order after conversion; re-picking those columns in settings rewrites them in board order. No deploy ordering is required — `normalizeStatusMapping` reads both shapes.

`packages/shared/src/tools/tool-io.ts` is regenerated and committed (`bun run --cwd=apps/api generate:tool-contracts`).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes
