### PR TITLE
feat(task-board): @-mention org members in descriptions and comments

### DIFF
--- a/apps/api/migrations/179-notification-mentioned.ts
+++ b/apps/api/migrations/179-notification-mentioned.ts
@@ -1,0 +1,46 @@
+import { type Kysely, sql } from "kysely";
+
+/** Migration 177's notification type list, plus `mentioned` — written when a
+ *  task description or comment `@`s a member. The CHECK constraint is replaced
+ *  wholesale: 177 may already be live, so editing its list in place wouldn't
+ *  reach a deployed database. A frozen snapshot like its predecessor;
+ *  `notification-types.test.ts` reads this one (the newest) to prove SQL and
+ *  TypeScript agree. */
+export const TYPES = [
+  "created",
+  "commented",
+  "mentioned",
+  "status_changed",
+  "assignee_changed",
+  "review_requested",
+  "review_approved",
+  "review_changes_requested",
+  "merge_failed",
+] as const;
+
+const NEW_TYPES = new Set<string>(["mentioned"]);
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await replaceNotificationTypeCheck(db, TYPES);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await replaceNotificationTypeCheck(
+    db,
+    TYPES.filter((t) => !NEW_TYPES.has(t)),
+  );
+}
+
+/** Swap `notifications`' type CHECK constraint for one allowing exactly
+ *  `types`. */
+async function replaceNotificationTypeCheck(
+  db: Kysely<unknown>,
+  types: readonly string[],
+): Promise<void> {
+  await sql`ALTER TABLE notifications DROP CONSTRAINT notifications_type_check`.execute(
+    db,
+  );
+  await sql`ALTER TABLE notifications ADD CONSTRAINT notifications_type_check CHECK (type IN (${sql.join(
+    types.map((t) => sql.lit(t)),
+  )}))`.execute(db);
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -177,6 +177,7 @@ import * as migration175taskboardsprints from "./175-task-board-sprints.ts";
 import * as migration176taskboarddonesweepindex from "./176-task-board-done-sweep-index.ts";
 import * as migration177notifications from "./177-notifications.ts";
 import * as migration178jirastatusmappingarray from "./178-jira-status-mapping-array.ts";
+import * as migration179notificationmentioned from "./179-notification-mentioned.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -385,6 +386,7 @@ const migrations: Record<string, Migration> = {
   "176-task-board-done-sweep-index": migration176taskboarddonesweepindex,
   "177-notifications": migration177notifications,
   "178-jira-status-mapping-array": migration178jirastatusmappingarray,
+  "179-notification-mentioned": migration179notificationmentioned,
 };
 
 export default migrations;

