### PR TITLE
fix(tags): bound tagIds array size on member/task-tag assignment tools

### DIFF
--- a/apps/api/src/tools/tags/member-set.test.ts
+++ b/apps/api/src/tools/tags/member-set.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { MEMBER_TAGS_SET } from "./member-set";
+
+describe("MEMBER_TAGS_SET input schema", () => {
+  test("accepts a reasonably sized tagIds array", () => {
+    const result = MEMBER_TAGS_SET.inputSchema.safeParse({
+      memberId: "member_1",
+      tagIds: ["tag_1", "tag_2"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a tagIds array over the bound", () => {
+    // Before the fix: unbounded, and each id drives its own serial DB query.
+    const result = MEMBER_TAGS_SET.inputSchema.safeParse({
+      memberId: "member_1",
+      tagIds: Array.from({ length: 1001 }, (_, i) => `tag_${i}`),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/tools/tags/member-set.ts
+++ b/apps/api/src/tools/tags/member-set.ts
@@ -21,7 +21,10 @@ export const MEMBER_TAGS_SET = defineTool({
   },
   inputSchema: z.object({
     memberId: z.string().describe("Member ID"),
-    tagIds: z.array(z.string()).describe("Array of tag IDs to assign"),
+    tagIds: z
+      .array(z.string())
+      .max(1000)
+      .describe("Array of tag IDs to assign"),
   }),
 
   outputSchema: z.object({

--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -42,7 +42,7 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
       .describe(
         "Sprint to plan this task into (1-based, counted from the org's sprint cadence). Omit or null to leave it in the backlog.",
       ),
-    tagIds: z.array(z.string()).optional(),
+    tagIds: z.array(z.string()).max(1000).optional(),
     prUrl: z
       .string()
       .nullable()

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -154,7 +154,7 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     /** New drag-to-reorder position within its lane (ascending). */
     sortOrder: z.number().optional(),
     /** Replaces the task's tags with this exact set (org tag ids). */
-    tagIds: z.array(z.string()).optional(),
+    tagIds: z.array(z.string()).max(1000).optional(),
     /** Link an existing chat thread to this task (many-to-many, idempotent). */
     linkThreadId: z.string().optional(),
     prUrl: z


### PR DESCRIPTION
Follows #6563 (bounded `TASK_BOARD_DISMISSED_RESTORE`'s `externalKeys`), which established the `.max(1000)` convention for user-controlled id-array inputs on this API. Grepping for the same unbounded shape (`z.array(z.string())` feeding a per-id DB check) turned up three more sites in the same family that never got it: `MEMBER_TAGS_SET.tagIds` (worst case — the handler `await`s a separate `getTag()` per id, so an oversized array is a serial-query DoS on one request), `TASK_BOARD_ITEM_CREATE.tagIds`, and `TASK_BOARD_ITEM_UPDATE.tagIds` (both loop the array in-memory but pass it straight to an unbounded join-table insert).

One concern: cap all three at `.max(1000)`, matching the existing convention (`dismissed.ts`, `thread/list.ts`, `notifications/mark-read.ts`).

Regression test: `apps/api/src/tools/tags/member-set.test.ts` asserts the schema now rejects a 1001-element `tagIds` array and still accepts a normal one (fails on current code, passes after the fix — same shape as `dismissed.test.ts`).

To confirm: `cd apps/api && bun test src/tools/tags/member-set.test.ts`.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test above, and `bunx oxlint` on all four changed files — all clean. Full CI validates the rest.