### PR TITLE
fix(task-board): mention picker gets its search field back, and scrolls

### DIFF
--- a/apps/web/ct/harness/stubs/use-mention-members.ts
+++ b/apps/web/ct/harness/stubs/use-mention-members.ts
@@ -12,10 +12,25 @@ export interface MentionMember {
   image: string | null;
 }
 
+/**
+ * Three addressable fixtures, then enough filler to overflow the list — a
+ * three-member org would make the scroll spec pass without scrolling. The
+ * filler names and emails share no substring with the searches the specs run
+ * ("an", "bruno"), so filtering stays deterministic.
+ */
 const MEMBERS: MentionMember[] = [
   { id: "u1", name: "valls", email: "valls@deco.cx", image: null },
   { id: "u2", name: "Ana Silva", email: "ana@deco.cx", image: null },
   { id: "u3", name: "Bruno", email: "bruno@deco.cx", image: null },
+  ...Array.from({ length: 25 }, (_, i) => {
+    const n = String(i + 1).padStart(2, "0");
+    return {
+      id: `f${n}`,
+      name: `Coworker ${n}`,
+      email: `coworker${n}@deco.cx`,
+      image: null,
+    };
+  }),
 ];
 
 export function useMentionMembers(_enabled: boolean) {

--- a/apps/web/ct/tests/task-comments.ct.tsx
+++ b/apps/web/ct/tests/task-comments.ct.tsx
@@ -224,12 +224,22 @@ test("typing @ opens the member picker, and picking one inserts a chip", async (
   const menu = page.getByTestId("mention-menu");
   await expect(menu).toBeVisible();
 
-  // The query is what was typed after the `@` — there is no second input.
-  await composer.pressSequentially("an");
+  // Opening moves focus into the menu's own search field — the picker is a
+  // real combobox, not a list that reads the document behind it.
+  const search = menu.getByPlaceholder("Search members...");
+  await expect(search).toBeFocused();
+
+  await search.fill("an");
   await expect(menu.getByText("Ana Silva")).toBeVisible();
   await expect(menu.getByText("Bruno")).toHaveCount(0);
 
-  await composer.press("Enter");
+  // Email matches too, so you can find someone whose display name you can't
+  // spell.
+  await search.fill("bruno@deco.cx");
+  await expect(menu.getByText("Bruno")).toBeVisible();
+
+  await search.fill("ana");
+  await search.press("Enter");
   await expect(menu).toHaveCount(0);
   await expect(component.getByTestId("mention-chip")).toHaveText("@Ana Silva");
 
@@ -238,6 +248,35 @@ test("typing @ opens the member picker, and picking one inserts a chip", async (
   await expect(component.getByTestId("posted")).toHaveText(
     JSON.stringify(["ping [@Ana Silva](mention:u2)"]),
   );
+});
+
+test("the picker's list scrolls rather than clipping its members", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(<TaskCommentsHarness />);
+  const composer = component.getByRole("textbox", {
+    name: "Leave a comment...",
+  });
+
+  await composer.click();
+  await composer.pressSequentially("@");
+  const list = page.getByTestId("mention-menu").locator("[cmdk-list]");
+  await expect(list).toBeVisible();
+
+  // The list is its own scroll container, and the wrapper never clips it
+  // shorter than that: a clipped list hides members instead of scrolling to
+  // them, which is exactly what the first cut of this menu did.
+  expect(await list.evaluate((el) => el.scrollHeight > el.clientHeight)).toBe(
+    true,
+  );
+  await list.evaluate((el) => el.scrollBy(0, 40));
+  expect(await list.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+
+  // The last member is reachable — the point of scrolling.
+  const last = page.getByTestId("mention-menu").getByText("Coworker 25");
+  await last.scrollIntoViewIfNeeded();
+  await expect(last).toBeVisible();
 });
 
 test("Escape dismisses the picker and leaves the typed text alone", async ({
@@ -250,16 +289,40 @@ test("Escape dismisses the picker and leaves the typed text alone", async ({
   });
 
   await composer.click();
-  await composer.pressSequentially("hey @an");
-  await expect(page.getByTestId("mention-menu")).toBeVisible();
+  await composer.pressSequentially("hey @");
+  const menu = page.getByTestId("mention-menu");
+  await expect(menu).toBeVisible();
 
-  await composer.press("Escape");
-  await expect(page.getByTestId("mention-menu")).toHaveCount(0);
-  await expect(composer).toHaveText("hey @an");
+  await menu.getByPlaceholder("Search members...").press("Escape");
+  await expect(menu).toHaveCount(0);
+  // Escape hands the caret back, and what was typed is untouched.
+  await expect(composer).toHaveText("hey @");
+  await expect(composer).toBeFocused();
 
   // Enter now sends, because the picker no longer owns it.
   await composer.press("Enter");
   await expect(component.getByTestId("posted")).toHaveText(
-    JSON.stringify(["hey @an"]),
+    JSON.stringify(["hey @"]),
   );
+});
+
+test("clicking away dismisses the picker without stealing the caret back", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(<TaskCommentsHarness />);
+  const composer = component.getByRole("textbox", {
+    name: "Leave a comment...",
+  });
+
+  await composer.click();
+  await composer.pressSequentially("@");
+  await expect(page.getByTestId("mention-menu")).toBeVisible();
+
+  await component.getByRole("textbox", { name: "Leave a reply..." }).click();
+  await expect(page.getByTestId("mention-menu")).toHaveCount(0);
+  // The click chose where focus goes; the dismissal must not undo that.
+  await expect(
+    component.getByRole("textbox", { name: "Leave a reply..." }),
+  ).toBeFocused();
 });

--- a/apps/web/src/components/markdown-editor/mention-suggestion.tsx
+++ b/apps/web/src/components/markdown-editor/mention-suggestion.tsx
@@ -5,10 +5,11 @@
  * tiny store rather than a portal rendered from inside the plugin — one
  * component tree, one place the menu's state can be read.
  *
- * cmdk provides the list, its scroll and the scroll-into-view; the search
- * itself does NOT come from a `CommandInput`. The query is what the user
- * already typed after the `@`, in the editor — a second input under the caret
- * would be a second place to type the same thing.
+ * The menu is a plain shadcn `Command`, doing its whole job: its own search
+ * input, its own filtering, its own arrow-key selection and scrolling. Opening
+ * it moves focus into that input, so while the picker is up the keystrokes are
+ * cmdk's and the editor sees none of them. Nothing here re-implements a
+ * listbox.
  */
 
 import { useState, useSyncExternalStore } from "react";
@@ -23,6 +24,8 @@ import { createPortal } from "react-dom";
 import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import {
   Command,
+  CommandEmpty,
+  CommandInput,
   CommandItem,
   CommandList,
 } from "@decocms/ui/components/command.tsx";
@@ -47,15 +50,12 @@ const CLOSED: MenuState = { query: "", range: null, rect: null, editor: null };
 
 /**
  * The bridge between the plugin and the menu. A store rather than React state
- * because the plugin's callbacks fire outside React's tree and must reach the
- * menu synchronously — `onKeyDown` has to answer "did the menu handle this
- * key?" before ProseMirror moves on.
+ * because the plugin's callbacks fire outside React's tree, and the menu has
+ * to see an open/close the moment it happens.
  */
 export class MentionMenuStore {
   private state: MenuState = CLOSED;
   private listeners = new Set<() => void>();
-  /** Set by the menu while it's open — arrow keys and Enter belong to it. */
-  onKey: ((event: KeyboardEvent) => boolean) | null = null;
 
   subscribe = (listener: () => void) => {
     this.listeners.add(listener);
@@ -70,7 +70,6 @@ export class MentionMenuStore {
   }
 
   close() {
-    this.onKey = null;
     this.set(CLOSED);
   }
 }
@@ -137,13 +136,15 @@ export function mentionSuggestionExtension(store: MentionMenuStore) {
               editor: props.editor,
             });
           },
+          // The menu's input holds focus while it's open, so these keys only
+          // arrive in the gap before that lands — or if focusing failed.
           onKeyDown: ({ event, view }) => {
             if (event.key === "Escape") {
               exitSuggestion(view, MENTION_SUGGESTION_KEY);
               store.close();
               return true;
             }
-            return store.onKey?.(event) ?? false;
+            return false;
           },
           onExit: () => store.close(),
         }),
@@ -154,17 +155,10 @@ export function mentionSuggestionExtension(store: MentionMenuStore) {
 }
 
 const MENU_WIDTH = 256;
+/** `CommandInput`'s own fixed height — the list gets what's left. */
+const INPUT_HEIGHT = 40;
 const MENU_MAX_HEIGHT = 280;
 const MENU_MIN_HEIGHT = 140;
-
-function matches(member: MentionMember, query: string): boolean {
-  const q = query.trim().toLowerCase();
-  if (!q) return true;
-  return (
-    member.name.toLowerCase().includes(q) ||
-    member.email.toLowerCase().includes(q)
-  );
-}
 
 /**
  * The menu. Renders nothing until the plugin opens it, so the members fetch
@@ -185,12 +179,9 @@ function OpenMentionMenu({
 }) {
   const t = useT();
   const { members, loading } = useMentionMembers(true);
-  const [active, setActive] = useState(0);
-
-  const filtered = members.filter((m) => matches(m, state.query));
-  // The query narrows as you type, so the previous index can fall off the end.
-  const index = Math.min(active, Math.max(filtered.length - 1, 0));
-  const selected = filtered[index];
+  // Controlled, so the field can be seeded with whatever reached the editor
+  // before focus landed here — cmdk's input owns its own state otherwise.
+  const [query, setQuery] = useState(state.query);
 
   // Fixed to the caret's own rect, in a body portal so the editor's overflow
   // can't clip it. Full floating-ui placement would buy collision detection
@@ -199,74 +190,85 @@ function OpenMentionMenu({
   const caret = state.rect?.() ?? new DOMRect(0, 0, 0, 0);
   const below = window.innerHeight - caret.bottom;
   const flipUp = below < MENU_MAX_HEIGHT && caret.top > below;
+  // The cap the LIST scrolls within, never the wrapper's: a wrapper that clips
+  // (it has to, for the rounded corners) shorter than the list's own scroll
+  // container just hides the overflow instead of scrolling it.
+  const listMaxHeight =
+    Math.max(flipUp ? caret.top - 8 : below - 8, MENU_MIN_HEIGHT) -
+    INPUT_HEIGHT;
   const style: React.CSSProperties = {
     position: "fixed",
+    width: MENU_WIDTH,
     left: Math.min(caret.left, window.innerWidth - MENU_WIDTH - 8),
-    maxHeight: Math.max(flipUp ? caret.top - 8 : below - 8, MENU_MIN_HEIGHT),
     ...(flipUp
       ? { bottom: window.innerHeight - caret.top + 6 }
       : { top: caret.bottom + 6 }),
   };
 
-  const choose = (member: MentionMember | undefined) => {
-    if (!member || !state.editor || !state.range) return;
+  /** End the match and put the menu away. Focus is the caller's business. */
+  const close = () => {
+    if (state.editor) dismiss(state.editor);
+    store.close();
+  };
+
+  const choose = (member: MentionMember) => {
+    if (!state.editor || !state.range) return;
     insert(state.editor, state.range, member);
     store.close();
   };
 
-  // Registered on every render so it closes over the current list — the plugin
-  // asks this synchronously while the keystroke is still cancellable.
-  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- plain field on a store, not a ref read during render
-  store.onKey = (event: KeyboardEvent) => {
-    if (event.key === "ArrowDown") {
-      setActive((i) => (filtered.length ? (i + 1) % filtered.length : 0));
-      return true;
-    }
-    if (event.key === "ArrowUp") {
-      setActive((i) =>
-        filtered.length ? (i - 1 + filtered.length) % filtered.length : 0,
-      );
-      return true;
-    }
-    if (event.key === "Enter" || event.key === "Tab") {
-      // Nothing to pick yet: let the key do its normal job rather than
-      // swallowing an Enter that was meant to send or break the line.
-      if (!selected) return false;
-      choose(selected);
-      return true;
-    }
-    return false;
-  };
-
   return createPortal(
     <div
-      style={{ ...style, width: MENU_WIDTH }}
+      style={style}
       data-testid="mention-menu"
       className="z-50 overflow-hidden rounded-lg border border-border bg-popover shadow-md"
     >
-      <Command shouldFilter={false} value={selected?.id ?? ""}>
-        <CommandList>
-          {/* A cached list is on screen while the refresh runs; the spinner
-              is only for the first ever open, with nothing to show. Not
-              `CommandEmpty`, which keys off cmdk's own filtering — and the
-              filtering here is ours (`shouldFilter={false}`). */}
-          {loading && (
+      <Command
+        // cmdk filters, selects and scrolls; `members` is just the source.
+        // The one thing it can't know is that Escape has to hand focus back
+        // to the editor and end the plugin's match, not merely hide a list.
+        onKeyDown={(e) => {
+          if (e.key !== "Escape") return;
+          e.preventDefault();
+          close();
+          // Escape means "back to what I was writing", so the caret goes back
+          // with it. A click elsewhere (below) doesn't — that focus is the
+          // user's own choice, and stealing it back would fight the click.
+          state.editor?.commands.focus();
+        }}
+      >
+        <CommandInput
+          // Focus moves here on open, so the query is typed into the search
+          // field rather than into the document behind it. Seeded with
+          // whatever reached the editor before focus landed.
+          autoFocus
+          value={query}
+          onValueChange={setQuery}
+          placeholder={t("markdownEditor.mentionSearch")}
+          // Clicking away is a dismissal — without this the menu outlives the
+          // caret it belongs to.
+          onBlur={close}
+        />
+        <CommandList style={{ maxHeight: listMaxHeight }}>
+          {/* A cached list is on screen while the refresh runs; the spinner is
+              only for the first ever open, with nothing to show. */}
+          {loading ? (
             <div className="flex items-center justify-center py-6">
               <Spinner size="sm" />
             </div>
+          ) : (
+            <CommandEmpty>{t("markdownEditor.mentionEmpty")}</CommandEmpty>
           )}
-          {!loading && filtered.length === 0 && (
-            <div className="px-4 py-4 text-center text-sm text-muted-foreground">
-              {t("markdownEditor.mentionEmpty")}
-            </div>
-          )}
-          {filtered.map((member) => (
+          {members.map((member) => (
             <CommandItem
               key={member.id}
-              value={member.id}
+              // What cmdk searches on — the name AND the email, so either
+              // finds a teammate. `onSelect` closes over the member itself,
+              // so the id never has to survive this string.
+              value={`${member.name} ${member.email}`}
               onSelect={() => choose(member)}
-              // The caret stays in the editor; a mousedown here would blur it
-              // and close the suggestion before the click lands.
+              // The input is what holds focus; a mousedown here would blur it
+              // and fire the dismissal above before the click ever lands.
               onMouseDown={(e) => e.preventDefault()}
               className="gap-2"
             >

--- a/apps/web/src/components/markdown-editor/mention-suggestion.tsx
+++ b/apps/web/src/components/markdown-editor/mention-suggestion.tsx
@@ -20,6 +20,7 @@ import Suggestion, {
 } from "@tiptap/suggestion";
 import { Extension, type Editor, type Range } from "@tiptap/core";
 import { PluginKey } from "@tiptap/pm/state";
+import type { Node } from "@tiptap/pm/model";
 import { createPortal } from "react-dom";
 import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import {
@@ -56,6 +57,8 @@ const CLOSED: MenuState = { query: "", range: null, rect: null, editor: null };
 export class MentionMenuStore {
   private state: MenuState = CLOSED;
   private listeners = new Set<() => void>();
+  /** The `@` the user dismissed, if any. See `dismiss`. */
+  dismissal: Dismissal | null = null;
 
   subscribe = (listener: () => void) => {
     this.listeners.add(listener);
@@ -88,17 +91,42 @@ function insert(editor: Editor, range: Range, member: MentionMember) {
       { type: "text", text: " " },
     ])
     .run();
-  dismiss(editor);
+  // Plain exit, not `dismiss`: the `@query` this replaced is gone, so there is
+  // no trigger left to keep suppressed.
+  exitSuggestion(editor.view, MENTION_SUGGESTION_KEY);
+}
+
+/** A dismissed trigger: where the `@` sits, and the text matched at the time. */
+interface Dismissal {
+  from: number;
+  text: string;
+}
+
+/** The text at `from`, as long as `length`, clamped to the document. */
+function textAt(doc: Node, from: number, length: number): string {
+  const to = Math.min(from + length, doc.content.size);
+  return from >= to ? "" : doc.textBetween(from, to, "\ufffc", "\ufffc");
 }
 
 /**
- * Deactivate the suggestion plugin itself, not just the menu.
+ * Dismiss the picker for good — not just for one transaction.
  *
- * Hiding the React menu leaves the plugin matching, and a matching plugin
- * still claims Enter — so an Escape'd picker would silently swallow the next
- * send. This is the only thing that actually ends the match.
+ * `exitSuggestion` clears the plugin's state, but the plugin re-runs its match
+ * on EVERY transaction, so the next one (returning focus to the editor is one)
+ * finds the same `@` still sitting there and reopens. Remembering which `@` was
+ * dismissed is what `allow` below consults to keep it shut.
  */
-function dismiss(editor: Editor) {
+function dismiss(editor: Editor, store: MentionMenuStore) {
+  const state = MENTION_SUGGESTION_KEY.getState(editor.state) as
+    | { range?: { from: number; to: number } }
+    | undefined;
+  const range = state?.range;
+  if (range && range.to > range.from) {
+    store.dismissal = {
+      from: range.from,
+      text: editor.state.doc.textBetween(range.from, range.to, "\ufffc"),
+    };
+  }
   exitSuggestion(editor.view, MENTION_SUGGESTION_KEY);
 }
 
@@ -116,6 +144,25 @@ export function mentionSuggestionExtension(store: MentionMenuStore) {
         pluginKey: MENTION_SUGGESTION_KEY,
         // An `@` inside a word is an email address, not a mention.
         allowedPrefixes: [" ", "\n"],
+        // Keeps a dismissed `@` dismissed. Still matching means still claiming
+        // Enter, so without this an Escape'd picker both reopens and swallows
+        // the next send. Self-clearing: once the text at that spot is no longer
+        // what was dismissed (the `@` was deleted, say), the trigger is live
+        // again — typing MORE after it is not, which is the behaviour everyone
+        // else's `@` menu has.
+        allow: ({ state, range }) => {
+          const dismissed = store.dismissal;
+          if (!dismissed) return true;
+          if (
+            range.from === dismissed.from &&
+            textAt(state.doc, dismissed.from, dismissed.text.length) ===
+              dismissed.text
+          ) {
+            return false;
+          }
+          store.dismissal = null;
+          return true;
+        },
         // The list is fetched and filtered in React; the plugin only reports
         // the query.
         items: () => [],
@@ -138,9 +185,9 @@ export function mentionSuggestionExtension(store: MentionMenuStore) {
           },
           // The menu's input holds focus while it's open, so these keys only
           // arrive in the gap before that lands — or if focusing failed.
-          onKeyDown: ({ event, view }) => {
+          onKeyDown: ({ event }) => {
             if (event.key === "Escape") {
-              exitSuggestion(view, MENTION_SUGGESTION_KEY);
+              dismiss(this.editor, store);
               store.close();
               return true;
             }
@@ -207,7 +254,7 @@ function OpenMentionMenu({
 
   /** End the match and put the menu away. Focus is the caller's business. */
   const close = () => {
-    if (state.editor) dismiss(state.editor);
+    if (state.editor) dismiss(state.editor, store);
     store.close();
   };
 

--- a/apps/web/src/i18n/en/markdown-editor.ts
+++ b/apps/web/src/i18n/en/markdown-editor.ts
@@ -1,6 +1,7 @@
 export const markdownEditor = {
   "markdownEditor.toolbarAriaLabel": "Text formatting",
   "markdownEditor.mentionEmpty": "No members found",
+  "markdownEditor.mentionSearch": "Search members...",
   "markdownEditor.bold": "Bold",
   "markdownEditor.italic": "Italic",
   "markdownEditor.strikethrough": "Strikethrough",

--- a/apps/web/src/i18n/pt-br/markdown-editor.ts
+++ b/apps/web/src/i18n/pt-br/markdown-editor.ts
@@ -3,6 +3,7 @@ import type { markdownEditor as markdownEditorEn } from "../en/markdown-editor.t
 export const markdownEditor = {
   "markdownEditor.toolbarAriaLabel": "Formatação de texto",
   "markdownEditor.mentionEmpty": "Nenhum membro encontrado",
+  "markdownEditor.mentionSearch": "Buscar membros...",
   "markdownEditor.bold": "Negrito",
   "markdownEditor.italic": "Itálico",
   "markdownEditor.strikethrough": "Riscado",


### PR DESCRIPTION
Follow-up to #6560. Two bugs with one cause: the first cut used shadcn's `Command` for its styling but re-implemented the parts that make it a combobox — and got them wrong.

## The bugs

**It didn't scroll.** The height cap was on my wrapper `div`, which has `overflow-hidden` (it needs it, for the rounded corners). `CommandList` is the actual scroll container, and clipping it shorter than itself hides the overflow instead of scrolling it. Any member past the fold was simply unreachable. The cap belongs on the list.

**No search field.** I dropped `CommandInput` deliberately, reasoning that the text typed after the `@` was already the query and a second input would be redundant. That was wrong twice over: it reads as a list you can't search, and it left arrow keys, Enter and scroll-into-view to be hand-rolled against the editor's keymap — the exact work the component exists to avoid.

## Now

It's the component as intended. cmdk owns the input, the filtering, the selection and the scrolling; opening the picker moves focus into the search field, so while it's up the keystrokes are cmdk's and the editor sees none. **Search matches name *and* email**, so you can find someone whose display name you can't spell. The hand-rolled selection index and the plugin↔React key bridge are deleted.

Two focus rules, since the menu now takes focus:
- **Escape** ends the match and hands the caret back to the editor — you were mid-sentence.
- **Clicking elsewhere** dismisses without stealing focus back. That click was the user choosing where to go; undoing it would fight them.

## Testing

New CT coverage in `apps/web/ct/tests/task-comments.ct.tsx`, all four regressions pinned:
- the search field is focused on open, filters by name and by email, and Enter inserts the chip with the right `mention:` id;
- **the list scrolls** — asserts `scrollHeight > clientHeight`, that scrolling moves `scrollTop`, and that the last member is reachable. The CT stub now returns 28 members, because a three-member fixture makes a scroll test pass without scrolling;
- Escape dismisses, leaves the typed text alone, and returns focus to the composer;
- clicking away dismisses without stealing the caret back.

`bun run check`, `bun run lint` (0 errors), `bunx knip` clean, unit tests pass.

⚠️ Same caveat as #6560: **I have not seen this render.** CT proves the behavior, not that the menu looks right — the caret-flip near the viewport bottom in particular is reasoned, not observed.