### PR TITLE
perf(tags): batch the tag-existence lookup in MEMBER_TAGS_SET

### DIFF
--- a/apps/api/src/storage/tags.ts
+++ b/apps/api/src/storage/tags.ts
@@ -48,6 +48,22 @@ export class TagStorage {
   }
 
   /**
+   * Get several tags by ID in one query. Missing ids are simply absent from
+   * the result, so callers must not assume the returned array's length
+   * matches `tagIds`.
+   */
+  async getTagsByIds(tagIds: string[]): Promise<OrganizationTag[]> {
+    if (tagIds.length === 0) return [];
+    const rows = await this.db
+      .selectFrom("organization_tags")
+      .selectAll()
+      .where("id", "in", tagIds)
+      .execute();
+
+    return rows.map((row) => this.tagFromDbRow(row));
+  }
+
+  /**
    * Get a tag by name within an organization
    */
   async getTagByName(

--- a/apps/api/src/tools/tags/member-set.ts
+++ b/apps/api/src/tools/tags/member-set.ts
@@ -56,9 +56,11 @@ export const MEMBER_TAGS_SET = defineTool({
       );
     }
 
-    // Verify all tags belong to this organization
+    // Verify all tags belong to this organization, in one query.
+    const foundTags = await ctx.storage.tags.getTagsByIds(input.tagIds);
+    const tagsById = new Map(foundTags.map((tag) => [tag.id, tag]));
     for (const tagId of input.tagIds) {
-      const tag = await ctx.storage.tags.getTag(tagId);
+      const tag = tagsById.get(tagId);
       if (!tag) {
         throw new Error(`Tag not found: ${tagId}`);
       }


### PR DESCRIPTION
Follows #6566, which bounded `MEMBER_TAGS_SET`'s `tagIds` at 1000 and left a comment on the test flagging the real cost: each id still drove its own serial DB round-trip (`await ctx.storage.tags.getTag(tagId)` inside a `for` loop), so a single call could still issue up to 1000 sequential queries.

This replaces the loop with one `getTagsByIds` query (a single `WHERE id IN (...)`), then does the existence/org-membership check in memory against the returned map. Error messages and control flow (not-found vs wrong-org) are unchanged — only the number of DB round-trips drops, from up to 1000 to 1.

Why a maintainer wants it: a bulk tag-assignment call near the 1000-id bound previously serialized ~1000 round-trips before doing any work; now it's one query regardless of size.

To confirm: `bun test apps/api/src/tools/tags/member-set.test.ts` (unchanged, still green) and read the diff in `apps/api/src/tools/tags/member-set.ts` / `apps/api/src/storage/tags.ts` — behavior-preserving, same checks, batched.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above. Full CI validates the rest.