### PR TITLE
feat(sections-editor): accept "datetime" format as alias for "date-time"

### DIFF
--- a/apps/web/ct/tests/widget-dispatch.ct.tsx
+++ b/apps/web/ct/tests/widget-dispatch.ct.tsx
@@ -206,6 +206,21 @@ test("date-time format → native datetime-local input", async ({ mount }) => {
   await expect(input).toHaveAttribute("type", "datetime-local");
 });
 
+test("datetime format (hyphen-less alias) → native datetime-local input", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    startsAt: { type: "string", title: "Starts At", format: "datetime" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Starts At");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("type", "datetime-local");
+});
+
 test("textarea format → textarea element", async ({ mount }) => {
   const meta = sectionWithProps({
     body: { type: "string", title: "Body", format: "textarea" },

--- a/apps/web/src/components/sections-editor/fields/string-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/string-field.tsx
@@ -217,7 +217,9 @@ export function StringField({
     );
   }
 
-  if (format === "date" || format === "date-time") {
+  // "date-time" is JSON Schema canonical; "datetime" is a common variant.
+  const isDateTime = format === "date-time" || format === "datetime";
+  if (format === "date" || isDateTime) {
     return (
       <div className="space-y-2">
         <FieldLabel
@@ -228,7 +230,7 @@ export function StringField({
         />
         <DatePickerInput
           id={path}
-          withTime={format === "date-time"}
+          withTime={isDateTime}
           value={strValue}
           onChange={onChange}
           calendarLabel={t("sectionsEditor.stringField.openCalendar")}


### PR DESCRIPTION
## Summary

The sections-editor date field only matched the JSON Schema canonical `date-time`. Some schema generators emit the hyphen-less `datetime`, which fell through to a plain text input instead of the date picker. This accepts both.

- `apps/web/src/components/sections-editor/fields/string-field.tsx`: `format: "datetime"` now renders `DatePickerInput` with `withTime` (i.e. `<input type="datetime-local">`), same as `date-time`.

## Testing

- Added a component test in `apps/web/ct/tests/widget-dispatch.ct.tsx` mirroring the existing `date-time` case, asserting the `datetime` alias resolves to `type="datetime-local"`.
- `bun run fmt` passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)