### PR TITLE
refactor(sandbox): remove retired tunnel references

### DIFF
--- a/apps/api/src/api/org-scoped.integration.test.ts
+++ b/apps/api/src/api/org-scoped.integration.test.ts
@@ -724,29 +724,6 @@ describe("org-scoped API coexistence", () => {
     }
   });
 
-  it("does not mount the link chunk ingest route", async () => {
-    const res = await app.fetch(
-      new Request("http://localhost/api/org_1/links/runs/run_1/chunks", {
-        method: "POST",
-        headers: {
-          Authorization: "Bearer test-key",
-          "content-type": "application/x-ndjson",
-        },
-        body: "{}\n",
-      }),
-    );
-    expect(res.status).toBe(404);
-    // org_1 is a seeded, admitted slug, so resolveOrgFromPath passes. With the
-    // route REMOVED the request falls through to the app-level `notFound`
-    // handler, which answers `{error:"Not Found", path}`. If the route were
-    // still mounted, validateRunAccess would answer `{error:"not found"}`
-    // (lowercase, no `path`). Asserting the global-handler shape is the real
-    // guard that the route is gone — not merely that run_1 is unseeded.
-    const body = (await res.json()) as { error?: string; path?: string };
-    expect(body.error).toBe("Not Found");
-    expect(body.path).toBe("/api/org_1/links/runs/run_1/chunks");
-  });
-
   it("DCR with non-JSON content type passes through byte-for-byte", async () => {
     // RFC 7591 mandates JSON, but a misbehaving client could POST /register
     // with a different content type. The metadata-injection branch is gated on

--- a/apps/api/src/api/routes/desktop-auth.ts
+++ b/apps/api/src/api/routes/desktop-auth.ts
@@ -5,7 +5,7 @@
  *
  * - `GET /api/auth/desktop/me` validates the native app's current OAuth
  *   bearer (or session cookie) without coupling authentication to an
- *   organization or to the retired presence protocol.
+ *   organization.
  * - `POST /api/auth/desktop/session-from-oauth` is the one Studio-side change
  * the native authentication contract needed to fix
  * the Google/GitHub/SAML system-browser desktop login path: an MCP OAuth

--- a/apps/docs/client/src/content/deco-studio/en/studio/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/architecture.mdx
@@ -91,7 +91,7 @@ Both paths are hosted and use Studio's fixed **AgentSandbox** provider when they
 - **Decopilot** runs its model loop in-process on the worker and reaches the managed sandbox for repository, filesystem, Git, and shell operations.
 - **Claude Code** runs its harness loop inside the managed sandbox; the worker proxies its stream into the same NATS and projector pipeline.
 
-Native coding-agent chats are a separate surface, not a third cloud transport. The desktop app runs Claude Code, Codex, or OpenCode locally and synchronizes the thread through its embedded `local-api`; no NATS pull queue or caller-selected sandbox provider is involved.
+Native coding-agent chats are a separate surface. The desktop app runs Claude Code, Codex, or OpenCode locally and synchronizes the thread through its embedded `local-api`.
 
 ## MCP: in-process vs. the proxy routes
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/architecture.mdx
@@ -91,7 +91,7 @@ Os dois caminhos são hosted e usam o provider fixo **AgentSandbox** do Studio q
 - **Decopilot** roda seu model loop in-process no worker e acessa a sandbox gerenciada para operações de repositório, filesystem, Git e shell.
 - **Claude Code** roda seu harness loop dentro da sandbox gerenciada; o worker encaminha seu stream para o mesmo pipeline de NATS e projector.
 
-Chats de coding agents nativos são uma superfície separada, não um terceiro transporte da cloud. A app desktop roda Claude Code, Codex ou OpenCode localmente e sincroniza a thread por meio do `local-api` embutido; não há pull queue no NATS nem provider de sandbox escolhido pelo caller.
+Chats de coding agents nativos são uma superfície separada. A app desktop roda Claude Code, Codex ou OpenCode localmente e sincroniza a thread por meio do `local-api` embutido.
 
 ## MCP: in-process vs. as rotas de proxy
 

--- a/apps/native/crates/local-api/src/routes/agent_capabilities.rs
+++ b/apps/native/crates/local-api/src/routes/agent_capabilities.rs
@@ -1,7 +1,7 @@
 //! Native coding-agent availability for the terminal picker.
 //!
-//! This is a guarded local-app route, not a Studio tool and not a desktop-link
-//! capability. It never reaches the hosted API or participates in chat
+//! This is a guarded local-app route, not a Studio tool. It never reaches the
+//! hosted API or participates in chat
 //! dispatch; it only reports which local CLI can be launched into a PTY.
 
 use axum::Json;

--- a/apps/native/crates/upstream/src/session.rs
+++ b/apps/native/crates/upstream/src/session.rs
@@ -55,7 +55,7 @@ use crate::tokens::{
 };
 
 /// `GET /api/auth/desktop/me` is the canonical desktop bearer probe. It has
-/// no link-presence or organization semantics: a valid desktop OAuth bearer
+/// no organization semantics: a valid desktop OAuth bearer
 /// returns `200`, while an unrecognized bearer returns `401`. Keeping the
 /// probe outside an org-scoped `/api/:org/...` route matters because an
 /// authenticated non-member can legitimately receive `403` there; that is

--- a/apps/native/docs/org-fs-plan.md
+++ b/apps/native/docs/org-fs-plan.md
@@ -215,7 +215,7 @@ the root — `{"dir":""}` returns `file does not exist`. Freshness is two-layere
 refresh.
 
 **The boot sweep is overdue, not theoretical.** This machine currently has
-**21 ghost NFS mounts** under the old TS link daemon's sandbox dirs with **no
+**21 ghost NFS mounts** under legacy sandbox directories with **no
 rclone process alive** to back them. Sweep by parsing `mount` for `nfs` entries
 whose *mountpoint* is under `<appRoot>/orgs/` and `umount -f` each — keyed on
 mountpoint, never the source, because rclone derives the export name from
@@ -357,9 +357,8 @@ both dialects compile and unit-test on either host.
   which reintroduces exactly the dependency macOS `nfsmount` avoids. Linux is
   no longer a non-goal: it mounts through rclone's own FUSE support, which
   needs no driver install beyond `fuse3`, and is described below.
-- **The link-daemon transport layer** (tunnel, outbox, NATS control plane,
-  local ingress, machine-id) — architecturally obsolete: the webview talks to
-  localhost, so there is no cluster→machine hop to maintain.
+- **Cluster-to-machine transport** — unnecessary because the webview talks to
+  localhost, so there is no remote hop to maintain.
 
 ## Risks
 

--- a/apps/web/src/components/sandbox/hooks/use-sandbox-start.test.ts
+++ b/apps/web/src/components/sandbox/hooks/use-sandbox-start.test.ts
@@ -20,7 +20,7 @@ describe("isRetryableSandboxStartError", () => {
     for (const message of [
       "Sandbox start was superseded by a stop",
       "Sandbox did not become ready within 180 seconds",
-      "tunnel_no_first_frame: no response frame arrived before firstFrameTimeoutMs",
+      "sandbox boot failed: repository clone was denied",
       "Virtual MCP not found",
     ]) {
       expect(isRetryableSandboxStartError(new Error(message))).toBe(false);

--- a/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
@@ -2,7 +2,7 @@
 # inside the cluster. The runner (packages/sandbox/server/provider/agent-sandbox/) needs:
 #   - sandboxclaims CRUD/patch (per-tenant claim lifecycle, idle TTL refresh)
 #   - sandboxes get/list/watch (waitForSandboxReady streams `?watch=true`)
-#   - pods/portforward create (kubectl-style tunnel to the daemon container)
+#   - pods/portforward create (kubectl-style port-forward to the daemon container)
 #   - sandboxwarmpools get (tenant pool reconciler: pool selector → its pods)
 # Pods get covers portforward error paths and the tenant-pool reconciler's
 # re-read of a pod's labels before it touches that pod's working tree.

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,9 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-# 0.16.0: removes the public NATS link tunnel and moves the retained internal
-# cluster credentials mount from tunnel.nats.clusterCreds to nats.clusterCreds.
-# Hosted execution is now enabled explicitly with
+# 0.16.0: hosted execution is now enabled explicitly with
 # STUDIO_AGENT_SANDBOX_ENABLED; the provider and runner selectors are gone.
 # 0.15.0: the single-writer migration Job now runs outside preview too
 # (migrateJob.enabled, default true). Every replica migrates the DBOS system

--- a/deploy/helm/studio/README.md
+++ b/deploy/helm/studio/README.md
@@ -892,11 +892,6 @@ bundled default configuration. When the target NATS deployment requires a
 credentials file, enable `nats.clusterCreds` and provide `NATS_CLUSTER_CREDS`
 through the chart-managed Secret, `secret.secretName`, or `externalSecret`:
 
-> Breaking values change: `tunnel.nats` has been removed. Move an existing
-> `tunnel.nats.clusterCreds` block to `nats.clusterCreds`. Retired
-> `tunnel.nats` values are ignored and no longer expose a public NATS link
-> tunnel.
-
 ```yaml
 nats:
   clusterCreds:

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
@@ -141,56 +141,6 @@ func TestRebaseWorkspaceCwd(t *testing.T) {
 	}
 }
 
-// `messagesRef` belonged to the retired relay/offload protocol. A direct
-// dispatch may carry an unknown top-level field during a rolling deployment,
-// but the daemon must never fetch it or replace the inline input with it.
-func TestDispatchIgnoresRetiredMessagesRef(t *testing.T) {
-	const token = "tkn"
-	body := `{
-		"runId": "run-legacy-ref",
-		"messagesRef": {
-			"url": "https://not-allowed.invalid/messages",
-			"bytes": 10,
-			"sha256": "retired"
-		},
-		"input": {
-			"threadId": "t1",
-			"userMessage": {"role": "user"},
-			"harness": {},
-			"workspace": {"cwd": null},
-			"models": {"thinking": {"id": "m", "title": "M", "credentialId": "c"}},
-			"mcp": {"url": "https://example.com/mcp", "headers": {}, "expiresAt": 123},
-			"mode": "default",
-			"temperature": 0.5,
-			"toolApprovalLevel": "auto",
-			"user": {"id": "u", "email": "u@example.com"},
-			"organizationId": "org",
-			"agent": {"id": "a"}
-		}
-	}`
-	req := httptest.NewRequest("POST", "/dispatch", strings.NewReader(body))
-	req.Header.Set("Authorization", "Bearer "+token)
-	rec := httptest.NewRecorder()
-	NewRegistry().HandleDispatch(rec, req, Deps{
-		DaemonToken: func() string { return token },
-	})
-
-	if rec.Code != 200 {
-		t.Fatalf("legacy messagesRef changed direct dispatch status: got %d body=%q", rec.Code, rec.Body.String())
-	}
-	var result struct {
-		Error *struct {
-			Code string `json:"code"`
-		} `json:"error"`
-	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
-		t.Fatalf("direct dispatch result is not JSON: %v", err)
-	}
-	if result.Error == nil || result.Error.Code != "unknown_harness" {
-		t.Fatalf("inline input did not reach the direct runner gate: %q", rec.Body.String())
-	}
-}
-
 // A dispatch for a run that is ALREADY in flight is what Studio sends when the
 // pod that owned the run died and another one picked the work up. It must stop
 // the run it displaces and wait for it to exit — two harnesses editing one

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -4,7 +4,7 @@
  * Provisions one SandboxClaim per (user, projectRef) against the
  * kubernetes-sigs/agent-sandbox operator. Studio runs outside the cluster
  * (Stage 1 / local-dev via kind), so traffic reaches the pod via a single
- * lazily-opened 127.0.0.1 TCP listener that tunnels each inbound connection
+ * lazily-opened 127.0.0.1 TCP listener that forwards each inbound connection
  * to the daemon container port through the apiserver as a fresh WebSocket.
  *
  * The daemon owns the public surface: it serves `/_sandbox/*` + `/health`
@@ -2563,7 +2563,7 @@ export class AgentSandboxProvider {
   // ---- Port-forwarding ------------------------------------------------------
 
   /**
-   * Opens a 127.0.0.1 TCP listener whose connections tunnel to
+   * Opens a 127.0.0.1 TCP listener whose connections are forwarded to
    * `podName:containerPort` via the apiserver. Each TCP connection spawns a
    * fresh WebSocket — matches `kubectl port-forward`'s semantics. Lifecycle
    * is mutual: client socket close → close the k8s WS; WS close → destroy

--- a/plugins/ban-e2e-app-imports.test.ts
+++ b/plugins/ban-e2e-app-imports.test.ts
@@ -77,15 +77,15 @@ describe("ban-e2e-app-imports", () => {
     expect(await lint(f)).toEqual([]);
   });
 
-  test("bans packages dropped from the allowlist with the link removal", async () => {
+  test("bans packages outside the allowlist", async () => {
     const f = fixture(
-      "packages/e2e/fixtures/dropped.ts",
-      `import { jetstream } from "@nats-io/jetstream";\n` +
-        `import { encodeSubjectToken } from "@decocms/tunnel/subject";\n` +
-        `import type { Capability } from "@decocms/sandbox/dispatch";\n` +
-        `import { DEFAULT_THREAD_TITLE } from "@decocms/harness/decopilot/prompt-constants";\n` +
-        `export const all = [jetstream, encodeSubjectToken, DEFAULT_THREAD_TITLE];\n` +
-        `export type C = Capability;\n`,
+      "packages/e2e/fixtures/unlisted.ts",
+      `import { first } from "unlisted-runtime";\n` +
+        `import { second } from "@example/unlisted-runtime";\n` +
+        `import type { Third } from "@decocms/unlisted-contract";\n` +
+        `import { fourth } from "@vendor/unlisted-helper";\n` +
+        `export const all = [first, second, fourth];\n` +
+        `export type T = Third;\n`,
     );
     const msgs = await lint(f);
     expect(msgs.length).toBe(4);
@@ -105,7 +105,7 @@ describe("ban-e2e-app-imports", () => {
   test("bans an @/ app path alias", async () => {
     const f = fixture(
       "packages/e2e/fixtures/alias.ts",
-      `import { workItemSchema } from "@/links/link-work-item";\nexport const w = workItemSchema;\n`,
+      `import { privateValue } from "@/internal/private-module";\nexport const value = privateValue;\n`,
     );
     const msgs = await lint(f);
     expect(msgs.length).toBe(1);


### PR DESCRIPTION
## Summary

- Remove obsolete tunnel and link upgrade notes, tombstone tests, lint fixtures, and an orphan daemon fixture.
- Rename comments around the still-live Kubernetes port-forward so they describe the current behavior.
- Leave live port-forwarding and internal NATS credentials unchanged.

## Verification

- bun run fmt:check
- bun run check
- bun run lint
- bun run knip
- Focused Bun and Go tests
- Helm lint

## Stack

1 of 6. Next: #6581.

No migration files changed. No deployment or configuration update is required.