### PR TITLE
fix(task-board): cap comment body length

### DIFF
--- a/apps/api/src/tools/task-board/comments.test.ts
+++ b/apps/api/src/tools/task-board/comments.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import {
+  TASK_BOARD_COMMENT_CREATE,
+  TASK_BOARD_COMMENT_UPDATE,
+} from "./comments";
+
+/**
+ * Regression: comment bodies had no length cap — an unbounded `text` column,
+ * writable directly by any org member's tool call. A single oversized POST
+ * could bloat a row (and everything that re-reads it: the activity feed, the
+ * Jira mirror, agent prompt context) with no server-side limit at all.
+ */
+describe("task board comment body length", () => {
+  it("TASK_BOARD_COMMENT_CREATE rejects a body over the cap", () => {
+    const result = TASK_BOARD_COMMENT_CREATE.inputSchema.safeParse({
+      taskBoardItemId: "tbi_1",
+      body: "x".repeat(50_001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("TASK_BOARD_COMMENT_CREATE accepts a body at the cap", () => {
+    const result = TASK_BOARD_COMMENT_CREATE.inputSchema.safeParse({
+      taskBoardItemId: "tbi_1",
+      body: "x".repeat(50_000),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("TASK_BOARD_COMMENT_UPDATE rejects a body over the cap", () => {
+    const result = TASK_BOARD_COMMENT_UPDATE.inputSchema.safeParse({
+      id: "cmt_1",
+      body: "x".repeat(50_001),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/tools/task-board/comments.ts
+++ b/apps/api/src/tools/task-board/comments.ts
@@ -12,6 +12,9 @@ import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import { enqueueJiraCommentPush } from "@/jira/dbos-jira-sync";
 import { taskRunContextStore } from "./task-run-context";
 
+/** No real comment is this long — caps the row a single POST can write. */
+const MAX_COMMENT_BODY_LENGTH = 50_000;
+
 const TaskBoardCommentSchema = z.object({
   id: z.string(),
   taskBoardItemId: z.string(),
@@ -94,7 +97,7 @@ export const TASK_BOARD_COMMENT_CREATE = defineTool({
   },
   inputSchema: z.object({
     taskBoardItemId: z.string(),
-    body: z.string().trim().min(1),
+    body: z.string().trim().min(1).max(MAX_COMMENT_BODY_LENGTH),
     /** Reply target. Replying to a reply lands on its thread root. */
     parentId: z.string().nullish(),
   }),
@@ -166,7 +169,7 @@ export const TASK_BOARD_COMMENT_UPDATE = defineTool({
   },
   inputSchema: z.object({
     id: z.string(),
-    body: z.string().trim().min(1).optional(),
+    body: z.string().trim().min(1).max(MAX_COMMENT_BODY_LENGTH).optional(),
     resolved: z.boolean().optional(),
   }),
   outputSchema: z.object({ comment: TaskBoardCommentSchema }),


### PR DESCRIPTION
**Source:** resource-bound gap found while auditing the task-board comments tool (`apps/api/src/tools/task-board/comments.ts`), which was recently touched by the new @-mention feature (#6560/#6565/#6568). Same category of fix as the two just-merged decofile block-size/key-length caps (#6571, #6573), and mirrors the existing `readme.max(50000)` cap on registry publish.

**Payoff:** `task_board_comments.body` is a plain unbounded Postgres `text` column (migration 159), and `TASK_BOARD_COMMENT_CREATE`/`TASK_BOARD_COMMENT_UPDATE` had no length limit on it at all — any org member (or, via `taskRunContextStore`, an automated task-run agent) could write an arbitrarily large row. That row gets re-read on every activity-feed load, mirrored onto the linked Jira issue via `enqueueJiraCommentPush`, and fed into agent prompt context, so an oversized body doesn't just bloat storage — it amplifies cost on every one of those paths.

**Fix:** added `.max(50_000)` to the `body` field on both tools' Zod input schemas (matching the existing registry `readme` cap). Zod rejects an oversized body before it reaches storage.

**Verify:** `bun test apps/api/src/tools/task-board/comments.test.ts` — asserts `TASK_BOARD_COMMENT_CREATE`/`UPDATE`'s `inputSchema` accepts a body at the 50,000-char cap and rejects one over it.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test above (3/3 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.