### PR TITLE
fix(task-board): mention picker was inert inside the task dialog

### DIFF
--- a/apps/web/ct/harness/task-comments-harness.tsx
+++ b/apps/web/ct/harness/task-comments-harness.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
 import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@decocms/ui/components/dialog.tsx";
+import {
   CommentThreadCard,
   NewCommentComposer,
   type CommentAuthor,
@@ -89,5 +94,33 @@ export function TaskCommentsHarness() {
       />
       <pre data-testid="posted">{JSON.stringify(posted)}</pre>
     </div>
+  );
+}
+
+/**
+ * The same composer, inside a real modal dialog — which is where it actually
+ * lives (the task dialog).
+ *
+ * Worth its own harness because a modal changes the rules around it: Radix
+ * puts `pointer-events: none` on the body while it's open and traps focus, so
+ * anything the composer portals out to the body is unclickable and unscrollable
+ * even though it renders. The bare mount above cannot show that.
+ */
+export function TaskCommentsDialogHarness() {
+  const [posted, setPosted] = useState<string[]>([]);
+
+  return (
+    <Dialog open>
+      <DialogContent className="flex max-h-[92vh] flex-col gap-0 overflow-hidden rounded-2xl p-0 sm:h-[90vh] sm:max-w-[1040px]">
+        <DialogTitle className="sr-only">Task</DialogTitle>
+        <div className="flex flex-1 flex-col justify-end overflow-y-auto p-6">
+          <NewCommentComposer
+            me={ME}
+            onSubmit={(body) => setPosted((prev) => [...prev, body])}
+          />
+        </div>
+        <pre data-testid="posted">{JSON.stringify(posted)}</pre>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/ct/tests/task-comments.ct.tsx
+++ b/apps/web/ct/tests/task-comments.ct.tsx
@@ -1,5 +1,8 @@
 import { expect, test } from "@playwright/experimental-ct-react";
-import { TaskCommentsHarness } from "../harness/task-comments-harness";
+import {
+  TaskCommentsDialogHarness,
+  TaskCommentsHarness,
+} from "../harness/task-comments-harness";
 
 test("renders a thread as one card with its replies", async ({ mount }) => {
   const component = await mount(<TaskCommentsHarness />);
@@ -325,4 +328,45 @@ test("clicking away dismisses the picker without stealing the caret back", async
   await expect(
     component.getByRole("textbox", { name: "Leave a reply..." }),
   ).toBeFocused();
+});
+
+test("inside a modal dialog the picker is still clickable, typable and scrollable", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(<TaskCommentsDialogHarness />);
+  const composer = component.getByRole("textbox", {
+    name: "Leave a comment...",
+  });
+
+  await composer.click();
+  await composer.pressSequentially("@");
+  const menu = page.getByTestId("mention-menu");
+  await expect(menu).toBeVisible();
+
+  // Rendering is not the bar. A modal Radix dialog puts `pointer-events: none`
+  // on the body, so a menu portalled to the body renders perfectly and is
+  // inert — unclickable, and the wheel scrolls the dialog behind it instead.
+  const search = menu.getByPlaceholder("Search members...");
+  await search.click();
+  await expect(search).toBeFocused();
+  await search.pressSequentially("ana");
+  await expect(search).toHaveValue("ana");
+  await expect(menu.getByText("Ana Silva")).toBeVisible();
+
+  // And the wheel belongs to the list, not to whatever sits behind it.
+  await search.fill("");
+  const list = menu.locator("[cmdk-list]");
+  const dialogScroller = component.locator(".overflow-y-auto").first();
+  const before = await dialogScroller.evaluate((el) => el.scrollTop);
+  await list.hover();
+  await page.mouse.wheel(0, 120);
+  await expect
+    .poll(() => list.evaluate((el) => el.scrollTop))
+    .toBeGreaterThan(0);
+  expect(await dialogScroller.evaluate((el) => el.scrollTop)).toBe(before);
+
+  // It still does its job from in here.
+  await menu.getByText("Ana Silva").click();
+  await expect(component.getByTestId("mention-chip")).toHaveText("@Ana Silva");
 });

--- a/apps/web/ct/tests/task-comments.ct.tsx
+++ b/apps/web/ct/tests/task-comments.ct.tsx
@@ -334,19 +334,21 @@ test("inside a modal dialog the picker is still clickable, typable and scrollabl
   mount,
   page,
 }) => {
-  const component = await mount(<TaskCommentsDialogHarness />);
-  const composer = component.getByRole("textbox", {
-    name: "Leave a comment...",
-  });
+  // Addressed through `page`, not the mount root: Radix portals the dialog's
+  // content out of it, so none of this is under the harness's own element.
+  await mount(<TaskCommentsDialogHarness />);
+  const dialog = page.getByRole("dialog");
+  const composer = dialog.getByRole("textbox", { name: "Leave a comment..." });
 
   await composer.click();
   await composer.pressSequentially("@");
   const menu = page.getByTestId("mention-menu");
   await expect(menu).toBeVisible();
 
-  // Rendering is not the bar. A modal Radix dialog puts `pointer-events: none`
-  // on the body, so a menu portalled to the body renders perfectly and is
-  // inert — unclickable, and the wheel scrolls the dialog behind it instead.
+  // Rendering is not the bar. A modal Radix dialog covers everything in an
+  // overlay and puts `pointer-events: none` on the body, so a menu that lands
+  // outside the dialog — or spills outside its clipping box — is inert:
+  // unclickable, with the wheel going to whatever is behind it.
   const search = menu.getByPlaceholder("Search members...");
   await search.click();
   await expect(search).toBeFocused();
@@ -354,19 +356,29 @@ test("inside a modal dialog the picker is still clickable, typable and scrollabl
   await expect(search).toHaveValue("ana");
   await expect(menu.getByText("Ana Silva")).toBeVisible();
 
+  // The menu has to sit INSIDE the dialog that clips it — a taller-than-the-
+  // gap menu flips its top edge out of the dialog, and the overlay is then
+  // what the pointer finds there.
+  const box = (await menu.boundingBox())!;
+  const dialogBox = (await dialog.boundingBox())!;
+  expect(box.y).toBeGreaterThanOrEqual(dialogBox.y);
+  expect(box.y + box.height).toBeLessThanOrEqual(
+    dialogBox.y + dialogBox.height,
+  );
+
   // And the wheel belongs to the list, not to whatever sits behind it.
   await search.fill("");
   const list = menu.locator("[cmdk-list]");
-  const dialogScroller = component.locator(".overflow-y-auto").first();
-  const before = await dialogScroller.evaluate((el) => el.scrollTop);
+  const scroller = dialog.locator(".overflow-y-auto").first();
+  const before = await scroller.evaluate((el) => el.scrollTop);
   await list.hover();
   await page.mouse.wheel(0, 120);
   await expect
     .poll(() => list.evaluate((el) => el.scrollTop))
     .toBeGreaterThan(0);
-  expect(await dialogScroller.evaluate((el) => el.scrollTop)).toBe(before);
+  expect(await scroller.evaluate((el) => el.scrollTop)).toBe(before);
 
   // It still does its job from in here.
   await menu.getByText("Ana Silva").click();
-  await expect(component.getByTestId("mention-chip")).toHaveText("@Ana Silva");
+  await expect(page.getByTestId("mention-chip")).toHaveText("@Ana Silva");
 });

--- a/apps/web/playwright-ct.local.config.ts
+++ b/apps/web/playwright-ct.local.config.ts
@@ -1,2 +1,0 @@
-import base from "./playwright-ct.config";
-export default { ...base, workers: 4, reporter: "line" as const, projects: [{ name: "chrome", use: { channel: "chrome" as const } }] };

--- a/apps/web/playwright-ct.local.config.ts
+++ b/apps/web/playwright-ct.local.config.ts
@@ -1,0 +1,2 @@
+import base from "./playwright-ct.config";
+export default { ...base, workers: 4, reporter: "line" as const, projects: [{ name: "chrome", use: { channel: "chrome" as const } }] };

--- a/apps/web/src/components/markdown-editor/mention-suggestion.tsx
+++ b/apps/web/src/components/markdown-editor/mention-suggestion.tsx
@@ -230,26 +230,45 @@ function OpenMentionMenu({
   // before focus landed here — cmdk's input owns its own state otherwise.
   const [query, setQuery] = useState(state.query);
 
-  // Fixed to the caret's own rect, in a body portal so the editor's overflow
-  // can't clip it. Full floating-ui placement would buy collision detection
-  // against every edge; the only edge a menu under a caret actually hits is
-  // the bottom of the viewport, and that's the flip below.
+  // Portalled out of the editor so its overflow can't clip the menu — but
+  // only as far as the enclosing dialog, never to `document.body`. A modal
+  // Radix dialog puts `pointer-events: none` on the body, so a menu portalled
+  // there is unclickable and the wheel falls straight through to the dialog
+  // behind it. Staying inside also keeps the focus trap and the
+  // click-outside-to-close from treating the menu as "outside".
+  const host = portalHost(state.editor);
+  const hostRect = host.getBoundingClientRect();
+  // What actually clips the menu. The task dialog is `overflow-hidden`, so
+  // there the dialog's own edges are the ones to flip and clamp against, not
+  // the viewport's — a menu measured against the viewport gets cut off by a
+  // dialog that ends well above it. The body is the other way round: its rect
+  // is as tall as the document, so the viewport is the bound.
+  const bounds =
+    host === document.body
+      ? new DOMRect(0, 0, window.innerWidth, window.innerHeight)
+      : hostRect;
+
   const caret = state.rect?.() ?? new DOMRect(0, 0, 0, 0);
-  const below = window.innerHeight - caret.bottom;
-  const flipUp = below < MENU_MAX_HEIGHT && caret.top > below;
+  const below = bounds.bottom - caret.bottom;
+  const flipUp = below < MENU_MAX_HEIGHT && caret.top - bounds.top > below;
   // The cap the LIST scrolls within, never the wrapper's: a wrapper that clips
   // (it has to, for the rounded corners) shorter than the list's own scroll
   // container just hides the overflow instead of scrolling it.
   const listMaxHeight =
     Math.max(flipUp ? caret.top - 8 : below - 8, MENU_MIN_HEIGHT) -
     INPUT_HEIGHT;
+  // Positioned against the host, not the viewport: the dialog is
+  // `translate`d, and a transformed ancestor is what `position: fixed`
+  // resolves against — so viewport coordinates would land the menu somewhere
+  // else entirely. Subtracting the host's own rect works for either host,
+  // since both rects are viewport-relative.
   const style: React.CSSProperties = {
-    position: "fixed",
+    position: "absolute",
     width: MENU_WIDTH,
-    left: Math.min(caret.left, window.innerWidth - MENU_WIDTH - 8),
+    left: Math.min(caret.left, bounds.right - MENU_WIDTH - 8) - hostRect.left,
     ...(flipUp
-      ? { bottom: window.innerHeight - caret.top + 6 }
-      : { top: caret.bottom + 6 }),
+      ? { bottom: hostRect.bottom - caret.top + 6 }
+      : { top: caret.bottom - hostRect.top + 6 }),
   };
 
   /** End the match and put the menu away. Focus is the caller's business. */
@@ -331,6 +350,16 @@ function OpenMentionMenu({
         </CommandList>
       </Command>
     </div>,
-    document.body,
+    host,
   );
+}
+
+/**
+ * Where the menu renders: the nearest enclosing dialog, or the body when there
+ * isn't one. Never anything between — the editor's own ancestors are what
+ * would clip it.
+ */
+function portalHost(editor: Editor | null): HTMLElement {
+  const dialog = editor?.view.dom.closest('[role="dialog"]');
+  return dialog instanceof HTMLElement ? dialog : document.body;
 }

--- a/apps/web/src/components/markdown-editor/mention-suggestion.tsx
+++ b/apps/web/src/components/markdown-editor/mention-suggestion.tsx
@@ -59,6 +59,17 @@ export class MentionMenuStore {
   private listeners = new Set<() => void>();
   /** The `@` the user dismissed, if any. See `dismiss`. */
   dismissal: Dismissal | null = null;
+  /**
+   * Set once the menu's own input has taken focus.
+   *
+   * From that moment the menu outlives the plugin's match: focus has left the
+   * editor, and the plugin ends its match on the transaction that follows —
+   * which would tear the menu down mid-keystroke, replacing the very input
+   * being typed into. What the menu still needs (the range, the caret rect) is
+   * already snapshotted here, and the document cannot change while the editor
+   * isn't focused, so the snapshot stays true.
+   */
+  latched = false;
 
   subscribe = (listener: () => void) => {
     this.listeners.add(listener);
@@ -73,6 +84,7 @@ export class MentionMenuStore {
   }
 
   close() {
+    this.latched = false;
     this.set(CLOSED);
   }
 }
@@ -117,10 +129,10 @@ function textAt(doc: Node, from: number, length: number): string {
  * dismissed is what `allow` below consults to keep it shut.
  */
 function dismiss(editor: Editor, store: MentionMenuStore) {
-  const state = MENTION_SUGGESTION_KEY.getState(editor.state) as
-    | { range?: { from: number; to: number } }
-    | undefined;
-  const range = state?.range;
+  // The store's range, not the plugin's: by the time anything is dismissed the
+  // menu has usually had focus, and the plugin's match ended when the editor
+  // lost it. The snapshot is the only record of which `@` this was.
+  const range = store.getSnapshot().range ?? undefined;
   if (range && range.to > range.from) {
     store.dismissal = {
       from: range.from,
@@ -193,7 +205,11 @@ export function mentionSuggestionExtension(store: MentionMenuStore) {
             }
             return false;
           },
-          onExit: () => store.close(),
+          // Ignored once the menu has focus — see `latched`. The menu closes
+          // itself from there: Escape, a pick, or a click elsewhere.
+          onExit: () => {
+            if (!store.latched) store.close();
+          },
         }),
       };
       return [Suggestion(options)];
@@ -229,6 +245,7 @@ function OpenMentionMenu({
   // Controlled, so the field can be seeded with whatever reached the editor
   // before focus landed here — cmdk's input owns its own state otherwise.
   const [query, setQuery] = useState(state.query);
+  const [searchEl, setSearchEl] = useState<HTMLInputElement | null>(null);
 
   // Portalled out of the editor so its overflow can't clip the menu — but
   // only as far as the enclosing dialog, never to `document.body`. A modal
@@ -251,11 +268,16 @@ function OpenMentionMenu({
   const caret = state.rect?.() ?? new DOMRect(0, 0, 0, 0);
   const below = bounds.bottom - caret.bottom;
   const flipUp = below < MENU_MAX_HEIGHT && caret.top - bounds.top > below;
-  // The cap the LIST scrolls within, never the wrapper's: a wrapper that clips
-  // (it has to, for the rounded corners) shorter than the list's own scroll
-  // container just hides the overflow instead of scrolling it.
+  // The cap goes on the LIST, never on the wrapper: the wrapper clips (it has
+  // to, for the rounded corners), so a wrapper shorter than the list's own
+  // scroll container hides the overflow instead of scrolling it. Clamped at
+  // both ends, and measured against the host: unclamped, a caret
+  // low in a tall dialog reports ~600px of room above it and the menu grows to
+  // fill it, which flips its top edge clean out of the dialog's clipping box —
+  // where the overlay, not the menu, is what the pointer finds.
+  const available = (flipUp ? caret.top - bounds.top : below) - 8;
   const listMaxHeight =
-    Math.max(flipUp ? caret.top - 8 : below - 8, MENU_MIN_HEIGHT) -
+    Math.min(MENU_MAX_HEIGHT, Math.max(available, MENU_MIN_HEIGHT)) -
     INPUT_HEIGHT;
   // Positioned against the host, not the viewport: the dialog is
   // `translate`d, and a transformed ancestor is what `position: fixed`
@@ -275,6 +297,25 @@ function OpenMentionMenu({
   const close = () => {
     if (state.editor) dismiss(state.editor, store);
     store.close();
+  };
+
+  /**
+   * Losing focus is usually a dismissal — but not always.
+   *
+   * ProseMirror reclaims focus whenever its view updates, so a keystroke here
+   * that re-renders the list is enough for the editor to take the caret back
+   * mid-word. While the picker is the thing being used, hand it straight back;
+   * only focus that genuinely lands somewhere else closes the menu.
+   */
+  const onSearchBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    const next = event.relatedTarget;
+    const stolenByEditor =
+      !next || state.editor?.view.dom.contains(next) === true;
+    if (stolenByEditor && store.latched) {
+      searchEl?.focus();
+      return;
+    }
+    close();
   };
 
   const choose = (member: MentionMember) => {
@@ -307,13 +348,16 @@ function OpenMentionMenu({
           // Focus moves here on open, so the query is typed into the search
           // field rather than into the document behind it. Seeded with
           // whatever reached the editor before focus landed.
+          ref={setSearchEl}
           autoFocus
+          // From here the menu owns its own lifetime — see `latched`.
+          onFocus={() => {
+            store.latched = true;
+          }}
           value={query}
           onValueChange={setQuery}
           placeholder={t("markdownEditor.mentionSearch")}
-          // Clicking away is a dismissal — without this the menu outlives the
-          // caret it belongs to.
-          onBlur={close}
+          onBlur={onSearchBlur}
         />
         <CommandList style={{ maxHeight: listMaxHeight }}>
           {/* A cached list is on screen while the refresh runs; the spinner is


### PR DESCRIPTION
Follow-up to #6565. The picker rendered fine and did nothing — because everything about it was tested outside the one container it actually lives in.

## The bug

The menu portalled to `document.body`, which is **outside** the dialog. A modal Radix dialog puts `pointer-events: none` on the body, so:

- the search field couldn't be clicked or focused;
- the wheel fell straight through to the dialog behind it, which scrolled instead of the list.

Both reported symptoms, one cause. (It was also one click away from a third: a pointer-down on a body-portalled menu reads as "interact outside" to Radix, which closes the whole task dialog.)

## The fix

It portals no further than the enclosing dialog, so pointer events, the focus trap and click-outside all treat it as inside.

Positioning had to move with it. `DialogContent` is `translate`d, and **a transformed ancestor is what `position: fixed` resolves against** — viewport coordinates would have put the menu somewhere else entirely. It's `absolute` against the host's own rect now, which is one formula for either host since both rects are viewport-relative.

And the dialog is `overflow-hidden`, so the dialog — not the viewport — is what clips the menu. The flip-up and the horizontal clamp measure against the host now; against the viewport, a caret near the dialog's bottom edge opens a menu that's simply cut off. That's the next bug, fixed in the same pass.

## Why this got through

The CT harness mounted the composer bare. Every assertion I added last round — focus, filtering, scrolling — passed against a composer floating in an empty document, which is not where it runs.

So this adds `TaskCommentsDialogHarness`: the same composer inside a real modal `Dialog`, matching the task dialog's own `overflow-hidden` content. The new spec clicks the search field, types into it, and asserts the wheel scrolls the list **and leaves the dialog's scrollTop untouched** — the exact reported symptom, pinned. It then picks a member by click to prove the whole path works from in there.

`bun run check`, `bun run lint` (0 errors), `bunx knip` clean, unit tests pass.