### PR TITLE
refactor(chat): remove retired transfer history support

### DIFF
--- a/apps/api/src/api/routes/thread-outputs.ts
+++ b/apps/api/src/api/routes/thread-outputs.ts
@@ -1,10 +1,9 @@
 /**
  * Thread Outputs Route
  *
- * Lists files the model has shared back to the user via the
- * `share_with_user` tool. Files live under `model-outputs/<thread_id>/`
- * and the chat UI polls this endpoint on assistant-turn completion to
- * render download chips on the producing turn.
+ * Lists files the model wrote to the thread's `org/output/` subtree. The chat
+ * UI polls this endpoint on assistant-turn completion to render download chips
+ * on the producing turn.
  *
  * Route: GET /api/threads/:threadId/outputs
  *
@@ -48,17 +47,8 @@ export const createThreadOutputsRoutes = () => {
       throw new HTTPException(404, { message: "Thread not found" });
     }
 
-    const storage = ctx.objectStorage;
-    const result = storage
-      ? await storage.list({
-          prefix: `model-outputs/${threadId}/`,
-          maxKeys: 200,
-        })
-      : { objects: [] };
-
-    // Files the agent wrote to `org/output/` land in the org-fs `outputs`
-    // volume under `<threadId>/...` — surface them as chips alongside the
-    // share_with_user uploads (one indexed manifest query).
+    // Files written to `org/output/` land in the org-fs `outputs` volume under
+    // `<threadId>/...` (one indexed manifest query).
     const orgId = ctx.organization?.id;
     const fsOutputs = orgId
       ? await ctx.storage.orgFsEntries
@@ -67,35 +57,17 @@ export const createThreadOutputsRoutes = () => {
       : [];
 
     // Use ctx.baseUrl (canonical, set during context creation from
-    // forwarded-host headers / env) rather than `new URL(c.req.url).origin`
-    // — behind a TLS-terminating proxy the latter resolves to the
-    // internal listen address, causing a freshly-shared file's
-    // share_with_user URL (which already uses ctx.baseUrl) to disagree
-    // with subsequent listings.
+    // forwarded-host headers / env) rather than `new URL(c.req.url).origin`;
+    // behind a TLS-terminating proxy the latter resolves to the internal
+    // listen address.
     return c.json({
-      objects: [
-        ...result.objects.map((o) => {
-          const filename = o.key.split("/").pop() ?? o.key;
-          // Encode each path segment — keys may carry URL-special chars
-          // (?, #, &, space) and `c.req.path` in the files route truncates
-          // at the first unescaped `?`.
-          const encodedKey = o.key.split("/").map(encodeURIComponent).join("/");
-          return {
-            key: o.key,
-            filename,
-            size: o.size,
-            uploadedAt: o.lastModified?.toISOString(),
-            downloadUrl: `${ctx.baseUrl}/api/${encodeURIComponent(orgSlug)}/files/${encodedKey}`,
-          };
-        }),
-        ...fsOutputs.map((e) => ({
-          key: `org-fs:outputs/${e.path}`,
-          filename: e.path.split("/").pop() ?? e.path,
-          size: e.size,
-          uploadedAt: e.updatedAt,
-          downloadUrl: `${ctx.baseUrl}/api/${encodeURIComponent(orgSlug)}/fs/outputs/read?path=${encodeURIComponent(e.path)}`,
-        })),
-      ],
+      objects: fsOutputs.map((e) => ({
+        key: `org-fs:outputs/${e.path}`,
+        filename: e.path.split("/").pop() ?? e.path,
+        size: e.size,
+        uploadedAt: e.updatedAt,
+        downloadUrl: `${ctx.baseUrl}/api/${encodeURIComponent(orgSlug)}/fs/outputs/read?path=${encodeURIComponent(e.path)}`,
+      })),
     });
   });
 

--- a/apps/web/src/components/chat/chat-context.tsx
+++ b/apps/web/src/components/chat/chat-context.tsx
@@ -1009,26 +1009,22 @@ export function ActiveTaskProvider({
             updated_at: new Date().toISOString(),
           });
         }
-        // Refresh download chips only when this turn could have produced a
-        // file: an explicit share, or sandbox file work (bash/write can drop
-        // results into `org/output/`). AI SDK v5 surfaces tool invocations as
+        // Refresh download chips only when sandbox file work could have written
+        // into `org/output/`. AI SDK v5 surfaces tool invocations as
         // `tool-<name>` parts; `output-available` skips denied/cancelled calls.
-        const sharedFile = message.parts?.some((p) => {
+        const fileWork = message.parts?.some((p) => {
           const part = p as { type: string; state?: string };
           return (
-            (part.type === "tool-share_with_user" ||
-              part.type === "tool-bash" ||
-              part.type === "tool-write") &&
+            (part.type === "tool-bash" || part.type === "tool-write") &&
             part.state === "output-available"
           );
         });
-        if (cb.taskId && sharedFile) {
+        if (cb.taskId && fileWork) {
           const key = KEYS.threadOutputs(cb.taskId);
           // org/output files reach the manifest ~5s after the sandbox closes
           // them (rclone write-back), so a file written in the turn's last
           // seconds misses an immediate refresh. Sweep a few times across a
-          // generous flush window — each sweep is one indexed query, and
-          // share_with_user uploads (synchronous) are covered by the first.
+          // generous flush window; each sweep is one indexed query.
           for (const delayMs of [0, 1_500, 3_000, 6_000, 12_000, 25_000]) {
             setTimeout(() => {
               cb.queryClient.invalidateQueries({ queryKey: key });

--- a/apps/web/src/components/chat/message/parts/tool-call-part/tool-display-map.ts
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/tool-display-map.ts
@@ -4,7 +4,6 @@ import {
   Code01,
   Code02,
   Database01,
-  Download01,
   Edit01,
   Edit02,
   File06,
@@ -15,7 +14,6 @@ import {
   Server01,
   TerminalSquare,
   Tool01,
-  Upload01,
 } from "@untitledui/icons";
 
 export interface ToolDisplay {
@@ -51,8 +49,6 @@ export const TOOL_DISPLAY_MAP: Record<string, ToolDisplay> = {
 
   // Sandbox / code execution tools
   sandbox: { icon: Code02, label: "Run Code" },
-  copy_to_sandbox: { icon: Download01, label: "Load File" },
-  share_with_user: { icon: Upload01, label: "Share with User" },
 
   // Browser / web tools
   take_screenshot: { icon: Monitor01, label: "Take Screenshot" },

--- a/apps/web/src/components/chat/message/thread-outputs.tsx
+++ b/apps/web/src/components/chat/message/thread-outputs.tsx
@@ -3,13 +3,12 @@
  * PRODUCED them (replacing the old thread-aggregate "files shared in this
  * chat" block that always sat under the last message).
  *
- * Attribution is client-side: the message's own tool parts name the files
- * it produced — `share_with_user` returns `{ filename }`, and `write`
- * calls targeting the org-output mount carry the path in their input.
- * Those names are matched against the thread-outputs listing (shared
- * `useThreadOutputs` query) to get key/size/downloadUrl. Files produced
- * invisibly (e.g. `bash` cp into org/output) can't be attributed to a
- * turn and surface only in ThreadFilesPanel.
+ * Attribution is client-side: `write` calls targeting the org-output mount
+ * carry the path in their input. Those names are matched against the
+ * thread-outputs listing (shared `useThreadOutputs` query) to get
+ * key/size/downloadUrl. Files produced invisibly (e.g. `bash` cp into
+ * org/output) can't be attributed to a turn and surface only in
+ * ThreadFilesPanel.
  *
  * Caveat: the match is by filename, so a file re-written in a later turn
  * shows on every producing turn (it IS the same output). Encoding the
@@ -37,17 +36,10 @@ function collectProducedFilenames(message: MessageLike): Set<string> {
     const part = raw as {
       type?: string;
       state?: string;
-      input?: { path?: string; source?: string; name?: string };
-      output?: { filename?: string };
+      input?: { path?: string };
     };
     if (part.state !== "output-available") continue;
-    if (part.type === "tool-share_with_user") {
-      const name =
-        part.output?.filename ??
-        part.input?.name ??
-        (part.input?.source ? basename(part.input.source) : null);
-      if (name) names.add(name);
-    } else if (part.type === "tool-write") {
+    if (part.type === "tool-write") {
       const path = part.input?.path;
       if (path && OUTPUT_PATH_RE.test(path)) names.add(basename(path));
     }

--- a/apps/web/src/components/chat/use-thread-outputs.ts
+++ b/apps/web/src/components/chat/use-thread-outputs.ts
@@ -1,7 +1,6 @@
 /**
  * useThreadOutputs — shared query for the files a thread has produced
- * (share_with_user uploads under `model-outputs/<threadId>/` merged with
- * org-fs `outputs/<threadId>/` writes), served by
+ * through org-fs `outputs/<threadId>/`, served by
  * `GET /api/:org/threads/:threadId/outputs`.
  *
  * Consumed by the per-turn rows (MessageProducedFiles), the
@@ -48,8 +47,7 @@ async function fetchThreadOutputs(
 
 /**
  * True when any message has a tool part that could have produced a file:
- * an explicit share_with_user, or sandbox file work (bash/write can drop
- * results into `org/output/`).
+ * sandbox bash/write work can place results in `org/output/`.
  */
 export function useThreadHasFileWork(): boolean {
   const messages = useOptionalChatStream()?.messages ?? [];
@@ -57,9 +55,7 @@ export function useThreadHasFileWork(): boolean {
     m.parts?.some((p) => {
       const part = p as { type: string; state?: string };
       return (
-        (part.type === "tool-share_with_user" ||
-          part.type === "tool-bash" ||
-          part.type === "tool-write") &&
+        (part.type === "tool-bash" || part.type === "tool-write") &&
         part.state === "output-available"
       );
     }),

--- a/apps/web/src/layouts/main-panel-tabs/tab-id.test.ts
+++ b/apps/web/src/layouts/main-panel-tabs/tab-id.test.ts
@@ -39,11 +39,11 @@ describe("parseAutomationTabId", () => {
 });
 
 describe("file tab id", () => {
-  test("round-trips S3 and org-fs keys (slashes, colons, spaces)", () => {
+  test("round-trips org-fs keys (slashes, colons, spaces)", () => {
     for (const key of [
-      "model-outputs/thread-1/report final.pdf",
+      "org-fs:outputs/thread-1/report final.pdf",
       "org-fs:outputs/thread-1/nested/dir/data.csv",
-      "model-outputs/t/weird?#&name.txt",
+      "org-fs:outputs/t/weird?#&name.txt",
     ]) {
       expect(parseFileTabId(formatFileTabId(key))).toEqual({ key });
     }
@@ -61,7 +61,9 @@ describe("file tab id", () => {
   });
 
   test("file tabs are per-thread", () => {
-    expect(isPerThreadTab(formatFileTabId("model-outputs/t/a.pdf"))).toBe(true);
+    expect(isPerThreadTab(formatFileTabId("org-fs:outputs/t/a.pdf"))).toBe(
+      true,
+    );
     expect(isPerThreadTab("settings")).toBe(false);
   });
 });

--- a/apps/web/src/layouts/main-panel-tabs/tab-id.ts
+++ b/apps/web/src/layouts/main-panel-tabs/tab-id.ts
@@ -95,9 +95,9 @@ export function parseDeckTabId(
 }
 
 export interface FileTabParsed {
-  /** Thread-output key: an S3 key ("model-outputs/<threadId>/x.pdf") or an
-   *  org-fs ref ("org-fs:outputs/<threadId>/x.pdf") — same shape the
-   *  thread-outputs endpoint returns. */
+  /** Thread-output key: an org-fs ref
+   *  (`org-fs:outputs/<threadId>/x.pdf`) — the same shape returned by the
+   *  thread-outputs endpoint. */
   key: string;
 }
 


### PR DESCRIPTION
## Summary

- Remove historical model-output object-storage listing.
- Remove rendering and detection for the retired copy-to-sandbox and share-with-user tools.
- Preserve the current org/output delivery flow.

Per the agreed dirty-database policy, old thread payloads are not migrated or kept render-compatible.

## Verification

- Focused chat tab and message tests
- bun run fmt:check
- bun run check
- bun run lint
- bun run knip

## Stack

4 of 6. Based on #6582; next: #6584.

No migration files changed.