### PR TITLE
fix(decopilot): cap the number of storage refs resolved per tool call

### DIFF
--- a/apps/api/src/api/routes/decopilot/file-materializer.test.ts
+++ b/apps/api/src/api/routes/decopilot/file-materializer.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import {
+  collectStudioStorageKeys,
+  MAX_STORAGE_KEYS,
+} from "./file-materializer";
+
+describe("collectStudioStorageKeys", () => {
+  it("collects every key in a nested tool-call args tree", () => {
+    const out = new Set<string>();
+    collectStudioStorageKeys(
+      {
+        a: "studio-storage://one",
+        nested: { b: ["studio-storage://two", "plain text"] },
+      },
+      out,
+    );
+    expect([...out]).toEqual(["one", "two"]);
+  });
+
+  it("caps the number of keys collected from a single string", () => {
+    const padded = Array.from(
+      { length: MAX_STORAGE_KEYS + 50 },
+      (_, i) => `studio-storage://key-${i}`,
+    ).join(" ");
+    const out = new Set<string>();
+    collectStudioStorageKeys(padded, out);
+    expect(out.size).toBe(MAX_STORAGE_KEYS);
+  });
+
+  it("caps the number of keys collected across many args fields", () => {
+    const args: Record<string, string> = {};
+    for (let i = 0; i < MAX_STORAGE_KEYS + 50; i++) {
+      args[`field${i}`] = `studio-storage://key-${i}`;
+    }
+    const out = new Set<string>();
+    collectStudioStorageKeys(args, out);
+    expect(out.size).toBe(MAX_STORAGE_KEYS);
+  });
+});

--- a/apps/api/src/api/routes/decopilot/file-materializer.ts
+++ b/apps/api/src/api/routes/decopilot/file-materializer.ts
@@ -596,10 +596,23 @@ export async function resolveArgsStorageRefs(
   return substituteValues(args, keyToPresigned) as Record<string, unknown>;
 }
 
-function collectStudioStorageKeys(value: unknown, out: Set<string>): void {
+/**
+ * No real tool call references this many distinct storage objects. Caps the
+ * work `resolveArgsStorageRefs` fans out per call (one presign per key) so
+ * args padded with thousands of fake `studio-storage://` refs can't blow it
+ * up — the same bound `parseMentions` applies to a comment body.
+ */
+export const MAX_STORAGE_KEYS = 200;
+
+export function collectStudioStorageKeys(
+  value: unknown,
+  out: Set<string>,
+): void {
+  if (out.size >= MAX_STORAGE_KEYS) return;
   if (typeof value === "string") {
     for (const match of value.matchAll(studioStorageRegex())) {
       out.add(match[1]!);
+      if (out.size >= MAX_STORAGE_KEYS) break;
     }
   } else if (Array.isArray(value)) {
     for (const item of value) collectStudioStorageKeys(item, out);


### PR DESCRIPTION
Reduction/hardening — same DoS-bound pattern as the just-merged #6569 (bound the number of blocks a single patch can touch) and #6570 (bound the number of mentions parsed from a body), applied to `resolveArgsStorageRefs` in `apps/api/src/api/routes/decopilot/file-materializer.ts`.

`resolveArgsStorageRefs` deep-walks every tool-call args tree (LLM-authored, and reachable via prompt injection from tool output/MCP content) and collects every `studio-storage://`/`mesh-storage://` ref it finds into an unbounded `Set`, then fires one `presignedGetUrl` call per distinct key via `Promise.all`. Args padded with thousands of fake storage refs (or a single string repeating the pattern) fan out into thousands of concurrent presign calls with no cap — the same class of unbounded-work-per-request bug the two just-merged PRs closed elsewhere in this codebase.

This caps `collectStudioStorageKeys` at `MAX_STORAGE_KEYS = 200` (mirroring the `MAX_MENTIONS` cap in `packages/shared/src/mentions.ts`), short-circuiting both the string scan and the object/array recursion once the cap is hit, so the presign fan-out and object walk are bounded regardless of how many refs the args tree contains. No real tool call touches anywhere near 200 distinct files at once.

Behavior-preserving for every real call (well under the cap); only the pathological case is now bounded instead of unbounded.

To confirm: `bun test apps/api/src/api/routes/decopilot/file-materializer.test.ts` — a new test file covering `collectStudioStorageKeys` on a nested args tree and on payloads that exceed the cap (both via one huge string and via many fields).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test above (3 pass), and `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.