### PR TITLE
fix(decofile): cap the size of a single patched block

### DIFF
--- a/apps/api/src/api/routes/decofile.test.ts
+++ b/apps/api/src/api/routes/decofile.test.ts
@@ -17,4 +17,12 @@ describe("decofile patchBodySchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test("rejects a single block over the size cap", () => {
+    // Before the fix: the key-count cap let one oversized value through.
+    const result = patchBodySchema.safeParse({
+      set: { "pages/home": { html: "x".repeat(300 * 1024) } },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/apps/api/src/api/routes/decofile.ts
+++ b/apps/api/src/api/routes/decofile.ts
@@ -69,6 +69,9 @@ function isValidBranch(branch: string): boolean {
 // Bounds the tree write GitHub does for one commit.
 const MAX_PATCH_KEYS = 500;
 
+// Bounds one block's own size — a block count cap alone still lets one oversized value through.
+const MAX_BLOCK_BYTES = 256 * 1024;
+
 export const patchBodySchema = z
   .object({
     set: z.record(z.string(), z.unknown()).optional(),
@@ -83,6 +86,13 @@ export const patchBodySchema = z
       Object.keys(b.set ?? {}).length + (b.delete?.length ?? 0) <=
       MAX_PATCH_KEYS,
     { message: `Patch cannot touch more than ${MAX_PATCH_KEYS} blocks` },
+  )
+  .refine(
+    (b) =>
+      Object.values(b.set ?? {}).every(
+        (value) => JSON.stringify(value).length <= MAX_BLOCK_BYTES,
+      ),
+    { message: `Each block must be at most ${MAX_BLOCK_BYTES} bytes` },
   );
 
 /**


### PR DESCRIPTION
Follows #6569, which bounded the number of blocks a single decofile patch can touch (max 500) but left each block's own size unbounded. A patch with a single `set` key and a multi-MB value still passes the 500-key cap, gets fully buffered into memory by `c.req.json()`, and lands as one oversized GitHub commit tree write — the same payload-size gap the checklist calls out (measure size before it blows up, not after).

Adds a 256KB-per-block cap to the same `patchBodySchema` refine chain already used by both the test and the PATCH handler.

**Regression test**: `apps/api/src/api/routes/decofile.test.ts` — "rejects a single block over the size cap" fails on the pre-fix schema (a 300KB single-block patch passes) and passes after.

**To confirm**: `cd apps/api && bun test src/api/routes/decofile.test.ts`

**Checked locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.