### PR TITLE
refactor(dev): stop interpreting legacy NATS state

### DIFF
--- a/apps/api/src/services/ensure-services.test.ts
+++ b/apps/api/src/services/ensure-services.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./ensure-services";
 
 describe("managedNatsCommand", () => {
-  it("runs JetStream on an explicit loopback port and bounded store", () => {
+  it("runs credential-free JetStream on a loopback port and bounded store", () => {
     expect(
       managedNatsCommand("/bin/nats-server", 14222, "/tmp/nats-data"),
     ).toEqual([

--- a/apps/api/src/services/ensure-services.ts
+++ b/apps/api/src/services/ensure-services.ts
@@ -64,11 +64,6 @@ interface StateFile {
   pid: number;
   port: number;
   startedAt: string;
-  /**
-   * Legacy operator-mode NATS state. Its presence forces a one-time restart
-   * into the current loopback-only JetStream configuration.
-   */
-  wsPort?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -624,40 +619,27 @@ async function ensureNats(home: string): Promise<ServiceInfo> {
     owner: "none",
   };
 
-  // Check state.json for an existing managed instance
-  const existing = readState(home, "nats");
-  if (existing !== null) {
-    if (isOwnedProcess(existing.pid, "nats-server")) {
-      // Older Studio versions wrote `wsPort` while running operator/JWT mode.
-      // That server rejects the new credential-free local connection, so
-      // restart it once instead of reusing an incompatible process.
-      if (existing.wsPort === undefined) {
-        // Operator/JWT keys from an older Studio release are no longer used.
-        // Remove the dormant secrets even when the current plain server is
-        // already healthy.
-        rmSync(join(servicesDir(home), "nats", "jwt"), {
-          recursive: true,
-          force: true,
-        });
-        info.state = "running";
-        info.pid = existing.pid;
-        info.port = existing.port;
-        info.owner = "managed";
-        return info;
-      }
-      await stopNats(home);
-    } else {
-      // Dead process — clean up stale state
-      await removeState(home, "nats");
-    }
-  }
-
   // Retired operator/account seeds are sensitive and have no remaining
   // consumer. The path is an exact app-managed subdirectory, never user input.
   rmSync(join(servicesDir(home), "nats", "jwt"), {
     recursive: true,
     force: true,
   });
+
+  // Check state.json for an existing managed instance
+  const existing = readState(home, "nats");
+  if (existing !== null) {
+    if (isOwnedProcess(existing.pid, "nats-server")) {
+      info.state = "running";
+      info.pid = existing.pid;
+      info.port = existing.port;
+      info.owner = "managed";
+      return info;
+    } else {
+      // Dead process — clean up stale state
+      await removeState(home, "nats");
+    }
+  }
 
   // Allocate one dynamic loopback port for Studio's local connection.
   const port = await findAvailablePort();


### PR DESCRIPTION
## Summary

- Remove the retired wsPort field and restart branch from local NATS state handling.
- Reuse a verified live nats-server process without interpreting unknown legacy fields.
- Preserve the security cleanup that removes stale local JWT material.

Old state can remain dirty; extra fields are ignored and no migration or backfill is added.

## Verification

- bun test apps/api/src/services/ensure-services.test.ts
- bun run fmt:check
- bun run check
- bun run lint
- bun run knip

## Stack

2 of 6. Based on #6580; next: #6582.

No migration files changed.