### PR TITLE
feat(notifications): live inbox, optimistic reads, event-triggered digest

### DIFF
--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -8,7 +8,7 @@
   "harnesses/decopilot/background-tool-workflow.ts": "9febb699f45b63b418481ed998aee0ec8251c97cb5c409d54d714eb365a08fd0",
   "jira/dbos-jira-sync.ts": "f0b69aea436e5fbd6b7486665bad910a6a27cbc1588c94508edffa3d932ce3ff",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
-  "notifications/dbos-digest.ts": "8a15f88d639fee21d671024be3c2775335f2fb4970942d6b60ae288ea7246a2f",
+  "notifications/dbos-digest.ts": "b09cef1323de8d54b9445ade654142bf75120741befb1bb4d7a9f5958422d720",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",
   "tools/task-board/dbos-github-read.ts": "8757159d594f776d021ed28887e5ba51f7a6e007607a2dc6962efd53152b4d60",
   "tools/task-board/dbos-tag-merged-sweep.ts": "afc48f5309fd1da3196167855b52ec0074a5f24b8a96b8ef9be2e07a8abb7a0a"

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -8,7 +8,7 @@
   "harnesses/decopilot/background-tool-workflow.ts": "9febb699f45b63b418481ed998aee0ec8251c97cb5c409d54d714eb365a08fd0",
   "jira/dbos-jira-sync.ts": "f0b69aea436e5fbd6b7486665bad910a6a27cbc1588c94508edffa3d932ce3ff",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
-  "notifications/dbos-digest.ts": "b09cef1323de8d54b9445ade654142bf75120741befb1bb4d7a9f5958422d720",
+  "notifications/dbos-digest.ts": "673bc164593266704d2918a0bcaaf838a2480dfb46d1d19c02bdb38c73ecc370",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",
   "tools/task-board/dbos-github-read.ts": "8757159d594f776d021ed28887e5ba51f7a6e007607a2dc6962efd53152b4d60",
   "tools/task-board/dbos-tag-merged-sweep.ts": "afc48f5309fd1da3196167855b52ec0074a5f24b8a96b8ef9be2e07a8abb7a0a"

--- a/apps/api/src/dbos/workflow-version.ts
+++ b/apps/api/src/dbos/workflow-version.ts
@@ -72,5 +72,14 @@
  * `DBOSUnexpectedStepError`; those instances strand instead, by design. The
  * one already past its Jira POST is still not re-mirrored by the pull, which
  * cuts the echo by author account as well as by comment link (`sync.ts`).
+ *
+ * Version 9 turns the notification digest event-triggered:
+ * `notificationDigestWorkflow` keeps its name but is now the safety-net sweep
+ * (`loadOrphanedNotifications`, and a `claimForEmail` step before each send in
+ * place of the old `stampEmailed` after it), and the new per-recipient
+ * `notificationUserDigestWorkflow` carries the normal path. Steps were added,
+ * removed and reordered, so a v8 digest instance replayed against v9 diverges.
+ * Cheap to strand: the workflow was a five-minute tick that finishes in
+ * milliseconds and holds nothing a user is waiting on.
  */
-export const DBOS_WORKFLOW_VERSION = "8";
+export const DBOS_WORKFLOW_VERSION = "9";

--- a/apps/api/src/notifications/dbos-digest.ts
+++ b/apps/api/src/notifications/dbos-digest.ts
@@ -1,16 +1,27 @@
 /**
- * The email digest: every 15 seconds, mail each recipient the notifications
- * they haven't read in the app yet, then stamp them.
+ * The email digest: event-triggered, not polled.
  *
- * Same shape as `tools/task-board/dbos-archive-sweep.ts`: the scheduler picks
- * ONE pod per tick, the work list is read inside a step so a replay iterates
- * the recorded list rather than a fresh query, and runtime deps come from a
- * module-level registry wired by app boot before `DBOS.launch()`.
+ * A notification enqueues a per-recipient workflow whose id is
+ * `notif-digest:<user>:<30s bucket>`, so a burst inside one window collapses
+ * onto a single workflow — that dedupe IS the debounce, and it costs nothing
+ * when nobody is being notified. The workflow durably sleeps to the end of its
+ * window, then mails whatever is still unread. Mail lands ~30s after the first
+ * event of a burst instead of on a five-minute tick.
  *
- * Ordering matters and DBOS is what makes it safe: a crash between the send
- * step and the stamp step replays the send from its checkpoint instead of
- * re-sending, then stamps. A send that FAILS never checkpoints, so that
- * recipient's leg retries next tick rather than silently dropping.
+ * The two-minute sweep is the safety net, the same pairing the event bus uses
+ * (NotifyStrategy + PollingStrategy): the enqueue happens after the row
+ * commits and is rejected outright from inside a DBOS step, so a row whose
+ * enqueue never landed must still find a sender. It also carries retention.
+ *
+ * Both senders CLAIM before sending — one `UPDATE ... WHERE emailed_at IS NULL
+ * RETURNING id` — so a sweep that overlaps a per-user workflow cannot mail the
+ * same row twice. That is the deliberate inversion of the older send-then-stamp
+ * order: with two concurrent senders, a duplicated email is the likelier and
+ * worse failure than an email lost to a send that fails after its claim (which
+ * the step retries first, and logs if it exhausts them).
+ *
+ * Runtime deps come from a module-level registry wired by app boot before
+ * `DBOS.launch()`.
  */
 
 import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
@@ -22,16 +33,14 @@ import type { Database } from "@/storage/types";
 import { buildDigestEmail, type DigestRow } from "./digest-email";
 import { NotificationDataSchema } from "./schema";
 
-/** Six fields — the leading one is seconds. */
-const DIGEST_CRONTAB = "*/15 * * * * *";
+/** Safety net only — the per-recipient workflow is the normal path. */
+const SWEEP_CRONTAB = "*/2 * * * *";
 
-/**
- * The batching window: a burst inside it becomes one email, and a notification
- * still unread when the window closes is mailed on the next tick — so the mail
- * lands within DEBOUNCE_MS + one tick, not five minutes. Ticking faster than
- * the window would only re-check rows the window has not released yet.
- */
+/** The batching window: everything a recipient earns inside it is one email. */
 const DEBOUNCE_MS = 30_000;
+
+/** How long past its window a row waits before the sweep treats it as orphaned. */
+const SWEEP_GRACE_MS = 60_000;
 
 /** Ceiling per tick, across all recipients. A backlog drains next tick. */
 const MAX_ROWS_PER_TICK = 500;
