### PR TITLE
feat(cms): confirm before changing an existing page's path

### DIFF
--- a/apps/web/src/components/sections-editor/sections-editor-panels.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor-panels.tsx
@@ -1,5 +1,15 @@
-import { useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { ChevronLeft, ChevronRight, Flag01 } from "@untitledui/icons";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@decocms/ui/components/alert-dialog.tsx";
 import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Tooltip,
@@ -221,13 +231,44 @@ export function PageHeaderInputs({
   const [name, setName] = useState(initialName);
   const [path, setPath] = useState(initialPath);
   const [prevKey, setPrevKey] = useState(pageKey);
+  // Path change awaiting confirmation; rewriting a live page's path is deliberate.
+  const [pendingPath, setPendingPath] = useState<string | null>(null);
+  // Set on Escape so the ensuing blur doesn't re-prompt.
+  const skipCommitRef = useRef(false);
 
   // Reset local state when navigating to a different page
   if (prevKey !== pageKey) {
     setPrevKey(pageKey);
     setName(initialName);
     setPath(initialPath);
+    setPendingPath(null);
   }
+
+  const commitPath = () => {
+    if (skipCommitRef.current) {
+      skipCommitRef.current = false;
+      return;
+    }
+    const trimmed = path.trim();
+    if (trimmed === initialPath.trim()) {
+      // No real change — normalize the displayed value and move on.
+      setPath(initialPath);
+      return;
+    }
+    setPendingPath(trimmed);
+  };
+
+  const confirmPathChange = () => {
+    if (pendingPath === null) return;
+    setPath(pendingPath);
+    onFieldChange("path", pendingPath);
+    setPendingPath(null);
+  };
+
+  const cancelPathChange = () => {
+    setPath(initialPath);
+    setPendingPath(null);
+  };
 
   return (
     <div className="space-y-1">
@@ -246,13 +287,55 @@ export function PageHeaderInputs({
       <input
         type="text"
         value={path}
-        onChange={(e) => {
-          setPath(e.target.value);
-          onFieldChange("path", e.target.value);
+        onChange={(e) => setPath(e.target.value)}
+        onBlur={commitPath}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            e.currentTarget.blur();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            skipCommitRef.current = true;
+            setPath(initialPath);
+            e.currentTarget.blur();
+          }
         }}
         className="w-full bg-transparent text-xs text-muted-foreground truncate outline-none border-none p-0 focus:ring-0 placeholder:text-muted-foreground"
         placeholder={t("sectionsEditor.sectionsEditorPanels.pathPlaceholder")}
       />
+      <AlertDialog
+        open={pendingPath !== null}
+        onOpenChange={(next) => {
+          if (!next) cancelPathChange();
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("sectionsEditor.sectionsEditorPanels.changePathTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("sectionsEditor.sectionsEditorPanels.changePathDescription", {
+                from: initialPath,
+                to: pendingPath ?? "",
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              {t("sectionsEditor.sectionsEditorPanels.changePathCancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                confirmPathChange();
+              }}
+            >
+              {t("sectionsEditor.sectionsEditorPanels.changePathConfirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/web/src/i18n/en/sections-editor.ts
+++ b/apps/web/src/i18n/en/sections-editor.ts
@@ -241,6 +241,12 @@ export const sectionsEditor = {
   "sectionsEditor.sectionsEditor.viewJson": "View JSON",
   "sectionsEditor.sectionsEditorPanels.addVariant": "Add variant",
   "sectionsEditor.sectionsEditorPanels.backToRule": "Back to rule",
+  "sectionsEditor.sectionsEditorPanels.changePathTitle":
+    "Change this page's path?",
+  "sectionsEditor.sectionsEditorPanels.changePathDescription":
+    'The page URL changes from "{from}" to "{to}". The old URL stops working and inbound links or SEO may break.',
+  "sectionsEditor.sectionsEditorPanels.changePathCancel": "Cancel",
+  "sectionsEditor.sectionsEditorPanels.changePathConfirm": "Change path",
   "sectionsEditor.sectionsEditorPanels.pageNamePlaceholder": "Page name",
   "sectionsEditor.sectionsEditorPanels.pathPlaceholder": "/path",
   "sectionsEditor.sectionsEditorPanels.variantRuleBreadcrumb":

--- a/apps/web/src/i18n/pt-br/sections-editor.ts
+++ b/apps/web/src/i18n/pt-br/sections-editor.ts
@@ -252,6 +252,12 @@ export const sectionsEditor = {
   "sectionsEditor.sectionsEditor.viewJson": "Ver JSON",
   "sectionsEditor.sectionsEditorPanels.addVariant": "Adicionar variante",
   "sectionsEditor.sectionsEditorPanels.backToRule": "Voltar para regra",
+  "sectionsEditor.sectionsEditorPanels.changePathTitle":
+    "Alterar o caminho desta página?",
+  "sectionsEditor.sectionsEditorPanels.changePathDescription":
+    'A URL da página muda de "{from}" para "{to}". A URL antiga deixa de funcionar e links de entrada ou SEO podem quebrar.',
+  "sectionsEditor.sectionsEditorPanels.changePathCancel": "Cancelar",
+  "sectionsEditor.sectionsEditorPanels.changePathConfirm": "Alterar caminho",
   "sectionsEditor.sectionsEditorPanels.pageNamePlaceholder": "Nome da página",
   "sectionsEditor.sectionsEditorPanels.pathPlaceholder": "/caminho",
   "sectionsEditor.sectionsEditorPanels.variantRuleBreadcrumb":


### PR DESCRIPTION
## Summary

Changing a CMS page's path was too easy: the inline path field in the sections-editor page header saved **on every keystroke** with no validation and no warning, so a live page's URL could be rewritten by accident (breaking the old URL, inbound links, and SEO).

This adds a confirmation guard on that field:

- The path field now **commits on blur/Enter** instead of per-keystroke (the page name keeps its live save — it's harmless).
- On a real path change it opens an `AlertDialog`: *"Change this page's path? The page URL changes from `/x` to `/y`. The old URL stops working and inbound links or SEO may break."*
  - **Cancel** / Escape / backdrop → reverts to the original path.
  - **Change path** → applies the change.
- Typing the same path (no real change) doesn't prompt; Escape reverts the field text without prompting.

## Affected areas
- `apps/web/src/components/sections-editor/sections-editor-panels.tsx` — `PageHeaderInputs`: commit-on-blur + confirmation dialog
- `apps/web/src/i18n/en/sections-editor.ts` + `pt-br/sections-editor.ts` — 4 new keys (title/description/cancel/confirm), all via `t()`

## Not included (deliberately)
The Content-tab **Rename** modal (`page-form-dialog.tsx`) also changes an existing page's path, but it's already a deliberate action with syntax + duplicate validation. Happy to add the same confirmation there for consistency if wanted.

## Testing notes
- `bun run --cwd=apps/web check` (tsc) passes — i18n key parity between en/pt-br is enforced at compile time.
- `bun run fmt` + `bun run lint` clean for the changed files.
- Manual: edit a page path inline → dialog appears on blur/Enter; Cancel reverts, Confirm applies; unchanged path is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)