### PR TITLE
fix(decofile): bound the number of blocks a single patch can touch

### DIFF
--- a/apps/api/src/api/routes/decofile.test.ts
+++ b/apps/api/src/api/routes/decofile.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { patchBodySchema } from "./decofile";
+
+describe("decofile patchBodySchema", () => {
+  test("accepts a reasonably sized patch", () => {
+    const result = patchBodySchema.safeParse({
+      set: { "pages/home": {} },
+      delete: ["pages/old"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a patch touching more than 500 blocks", () => {
+    // Before the fix: unbounded, one commit tree write per key.
+    const result = patchBodySchema.safeParse({
+      delete: Array.from({ length: 501 }, (_, i) => `pages/block_${i}`),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/api/routes/decofile.ts
+++ b/apps/api/src/api/routes/decofile.ts
@@ -66,7 +66,10 @@ function isValidBranch(branch: string): boolean {
   );
 }
 
-const patchBodySchema = z
+// Bounds the tree write GitHub does for one commit.
+const MAX_PATCH_KEYS = 500;
+
+export const patchBodySchema = z
   .object({
     set: z.record(z.string(), z.unknown()).optional(),
     delete: z.array(z.string()).optional(),
@@ -74,6 +77,12 @@ const patchBodySchema = z
   .refine(
     (b) => Object.keys(b.set ?? {}).length > 0 || (b.delete?.length ?? 0) > 0,
     { message: "Patch must set or delete at least one block" },
+  )
+  .refine(
+    (b) =>
+      Object.keys(b.set ?? {}).length + (b.delete?.length ?? 0) <=
+      MAX_PATCH_KEYS,
+    { message: `Patch cannot touch more than ${MAX_PATCH_KEYS} blocks` },
   );
 
 /**


### PR DESCRIPTION
Follows #6566 / #6567 — same pattern (an unbounded client-controlled array with no size cap on an authenticated tool/route), applied to `PATCH /api/:org/decofile/:virtualMcpId/:branch`.

`patchBodySchema` accepted an unbounded `set` object and `delete` array. Each key becomes an entry in a GitHub tree write for one commit (`enqueueDecofilePatch` -> commit-coalescer), so a single request could queue an arbitrarily large tree/commit with no upper bound.

Adds a second `.refine` capping `set` keys + `delete` entries at 500 total, returning a 400 instead of accepting the patch.

Failure scenario: a caller (or a bug in a client) sends `{ delete: [...5000 keys] }` in one PATCH — pre-fix this is accepted and handed straight to the git commit coalescer; post-fix it's rejected with `Patch cannot touch more than 500 blocks`.

Regression test: `apps/api/src/api/routes/decofile.test.ts` exports and exercises `patchBodySchema` directly (no DB/GitHub needed) — asserts a normal-sized patch still parses and a 501-key patch is rejected.

To confirm: `bun test apps/api/src/api/routes/decofile.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI covers the rest.