### PR TITLE
fix(decopilot): lazily create the projector's poison-run counter

### DIFF
--- a/apps/api/src/api/routes/decopilot/projector-metrics.ts
+++ b/apps/api/src/api/routes/decopilot/projector-metrics.ts
@@ -7,13 +7,18 @@
  */
 import { meter } from "@/observability";
 
-const poisonRunsCounter = meter.createCounter(
-  "decopilot.projector.poison_runs",
-  {
+// Lazy: `meter` is a NoopMeter until initObservability() runs post-import.
+const lazyInstrument = <T>(make: () => T): (() => T) => {
+  let v: T | undefined;
+  return () => (v ??= make());
+};
+
+const poisonRunsCounter = lazyInstrument(() =>
+  meter.createCounter("decopilot.projector.poison_runs", {
     description:
       "Number of decopilot runs that exhausted retries and were sent to the DLQ",
     unit: "{runs}",
-  },
+  }),
 );
 
 /**
@@ -34,5 +39,5 @@ export function computeLagMs(publishedAtMs: number, nowMs: number): number {
  */
 export function recordPoison(runId: string, orgId?: string): void {
   void runId;
-  poisonRunsCounter.add(1, { "org.id": orgId ?? "unknown" });
+  poisonRunsCounter().add(1, { "org.id": orgId ?? "unknown" });
 }


### PR DESCRIPTION
**Source:** bug found while hunting the decopilot API-routes area for hardening work.

**Payoff:** `decopilot.projector.poison_runs` is the durable projector's only signal for a run that exhausted retries and hit the DLQ — its own docstring says it exists "so alerting fires without log scraping." It was created at module-import time (`meter.createCounter(...)` at the top of `projector-metrics.ts`), off whatever `meter` binding happened to be live at that moment. `meter` is a `NoopMeter` until `initObservability()` runs at bootstrap; an instrument created against the noop stays bound to it forever, even after `meter` is later reassigned to the real provider — so a module imported ahead of that point silently drops every recorded metric with no error anywhere. Every other metrics module in this same directory (`run-registry.ts`, `nats-stream-buffer.ts`, `stream-metrics.ts`) and its neighbor `dispatch-queue/hosted-harness-workflow.ts` documents this exact hazard and works around it with a lazy factory — `projector-metrics.ts` was the one holdout still creating its instrument eagerly.

**Fix:** wrap the counter creation in the same `lazyInstrument()` idiom the sibling files already use, so the counter is built on first call to `recordPoison`, after `initObservability()` has run.

**Reviewer check:** `cd apps/api && bunx tsc --noEmit` and `bunx oxlint apps/api/src/api/routes/decopilot/projector-metrics.ts`.

**Verified locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace), `bunx oxlint` on the changed file — all clean. Purely a metrics-binding fix (no behavior/logic change), so there's no existing test to invert; full CI covers the rest.