### PR TITLE
fix(oauth-proxy): refuse redirects when fetching origin OAuth metadata

### DIFF
--- a/apps/api/src/api/routes/oauth-proxy-ssrf.test.ts
+++ b/apps/api/src/api/routes/oauth-proxy-ssrf.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   assertOriginEndpointIsSafe,
   fetchAuthorizationServerMetadata,
+  fetchProtectedResourceMetadata,
 } from "./oauth-proxy";
 
 /**
@@ -35,6 +36,43 @@ describe("fetchAuthorizationServerMetadata SSRF guard", () => {
  * address and get the proxy to fetch or redirect there server-side,
  * forwarding the caller's Authorization header along with it.
  */
+/**
+ * `isPrivateUrl` only vets the URL we're about to fetch — a compromised MCP
+ * server can 3xx-redirect the metadata fetch anywhere it likes, and fetch
+ * follows redirects by default, bypassing that check entirely.
+ */
+describe("fetchProtectedResourceMetadata redirect SSRF guard", () => {
+  test("never follows a redirect to another server", async () => {
+    let canaryHit = false;
+    const canary = Bun.serve({
+      port: 0,
+      fetch() {
+        canaryHit = true;
+        return Response.json({});
+      },
+    });
+    const origin = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: `http://localhost:${canary.port}/` },
+        });
+      },
+    });
+
+    try {
+      await expect(
+        fetchProtectedResourceMetadata(`http://localhost:${origin.port}`),
+      ).rejects.toThrow(/redirect/i);
+      expect(canaryHit).toBe(false);
+    } finally {
+      origin.stop(true);
+      canary.stop(true);
+    }
+  });
+});
+
 describe("assertOriginEndpointIsSafe SSRF guard", () => {
   test("refuses a private/internal endpoint URL", () => {
     const response = assertOriginEndpointIsSafe(

--- a/apps/api/src/api/routes/oauth-proxy.ts
+++ b/apps/api/src/api/routes/oauth-proxy.ts
@@ -656,14 +656,12 @@ const METADATA_FETCH_TIMEOUT_MS = 4000;
  * `fetchMetadataWithRetry`.
  */
 // Refuses 3xx so an attacker-controlled origin can't redirect this fetch to a private address and bypass isPrivateUrl.
-const noRedirectFetch = createNoRedirectFetch();
-
 function fetchWithTimeout(
   url: string,
   init: RequestInit,
   timeoutMs = METADATA_FETCH_TIMEOUT_MS,
 ): Promise<Response> {
-  return noRedirectFetch(url, {
+  return createNoRedirectFetch()(url, {
     ...init,
     signal: AbortSignal.timeout(timeoutMs),
   });

--- a/apps/api/src/api/routes/oauth-proxy.ts
+++ b/apps/api/src/api/routes/oauth-proxy.ts
@@ -18,7 +18,10 @@ import { ContextFactory } from "../../core/context-factory";
 import type { StudioContext } from "../../core/studio-context";
 import { auth } from "../../auth";
 import { retry, RetryError } from "@decocms/shared/std";
-import { isPrivateUrl } from "@/tools/registry/discover-tools";
+import {
+  createNoRedirectFetch,
+  isPrivateUrl,
+} from "@/tools/registry/discover-tools";
 import {
   authorizationServerMetadataUrls,
   buildPathPrefix,
@@ -652,12 +655,18 @@ const METADATA_FETCH_TIMEOUT_MS = 4000;
  * retry; callers that want transient-failure resilience use
  * `fetchMetadataWithRetry`.
  */
+// Refuses 3xx so an attacker-controlled origin can't redirect this fetch to a private address and bypass isPrivateUrl.
+const noRedirectFetch = createNoRedirectFetch();
+
 function fetchWithTimeout(
   url: string,
   init: RequestInit,
   timeoutMs = METADATA_FETCH_TIMEOUT_MS,
 ): Promise<Response> {
-  return fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+  return noRedirectFetch(url, {
+    ...init,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
 }
 
 /**


### PR DESCRIPTION
The protected-resource and authorization-server metadata fetches (`fetchWithTimeout`, used by `fetchProtectedResourceMetadata` / `fetchAuthorizationServerMetadata` / `checkOriginSupportsOAuth`) called `fetch` directly with no redirect handling. `isPrivateUrl` only vets the URL we're about to connect to; a compromised/malicious MCP server can 3xx-redirect that request to a private/metadata address (e.g. `169.254.169.254`) and `fetch` follows redirects by default, bypassing the check entirely. This exact class was already fixed for the tools/list discovery path (`createNoRedirectFetch` in `discover-tools.ts`) and the token/register proxy route (`app.ts`) — this closes the same gap in the metadata-fetch helpers, which is why the two existing `oauth-proxy-ssrf.test.ts` describe blocks (initial-URL checks only) never caught it.

Why a maintainer wants this: it's a real, reachable SSRF vector — any MCP connection URL an org admin adds is enough to trigger the metadata fetch, and the origin fully controls the redirect target server-side.

Fix: wires the existing `createNoRedirectFetch` helper into `fetchWithTimeout` so every metadata fetch in this file refuses a 3xx instead of following it, one line change plus the wrapper. Failure scenario without the fix: an origin server serving `/.well-known/oauth-authorization-server` (or the protected-resource metadata) responds `302 Location: http://169.254.169.254/...` and Studio's backend transparently fetches the internal/metadata address on the origin's behalf. New regression test (`fetchProtectedResourceMetadata redirect SSRF guard` in `oauth-proxy-ssrf.test.ts`) spins up two local `Bun.serve` instances — an "origin" that 302s to a "canary" — and asserts the canary is never hit and the call rejects instead of silently succeeding.

Reviewer check: `bun test apps/api/src/api/routes/oauth-proxy-ssrf.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above (6 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.