### PR TITLE
fix(task-board): cap repo field length

### DIFF
--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -4,6 +4,7 @@ import { MAX_SPRINT } from "@decocms/shared/sprints";
 import { getUserId, requireAuth } from "@/core/studio-context";
 import {
   MAX_TASK_DESCRIPTION_LENGTH,
+  MAX_TASK_REPO_LENGTH,
   MAX_TASK_TITLE_LENGTH,
   SUPER_AGENT_ASSIGNEE_ID,
   TaskBoardItemPrioritySchema,
@@ -38,7 +39,7 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
     priority: TaskBoardItemPrioritySchema.optional(),
     type: TaskBoardItemTypeSchema.optional(),
     assigneeId: z.string().nullable().optional(),
-    repo: z.string().nullable().optional(),
+    repo: z.string().max(MAX_TASK_REPO_LENGTH).nullable().optional(),
     dueDate: z.string().datetime().nullable().optional(),
     sprint: z
       .number()

--- a/apps/api/src/tools/task-board/repo-length.test.ts
+++ b/apps/api/src/tools/task-board/repo-length.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { TASK_BOARD_ITEM_CREATE } from "./create";
+import { TASK_BOARD_ITEM_UPDATE } from "./update";
+
+/**
+ * Regression: a task's `repo` had no length cap — an unbounded `text` column,
+ * writable directly by any org member's tool call. Same gap as the title cap
+ * (#6577) and the description cap (#6576), just on the sibling field.
+ */
+describe("task board item repo length", () => {
+  it("TASK_BOARD_ITEM_CREATE rejects a repo over the cap", () => {
+    const result = TASK_BOARD_ITEM_CREATE.inputSchema.safeParse({
+      title: "task",
+      repo: "x".repeat(201),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("TASK_BOARD_ITEM_CREATE accepts a repo at the cap", () => {
+    const result = TASK_BOARD_ITEM_CREATE.inputSchema.safeParse({
+      title: "task",
+      repo: "x".repeat(200),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("TASK_BOARD_ITEM_UPDATE rejects a repo over the cap", () => {
+    const result = TASK_BOARD_ITEM_UPDATE.inputSchema.safeParse({
+      id: "tbi_1",
+      repo: "x".repeat(201),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("TASK_BOARD_ITEM_UPDATE accepts a repo at the cap", () => {
+    const result = TASK_BOARD_ITEM_UPDATE.inputSchema.safeParse({
+      id: "tbi_1",
+      repo: "x".repeat(200),
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -9,6 +9,10 @@ export const MAX_TASK_DESCRIPTION_LENGTH = 50_000;
  *  a title is a one-line label, not a place for the description's content. */
 export const MAX_TASK_TITLE_LENGTH = 500;
 
+/** `owner/name` — GitHub caps a login at 39 chars and a repo name at 100,
+ *  so nothing legitimate approaches this; same reasoning as the caps above. */
+export const MAX_TASK_REPO_LENGTH = 200;
+
 export const TaskBoardItemStatusSchema = z.enum([
   "triage",
   "todo",

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/storage/types";
 import {
   MAX_TASK_DESCRIPTION_LENGTH,
+  MAX_TASK_REPO_LENGTH,
   MAX_TASK_TITLE_LENGTH,
   SUPER_AGENT_ASSIGNEE_ID,
   TaskBoardItemPrioritySchema,
@@ -183,7 +184,7 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     priority: TaskBoardItemPrioritySchema.optional(),
     type: TaskBoardItemTypeSchema.optional(),
     assigneeId: z.string().nullable().optional(),
-    repo: z.string().nullable().optional(),
+    repo: z.string().max(MAX_TASK_REPO_LENGTH).nullable().optional(),
     dueDate: z.string().datetime().nullable().optional(),
     /** Sprint to plan this task into (1-based); null moves it to the backlog. */
     sprint: z.number().int().min(1).max(MAX_SPRINT).nullable().optional(),


### PR DESCRIPTION
Follows #6577 — that PR added length caps to task title/description (and #6574 to comment body), all citing the same "unbounded text column a single tool call can write" reasoning. `repo` (the `owner/name` string on TASK_BOARD_ITEM_CREATE/UPDATE) was the sibling field left without a cap.

**Payoff:** closes the same DoS-by-oversized-row gap the sibling PRs closed, on the one field they missed.

**Fix:** added `MAX_TASK_REPO_LENGTH = 200` to `schema.ts` (GitHub caps a login at 39 chars and a repo name at 100, so nothing legitimate approaches 200) and applied `.max(MAX_TASK_REPO_LENGTH)` to `repo` in both `create.ts` and `update.ts`.

**Regression test:** `apps/api/src/tools/task-board/repo-length.test.ts` — asserts CREATE/UPDATE reject a 201-char repo and accept 200 chars, mirroring the existing `title-length.test.ts`.

**To verify:** `bun test apps/api/src/tools/task-board/repo-length.test.ts`

**Checked locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test above, and `bunx oxlint` on the 4 changed files — all clean. Full CI validates the rest.