### PR TITLE
fix(docs): replace English anchor links with Portuguese equivalents in pt-br documentation

### DIFF
--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/agents.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/agents.mdx
@@ -26,7 +26,7 @@ Você chega a um agent pela home grid, pela lista de threads na sidebar ou pelo 
 
 Quando você abre um agent, a tela se divide em duas:
 
-- **Esquerda — chat.** Converse com o agent em linguagem natural; ele usa as tools anexadas para fazer o trabalho. Suas mensagens e threads passadas com este agent ficam aqui. Acima do input estão o **model picker** e o **runtime picker** (veja [Onde um agent roda](#where-an-agent-runs)).
+- **Esquerda — chat.** Converse com o agent em linguagem natural; ele usa as tools anexadas para fazer o trabalho. Suas mensagens e threads passadas com este agent ficam aqui. Acima do input estão o **model picker** e o **runtime picker** (veja [Onde um agent roda](#onde-um-agent-roda)).
 - **Direita — um painel com abas.** Quais abas aparecem depende do que o agent é:
 
 | Tab | Quando aparece |

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/concepts.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/concepts.mdx
@@ -37,7 +37,7 @@ A sidebar fixa à esquerda é a mesma em qualquer lugar que você vá:
 
 Abra um agent — ou inicie uma thread com ele — e a tela se divide em duas:
 
-- **Esquerda — chat.** Converse com o agent em linguagem natural; ele usa as tools anexadas para fazer o trabalho. As mensagens anteriores ficam aqui. Acima do campo de entrada ficam o **model picker** e o **runtime picker** (onde o agent roda — veja [Agents](/pt-br/studio/agents#where-an-agent-runs)).
+- **Esquerda — chat.** Converse com o agent em linguagem natural; ele usa as tools anexadas para fazer o trabalho. As mensagens anteriores ficam aqui. Acima do campo de entrada ficam o **model picker** e o **runtime picker** (onde o agent roda — veja [Agents](/pt-br/studio/agents#onde-um-agent-roda)).
 - **Direita — um painel com abas.** Quais abas aparecem depende do agent:
   - **Settings** — instruções, connections anexadas, files & skills (exibido se você pode gerenciar agents)
   - **Automations** — schedules e gatilhos de eventos (sempre disponível)

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/overview.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/overview.mdx
@@ -49,7 +49,7 @@ O Studio se adapta ao seu nível. O mesmo produto suporta três tipos de trabalh
 
 - **Chat — para todo mundo.** Basta conversar com o [Decopilot](./decopilot/overview), o pilot embutido na sua tela inicial. Peça o que quiser e ele resolve — respondendo perguntas, executando suas tools e até criando agents, automations e connections _por_ você. Um usuário totalmente novo e não técnico já consegue ser produtivo no primeiro dia, sem configurar nada.
 - **Configurar — para power users.** Quando você quer sistemas repetíveis, monte-os na mão: desenhe [agents](./agents) focados, escolha a dedo suas [tools](./connections), agende [automations](./automations) e gerencie roles e acesso. Você está construindo a máquina da qual o time inteiro depende.
-- **Construir — para desenvolvedores.** Vá mais fundo com código. Vincule um agent a um [sandbox](./agents#where-an-agent-runs) e a um repo Git, rode-o localmente com seu próprio harness e estenda o próprio Studio publicando [MCP apps](./agents) — tools empacotadas com sua própria UI em React. Seu repo continua sendo a fonte da verdade.
+- **Construir — para desenvolvedores.** Vá mais fundo com código. Vincule um agent a um [sandbox](./agents#onde-um-agent-roda) e a um repo Git, rode-o localmente com seu próprio harness e estenda o próprio Studio publicando [MCP apps](./agents) — tools empacotadas com sua própria UI em React. Seu repo continua sendo a fonte da verdade.
 
 A maioria dos times usa as três ao mesmo tempo: o pilot para tarefas rápidas, sistemas feitos à mão para a rotina e código para qualquer coisa sob medida.
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/quickstart.mdx
@@ -23,7 +23,7 @@ brew tap decocms/studio https://github.com/decocms/studio
 brew install --cask deco-studio
 ```
 
-Por enquanto, macOS (Apple Silicon). Veja [onde um agent roda](./agents#where-an-agent-runs) para entender como runtimes locais funcionam.
+Por enquanto, macOS (Apple Silicon). Veja [onde um agent roda](./agents#onde-um-agent-roda) para entender como runtimes locais funcionam.
 
 <Callout type="info">
   Quer rodar o servidor do Studio na sua própria infraestrutura? Veja [Self-hosting](./self-hosting/quickstart).
@@ -49,7 +49,7 @@ Quando estiver pronto para criar um worker focado e reutilizável, crie um agent
 
 Use o botão **+** / "Browse agents" na sidebar para criar um novo agent. Assim que ele abrir, a tela se divide em duas partes:
 
-- **Esquerda** — o chat. Acima do input ficam o **model picker** (nível do modelo) e o **runtime picker** (onde o agent roda — na cloud ou na sua própria máquina; veja [Agents](/pt-br/studio/agents#where-an-agent-runs)).
+- **Esquerda** — o chat. Acima do input ficam o **model picker** (nível do modelo) e o **runtime picker** (onde o agent roda — na cloud ou na sua própria máquina; veja [Agents](/pt-br/studio/agents#onde-um-agent-roda)).
 - **Direita** — um painel com abas. A aba **Settings** guarda instruções, connections e arquivos; **Automations** guarda schedules e triggers. Outras abas (Preview, Content, Review changes) aparecem apenas para agents vinculados a um repo ou site.
 
 Abra a aba **Settings** e escreva uma instrução de uma linha descrevendo o que este agent deve fazer.


### PR DESCRIPTION
## Summary

Fixed broken internal anchor links in Portuguese (pt-br) documentation. The links were pointing to English anchor slugs (e.g., `#where-an-agent-runs`) but the headings in Portuguese files use Portuguese slugs (e.g., `#onde-um-agent-roda`).

## Changes

Replaced 5 instances of broken English anchor references with their Portuguese equivalents across 4 files:

- `apps/docs/client/src/content/deco-studio/pt-br/studio/agents.mdx`: `#where-an-agent-runs` → `#onde-um-agent-roda`
- `apps/docs/client/src/content/deco-studio/pt-br/studio/concepts.mdx`: `#where-an-agent-runs` → `#onde-um-agent-roda`
- `apps/docs/client/src/content/deco-studio/pt-br/studio/overview.mdx`: `#where-an-agent-runs` → `#onde-um-agent-roda`
- `apps/docs/client/src/content/deco-studio/pt-br/studio/quickstart.mdx`: 2 instances of `#where-an-agent-runs` → `#onde-um-agent-roda`

## Why this matters

The broken anchor links were introduced when PR #6532 updated the terminology in both English and Portuguese documentation, but the Portuguese translation files retained the English anchor references. Documentation readers in Portuguese-speaking regions would encounter broken links when clicking on internal cross-references.

## Verification

Run `bun run fmt` to verify formatting (passes). The changes are in documentation only, so no tests or TypeScript checks are needed. Verified that all 5 instances were fixed and no broken English anchors remain in Portuguese files.

**Diff**: `-5 / +5` (pure link corrections, behavior-preserving)