### PR TITLE
fix(task-board): cap task description length

### DIFF
--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -3,6 +3,7 @@ import { defineTool } from "@/core/define-tool";
 import { MAX_SPRINT } from "@decocms/shared/sprints";
 import { getUserId, requireAuth } from "@/core/studio-context";
 import {
+  MAX_TASK_DESCRIPTION_LENGTH,
   SUPER_AGENT_ASSIGNEE_ID,
   TaskBoardItemPrioritySchema,
   TaskBoardItemTypeSchema,
@@ -27,7 +28,11 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
   },
   inputSchema: z.object({
     title: z.string().min(1),
-    description: z.string().nullable().optional(),
+    description: z
+      .string()
+      .max(MAX_TASK_DESCRIPTION_LENGTH)
+      .nullable()
+      .optional(),
     status: TaskBoardItemStatusSchema.optional(),
     priority: TaskBoardItemPrioritySchema.optional(),
     type: TaskBoardItemTypeSchema.optional(),

--- a/apps/api/src/tools/task-board/description-length.test.ts
+++ b/apps/api/src/tools/task-board/description-length.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { TASK_BOARD_ITEM_CREATE } from "./create";
+import { TASK_BOARD_ITEM_UPDATE } from "./update";
+
+/**
+ * Regression: a task's `description` had no length cap — an unbounded
+ * `text` column, writable directly by any org member's tool call. Same gap
+ * as the comment body cap (#6574), just on the sibling field.
+ */
+describe("task board item description length", () => {
+  it("TASK_BOARD_ITEM_CREATE rejects a description over the cap", () => {
+    const result = TASK_BOARD_ITEM_CREATE.inputSchema.safeParse({
+      title: "t",
+      description: "x".repeat(50_001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("TASK_BOARD_ITEM_CREATE accepts a description at the cap", () => {
+    const result = TASK_BOARD_ITEM_CREATE.inputSchema.safeParse({
+      title: "t",
+      description: "x".repeat(50_000),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("TASK_BOARD_ITEM_UPDATE rejects a description over the cap", () => {
+    const result = TASK_BOARD_ITEM_UPDATE.inputSchema.safeParse({
+      id: "tbi_1",
+      description: "x".repeat(50_001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("TASK_BOARD_ITEM_UPDATE accepts a description at the cap", () => {
+    const result = TASK_BOARD_ITEM_UPDATE.inputSchema.safeParse({
+      id: "tbi_1",
+      description: "x".repeat(50_000),
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -2,6 +2,9 @@ import { z } from "zod";
 
 export { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 
+/** No real task description is this long — caps the row a single write can write. */
+export const MAX_TASK_DESCRIPTION_LENGTH = 50_000;
+
 export const TaskBoardItemStatusSchema = z.enum([
   "triage",
   "todo",

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -8,6 +8,7 @@ import type {
   TaskBoardItemStatus,
 } from "@/storage/types";
 import {
+  MAX_TASK_DESCRIPTION_LENGTH,
   SUPER_AGENT_ASSIGNEE_ID,
   TaskBoardItemPrioritySchema,
   TaskBoardItemTypeSchema,
@@ -172,7 +173,11 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
   inputSchema: z.object({
     id: z.string(),
     title: z.string().min(1).optional(),
-    description: z.string().nullable().optional(),
+    description: z
+      .string()
+      .max(MAX_TASK_DESCRIPTION_LENGTH)
+      .nullable()
+      .optional(),
     status: TaskBoardItemStatusSchema.optional(),
     priority: TaskBoardItemPrioritySchema.optional(),
     type: TaskBoardItemTypeSchema.optional(),


### PR DESCRIPTION
Follows #6574 (task board comment body cap) — that PR fixed the exact same gap on `TASK_BOARD_COMMENT_CREATE`/`UPDATE`'s `body` field but left the sibling `description` field on `TASK_BOARD_ITEM_CREATE`/`TASK_BOARD_ITEM_UPDATE` unbounded.

**Why it matters:** `description` is an unbounded `text` column, writable directly by any org member's tool call with no server-side limit. A single oversized create/update call could bloat a row (and everything that re-reads it: the activity feed, mention notifications, Jira mirror, agent prompt context) — the exact failure mode #6574 called out for comments.

**Fix:** added `MAX_TASK_DESCRIPTION_LENGTH = 50_000` in `schema.ts` (task-board's shared home for these constants) and applied `.max(...)` to `description` in both `TASK_BOARD_ITEM_CREATE`'s and `TASK_BOARD_ITEM_UPDATE`'s input schemas, mirroring the comment-body cap exactly.

**Regression test:** `apps/api/src/tools/task-board/description-length.test.ts` — asserts both tools accept a description at the 50k cap and reject one byte over it.

**Reviewer check:** `bun test apps/api/src/tools/task-board/description-length.test.ts`

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` (workspace root, clean), `bunx oxlint` on the 4 touched files (0 warnings/errors), and the targeted test above (4/4 pass). Full CI validates the rest.