### PR TITLE
fix(sections-editor): resolve nested array item by outermost crumb

### DIFF
--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -1405,6 +1405,49 @@ describe("structural fieldKey resolution", () => {
     ).toBe("b");
   });
 
+  test("a nested array crumb sharing a key name with a top-level array does not hijack it", () => {
+    // The outermost crumb (`tabs`) owns the root scope; the inner `cards` crumb belongs to the tab item, not the same-named top-level `cards`.
+    const cardItem = {
+      type: "object",
+      properties: { title: { type: "string" } },
+    } as SchemaProperty;
+    const nestedProps = {
+      cards: { title: "Cards", type: "array", items: cardItem },
+      tabs: {
+        title: "Tabs",
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            cards: { title: "Cards da tab", type: "array", items: cardItem },
+          },
+        },
+      },
+    } as Record<string, SchemaProperty>;
+    const nestedValue = {
+      cards: [{ title: "Coleção 1" }, { title: "Coleção 2" }],
+      tabs: [{ title: "Ouro", cards: [{}, {}] }],
+    };
+    const trail: Crumb[] = [
+      { label: "Ouro", itemIndex: 0, fieldKey: "tabs" },
+      {
+        label: "Item 1",
+        itemIndex: 0,
+        fieldKey: "cards",
+        arrayLabel: "Cards da tab",
+      },
+    ];
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(nestedProps),
+        nestedProps,
+        nestedValue,
+        trail,
+      ),
+    ).toBe("tabs");
+  });
+
   test("a legacy crumb without fieldKey can't disambiguate and picks the first sibling", () => {
     const legacyTrail: Crumb[] = [
       { label: "Item 1", itemIndex: 0, arrayLabel: "Items" },

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -551,12 +551,14 @@ function resolveActiveFieldKeyInScope(
   if (breadcrumbPath.length === 0) return null;
   const head = crumbLabel(breadcrumbPath[0]!);
 
-  // Structural fast-path: an item crumb records the array's own key at drill-in, so a drill-down field it names resolves by exact key match — no label/title/arrayLabel guessing. Label matching below stays the fallback for older/context crumbs.
-  for (const key of keys) {
-    const schema = properties[key];
-    if (!schema || !isArrayDrillDownField(schema, objValue[key])) continue;
-    if (breadcrumbPath.some((crumb) => crumbFieldKey(crumb) === key))
-      return key;
+  // Structural fast-path: an item crumb records the array's own key at drill-in, so a drill-down field it names resolves by exact key match — no label/title/arrayLabel guessing. Only the OUTERMOST crumb owns this scope; a deeper crumb (a nested array with the SAME key name, e.g. `tabs[].cards` vs a top-level `cards`) belongs to a nested scope and must not hijack the match. Label matching below stays the fallback for older/context crumbs.
+  const headFieldKey = crumbFieldKey(breadcrumbPath[0]!);
+  if (headFieldKey != null) {
+    for (const key of keys) {
+      const schema = properties[key];
+      if (!schema || !isArrayDrillDownField(schema, objValue[key])) continue;
+      if (key === headFieldKey) return key;
+    }
   }
 
   for (const key of keys) {


### PR DESCRIPTION
## Summary

Fixes a sections-editor drill-in bug where a section with a **top-level array and a nested array sharing the same property key** resolved to the wrong array.

In montecarlo's `CollectionsCarousel` there are two arrays named `cards`: a top-level `cards: Card[]` and a nested `cards: Card[]` inside each `tabs[]` item. Drilling **CollectionsCarousel → Ouro → a card** rendered the *top-level* cards ("Coleção 1 - Especiais…") instead of the tab's own cards.

## Root cause

`resolveActiveFieldKeyInScope` has a structural fast-path: each array-item crumb records the array's own property key (`fieldKey`) at drill-in, so navigation resolves the owning field by exact key match. But it matched with `breadcrumbPath.some(crumb => crumbFieldKey(crumb) === key)` — scanning **every** crumb. At the root scope the trail is `[Ouro(fieldKey:tabs), Card(fieldKey:cards)]`, so the **inner** `cards` crumb collided with the same-named top-level `cards` field (which sorts before `tabs`) and hijacked resolution.

## Fix

Only the **outermost** crumb owns a given scope — deeper crumbs are consumed as the form descends into nested arrays. The fast-path now keys off `crumbFieldKey(breadcrumbPath[0])` only, instead of `.some(...)` over the whole trail.

## Testing

- Added a regression test in the `structural fieldKey resolution` block reproducing the exact top-level-`cards` + `tabs[].cards` shape (fails before, passes after).
- All 719 sections-editor tests pass; `bun run fmt` clean.

## Affected areas

Sections-editor breadcrumb / drill-down navigation only. No schema or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)