### PR TITLE
fix(sections-editor): treat an empty resolveType as not a saved-block reference

### DIFF
--- a/apps/web/src/components/sections-editor/block-type-utils.test.ts
+++ b/apps/web/src/components/sections-editor/block-type-utils.test.ts
@@ -53,6 +53,7 @@ describe("block-type-utils", () => {
     );
     expect(isSavedBlockResolveType("__proto__")).toBe(false);
     expect(isSavedBlockResolveType("constructor")).toBe(false);
+    expect(isSavedBlockResolveType("")).toBe(false);
   });
 
   it("isAutoPreviewBlockKey detects generated preview stubs", () => {

--- a/apps/web/src/components/sections-editor/block-type-utils.ts
+++ b/apps/web/src/components/sections-editor/block-type-utils.ts
@@ -80,6 +80,7 @@ export function isManifestMatcherResolveType(
 
 /** Block id reference (no module path) — e.g. `Header`, not `site/sections/Header.tsx`. */
 export function isSavedBlockResolveType(resolveType: string): boolean {
+  if (!resolveType) return false;
   // Module paths end with a file extension (e.g. site/sections/Header.tsx)
   if (/\.\w+$/.test(resolveType)) return false;
   if (resolveType === "__proto__" || resolveType === "constructor") {


### PR DESCRIPTION
**Source:** a bug found while auditing `apps/web/src/components/sections-editor/parse-sections.ts` / `unwrap-section.ts` (this tick's focus area) and their shared dependency `block-type-utils.ts`.

**Bug:** `isSavedBlockResolveType("")` returned `true` — an empty `resolveType` matches neither the file-extension check nor the `__proto__`/`constructor` denylist, so it falls through to the default `true`. Every call site that doesn't separately guard against an empty string then treats a value shaped like `{ __resolveType: "" }` as a saved-block reference. `parse-sections.ts` already works around this at two call sites with an explicit `rt !== ""` check — a sign the empty-string case was known-broken rather than fixed at the source, and other call sites (e.g. `detectBlockRefType` in `block-ref-field-utils.ts`, `isSavedMatcherBlockReference` in `matcher-rules.ts`) don't have that guard.

**Fix:** `isSavedBlockResolveType` now returns `false` for an empty string, matching the two callers that already special-cased it — so future/other callers get the correct answer without needing to know about this edge case.

**Regression test:** added `expect(isSavedBlockResolveType("")).toBe(false)` to `block-type-utils.test.ts` (previously untested).

**Reviewer check:** `bun test apps/web/src/components/sections-editor/block-type-utils.test.ts`

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` (apps/web), the targeted test above plus `unwrap-section.test.ts`/`section-list.test.ts`/`section-variants.test.ts`/`matcher-rules.test.ts` (all pass, no regressions), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.