### PR TITLE
fix(oauth): reject a private-network token_endpoint from origin auth-server metadata

### DIFF
--- a/apps/api/src/oauth/resolve-token-endpoint.test.ts
+++ b/apps/api/src/oauth/resolve-token-endpoint.test.ts
@@ -46,6 +46,22 @@ describe("resolveOriginTokenEndpoint", () => {
     expect(result).toBeNull();
   });
 
+  it("rejects a private/internal token_endpoint instead of handing it back", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({ token_endpoint: "http://169.254.169.254/token" }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+    );
+
+    const result = await resolveOriginTokenEndpoint("https://mcp.example.com");
+    expect(result).toBeNull();
+  });
+
   it("rejects a non-string token_endpoint instead of handing it back", async () => {
     installFetch(
       () =>

--- a/apps/api/src/oauth/resolve-token-endpoint.ts
+++ b/apps/api/src/oauth/resolve-token-endpoint.ts
@@ -11,6 +11,7 @@ import {
   fetchProtectedResourceMetadata,
   fetchAuthorizationServerMetadata,
 } from "../api/routes/oauth-proxy";
+import { isPrivateUrl } from "../tools/registry/discover-tools";
 
 /**
  * Resolve the origin's actual OAuth token endpoint from a connection URL.
@@ -51,11 +52,14 @@ export async function resolveOriginTokenEndpoint(
       const data = (await authRes.json()) as {
         token_endpoint?: unknown;
       };
-      // token_endpoint is untrusted input — only hand back a real http(s) URL.
+      // token_endpoint is untrusted, origin-controlled input — reject a private/internal target.
       if (typeof data.token_endpoint === "string") {
         try {
           const parsed = new URL(data.token_endpoint);
-          if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+          if (
+            (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+            !isPrivateUrl(data.token_endpoint)
+          ) {
             return data.token_endpoint;
           }
         } catch {


### PR DESCRIPTION
Follows #6543, which closed an SSRF gap where an origin-controlled `authorization_endpoint`/`token_endpoint`/`registration_endpoint` from auth-server metadata was fetched by the proxy without checking it wasn't a private/internal address. This closes the same class one hop further downstream: `resolveOriginTokenEndpoint` (apps/api/src/oauth/resolve-token-endpoint.ts) reads `token_endpoint` from that same origin-controlled metadata and only validated the http(s) protocol, not the target host. The returned value gets persisted as the connection's `tokenEndpoint` (apps/api/src/api/app.ts and apps/api/src/api/routes/downstream-token.ts) and is later `fetch`ed server-side on every scheduled refresh (`refreshAccessToken` in apps/api/src/oauth/refresh-access-token.ts), POSTing the connection's client_id/client_secret/refresh_token to it.

**Failure scenario:** a malicious or compromised MCP server advertises `token_endpoint: "http://169.254.169.254/..."` (or any other internal address) in its auth-server metadata. Studio discovers and persists it once, then the refresh loop repeatedly POSTs the connection's OAuth credentials to that internal address on every scheduled refresh.

**Fix:** apply the same `isPrivateUrl` guard already used in `oauth-proxy.ts`'s `fetchAuthorizationServerMetadata`/`assertOriginEndpointIsSafe` to the discovered `token_endpoint` before handing it back. Added a regression test (`resolve-token-endpoint.test.ts`) asserting a private-IP `token_endpoint` is rejected instead of returned.

**To verify:** `cd apps/api && bunx tsc --noEmit` (green), `bun test apps/api/src/oauth/resolve-token-endpoint.test.ts` (4 pass).

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in apps/api, the targeted test file, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.