### PR TITLE
fix(task-board): bound TASK_BOARD_DISMISSED_RESTORE's externalKeys array

### DIFF
--- a/apps/api/src/tools/task-board/dismissed.test.ts
+++ b/apps/api/src/tools/task-board/dismissed.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { TASK_BOARD_DISMISSED_RESTORE } from "./dismissed";
+
+describe("TASK_BOARD_DISMISSED_RESTORE input schema", () => {
+  test("accepts a reasonably sized externalKeys array", () => {
+    const result = TASK_BOARD_DISMISSED_RESTORE.inputSchema.safeParse({
+      externalKeys: ["a", "b"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects an externalKeys array over the bound", () => {
+    const result = TASK_BOARD_DISMISSED_RESTORE.inputSchema.safeParse({
+      externalKeys: Array.from({ length: 1001 }, (_, i) => `key_${i}`),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/tools/task-board/dismissed.ts
+++ b/apps/api/src/tools/task-board/dismissed.ts
@@ -64,7 +64,7 @@ export const TASK_BOARD_DISMISSED_RESTORE = defineTool({
   inputSchema: z.object({
     /** Omitted restores everything; an empty array restores nothing, so a
      *  caller filtering a list down to zero can't accidentally clear the lot. */
-    externalKeys: z.array(z.string()).optional(),
+    externalKeys: z.array(z.string()).max(1000).optional(),
   }),
   outputSchema: z.object({ restored: z.number() }),
   handler: async (input, ctx) => {


### PR DESCRIPTION
Follows #6558, which capped `NOTIFICATION_MARK_READ`'s `ids` array at 1000 entries because it fed a SQL `IN (...)` clause unbounded. `TASK_BOARD_DISMISSED_RESTORE`'s `externalKeys` has the exact same shape: `apps/api/src/storage/task-board.ts` `restoreDismissedFindings` puts it straight into `.where("external_key", "in", externalKeys)` with no size limit, so a caller can send an arbitrarily large array.

Why it matters: an unbounded array in an untrusted request body feeding a DB query is a resource-exhaustion / trust-boundary gap on the same tool surface the maintainers just hardened elsewhere — closing the sibling instance is a small, obvious win.

Fix: added `.max(1000)` to the `externalKeys` schema, matching the bound just chosen for `NOTIFICATION_MARK_READ`. Added `apps/api/src/tools/task-board/dismissed.test.ts` asserting the schema accepts a normal-sized array and rejects one over 1000 entries (mirrors `mark-read.test.ts`).

To confirm: `bun test apps/api/src/tools/task-board/dismissed.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI covers the rest.