### PR TITLE
fix(decofile): cap block key length in patch bodies

### DIFF
--- a/apps/api/src/api/routes/decofile.test.ts
+++ b/apps/api/src/api/routes/decofile.test.ts
@@ -25,4 +25,12 @@ describe("decofile patchBodySchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test("rejects a delete key over the key-length cap", () => {
+    // Before the fix: only the block value was size-capped, not the key.
+    const result = patchBodySchema.safeParse({
+      delete: ["x".repeat(2000)],
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/apps/api/src/api/routes/decofile.ts
+++ b/apps/api/src/api/routes/decofile.ts
@@ -72,6 +72,9 @@ const MAX_PATCH_KEYS = 500;
 // Bounds one block's own size — a block count cap alone still lets one oversized value through.
 const MAX_BLOCK_BYTES = 256 * 1024;
 
+// Bounds one block key's length — a key becomes a GitHub tree path.
+const MAX_BLOCK_KEY_LENGTH = 1024;
+
 export const patchBodySchema = z
   .object({
     set: z.record(z.string(), z.unknown()).optional(),
@@ -93,6 +96,15 @@ export const patchBodySchema = z
         (value) => JSON.stringify(value).length <= MAX_BLOCK_BYTES,
       ),
     { message: `Each block must be at most ${MAX_BLOCK_BYTES} bytes` },
+  )
+  .refine(
+    (b) =>
+      [...Object.keys(b.set ?? {}), ...(b.delete ?? [])].every(
+        (key) => key.length <= MAX_BLOCK_KEY_LENGTH,
+      ),
+    {
+      message: `Each block key must be at most ${MAX_BLOCK_KEY_LENGTH} characters`,
+    },
   );
 
 /**


### PR DESCRIPTION
Follows #6571, which capped one block's *value* size (`MAX_BLOCK_BYTES`) but left the *key* unbounded.

The block key is used directly as a GitHub tree path (`blockKeyToFileStem` → `encodeURIComponent(key)`) for both `set` and `delete`. `MAX_PATCH_KEYS` only bounds how many keys a patch touches, not their length — so a single `delete` entry with a multi-megabyte string still reaches the GitHub tree write completely unbounded, the exact failure class #6571 just closed for values.

**Fix**: a new `MAX_BLOCK_KEY_LENGTH` (1024 chars) refine on `patchBodySchema`, checked across both `set` keys and `delete` entries.

**Regression test**: `apps/api/src/api/routes/decofile.test.ts` — "rejects a delete key over the key-length cap", which fails on current `main` (a 2000-char delete key is accepted) and passes after the fix.

**To verify**: `bun test apps/api/src/api/routes/decofile.test.ts`

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/api/routes/decofile.test.ts`, `bunx oxlint apps/api/src/api/routes/decofile.ts apps/api/src/api/routes/decofile.test.ts` — all clean. Full CI validates the rest.