### PR TITLE
fix(task-board): notify newly @-mentioned members when a comment is edited

### DIFF
--- a/apps/api/src/storage/task-board-comments.integration.test.ts
+++ b/apps/api/src/storage/task-board-comments.integration.test.ts
@@ -5,19 +5,40 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../database/test-db-pg";
+import type { StudioContext } from "../core/studio-context";
 import type { StudioDatabase } from "../database";
 import { TaskBoardStorage } from "./task-board";
+import { NotificationStorage } from "./notifications";
+import { TASK_BOARD_COMMENT_UPDATE } from "../tools/task-board/comments";
+import { mentionMarkdown } from "@decocms/shared/mentions";
 
 describe("TaskBoardStorage comments", () => {
   let database: StudioDatabase;
   let storage: TaskBoardStorage;
+  let notifications: NotificationStorage;
   let itemId: string;
+  let ctx: StudioContext;
 
   beforeAll(async () => {
     database = await connectTestPgDatabase();
     await resetTestPgDatabase(database);
     await seedCommonTestPgFixtures(database);
     storage = new TaskBoardStorage(database.db);
+    notifications = new NotificationStorage(database.db);
+    ctx = {
+      timings: {
+        measure: async <T>(_name: string, cb: () => Promise<T>) => await cb(),
+      },
+      auth: { user: { id: "user_1", email: "user_1@test.com", name: "u1" } },
+      organization: { id: "org_test", slug: "org_test", name: "org_test" },
+      storage: { taskBoard: storage, notifications },
+      access: {
+        granted: () => true,
+        check: async () => {},
+        grant: () => {},
+        setToolName: () => {},
+      },
+    } as unknown as StudioContext;
 
     const item = await storage.create({
       organizationId: "org_test",
@@ -108,6 +129,39 @@ describe("TaskBoardStorage comments", () => {
       "user_123",
     );
     expect(deleted).toBe(true);
+  });
+
+  it("notifies a member newly @-mentioned by editing a comment's body", async () => {
+    await database.db
+      .insertInto("member")
+      .values({
+        id: "member_comment_mention",
+        organizationId: "org_test",
+        userId: "user_123",
+        role: "member",
+        createdAt: new Date().toISOString(),
+      })
+      .execute();
+    const comment = await storage.createComment({
+      taskBoardItemId: itemId,
+      organizationId: "org_test",
+      authorId: "user_1",
+      body: "no mentions yet",
+    });
+    expect(comment).not.toBeNull();
+
+    // Before fix: TASK_BOARD_COMMENT_UPDATE never ran notifyMentions.
+    await TASK_BOARD_COMMENT_UPDATE.handler(
+      {
+        id: comment!.id,
+        body: `cc ${mentionMarkdown("user_123", "u123")} please take a look`,
+      },
+      ctx,
+    );
+
+    const unread = await notifications.listUnread("user_123", "org_test");
+    expect(unread.unreadCount).toBe(1);
+    expect(unread.notifications[0]!.type).toBe("mentioned");
   });
 
   it("rejects resolving a reply — resolved is a thread-root-only property", async () => {

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -2046,6 +2046,20 @@ export class TaskBoardStorage {
     return true;
   }
 
+  async getComment(
+    id: string,
+    organizationId: string,
+  ): Promise<TaskBoardComment | null> {
+    const row = await this.db
+      .selectFrom("task_board_comments as c")
+      .innerJoin("task_board_items as item", "item.id", "c.task_board_item_id")
+      .selectAll("c")
+      .where("c.id", "=", id)
+      .where("item.organization_id", "=", organizationId)
+      .executeTakeFirst();
+    return row ? commentFromDbRow(row) : null;
+  }
+
   private async commentInOrg(
     id: string,
     organizationId: string,

--- a/apps/api/src/tools/task-board/comments.ts
+++ b/apps/api/src/tools/task-board/comments.ts
@@ -173,9 +173,14 @@ export const TASK_BOARD_COMMENT_UPDATE = defineTool({
   handler: async (input, ctx) => {
     requireAuth(ctx);
     await ctx.access.check();
+    const organizationId = requireOrg(ctx);
+    const existing =
+      input.body !== undefined
+        ? await ctx.storage.taskBoard.getComment(input.id, organizationId)
+        : null;
     const comment = await ctx.storage.taskBoard.updateComment({
       id: input.id,
-      organizationId: requireOrg(ctx),
+      organizationId,
       callerId: getUserId(ctx)!,
       body: input.body,
       resolved: input.resolved,
@@ -184,6 +189,16 @@ export const TASK_BOARD_COMMENT_UPDATE = defineTool({
       throw new Error(
         "Comment not found, or you can only edit your own comments",
       );
+    }
+    // Notify only mentions this edit added, same as an edited description.
+    if (input.body !== undefined && comment.body !== existing?.body) {
+      await ctx.storage.notifications.notifyMentions({
+        taskBoardItemId: comment.taskBoardItemId,
+        organizationId,
+        actorId: getUserId(ctx)!,
+        body: comment.body,
+        previousBody: existing?.body ?? null,
+      });
     }
     return { comment };
   },


### PR DESCRIPTION
Follows #6560, which added `@`-mention notifications for task descriptions and comments — create paths (`TASK_BOARD_ITEM_CREATE`, `TASK_BOARD_COMMENT_CREATE`) and the description-edit path (`TASK_BOARD_ITEM_UPDATE`) all call `notifyMentions`, comparing against the previous body so only newly-added mentions notify. `TASK_BOARD_COMMENT_UPDATE` was left out: editing a comment's body to add an `@`-mention silently notified nobody.

Fix mirrors the existing description-edit pattern: fetch the comment before the update (`TaskBoardStorage.getComment`, a small addition next to the existing `commentInOrg` helper), diff old vs new body, and call `notifyMentions` when it changed.

Failure scenario: a user edits their own comment to add `[@Ana](mention:usr_123)` — before this fix, Ana never gets notified, even though the identical edit on a task description does.

Regression test (`task-board-comments.integration.test.ts`, real Postgres): seeds a member, posts a comment with no mentions, edits it through the actual `TASK_BOARD_COMMENT_UPDATE.handler` to add one, and asserts the mentioned member's inbox gets a `mentioned` notification. Fails on main (no notification), passes with the fix.

Reviewer command: `DATABASE_URL=... bun test apps/api/src/storage/task-board-comments.integration.test.ts` (needs a local Postgres per the file's own docstring; CI's storage-integration job runs it).

Locally verified: `bunx tsc --noEmit` in apps/api (clean) and `bunx oxlint` on the three changed files (0 warnings/errors). Could not run the integration test itself locally (no Postgres in this environment) — CI's storage-integration workflow covers that.