### PR TITLE
fix(notifications): bound NOTIFICATION_MARK_READ's ids array

### DIFF
--- a/apps/api/src/tools/notifications/mark-read.test.ts
+++ b/apps/api/src/tools/notifications/mark-read.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { NOTIFICATION_MARK_READ } from "./mark-read";
+
+describe("NOTIFICATION_MARK_READ input schema", () => {
+  test("accepts a reasonably sized ids array", () => {
+    const result = NOTIFICATION_MARK_READ.inputSchema.safeParse({
+      ids: ["notif_1", "notif_2"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects an ids array over the bound", () => {
+    const result = NOTIFICATION_MARK_READ.inputSchema.safeParse({
+      ids: Array.from({ length: 1001 }, (_, i) => `notif_${i}`),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/tools/notifications/mark-read.ts
+++ b/apps/api/src/tools/notifications/mark-read.ts
@@ -14,7 +14,7 @@ export const NOTIFICATION_MARK_READ = defineTool({
     idempotentHint: true,
     openWorldHint: false,
   },
-  inputSchema: z.object({ ids: z.array(z.string()).optional() }),
+  inputSchema: z.object({ ids: z.array(z.string()).max(1000).optional() }),
   outputSchema: z.object({ marked: z.number() }),
   handler: async (input, ctx) => {
     requireAuth(ctx);


### PR DESCRIPTION
Bug found while auditing apps/api/src/tools/notifications (W3 focus area) — not tied to an existing issue.

`NOTIFICATION_MARK_READ`'s `ids` input had no size cap: `z.array(z.string()).optional()`. That array is passed straight into `NotificationStorage.markRead`, which does `.where("id", "in", ids)` — an unbounded IN clause driven directly by tool-call input. This is the same unbounded-array-size DoS class the codebase already guards elsewhere (e.g. `thread/list.ts`'s `trigger_ids: z.array(z.string()).max(1000)`), and notifications was the one spot that slipped through.

A maintainer wants this because it closes the gap cheaply and consistently with the sibling tool, without touching behavior for any real caller (the UI only ever sends a page's worth of ids, well under 1000).

Fix: added `.max(1000)` to the `ids` schema, matching the existing `trigger_ids` convention. Added `mark-read.test.ts`, a pure schema unit test (no mocks/DB) asserting the bound rejects an over-sized array and accepts a normal one.

Reviewer check: `bun test apps/api/src/tools/notifications/mark-read.test.ts`

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.