### PR TITLE
fix(virtual-mcp): bound VIRTUAL_MCP_LAST_USED_LIST's ids array

### DIFF
--- a/apps/api/src/tools/virtual/last-used-list.test.ts
+++ b/apps/api/src/tools/virtual/last-used-list.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { VIRTUAL_MCP_LAST_USED_LIST } from "./last-used-list";
+
+describe("VIRTUAL_MCP_LAST_USED_LIST input schema", () => {
+  test("accepts a reasonably sized ids array", () => {
+    const result = VIRTUAL_MCP_LAST_USED_LIST.inputSchema.safeParse({
+      ids: ["a", "b"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects an ids array over the bound", () => {
+    const result = VIRTUAL_MCP_LAST_USED_LIST.inputSchema.safeParse({
+      ids: Array.from({ length: 1001 }, (_, i) => `id_${i}`),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/tools/virtual/last-used-list.ts
+++ b/apps/api/src/tools/virtual/last-used-list.ts
@@ -11,7 +11,7 @@ import { defineTool } from "../../core/define-tool";
 import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 const InputSchema = z.object({
-  ids: z.array(z.string()).describe("Virtual MCP ids to look up"),
+  ids: z.array(z.string()).max(1000).describe("Virtual MCP ids to look up"),
 });
 
 const OutputSchema = z.object({


### PR DESCRIPTION
Follows #6558/#6563/#6566, which bounded the same class of unbounded array input on NOTIFICATION_MARK_READ, TASK_BOARD_DISMISSED_RESTORE, and member/task-tag assignment tools.

`VIRTUAL_MCP_LAST_USED_LIST`'s `ids` input had no upper bound and flows directly into `findLastUsedByVirtualMcpIds`'s SQL `IN (...)` clause (apps/api/src/storage/threads.ts). A caller can pass an arbitrarily large array to blow up that query — the same resource-exhaustion gap the three prior PRs closed elsewhere.

Fix: cap `ids` at 1000 entries via `.max(1000)` on the Zod input schema, matching the bound used in the sibling fixes.

Regression test: `apps/api/src/tools/virtual/last-used-list.test.ts` asserts the schema accepts a small array and rejects one with 1001 entries.

To verify: `bun test apps/api/src/tools/virtual/last-used-list.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.