### PR TITLE
fix(mentions): bound the number of mentions parsed from a body

### DIFF
--- a/packages/shared/src/mentions.test.ts
+++ b/packages/shared/src/mentions.test.ts
@@ -17,3 +17,10 @@ test("no mentions is empty, not a throw", () => {
   expect(parseMentions("")).toEqual([]);
   expect(parseMentions("plain @ana text")).toEqual([]);
 });
+
+test("caps the number of parsed mentions", () => {
+  const body = Array.from({ length: 200 }, (_, i) =>
+    mentionMarkdown(`usr_${i}`, `User ${i}`),
+  ).join(" ");
+  expect(parseMentions(body)).toHaveLength(50);
+});

--- a/packages/shared/src/mentions.ts
+++ b/packages/shared/src/mentions.ts
@@ -19,9 +19,22 @@ export const MENTION_HREF_PREFIX = "mention:";
  *  `)` — both hold for user ids, and the editor escapes what it writes. */
 const MENTION_RE = /\[@([^\]]+)\]\(mention:([^)\s]+)\)/g;
 
-/** Every distinct user id mentioned in a markdown body, in first-seen order. */
+/**
+ * No real comment/description mentions this many people. Caps the work done
+ * per edit (a DB `IN` lookup and a notification fan-out per id) so a body
+ * padded with thousands of fake `[@x](mention:id)` links can't blow either up.
+ */
+const MAX_MENTIONS = 50;
+
+/** Every distinct user id mentioned in a markdown body, in first-seen order,
+ *  capped at MAX_MENTIONS. */
 export function parseMentions(markdown: string): string[] {
-  return [...new Set([...markdown.matchAll(MENTION_RE)].map((m) => m[2]!))];
+  const ids = new Set<string>();
+  for (const m of markdown.matchAll(MENTION_RE)) {
+    ids.add(m[2]!);
+    if (ids.size >= MAX_MENTIONS) break;
+  }
+  return [...ids];
 }
 
 /** The markdown for one mention. */


### PR DESCRIPTION
**Source:** reduction/bug (C3) — same class as the recently-merged #6566 (bound tagIds array) and #6567 (bound VIRTUAL_MCP_LAST_USED_LIST ids array).

**Why:** `parseMentions` (`packages/shared/src/mentions.ts`) extracts every distinct `[@Name](mention:id)` id out of a comment/description body with no limit. Neither the comment body (`comments.ts`) nor the description (`create.ts`/`update.ts`) input schemas cap length, so a body padded with thousands of fake mention links inflates the downstream work in `notifyMentions` (`apps/api/src/notifications/mentions.ts`): a `member` table `IN (...)` lookup sized to the parsed-id count, and a notification fan-out per matched recipient. Capping at the source keeps every caller (create/update/comment) bounded without touching each one.

**Fix:** `parseMentions` now stops collecting once it has 50 distinct ids (first-seen order preserved, same as before).

**Failure scenario:** a comment or description body containing thousands of distinct `[@x](mention:fake_id_N)` links previously produced a proportionally sized `IN` clause and notification fan-out on every create/edit.

**Regression test:** `packages/shared/src/mentions.test.ts` — a 200-mention body now yields exactly 50 parsed ids.

**Reviewer check:** `bun test packages/shared/src/mentions.test.ts`

**Local verification:** `bun run fmt`, `bunx tsc --noEmit` (packages/shared), the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI covers the rest.