### PR TITLE
feat(web): pin non-code agents to the first-class sidebar (org-wide)

### DIFF
--- a/apps/web/src/components/project-card.tsx
+++ b/apps/web/src/components/project-card.tsx
@@ -1,4 +1,10 @@
-import { DotsVertical, Home02, Settings02, Trash01 } from "@untitledui/icons";
+import {
+  DotsVertical,
+  Home02,
+  Pin01,
+  Settings02,
+  Trash01,
+} from "@untitledui/icons";
 import { formatDistanceToNow } from "date-fns";
 import { ptBR as ptBRLocale } from "date-fns/locale/pt-BR";
 import { toast } from "sonner";
@@ -10,7 +16,9 @@ import {
   useMainAgentId,
   useSetMainAgent,
 } from "@/hooks/use-organization-settings";
-import { useCapability } from "@/hooks/use-capability";
+import { useCapabilities, useCapability } from "@/hooks/use-capability";
+import { agentCanBePinned } from "@/lib/agent-capabilities";
+import { useVirtualMCPActions } from "@/sdk";
 import { Button } from "@decocms/ui/components/button.tsx";
 import { Card } from "@decocms/ui/components/card.tsx";
 import {
@@ -43,6 +51,15 @@ export function ProjectCard({
   // the action isn't shown to users whose click would fail server-side.
   const { granted: canSetMainAgent } = useCapability("org:manage");
   const isMainAgent = mainAgentId === project.id;
+
+  // Org-wide pin: backend gates `pinned` on owner/admin; coding agents auto-list.
+  const actions = useVirtualMCPActions();
+  const { isPrivileged } = useCapabilities();
+  const canPin = isPrivileged && agentCanBePinned(project);
+  const isPinned = !!project.pinned;
+  const togglePin = () => {
+    actions.update.mutate({ id: project.id, data: { pinned: !isPinned } });
+  };
 
   const toggleMainAgent = () => {
     const next = isMainAgent ? null : project.id;
@@ -107,6 +124,19 @@ export function ProjectCard({
                       {isMainAgent
                         ? t("home.projectCard.unsetMainAgent")
                         : t("home.projectCard.setAsMainAgent")}
+                    </DropdownMenuItem>
+                  )}
+                  {canPin && (
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        togglePin();
+                      }}
+                    >
+                      <Pin01 size={16} />
+                      {isPinned
+                        ? t("home.projectCard.unpinFromSidebar")
+                        : t("home.projectCard.pinToSidebar")}
                     </DropdownMenuItem>
                   )}
                   {onDeleteClick && (

--- a/apps/web/src/components/sidebar/nav-destinations.tsx
+++ b/apps/web/src/components/sidebar/nav-destinations.tsx
@@ -29,8 +29,13 @@ import {
   useProjectContext,
   useVirtualMCPs,
 } from "@/sdk";
+import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
 import { AgentAvatar } from "@/components/agent-icon";
-import { agentHasClonableSource } from "@/lib/agent-capabilities";
+import {
+  agentHasClonableSource,
+  agentIsSidebarPinned,
+  getDevAgentIds,
+} from "@/lib/agent-capabilities";
 import { getActiveGithubRepo } from "@/lib/github-repo";
 import { useThreads } from "@/components/chat/store/hooks";
 import { usePanelActions } from "@/layouts/shell-layout";
@@ -96,7 +101,7 @@ function useNavDestinations({
       });
       return;
     }
-    // Reuse-or-create via setTaskId/createNewTask — same path useCodingAgents uses.
+    // Reuse-or-create via setTaskId/createNewTask — same path useAgentNavRows uses.
     const existing = findReusableNewChat(
       threads,
       decopilotId,
@@ -169,26 +174,24 @@ function useNavDestinations({
   return destinations;
 }
 
-/**
- * The org's coding agents — every virtual MCP backed by a GitHub repo (imported
- * from GitHub or cloned from a template), listed by title, repo name as fallback.
- *
- * Selecting one opens that agent's chat, reusing its existing empty "New chat"
- * so repeat clicks don't pile up threads.
- */
-function useCodingAgents({
-  onNavigate,
-}: {
-  onNavigate?: () => void;
-} = {}): NavDestination[] {
+/** Sidebar agent rows matching `predicate` (coding agents / org-pinned non-code); selecting one opens its chat, reusing an empty "New chat". */
+function useAgentNavRows(
+  predicate: (agent: VirtualMCPEntity, devAgentIds: Set<string>) => boolean,
+  {
+    onNavigate,
+  }: {
+    onNavigate?: () => void;
+  } = {},
+): NavDestination[] {
   const search = useSearch({ strict: false }) as { virtualmcpid?: string };
   const agents = useVirtualMCPs() ?? [];
+  const devAgentIds = getDevAgentIds(agents);
   const { threads } = useThreads();
   const { data: session } = authClient.useSession();
   const { setTaskId, createNewTask } = usePanelActions();
 
   return agents
-    .filter((agent) => agentHasClonableSource(agent.metadata))
+    .filter((agent) => predicate(agent, devAgentIds))
     .map((agent) => {
       const repo = getActiveGithubRepo(agent);
       return {
@@ -231,7 +234,16 @@ export function NavDestinationsContent({
   onNavigate?: () => void;
 }) {
   const destinations = useNavDestinations({ onNavigate });
-  const codingAgents = useCodingAgents({ onNavigate });
+  const codingAgents = useAgentNavRows(
+    (agent) => agentHasClonableSource(agent.metadata),
+    { onNavigate },
+  );
+  const pinnedAgents = useAgentNavRows(
+    (agent, devAgentIds) =>
+      agentIsSidebarPinned(agent) && !devAgentIds.has(agent.id),
+    { onNavigate },
+  );
+  const agentRows = [...codingAgents, ...pinnedAgents];
   // Expanded, the label is right there — a tooltip repeating it is noise.
   const { state, isMobile } = useSidebar();
   const showTooltip = state === "collapsed" && !isMobile;
@@ -253,8 +265,8 @@ export function NavDestinationsContent({
   return (
     <SidebarMenu className="gap-1">
       {destinations.map(row)}
-      {codingAgents.length > 0 && <li aria-hidden className="h-2" />}
-      {codingAgents.map(row)}
+      {agentRows.length > 0 && <li aria-hidden className="h-2" />}
+      {agentRows.map(row)}
     </SidebarMenu>
   );
 }

--- a/apps/web/src/i18n/en/home.ts
+++ b/apps/web/src/i18n/en/home.ts
@@ -112,4 +112,6 @@ export const home = {
   "home.projectCard.mainAgentSet": '"{title}" is now the main agent',
   "home.projectCard.mainAgentUnset": 'Removed "{title}" as the main agent',
   "home.projectCard.mainAgentError": "Couldn't update the main agent",
+  "home.projectCard.pinToSidebar": "Pin to sidebar",
+  "home.projectCard.unpinFromSidebar": "Unpin from sidebar",
 } as const;

--- a/apps/web/src/i18n/pt-br/home.ts
+++ b/apps/web/src/i18n/pt-br/home.ts
@@ -118,4 +118,6 @@ export const home = {
   "home.projectCard.mainAgentUnset": 'Removido "{title}" como agente principal',
   "home.projectCard.mainAgentError":
     "Não foi possível atualizar o agente principal",
+  "home.projectCard.pinToSidebar": "Fixar na barra lateral",
+  "home.projectCard.unpinFromSidebar": "Desafixar da barra lateral",
 } satisfies Record<keyof typeof homeEn, string>;

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, it } from "bun:test";
 import {
+  agentCanBePinned,
   agentHasClonableSource,
   agentHasConnectedGithub,
+  agentIsSidebarPinned,
   agentShowsGithubHeaderActions,
 } from "./agent-capabilities";
+
+const CODE_META = {
+  githubRepo: {
+    url: "https://github.com/acme/app",
+    owner: "acme",
+    name: "app",
+  },
+};
 
 describe("agentHasClonableSource", () => {
   it("returns false for null/undefined metadata", () => {
@@ -50,6 +60,36 @@ describe("agentHasClonableSource", () => {
   it("ignores non-object metadata", () => {
     expect(agentHasClonableSource("string")).toBe(false);
     expect(agentHasClonableSource(42)).toBe(false);
+  });
+});
+
+describe("agentCanBePinned", () => {
+  it("returns true for a non-code agent (no clonable source)", () => {
+    expect(agentCanBePinned({ metadata: {} })).toBe(true);
+    expect(agentCanBePinned({ metadata: null })).toBe(true);
+  });
+
+  it("returns false for a code agent (clonable source)", () => {
+    expect(agentCanBePinned({ metadata: CODE_META })).toBe(false);
+  });
+});
+
+describe("agentIsSidebarPinned", () => {
+  it("returns true only when a non-code agent is pinned", () => {
+    expect(agentIsSidebarPinned({ pinned: true, metadata: {} })).toBe(true);
+  });
+
+  it("returns false when not pinned", () => {
+    expect(agentIsSidebarPinned({ pinned: false, metadata: {} })).toBe(false);
+    expect(agentIsSidebarPinned({ pinned: undefined, metadata: {} })).toBe(
+      false,
+    );
+  });
+
+  it("returns false for a pinned code agent (already auto-listed)", () => {
+    expect(agentIsSidebarPinned({ pinned: true, metadata: CODE_META })).toBe(
+      false,
+    );
   });
 });
 

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -20,6 +20,28 @@ export function agentHasClonableSource(metadata: unknown): boolean {
 }
 
 /**
+ * Whether the org-wide "pin to sidebar" action applies to this agent. Coding
+ * agents (clonable source) are auto-listed in the first-class sidebar already,
+ * so pinning them is a no-op — the pin affordance is offered only for non-code
+ * agents, which otherwise have no standing sidebar entry.
+ */
+export function agentCanBePinned(agent: { metadata?: unknown }): boolean {
+  return !agentHasClonableSource(agent.metadata);
+}
+
+/**
+ * True when an agent should render in the first-class sidebar as an org-pinned
+ * entry: it carries the org-wide `pinned` flag AND is a non-code agent (coding
+ * agents already list there, so this keeps them from double-rendering).
+ */
+export function agentIsSidebarPinned(agent: {
+  pinned?: boolean | null;
+  metadata?: unknown;
+}): boolean {
+  return !!agent.pinned && agentCanBePinned(agent);
+}
+
+/**
  * True only when the virtual MCP has a GitHub repo with an attached
  * connection (i.e. authenticated github identity, not a public-clone
  * template). Gate the git tab on this predicate.


### PR DESCRIPTION
## Summary

Under the first-class navigation (`nav_v2`), the sidebar auto-lists coding agents but has no standing entry for **non-code agents** — they're only reachable via Settings → Agents or a direct URL. This adds an admin-controlled, **org-wide** pin so a non-code agent can be surfaced in the sidebar for every member of the org.

No backend change: reuses the existing org-scoped `connections.pinned` field and its already-admin-gated `COLLECTION_VIRTUAL_MCP_UPDATE` write.

## What's included

- **ProjectCard** (rendered on Settings → Agents): a **"Pin/Unpin from sidebar"** item in the card's `⋮` menu.
  - Shown only to **owner/admin** (`useCapabilities().isPrivileged`) — mirrors the backend `requireOrgAdminForPinnedField` gate.
  - Shown only for **non-code agents** (`agentCanBePinned`) — coding agents already auto-list in the sidebar, so pinning them is a no-op.
- **nav_v2 sidebar** (`nav-destinations.tsx`): renders org-pinned non-code agents next to the coding agents. Generalized `useCodingAgents` → `useAgentNavRows(predicate)`; dev agents excluded.
- **Pure helpers** `agentCanBePinned` / `agentIsSidebarPinned` in `agent-capabilities.ts`, with unit tests.
- **i18n**: `home.projectCard.pinToSidebar` / `unpinFromSidebar` (en + pt-br).

## Testing

- `bun run fmt` / `fmt:check` — clean
- `bun run --cwd=apps/web check` (tsc) — clean
- `bun run lint` — 0 errors
- `bun test apps/web/src/lib/agent-capabilities.test.ts` — 18 pass

## Notes / follow-ups (deliberately out of scope)

- **Unpinning code agents is not supported.** Coding agents always show in the sidebar; there is no way to hide one yet. Doing that cleanly needs a tri-state (`pinned` nullable: unset = code shown / non-code hidden, `true` = always shown, `false` = hidden) plus a backfill migration for legacy `pinned=true` (project/space) rows. Left for a follow-up.
- Unpin is only reachable from the Agents page card menu (no unpin affordance on the sidebar row itself yet).
- Only wired for `nav_v2`; the legacy sidebar does not render pinned agents (it never did).
- No e2e for the pin → appears-in-sidebar flow (pure logic covered by unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)