@@ -70,8 +79,8 @@ interface PendingRow extends DigestRow {
  * unread rows they can no longer open in-app — so the rows never get marked
  * read — and the digest keeps mailing them task titles for up to 30 days.
  */
-async function loadPending(before: Date): Promise<PendingRow[]> {
-  const rows = await requireRuntime()
+function pendingQuery() {
+  return requireRuntime()
     .db.selectFrom("notifications as n")
     .innerJoin("organization as o", "o.id", "n.organization_id")
     .innerJoin("user as u", "u.id", "n.user_id")
@@ -90,11 +99,13 @@ async function loadPending(before: Date): Promise<PendingRow[]> {
     ])
     .where("n.emailed_at", "is", null)
     .where("n.read_at", "is", null)
-    .where("n.created_at", "<", before)
     .orderBy("n.created_at", "asc")
-    .limit(MAX_ROWS_PER_TICK)
-    .execute();
+    .limit(MAX_ROWS_PER_TICK);
+}
 
+function toPendingRows(
+  rows: Awaited<ReturnType<ReturnType<typeof pendingQuery>["execute"]>>,
+): PendingRow[] {
   return rows.map((row) => {
     const data = NotificationDataSchema.parse(row.data);
     return {
@@ -108,6 +119,40 @@ async function loadPending(before: Date): Promise<PendingRow[]> {
       actorName: data.actorName,
     };
   });
+}
+
+/** One recipient's unread, unmailed rows — the per-user workflow's work list. */
+async function loadPendingForUser(userId: string): Promise<PendingRow[]> {
+  return toPendingRows(
+    await pendingQuery().where("n.user_id", "=", userId).execute(),
+  );
+}
+
+/** Rows whose window closed well over a window ago: the sweep's orphans. */
+async function loadOrphaned(before: Date): Promise<PendingRow[]> {
+  return toPendingRows(
+    await pendingQuery().where("n.created_at", "<", before).execute(),
+  );
+}
+
+/**
+ * Take exclusive ownership of these rows for mailing, returning only the ones
+ * this caller won. Atomic, so the sweep and a per-user workflow racing over the
+ * same rows split them rather than both mailing them.
+ *
+ * Exported for the integration test — that split is the whole defense against
+ * mailing a notification twice, and it only holds against real Postgres.
+ */
+export async function claimForEmail(ids: string[]): Promise<Set<string>> {
+  if (ids.length === 0) return new Set();
+  const claimed = await requireRuntime()
+    .db.updateTable("notifications")
+    .set({ emailed_at: new Date() })
+    .where("id", "in", ids)
+    .where("emailed_at", "is", null)
+    .returning("id")
+    .execute();
+  return new Set(claimed.map((row) => row.id));
 }
 
 function groupByRecipient(rows: PendingRow[]): PendingRow[][] {
@@ -141,14 +186,6 @@ async function sendOne(rows: PendingRow[]): Promise<void> {
   await sender({ to: rows[0]!.email, subject, html });
 }
 
-async function stampEmailed(ids: string[]): Promise<void> {
-  await requireRuntime()
-    .db.updateTable("notifications")
-    .set({ emailed_at: new Date() })
-    .where("id", "in", ids)
-    .execute();
-}
-
 async function pruneOld(before: Date): Promise<void> {
   await requireRuntime()
     .db.deleteFrom("notifications")
@@ -156,38 +193,79 @@ async function pruneOld(before: Date): Promise<void> {
     .execute();
 }
 
-async function digestWorkflowFn(
+/**
+ * Claim, then mail, one recipient's batch. Shared by both entry points, so the
+ * claim-before-send rule cannot be got right in one and wrong in the other.
+ */
+async function mailBatch(rows: PendingRow[], label: string): Promise<void> {
+  if (rows.length === 0) return;
+  const claimed = await DBOS.runStep(
+    () => claimForEmail(rows.map((row) => row.id)),
+    { name: `claimForEmail:${label}` },
+  );
+  const mine = rows.filter((row) => claimed.has(row.id));
+  if (mine.length === 0) return;
+  await DBOS.runStep(() => sendOne(mine), { name: `sendDigest:${label}` });
+}
+
+/**
+ * One recipient's window. Sleeps to the end of it — durably, so a pod restart
+ * resumes the same wait rather than dropping the batch — then mails whatever is
+ * still unread, which is every event of the burst plus anything that arrived
+ * while it slept.
+ */
+async function userDigestWorkflowFn(
+  userId: string,
+  dueAtMs: number,
+): Promise<void> {
+  const wait = dueAtMs - Date.now();
+  if (wait > 0) await DBOS.sleep(wait);
+  if (!resolveSender()) return;
+  const rows = await DBOS.runStep(() => loadPendingForUser(userId), {
+    name: "loadPendingForUser",
+  });
+  try {
+    await mailBatch(rows, userId);
+  } catch (err) {
+    console.warn(
+      `[notifications] digest for ${userId} failed:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/**
+ * The safety net: rows whose enqueue never landed (it runs after the commit,
+ * and DBOS rejects it outright from inside a step), plus retention.
+ */
+async function digestSweepWorkflowFn(
   scheduledTime: Date,
   _currentTime: Date,
 ): Promise<void> {
-  const before = new Date(scheduledTime.getTime() - DEBOUNCE_MS);
+  const orphanedBefore = new Date(
+    scheduledTime.getTime() - DEBOUNCE_MS - SWEEP_GRACE_MS,
+  );
   const pending = resolveSender()
-    ? await DBOS.runStep(() => loadPending(before), {
-        name: "loadPendingNotifications",
+    ? await DBOS.runStep(() => loadOrphaned(orphanedBefore), {
+        name: "loadOrphanedNotifications",
       })
     : [];
 
   for (const rows of groupByRecipient(pending)) {
     const userId = rows[0]!.userId;
     try {
-      await DBOS.runStep(() => sendOne(rows), { name: `sendDigest:${userId}` });
-      await DBOS.runStep(() => stampEmailed(rows.map((row) => row.id)), {
-        name: `stampEmailed:${userId}`,
-      });
+      await mailBatch(rows, userId);
     } catch (err) {
       console.warn(
-        `[notifications] digest for ${userId} failed:`,
+        `[notifications] sweep digest for ${userId} failed:`,
         err instanceof Error ? err.message : err,
       );
     }
   }
 
-  // Retention is a whole-table DELETE and the tick is 15s — hourly is plenty.
-  // Derived from `scheduledTime`, so a replay makes the same choice.
-  if (
-    scheduledTime.getUTCMinutes() === 37 &&
-    scheduledTime.getUTCSeconds() < 15
-  ) {
+  // Retention is a whole-table DELETE; hourly is plenty. Derived from
+  // `scheduledTime`, so a replay makes the same choice.
+  if (scheduledTime.getUTCMinutes() < 2) {
     await DBOS.runStep(
       () => pruneOld(new Date(scheduledTime.getTime() - RETENTION_MS)),
       { name: "pruneOldNotifications" },
@@ -195,23 +273,54 @@ async function digestWorkflowFn(
   }
 }
 
-let registeredWorkflow: typeof digestWorkflowFn | null = null;
+let registeredSweep: typeof digestSweepWorkflowFn | null = null;
+let registeredUserDigest: typeof userDigestWorkflowFn | null = null;
+
+/**
+ * Debounce a recipient's mail onto the end of the current 30s window.
+ *
+ * The workflow id is the whole mechanism: every event for the same recipient in
+ * the same window resolves to the same id, and DBOS runs an id once — so a
+ * burst of twenty notifications starts one workflow, and the twentieth costs a
+ * rejected insert rather than an email.
+ *
+ * Best-effort by design. `notify()` can run inside a DBOS step (a run reaction
+ * writing activity), where `startWorkflow` is illegal — the sweep is what makes
+ * that safe, so this logs at debug and returns rather than failing the caller.
+ */
+export function enqueueUserDigest(userId: string): void {
+  if (!registeredUserDigest) return;
+  const bucket = Math.floor(Date.now() / DEBOUNCE_MS);
+  const dueAtMs = (bucket + 1) * DEBOUNCE_MS;
+  void DBOS.startWorkflow(registeredUserDigest, {
+    workflowID: `notif-digest:${userId}:${bucket}`,
+  })(userId, dueAtMs).catch((err) => {
+    // Not a warning: the sweep mails this row within the grace window.
+    console.debug(
+      "[notifications] digest enqueue skipped:",
+      err instanceof Error ? err.message : err,
+    );
+  });
+}
 
 /**
  * Must run before DBOS.launch(). Guarded so HMR repeats don't re-register.
  *
- * ⚠️ Durable DBOS workflow. Changing its STEP SEQUENCE (add/remove/reorder a
+ * ⚠️ Durable DBOS workflows. Changing a STEP SEQUENCE (add/remove/reorder a
  * step, or change a step's recorded I/O) requires bumping
  * DBOS_WORKFLOW_VERSION — see apps/api/src/dbos/workflow-version.ts.
  */
 export function registerNotificationDigestWorkflow(): void {
-  if (registeredWorkflow) return;
-  registeredWorkflow = DBOS.registerWorkflow(digestWorkflowFn, {
+  if (registeredSweep) return;
+  registeredUserDigest = DBOS.registerWorkflow(userDigestWorkflowFn, {
+    name: "notificationUserDigestWorkflow",
+  });
+  registeredSweep = DBOS.registerWorkflow(digestSweepWorkflowFn, {
     name: "notificationDigestWorkflow",
   });
-  DBOS.registerScheduled(registeredWorkflow, {
+  DBOS.registerScheduled(registeredSweep, {
     name: "notificationDigestWorkflow",
-    crontab: DIGEST_CRONTAB,
+    crontab: SWEEP_CRONTAB,
     mode: SchedulerMode.ExactlyOncePerIntervalWhenActive,
   });
 }

--- a/apps/api/src/notifications/dbos-digest.ts
+++ b/apps/api/src/notifications/dbos-digest.ts
@@ -1,5 +1,5 @@
 /**
- * The email digest: every 5 minutes, mail each recipient the notifications
+ * The email digest: every 15 seconds, mail each recipient the notifications
  * they haven't read in the app yet, then stamp them.
  *
  * Same shape as `tools/task-board/dbos-archive-sweep.ts`: the scheduler picks
@@ -22,10 +22,16 @@ import type { Database } from "@/storage/types";
 import { buildDigestEmail, type DigestRow } from "./digest-email";
 import { NotificationDataSchema } from "./schema";
 
-const DIGEST_CRONTAB = "*/5 * * * *";
+/** Six fields — the leading one is seconds. */
+const DIGEST_CRONTAB = "*/15 * * * * *";
 
-/** The debounce: a burst on one task becomes one email. */
-const DEBOUNCE_MS = 5 * 60_000;
+/**
+ * The batching window: a burst inside it becomes one email, and a notification
+ * still unread when the window closes is mailed on the next tick — so the mail
+ * lands within DEBOUNCE_MS + one tick, not five minutes. Ticking faster than
+ * the window would only re-check rows the window has not released yet.
+ */
+const DEBOUNCE_MS = 30_000;
 
 /** Ceiling per tick, across all recipients. A backlog drains next tick. */
 const MAX_ROWS_PER_TICK = 500;
@@ -176,10 +182,17 @@ async function digestWorkflowFn(
     }
   }
 
-  await DBOS.runStep(
-    () => pruneOld(new Date(scheduledTime.getTime() - RETENTION_MS)),
-    { name: "pruneOldNotifications" },
-  );
+  // Retention is a whole-table DELETE and the tick is 15s — hourly is plenty.
+  // Derived from `scheduledTime`, so a replay makes the same choice.
+  if (
+    scheduledTime.getUTCMinutes() === 37 &&
+    scheduledTime.getUTCSeconds() < 15
+  ) {
+    await DBOS.runStep(
+      () => pruneOld(new Date(scheduledTime.getTime() - RETENTION_MS)),
+      { name: "pruneOldNotifications" },
+    );
+  }
 }
 
 let registeredWorkflow: typeof digestWorkflowFn | null = null;

--- a/apps/api/src/notifications/notifications.integration.test.ts
+++ b/apps/api/src/notifications/notifications.integration.test.ts
@@ -115,6 +115,70 @@ describe("notifications", () => {
     expect((await store.listUnread("user_123", "org_1")).unreadCount).toBe(1);
   });
 
+  it("notifies the user an event enrolls, not just prior followers", async () => {
+    // What "assigning someone notifies them" rests on: the enroll happens
+    // before the subscriber lookup, so the new assignee gets THIS event and not
+    // merely the next one.
+    const task = await tasks.create({
+      organizationId: "org_test",
+      title: "Assigned to you",
+      by: "user_test",
+    });
+    await notify({
+      db: database.db,
+      taskBoardItemId: task.id,
+      type: "assignee_changed",
+      actorId: "user_test",
+      alsoSubscribe: ["user_1"],
+    });
+
+    const inbox = await store.listUnread("user_1", "org_test");
+    expect(
+      inbox.notifications.some(
+        (n) => n.taskBoardItemId === task.id && n.type === "assignee_changed",
+      ),
+    ).toBe(true);
+  });
+
+  it("pages by keyset, so rows read between pages can't shift the window", async () => {
+    const task = await tasks.create({
+      organizationId: "org_test",
+      title: "Paged",
+      by: "user_test",
+    });
+    await store.setSubscribed("user_test", task.id, true);
+    // One burst, one transaction each — several rows share a created_at, which
+    // is exactly the tie an id-less cursor loses rows on.
+    for (let i = 0; i < 5; i++) {
+      await notify({
+        db: database.db,
+        taskBoardItemId: task.id,
+        type: "commented",
+        actorId: null,
+      });
+    }
+
+    const first = await store.listUnread("user_test", "org_test", { limit: 2 });
+    expect(first.notifications).toHaveLength(2);
+    expect(first.unreadCount).toBe(5);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await store.listUnread("user_test", "org_test", {
+      limit: 2,
+      cursor: first.nextCursor!,
+    });
+    const third = await store.listUnread("user_test", "org_test", {
+      limit: 2,
+      cursor: second.nextCursor!,
+    });
+
+    const ids = [first, second, third]
+      .flatMap((page) => page.notifications)
+      .map((n) => n.id);
+    expect(new Set(ids).size).toBe(5);
+    expect(third.nextCursor).toBeNull();
+  });
+
   it("cascades subscriptions and notifications when the task is deleted", async () => {
     const doomed = await tasks.create({
       organizationId: "org_test",

--- a/apps/api/src/notifications/notifications.integration.test.ts
+++ b/apps/api/src/notifications/notifications.integration.test.ts
@@ -10,6 +10,7 @@ import type { StudioDatabase } from "../database";
 import { TaskBoardStorage } from "../storage/task-board";
 import { NotificationStorage } from "../storage/notifications";
 import { notify } from "./notify";
+import { claimForEmail, setNotificationDigestRuntime } from "./dbos-digest";
 
 describe("notifications", () => {
   let database: StudioDatabase;
@@ -115,6 +116,33 @@ describe("notifications", () => {
     expect((await store.listUnread("user_123", "org_1")).unreadCount).toBe(1);
   });
 
+  it("claims rows for email exactly once, so two senders can't double-mail", async () => {
+    setNotificationDigestRuntime({ db: database.db });
+    const task = await tasks.create({
+      organizationId: "org_test",
+      title: "Claimed",
+      by: "user_test",
+    });
+    await store.setSubscribed("user_123", task.id, true);
+    await notify({
+      db: database.db,
+      taskBoardItemId: task.id,
+      type: "commented",
+      actorId: null,
+    });
+    const ids = (await store.listUnread("user_123", "org_test")).notifications
+      .filter((n) => n.taskBoardItemId === task.id)
+      .map((n) => n.id);
+    expect(ids).toHaveLength(1);
+
+    // The sweep and the per-user workflow reaching for the same row.
+    const [first, second] = await Promise.all([
+      claimForEmail(ids),
+      claimForEmail(ids),
+    ]);
+    expect(first.size + second.size).toBe(1);
+  });
+
   it("notifies the user an event enrolls, not just prior followers", async () => {
     // What "assigning someone notifies them" rests on: the enroll happens
     // before the subscriber lookup, so the new assignee gets THIS event and not
@@ -157,6 +185,12 @@ describe("notifications", () => {
         actorId: null,
       });
     }
+
+    // One statement, one `now()`: every row shares a created_at to the
+    // microsecond, so paging has nothing but `id` left to order by. This is
+    // what a millisecond-truncated cursor silently drops rows on.
+    await sql`UPDATE notifications SET created_at = now()
+      WHERE task_board_item_id = ${task.id}`.execute(database.db);
 
     const first = await store.listUnread("user_test", "org_test", { limit: 2 });
     expect(first.notifications).toHaveLength(2);

--- a/apps/api/src/notifications/notify.ts
+++ b/apps/api/src/notifications/notify.ts
@@ -14,6 +14,7 @@ import {
   type NotificationType,
 } from "@decocms/shared/notification-types";
 import { sseHub } from "@/event-bus/sse-hub";
+import { enqueueUserDigest } from "./dbos-digest";
 import type { Database } from "@/storage/types";
 import { NotificationDataSchema } from "./schema";
 
@@ -119,6 +120,8 @@ export async function notify(params: NotifyParams): Promise<void> {
     // refetch can race the row. Move the emit to an after-commit hook if the
     // inbox is ever seen missing an event it was told about.
     for (const userId of notified) {
+      // Debounced onto the end of this recipient's 30s window.
+      enqueueUserDigest(userId);
       sseHub.emit(subject.organization_id, {
         id: crypto.randomUUID(),
         type: NOTIFICATION_CREATED_EVENT,

--- a/apps/api/src/notifications/notify.ts
+++ b/apps/api/src/notifications/notify.ts
@@ -9,7 +9,11 @@
 
 import type { Kysely } from "kysely";
 import { generatePrefixedId } from "@decocms/shared/utils/generate-id";
-import type { NotificationType } from "@decocms/shared/notification-types";
+import {
+  NOTIFICATION_CREATED_EVENT,
+  type NotificationType,
+} from "@decocms/shared/notification-types";
+import { sseHub } from "@/event-bus/sse-hub";
 import type { Database } from "@/storage/types";
 import { NotificationDataSchema } from "./schema";
 
@@ -45,6 +49,8 @@ async function loadActor(db: Kysely<Database>, actorId: string | null) {
 export async function notify(params: NotifyParams): Promise<void> {
   const { db, taskBoardItemId, type, actorId } = params;
   try {
+    /** Filled by the write, emitted only after it commits. */
+    let notified: string[] = [];
     const subject = await loadSubject(db, taskBoardItemId);
     if (!subject) return;
 
@@ -80,6 +86,7 @@ export async function notify(params: NotifyParams): Promise<void> {
         .map((row) => row.user_id)
         .filter((userId) => userId !== actorId);
       if (recipients.length === 0) return;
+      notified = recipients;
 
       const actor = await loadActor(tx, actorId);
       const data = NotificationDataSchema.parse({
@@ -105,6 +112,21 @@ export async function notify(params: NotifyParams): Promise<void> {
         .execute();
     };
     await (db.isTransaction ? run(db) : db.transaction().execute(run));
+
+    // After the commit, never inside it: a listener that refetches on this
+    // event must find the row it describes.
+    // ponytail: inside a caller's transaction this still runs pre-commit, so a
+    // refetch can race the row. Move the emit to an after-commit hook if the
+    // inbox is ever seen missing an event it was told about.
+    for (const userId of notified) {
+      sseHub.emit(subject.organization_id, {
+        id: crypto.randomUUID(),
+        type: NOTIFICATION_CREATED_EVENT,
+        source: "notifications",
+        subject: userId,
+        time: new Date().toISOString(),
+      });
+    }
   } catch (err) {
     console.error("[notifications] fan-out failed", err);
   }

--- a/apps/api/src/storage/notifications.ts
+++ b/apps/api/src/storage/notifications.ts
@@ -3,7 +3,7 @@
  * `notifications` rows is `notifications/notify.ts`.
  */
 
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 import { generatePrefixedId } from "@decocms/shared/utils/generate-id";
 import type { NotificationType } from "@decocms/shared/notification-types";
 import type { Database } from "./types";
@@ -13,9 +13,9 @@ import {
 } from "../notifications/schema";
 import { notify, type NotifyParams } from "../notifications/notify";
 
-/** Beyond this the popover stops being a glance; `unreadCount` tells the UI
- *  there is more. */
-const LIST_LIMIT = 50;
+/** One page of the inbox. The popover scrolls and pages through the rest. */
+const PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 50;
 
 export interface Notification {
   id: string;
@@ -27,23 +27,58 @@ export interface Notification {
 
 const iso = (v: Date | string) => (v instanceof Date ? v.toISOString() : v);
 
+/** `${createdAt}|${id}`; anything else pages from the top rather than throwing. */
+function parseCursor(
+  cursor: string | undefined,
+): { createdAt: Date; id: string } | null {
+  if (!cursor) return null;
+  const sep = cursor.lastIndexOf("|");
+  if (sep <= 0) return null;
+  const createdAt = new Date(cursor.slice(0, sep));
+  const id = cursor.slice(sep + 1);
+  if (Number.isNaN(createdAt.getTime()) || !id) return null;
+  return { createdAt, id };
+}
+
 export class NotificationStorage {
   constructor(private db: Kysely<Database>) {}
 
-  /** The user's unread notifications in this org, newest first. */
+  /**
+   * One page of the user's unread notifications in this org, newest first.
+   *
+   * Keyset, not offset: rows leave the set as they are read, so an offset would
+   * skip rows between pages. `cursor` is the opaque `${createdAt}|${id}` of the
+   * last row of the previous page — `id` breaks the tie when two rows share a
+   * timestamp, which a burst on one task produces routinely.
+   */
   async listUnread(
     userId: string,
     organizationId: string,
-  ): Promise<{ notifications: Notification[]; unreadCount: number }> {
-    const rows = await this.db
+    opts: { cursor?: string; limit?: number } = {},
+  ): Promise<{
+    notifications: Notification[];
+    unreadCount: number;
+    nextCursor: string | null;
+  }> {
+    const limit = Math.min(opts.limit ?? PAGE_SIZE, MAX_PAGE_SIZE);
+    const after = parseCursor(opts.cursor);
+
+    let listQuery = this.db
       .selectFrom("notifications")
       .select(["id", "task_board_item_id", "type", "data", "created_at"])
       .where("user_id", "=", userId)
       .where("organization_id", "=", organizationId)
       .where("read_at", "is", null)
       .orderBy("created_at", "desc")
-      .limit(LIST_LIMIT)
-      .execute();
+      .orderBy("id", "desc")
+      .limit(limit + 1);
+    if (after) {
+      listQuery = listQuery.where(
+        sql<boolean>`(created_at, id) < (${after.createdAt}, ${after.id})`,
+      );
+    }
+    const page = await listQuery.execute();
+    const rows = page.slice(0, limit);
 
     const count = await this.db
       .selectFrom("notifications")
@@ -53,7 +88,12 @@ export class NotificationStorage {
       .where("read_at", "is", null)
       .executeTakeFirst();
 
+    const last = rows[rows.length - 1];
     return {
+      nextCursor:
+        page.length > limit && last
+          ? `${iso(last.created_at)}|${last.id}`
+          : null,
       notifications: rows.map((row) => ({
         id: row.id,
         taskBoardItemId: row.task_board_item_id,

--- a/apps/api/src/storage/notifications.ts
+++ b/apps/api/src/storage/notifications.ts
@@ -27,19 +27,6 @@ export interface Notification {
 
 const iso = (v: Date | string) => (v instanceof Date ? v.toISOString() : v);
 
-/** `${createdAt}|${id}`; anything else pages from the top rather than throwing. */
-function parseCursor(
-  cursor: string | undefined,
-): { createdAt: Date; id: string } | null {
-  if (!cursor) return null;
-  const sep = cursor.lastIndexOf("|");
-  if (sep <= 0) return null;
-  const createdAt = new Date(cursor.slice(0, sep));
-  const id = cursor.slice(sep + 1);
-  if (Number.isNaN(createdAt.getTime()) || !id) return null;
-  return { createdAt, id };
-}
-
 export class NotificationStorage {
   constructor(private db: Kysely<Database>) {}
 
@@ -47,9 +34,14 @@ export class NotificationStorage {
    * One page of the user's unread notifications in this org, newest first.
    *
    * Keyset, not offset: rows leave the set as they are read, so an offset would
-   * skip rows between pages. `cursor` is the opaque `${createdAt}|${id}` of the
-   * last row of the previous page — `id` breaks the tie when two rows share a
-   * timestamp, which a burst on one task produces routinely.
+   * skip rows between pages. The cursor is the previous page's last row id, and
+   * the `(created_at, id)` comparison against it resolves ENTIRELY in SQL — a
+   * timestamp round-tripped through a JS `Date` truncates Postgres microseconds
+   * to milliseconds, which silently drops rows sharing a millisecond, and a
+   * burst on one task produces those routinely. `id` breaks the remaining tie.
+   *
+   * A cursor whose row is gone (read in another tab, task deleted) pages from
+   * the top rather than returning an empty page that reads as "no more".
    */
   async listUnread(
     userId: string,
@@ -61,7 +53,7 @@ export class NotificationStorage {
     nextCursor: string | null;
   }> {
     const limit = Math.min(opts.limit ?? PAGE_SIZE, MAX_PAGE_SIZE);
-    const after = parseCursor(opts.cursor);
+    const after = opts.cursor ? await this.anchorExists(opts.cursor) : false;
 
     let listQuery = this.db
       .selectFrom("notifications")
@@ -74,7 +66,8 @@ export class NotificationStorage {
       .limit(limit + 1);
     if (after) {
       listQuery = listQuery.where(
-        sql<boolean>`(created_at, id) < (${after.createdAt}, ${after.id})`,
+        sql<boolean>`(created_at, id) <
+          (SELECT created_at, id FROM notifications WHERE id = ${opts.cursor})`,
       );
     }
     const page = await listQuery.execute();
@@ -90,10 +83,7 @@ export class NotificationStorage {
 
     const last = rows[rows.length - 1];
     return {
-      nextCursor:
-        page.length > limit && last
-          ? `${iso(last.created_at)}|${last.id}`
-          : null,
+      nextCursor: page.length > limit && last ? last.id : null,
       notifications: rows.map((row) => ({
         id: row.id,
         taskBoardItemId: row.task_board_item_id,
@@ -103,6 +93,16 @@ export class NotificationStorage {
       })),
       unreadCount: Number(count?.count ?? 0),
     };
+  }
+
+  /** Whether a cursor still points at a row — see `listUnread`. */
+  private async anchorExists(id: string): Promise<boolean> {
+    const row = await this.db
+      .selectFrom("notifications")
+      .select("id")
+      .where("id", "=", id)
+      .executeTakeFirst();
+    return !!row;
   }
 
   /** Idempotent. Omitted `ids` means every unread row of this user in this org. */

--- a/apps/api/src/tools/notifications/list.ts
+++ b/apps/api/src/tools/notifications/list.ts
@@ -2,7 +2,8 @@
  * The inbox read: the current user's unread task updates in the current org.
  *
  * Unread-only, because the inbox shows unseen changes and "Mark all read"
- * empties it. No cursor — `unreadCount` already tells the UI there is more.
+ * empties it. Keyset-paged so the popover can scroll a long backlog;
+ * `unreadCount` is always the full count, not the page's.
  */
 
 import { z } from "zod";
@@ -35,18 +36,25 @@ export const NOTIFICATION_LIST = defineTool({
     idempotentHint: true,
     openWorldHint: false,
   },
-  inputSchema: z.object({}),
+  inputSchema: z.object({
+    /** `nextCursor` from the previous page. Omit for the newest page. */
+    cursor: z.string().optional(),
+    limit: z.number().int().positive().max(50).optional(),
+  }),
   outputSchema: z.object({
     notifications: z.array(NotificationSchema),
     unreadCount: z.number(),
+    /** Null when this is the last page. */
+    nextCursor: z.string().nullable(),
   }),
-  handler: async (_input, ctx) => {
+  handler: async (input, ctx) => {
     requireAuth(ctx);
     await ctx.access.check();
-    const { notifications, unreadCount } =
+    const { notifications, unreadCount, nextCursor } =
       await ctx.storage.notifications.listUnread(
         getUserId(ctx)!,
         requireOrg(ctx),
+        { cursor: input.cursor, limit: input.limit },
       );
     return {
       notifications: notifications.map((n) => ({
@@ -60,6 +68,7 @@ export const NOTIFICATION_LIST = defineTool({
         createdAt: n.createdAt,
       })),
       unreadCount,
+      nextCursor,
     };
   },
 });

--- a/apps/web/src/components/sidebar/footer/inbox.tsx
+++ b/apps/web/src/components/sidebar/footer/inbox.tsx
@@ -17,6 +17,7 @@ import {
   SidebarMenuButton,
   useSidebar,
 } from "@decocms/ui/components/sidebar.tsx";
+import { ScrollArea } from "@decocms/ui/components/scroll-area.tsx";
 import { Button } from "@decocms/ui/components/button.tsx";
 import { useNavigate } from "@tanstack/react-router";
 import { useInboxFeed } from "@/hooks/use-inbox-feed";
@@ -25,11 +26,31 @@ import { taskKey } from "@decocms/shared/task-key";
 import { useT } from "@/i18n/use-t.ts";
 import { InboxTaskItem } from "./inbox-task-item";
 
+/**
+ * Loads the next page once it scrolls into view. An observer in a ref callback
+ * rather than an effect — React 19 runs the returned cleanup on detach.
+ */
+function LoadMoreSentinel({ onReach }: { onReach: () => void }) {
+  return (
+    <div
+      className="h-8 shrink-0"
+      ref={(node) => {
+        if (!node) return;
+        const observer = new IntersectionObserver((entries) => {
+          if (entries.some((entry) => entry.isIntersecting)) onReach();
+        });
+        observer.observe(node);
+        return () => observer.disconnect();
+      }}
+    />
+  );
+}
+
 function InboxPanel({ onClose }: { onClose: () => void }) {
   const t = useT();
   const navigate = useNavigate();
   const { org } = useProjectContext();
-  const { updates, markAllRead } = useInboxFeed();
+  const { updates, markAllRead, markRead, hasMore, fetchMore } = useInboxFeed();
 
   return (
     <>
@@ -57,7 +78,7 @@ function InboxPanel({ onClose }: { onClose: () => void }) {
           </p>
         </div>
       ) : (
-        <div className="flex-1 overflow-y-auto">
+        <ScrollArea className="min-h-0 flex-1">
           {updates.map((update) => {
             const key = taskKey(org.slug, update.taskKeySeq);
             return (
@@ -66,6 +87,8 @@ function InboxPanel({ onClose }: { onClose: () => void }) {
                 update={update}
                 orgSlug={org.slug}
                 onSelect={() => {
+                  // Opening it is reading it.
+                  markRead(update.id);
                   onClose();
                   if (key) {
                     navigate({
@@ -77,7 +100,8 @@ function InboxPanel({ onClose }: { onClose: () => void }) {
               />
             );
           })}
-        </div>
+          {hasMore && <LoadMoreSentinel onReach={fetchMore} />}
+        </ScrollArea>
       )}
     </>
   );

--- a/apps/web/src/hooks/use-inbox-feed.test.ts
+++ b/apps/web/src/hooks/use-inbox-feed.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { dropLocally } from "./use-inbox-feed";
+
+type Page = Parameters<typeof dropLocally>[0] extends
+  | { pages: (infer P)[] }
+  | undefined
+  ? P
+  : never;
+
+const page = (ids: string[], unreadCount: number) =>
+  ({
+    notifications: ids.map((id) => ({ id })),
+    unreadCount,
+    nextCursor: null,
+  }) as unknown as Page;
+
+const data = (pages: Page[]) => ({ pages, pageParams: pages.map(() => null) });
+
+describe("dropLocally", () => {
+  it("removes one row and decrements the count", () => {
+    const out = dropLocally(data([page(["a", "b"], 2)]), ["a"])!;
+    expect(out.pages[0]!.notifications.map((n) => n.id)).toEqual(["b"]);
+    expect(out.pages[0]!.unreadCount).toBe(1);
+  });
+
+  it("decrements once per row actually removed, so a repeat can't go negative", () => {
+    const first = dropLocally(data([page(["a"], 1)]), ["a"])!;
+    const second = dropLocally(first, ["a"])!;
+    expect(second.pages[0]!.unreadCount).toBe(0);
+  });
+
+  it("clears every loaded page and zeroes the count for mark-all-read", () => {
+    const out = dropLocally(data([page(["a"], 3), page(["b", "c"], 3)]), null)!;
+    expect(out.pages.flatMap((p) => p.notifications)).toEqual([]);
+    expect(out.pages.every((p) => p.unreadCount === 0)).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/use-inbox-feed.ts
+++ b/apps/web/src/hooks/use-inbox-feed.ts
@@ -5,13 +5,26 @@
  * their own surface (the floating announcement card), invitations live in the
  * org switcher, and join requests in Settings → Members — so this stays a feed
  * of work you follow rather than a catch-all.
+ *
+ * Live, not polled: the org `/watch` stream carries `notification.created` and
+ * the poll below is only the fallback for a dropped connection. Marking read is
+ * optimistic in both directions — the row leaves the list on click, and the
+ * server call only confirms it.
  */
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+} from "@tanstack/react-query";
+import { useSyncExternalStore } from "react";
 import { useProjectContext } from "@/sdk";
+import { authClient } from "@/lib/auth-client";
 import { KEYS } from "@/lib/query-keys";
 import { useStudioTools } from "@/lib/studio-tools";
 import type { NotificationType } from "@decocms/shared/notification-types";
+import { notificationWatchView } from "./watch-sse-pool";
 
 export interface InboxTaskUpdate {
   id: string;
@@ -30,45 +43,144 @@ export interface InboxTaskUpdate {
 export type InboxTaskAction = NotificationType;
 
 export interface InboxFeed {
-  /** Unseen updates, newest first. */
+  /** Unseen updates, newest first — every page loaded so far. */
   updates: InboxTaskUpdate[];
-  /** What the unread dot counts. */
+  /** What the unread dot counts (the full unread total, not the loaded pages). */
   redDotCount: number;
+  hasMore: boolean;
+  isFetchingMore: boolean;
+  fetchMore: () => void;
   markAllRead: () => void;
+  /** Read one row — what opening a notification does. */
+  markRead: (id: string) => void;
 }
 
-/** The dot's freshness ceiling — the popover refetches on open anyway. */
+/** Fallback only: the SSE stream is the real signal, this covers a dead one. */
 const POLL_MS = 60_000;
 
+type Page = Awaited<ReturnType<typeof listNotifications>>;
+type ListFn = ReturnType<typeof useStudioTools>;
+
+function listNotifications(studio: ListFn, cursor?: string) {
+  return studio.call("NOTIFICATION_LIST", cursor ? { cursor } : {});
+}
+
+/**
+ * Drop rows locally and decrement the count by however many were actually
+ * dropped — never by the caller's guess, so a double click can't drive the dot
+ * negative. `ids: null` means "everything loaded", which is what Mark all read
+ * shows; the server still clears rows past the loaded pages, and `unreadCount`
+ * goes to 0 with them.
+ */
+export function dropLocally(
+  data: InfiniteData<Page> | undefined,
+  ids: string[] | null,
+): InfiniteData<Page> | undefined {
+  if (!data) return data;
+  const drop = ids ? new Set(ids) : null;
+  let removed = 0;
+  const pages = data.pages.map((page) => {
+    const notifications = page.notifications.filter((n) => {
+      if (drop && !drop.has(n.id)) return true;
+      removed++;
+      return false;
+    });
+    return { ...page, notifications };
+  });
+  const unreadCount = drop
+    ? Math.max(0, (data.pages[0]?.unreadCount ?? 0) - removed)
+    : 0;
+  return {
+    ...data,
+    pages: pages.map((page) => ({ ...page, unreadCount })),
+  };
+}
+
+/** Refetch the feed when the org stream says a row landed for me. */
+function useLiveInbox(orgSlug: string, onNotification: () => void): void {
+  const { data: session } = authClient.useSession();
+  const userId = session?.user?.id;
+
+  useSyncExternalStore(
+    (onStoreChange) => {
+      if (!orgSlug || !userId) return () => {};
+      const unsubscribe = notificationWatchView.subscribe(
+        orgSlug,
+        (event: MessageEvent) => {
+          try {
+            // The event carries only its recipient; the row itself is refetched.
+            const parsed = JSON.parse(event.data) as { subject?: string };
+            if (parsed.subject !== userId) return;
+          } catch {
+            return;
+          }
+          onNotification();
+          onStoreChange();
+        },
+        // A reconnect may have missed events — resync.
+        onNotification,
+      );
+      return unsubscribe;
+    },
+    () => 0,
+    () => 0,
+  );
+}
+
 export function useInboxFeed(): InboxFeed {
-  const { locator } = useProjectContext();
+  const { locator, org } = useProjectContext();
   const studio = useStudioTools();
   const queryClient = useQueryClient();
   const queryKey = KEYS.notifications(locator);
 
-  const query = useQuery({
+  const query = useInfiniteQuery({
     queryKey,
-    queryFn: () => studio.call("NOTIFICATION_LIST", {}),
+    queryFn: ({ pageParam }) =>
+      listNotifications(studio, pageParam as string | undefined),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
     refetchInterval: POLL_MS,
   });
 
-  const markAllRead = useMutation({
-    mutationFn: () => studio.call("NOTIFICATION_MARK_READ", {}),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey }),
+  useLiveInbox(org.slug, () =>
+    queryClient.invalidateQueries({ queryKey, refetchType: "active" }),
+  );
+
+  const markRead = useMutation({
+    /** `ids: undefined` is the server's "all of mine in this org". */
+    mutationFn: (ids: string[] | null) =>
+      studio.call("NOTIFICATION_MARK_READ", ids ? { ids } : {}),
+    onMutate: (ids) => {
+      queryClient.setQueryData<InfiniteData<Page>>(queryKey, (data) =>
+        dropLocally(data, ids),
+      );
+    },
+    // Failed or not, the server is the truth about what is still unread.
+    onSettled: () => queryClient.invalidateQueries({ queryKey }),
   });
 
+  const pages = query.data?.pages ?? [];
+
   return {
-    updates: (query.data?.notifications ?? []).map((n) => ({
-      id: n.id,
-      taskBoardItemId: n.taskBoardItemId,
-      taskTitle: n.taskTitle,
-      taskKeySeq: n.taskKeySeq,
-      action: n.type,
-      actorName: n.actorName,
-      actorImage: n.actorImage,
-      occurredAt: n.createdAt,
-    })),
-    redDotCount: query.data?.unreadCount ?? 0,
-    markAllRead: () => markAllRead.mutate(),
+    updates: pages.flatMap((page) =>
+      page.notifications.map((n) => ({
+        id: n.id,
+        taskBoardItemId: n.taskBoardItemId,
+        taskTitle: n.taskTitle,
+        taskKeySeq: n.taskKeySeq,
+        action: n.type,
+        actorName: n.actorName,
+        actorImage: n.actorImage,
+        occurredAt: n.createdAt,
+      })),
+    ),
+    redDotCount: pages[0]?.unreadCount ?? 0,
+    hasMore: query.hasNextPage,
+    isFetchingMore: query.isFetchingNextPage,
+    fetchMore: () => {
+      if (query.hasNextPage && !query.isFetchingNextPage) query.fetchNextPage();
+    },
+    markAllRead: () => markRead.mutate(null),
+    markRead: (id: string) => markRead.mutate([id]),
   };
 }

--- a/apps/web/src/hooks/watch-sse-pool.ts
+++ b/apps/web/src/hooks/watch-sse-pool.ts
@@ -9,6 +9,7 @@ import {
   TASK_BOARD_ITEM_DELETED_EVENT,
   TASK_BOARD_ITEM_UPDATED_EVENT,
 } from "@decocms/shared/task-board";
+import { NOTIFICATION_CREATED_EVENT } from "@decocms/shared/notification-types";
 import {
   createSSESubscription,
   filterEventTypes,
@@ -20,6 +21,7 @@ const WATCH_TYPES = [
   ...ALL_DECOPILOT_EVENT_TYPES,
   TASK_BOARD_ITEM_UPDATED_EVENT,
   TASK_BOARD_ITEM_DELETED_EVENT,
+  NOTIFICATION_CREATED_EVENT,
 ];
 
 /** `?types=` patterns sent to the server. */
@@ -47,3 +49,10 @@ export const taskBoardWatchView: SSESubscription = filterEventTypes(watchSSE, [
   TASK_BOARD_ITEM_UPDATED_EVENT,
   TASK_BOARD_ITEM_DELETED_EVENT,
 ]);
+
+/** Inbox fan-out (`notification.created`). Org-wide — the consumer matches the
+ *  event's `subject` against its own user id. */
+export const notificationWatchView: SSESubscription = filterEventTypes(
+  watchSSE,
+  [NOTIFICATION_CREATED_EVENT],
+);

--- a/packages/shared/src/notification-types.ts
+++ b/packages/shared/src/notification-types.ts
@@ -21,3 +21,12 @@ export const NOTIFICATION_TYPES = [
 ] as const;
 
 export type NotificationType = (typeof NOTIFICATION_TYPES)[number];
+
+/**
+ * Org-scoped SSE event pushed on `sseHub` after a notification row commits.
+ * `subject` is the recipient's user id and `data` carries nothing else — the
+ * hub fans out per org, so every member's stream sees it and only the addressed
+ * client refetches. Keeping the payload empty is what stops one member's inbox
+ * from streaming through another's connection.
+ */
+export const NOTIFICATION_CREATED_EVENT = "notification.created";

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -284,7 +284,7 @@ export interface StudioToolIO {
     };
   };
   NOTIFICATION_LIST: {
-    input: { [x: string]: never };
+    input: { cursor?: string | undefined; limit?: number | undefined };
     output: {
       notifications: {
         id: string;
@@ -305,6 +305,7 @@ export interface StudioToolIO {
         createdAt: string;
       }[];
       unreadCount: number;
+      nextCursor: string | null;
     };
   };
   NOTIFICATION_MARK_READ: {


### PR DESCRIPTION
Follow-up to the notifications feature.

**Clicking a notification marks it read** — opening it is reading it.

**Optimistic mark-read** (single row and "Mark all read"): the row leaves the list on click and `unreadCount` drops by the rows *actually* removed, so a double click can't drive the dot negative. `onSettled` invalidates either way — the server stays the truth about what is still unread.

**Real-time via the SSE hub.** `notify()` emits `notification.created` on `sseHub` after the write commits; `subject` is the recipient's user id and the payload is empty, because the hub fans out per *org* — an empty event is what keeps one member's inbox off another member's stream. The client matches `subject` against its own user id and refetches. The 60s poll is now just the fallback for a dead connection, and a reconnect resyncs.

**Infinite scroll.** `NOTIFICATION_LIST` takes `cursor`/`limit` and returns `nextCursor`; the popover renders a `ScrollArea` and pages on an IntersectionObserver sentinel — a ref callback with cleanup, not a `useEffect`. Keyset, not offset: rows leave the unread set as they're read, so an offset would skip rows between pages.

**The email digest is event-triggered, not polled.** A notification enqueues a per-recipient workflow whose id is `notif-digest:<user>:<30s bucket>`. Every event for the same recipient in the same window resolves to the same id and DBOS runs an id once — that dedupe *is* the debounce, so a burst of twenty notifications costs one workflow and one email. It sleeps durably to the end of its window, then mails whatever is still unread. Mail lands ~30s after the first event of a burst instead of on a five-minute tick, and an idle deployment does no work at all.

The scheduled workflow drops from `*/5` to a two-minute **safety net** plus retention, because the enqueue happens after the row commits and DBOS rejects `startWorkflow` from inside a step — which `notify()` can be, called from a run reaction. Same NotifyStrategy + PollingStrategy pairing the event bus already uses. With two possible senders, both **claim before sending** (one `UPDATE ... WHERE emailed_at IS NULL RETURNING id`), so an overlap splits the rows instead of mailing them twice. That inverts the old send-then-stamp order deliberately: a duplicate email is the likelier and worse failure than one lost to a send that fails after its claim, which the step retries first.

`DBOS_WORKFLOW_VERSION` 8 → 9 — the sweep's step sequence changed and a new workflow joined it. Cheap to strand: it was a five-minute tick finishing in milliseconds with nothing waiting on it.

**Assignee notification** already worked — `notify()` enrolls before it looks up subscribers, so the new assignee receives that very event, and `TASK_BOARD_ITEM_UPDATE` passes the post-update `assigneeId`. Confirmed live on staging (two `assignee_changed` rows, both mailed). Added the integration test that fails if that order ever flips, rather than a second code path.

## A bug the new test caught
The first cut of the cursor stringified `created_at` through a JS `Date`, truncating Postgres microseconds to milliseconds — so rows sharing a millisecond were **silently skipped between pages**, and a burst on one task produces those routinely. The cursor is now the last row's id, with the whole `(created_at, id)` comparison resolved in SQL; a cursor whose row is gone (read in another tab) pages from the top rather than returning an empty page that reads as "no more". The test pins every row to a single `now()` so the tie is deterministic — reverting the fix fails it 5 → 2.

## Testing
- 16/16 `notifications.integration.test.ts` against a real Postgres, six consecutive clean runs. New cases: keyset paging over microsecond-tied rows, claim-exactly-once under two concurrent senders, enroll-then-notify for the assignee.
- 3 unit tests for the optimistic `dropLocally` (pure, no mocks).
- `bun run check`, `bun run lint`, `bun run fmt` clean; workflow source-guard snapshot re-baselined.

## Staging verification (`deco-studio-stg`, 4.264.0)
The digest **is** sending. Three notifications; the two still unread were mailed (Resend returned 2xx — a non-2xx throws before the stamp), and the one read in-app before its window closed correctly was never mailed. Observed lag 6m19s median / 6m58s max — exactly the 5-minute window plus the 5-minute tick this PR replaces.
