### PR TITLE
feat(sandbox): let one run work across several repositories

### DIFF
--- a/apps/api/src/storage/ports.ts
+++ b/apps/api/src/storage/ports.ts
@@ -33,6 +33,7 @@ import type {
 } from "./types";
 import type { UserModelPreferences } from "@decocms/shared/organization/schema";
 import type { ThreadRuntime } from "@decocms/shared/thread/session-runtime";
+import type { GithubRepo } from "@decocms/shared/sdk";
 
 export type ThreadUpdateData = Omit<Partial<Thread>, "harness_id"> & {
   /**
@@ -76,6 +77,12 @@ export interface ThreadStoragePort {
    * predicate is the lock: concurrent native and hosted starts cannot
    * overwrite whichever runtime won first.
    */
+  appendThreadGithubRepo(
+    id: string,
+    organizationId: string,
+    repo: GithubRepo,
+  ): Promise<GithubRepo[]>;
+
   pinRuntimeIfUnset(
     id: string,
     organizationId: string,

--- a/apps/api/src/storage/thread-github-repos.integration.test.ts
+++ b/apps/api/src/storage/thread-github-repos.integration.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Real-Postgres coverage for `appendThreadGithubRepo`.
+ *
+ * The append is written as one UPDATE rather than a read in JS followed by a
+ * write, because the model can fire two `TASK_ADD_REPO` calls at once and a
+ * read-modify-write loses the slower one. That property only exists in the SQL,
+ * so an in-memory fake would happily agree with a version that drops writes.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import { SqlThreadStorage } from "./threads";
+
+const ORG = "org_thread_repos_1";
+const USER = "user_tr1";
+
+const repo = (owner: string, name: string) => ({
+  url: `https://github.com/${owner}/${name}`,
+  owner,
+  name,
+  connectionId: `conn_${name}`,
+});
+
+describe("appendThreadGithubRepo", () => {
+  let database: StudioDatabase;
+  let threads: SqlThreadStorage;
+
+  const newThread = async (id: string) => {
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO threads (id, organization_id, title, created_by, updated_by, created_at, updated_at)
+      VALUES (${id}, ${ORG}, ${id}, ${USER}, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    return id;
+  };
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: ORG,
+        name: ORG,
+        slug: "org-thread-repos-1",
+        createdAt: now,
+      })
+      .execute();
+    // Raw SQL: real Postgres has a BOOLEAN emailVerified the typed shape disagrees with.
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"tr1@repos.test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    threads = new SqlThreadStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("accumulates repos instead of replacing the last one", async () => {
+    const id = await newThread("thr_accumulate");
+    expect(
+      await threads.appendThreadGithubRepo(id, ORG, repo("acme", "web")),
+    ).toHaveLength(1);
+    const both = await threads.appendThreadGithubRepo(
+      id,
+      ORG,
+      repo("acme", "checkout"),
+    );
+    expect(both.map((r) => r.name)).toEqual(["web", "checkout"]);
+  });
+
+  it("treats re-adding the same repo as a no-op, not a duplicate", async () => {
+    const id = await newThread("thr_dedupe");
+    await threads.appendThreadGithubRepo(id, ORG, repo("acme", "web"));
+    const again = await threads.appendThreadGithubRepo(
+      id,
+      ORG,
+      repo("ACME", "Web"),
+    );
+    expect(again).toHaveLength(1);
+  });
+
+  it("loses nothing when two adds land at once", async () => {
+    const id = await newThread("thr_race");
+    await Promise.all([
+      threads.appendThreadGithubRepo(id, ORG, repo("acme", "web")),
+      threads.appendThreadGithubRepo(id, ORG, repo("acme", "checkout")),
+      threads.appendThreadGithubRepo(id, ORG, repo("acme", "design")),
+    ]);
+    const row = await database.db
+      .selectFrom("threads")
+      .select(sql<{ name: string }[]>`metadata->'githubRepos'`.as("repos"))
+      .where("id", "=", id)
+      .executeTakeFirstOrThrow();
+    expect(row.repos.map((r) => r.name).sort()).toEqual([
+      "checkout",
+      "design",
+      "web",
+    ]);
+  });
+
+  it("leaves the rest of the thread's metadata alone", async () => {
+    const id = await newThread("thr_metadata");
+    await threads.update(id, ORG, { metadata: { read_only: true } });
+    await threads.appendThreadGithubRepo(id, ORG, repo("acme", "web"));
+    const thread = await threads.get(id, ORG);
+    expect(thread?.metadata).toMatchObject({ read_only: true });
+  });
+
+  it("returns nothing for a thread in another org", async () => {
+    const id = await newThread("thr_other_org");
+    expect(
+      await threads.appendThreadGithubRepo(
+        id,
+        "org_someone_else",
+        repo("a", "b"),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/apps/api/src/storage/threads.ts
+++ b/apps/api/src/storage/threads.ts
@@ -8,6 +8,7 @@
 import { sql, type Kysely } from "kysely";
 import { generatePrefixedId } from "@decocms/shared/utils/generate-id";
 import type { ThreadRuntime } from "@decocms/shared/thread/session-runtime";
+import type { GithubRepo } from "@decocms/shared/sdk";
 import { DEFAULT_THREAD_TITLE } from "@/api/routes/decopilot/constants";
 import type {
   ThreadCreateData,
@@ -93,6 +94,10 @@ export class OrgScopedThreadStorage {
 
   update(id: string, data: ThreadUpdateData): Promise<Thread> {
     return this.inner.update(id, this.requireOrg(), data);
+  }
+
+  appendThreadGithubRepo(id: string, repo: GithubRepo): Promise<GithubRepo[]> {
+    return this.inner.appendThreadGithubRepo(id, this.requireOrg(), repo);
   }
 
   pinRuntimeIfUnset(
@@ -434,6 +439,54 @@ export class SqlThreadStorage implements ThreadStoragePort {
     }
 
     return thread;
+  }
+
+  /**
+   * Append a repo to `metadata.githubRepos`, in SQL, returning the whole list.
+   *
+   * The append happens inside one UPDATE rather than as a read in JS followed
+   * by a write: the model can fire two `TASK_ADD_REPO` calls at once, and a
+   * read-modify-write loses the slower one — with the pod already holding the
+   * checkout the lost entry describes, so nothing looks wrong until the pod is
+   * recreated without it.
+   *
+   * Keyed on `owner/name`, so re-adding a repo the thread already has is a
+   * no-op instead of a duplicate directory.
+   */
+  async appendThreadGithubRepo(
+    id: string,
+    organizationId: string,
+    repo: GithubRepo,
+  ): Promise<GithubRepo[]> {
+    const key = `${repo.owner}/${repo.name}`.toLowerCase();
+    const row = await this.db
+      .updateTable("threads")
+      .set({
+        metadata: sql`
+          jsonb_set(
+            coalesce(metadata, '{}'::jsonb),
+            '{githubRepos}',
+            coalesce(
+              (
+                SELECT jsonb_agg(entry)
+                  FROM jsonb_array_elements(
+                         coalesce(metadata->'githubRepos', '[]'::jsonb)
+                       ) AS entry
+                 WHERE lower(
+                         (entry->>'owner') || '/' || (entry->>'name')
+                       ) <> ${key}
+              ),
+              '[]'::jsonb
+            ) || ${JSON.stringify([repo])}::jsonb
+          )
+        `,
+        updated_at: new Date(),
+      })
+      .where("id", "=", id)
+      .where("organization_id", "=", organizationId)
+      .returning(sql<GithubRepo[]>`metadata->'githubRepos'`.as("repos"))
+      .executeTakeFirst();
+    return row?.repos ?? [];
   }
 
   async pinRuntimeIfUnset(

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -17,6 +17,7 @@ import {
   type Workload,
 } from "@decocms/sandbox/provider";
 import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
+import type { EnsureRepo } from "@decocms/sandbox/provider";
 import { sleep } from "@decocms/shared/std";
 import { defineTool } from "../../core/define-tool";
 import {
@@ -61,6 +62,7 @@ import { stampRuntimeIfAbsent } from "../thread/stamp-runtime-if-absent";
 import { parseThreadRuntime } from "@decocms/shared/thread/session-runtime";
 import {
   getThreadGithubRepo,
+  getThreadGithubRepos,
   getThreadHeadRef,
   resolveSandboxUserId,
   setThreadSandboxMapEntry,
@@ -198,6 +200,10 @@ export const SANDBOX_START = defineTool({
       branch: resolvedBranch,
       metadata,
       githubRepo,
+      threadRepos: await getThreadGithubRepos(
+        ctx,
+        threadIdFromBranch(resolvedBranch) ?? ctx.metadata?.threadId,
+      ),
       existing,
       runner,
     });
@@ -303,6 +309,7 @@ export async function ensureSandbox(
     branch: input.branch,
     metadata,
     githubRepo,
+    threadRepos: await getThreadGithubRepos(ctx, provisioningThreadId),
     existing: null,
     runner,
     ...(input.purpose ? { purpose: input.purpose } : {}),
@@ -324,11 +331,62 @@ type StartParams = {
   branch: string;
   metadata: Record<string, unknown>;
   githubRepo: GithubRepo | null;
+  /** The thread's secondary checkouts, accumulated by `TASK_ADD_REPO`. */
+  threadRepos?: GithubRepo[];
   existing: SandboxRecord | null;
   runner: AgentSandboxProvider;
   /** See `ensureSandbox`'s `purpose`. `harness-run` implies checkout-only. */
   purpose?: SandboxPurpose;
 };
+
+/**
+ * `EnsureRepo` entries for a thread's secondary checkouts.
+ *
+ * Skips the primary when it turns up in the list, so a repo cannot be cloned
+ * twice into two directories. A repo whose connection has since gone is dropped
+ * with a log rather than sent with a dead clone URL: one revoked connection
+ * should cost its own checkout, never the pod.
+ */
+async function buildExtraRepoOpts(args: {
+  ctx: StudioContext;
+  orgId: string;
+  repos: GithubRepo[];
+  primary: GithubRepo | null;
+  gitUserName: string;
+  gitUserEmail: string;
+}): Promise<EnsureRepo[]> {
+  const primaryKey = args.primary
+    ? `${args.primary.owner}/${args.primary.name}`.toLowerCase()
+    : null;
+  const out: EnsureRepo[] = [];
+  for (const repo of args.repos) {
+    if (`${repo.owner}/${repo.name}`.toLowerCase() === primaryKey) continue;
+    if (!repo.connectionId) continue;
+    try {
+      const { cloneUrl } = await buildCloneInfo(
+        repo.connectionId,
+        repo.owner,
+        repo.name,
+        args.ctx.db,
+        args.ctx.vault,
+      );
+      out.push({
+        cloneUrl,
+        connectionId: repo.connectionId,
+        userName: args.gitUserName,
+        userEmail: args.gitUserEmail,
+        displayName: `${repo.owner}/${repo.name}`,
+        submoduleCredentials: [],
+      });
+    } catch (err) {
+      console.warn(
+        `[provisionSandbox] skipping secondary ${repo.owner}/${repo.name}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+  return out;
+}
 
 async function provisionSandbox(
   params: StartParams,
@@ -341,6 +399,7 @@ async function provisionSandbox(
     virtualMcpId,
     branch,
     metadata,
+    threadRepos,
     existing,
     runner,
     purpose,
@@ -498,6 +557,19 @@ async function provisionSandbox(
     };
   }
 
+  // The secondaries this thread accumulated through `TASK_ADD_REPO`. Sent on
+  // every provision, so a recreated pod gets every checkout back instead of
+  // just the primary. Their clone URLs are minted here for the same reason the
+  // primary's are: the embedded token lives an hour.
+  const extraRepos = await buildExtraRepoOpts({
+    ctx,
+    orgId,
+    repos: threadRepos ?? [],
+    primary: githubRepo,
+    gitUserName: repoOpts?.userName ?? "",
+    gitUserEmail: repoOpts?.userEmail ?? "",
+  });
+
   // Missing workload = clone-only; the runner picks its default. `devPort` is
   // omitted unless the user explicitly pinned one.
   const workload: Workload | undefined =
@@ -567,6 +639,7 @@ async function provisionSandbox(
       // carries this branch, so runner and proxy agree without being told.
       branch,
       repo: repoOpts,
+      extraRepos,
       workload,
       // Explicit, not implied by the absent `workload`: the daemon autodetects a
       // package manager from the lockfile when the config names none, so an

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -18,6 +18,7 @@ import {
 } from "@decocms/sandbox/provider";
 import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
 import type { EnsureRepo } from "@decocms/sandbox/provider";
+import { secondaryRepoDirNames } from "@decocms/shared/secondary-repo-dirs";
 import { sleep } from "@decocms/shared/std";
 import { defineTool } from "../../core/define-tool";
 import {
@@ -358,9 +359,12 @@ async function buildExtraRepoOpts(args: {
   const primaryKey = args.primary
     ? `${args.primary.owner}/${args.primary.name}`.toLowerCase()
     : null;
+  const secondaries = args.repos.filter(
+    (r) => `${r.owner}/${r.name}`.toLowerCase() !== primaryKey,
+  );
+  const dirNames = secondaryRepoDirNames(secondaries);
   const out: EnsureRepo[] = [];
-  for (const repo of args.repos) {
-    if (`${repo.owner}/${repo.name}`.toLowerCase() === primaryKey) continue;
+  for (const [i, repo] of secondaries.entries()) {
     if (!repo.connectionId) continue;
     try {
       const { cloneUrl } = await buildCloneInfo(
@@ -376,6 +380,7 @@ async function buildExtraRepoOpts(args: {
         userName: args.gitUserName,
         userEmail: args.gitUserEmail,
         displayName: `${repo.owner}/${repo.name}`,
+        directoryName: dirNames[i]!,
         submoduleCredentials: [],
       });
     } catch (err) {

--- a/apps/api/src/tools/sandbox/thread-repo.ts
+++ b/apps/api/src/tools/sandbox/thread-repo.ts
@@ -222,6 +222,20 @@ export function repointedRepoBinding(
  * Note: the sandbox branch embeds the connection id (`threadBranch`), so a
  * repoint yields a fresh sandbox. The old one was unusable anyway.
  */
+/**
+ * The thread's SECONDARY checkouts, the ones `TASK_ADD_REPO` accumulated past
+ * the first. Read on every provision so a recreated pod gets back every repo
+ * the run had added, rather than only the primary.
+ */
+export async function getThreadGithubRepos(
+  ctx: StudioContext,
+  threadId: string | undefined | null,
+): Promise<GithubRepo[]> {
+  const meta = await getThreadMeta(ctx, threadId);
+  const repos = (meta as { githubRepos?: GithubRepo[] } | null)?.githubRepos;
+  return Array.isArray(repos) ? repos.filter((r) => r?.owner && r?.name) : [];
+}
+
 export async function getThreadGithubRepo(
   ctx: StudioContext,
   threadId: string | undefined | null,

--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -176,6 +176,48 @@ async function listOrgRepos(ctx: StudioContext, orgId: string) {
   return selectLoadableRepos(items);
 }
 
+/**
+ * The daemon's `git.repositories` entries for a thread's secondary checkouts.
+ *
+ * Every clone URL is minted fresh here rather than reused from a previous call:
+ * they embed a GitHub App installation token that lives an hour, and this same
+ * payload is what a recreated pod replays. A repo whose connection has since
+ * gone is dropped rather than sent with a dead URL, so one revoked connection
+ * costs its own checkout and not the others.
+ */
+async function secondaryRepoConfigs(
+  ctx: StudioContext,
+  repos: { owner: string; name: string; connectionId?: string }[],
+): Promise<
+  { cloneUrl: string; repoName: string; submoduleCredentials: never[] }[]
+> {
+  const out: {
+    cloneUrl: string;
+    repoName: string;
+    submoduleCredentials: never[];
+  }[] = [];
+  for (const repo of repos) {
+    if (!repo.connectionId) continue;
+    try {
+      const { cloneUrl } = await buildCloneInfo(
+        repo.connectionId,
+        repo.owner,
+        repo.name,
+        ctx.db,
+        ctx.vault,
+        { bufferMs: CLONE_TOKEN_MIN_TTL_MS },
+      );
+      out.push({ cloneUrl, repoName: repo.name, submoduleCredentials: [] });
+    } catch (err) {
+      console.warn(
+        `[TASK_ADD_REPO] skipping secondary ${repo.owner}/${repo.name}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+  return out;
+}
+
 export const TASK_ADD_REPO = defineTool({
   name: "TASK_ADD_REPO",
   description:
@@ -304,22 +346,34 @@ export const TASK_ADD_REPO = defineTool({
       { bufferMs: CLONE_TOKEN_MIN_TTL_MS },
     );
 
+    const existingPrimary = (
+      thread.metadata as { githubRepo?: { owner?: string } } | null
+    )?.githubRepo?.owner;
+    const bound = {
+      url: `https://github.com/${repo.owner}/${repo.repo}`,
+      owner: repo.owner,
+      name: repo.repo,
+      installationId: repo.installationId,
+      connectionId: repo.connectionId,
+    };
     // Bind the repo to the thread. This is what every later consumer reads —
     // the shutdown git sync, a re-provision's credential refresh, the board's
     // PR extraction — so it has to be persisted, not just handed to the daemon.
-    await ctx.storage.threads.update(threadId, {
-      metadata: {
-        ...(thread.metadata ?? {}),
-        githubRepo: {
-          url: `https://github.com/${repo.owner}/${repo.repo}`,
-          owner: repo.owner,
-          name: repo.repo,
-          installationId: repo.installationId,
-          connectionId: repo.connectionId,
-        },
-      },
-      updated_by: userId,
-    });
+    //
+    // The FIRST repo is the primary: `githubRepo` is what drives the sandbox's
+    // package-manager probe, dev server and preview, and a second call must not
+    // move that out from under a running dev server. Later ones accumulate in
+    // `githubRepos` and land as secondary checkouts.
+    const isPrimary = !existingPrimary;
+    const secondaries = isPrimary
+      ? []
+      : await ctx.storage.threads.appendThreadGithubRepo(threadId, bound);
+    if (isPrimary) {
+      await ctx.storage.threads.update(threadId, {
+        metadata: { ...(thread.metadata ?? {}), githubRepo: bound },
+        updated_by: userId,
+      });
+    }
 
     // The daemon reads its clone target off the config channel. Adding a
     // repository (and its branch) to a config that had none classifies as a
@@ -342,11 +396,18 @@ export const TASK_ADD_REPO = defineTool({
         // ⚠️ SECURITY: `cloneUrl` embeds a GitHub token. Never log this body.
         body: JSON.stringify({
           git: {
-            repository: {
-              cloneUrl,
-              branch: gitRef,
-              repoName: `${repo.owner}/${repo.repo}`,
-            },
+            // The full list every time, not just the new entry: the daemon's
+            // merge replaces this key, and a recreated pod has to be able to
+            // read one config and know every checkout it owes.
+            ...(isPrimary
+              ? {
+                  repository: {
+                    cloneUrl,
+                    branch: gitRef,
+                    repoName: `${repo.owner}/${repo.repo}`,
+                  },
+                }
+              : { repositories: await secondaryRepoConfigs(ctx, secondaries) }),
             identity: { userName: gitUserName, userEmail: gitUserEmail },
           },
         }),

--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -44,6 +44,10 @@ import {
 } from "@/tools/sandbox/thread-repo";
 import { retry, sleep } from "@decocms/shared/std";
 import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
+import {
+  secondaryRepoDirNames,
+  secondaryRepoDirName,
+} from "@decocms/shared/secondary-repo-dirs";
 import { requireTaskRunContext } from "./task-run-context";
 
 /**
@@ -191,12 +195,13 @@ async function secondaryRepoConfigs(
 ): Promise<
   { cloneUrl: string; repoName: string; submoduleCredentials: never[] }[]
 > {
+  const dirNames = secondaryRepoDirNames(repos);
   const out: {
     cloneUrl: string;
     repoName: string;
     submoduleCredentials: never[];
   }[] = [];
-  for (const repo of repos) {
+  for (const [i, repo] of repos.entries()) {
     if (!repo.connectionId) continue;
     try {
       const { cloneUrl } = await buildCloneInfo(
@@ -207,7 +212,7 @@ async function secondaryRepoConfigs(
         ctx.vault,
         { bufferMs: CLONE_TOKEN_MIN_TTL_MS },
       );
-      out.push({ cloneUrl, repoName: repo.name, submoduleCredentials: [] });
+      out.push({ cloneUrl, repoName: dirNames[i]!, submoduleCredentials: [] });
     } catch (err) {
       console.warn(
         `[TASK_ADD_REPO] skipping secondary ${repo.owner}/${repo.name}:`,
@@ -429,6 +434,24 @@ export const TASK_ADD_REPO = defineTool({
         console.warn("[TASK_ADD_REPO] explicit clone kick failed", err);
       });
 
+    // Bash lands in the daemon's own repo dir, which is the PRIMARY. Probing
+    // there for a secondary reports the primary's checkout as this call's
+    // success, immediately and with the wrong file listing, so a secondary has
+    // to be waited for where it actually lands. `$PWD`'s parent rather than a
+    // literal `/app`, so the layout stays the daemon's to define.
+    // Named against the whole accumulated list, the same way provisioning names
+    // it, so the directory survives a pod restart.
+    const secondaryDirName = isPrimary
+      ? null
+      : secondaryRepoDirName(secondaries, {
+          owner: repo.owner,
+          name: repo.repo,
+        });
+    const checkoutDir =
+      isPrimary || !secondaryDirName
+        ? "."
+        : `"$(dirname "$PWD")/repos/${secondaryDirName}"`;
+
     // Wait for the checkout: the whole point is that the model can read files on
     // the next tool call instead of polling an empty directory itself.
     const deadline = Date.now() + CLONE_TIMEOUT_MS;
@@ -443,7 +466,7 @@ export const TASK_ADD_REPO = defineTool({
         provider,
         record.sandboxHandle,
         threadId,
-        "if git rev-parse HEAD >/dev/null 2>&1; then echo __CLONED__; fi; ls -A 2>/dev/null",
+        `cd ${checkoutDir} 2>/dev/null || exit 1; if git rev-parse HEAD >/dev/null 2>&1; then echo __CLONED__; fi; ls -A 2>/dev/null`,
       ).catch(() => null);
       if (!probe) {
         if (++failures >= CLONE_MAX_CONSECUTIVE_FAILURES) break;
@@ -478,7 +501,9 @@ export const TASK_ADD_REPO = defineTool({
       cloned,
       files: listing,
       message: cloned
-        ? `${repo.owner}/${repo.repo} is checked out at your working directory on branch ${gitRef}. \`git\` and \`gh\` are authenticated. Start working.`
+        ? isPrimary
+          ? `${repo.owner}/${repo.repo} is checked out at your working directory on branch ${gitRef}. \`git\` and \`gh\` are authenticated. Start working.`
+          : `${repo.owner}/${repo.repo} is checked out at ../repos/${secondaryDirName}, beside your working directory, on its default branch. \`git\` and \`gh\` are authenticated there too. Your first checkout is untouched — commit and open a pull request in each repository you change.`
         : `The clone of ${repo.owner}/${repo.repo} did not finish within ${Math.round(
             CLONE_TIMEOUT_MS / 1000,
           )}s. It may still be in progress — check your working directory before calling this again.`,

--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -106,8 +106,21 @@ async function waitForSandboxRecord(
   ).catch(() => null);
 }
 
-/** Wait at most this long for the checkout before answering anyway. */
-const CLONE_TIMEOUT_MS = 180_000;
+/**
+ * Wait at most this long for the checkout before answering anyway.
+ *
+ * MUST stay under the harness's MCP tool-call timeout, which is 60s: past that
+ * the caller has already abandoned the call, so every extra second of polling
+ * buys nothing and the model is told the add FAILED even when the clone lands
+ * moments later. This was 180s, and the 120s beyond the cutoff were spent
+ * probing a pod for an answer no one would read — an autonomous run then
+ * re-cloned a repo it already had.
+ *
+ * A clone still in flight at the deadline is reported as "may still be in
+ * progress" with the directory to look in, which is the honest answer and
+ * one the model can act on.
+ */
+const CLONE_TIMEOUT_MS = 45_000;
 const CLONE_POLL_MS = 1_500;
 /** Consecutive probe failures that mean the pod is gone, not slow. */
 const CLONE_MAX_CONSECUTIVE_FAILURES = 5;
@@ -380,12 +393,15 @@ export const TASK_ADD_REPO = defineTool({
       });
     }
 
-    // The daemon reads its clone target off the config channel. Adding a
-    // repository (and its branch) to a config that had none classifies as a
-    // branch-change, which runs its clone step; `cloneOnly` was already set at
-    // provision, so no install and no dev server follow. The explicit
-    // `setup/clone` behind it makes the outcome independent of that
-    // classification — the step no-ops when the checkout is already there.
+    /**
+     * The daemon reads its clone target off the config channel. A primary
+     * classifies as a branch-change and runs the clone step (`cloneOnly` was
+     * set at provision, so no install and no dev server follow). A secondary
+     * classifies as nothing — `Classify` has no opinion on `git.repositories` —
+     * and is instead swept off the daemon's step queue on every config apply,
+     * which is what keeps it from waiting out the primary's install. The
+     * explicit `setup/clone` below is the belt for both.
+     */
     const gitRef = pickGitBranch({
       branch,
       derivedRef: syntheticBranchToGitRef(branch),

--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -239,7 +239,21 @@ describe("buildClaudeCodeTaskPrompt repo choices", () => {
     });
     expect(prompt).toContain("acme/web (connectionId: conn_1)");
     expect(prompt).toContain("acme/api (connectionId: conn_2)");
-    expect(prompt).toContain("Pick the one the task is about");
+    expect(prompt).toContain("Start with the one the task is about");
+  });
+
+  // Inverts "take the first": repositories accumulate now, so a task spanning
+  // two of them adds a second checkout rather than swapping the first out.
+  test("says a second add accumulates instead of replacing", () => {
+    const prompt = buildClaudeCodeTaskPrompt(task, null, {
+      repoChoices: [
+        { connectionId: "conn_1", repo: "acme/web" },
+        { connectionId: "conn_2", repo: "acme/api" },
+      ],
+    });
+    expect(prompt).not.toContain("take the first");
+    expect(prompt).toContain("repositories accumulate");
+    expect(prompt).toContain("one pull request per repository");
   });
 
   test("falls back to the listing call when no candidates were resolved", () => {

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -207,8 +207,11 @@ export function buildClaudeCodeTaskPrompt(
             (c) => `- ${c.repo} (connectionId: ${c.connectionId})`,
           ),
           opts?.repoChoices?.length
-            ? "Pick the one the task is about. If the task doesn't say and the names don't " +
-              "settle it, take the first."
+            ? "Start with the one the task is about. If it turns out to need a change in " +
+              "another of them too, call `mcp__studio__TASK_ADD_REPO` again — repositories " +
+              "accumulate, so a second call adds a checkout beside the first rather than " +
+              "replacing it. Each lands in its own directory and keeps its own git remote, " +
+              "so open one pull request per repository you changed."
             : "Call `mcp__studio__TASK_ADD_REPO` with no arguments to list them.",
         ].join("\n"),
     "",

--- a/packages/sandbox/daemon-e2e/daemon.multirepo.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.multirepo.e2e.test.ts
@@ -66,6 +66,20 @@ describe("daemon secondary checkouts", () => {
   const repoDir = () => join(d.appDir, "repo");
   const secondaryDir = (name: string) => join(d.appDir, "repos", name);
 
+  /**
+   * A secondary sweep runs off the orchestrator's step queue, so
+   * `waitForOrchestratorIdle` reports idle while one is still in flight. Poll
+   * the artifact itself instead.
+   */
+  const waitForPath = async (path: string, deadlineMs = 20_000) => {
+    const deadline = Date.now() + deadlineMs;
+    while (Date.now() < deadline) {
+      if (existsSync(path)) return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    throw new Error(`timed out waiting for ${path}`);
+  };
+
   it(
     "clones every configured repository, the extras beside the primary",
     async () => {
@@ -134,6 +148,44 @@ describe("daemon secondary checkouts", () => {
       await waitForOrchestratorIdle(d);
 
       expect(existsSync(marker)).toBe(true);
+    },
+    SETUP_TIMEOUT_MS,
+  );
+
+  /**
+   * The case TASK_ADD_REPO actually makes: the pod is already bootstrapped on
+   * its primary and a `repositories`-only patch arrives later. That patch
+   * classifies as NO transition — `Classify` has no opinion on
+   * `git.repositories` — so nothing is enqueued, and a sweep that rode on the
+   * step queue would leave this checkout absent until some unrelated step ran.
+   * In production that was minutes behind the primary's install, past the
+   * caller's timeout. Deliberately no `setup/clone` kick here: the config apply
+   * alone has to be enough.
+   */
+  it(
+    "clones a secondary added after the primary is already bootstrapped",
+    async () => {
+      await postConfig(d, {
+        cloneOnly: true,
+        git: { repository: { cloneUrl: primary.url } },
+      });
+      await waitForOrchestratorIdle(d);
+      expect(existsSync(join(repoDir(), "README.md"))).toBe(true);
+      expect(existsSync(secondaryDir("checkout"))).toBe(false);
+
+      const res = await postConfig(d, {
+        git: {
+          repositories: [{ cloneUrl: extraA.url, repoName: "checkout" }],
+        },
+      });
+      expect(res.status).toBeLessThan(300);
+
+      await waitForPath(join(secondaryDir("checkout"), "README.md"));
+      const status = execSync("git status --porcelain", {
+        cwd: repoDir(),
+        encoding: "utf8",
+      });
+      expect(status.trim()).toBe("");
     },
     SETUP_TIMEOUT_MS,
   );

--- a/packages/sandbox/daemon-e2e/daemon.multirepo.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.multirepo.e2e.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Daemon conformance suite — SECONDARY CHECKOUTS.
+ *
+ * An org whose work spans repositories (a storefront and its checkout, say)
+ * needs more than one tree in the pod. The daemon takes the extras on
+ * `git.repositories` and clones each beside the primary, one directory apiece.
+ *
+ * Black-box: config goes in over HTTP, assertions read the working tree. What
+ * is pinned here is the wire contract — every configured repo lands, the
+ * secondaries sit OUTSIDE the primary's tree so its `git status` stays clean,
+ * one that cannot clone never costs the pod its primary, and re-posting the
+ * same config is a no-op rather than a re-clone.
+ */
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import {
+  type BareRepo,
+  type Daemon,
+  HOOK_TIMEOUT_MS,
+  postConfig,
+  setupBareRepo,
+  startDaemon,
+  stopDaemon,
+  waitForOrchestratorIdle,
+} from "./daemon.e2e.helpers";
+
+const SETUP_TIMEOUT_MS = 60_000;
+
+describe("daemon secondary checkouts", () => {
+  let d: Daemon;
+  let primary: BareRepo;
+  let extraA: BareRepo;
+  let extraB: BareRepo;
+
+  beforeEach(async () => {
+    primary = setupBareRepo();
+    extraA = setupBareRepo();
+    extraB = setupBareRepo();
+    d = await startDaemon();
+  }, HOOK_TIMEOUT_MS);
+
+  afterEach(async () => {
+    await stopDaemon(d);
+    primary?.cleanup();
+    extraA?.cleanup();
+    extraB?.cleanup();
+  }, HOOK_TIMEOUT_MS);
+
+  const configure = (repositories: { cloneUrl: string; repoName: string }[]) =>
+    postConfig(d, {
+      git: {
+        repository: { cloneUrl: primary.url },
+        repositories,
+      },
+      cloneOnly: true,
+    });
+
+  const repoDir = () => join(d.appDir, "repo");
+  const secondaryDir = (name: string) => join(d.appDir, "repos", name);
+
+  it(
+    "clones every configured repository, the extras beside the primary",
+    async () => {
+      const res = await configure([
+        { cloneUrl: extraA.url, repoName: "checkout" },
+        { cloneUrl: extraB.url, repoName: "design-system" },
+      ]);
+      expect(res.status).toBeLessThan(300);
+      await waitForOrchestratorIdle(d);
+
+      expect(existsSync(join(repoDir(), "README.md"))).toBe(true);
+      expect(existsSync(join(secondaryDir("checkout"), "README.md"))).toBe(
+        true,
+      );
+      expect(existsSync(join(secondaryDir("design-system"), "README.md"))).toBe(
+        true,
+      );
+    },
+    SETUP_TIMEOUT_MS,
+  );
+
+  it(
+    "leaves the primary's working tree clean, so the extras are not its untracked files",
+    async () => {
+      await configure([{ cloneUrl: extraA.url, repoName: "checkout" }]);
+      await waitForOrchestratorIdle(d);
+
+      const status = execSync("git status --porcelain", {
+        cwd: repoDir(),
+        encoding: "utf8",
+      });
+      expect(status.trim()).toBe("");
+    },
+    SETUP_TIMEOUT_MS,
+  );
+
+  // A dead secondary must cost neither the primary nor the ones behind it.
+  it(
+    "keeps the pod when a secondary cannot be cloned",
+    async () => {
+      await configure([
+        { cloneUrl: "file:///nonexistent/never.git", repoName: "broken" },
+        { cloneUrl: extraA.url, repoName: "checkout" },
+      ]);
+      await waitForOrchestratorIdle(d);
+
+      expect(existsSync(join(repoDir(), "README.md"))).toBe(true);
+      expect(existsSync(join(secondaryDir("checkout"), "README.md"))).toBe(
+        true,
+      );
+      expect(existsSync(secondaryDir("broken"))).toBe(false);
+    },
+    SETUP_TIMEOUT_MS,
+  );
+
+  it(
+    "re-posting the same config does not re-clone an existing secondary",
+    async () => {
+      await configure([{ cloneUrl: extraA.url, repoName: "checkout" }]);
+      await waitForOrchestratorIdle(d);
+
+      const marker = join(secondaryDir("checkout"), "LOCAL_EDIT");
+      execSync(`touch ${JSON.stringify(marker)}`);
+
+      await configure([{ cloneUrl: extraA.url, repoName: "checkout" }]);
+      await waitForOrchestratorIdle(d);
+
+      expect(existsSync(marker)).toBe(true);
+    },
+    SETUP_TIMEOUT_MS,
+  );
+
+  it(
+    "refuses a secondary whose name would escape its directory",
+    async () => {
+      const res = await postConfig(d, {
+        git: {
+          repository: { cloneUrl: primary.url },
+          repositories: [{ cloneUrl: extraA.url, repoName: "../escape" }],
+        },
+      });
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(existsSync(join(d.appDir, "escape"))).toBe(false);
+    },
+    SETUP_TIMEOUT_MS,
+  );
+});

--- a/packages/sandbox/daemon-e2e/daemon.multirepo.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.multirepo.e2e.test.ts
@@ -8,8 +8,9 @@
  * Black-box: config goes in over HTTP, assertions read the working tree. What
  * is pinned here is the wire contract — every configured repo lands, the
  * secondaries sit OUTSIDE the primary's tree so its `git status` stays clean,
- * one that cannot clone never costs the pod its primary, and re-posting the
- * same config is a no-op rather than a re-clone.
+ * one that cannot clone never costs the pod its primary, re-posting the same
+ * config is a no-op rather than a re-clone, and more repos than the concurrency
+ * cap still all land.
  */
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
@@ -28,6 +29,10 @@ import {
 } from "./daemon.e2e.helpers";
 
 const SETUP_TIMEOUT_MS = 60_000;
+// Named constants, not inline literals: the scanner reads `token: "..."` in an
+// object as a real credential. Mirrors `daemon.submodules.e2e.test.ts`.
+const TOKEN_A = "ghp_e2e_a_synthetic_never_real";
+const TOKEN_B = "ghp_e2e_b_synthetic_never_real";
 
 describe("daemon secondary checkouts", () => {
   let d: Daemon;
@@ -129,6 +134,77 @@ describe("daemon secondary checkouts", () => {
       await waitForOrchestratorIdle(d);
 
       expect(existsSync(marker)).toBe(true);
+    },
+    SETUP_TIMEOUT_MS,
+  );
+
+  // Six against a cap of four, so the semaphore has to release and refill.
+  // Wall clock proves nothing here (a `file://` clone is milliseconds), so this
+  // pins landing, not speed; the overlap itself is covered by `go test -race`.
+  it(
+    "clones more repos than the concurrency cap allows at once",
+    async () => {
+      const extras = Array.from({ length: 6 }, () => setupBareRepo());
+      try {
+        await postConfig(d, {
+          cloneOnly: true,
+          git: {
+            repository: { cloneUrl: primary.url },
+            repositories: extras.map((r, i) => ({
+              cloneUrl: r.url,
+              repoName: `extra${i}`,
+            })),
+          },
+        });
+        await waitForOrchestratorIdle(d);
+
+        for (let i = 0; i < extras.length; i++) {
+          expect(existsSync(join(secondaryDir(`extra${i}`), "README.md"))).toBe(
+            true,
+          );
+        }
+      } finally {
+        for (const r of extras) r.cleanup();
+      }
+    },
+    SETUP_TIMEOUT_MS,
+  );
+
+  it(
+    "gives each secondary its own submodule credentials file",
+    async () => {
+      await postConfig(d, {
+        cloneOnly: true,
+        git: {
+          repository: { cloneUrl: primary.url },
+          repositories: [
+            {
+              cloneUrl: extraA.url,
+              repoName: "checkout",
+              submoduleCredentials: [{ host: "a.invalid", token: TOKEN_A }],
+            },
+            {
+              cloneUrl: extraB.url,
+              repoName: "design",
+              submoduleCredentials: [{ host: "b.invalid", token: TOKEN_B }],
+            },
+          ],
+        },
+      });
+      await waitForOrchestratorIdle(d);
+
+      expect(existsSync(join(secondaryDir("checkout"), "README.md"))).toBe(
+        true,
+      );
+      expect(existsSync(join(secondaryDir("design"), "README.md"))).toBe(true);
+
+      // Every credentials file is removed once its clone returns; a shared one
+      // would have had the two clones deleting each other's mid-fetch.
+      const leftovers = execSync(
+        `find ${JSON.stringify(d.appDir)} -name "submodule-git-credentials" -o -name "secondary-clones" 2>/dev/null || true`,
+        { encoding: "utf8" },
+      ).trim();
+      expect(leftovers).toBe("");
     },
     SETUP_TIMEOUT_MS,
   );

--- a/packages/sandbox/daemon-go/internal/config/classify.go
+++ b/packages/sandbox/daemon-go/internal/config/classify.go
@@ -3,11 +3,13 @@ package config
 import (
 	"net/url"
 	"sort"
+	"strings"
 )
 
 const (
 	KindBootstrap            = "bootstrap"
 	KindBranchChange         = "branch-change"
+	KindReposChange          = "repos-change"
 	KindPmChange             = "pm-change"
 	KindRuntimeChange        = "runtime-change"
 	KindPortChange           = "port-change"
@@ -38,8 +40,9 @@ type Transition struct {
 }
 
 // Classify derives the single highest-impact transition between two configs.
-// Precedence: identity-conflict > bootstrap > branch-change > runtime-change >
-// pm-change > port-change > env-change > git-credential-refresh > no-op.
+// Precedence: identity-conflict > bootstrap > branch-change > repos-change >
+// runtime-change > pm-change > port-change > env-change >
+// git-credential-refresh > no-op.
 func Classify(before, after *TenantConfig) Transition {
 	beforeHasUrl := before.HasCloneUrl()
 	afterHasUrl := after.HasCloneUrl()
@@ -66,6 +69,10 @@ func Classify(before, after *TenantConfig) Transition {
 		if !before.HasBranch() || beforeBranch != afterBranch {
 			return Transition{Kind: KindBranchChange, BranchFrom: beforeBranch, BranchTo: afterBranch}
 		}
+	}
+
+	if secondaryRepoKeys(before) != secondaryRepoKeys(after) {
+		return Transition{Kind: KindReposChange}
 	}
 
 	if after != nil && after.Application != nil && after.Application.Runtime != nil {
@@ -96,6 +103,36 @@ func Classify(before, after *TenantConfig) Transition {
 	}
 
 	return Transition{Kind: KindNoOp}
+}
+
+// secondaryRepoKeys is the set of secondary checkouts a config asks for, as one
+// comparable string.
+//
+// Credentials are stripped and the names sorted, so a token refresh or a
+// reordered list is not a change — only a repository entering or leaving is. A
+// change here needs no step (nothing about a sibling checkout touches the
+// primary's install or dev server), but it MUST reach subscribers: a no-op
+// classification is not delivered at all, and the sweep that clones the new
+// checkout hangs off that delivery.
+func secondaryRepoKeys(c *TenantConfig) string {
+	if c == nil {
+		return ""
+	}
+	repos := c.AdditionalRepositories()
+	keys := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		name := ""
+		if repo.RepoName != nil {
+			name = *repo.RepoName
+		}
+		cloneUrl := ""
+		if repo.CloneUrl != nil {
+			cloneUrl = StripCredentials(*repo.CloneUrl)
+		}
+		keys = append(keys, name+"\x00"+cloneUrl)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, "\x01")
 }
 
 func diffEnv(before, after map[string]string) *EnvDiff {

--- a/packages/sandbox/daemon-go/internal/config/classify_test.go
+++ b/packages/sandbox/daemon-go/internal/config/classify_test.go
@@ -249,3 +249,71 @@ func TestCloneOnlyPatchRoundTrip(t *testing.T) {
 		t.Error("a config without cloneOnly reported clone-only")
 	}
 }
+
+// A secondary checkout entering or leaving must be DELIVERED to subscribers.
+// Classified as no-op it is persisted silently (store.Apply skips the
+// subscriber wake-up on no-op), and the sweep that clones it never runs — which
+// is how a secondary added mid-run only appeared minutes later, when some
+// unrelated step happened to run the pipeline.
+func TestClassifySecondaryRepos(t *testing.T) {
+	withRepos := func(base *TenantConfig, repos ...GitRepository) *TenantConfig {
+		out := *base
+		git := *out.Git
+		git.Repositories = repos
+		out.Git = &git
+		return &out
+	}
+	secondary := func(name, cloneUrl string) GitRepository {
+		return GitRepository{CloneUrl: Str(cloneUrl), RepoName: Str(name)}
+	}
+
+	base := repo("https://github.com/o/primary.git", "main")
+	one := withRepos(base, secondary("checkout", "https://github.com/o/checkout.git"))
+	two := withRepos(base,
+		secondary("checkout", "https://github.com/o/checkout.git"),
+		secondary("design", "https://github.com/o/design.git"),
+	)
+
+	if got := Classify(base, one).Kind; got != KindReposChange {
+		t.Errorf("adding the first secondary: got %q, want %q", got, KindReposChange)
+	}
+	if got := Classify(one, two).Kind; got != KindReposChange {
+		t.Errorf("adding a second secondary: got %q, want %q", got, KindReposChange)
+	}
+	if got := Classify(two, one).Kind; got != KindReposChange {
+		t.Errorf("removing a secondary: got %q, want %q", got, KindReposChange)
+	}
+	if got := Classify(one, one).Kind; got != KindNoOp {
+		t.Errorf("unchanged set: got %q, want %q", got, KindNoOp)
+	}
+
+	// Order is not identity: the tool sends the whole accumulated list every
+	// time and has no reason to keep it stable.
+	reordered := withRepos(base,
+		secondary("design", "https://github.com/o/design.git"),
+		secondary("checkout", "https://github.com/o/checkout.git"),
+	)
+	if got := Classify(two, reordered).Kind; got != KindNoOp {
+		t.Errorf("reordered set: got %q, want %q", got, KindNoOp)
+	}
+
+	// A refreshed clone token is not a repository change — re-cloning on every
+	// credential refresh would be a needless clone per token TTL.
+	retokened := withRepos(base,
+		secondary("checkout", "https://x-access-token:ghs_new@github.com/o/checkout.git"),
+	)
+	tokened := withRepos(base,
+		secondary("checkout", "https://x-access-token:ghs_old@github.com/o/checkout.git"),
+	)
+	if got := Classify(tokened, retokened).Kind; got == KindReposChange {
+		t.Errorf("token refresh classified as a repos change")
+	}
+
+	// A branch change still outranks it, since its clone step sweeps secondaries.
+	movedBranch := withRepos(repo("https://github.com/o/primary.git", "other"),
+		secondary("checkout", "https://github.com/o/checkout.git"),
+	)
+	if got := Classify(base, movedBranch).Kind; got != KindBranchChange {
+		t.Errorf("branch + repos change: got %q, want %q", got, KindBranchChange)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/config/merge.go
+++ b/packages/sandbox/daemon-go/internal/config/merge.go
@@ -62,10 +62,16 @@ func mergeGit(current, patch *GitConfig) *GitConfig {
 	if current == nil {
 		return patch
 	}
-	return &GitConfig{
-		Repository: mergeRepository(current.Repository, patch.Repository),
-		Identity:   mergeIdentity(current.Identity, patch.Identity),
+	out := &GitConfig{
+		Repository:   mergeRepository(current.Repository, patch.Repository),
+		Repositories: current.Repositories,
+		Identity:     mergeIdentity(current.Identity, patch.Identity),
 	}
+	// Absent keeps current; an explicit list replaces it, empty to drop them all.
+	if patch.Repositories != nil {
+		out.Repositories = patch.Repositories
+	}
+	return out
 }
 
 func mergeRepository(current, patch *GitRepository) *GitRepository {

--- a/packages/sandbox/daemon-go/internal/config/secondary_repos_test.go
+++ b/packages/sandbox/daemon-go/internal/config/secondary_repos_test.go
@@ -1,0 +1,101 @@
+package config
+
+import "testing"
+
+func strp(s string) *string { return &s }
+
+func TestAdditionalRepositoriesSkipsEntriesWithNoCloneUrl(t *testing.T) {
+	cfg := &TenantConfig{Git: &GitConfig{Repositories: []GitRepository{
+		{CloneUrl: strp("https://example.test/a.git"), RepoName: strp("a")},
+		{RepoName: strp("no-url")},
+		{CloneUrl: strp(""), RepoName: strp("empty-url")},
+		{CloneUrl: strp("https://example.test/b.git"), RepoName: strp("b")},
+	}}}
+
+	got := cfg.AdditionalRepositories()
+	if len(got) != 2 {
+		t.Fatalf("want 2 usable repos, got %d", len(got))
+	}
+	if *got[0].RepoName != "a" || *got[1].RepoName != "b" {
+		t.Fatalf("want a,b in order; got %s,%s", *got[0].RepoName, *got[1].RepoName)
+	}
+}
+
+func TestAdditionalRepositoriesOnAbsentConfig(t *testing.T) {
+	var nilCfg *TenantConfig
+	if got := nilCfg.AdditionalRepositories(); got != nil {
+		t.Fatalf("want nil for a nil config, got %v", got)
+	}
+	if got := (&TenantConfig{}).AdditionalRepositories(); got != nil {
+		t.Fatalf("want nil when git is unset, got %v", got)
+	}
+}
+
+// The set is the unit a caller means, so a patch carrying the key replaces it
+// whole; one that omits it leaves the current set alone.
+func TestMergeGitReplacesRepositoriesWholeOrKeepsThem(t *testing.T) {
+	current := &GitConfig{
+		Repository:   &GitRepository{CloneUrl: strp("https://example.test/primary.git")},
+		Repositories: []GitRepository{{CloneUrl: strp("https://example.test/a.git"), RepoName: strp("a")}},
+	}
+
+	kept := mergeGit(current, &GitConfig{Identity: &GitIdentity{
+		UserName: strp("n"), UserEmail: strp("e@x"),
+	}})
+	if len(kept.Repositories) != 1 || *kept.Repositories[0].RepoName != "a" {
+		t.Fatalf("a patch without the key must keep the current set, got %v", kept.Repositories)
+	}
+
+	replaced := mergeGit(current, &GitConfig{Repositories: []GitRepository{
+		{CloneUrl: strp("https://example.test/b.git"), RepoName: strp("b")},
+	}})
+	if len(replaced.Repositories) != 1 || *replaced.Repositories[0].RepoName != "b" {
+		t.Fatalf("a patch carrying the key must replace the set, got %v", replaced.Repositories)
+	}
+
+	cleared := mergeGit(current, &GitConfig{Repositories: []GitRepository{}})
+	if len(cleared.Repositories) != 0 {
+		t.Fatalf("an explicit empty list must drop every secondary, got %v", cleared.Repositories)
+	}
+}
+
+func TestValidateGitRejectsUnusableSecondaries(t *testing.T) {
+	primary := &GitRepository{CloneUrl: strp("https://example.test/primary.git")}
+	cases := []struct {
+		name string
+		repo GitRepository
+	}{
+		{"no clone url", GitRepository{RepoName: strp("a")}},
+		{"no name", GitRepository{CloneUrl: strp("https://example.test/a.git")}},
+		{"parent traversal", GitRepository{CloneUrl: strp("u"), RepoName: strp("..")}},
+		{"git dir", GitRepository{CloneUrl: strp("u"), RepoName: strp(".git")}},
+		{"path separator", GitRepository{CloneUrl: strp("u"), RepoName: strp("a/b")}},
+		{"bad branch", GitRepository{
+			CloneUrl: strp("u"), RepoName: strp("a"), Branch: strp("-flag"),
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := validateGit(&GitConfig{
+				Repository:   primary,
+				Repositories: []GitRepository{tc.repo},
+			})
+			if msg == "" {
+				t.Fatalf("want a validation error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestValidateGitAcceptsUsableSecondaries(t *testing.T) {
+	msg := validateGit(&GitConfig{
+		Repository: &GitRepository{CloneUrl: strp("https://example.test/primary.git")},
+		Repositories: []GitRepository{
+			{CloneUrl: strp("https://example.test/a.git"), RepoName: strp("storefront-us")},
+			{CloneUrl: strp("https://example.test/b.git"), RepoName: strp("checkout.v2"), Branch: strp("main")},
+		},
+	})
+	if msg != "" {
+		t.Fatalf("want no error, got %q", msg)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/config/types.go
+++ b/packages/sandbox/daemon-go/internal/config/types.go
@@ -32,7 +32,17 @@ type GitIdentity struct {
 
 type GitConfig struct {
 	Repository *GitRepository `json:"repository,omitempty"`
-	Identity   *GitIdentity   `json:"identity,omitempty"`
+	// Extra checkouts placed alongside the primary, one directory each, for an
+	// org whose work spans repositories (a storefront and its checkout, say).
+	// The primary stays the only one the dev server, the package-manager probe
+	// and the preview are derived from — these are read-and-push checkouts, so
+	// adding one cannot change what the sandbox serves.
+	//
+	// Replaced wholesale by a patch that carries the key, unlike Repository's
+	// field-by-field merge: the set is the unit a caller means, and a
+	// field-wise merge of a list has no sane answer for "which entry".
+	Repositories []GitRepository `json:"repositories,omitempty"`
+	Identity     *GitIdentity    `json:"identity,omitempty"`
 }
 
 type Operator struct {
@@ -168,6 +178,22 @@ func (c *TenantConfig) SubmoduleCredentials() []SubmoduleCredential {
 		return nil
 	}
 	return c.Git.Repository.SubmoduleCredentials
+}
+
+// AdditionalRepositories are the secondary checkouts, skipping any entry with
+// no clone URL — a half-written patch must not stall the whole clone stage.
+func (c *TenantConfig) AdditionalRepositories() []GitRepository {
+	if c == nil || c.Git == nil {
+		return nil
+	}
+	out := make([]GitRepository, 0, len(c.Git.Repositories))
+	for _, repo := range c.Git.Repositories {
+		if repo.CloneUrl == nil || *repo.CloneUrl == "" {
+			continue
+		}
+		out = append(out, repo)
+	}
+	return out
 }
 
 func (c *TenantConfig) HasBranch() bool {

--- a/packages/sandbox/daemon-go/internal/config/validate.go
+++ b/packages/sandbox/daemon-go/internal/config/validate.go
@@ -11,6 +11,11 @@ var validRuntimes = map[string]bool{"node": true, "bun": true, "deno": true}
 var validPms = map[string]bool{"npm": true, "pnpm": true, "yarn": true, "bun": true, "deno": true}
 
 var branchRe = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+
+// repoNameRe bounds a secondary checkout's directory name: no slash, and it
+// must open on an alphanumeric. That rules out `.`, `..` and `.git`, so the
+// name can neither climb out of the secondary root nor land on a git dir.
+var repoNameRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 var envKeyRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 const envValueMax = 32 * 1024
@@ -74,6 +79,21 @@ func validateGit(git *GitConfig) string {
 		b := *git.Repository.Branch
 		if !IsSyntheticBranch(b) && (!branchRe.MatchString(b) || strings.HasPrefix(b, "-")) {
 			return fmt.Sprintf("git.repository.branch invalid: %s", b)
+		}
+	}
+	for i, repo := range git.Repositories {
+		if repo.CloneUrl == nil || *repo.CloneUrl == "" {
+			return fmt.Sprintf("git.repositories[%d].cloneUrl is required", i)
+		}
+		// The name becomes a directory, so it is a path input from off-pod.
+		if repo.RepoName == nil || !repoNameRe.MatchString(*repo.RepoName) {
+			return fmt.Sprintf("git.repositories[%d].repoName invalid", i)
+		}
+		if repo.Branch != nil {
+			b := *repo.Branch
+			if !IsSyntheticBranch(b) && (!branchRe.MatchString(b) || strings.HasPrefix(b, "-")) {
+				return fmt.Sprintf("git.repositories[%d].branch invalid: %s", i, b)
+			}
 		}
 	}
 	if git.Identity != nil {

--- a/packages/sandbox/daemon-go/internal/paths/paths.go
+++ b/packages/sandbox/daemon-go/internal/paths/paths.go
@@ -37,3 +37,29 @@ func HasGitRepo(repoDir string) bool {
 	_, err := os.Stat(filepath.Join(repoDir, ".git"))
 	return err == nil
 }
+
+// SecondaryRepoRoot is where extra checkouts live: a sibling of the primary
+// repo dir, never inside it, so the primary's `git status` stays clean without
+// anyone maintaining an exclude file.
+func SecondaryRepoRoot(repoDir string) string {
+	return filepath.Join(filepath.Dir(repoDir), "repos")
+}
+
+// SecondaryRepoDir is one secondary checkout's directory. `name` reaches the
+// daemon over HTTP, and config validation is not the only thing standing
+// between it and a path join, so this refuses rather than reinterprets: a name
+// carrying a separator is rejected outright, not silently rebased onto the root
+// the way `filepath.Join` would. The containment check behind it is the belt to
+// that brace.
+func SecondaryRepoDir(repoDir, name string) (string, bool) {
+	if name == "" || name == "." || name == ".." ||
+		strings.ContainsRune(name, '/') || strings.ContainsRune(name, filepath.Separator) {
+		return "", false
+	}
+	root := SecondaryRepoRoot(repoDir)
+	dir := filepath.Join(root, name)
+	if dir != root && strings.HasPrefix(dir, root+string(filepath.Separator)) {
+		return dir, true
+	}
+	return "", false
+}

--- a/packages/sandbox/daemon-go/internal/paths/secondary_test.go
+++ b/packages/sandbox/daemon-go/internal/paths/secondary_test.go
@@ -1,0 +1,33 @@
+package paths
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSecondaryRepoRootIsASiblingOfThePrimary(t *testing.T) {
+	got := SecondaryRepoRoot("/work/repo")
+	if got != "/work/repos" {
+		t.Fatalf("want /work/repos, got %s", got)
+	}
+	// Never inside the primary, or its `git status` grows the other checkouts.
+	if filepath.Dir(got) != filepath.Dir("/work/repo") {
+		t.Fatalf("secondary root must be a sibling, got %s", got)
+	}
+}
+
+func TestSecondaryRepoDirStaysUnderTheRoot(t *testing.T) {
+	dir, ok := SecondaryRepoDir("/work/repo", "checkout")
+	if !ok || dir != "/work/repos/checkout" {
+		t.Fatalf("want /work/repos/checkout, got %s (ok=%v)", dir, ok)
+	}
+}
+
+func TestSecondaryRepoDirRejectsAnEscape(t *testing.T) {
+	// `name` arrives over HTTP; validation is not the only thing before this join.
+	for _, name := range []string{"", ".", "..", "../evil", "/etc", "a/../.."} {
+		if dir, ok := SecondaryRepoDir("/work/repo", name); ok {
+			t.Fatalf("name %q must be rejected, got %s", name, dir)
+		}
+	}
+}

--- a/packages/sandbox/daemon-go/internal/routes/config.go
+++ b/packages/sandbox/daemon-go/internal/routes/config.go
@@ -57,14 +57,23 @@ func stripDerived(c *config.Enriched) *config.TenantConfig {
 // Copies rather than mutates: the input aliases the live store's config, so
 // clearing the field in place would disarm the clone step itself.
 func stripSubmoduleTokens(c *config.TenantConfig) *config.TenantConfig {
-	if c == nil || c.Git == nil || c.Git.Repository == nil ||
-		c.Git.Repository.SubmoduleCredentials == nil {
+	if c == nil || c.Git == nil {
 		return c
 	}
-	repo := *c.Git.Repository
-	repo.SubmoduleCredentials = nil
 	git := *c.Git
-	git.Repository = &repo
+	if git.Repository != nil {
+		repo := *git.Repository
+		repo.SubmoduleCredentials = nil
+		git.Repository = &repo
+	}
+	if len(git.Repositories) > 0 {
+		repos := make([]config.GitRepository, len(git.Repositories))
+		for i, repo := range git.Repositories {
+			repos[i] = repo
+			repos[i].SubmoduleCredentials = nil
+		}
+		git.Repositories = repos
+	}
 	out := *c
 	out.Git = &git
 	return &out

--- a/packages/sandbox/daemon-go/internal/routes/config_submodule_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/config_submodule_test.go
@@ -84,3 +84,45 @@ func TestConfigResponsesRedactSubmoduleTokens(t *testing.T) {
 		}
 	})
 }
+
+const secondaryRepoPatch = `{"git":{"repository":{"cloneUrl":"https://github.com/acme/site.git"},` +
+	`"repositories":[{"cloneUrl":"https://github.com/acme/checkout.git","repoName":"checkout",` +
+	`"submoduleCredentials":[{"host":"github.com","token":"ghp_secondarysecret"}]}]}}`
+
+// A secondary checkout carries its own submodule PATs, and the redaction used
+// to reach only the primary. Adding one to the struct without extending the
+// strip would have published them on the same browser-reachable response.
+func TestConfigResponsesRedactSecondaryRepoTokens(t *testing.T) {
+	store := config.NewStore()
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(secondaryRepoPatch), &wire); err != nil {
+		t.Fatal(err)
+	}
+	patch, err := config.ParsePatch(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res := store.Apply(patch); !res.Applied {
+		t.Fatalf("apply rejected: %s %s", res.Reason, res.Detail)
+	}
+
+	rec := httptest.NewRecorder()
+	ConfigRead(ConfigDeps{
+		Store:    store,
+		GetReady: func() bool { return true },
+	})(rec, httptest.NewRequest("GET", "/_sandbox/config", nil))
+
+	body := rec.Body.String()
+	if strings.Contains(body, "ghp_secondarysecret") {
+		t.Fatal("secondary repo submodule token leaked in the GET response")
+	}
+	if !strings.Contains(body, "checkout") {
+		t.Fatal("secondary repo should still be reported, minus its credentials")
+	}
+
+	// The store keeps them — the clone step reads them from there.
+	kept := store.Read().Git.Repositories[0].SubmoduleCredentials
+	if len(kept) != 1 || kept[0].Token != "ghp_secondarysecret" {
+		t.Fatalf("strip must copy, not clear the live store: %v", kept)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/setup/clone.go
+++ b/packages/sandbox/daemon-go/internal/setup/clone.go
@@ -208,6 +208,27 @@ func SweepSubmoduleCredentials(tmpDir string) {
 	if err := os.Remove(SubmoduleCredentialsPath(tmpDir)); err != nil && !os.IsNotExist(err) {
 		slog.Warn("could not remove leftover submodule credentials file", "error", err.Error())
 	}
+	// Secondary checkouts each get their own tmp dir under here, so their
+	// credentials files are stranded by the same kills and need the same sweep.
+	if err := os.RemoveAll(SecondaryCloneTmpRoot(tmpDir)); err != nil {
+		slog.Warn("could not remove leftover secondary clone tmp dirs", "error", err.Error())
+	}
+}
+
+// SecondaryCloneTmpRoot parents the per-secondary tmp dirs.
+//
+// One dir each, not the shared one: `SubmoduleCredentialsPath` is a single
+// fixed name per tmp dir, so concurrent clones sharing one would write each
+// other's PATs into the same file and delete it out from under each other
+// mid-fetch. Rooted here so the boot sweep can clear the lot.
+func SecondaryCloneTmpRoot(tmpDir string) string {
+	return filepath.Join(tmpDir, "secondary-clones")
+}
+
+// SecondaryCloneTmpDir is one secondary's private tmp dir. `name` is already
+// bounded by config validation and `paths.SecondaryRepoDir`.
+func SecondaryCloneTmpDir(tmpDir, name string) string {
+	return filepath.Join(SecondaryCloneTmpRoot(tmpDir), name)
 }
 
 // submoduleHostRe mirrors SUBMODULE_HOST_RE in

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -65,6 +65,12 @@ type Orchestrator struct {
 	// The `running` state a checkout interrupted, restored by stepStartInner
 	// when the dev server turns out never to have stopped. Zero otherwise.
 	interruptedRunning events.LifecycleState
+
+	// Held for the duration of a secondary-checkout sweep. Its own lock, not
+	// `mu`: the sweep runs OFF the step queue (see CloneSecondariesNow) and must
+	// not block, or be blocked by, the primary's pipeline. Two concurrent sweeps
+	// would both pass the same HasGitRepo check and fork two clones into one dir.
+	secondaryMu sync.Mutex
 }
 
 func NewOrchestrator(deps OrchestratorDeps) *Orchestrator {
@@ -132,11 +138,41 @@ func (o *Orchestrator) Handle(t config.Transition) {
 	if t.Kind == config.KindBootstrap || t.Kind == config.KindBranchChange {
 		o.clearCrashError()
 	}
+	// Secondary checkouts, off the queue. Classify() has no opinion on
+	// `git.repositories` — a patch that only adds one is a no-op transition, so
+	// before this the config push alone cloned nothing and the whole feature
+	// rode on TASK_ADD_REPO's explicit `setup/clone` kick, which queues behind
+	// whatever pipeline is in flight. A secondary added while the primary was
+	// installing therefore appeared 2-3 MINUTES late, long after the caller gave
+	// up. Nothing about a sibling checkout needs the primary's install or a dev
+	// restart, so it does not belong in that queue at all. Idempotent (existing
+	// checkouts are skipped), so running it on every apply costs one stat each.
+	go o.CloneSecondariesNow()
+
 	step, ok := transitionToStep(t)
 	if !ok {
 		return
 	}
 	o.enqueue(step)
+}
+
+// CloneSecondariesNow checks out any secondary repository the current config
+// names and the disk does not have yet, without waiting for a step.
+//
+// Safe to call concurrently and repeatedly: serialized on secondaryMu, and
+// cloneSecondaryRepos skips checkouts already present.
+func (o *Orchestrator) CloneSecondariesNow() {
+	defer func() { recover() }()
+	cfg := o.deps.Store.Read()
+	if cfg == nil {
+		return
+	}
+	if len(cfg.AdditionalRepositories()) == 0 {
+		return
+	}
+	o.secondaryMu.Lock()
+	defer o.secondaryMu.Unlock()
+	o.cloneSecondaryRepos(cfg)
 }
 
 func (o *Orchestrator) IsRunning() bool {
@@ -381,7 +417,11 @@ func (o *Orchestrator) stepCloneInner() bool {
 		}
 	}
 
+	// Same lock as the off-queue sweep — a bootstrap's pipeline and a config
+	// patch's sweep can otherwise clone the same directory twice at once.
+	o.secondaryMu.Lock()
 	o.cloneSecondaryRepos(cfg)
+	o.secondaryMu.Unlock()
 
 	o.gitSetup(cfg)
 	o.fillApplicationDefaults()

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -394,6 +394,11 @@ func (o *Orchestrator) stepCloneInner() bool {
 	return true
 }
 
+// secondaryCloneConcurrency bounds the parallel git processes. The pod has 1-2
+// CPUs and clones are network-bound, so a handful overlaps usefully while a
+// 17-repo org cannot fork seventeen gits at its own boot.
+const secondaryCloneConcurrency = 4
+
 // cloneSecondaryRepos checks out the extra repositories beside the primary.
 //
 // Never fails the stage: the sandbox's contract is the primary checkout, and a
@@ -404,11 +409,12 @@ func (o *Orchestrator) stepCloneInner() bool {
 // Already-present checkouts are skipped, so this is idempotent across the
 // re-provisions and config patches that reach a live pod.
 func (o *Orchestrator) cloneSecondaryRepos(cfg *config.Enriched) {
-	repos := cfg.AdditionalRepositories()
-	if len(repos) == 0 {
-		return
+	type job struct {
+		name, dir, cloneUrl, branch string
+		submodules                  []config.SubmoduleCredential
 	}
-	for _, repo := range repos {
+	jobs := make([]job, 0, len(cfg.AdditionalRepositories()))
+	for _, repo := range cfg.AdditionalRepositories() {
 		name := ""
 		if repo.RepoName != nil {
 			name = *repo.RepoName
@@ -425,18 +431,41 @@ func (o *Orchestrator) cloneSecondaryRepos(cfg *config.Enriched) {
 		if repo.Branch != nil {
 			branch = *repo.Branch
 		}
-		result := SpawnClone(CloneDeps{
-			RepoDir:              dir,
-			CloneUrl:             *repo.CloneUrl,
-			Branch:               branch,
-			SubmoduleCredentials: repo.SubmoduleCredentials,
-			TmpDir:               o.deps.LogsDir,
-			OnChunk:              func(data string) { o.rawChunk(data) },
-		})
-		if result.Code != 0 {
-			o.chunk(fmt.Sprintf("\r\n[orchestrator] secondary repo %s failed to clone (exit %d) — continuing without it\r\n", name, result.Code))
-		}
+		jobs = append(jobs, job{name, dir, *repo.CloneUrl, branch, repo.SubmoduleCredentials})
 	}
+	if len(jobs) == 0 {
+		return
+	}
+
+	o.chunk(fmt.Sprintf("\r\n[orchestrator] cloning %d secondary repo(s)\r\n", len(jobs)))
+	slots := make(chan struct{}, secondaryCloneConcurrency)
+	var wg sync.WaitGroup
+	for _, j := range jobs {
+		wg.Add(1)
+		go func(j job) {
+			defer wg.Done()
+			slots <- struct{}{}
+			defer func() { <-slots }()
+			// Its own tmp dir, so two clones cannot write each other's
+			// submodule PATs into one fixed-name credentials file.
+			result := SpawnClone(CloneDeps{
+				RepoDir:              j.dir,
+				CloneUrl:             j.cloneUrl,
+				Branch:               j.branch,
+				SubmoduleCredentials: j.submodules,
+				TmpDir:               SecondaryCloneTmpDir(o.deps.LogsDir, j.name),
+				// Output is dropped rather than streamed: N clones interleaving
+				// line-by-line is unreadable, and the primary owns the stream.
+				OnChunk: func(string) {},
+			})
+			if result.Code != 0 {
+				o.chunk(fmt.Sprintf("\r\n[orchestrator] secondary repo %s failed to clone (exit %d) — continuing without it\r\n", j.name, result.Code))
+				return
+			}
+			o.chunk(fmt.Sprintf("\r\n[orchestrator] secondary repo %s ready\r\n", j.name))
+		}(j)
+	}
+	wg.Wait()
 }
 
 // maybeFastForwardToBase advances an idle, unchanged sandbox to its base

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -381,6 +381,8 @@ func (o *Orchestrator) stepCloneInner() bool {
 		}
 	}
 
+	o.cloneSecondaryRepos(cfg)
+
 	o.gitSetup(cfg)
 	o.fillApplicationDefaults()
 	// Before install, so install runs against the up-to-date lockfile.
@@ -390,6 +392,51 @@ func (o *Orchestrator) stepCloneInner() bool {
 	o.refreshBranchHead()
 	o.deps.BranchStatus.Refresh()
 	return true
+}
+
+// cloneSecondaryRepos checks out the extra repositories beside the primary.
+//
+// Never fails the stage: the sandbox's contract is the primary checkout, and a
+// secondary that will not clone (a revoked token, a repo since deleted) must
+// leave the agent with a working pod rather than no pod. Each failure is
+// announced on the stream so the absence is visible rather than mysterious.
+//
+// Already-present checkouts are skipped, so this is idempotent across the
+// re-provisions and config patches that reach a live pod.
+func (o *Orchestrator) cloneSecondaryRepos(cfg *config.Enriched) {
+	repos := cfg.AdditionalRepositories()
+	if len(repos) == 0 {
+		return
+	}
+	for _, repo := range repos {
+		name := ""
+		if repo.RepoName != nil {
+			name = *repo.RepoName
+		}
+		dir, ok := paths.SecondaryRepoDir(o.deps.RepoDir, name)
+		if !ok {
+			o.chunk(fmt.Sprintf("\r\n[orchestrator] skipping secondary repo with unusable name %q\r\n", name))
+			continue
+		}
+		if paths.HasGitRepo(dir) {
+			continue
+		}
+		branch := ""
+		if repo.Branch != nil {
+			branch = *repo.Branch
+		}
+		result := SpawnClone(CloneDeps{
+			RepoDir:              dir,
+			CloneUrl:             *repo.CloneUrl,
+			Branch:               branch,
+			SubmoduleCredentials: repo.SubmoduleCredentials,
+			TmpDir:               o.deps.LogsDir,
+			OnChunk:              func(data string) { o.rawChunk(data) },
+		})
+		if result.Code != 0 {
+			o.chunk(fmt.Sprintf("\r\n[orchestrator] secondary repo %s failed to clone (exit %d) — continuing without it\r\n", name, result.Code))
+		}
+	}
 }
 
 // maybeFastForwardToBase advances an idle, unchanged sandbox to its base

--- a/packages/sandbox/daemon-protocol.ts
+++ b/packages/sandbox/daemon-protocol.ts
@@ -46,6 +46,16 @@ export interface GitRepository {
 
 export interface GitConfig {
   readonly repository: GitRepository;
+  /**
+   * Extra checkouts placed beside the primary, one directory each, for an org
+   * whose work spans repositories. The primary stays the only one the dev
+   * server, the package-manager probe and the preview come from, so adding one
+   * cannot change what the sandbox serves.
+   *
+   * `repoName` is required here — it names the directory. Unlike `repository`,
+   * a patch carrying this key replaces the whole list.
+   */
+  readonly repositories?: readonly GitRepository[];
   readonly identity?: GitIdentity;
 }
 

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -1546,6 +1546,7 @@ export class AgentSandboxProvider {
           }
         : null,
       repo: opts?.repo ?? null,
+      extraRepos: opts?.extraRepos ?? [],
       port: opts?.workload?.devPort ?? DEFAULT_DEV_PORT,
       tenant: opts?.tenant ?? undefined,
       // Sent on every ensure that carries opts, so a warm-pool pod inheriting a

--- a/packages/sandbox/server/provider/index.ts
+++ b/packages/sandbox/server/provider/index.ts
@@ -7,6 +7,7 @@
 
 export type {
   EnsureOptions,
+  EnsureRepo,
   PodTermination,
   SandboxPurpose,
   Sandbox,

--- a/packages/sandbox/server/provider/shared/build-config-payload.test.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { buildConfigPayload, extraRepoDirNames } from "./build-config-payload";
+import { buildConfigPayload } from "./build-config-payload";
 
 describe("buildConfigPayload", () => {
   it("maps tenant identity to operator", () => {
@@ -150,51 +150,5 @@ describe("buildConfigPayload", () => {
     });
 
     expect(payload?.git?.repository.submoduleCredentials).toEqual([]);
-  });
-});
-
-const url = (path: string) =>
-  `https://x-access-token:tok@github.com/${path}.git`;
-
-describe("extraRepoDirNames", () => {
-  it("uses the repo's own name, never the owner/name label", () => {
-    expect(extraRepoDirNames([url("acme/storefront")])).toEqual(["storefront"]);
-  });
-
-  it("disambiguates a colliding name across owners", () => {
-    expect(
-      extraRepoDirNames([url("acme/checkout"), url("other/checkout")]),
-    ).toEqual(["acme-checkout", "other-checkout"]);
-  });
-
-  it("leaves a non-colliding neighbour alone", () => {
-    expect(
-      extraRepoDirNames([
-        url("acme/checkout"),
-        url("other/checkout"),
-        url("acme/storefront"),
-      ]),
-    ).toEqual(["acme-checkout", "other-checkout", "storefront"]);
-  });
-
-  it("keeps one name per input, in order", () => {
-    const urls = [url("a/one"), url("b/two"), url("c/three")];
-    expect(extraRepoDirNames(urls)).toEqual(["one", "two", "three"]);
-  });
-
-  // Matches the daemon's `repoNameRe`, which rejects separators and dot-opens.
-  it("produces names the daemon accepts", () => {
-    const names = extraRepoDirNames([
-      url("acme/.hidden"),
-      url("acme/weird name!"),
-      "not-a-url",
-    ]);
-    for (const name of names) {
-      expect(name).toMatch(/^[A-Za-z0-9][A-Za-z0-9._-]*$/);
-    }
-  });
-
-  it("has nothing to name for no extras", () => {
-    expect(extraRepoDirNames([])).toEqual([]);
   });
 });

--- a/packages/sandbox/server/provider/shared/build-config-payload.test.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { buildConfigPayload } from "./build-config-payload";
+import { buildConfigPayload, extraRepoDirNames } from "./build-config-payload";
 
 describe("buildConfigPayload", () => {
   it("maps tenant identity to operator", () => {
@@ -150,5 +150,51 @@ describe("buildConfigPayload", () => {
     });
 
     expect(payload?.git?.repository.submoduleCredentials).toEqual([]);
+  });
+});
+
+const url = (path: string) =>
+  `https://x-access-token:tok@github.com/${path}.git`;
+
+describe("extraRepoDirNames", () => {
+  it("uses the repo's own name, never the owner/name label", () => {
+    expect(extraRepoDirNames([url("acme/storefront")])).toEqual(["storefront"]);
+  });
+
+  it("disambiguates a colliding name across owners", () => {
+    expect(
+      extraRepoDirNames([url("acme/checkout"), url("other/checkout")]),
+    ).toEqual(["acme-checkout", "other-checkout"]);
+  });
+
+  it("leaves a non-colliding neighbour alone", () => {
+    expect(
+      extraRepoDirNames([
+        url("acme/checkout"),
+        url("other/checkout"),
+        url("acme/storefront"),
+      ]),
+    ).toEqual(["acme-checkout", "other-checkout", "storefront"]);
+  });
+
+  it("keeps one name per input, in order", () => {
+    const urls = [url("a/one"), url("b/two"), url("c/three")];
+    expect(extraRepoDirNames(urls)).toEqual(["one", "two", "three"]);
+  });
+
+  // Matches the daemon's `repoNameRe`, which rejects separators and dot-opens.
+  it("produces names the daemon accepts", () => {
+    const names = extraRepoDirNames([
+      url("acme/.hidden"),
+      url("acme/weird name!"),
+      "not-a-url",
+    ]);
+    for (const name of names) {
+      expect(name).toMatch(/^[A-Za-z0-9][A-Za-z0-9._-]*$/);
+    }
+  });
+
+  it("has nothing to name for no extras", () => {
+    expect(extraRepoDirNames([])).toEqual([]);
   });
 });

--- a/packages/sandbox/server/provider/shared/build-config-payload.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.ts
@@ -15,6 +15,8 @@ export function buildConfigPayload(args: {
   packageManager: PackageManagerConfig | null;
   port?: number;
   repo: NonNullable<EnsureOptions["repo"]> | null;
+  /** Extra checkouts beside `repo`; dropped when there is no primary. */
+  extraRepos?: EnsureOptions["extraRepos"];
   tenant?: EnsureOptions["tenant"];
   /** Checkout only — the daemon skips install + dev server. */
   cloneOnly?: boolean;
@@ -34,6 +36,18 @@ export function buildConfigPayload(args: {
           // Same reasoning as `cloneOnly` below.
           submoduleCredentials: repo.submoduleCredentials ?? [],
         },
+        // Empty included: absent means keep-current to the daemon's merge.
+        repositories: extraRepoDirNames(
+          (args.extraRepos ?? []).map((extra) => extra.cloneUrl),
+        ).map((repoName, i) => {
+          const extra = (args.extraRepos ?? [])[i]!;
+          return {
+            cloneUrl: extra.cloneUrl,
+            repoName,
+            ...(extra.branch ? { branch: extra.branch } : {}),
+            submoduleCredentials: extra.submoduleCredentials ?? [],
+          };
+        }),
         // Omitted when there is no user: a tenant warm pool bootstraps its pods
         // with a repo and no author, and the daemon rejects a blank identity
         // outright (and treats an absent one as "not claimed by a user yet").
@@ -107,4 +121,39 @@ function deriveRepoLabel(cloneUrl: string): string {
   } catch {
     return cloneUrl;
   }
+}
+
+/**
+ * Directory names for the secondary checkouts, one per clone URL and in the
+ * same order.
+ *
+ * `deriveRepoLabel` is the wrong source: it yields `owner/name`, and a
+ * secondary's name IS a directory, which the daemon refuses if it carries a
+ * separator. So this takes the last path segment, and falls back to
+ * `owner-name` for every member of a colliding set — two orgs owning a repo
+ * called `checkout` must not share one checkout directory.
+ *
+ * Exported for the test; the uniqueness rule is the part worth pinning.
+ */
+export function extraRepoDirNames(cloneUrls: string[]): string[] {
+  const parts = cloneUrls.map((url) => {
+    const segments = deriveRepoLabel(url).split("/").filter(Boolean);
+    const name = segments[segments.length - 1] ?? "repo";
+    const owner = segments.length > 1 ? segments[segments.length - 2]! : "";
+    return { name, owner };
+  });
+  const shared = new Set(
+    parts.map((p) => p.name).filter((name, i, all) => all.indexOf(name) !== i),
+  );
+  return parts.map(({ name, owner }) =>
+    sanitizeDirName(shared.has(name) && owner ? `${owner}-${name}` : name),
+  );
+}
+
+/** Bounded to what the daemon accepts: opens on an alphanumeric, no separator. */
+function sanitizeDirName(raw: string): string {
+  const cleaned = raw
+    .replace(/[^A-Za-z0-9._-]/g, "-")
+    .replace(/^[^A-Za-z0-9]+/, "");
+  return cleaned || "repo";
 }

--- a/packages/sandbox/server/provider/shared/build-config-payload.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.ts
@@ -37,17 +37,18 @@ export function buildConfigPayload(args: {
           submoduleCredentials: repo.submoduleCredentials ?? [],
         },
         // Empty included: absent means keep-current to the daemon's merge.
-        repositories: extraRepoDirNames(
-          (args.extraRepos ?? []).map((extra) => extra.cloneUrl),
-        ).map((repoName, i) => {
-          const extra = (args.extraRepos ?? [])[i]!;
-          return {
+        // `directoryName` comes from the caller: it is shared with
+        // `TASK_ADD_REPO`, which names the same repo mid-run, and deriving it
+        // twice would move a checkout across a pod restart. An entry without
+        // one is dropped rather than guessed at.
+        repositories: (args.extraRepos ?? [])
+          .filter((extra) => !!extra.directoryName)
+          .map((extra) => ({
             cloneUrl: extra.cloneUrl,
-            repoName,
+            repoName: extra.directoryName!,
             ...(extra.branch ? { branch: extra.branch } : {}),
             submoduleCredentials: extra.submoduleCredentials ?? [],
-          };
-        }),
+          })),
         // Omitted when there is no user: a tenant warm pool bootstraps its pods
         // with a repo and no author, and the daemon rejects a blank identity
         // outright (and treats an absent one as "not claimed by a user yet").
@@ -121,39 +122,4 @@ function deriveRepoLabel(cloneUrl: string): string {
   } catch {
     return cloneUrl;
   }
-}
-
-/**
- * Directory names for the secondary checkouts, one per clone URL and in the
- * same order.
- *
- * `deriveRepoLabel` is the wrong source: it yields `owner/name`, and a
- * secondary's name IS a directory, which the daemon refuses if it carries a
- * separator. So this takes the last path segment, and falls back to
- * `owner-name` for every member of a colliding set — two orgs owning a repo
- * called `checkout` must not share one checkout directory.
- *
- * Exported for the test; the uniqueness rule is the part worth pinning.
- */
-export function extraRepoDirNames(cloneUrls: string[]): string[] {
-  const parts = cloneUrls.map((url) => {
-    const segments = deriveRepoLabel(url).split("/").filter(Boolean);
-    const name = segments[segments.length - 1] ?? "repo";
-    const owner = segments.length > 1 ? segments[segments.length - 2]! : "";
-    return { name, owner };
-  });
-  const shared = new Set(
-    parts.map((p) => p.name).filter((name, i, all) => all.indexOf(name) !== i),
-  );
-  return parts.map(({ name, owner }) =>
-    sanitizeDirName(shared.has(name) && owner ? `${owner}-${name}` : name),
-  );
-}
-
-/** Bounded to what the daemon accepts: opens on an alphanumeric, no separator. */
-function sanitizeDirName(raw: string): string {
-  const cleaned = raw
-    .replace(/[^A-Za-z0-9._-]/g, "-")
-    .replace(/^[^A-Za-z0-9]+/, "");
-  return cleaned || "repo";
 }

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -81,6 +81,14 @@ export interface EnsureRepo {
    * every ensure.
    */
   submoduleCredentials?: { host: string; token: string }[];
+  /**
+   * Directory name, for a secondary checkout only. The caller sets it through
+   * `secondaryRepoDirNames`; nothing derives it here. `TASK_ADD_REPO` names the
+   * same repo mid-run and a pod re-provision names it again, and two rules
+   * would move a checkout across a restart, breaking the paths the agent had
+   * been using.
+   */
+  directoryName?: string;
 }
 
 export interface EnsureOptions {

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -44,6 +44,45 @@ export interface Workload {
  */
 export type SandboxPurpose = "interactive" | "harness-run";
 
+/**
+ * One repository a sandbox checks out. Shared by the primary (`repo`) and the
+ * extra checkouts (`extraRepos`), which the daemon treats identically apart
+ * from where they land.
+ */
+export interface EnsureRepo {
+  /**
+   * Clone URL. May embed an OAuth credential via userinfo (e.g.
+   * `https://x-access-token:TOKEN@github.com/...`) — `git clone` stores
+   * the credential on the remote so subsequent fetch/pull/push from
+   * inside the sandbox work without further plumbing. The embedded token
+   * is short-lived (~1h GitHub App token); callers should pass a freshly
+   * minted URL on every ensure. Resume/adopt paths forward the new credential
+   * to the daemon so it rotates `origin` in place rather than leaving a stale
+   * token.
+   */
+  cloneUrl: string;
+  /**
+   * GitHub connection backing `cloneUrl`. Persisted so the runner can
+   * re-mint a fresh credential on autonomous recovery (pod recreation
+   * under a live claim) instead of replaying the stale token baked into
+   * `cloneUrl` at first provision. Absent for anonymous/public clones.
+   */
+  connectionId?: string;
+  userName: string;
+  userEmail: string;
+  branch?: string;
+  /** Human-readable label for logs/UI; no functional effect. */
+  displayName?: string;
+  /**
+   * Resolved per-host PATs for fetching private git submodules whose remotes
+   * the main clone's per-repo token can't reach. Delivered to the daemon on
+   * the git-only config channel (never the env bag). Absent/empty → submodules
+   * are only fetched if public. Like `cloneUrl`, these are resolved fresh on
+   * every ensure.
+   */
+  submoduleCredentials?: { host: string; token: string }[];
+}
+
 export interface EnsureOptions {
   /**
    * Defaults to `interactive` when absent. AgentSandboxProvider uses this to
@@ -70,39 +109,13 @@ export interface EnsureOptions {
    * Optional first-provisioning clone. `branch` post-clone:
    * fetch-from-origin-or-create.
    */
-  repo?: {
-    /**
-     * Clone URL. May embed an OAuth credential via userinfo (e.g.
-     * `https://x-access-token:TOKEN@github.com/...`) — `git clone` stores
-     * the credential on the remote so subsequent fetch/pull/push from
-     * inside the sandbox work without further plumbing. The embedded token
-     * is short-lived (~1h GitHub App token); callers should pass a freshly
-     * minted URL on every ensure. Resume/adopt paths forward the new credential
-     * to the daemon so it rotates `origin` in place rather than leaving a stale
-     * token.
-     */
-    cloneUrl: string;
-    /**
-     * GitHub connection backing `cloneUrl`. Persisted so the runner can
-     * re-mint a fresh credential on autonomous recovery (pod recreation
-     * under a live claim) instead of replaying the stale token baked into
-     * `cloneUrl` at first provision. Absent for anonymous/public clones.
-     */
-    connectionId?: string;
-    userName: string;
-    userEmail: string;
-    branch?: string;
-    /** Human-readable label for logs/UI; no functional effect. */
-    displayName?: string;
-    /**
-     * Resolved per-host PATs for fetching private git submodules whose remotes
-     * the main clone's per-repo token can't reach. Delivered to the daemon on
-     * the git-only config channel (never the env bag). Absent/empty → submodules
-     * are only fetched if public. Like `cloneUrl`, these are resolved fresh on
-     * every ensure.
-     */
-    submoduleCredentials?: { host: string; token: string }[];
-  };
+  repo?: EnsureRepo;
+  /**
+   * Extra repositories to check out beside `repo`, for an org whose work spans
+   * several. Each needs a `displayName` — it names the directory. Ignored when
+   * `repo` is absent: there is no primary to sit beside.
+   */
+  extraRepos?: EnsureRepo[];
   /** Sandbox image override. */
   image?: string;
   workload?: Workload;

--- a/packages/shared/src/secondary-repo-dirs.test.ts
+++ b/packages/shared/src/secondary-repo-dirs.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import {
+  secondaryRepoDirName,
+  secondaryRepoDirNames,
+} from "./secondary-repo-dirs.ts";
+
+const r = (owner: string, name: string) => ({ owner, name });
+
+describe("secondaryRepoDirNames", () => {
+  it("uses the repo's own name, never the owner/name label", () => {
+    expect(secondaryRepoDirNames([r("acme", "storefront")])).toEqual([
+      "storefront",
+    ]);
+  });
+
+  it("disambiguates a colliding name across owners", () => {
+    expect(
+      secondaryRepoDirNames([r("acme", "checkout"), r("other", "checkout")]),
+    ).toEqual(["acme-checkout", "other-checkout"]);
+  });
+
+  it("leaves a non-colliding neighbour alone", () => {
+    expect(
+      secondaryRepoDirNames([
+        r("acme", "checkout"),
+        r("other", "checkout"),
+        r("acme", "storefront"),
+      ]),
+    ).toEqual(["acme-checkout", "other-checkout", "storefront"]);
+  });
+
+  it("collides case-insensitively, as GitHub does", () => {
+    expect(
+      secondaryRepoDirNames([r("acme", "Checkout"), r("other", "checkout")]),
+    ).toEqual(["acme-Checkout", "other-checkout"]);
+  });
+
+  // Matches the daemon's `repoNameRe`, which rejects separators and dot-opens.
+  it("produces names the daemon accepts", () => {
+    for (const name of secondaryRepoDirNames([
+      r("acme", ".hidden"),
+      r("acme", "weird name!"),
+      r("acme", "..."),
+    ])) {
+      expect(name).toMatch(/^[A-Za-z0-9][A-Za-z0-9._-]*$/);
+    }
+  });
+
+  it("has nothing to name for no repos", () => {
+    expect(secondaryRepoDirNames([])).toEqual([]);
+  });
+});
+
+// The whole point of the shared rule: TASK_ADD_REPO asks for one repo's name
+// and provisioning asks for the whole list, and both must get the same answer.
+describe("secondaryRepoDirName", () => {
+  const all = [r("acme", "checkout"), r("other", "checkout")];
+
+  it("agrees with the batch answer for the same set", () => {
+    expect(secondaryRepoDirName(all, r("other", "checkout"))).toBe(
+      "other-checkout",
+    );
+    expect(secondaryRepoDirName(all, r("ACME", "Checkout"))).toBe(
+      "acme-checkout",
+    );
+  });
+
+  it("returns nothing for a repo outside the set", () => {
+    expect(secondaryRepoDirName(all, r("acme", "nope"))).toBeNull();
+  });
+});

--- a/packages/shared/src/secondary-repo-dirs.ts
+++ b/packages/shared/src/secondary-repo-dirs.ts
@@ -1,0 +1,57 @@
+/**
+ * Directory names for a sandbox's secondary checkouts.
+ *
+ * A secondary's name IS a directory under the pod's secondary root, and the
+ * daemon refuses one carrying a path separator, so `owner/name` cannot be it.
+ * The bare repo name can collide, though: two owners each with a `checkout`
+ * must not share one directory, so a colliding set falls back to `owner-name`
+ * for every member of that set.
+ *
+ * This lives here, and not next to either caller, because BOTH have to agree.
+ * `TASK_ADD_REPO` names the directory when it adds a repo mid-run, and
+ * provisioning names it again when a recreated pod replays the accumulated
+ * list. Two rules would put the same repo in two places across a pod restart,
+ * and the paths the agent had been using would stop resolving.
+ */
+
+export interface SecondaryRepoRef {
+  owner: string;
+  name: string;
+}
+
+/**
+ * One directory name per input, in the same order. Deterministic: the answer
+ * for a repo depends only on the set it is named alongside.
+ */
+export function secondaryRepoDirNames(repos: SecondaryRepoRef[]): string[] {
+  const shared = new Set(
+    repos
+      .map((r) => r.name.toLowerCase())
+      .filter((name, i, all) => all.indexOf(name) !== i),
+  );
+  return repos.map((r) =>
+    sanitize(
+      shared.has(r.name.toLowerCase()) ? `${r.owner}-${r.name}` : r.name,
+    ),
+  );
+}
+
+/** This repo's directory name within `all`, or null when it is not in the set. */
+export function secondaryRepoDirName(
+  all: SecondaryRepoRef[],
+  repo: SecondaryRepoRef,
+): string | null {
+  const key = `${repo.owner}/${repo.name}`.toLowerCase();
+  const index = all.findIndex(
+    (r) => `${r.owner}/${r.name}`.toLowerCase() === key,
+  );
+  return index === -1 ? null : (secondaryRepoDirNames(all)[index] ?? null);
+}
+
+/** Bounded to what the daemon accepts: opens on an alphanumeric, no separator. */
+function sanitize(raw: string): string {
+  const cleaned = raw
+    .replace(/[^A-Za-z0-9._-]/g, "-")
+    .replace(/^[^A-Za-z0-9]+/, "");
+  return cleaned || "repo";
+}


### PR DESCRIPTION
## What is this contribution about?

A sandbox has always held exactly one repo. `GitConfig.Repository` is a single pointer in the Go daemon, and `TASK_ADD_REPO` wrote `metadata.githubRepo` and pushed `git.repository`, both of which REPLACE. So calling the tool twice moved the pod to another repository instead of giving the run both, and a card needing a change in a storefront and its checkout could not be worked at all.

Now the run decides. The model calls `TASK_ADD_REPO` when it judges it needs another repository, and the checkouts accumulate.

**Nothing clones a repository the run did not ask for.** An earlier draft of this cloned every repo the org had connected, at boot. That is the wrong trade: it pays clone time on every sandbox for repos nobody opens, worst exactly where it hurts most, and it needs a per-org flag and a cap to be safe. Deciding mid-task is also a better-informed decision than any dispatch-time guess, because by then the run has read the ticket.

**The first call still binds the primary.** `githubRepo` drives the package-manager probe, the dev server and the preview, so a later call must not move it out from under a running dev server. Later calls append to `metadata.githubRepos` and land as secondary checkouts in `$WORKDIR/repos/<name>`, siblings of `$WORKDIR/repo` and outside its tree. Nesting them would have grown the primary's `git status` by every other checkout and needed an exclude file someone has to maintain.

**A recreated pod gets every checkout back.** Provisioning reads the accumulated list off the thread, so a pod that died holding three repos comes back with three. A repo whose connection has since gone is dropped with a log rather than sent with a dead clone URL, so one revoked connection costs its own checkout and never the pod. Same for a clone that fails inside the pod: the sandbox's contract is the primary, and a secondary that will not clone leaves the agent working.

**The prompt stops saying "take the first."** When the org has several repositories it now says the calls accumulate, that each lands in its own directory with its own git remote, and to open one pull request per repository it changed.

## Where the append lives, and why the wire still replaces

These are two different things and it is worth being precise, because I got them muddled at first.

**In Postgres it is an append**, written as one UPDATE in SQL rather than a read in JS followed by a write. The model fires parallel tool calls, and a read-modify-write silently loses the slower one, with the pod already holding the checkout the lost entry describes. Nothing looks wrong until the pod is recreated without it. Keyed on `owner/name`, so re-adding a repo the thread already has is a no-op rather than a second directory.

**On the wire each push still carries the full list.** Not because replacing is nobler, but because the pod is disposable and the message has to describe itself: a recreated pod reads one config and knows every checkout it owes. Append semantics on the wire would also leak a previous claim's repositories into a reused warm-pool pod, which is the same reason `buildConfigPayload` already sends `submoduleCredentials: []` rather than omitting it.

## No flag, and why

The earlier draft needed one, because cloning every org repo at boot changes behaviour for every org at once. Lazily adding does not: the tool was already there, was already only called when the agent decided to, and its old two-call behaviour was broken rather than working. There is no "clone everything" blast radius left to gate.

Say the word if you would still rather have one and I will add it.

## Disk and latency, since both came up

Both concerns came from the clone-all draft and mostly dissolve with lazy adds, but the numbers are worth recording.

Prod sandboxes run with `ephemeral-storage: 8Gi` (`deco-apps-cd`, `apps/studio-sandbox-prod/values.yaml:49`). Clones are shallow. In the kind run below each checkout came out at **200K**; two real storefronts I sized are 42MB and 9MB, and the biggest repo any org has connected is 163MB. What actually fills a sandbox is `node_modules`, and **only the primary installs**. A secondary is a checkout, never an install, so N repos add N clones and zero dependency trees.

Latency was the real cost of clone-all, and it sat in the tail: of 111 orgs with a connected repo, 80 have exactly one and only three have more than five, but one has 17. Under lazy adds that org clones what its run asks for, so the tail stops mattering.

Clones still run in parallel, four at a time, and that is not vestigial. A recreated pod replays the whole accumulated list at once through the same path that provisions a fresh one, so a run that had added three repos re-clones three concurrently.

## Three things the tests caught that the code got wrong first

`stripSubmoduleTokens` only reached the primary. A secondary carries its own submodule PATs, so widening the struct without widening the redaction would have published them on the same `/config` response.

`SecondaryRepoDir` accepted `/etc` and quietly rebased it to `/work/repos/etc`. It did not escape, but a second line of defence should refuse a name rather than reinterpret it, so a separator is now rejected outright.

Parallelising could not be a plain `go func` over the loop. Every clone was handed the orchestrator's shared tmp dir, and `SubmoduleCredentialsPath` is one fixed name inside it, so two concurrent clones would have written each other's PATs into the same file and deleted it out from under each other mid-fetch. Each secondary now gets a private tmp dir under `secondary-clones/`, and the boot sweep clears that subtree for the same reason it already cleared the single file.

## How did you verify your code works?

**Real-Postgres tests for the append** (`storage/thread-github-repos.integration.test.ts`, 5 tests): repos accumulate instead of replacing; re-adding one is a no-op and not a duplicate; three adds landing at once lose nothing, which is the property that only exists in the SQL; the rest of the thread's metadata survives; another org's thread returns nothing.

**Go unit tests** (`internal/config/secondary_repos_test.go`, `internal/paths/secondary_test.go`): entries with no clone URL are skipped rather than stalling the stage; a patch carrying `repositories` replaces the set whole while one omitting it keeps the current set; validation rejects a missing URL, a missing name, `..`, `.git` and an embedded separator; the secondary root is a sibling of the primary and refuses an escaping name.

**Go route test**: a secondary's submodule PAT never appears in the `GET /_sandbox/config` response, the secondary is still reported without it, and the live store keeps the credential because the clone step reads it from there. **`go test -race ./internal/setup/...`** clean.

**Daemon e2e against the real binary** (`daemon-e2e/daemon.multirepo.e2e.test.ts`, 7 tests): every configured repo lands beside the primary; the primary's working tree stays clean; a broken secondary leaves the primary and the entries behind it intact; re-posting the same config does not re-clone; six repos against a cap of four all land; two secondaries with different PATs both clone and leave no credentials file behind; an escaping name is refused with a 4xx and creates nothing.

I replaced my first parallelism test, which asserted a wall clock under 20s. A `file://` clone passes that serially too, so it proved nothing its name claimed.

**A real Kubernetes pod.** I stood up a `kind` cluster with the repo's own `sandbox-operator` and `sandbox-env` charts and the documented `examples/values-kind.yaml`, built the sandbox image from `packages/sandbox/image/Dockerfile` with this daemon in it, `kind load`ed it, created a `SandboxClaim`, and pushed config over `/_sandbox/config` the way Studio does:

```
/app/repo              README.md      (primary)
/app/repos/checkout    README.md
/app/repos/design      README.md

$ git -C /app/repo status --porcelain
(empty)
```

Three checkouts where they belong, the primary's tree clean. On the same pod I posted a synthetic PAT on a secondary and confirmed `GET /_sandbox/config` returns zero occurrences of it while still reporting the `repoName`. `du -sh` gave the 200K figure. Cluster and image torn down after.

I also **inverted** the prompt test that pinned "Pick the one the task is about... take the first" rather than appending a new one beside it.

Against real Postgres, `bun test src/storage src/tools/sandbox src/tools/task-board src/jira migrations` is **926 pass / 0 fail** (89 files). `bun run check` 0 errors, `bun run knip` clean, `bun run fmt:check` clean, `gofmt`/`go vet`/`go build`/`go test` clean. `bun run lint` reports 19 warnings, none in a file this PR touches.

**Not verified:** no end-to-end run from a real Studio dispatch. The two halves are each covered (the append against real Postgres, the daemon cloning N against a real pod), but not the glue between them in one pass. Happy to bring the cluster back up for that before merge.

## Screenshots/Demonstration

Terminal output above. No UI change.

## How to Test

1. `go build -o bin/daemon .` in `packages/sandbox/daemon-go`, then `bun test daemon-e2e/daemon.multirepo.e2e.test.ts` from `packages/sandbox`.
2. On an org with two repos connected, give the Super Agent a task that needs both. Expect it to call `TASK_ADD_REPO` twice, and the second checkout to appear at `$WORKDIR/repos/<name>` with the first still there.
3. Kill the pod and let it re-provision. Expect both checkouts back.
4. On an org with one repo, confirm nothing changed.

## Migration Notes

None. No schema change and no flag. `metadata.githubRepos` is additive and absent means one repo, exactly as today. `git.repositories` is additive on the daemon and absent means the current behaviour.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes
