### PR TITLE
fix(task-board): cap task title length

### DIFF
--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -4,6 +4,7 @@ import { MAX_SPRINT } from "@decocms/shared/sprints";
 import { getUserId, requireAuth } from "@/core/studio-context";
 import {
   MAX_TASK_DESCRIPTION_LENGTH,
+  MAX_TASK_TITLE_LENGTH,
   SUPER_AGENT_ASSIGNEE_ID,
   TaskBoardItemPrioritySchema,
   TaskBoardItemTypeSchema,
@@ -27,7 +28,7 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
     openWorldHint: false,
   },
   inputSchema: z.object({
-    title: z.string().min(1),
+    title: z.string().min(1).max(MAX_TASK_TITLE_LENGTH),
     description: z
       .string()
       .max(MAX_TASK_DESCRIPTION_LENGTH)

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -5,6 +5,10 @@ export { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 /** No real task description is this long — caps the row a single write can write. */
 export const MAX_TASK_DESCRIPTION_LENGTH = 50_000;
 
+/** No real task title is this long — same reasoning as MAX_TASK_DESCRIPTION_LENGTH,
+ *  a title is a one-line label, not a place for the description's content. */
+export const MAX_TASK_TITLE_LENGTH = 500;
+
 export const TaskBoardItemStatusSchema = z.enum([
   "triage",
   "todo",

--- a/apps/api/src/tools/task-board/title-length.test.ts
+++ b/apps/api/src/tools/task-board/title-length.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { TASK_BOARD_ITEM_CREATE } from "./create";
+import { TASK_BOARD_ITEM_UPDATE } from "./update";
+
+/**
+ * Regression: a task's `title` had no length cap — an unbounded `text`
+ * column, writable directly by any org member's tool call. Same gap as the
+ * description cap (#6576) and the comment body cap (#6574), just on the
+ * sibling field.
+ */
+describe("task board item title length", () => {
+  it("TASK_BOARD_ITEM_CREATE rejects a title over the cap", () => {
+    const result = TASK_BOARD_ITEM_CREATE.inputSchema.safeParse({
+      title: "x".repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("TASK_BOARD_ITEM_CREATE accepts a title at the cap", () => {
+    const result = TASK_BOARD_ITEM_CREATE.inputSchema.safeParse({
+      title: "x".repeat(500),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("TASK_BOARD_ITEM_UPDATE rejects a title over the cap", () => {
+    const result = TASK_BOARD_ITEM_UPDATE.inputSchema.safeParse({
+      id: "tbi_1",
+      title: "x".repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("TASK_BOARD_ITEM_UPDATE accepts a title at the cap", () => {
+    const result = TASK_BOARD_ITEM_UPDATE.inputSchema.safeParse({
+      id: "tbi_1",
+      title: "x".repeat(500),
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/storage/types";
 import {
   MAX_TASK_DESCRIPTION_LENGTH,
+  MAX_TASK_TITLE_LENGTH,
   SUPER_AGENT_ASSIGNEE_ID,
   TaskBoardItemPrioritySchema,
   TaskBoardItemTypeSchema,
@@ -172,7 +173,7 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
   },
   inputSchema: z.object({
     id: z.string(),
-    title: z.string().min(1).optional(),
+    title: z.string().min(1).max(MAX_TASK_TITLE_LENGTH).optional(),
     description: z
       .string()
       .max(MAX_TASK_DESCRIPTION_LENGTH)


### PR DESCRIPTION
Follows #6576 (description length cap) and #6574 (comment body length cap) — both fixed the same "unbounded text column, writable directly by any org member's tool call" gap on a sibling field but left `title` on `TASK_BOARD_ITEM_CREATE`/`TASK_BOARD_ITEM_UPDATE` unbounded. `title` is a plain `text` column (`126-task-board.ts`) with no server-side length limit.

Why a maintainer wants this: a caller (any org member, or a script driving the MCP tool) can currently write an arbitrarily large `title`, bloating the row and every place the title renders (board card, activity feed, notifications) with no cap — same class of gap the two prior PRs closed on `description` and comment `body`.

Adds `MAX_TASK_TITLE_LENGTH = 500` in `schema.ts` and applies `.max()` on both `create.ts` and `update.ts`'s `title` field. Regression test in `title-length.test.ts` mirrors `description-length.test.ts`'s pattern: rejects a title one char over the cap, accepts one at the cap, for both CREATE and UPDATE.

To confirm: `bun test apps/api/src/tools/task-board/title-length.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above (4/4 pass), and `bunx oxlint` on the four changed files (0 warnings/errors). Full CI validates the rest.