--- a/apps/api/src/notifications/digest-email.ts
+++ b/apps/api/src/notifications/digest-email.ts
@@ -22,6 +22,7 @@ export interface DigestRow {
 const VERB: Record<NotificationType, string> = {
   created: "created",
   commented: "commented on",
+  mentioned: "mentioned you on",
   status_changed: "moved",
   assignee_changed: "reassigned",
   review_requested: "requested review on",

--- a/apps/api/src/notifications/mentions.ts
+++ b/apps/api/src/notifications/mentions.ts
@@ -1,0 +1,64 @@
+/**
+ * Fan-out for `@`-mentions written into a task description or a comment.
+ *
+ * Only NEW mentions notify: editing a description re-sends its whole body, so
+ * without the diff every typo fix would re-ping everyone already named in it.
+ *
+ * The ids come out of user-authored markdown, so they are input, not fact:
+ * membership of THIS org is checked here before anything is written. Skipping
+ * that would turn a hand-written body into a way to notify any user id in the
+ * deployment.
+ */
+
+import type { Kysely } from "kysely";
+import { parseMentions } from "@decocms/shared/mentions";
+import type { Database } from "@/storage/types";
+import { notify } from "./notify";
+
+export interface NotifyMentionsParams {
+  db: Kysely<Database>;
+  taskBoardItemId: string;
+  organizationId: string;
+  /** Null = agent/system. Never notified of its own mention. */
+  actorId: string | null;
+  /** The body as saved. */
+  body: string;
+  /** The body before this edit, if it's an edit. Mentions already in it are
+   *  not re-notified. */
+  previousBody?: string | null;
+}
+
+/** Never throws — like `notify`, a failed ping must not fail the write that
+ *  earned it. */
+export async function notifyMentions(
+  params: NotifyMentionsParams,
+): Promise<void> {
+  const { db, organizationId, actorId } = params;
+  try {
+    const before = new Set(parseMentions(params.previousBody ?? ""));
+    const fresh = parseMentions(params.body).filter((id) => !before.has(id));
+    const candidates = fresh.filter((id) => id !== actorId);
+    if (candidates.length === 0) return;
+
+    const members = await db
+      .selectFrom("member")
+      .select("userId")
+      .where("organizationId", "=", organizationId)
+      .where("userId", "in", candidates)
+      .execute();
+    const recipients = members.map((m) => m.userId);
+    if (recipients.length === 0) return;
+
+    await notify({
+      db,
+      taskBoardItemId: params.taskBoardItemId,
+      type: "mentioned",
+      actorId,
+      // Being named on a task is enrolment in it — the same way commenting is.
+      alsoSubscribe: recipients,
+      recipients,
+    });
+  } catch (err) {
+    console.error("[notifications] mention fan-out failed", err);
+  }
+}

--- a/apps/api/src/notifications/notification-types.test.ts
+++ b/apps/api/src/notifications/notification-types.test.ts
@@ -8,7 +8,7 @@
 
 import { expect, test } from "bun:test";
 import { NOTIFICATION_TYPES } from "@decocms/shared/notification-types";
-import { TYPES as MIGRATION_TYPES } from "../../migrations/177-notifications";
+import { TYPES as MIGRATION_TYPES } from "../../migrations/179-notification-mentioned";
 import { TASK_BOARD_ACTIVITY_ACTIONS } from "../tools/task-board/schema";
 import { COALESCED_ACTIONS } from "../storage/task-board";
 
@@ -16,10 +16,10 @@ test("the DB CHECK constraint allows exactly the types TypeScript declares", () 
   expect([...MIGRATION_TYPES].sort()).toEqual([...NOTIFICATION_TYPES].sort());
 });
 
-test("every type but `commented` is an activity action, so fan-out passes it through", () => {
+test("every type but `commented`/`mentioned` is an activity action, so fan-out passes it through", () => {
   const actions = new Set<string>(TASK_BOARD_ACTIVITY_ACTIONS);
   for (const type of NOTIFICATION_TYPES) {
-    if (type === "commented") continue;
+    if (type === "commented" || type === "mentioned") continue;
     expect(actions.has(type)).toBe(true);
   }
 });

--- a/apps/api/src/notifications/notify.ts
+++ b/apps/api/src/notifications/notify.ts
@@ -26,6 +26,14 @@ export interface NotifyParams {
   actorId: string | null;
   /** Users this event enrolls. A muted subscription stays muted. */
   alsoSubscribe?: (string | null | undefined)[];
+  /**
+   * Addressed recipients, replacing the subscriber lookup entirely.
+   *
+   * A mention is aimed at the people named in it, so it must reach them even
+   * with the task muted, and must NOT reach the other followers — the opposite
+   * of every subscription-driven event. Still excludes the actor.
+   */
+  recipients?: (string | null | undefined)[];
 }
 
 /** The task's org and title, which `recordActivity` doesn't carry. */
@@ -76,16 +84,19 @@ export async function notify(params: NotifyParams): Promise<void> {
           .execute();
       }
 
-      const subscribers = await tx
-        .selectFrom("notification_subscriptions")
-        .select("user_id")
-        .where("task_board_item_id", "=", taskBoardItemId)
-        .where("subscribed", "=", true)
-        .execute();
+      const addressed = params.recipients;
+      const candidates = addressed
+        ? [...new Set(addressed.filter((id): id is string => !!id))]
+        : (
+            await tx
+              .selectFrom("notification_subscriptions")
+              .select("user_id")
+              .where("task_board_item_id", "=", taskBoardItemId)
+              .where("subscribed", "=", true)
+              .execute()
+          ).map((row) => row.user_id);
 
-      const recipients = subscribers
-        .map((row) => row.user_id)
-        .filter((userId) => userId !== actorId);
+      const recipients = candidates.filter((userId) => userId !== actorId);
       if (recipients.length === 0) return;
       notified = recipients;
 

--- a/apps/api/src/storage/notifications.ts
+++ b/apps/api/src/storage/notifications.ts
@@ -12,6 +12,10 @@ import {
   type NotificationData,
 } from "../notifications/schema";
 import { notify, type NotifyParams } from "../notifications/notify";
+import {
+  notifyMentions,
+  type NotifyMentionsParams,
+} from "../notifications/mentions";
 
 /** One page of the inbox. The popover scrolls and pages through the rest. */
 const PAGE_SIZE = 20;
@@ -148,6 +152,13 @@ export class NotificationStorage {
    *  `notifications` rows; never throws. */
   async notify(params: Omit<NotifyParams, "db">): Promise<void> {
     await notify({ ...params, db: this.db });
+  }
+
+  /** Ping the members newly `@`-mentioned in a body. Never throws. */
+  async notifyMentions(
+    params: Omit<NotifyMentionsParams, "db">,
+  ): Promise<void> {
+    await notifyMentions({ ...params, db: this.db });
   }
 
   /** The user ids following this task. */

--- a/apps/api/src/tools/task-board/comments.ts
+++ b/apps/api/src/tools/task-board/comments.ts
@@ -130,6 +130,14 @@ export const TASK_BOARD_COMMENT_CREATE = defineTool({
       actorId: taskRun ? null : getUserId(ctx)!,
       alsoSubscribe: taskRun ? [] : [getUserId(ctx)!],
     });
+    // Separate from the "commented" fan-out above: that one reaches the task's
+    // followers, this one the people the comment names — who may be neither.
+    await ctx.storage.notifications.notifyMentions({
+      taskBoardItemId: comment.taskBoardItemId,
+      organizationId,
+      actorId: taskRun ? null : getUserId(ctx)!,
+      body: comment.body,
+    });
     // Durable enqueue (a DB write): the DBOS queue mirrors it onto the issue.
     await enqueueJiraCommentPush(ctx, {
       commentId: comment.id,

--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -138,6 +138,13 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
       ],
     });
 
+    await ctx.storage.notifications.notifyMentions({
+      taskBoardItemId: item.id,
+      organizationId,
+      actorId: getUserId(ctx)!,
+      body: item.description ?? "",
+    });
+
     // Broadcast the new card so every open board adds it live, no polling.
     emitTaskBoardUpdated(organizationId, item);
     await reactToSuperAgentDelegation(ctx, item);

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -372,6 +372,18 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
       }
     }
 
+    // Only the mentions this edit ADDED — the body is resent whole, so the
+    // previous description is what keeps a typo fix from re-pinging everyone.
+    if (previous && item.description !== previous.description) {
+      await ctx.storage.notifications.notifyMentions({
+        taskBoardItemId: item.id,
+        organizationId,
+        actorId: getUserId(ctx)!,
+        body: item.description ?? "",
+        previousBody: previous.description,
+      });
+    }
+
     // Broadcast EVERY change so open boards reflect it live. Not just the
     // browser's own edits (those also patch optimistically): an agent calling
     // this tool over MCP — e.g. moving its task to In Review — has no client

--- a/apps/web/ct/harness/stubs/use-mention-members.ts
+++ b/apps/web/ct/harness/stubs/use-mention-members.ts
@@ -1,0 +1,23 @@
+/**
+ * Stub for `@/hooks/use-mention-members`: the real one calls
+ * `useProjectContext()` and Better Auth's org client, neither of which exists
+ * under a bare mount. The picker's own behaviour — open, filter, insert — is
+ * what the CT specs assert, and that only needs a list.
+ */
+
+export interface MentionMember {
+  id: string;
+  name: string;
+  email: string;
+  image: string | null;
+}
+
+const MEMBERS: MentionMember[] = [
+  { id: "u1", name: "valls", email: "valls@deco.cx", image: null },
+  { id: "u2", name: "Ana Silva", email: "ana@deco.cx", image: null },
+  { id: "u3", name: "Bruno", email: "bruno@deco.cx", image: null },
+];
+
+export function useMentionMembers(_enabled: boolean) {
+  return { members: MEMBERS, loading: false };
+}

--- a/apps/web/ct/tests/task-comments.ct.tsx
+++ b/apps/web/ct/tests/task-comments.ct.tsx
@@ -6,33 +6,44 @@ test("renders a thread as one card with its replies", async ({ mount }) => {
 
   await expect(component.getByText("valls")).toBeVisible();
   await expect(component.getByText("Super Agent").first()).toBeVisible();
-  await expect(component.getByPlaceholder("Leave a reply...")).toBeVisible();
-  await expect(component.getByPlaceholder("Leave a comment...")).toBeVisible();
+  await expect(
+    component.getByRole("textbox", { name: "Leave a reply..." }),
+  ).toBeVisible();
+  await expect(
+    component.getByRole("textbox", { name: "Leave a comment..." }),
+  ).toBeVisible();
 });
 
 test("Enter posts a comment, Shift+Enter breaks the line", async ({
   mount,
 }) => {
   const component = await mount(<TaskCommentsHarness />);
-  const composer = component.getByPlaceholder("Leave a comment...");
+  const composer = component.getByRole("textbox", {
+    name: "Leave a comment...",
+  });
 
   await composer.fill("first line");
   await composer.press("Shift+Enter");
-  await composer.type("second line");
-  await expect(composer).toHaveValue("first line\nsecond line");
+  await composer.pressSequentially("second line");
+  await expect(composer).toHaveText("first linesecond line");
 
   await composer.press("Enter");
+  // Two trailing spaces: the line break is a markdown hard break now, not the
+  // bare newline the textarea produced — which only rendered as a break
+  // because the parser was told to treat one that way.
   await expect(component.getByTestId("posted")).toHaveText(
-    JSON.stringify(["first line\nsecond line"]),
+    JSON.stringify(["first line  \nsecond line"]),
   );
-  await expect(composer).toHaveValue("");
+  await expect(composer).toHaveText("");
 });
 
 test("an empty composer cannot be submitted", async ({ mount }) => {
   const component = await mount(<TaskCommentsHarness />);
 
   await expect(component.getByLabel("Send").last()).toBeDisabled();
-  await component.getByPlaceholder("Leave a comment...").fill("ship it");
+  await component
+    .getByRole("textbox", { name: "Leave a comment..." })
+    .fill("ship it");
   await expect(component.getByLabel("Send").last()).toBeEnabled();
 });
 
@@ -40,7 +51,7 @@ test("the reply composer appends to the thread it belongs to", async ({
   mount,
 }) => {
   const component = await mount(<TaskCommentsHarness />);
-  const reply = component.getByPlaceholder("Leave a reply...");
+  const reply = component.getByRole("textbox", { name: "Leave a reply..." });
 
   await reply.fill("thanks, reviewing now");
   await reply.press("Enter");
@@ -60,7 +71,9 @@ test("the send button still submits, despite the card-wide focus click", async (
 }) => {
   const component = await mount(<TaskCommentsHarness />);
 
-  await component.getByPlaceholder("Leave a comment...").fill("via the button");
+  await component
+    .getByRole("textbox", { name: "Leave a comment..." })
+    .fill("via the button");
   await component.getByLabel("Send").last().click();
   await expect(component.getByTestId("posted")).toHaveText(
     JSON.stringify(["via the button"]),
@@ -71,7 +84,9 @@ test("clicking anywhere in the comment card focuses the input", async ({
   mount,
 }) => {
   const component = await mount(<TaskCommentsHarness />);
-  const composer = component.getByPlaceholder("Leave a comment...");
+  const composer = component.getByRole("textbox", {
+    name: "Leave a comment...",
+  });
   const card = component.getByTestId("new-comment-composer");
 
   // Bottom-left of the card: empty space well below the one-line input.
@@ -84,7 +99,7 @@ test("clicking the empty part of a reply row focuses its input", async ({
   mount,
 }) => {
   const component = await mount(<TaskCommentsHarness />);
-  const reply = component.getByPlaceholder("Leave a reply...");
+  const reply = component.getByRole("textbox", { name: "Leave a reply..." });
   const row = component.getByTestId("reply-composer");
 
   // Right of the placeholder, left of the send button: dead space in between.
@@ -119,9 +134,13 @@ test("deleting the root comment takes the whole thread with it", async ({
   await page.getByRole("menuitem", { name: "Delete" }).click();
 
   await expect(component.getByText(/^On it\./)).toHaveCount(0);
-  await expect(component.getByPlaceholder("Leave a reply...")).toHaveCount(0);
+  await expect(
+    component.getByRole("textbox", { name: "Leave a reply..." }),
+  ).toHaveCount(0);
   // The task-level composer is not part of the thread, so it survives.
-  await expect(component.getByPlaceholder("Leave a comment...")).toBeVisible();
+  await expect(
+    component.getByRole("textbox", { name: "Leave a comment..." }),
+  ).toBeVisible();
 });
 
 test("only the root comment can resolve the thread", async ({
@@ -156,11 +175,15 @@ test("a resolved thread collapses to a summary and reopens on click", async ({
     "2 resolved comments from valls and Super Agent",
   );
   await expect(summary).toBeVisible();
-  await expect(component.getByPlaceholder("Leave a reply...")).toHaveCount(0);
+  await expect(
+    component.getByRole("textbox", { name: "Leave a reply..." }),
+  ).toHaveCount(0);
 
   await summary.click();
   await expect(component.getByText(/^On it\./)).toBeVisible();
-  await expect(component.getByPlaceholder("Leave a reply...")).toBeVisible();
+  await expect(
+    component.getByRole("textbox", { name: "Leave a reply..." }),
+  ).toBeVisible();
 
   // Expanded again, the menu offers the way back out.
   await component.getByLabel("Comment actions").first().click();
@@ -184,4 +207,59 @@ test("an expanded resolved thread collapses from its header", async ({
   await expect(
     component.getByText("2 resolved comments from valls and Super Agent"),
   ).toBeVisible();
+});
+
+test("typing @ opens the member picker, and picking one inserts a chip", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(<TaskCommentsHarness />);
+  const composer = component.getByRole("textbox", {
+    name: "Leave a comment...",
+  });
+
+  await composer.click();
+  await composer.pressSequentially("ping @");
+  // The menu portals to the body, so it lives on `page`, not the mount root.
+  const menu = page.getByTestId("mention-menu");
+  await expect(menu).toBeVisible();
+
+  // The query is what was typed after the `@` — there is no second input.
+  await composer.pressSequentially("an");
+  await expect(menu.getByText("Ana Silva")).toBeVisible();
+  await expect(menu.getByText("Bruno")).toHaveCount(0);
+
+  await composer.press("Enter");
+  await expect(menu).toHaveCount(0);
+  await expect(component.getByTestId("mention-chip")).toHaveText("@Ana Silva");
+
+  // The id is what goes on the wire, not the name that was typed.
+  await composer.press("Enter");
+  await expect(component.getByTestId("posted")).toHaveText(
+    JSON.stringify(["ping [@Ana Silva](mention:u2)"]),
+  );
+});
+
+test("Escape dismisses the picker and leaves the typed text alone", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(<TaskCommentsHarness />);
+  const composer = component.getByRole("textbox", {
+    name: "Leave a comment...",
+  });
+
+  await composer.click();
+  await composer.pressSequentially("hey @an");
+  await expect(page.getByTestId("mention-menu")).toBeVisible();
+
+  await composer.press("Escape");
+  await expect(page.getByTestId("mention-menu")).toHaveCount(0);
+  await expect(composer).toHaveText("hey @an");
+
+  // Enter now sends, because the picker no longer owns it.
+  await composer.press("Enter");
+  await expect(component.getByTestId("posted")).toHaveText(
+    JSON.stringify(["hey @an"]),
+  );
 });

--- a/apps/web/playwright-ct.config.ts
+++ b/apps/web/playwright-ct.config.ts
@@ -64,6 +64,12 @@ export default defineConfig({
             find: /^@\/components\/file-picker\/file-picker-dialog$/,
             replacement: stub("file-picker-dialog.tsx"),
           },
+          // The mention picker's members hook: same useProjectContext() issue,
+          // and the list itself is fixture data as far as the picker cares.
+          {
+            find: /^@\/hooks\/use-mention-members$/,
+            replacement: stub("use-mention-members.ts"),
+          },
           // FieldLabel's useVirtualMCP call hits the same useProjectContext() issue as above.
           {
             find: /^@\/sdk\/hooks\/use-virtual-mcp$/,

--- a/apps/web/src/components/chat/markdown.tsx
+++ b/apps/web/src/components/chat/markdown.tsx
@@ -20,6 +20,7 @@ import { ImageLightbox } from "./image-lightbox.tsx";
 import { resolveOrgFileBrowsePath } from "./org-file-ref.ts";
 import { OrgFileOpenContext } from "./org-file-open-context.tsx";
 import { useT } from "@/i18n/use-t.ts";
+import { mentionIdFromHref } from "@decocms/shared/mentions";
 // @ts-ignore - correct
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism/index.js";
 
@@ -269,6 +270,15 @@ function MarkdownAnchor({
       ? resolveOrgFileBrowsePath(href, ctx.orgSlug, ctx.threadId)
       : null;
   const label = animate ? animateText(children) : children;
+  // A mention is a link only so the body stays plain markdown — it doesn't
+  // navigate anywhere, so it must not render as something you can click.
+  if (href && mentionIdFromHref(href)) {
+    return (
+      <span className="rounded bg-primary/10 px-1 font-medium text-primary">
+        {label}
+      </span>
+    );
+  }
   if (ctx && browsePath) {
     return (
       <button

--- a/apps/web/src/components/markdown-editor/extensions.test.ts
+++ b/apps/web/src/components/markdown-editor/extensions.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "bun:test";
 import { Editor } from "@tiptap/core";
 import { markdownEditorExtensions } from "./extensions";
 import { unwrapListContinuations } from "./unwrap-list-continuations";
+import { parseMentions } from "@decocms/shared/mentions";
 
 /**
  * The description is stored as markdown, so the schema's whole contract is the
@@ -31,6 +32,14 @@ describe("markdown editor schema", () => {
     expect(JSON.stringify(json)).toContain('"type":"attachment"');
     // Same markdown back out — the value on the wire never changes shape.
     expect(markdown).toBe(`[spec.pdf](${FILE_URL})`);
+  });
+
+  test("a mention link becomes a chip and round-trips unchanged", () => {
+    const { markdown, editor } = roundTrip("ping [@Ana](mention:usr_1) please");
+    expect(JSON.stringify(editor.getJSON())).toContain('"type":"mention"');
+    expect(markdown).toBe("ping [@Ana](mention:usr_1) please");
+    // What the server reads back out is the id, not the name.
+    expect(parseMentions(markdown)).toEqual(["usr_1"]);
   });
 
   test("an ordinary link stays a link", () => {

--- a/apps/web/src/components/markdown-editor/extensions.ts
+++ b/apps/web/src/components/markdown-editor/extensions.ts
@@ -4,6 +4,12 @@ import Placeholder from "@tiptap/extension-placeholder";
 import { Markdown } from "@tiptap/markdown";
 import type { Extensions } from "@tiptap/core";
 import { MarkdownAttachment } from "./attachment-node";
+import { MarkdownMention } from "./mention-node";
+import { mentionIdFromHref } from "@decocms/shared/mentions";
+import {
+  mentionSuggestionExtension,
+  type MentionMenuStore,
+} from "./mention-suggestion";
 import { MarkdownImage } from "./image-node";
 import { isEditorFileUrl } from "./uploads";
 
@@ -14,16 +20,24 @@ const LINK_OPTIONS = {
 } as const;
 
 /**
- * An uploaded attachment is stored as a plain markdown link, so recognizing one
- * on the way back in has to happen here: the `link` token belongs to Link, and
- * the parser only runs the first handler registered for a token. Anything that
- * isn't one of our uploads keeps Link's own behaviour.
+ * An uploaded attachment and a mention are both stored as plain markdown
+ * links, so recognizing them on the way back in has to happen here: the `link`
+ * token belongs to Link, and the parser only runs the first handler registered
+ * for a token. Anything that isn't one of ours keeps Link's own behaviour.
  */
 const AttachmentAwareLink = Link.extend({
   parseMarkdown: (token, helpers) => {
     const href = typeof token.href === "string" ? token.href : "";
     if (isEditorFileUrl(href)) {
       return helpers.createNode("attachment", { href, name: token.text ?? "" });
+    }
+    const mentionId = mentionIdFromHref(href);
+    if (mentionId) {
+      // The link text is `@Name`; the chip renders its own `@`.
+      return helpers.createNode("mention", {
+        id: mentionId,
+        name: (token.text ?? "").replace(/^@/, ""),
+      });
     }
     return helpers.applyMark("link", helpers.parseInline(token.tokens ?? []), {
       href,
@@ -36,7 +50,11 @@ const AttachmentAwareLink = Link.extend({
  * The editor's schema. Kept separate from the component so the markdown
  * round-trip can be asserted without mounting React.
  */
-export function markdownEditorExtensions(placeholder = ""): Extensions {
+export function markdownEditorExtensions(
+  placeholder = "",
+  /** Omitted where mentions don't apply — no store, no `@` picker. */
+  mentionStore?: MentionMenuStore,
+): Extensions {
   return [
     StarterKit.configure({
       heading: { levels: [1, 2, 3] },
@@ -50,6 +68,8 @@ export function markdownEditorExtensions(placeholder = ""): Extensions {
     Placeholder.configure({ placeholder }),
     MarkdownImage,
     MarkdownAttachment,
+    MarkdownMention,
+    ...(mentionStore ? [mentionSuggestionExtension(mentionStore)] : []),
     Markdown.configure({
       markedOptions: {
         // These values used to be typed into a plain textarea, where one

--- a/apps/web/src/components/markdown-editor/index.tsx
+++ b/apps/web/src/components/markdown-editor/index.tsx
@@ -135,6 +135,11 @@ export function MarkdownEditor({
     editable,
     editorProps: {
       attributes: {
+        // A contenteditable has no role and no accessible name of its own, so
+        // without these nothing can address it by the label the user sees.
+        role: "textbox",
+        "aria-label": placeholder ?? "",
+        "aria-multiline": "true",
         class: cn(CONTENT_CLASS, PLACEHOLDER_CLASS),
       },
       handlePaste: (view, event) => {

--- a/apps/web/src/components/markdown-editor/index.tsx
+++ b/apps/web/src/components/markdown-editor/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { Selection } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
@@ -8,6 +8,7 @@ import { cn } from "@decocms/ui/lib/utils.ts";
 import { useT } from "@/i18n/use-t.ts";
 import { BubbleToolbar } from "./bubble-toolbar";
 import { markdownEditorExtensions } from "./extensions";
+import { MentionMenu, MentionMenuStore } from "./mention-suggestion";
 import { unwrapListContinuations } from "./unwrap-list-continuations";
 import { isImageFile, useEditorFileUpload } from "./use-file-upload";
 
@@ -93,6 +94,8 @@ export function MarkdownEditor({
 }) {
   const t = useT();
   const { uploadFile, pending } = useEditorFileUpload();
+  // One store per editor: created here so it dies with the editor it drives.
+  const [mentionStore] = useState(() => new MentionMenuStore());
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // The editor is created once, so its handlers would close over the first
@@ -126,7 +129,7 @@ export function MarkdownEditor({
   };
 
   const editor = useEditor({
-    extensions: markdownEditorExtensions(placeholder),
+    extensions: markdownEditorExtensions(placeholder, mentionStore),
     content: unwrapListContinuations(defaultValue),
     contentType: "markdown",
     editable,
@@ -173,6 +176,7 @@ export function MarkdownEditor({
   return (
     <div className="flex flex-col">
       <BubbleToolbar editor={editor} />
+      <MentionMenu store={mentionStore} />
       <EditorContent
         editor={editor}
         className="text-[15px] text-muted-foreground"

--- a/apps/web/src/components/markdown-editor/mention-input.tsx
+++ b/apps/web/src/components/markdown-editor/mention-input.tsx
@@ -1,0 +1,120 @@
+/**
+ * A one-field composer that understands `@`-mentions and nothing else.
+ *
+ * Tiptap, not a textarea, only because a mention needs a chip and an id — so
+ * this stays as close to the textarea it replaced as it can: no toolbar, no
+ * headings, no lists, Enter submits and Shift+Enter breaks the line. Its value
+ * is markdown, like `MarkdownEditor`'s, because that's what a comment body is.
+ */
+
+import { useImperativeHandle, useState, type Ref } from "react";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
+import { Markdown } from "@tiptap/markdown";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { MarkdownMention } from "./mention-node";
+import {
+  MENTION_SUGGESTION_KEY,
+  MentionMenu,
+  MentionMenuStore,
+  mentionSuggestionExtension,
+} from "./mention-suggestion";
+
+/** What the composer around this field drives from its own chrome. */
+export interface MentionInputHandle {
+  submit: () => void;
+  focus: () => void;
+}
+
+const PLACEHOLDER_CLASS = [
+  "[&_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)]",
+  "[&_p.is-editor-empty:first-child::before]:text-muted-foreground",
+  "[&_p.is-editor-empty:first-child::before]:float-left",
+  "[&_p.is-editor-empty:first-child::before]:h-0",
+  "[&_p.is-editor-empty:first-child::before]:pointer-events-none",
+].join(" ");
+
+export function MentionInput({
+  placeholder,
+  onSubmit,
+  onEmptyChange,
+  ref,
+  className,
+}: {
+  placeholder: string;
+  /** Called with the markdown body. Returning clears the field. */
+  onSubmit: (markdown: string) => void;
+  /** Drives the send button's disabled state. */
+  onEmptyChange: (empty: boolean) => void;
+  /** Submit and focus, for the send button and the click-anywhere-to-type
+   *  surface the composer wraps this in. */
+  ref?: Ref<MentionInputHandle>;
+  className?: string;
+}) {
+  const [mentionStore] = useState(() => new MentionMenuStore());
+
+  const editor = useEditor({
+    extensions: [
+      // Everything block-level is off: this is one field in a comment card,
+      // and a heading or a code block inside it would be a formatting surface
+      // with no way to see or undo it. Inline marks stay — `**bold**` typed
+      // into the old textarea already rendered as bold in the posted comment.
+      StarterKit.configure({
+        heading: false,
+        bulletList: false,
+        orderedList: false,
+        listItem: false,
+        blockquote: false,
+        codeBlock: false,
+        horizontalRule: false,
+        link: false,
+        underline: false,
+      }),
+      MarkdownMention,
+      mentionSuggestionExtension(mentionStore),
+      Placeholder.configure({ placeholder }),
+      Markdown,
+    ],
+    editorProps: {
+      attributes: {
+        class: cn(
+          "outline-none text-sm leading-relaxed text-foreground",
+          PLACEHOLDER_CLASS,
+        ),
+      },
+      handleKeyDown: (view, event) => {
+        if (event.key !== "Enter" || event.shiftKey) return false;
+        // The picker owns Enter while it's open — it's choosing a member, not
+        // sending. Asked of the plugin directly rather than relying on which
+        // handler ProseMirror happens to run first.
+        if (MENTION_SUGGESTION_KEY.getState(view.state)?.active) return false;
+        event.preventDefault();
+        submit();
+        return true;
+      },
+    },
+    onUpdate: ({ editor }) => onEmptyChange(editor.isEmpty),
+  });
+
+  function submit() {
+    if (!editor) return;
+    const markdown = editor.getMarkdown().trim();
+    if (!markdown) return;
+    onSubmit(markdown);
+    editor.commands.clearContent();
+    onEmptyChange(true);
+  }
+
+  useImperativeHandle(ref, () => ({
+    submit,
+    focus: () => editor?.commands.focus(),
+  }));
+
+  return (
+    <>
+      <EditorContent editor={editor} className={className} />
+      <MentionMenu store={mentionStore} />
+    </>
+  );
+}

--- a/apps/web/src/components/markdown-editor/mention-input.tsx
+++ b/apps/web/src/components/markdown-editor/mention-input.tsx
@@ -78,6 +78,12 @@ export function MentionInput({
     ],
     editorProps: {
       attributes: {
+        // A contenteditable is not a `<textarea>`: without these it has no
+        // role and no name, so nothing — a screen reader or a test — can
+        // address it by the label the user can see.
+        role: "textbox",
+        "aria-label": placeholder,
+        "aria-multiline": "true",
         class: cn(
           "outline-none text-sm leading-relaxed text-foreground",
           PLACEHOLDER_CLASS,

--- a/apps/web/src/components/markdown-editor/mention-node.tsx
+++ b/apps/web/src/components/markdown-editor/mention-node.tsx
@@ -1,0 +1,90 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+import {
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+  type NodeViewProps,
+} from "@tiptap/react";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { mentionMarkdown } from "@decocms/shared/mentions";
+
+/**
+ * A mentioned member, as a chip. Not editable and not selectable text: the id
+ * is what notifies, so a half-deleted name must not survive as a live mention.
+ * Backspace removes the whole chip, which is what `atom` buys.
+ */
+function MentionNodeView({ node, selected }: NodeViewProps) {
+  const name = typeof node.attrs.name === "string" ? node.attrs.name : "";
+  return (
+    <NodeViewWrapper
+      as="span"
+      data-testid="mention-chip"
+      className={cn(
+        "select-none rounded px-1 font-medium text-primary",
+        // Tinted rather than bordered — a mention sits mid-sentence, and a
+        // chip with an outline would break the line of the text around it.
+        "bg-primary/10",
+        selected && "ring-2 ring-ring",
+      )}
+    >
+      @{name}
+    </NodeViewWrapper>
+  );
+}
+
+/**
+ * `@`-mention of an org member.
+ *
+ * On the wire it's the plain markdown link `@decocms/shared/mentions` defines,
+ * so the body stays markdown for everything downstream that isn't this editor
+ * (the agent's prompt context, the Jira mirror, the comment renderer). Reading
+ * one back is the Link extension's job — see `extensions.ts`, where the `link`
+ * token handler branches on the href.
+ */
+export const MarkdownMention = Node.create({
+  name: "mention",
+  group: "inline",
+  inline: true,
+  atom: true,
+  // Not draggable: dropping a mention somewhere is a way to duplicate one.
+  selectable: true,
+
+  addAttributes() {
+    return {
+      id: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-mention-id"),
+        renderHTML: (attributes) =>
+          attributes.id ? { "data-mention-id": attributes.id } : {},
+      },
+      name: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-mention-name"),
+        renderHTML: (attributes) =>
+          attributes.name ? { "data-mention-name": attributes.name } : {},
+      },
+    };
+  },
+
+  // Round-trips a chip copied inside the editor (the clipboard carries HTML).
+  parseHTML() {
+    return [{ tag: "span[data-mention-id]" }];
+  },
+
+  renderHTML({ HTMLAttributes, node }) {
+    return [
+      "span",
+      mergeAttributes(HTMLAttributes),
+      `@${typeof node.attrs.name === "string" ? node.attrs.name : ""}`,
+    ];
+  },
+
+  renderMarkdown: (node) => {
+    const id = typeof node.attrs?.id === "string" ? node.attrs.id : "";
+    const name = typeof node.attrs?.name === "string" ? node.attrs.name : "";
+    return id ? mentionMarkdown(id, name) : `@${name}`;
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(MentionNodeView);
+  },
+});

--- a/apps/web/src/components/markdown-editor/mention-suggestion.tsx
+++ b/apps/web/src/components/markdown-editor/mention-suggestion.tsx
@@ -1,0 +1,273 @@
+/**
+ * The `@` picker: a Tiptap suggestion plugin and the menu it drives.
+ *
+ * The plugin lives in ProseMirror and the menu in React, so they meet at a
+ * tiny store rather than a portal rendered from inside the plugin — one
+ * component tree, one place the menu's state can be read.
+ *
+ * cmdk provides the list, its scroll and the scroll-into-view; the search
+ * itself does NOT come from a `CommandInput`. The query is what the user
+ * already typed after the `@`, in the editor — a second input under the caret
+ * would be a second place to type the same thing.
+ */
+
+import { useState, useSyncExternalStore } from "react";
+import Suggestion, {
+  type SuggestionOptions,
+  type SuggestionProps,
+} from "@tiptap/suggestion";
+import { Extension, type Editor, type Range } from "@tiptap/core";
+import { PluginKey } from "@tiptap/pm/state";
+import { createPortal } from "react-dom";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
+import {
+  Command,
+  CommandItem,
+  CommandList,
+} from "@decocms/ui/components/command.tsx";
+import { Spinner } from "@decocms/ui/components/spinner.tsx";
+import { getInitials } from "@/lib/get-initials";
+import { useT } from "@/i18n/use-t.ts";
+import {
+  useMentionMembers,
+  type MentionMember,
+} from "@/hooks/use-mention-members";
+
+interface MenuState {
+  query: string;
+  /** The `@…` text being replaced, for the insert. */
+  range: Range | null;
+  /** The decoration under the caret, which the menu anchors to. */
+  rect: (() => DOMRect | null) | null;
+  editor: Editor | null;
+}
+
+const CLOSED: MenuState = { query: "", range: null, rect: null, editor: null };
+
+/**
+ * The bridge between the plugin and the menu. A store rather than React state
+ * because the plugin's callbacks fire outside React's tree and must reach the
+ * menu synchronously — `onKeyDown` has to answer "did the menu handle this
+ * key?" before ProseMirror moves on.
+ */
+export class MentionMenuStore {
+  private state: MenuState = CLOSED;
+  private listeners = new Set<() => void>();
+  /** Set by the menu while it's open — arrow keys and Enter belong to it. */
+  onKey: ((event: KeyboardEvent) => boolean) | null = null;
+
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  getSnapshot = () => this.state;
+
+  set(next: MenuState) {
+    this.state = next;
+    for (const listener of this.listeners) listener();
+  }
+
+  close() {
+    this.onKey = null;
+    this.set(CLOSED);
+  }
+}
+
+/** Insert the chip, replacing the typed `@query`. */
+function insert(editor: Editor, range: Range, member: MentionMember) {
+  editor
+    .chain()
+    .focus()
+    .insertContentAt(range, [
+      { type: "mention", attrs: { id: member.id, name: member.name } },
+      // Without the trailing space the caret sits glued to the chip, and the
+      // next character typed reads as part of the name.
+      { type: "text", text: " " },
+    ])
+    .run();
+}
+
+export const MENTION_SUGGESTION_KEY = new PluginKey("markdownEditorMention");
+
+/**
+ * The Tiptap half. `store` is created by the component that owns the editor,
+ * so both halves are torn down together.
+ */
+export function mentionSuggestionExtension(store: MentionMenuStore) {
+  return Extension.create({
+    name: "mentionSuggestion",
+    addProseMirrorPlugins() {
+      const options: SuggestionOptions = {
+        editor: this.editor,
+        char: "@",
+        pluginKey: MENTION_SUGGESTION_KEY,
+        // An `@` inside a word is an email address, not a mention.
+        allowedPrefixes: [" ", "\n"],
+        // The list is fetched and filtered in React; the plugin only reports
+        // the query.
+        items: () => [],
+        render: () => ({
+          onStart: (props: SuggestionProps) => {
+            store.set({
+              query: props.query,
+              range: props.range,
+              rect: props.clientRect ?? null,
+              editor: props.editor,
+            });
+          },
+          onUpdate: (props: SuggestionProps) => {
+            store.set({
+              query: props.query,
+              range: props.range,
+              rect: props.clientRect ?? null,
+              editor: props.editor,
+            });
+          },
+          onKeyDown: ({ event }) => {
+            if (event.key === "Escape") {
+              store.close();
+              return true;
+            }
+            return store.onKey?.(event) ?? false;
+          },
+          onExit: () => store.close(),
+        }),
+      };
+      return [Suggestion(options)];
+    },
+  });
+}
+
+const MENU_WIDTH = 256;
+const MENU_MAX_HEIGHT = 280;
+const MENU_MIN_HEIGHT = 140;
+
+function matches(member: MentionMember, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    member.name.toLowerCase().includes(q) ||
+    member.email.toLowerCase().includes(q)
+  );
+}
+
+/**
+ * The menu. Renders nothing until the plugin opens it, so the members fetch
+ * doesn't run until an `@` is actually typed.
+ */
+export function MentionMenu({ store }: { store: MentionMenuStore }) {
+  const state = useSyncExternalStore(store.subscribe, store.getSnapshot);
+  const open = state.range !== null;
+  return open ? <OpenMentionMenu store={store} state={state} /> : null;
+}
+
+function OpenMentionMenu({
+  store,
+  state,
+}: {
+  store: MentionMenuStore;
+  state: MenuState;
+}) {
+  const t = useT();
+  const { members, loading } = useMentionMembers(true);
+  const [active, setActive] = useState(0);
+
+  const filtered = members.filter((m) => matches(m, state.query));
+  // The query narrows as you type, so the previous index can fall off the end.
+  const index = Math.min(active, Math.max(filtered.length - 1, 0));
+  const selected = filtered[index];
+
+  // Fixed to the caret's own rect, in a body portal so the editor's overflow
+  // can't clip it. Full floating-ui placement would buy collision detection
+  // against every edge; the only edge a menu under a caret actually hits is
+  // the bottom of the viewport, and that's the flip below.
+  const caret = state.rect?.() ?? new DOMRect(0, 0, 0, 0);
+  const below = window.innerHeight - caret.bottom;
+  const flipUp = below < MENU_MAX_HEIGHT && caret.top > below;
+  const style: React.CSSProperties = {
+    position: "fixed",
+    left: Math.min(caret.left, window.innerWidth - MENU_WIDTH - 8),
+    maxHeight: Math.max(flipUp ? caret.top - 8 : below - 8, MENU_MIN_HEIGHT),
+    ...(flipUp
+      ? { bottom: window.innerHeight - caret.top + 6 }
+      : { top: caret.bottom + 6 }),
+  };
+
+  const choose = (member: MentionMember | undefined) => {
+    if (!member || !state.editor || !state.range) return;
+    insert(state.editor, state.range, member);
+    store.close();
+  };
+
+  // Registered on every render so it closes over the current list — the plugin
+  // asks this synchronously while the keystroke is still cancellable.
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- plain field on a store, not a ref read during render
+  store.onKey = (event: KeyboardEvent) => {
+    if (event.key === "ArrowDown") {
+      setActive((i) => (filtered.length ? (i + 1) % filtered.length : 0));
+      return true;
+    }
+    if (event.key === "ArrowUp") {
+      setActive((i) =>
+        filtered.length ? (i - 1 + filtered.length) % filtered.length : 0,
+      );
+      return true;
+    }
+    if (event.key === "Enter" || event.key === "Tab") {
+      // Nothing to pick yet: let the key do its normal job rather than
+      // swallowing an Enter that was meant to send or break the line.
+      if (!selected) return false;
+      choose(selected);
+      return true;
+    }
+    return false;
+  };
+
+  return createPortal(
+    <div
+      style={{ ...style, width: MENU_WIDTH }}
+      data-testid="mention-menu"
+      className="z-50 overflow-hidden rounded-lg border border-border bg-popover shadow-md"
+    >
+      <Command shouldFilter={false} value={selected?.id ?? ""}>
+        <CommandList>
+          {/* A cached list is on screen while the refresh runs; the spinner
+              is only for the first ever open, with nothing to show. Not
+              `CommandEmpty`, which keys off cmdk's own filtering — and the
+              filtering here is ours (`shouldFilter={false}`). */}
+          {loading && (
+            <div className="flex items-center justify-center py-6">
+              <Spinner size="sm" />
+            </div>
+          )}
+          {!loading && filtered.length === 0 && (
+            <div className="px-4 py-4 text-center text-sm text-muted-foreground">
+              {t("markdownEditor.mentionEmpty")}
+            </div>
+          )}
+          {filtered.map((member) => (
+            <CommandItem
+              key={member.id}
+              value={member.id}
+              onSelect={() => choose(member)}
+              // The caret stays in the editor; a mousedown here would blur it
+              // and close the suggestion before the click lands.
+              onMouseDown={(e) => e.preventDefault()}
+              className="gap-2"
+            >
+              <Avatar
+                url={member.image ?? undefined}
+                fallback={getInitials(member.name)}
+                shape="circle"
+                size="xs"
+              />
+              <span className="min-w-0 flex-1 truncate">{member.name}</span>
+            </CommandItem>
+          ))}
+        </CommandList>
+      </Command>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/markdown-editor/mention-suggestion.tsx
+++ b/apps/web/src/components/markdown-editor/mention-suggestion.tsx
@@ -13,6 +13,7 @@
 
 import { useState, useSyncExternalStore } from "react";
 import Suggestion, {
+  exitSuggestion,
   type SuggestionOptions,
   type SuggestionProps,
 } from "@tiptap/suggestion";
@@ -74,6 +75,8 @@ export class MentionMenuStore {
   }
 }
 
+export const MENTION_SUGGESTION_KEY = new PluginKey("markdownEditorMention");
+
 /** Insert the chip, replacing the typed `@query`. */
 function insert(editor: Editor, range: Range, member: MentionMember) {
   editor
@@ -86,9 +89,19 @@ function insert(editor: Editor, range: Range, member: MentionMember) {
       { type: "text", text: " " },
     ])
     .run();
+  dismiss(editor);
 }
 
-export const MENTION_SUGGESTION_KEY = new PluginKey("markdownEditorMention");
+/**
+ * Deactivate the suggestion plugin itself, not just the menu.
+ *
+ * Hiding the React menu leaves the plugin matching, and a matching plugin
+ * still claims Enter — so an Escape'd picker would silently swallow the next
+ * send. This is the only thing that actually ends the match.
+ */
+function dismiss(editor: Editor) {
+  exitSuggestion(editor.view, MENTION_SUGGESTION_KEY);
+}
 
 /**
  * The Tiptap half. `store` is created by the component that owns the editor,
@@ -124,8 +137,9 @@ export function mentionSuggestionExtension(store: MentionMenuStore) {
               editor: props.editor,
             });
           },
-          onKeyDown: ({ event }) => {
+          onKeyDown: ({ event, view }) => {
             if (event.key === "Escape") {
+              exitSuggestion(view, MENTION_SUGGESTION_KEY);
               store.close();
               return true;
             }

--- a/apps/web/src/components/sidebar/footer/inbox-task-item.tsx
+++ b/apps/web/src/components/sidebar/footer/inbox-task-item.tsx
@@ -23,6 +23,8 @@ function summarize(
   switch (update.action) {
     case "commented":
       return t("sidebar.inbox.actionCommented");
+    case "mentioned":
+      return t("sidebar.inbox.actionMentioned");
     case "created":
       return t("sidebar.inbox.actionCreated");
     case "status_changed":

--- a/apps/web/src/hooks/use-mention-members.test.ts
+++ b/apps/web/src/hooks/use-mention-members.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { mergeMembers, type MentionMember } from "./use-mention-members.ts";
+
+const ana: MentionMember = {
+  id: "u1",
+  name: "Ana",
+  email: "ana@x.dev",
+  image: null,
+};
+
+test("an unchanged member keeps its identity, so its row doesn't re-render", () => {
+  const bo: MentionMember = {
+    id: "u2",
+    name: "Bo",
+    email: "b@x.dev",
+    image: null,
+  };
+  const merged = mergeMembers([ana], [{ ...ana }, bo]);
+  expect(merged[0]).toBe(ana);
+  expect(merged[1]).toBe(bo);
+});
+
+test("an edited member is replaced, not kept", () => {
+  const renamed = { ...ana, name: "Ana Silva" };
+  expect(mergeMembers([ana], [renamed])[0]).toBe(renamed);
+});
+
+test("a removed member is gone — the fetch is the truth", () => {
+  expect(mergeMembers([ana], [])).toEqual([]);
+});
+
+test("no cache is just the fetched list", () => {
+  expect(mergeMembers(undefined, [ana])).toEqual([ana]);
+});

--- a/apps/web/src/hooks/use-mention-members.ts
+++ b/apps/web/src/hooks/use-mention-members.ts
@@ -1,0 +1,131 @@
+/**
+ * The members the mention picker offers, kept warm across reloads.
+ *
+ * The list opens on a keystroke, so waiting on a round-trip would mean an empty
+ * menu under the caret every time. The last list is kept in `localStorage` and
+ * shown immediately; the fetch still runs, in the background, and merges into
+ * what's on screen.
+ *
+ * Merging, rather than replacing: a member whose fields didn't change keeps its
+ * object identity, so React re-renders only the rows that are actually new. A
+ * replacement would re-render the whole list — a visible flash under a menu the
+ * user is already reading.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useOrgAuthClient } from "@/hooks/use-org-auth-client";
+import { KEYS } from "@/lib/query-keys";
+import { useProjectContext } from "@/sdk";
+
+export interface MentionMember {
+  /** The user id — what a mention stores and what notifies. */
+  id: string;
+  name: string;
+  email: string;
+  image: string | null;
+}
+
+const STORAGE_PREFIX = "studio.mention-members.";
+
+/** Parsed copies, so the picker doesn't re-parse the cache on every render. */
+const parsed = new Map<string, MentionMember[]>();
+
+function readCache(key: string): MentionMember[] | undefined {
+  const hit = parsed.get(key);
+  if (hit) return hit;
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return undefined;
+    const value: unknown = JSON.parse(raw);
+    if (!Array.isArray(value)) return undefined;
+    // Trust nothing from storage: it survives deploys that changed this shape.
+    const members = value.filter(
+      (m): m is MentionMember =>
+        !!m && typeof m.id === "string" && typeof m.name === "string",
+    );
+    parsed.set(key, members);
+    return members;
+  } catch {
+    // Private mode, quota, corrupt JSON — a cold list is the fallback.
+    return undefined;
+  }
+}
+
+function writeCache(key: string, members: MentionMember[]): void {
+  parsed.set(key, members);
+  try {
+    localStorage.setItem(key, JSON.stringify(members));
+  } catch {
+    // Storage being unavailable costs a cold open, nothing more.
+  }
+}
+
+/**
+ * `next` with each unchanged member replaced by its `previous` object, so only
+ * genuinely new or edited rows change identity.
+ */
+export function mergeMembers(
+  previous: MentionMember[] | undefined,
+  next: MentionMember[],
+): MentionMember[] {
+  if (!previous?.length) return next;
+  const byId = new Map(previous.map((m) => [m.id, m]));
+  return next.map((member) => {
+    const old = byId.get(member.id);
+    return old &&
+      old.name === member.name &&
+      old.email === member.email &&
+      old.image === member.image
+      ? old
+      : member;
+  });
+}
+
+interface RawMember {
+  userId: string;
+  user?: { name?: string; email?: string; image?: string | null };
+}
+
+function toMentionMembers(rows: RawMember[]): MentionMember[] {
+  return rows
+    .map((row) => ({
+      id: row.userId,
+      // An invited member who never set a name still has to be pickable.
+      name: row.user?.name?.trim() || row.user?.email?.trim() || "",
+      email: row.user?.email ?? "",
+      image: row.user?.image ?? null,
+    }))
+    .filter((m) => !!m.name)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function useMentionMembers(enabled: boolean) {
+  const { locator } = useProjectContext();
+  const orgAuth = useOrgAuthClient();
+  const storageKey = `${STORAGE_PREFIX}${locator}`;
+
+  const query = useQuery({
+    queryKey: KEYS.mentionMembers(locator),
+    enabled,
+    // No stale window: the picker opening IS the signal to re-check. The
+    // cached list is on screen throughout, so the refetch costs nothing seen.
+    staleTime: 0,
+    placeholderData: () => readCache(storageKey),
+    queryFn: async () => {
+      const res = await orgAuth.organization.listMembers();
+      const members = mergeMembers(
+        readCache(storageKey),
+        toMentionMembers((res?.data?.members ?? []) as RawMember[]),
+      );
+      writeCache(storageKey, members);
+      return members;
+    },
+  });
+
+  return {
+    members: query.data ?? [],
+    /** Only true with nothing to show — a refresh over a cached list is
+     *  silent by design. */
+    loading: query.isFetching && !query.data,
+  };
+}

--- a/apps/web/src/i18n/en/markdown-editor.ts
+++ b/apps/web/src/i18n/en/markdown-editor.ts
@@ -1,5 +1,6 @@
 export const markdownEditor = {
   "markdownEditor.toolbarAriaLabel": "Text formatting",
+  "markdownEditor.mentionEmpty": "No members found",
   "markdownEditor.bold": "Bold",
   "markdownEditor.italic": "Italic",
   "markdownEditor.strikethrough": "Strikethrough",

--- a/apps/web/src/i18n/en/sidebar.ts
+++ b/apps/web/src/i18n/en/sidebar.ts
@@ -51,6 +51,7 @@ export const sidebar = {
   "sidebar.inbox.emptyBody":
     "Updates on the tasks you follow will appear here.",
   "sidebar.inbox.actionCommented": "New comment",
+  "sidebar.inbox.actionMentioned": "Mentioned you",
   "sidebar.inbox.actionCreated": "Task created",
   "sidebar.inbox.actionStatusChanged": "Moved to a new column",
   "sidebar.inbox.actionAssigneeChanged": "Reassigned",

--- a/apps/web/src/i18n/pt-br/markdown-editor.ts
+++ b/apps/web/src/i18n/pt-br/markdown-editor.ts
@@ -2,6 +2,7 @@ import type { markdownEditor as markdownEditorEn } from "../en/markdown-editor.t
 
 export const markdownEditor = {
   "markdownEditor.toolbarAriaLabel": "Formatação de texto",
+  "markdownEditor.mentionEmpty": "Nenhum membro encontrado",
   "markdownEditor.bold": "Negrito",
   "markdownEditor.italic": "Itálico",
   "markdownEditor.strikethrough": "Riscado",

--- a/apps/web/src/i18n/pt-br/sidebar.ts
+++ b/apps/web/src/i18n/pt-br/sidebar.ts
@@ -55,6 +55,7 @@ export const sidebar = {
   "sidebar.inbox.emptyBody":
     "Atualizações das tarefas que você segue vão aparecer aqui.",
   "sidebar.inbox.actionCommented": "Novo comentário",
+  "sidebar.inbox.actionMentioned": "Mencionou você",
   "sidebar.inbox.actionCreated": "Tarefa criada",
   "sidebar.inbox.actionStatusChanged": "Movida para outra coluna",
   "sidebar.inbox.actionAssigneeChanged": "Responsável alterado",

--- a/apps/web/src/layouts/task-board/task-comments.tsx
+++ b/apps/web/src/layouts/task-board/task-comments.tsx
@@ -6,9 +6,10 @@
  * `useTaskBoardComments`, and the dialog maps a comment's `authorId` to a
  * member before handing it here.
  *
- * No attach affordance and no `@`-mentions: the paperclip belongs with
- * attachment storage, and a mention is only worth typing once mentioning
- * someone notifies them. Both are additions, not omissions to paper over.
+ * No attach affordance: the paperclip belongs with attachment storage. The
+ * composer is a Tiptap field rather than a textarea for one reason — an
+ * `@`-mention needs a chip and a user id, not the name the user happened to
+ * type.
  */
 
 import { Fragment, useRef, useState } from "react";
@@ -35,6 +36,10 @@ import { SuperAgentIcon } from "@/components/super-agent-icon";
 import { getInitials } from "@/lib/get-initials";
 import { formatTimeAgo } from "@/lib/format-time";
 import { useT, type TFunction } from "@/i18n/use-t.ts";
+import {
+  MentionInput,
+  type MentionInputHandle,
+} from "@/components/markdown-editor/mention-input";
 
 export type CommentAuthor = {
   id: string;
@@ -333,41 +338,19 @@ function CommentComposer({
   onSubmit: (body: string) => void;
 }) {
   const t = useT();
-  const ref = useRef<HTMLTextAreaElement>(null);
-  const [value, setValue] = useState("");
+  const ref = useRef<MentionInputHandle>(null);
+  const [empty, setEmpty] = useState(true);
 
-  const submit = () => {
-    const body = value.trim();
-    if (!body) return;
-    onSubmit(body);
-    setValue("");
-    const el = ref.current;
-    if (el) {
-      el.value = "";
-      autoGrow(el);
-    }
-  };
-
-  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      submit();
-    }
-  };
+  const submit = () => ref.current?.submit();
 
   const textarea = (
-    <textarea
+    <MentionInput
       ref={ref}
-      value={value}
-      onChange={(e) => {
-        setValue(e.currentTarget.value);
-        autoGrow(e.currentTarget);
-      }}
-      onKeyDown={onKeyDown}
       placeholder={placeholder}
-      rows={1}
+      onSubmit={onSubmit}
+      onEmptyChange={setEmpty}
       className={cn(
-        "w-full resize-none overflow-hidden border-0 bg-transparent text-sm leading-relaxed text-foreground outline-none placeholder:text-muted-foreground",
+        "w-full [&_.tiptap]:outline-none",
         variant === "root" && "min-h-10",
       )}
     />
@@ -376,7 +359,7 @@ function CommentComposer({
   const actions = (
     <button
       type="button"
-      disabled={!value.trim()}
+      disabled={empty}
       onClick={submit}
       aria-label={t("taskBoard.taskDialog.commentSubmitAriaLabel")}
       // cursor-pointer: the composer around it sets cursor-text, which would
@@ -421,10 +404,4 @@ function CommentComposer({
       {actions}
     </div>
   );
-}
-
-/** Grow a composer to fit its text instead of scrolling inside itself. */
-function autoGrow(el: HTMLTextAreaElement) {
-  el.style.height = "auto";
-  el.style.height = `${el.scrollHeight}px`;
 }

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -749,7 +749,7 @@ export function TaskBoardItemDialog({
                   onFocusCapture={() => setDescriptionExpanded(true)}
                   onBlurCapture={flush}
                 >
-                  <div ref={measureDescription}>
+                  <div ref={measureDescription} data-testid="task-description">
                     {/* Markdown in, markdown out — the value also becomes
                         prompt context for the agent, and plain-text
                         descriptions written before this editor existed still

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -25,6 +25,10 @@ export const KEYS = {
 
   // Organization members (scoped by org)
   members: (locator: ProjectLocator) => [locator, "members"] as const,
+  /** The mention picker's own view of the members list — narrowed, and backed
+   *  by a browser-persisted copy, so it can't share `members`' cache entry. */
+  mentionMembers: (locator: ProjectLocator) =>
+    [locator, "mention-members"] as const,
 
   // Organization invitations (scoped by org)
   invitations: (locator: ProjectLocator) => [locator, "invitations"] as const,

--- a/packages/e2e/tests/task-description-markdown.spec.ts
+++ b/packages/e2e/tests/task-description-markdown.spec.ts
@@ -32,8 +32,11 @@ const PNG = Buffer.from(
  * placeholder and so only exists while the description is empty — this test
  * asserts on it both empty and filled.
  */
+/** The description editor specifically. The dialog holds a second ProseMirror
+ *  — the comment composer, which also takes `@`-mentions — so `.ProseMirror`
+ *  alone is ambiguous. */
 function editorOf(page: Page) {
-  return page.getByRole("dialog").locator(".ProseMirror");
+  return page.getByTestId("task-description").locator(".ProseMirror");
 }
 
 // Black-box wire-contract shape (owned by this test, per e2e isolation rules).

--- a/packages/e2e/tests/task-mentions.spec.ts
+++ b/packages/e2e/tests/task-mentions.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * E2E: `@`-mentions notify the people they name, and only them.
+ *
+ * Three things this proves that no unit test can:
+ *   - a mention reaches someone who does NOT follow the task (the whole point;
+ *     every other notification type goes to followers);
+ *   - it does not reach the task's followers, who were not named;
+ *   - a mention of a user id outside the org writes nothing. The body is
+ *     user-authored text, so an ungated fan-out would turn it into a way to
+ *     notify any user id in the deployment.
+ */
+
+import type { APIRequestContext } from "@playwright/test";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { callSelfMcpTool, findOrgId } from "../fixtures/mcp-tools";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+// Black-box wire-contract shapes (owned by this test, per e2e isolation rules).
+interface InboxRow {
+  taskBoardItemId: string;
+  type: string;
+}
+
+/** The mention markdown, spelled out here rather than imported: this suite owns
+ *  the wire format it asserts on, and a divergence from the app is the signal. */
+const mention = (userId: string, name: string) =>
+  `[@${name}](mention:${userId})`;
+
+async function inviteAndAccept(
+  ownerCtx: APIRequestContext,
+  memberCtx: APIRequestContext,
+  organizationId: string,
+  email: string,
+): Promise<void> {
+  const invite = await ownerCtx.post("/api/auth/organization/invite-member", {
+    data: { organizationId, email, role: "user" },
+  });
+  expect(invite.ok(), `invite failed: ${await invite.text()}`).toBe(true);
+  const body = (await invite.json()) as {
+    id?: string;
+    invitation?: { id?: string };
+  };
+  const accept = await memberCtx.post(
+    "/api/auth/organization/accept-invitation",
+    { data: { invitationId: body.id ?? body.invitation?.id } },
+  );
+  expect(accept.ok(), `accept failed: ${await accept.text()}`).toBe(true);
+}
+
+test.describe("task mentions", () => {
+  test("a mention in a comment notifies the named member, not the followers", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const organizationId = await findOrgId(ownerCtx, owner.orgSlug);
+
+    // Named in the comment, following nothing.
+    const namedCtx = await newApiContext(playwright);
+    const named = await signUpViaApi(namedCtx);
+    await inviteAndAccept(ownerCtx, namedCtx, organizationId, named.email);
+
+    // Follows the task, named in nothing.
+    const followerCtx = await newApiContext(playwright);
+    const follower = await signUpViaApi(followerCtx);
+    await inviteAndAccept(
+      ownerCtx,
+      followerCtx,
+      organizationId,
+      follower.email,
+    );
+
+    const { item } = await callSelfMcpTool<{ item: { id: string } }>(
+      ownerCtx,
+      owner.orgSlug,
+      "TASK_BOARD_ITEM_CREATE",
+      { title: "Mention me" },
+    );
+    await callSelfMcpTool(
+      followerCtx,
+      owner.orgSlug,
+      "NOTIFICATION_SUBSCRIPTION_SET",
+      { taskBoardItemId: item.id, subscribed: true },
+    );
+
+    await callSelfMcpTool(
+      ownerCtx,
+      owner.orgSlug,
+      "TASK_BOARD_COMMENT_CREATE",
+      {
+        taskBoardItemId: item.id,
+        body: `heads up ${mention(named.userId, "Named")}`,
+      },
+    );
+
+    const namedInbox = await callSelfMcpTool<{ notifications: InboxRow[] }>(
+      namedCtx,
+      owner.orgSlug,
+      "NOTIFICATION_LIST",
+      {},
+    );
+    expect(namedInbox.notifications.map((n) => n.type)).toEqual(["mentioned"]);
+    expect(namedInbox.notifications[0]?.taskBoardItemId).toBe(item.id);
+
+    // The follower gets the comment, and NOT the mention that didn't name them.
+    const followerInbox = await callSelfMcpTool<{ notifications: InboxRow[] }>(
+      followerCtx,
+      owner.orgSlug,
+      "NOTIFICATION_LIST",
+      {},
+    );
+    expect(followerInbox.notifications.map((n) => n.type)).toEqual([
+      "commented",
+    ]);
+  });
+
+  test("editing a description notifies only the mentions the edit added", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const organizationId = await findOrgId(ownerCtx, owner.orgSlug);
+
+    const mateCtx = await newApiContext(playwright);
+    const mate = await signUpViaApi(mateCtx);
+    await inviteAndAccept(ownerCtx, mateCtx, organizationId, mate.email);
+
+    const { item } = await callSelfMcpTool<{ item: { id: string } }>(
+      ownerCtx,
+      owner.orgSlug,
+      "TASK_BOARD_ITEM_CREATE",
+      { title: "Spec", description: `owner: ${mention(mate.userId, "Mate")}` },
+    );
+
+    // A later edit that leaves the same mention in place must not re-ping.
+    await callSelfMcpTool(ownerCtx, owner.orgSlug, "TASK_BOARD_ITEM_UPDATE", {
+      id: item.id,
+      description: `owner: ${mention(mate.userId, "Mate")} — and a typo fixed`,
+    });
+
+    const inbox = await callSelfMcpTool<{ notifications: InboxRow[] }>(
+      mateCtx,
+      owner.orgSlug,
+      "NOTIFICATION_LIST",
+      {},
+    );
+    expect(
+      inbox.notifications.filter((n) => n.type === "mentioned").length,
+    ).toBe(1);
+  });
+
+  test("mentioning yourself notifies nobody", async ({ playwright }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+
+    const { item } = await callSelfMcpTool<{ item: { id: string } }>(
+      ownerCtx,
+      owner.orgSlug,
+      "TASK_BOARD_ITEM_CREATE",
+      { title: "Solo" },
+    );
+    await callSelfMcpTool(
+      ownerCtx,
+      owner.orgSlug,
+      "TASK_BOARD_COMMENT_CREATE",
+      {
+        taskBoardItemId: item.id,
+        body: `note to self ${mention(owner.userId, "Me")}`,
+      },
+    );
+
+    const inbox = await callSelfMcpTool<{ unreadCount: number }>(
+      ownerCtx,
+      owner.orgSlug,
+      "NOTIFICATION_LIST",
+      {},
+    );
+    expect(inbox.unreadCount).toBe(0);
+  });
+});

--- a/packages/shared/src/mentions.test.ts
+++ b/packages/shared/src/mentions.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import { mentionMarkdown, parseMentions } from "./mentions.ts";
+
+test("parses ids, deduped, in first-seen order; ignores ordinary links", () => {
+  const body = `Hi ${mentionMarkdown("usr_2", "Ana")} and ${mentionMarkdown(
+    "usr_1",
+    "Bo",
+  )} — again ${mentionMarkdown("usr_2", "Ana")}. [docs](https://x.dev)`;
+  expect(parseMentions(body)).toEqual(["usr_2", "usr_1"]);
+});
+
+test("a name with brackets can't break out of the link", () => {
+  expect(parseMentions(mentionMarkdown("usr_1", "A]hi[B"))).toEqual(["usr_1"]);
+});
+
+test("no mentions is empty, not a throw", () => {
+  expect(parseMentions("")).toEqual([]);
+  expect(parseMentions("plain @ana text")).toEqual([]);
+});

--- a/packages/shared/src/mentions.ts
+++ b/packages/shared/src/mentions.ts
@@ -1,0 +1,40 @@
+/**
+ * How an `@`-mention of a member is written into markdown, and how it's read
+ * back out.
+ *
+ * A plain markdown link is the whole format: `[@Ana](mention:usr_123)`. The
+ * body of a description or a comment is markdown everywhere else it's used —
+ * fed to agents as prompt context, mirrored onto a Jira issue, rendered by a
+ * markdown component that never heard of mentions — and a link degrades
+ * legibly in all three. A bespoke syntax would render as literal punctuation
+ * in every one of them.
+ *
+ * The id, not the name, is the mention: names repeat inside an org and change
+ * afterwards, so who gets notified must not depend on either.
+ */
+
+export const MENTION_HREF_PREFIX = "mention:";
+
+/** `[@Name](mention:id)`. The name may not contain `]`, the id may not contain
+ *  `)` — both hold for user ids, and the editor escapes what it writes. */
+const MENTION_RE = /\[@([^\]]+)\]\(mention:([^)\s]+)\)/g;
+
+/** Every distinct user id mentioned in a markdown body, in first-seen order. */
+export function parseMentions(markdown: string): string[] {
+  return [...new Set([...markdown.matchAll(MENTION_RE)].map((m) => m[2]!))];
+}
+
+/** The markdown for one mention. */
+export function mentionMarkdown(userId: string, name: string): string {
+  // `]` would end the link text early and `[` would nest a link — neither can
+  // appear in the output, so strip rather than escape (a name is a label here,
+  // not content to preserve byte-for-byte).
+  return `[@${name.replace(/[[\]]/g, "")}](${MENTION_HREF_PREFIX}${userId})`;
+}
+
+/** The user id in a `mention:` href, or null for any other link. */
+export function mentionIdFromHref(href: string): string | null {
+  return href.startsWith(MENTION_HREF_PREFIX)
+    ? href.slice(MENTION_HREF_PREFIX.length)
+    : null;
+}

--- a/packages/shared/src/notification-types.ts
+++ b/packages/shared/src/notification-types.ts
@@ -5,13 +5,14 @@
  * CHECK constraint (bound by a test), the API's zod enum, and the inbox UI's
  * `InboxTaskAction`.
  *
- * Unprefixed on purpose — every value except `commented` is already a
+ * Unprefixed on purpose — every value except `commented`/`mentioned` is already a
  * `TaskBoardActivityAction`, so the fan-out passes `entry.action` straight
  * through with no prefix to add and none to strip again in the UI.
  */
 export const NOTIFICATION_TYPES = [
   "created",
   "commented",
+  "mentioned",
   "status_changed",
   "assignee_changed",
   "review_requested",


### PR DESCRIPTION
## Summary

You can now `@` an org member in a task description or a comment, and they get notified — the piece the comment composer deferred until notifications shipped.

- **Typing**: `@` opens a member picker (cmdk `Command` — scroll and keyboard nav come with it) anchored under the caret. Search is what you already typed after the `@`; there is no second input.
- **Storage**: a mention is a plain markdown link, `[@Ana](mention:usr_1)`. The body is markdown everywhere else it's consumed (agent prompt context, the Jira mirror, `MemoizedMarkdown`), and a link degrades legibly in all three. The **id** notifies, never the name.
- **Notifying**: new `mentioned` notification type, with its own fan-out path.

## Decisions worth reviewing

**Mentions do not use the subscriber fan-out.** Every other notification goes to a task's followers. A mention is aimed at the people it names, so it must reach them with the task muted and must *not* reach followers it didn't name. `notify()` gained a `recipients` param that replaces the subscriber lookup; being named also enrols you in the task, the way commenting does.

**Only added mentions notify.** A description edit resends the whole body, so `notifyMentions` diffs against the previous one — otherwise fixing a typo re-pings everyone named in it.

**Parsed ids are user input.** The body is user-authored text, so org membership is checked before any row is written; otherwise a hand-written body could notify any user id in the deployment.

**The comment composer is now Tiptap, not a textarea.** Only because a mention needs a chip and an id. Block formatting is off, Enter still sends, Shift+Enter still breaks the line; the picker owns Enter while it's open (asked of the plugin's state directly, not left to handler ordering).

**Members list**: cached in `localStorage`, so the first `@` after a reload renders instantly. The refetch runs every open and merges — unchanged members keep object identity, so only genuinely new rows re-render, and the spinner only ever shows with nothing cached to display.

## Testing

- `bun run check`, `bun run lint` (0 errors), `bunx knip` clean.
- Unit: markdown format parse/round-trip (`packages/shared/src/mentions.test.ts`, `markdown-editor/extensions.test.ts`), members merge identity (`use-mention-members.test.ts`), the migration↔TypeScript type-list binding.
- E2E added (`packages/e2e/tests/task-mentions.spec.ts`): a mention reaches a non-follower and not the followers; an edit notifies only what it added; self-mention notifies nobody.
- ⚠️ **The e2e suite was not run green locally** — it reuses an already-running dev server and times out here; the pre-existing `notifications-inbox.spec.ts` fails identically on this machine, so this is environmental, not the change. Needs CI.
- No screenshots: the browser extension wasn't connected in this session, so **the picker has not been seen rendering**. Worth a manual look before merge.

## Deliberately out of scope

- Editing a comment to add a mention doesn't notify (only create does).
- The membership gate isn't asserted in e2e: a non-member can't read the org those rows belong to, so over the wire the guard working and failing look identical.