### PR TITLE
refactor(sandbox): narrow daemon hook contract

### DIFF
--- a/apps/api/src/harnesses/decopilot/built-in-tools/swappable-fs.test.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/swappable-fs.test.ts
@@ -2,16 +2,10 @@ import { expect, test } from "bun:test";
 import type { SandboxFsHooks } from "@/harnesses/lib/decopilot/built-in-tools/vm-tools/sandbox-fs-hooks-types";
 import { createSwappableFs } from "./swappable-fs";
 
-/** A stub fs whose every hook resolves a value tagged with `label`, so a test
- *  can tell which backing fs a call was routed to. */
+/** A stub whose hooks return `label` so tests can identify their target. */
 function stubFs(label: string): SandboxFsHooks {
   return {
-    onRead: async () => label,
-    onWrite: async () => {},
-    onEdit: async () => {},
     onBash: async () => ({ stdout: label, stderr: "", exitCode: 0 }),
-    onGlob: async () => [label],
-    onGrep: async () => [{ file: label, line: 1, text: label }],
     onProxy: async () => ({ label }),
   };
 }
@@ -19,7 +13,9 @@ function stubFs(label: string): SandboxFsHooks {
 test("forwards calls to the initial fs before any swap", async () => {
   const { fs } = createSwappableFs(stubFs("old"));
   expect((await fs.onBash("ls")).stdout).toBe("old");
-  expect(await fs.onRead("/x")).toBe("old");
+  expect(await fs.onProxy("/_sandbox/read", { path: "/x" })).toEqual({
+    label: "old",
+  });
 });
 
 test("swap re-points subsequent calls at the new fs", async () => {
@@ -32,5 +28,7 @@ test("swap re-points subsequent calls at the new fs", async () => {
   // The captured method reference now routes to the swapped-in fs — this is the
   // property that makes load_repo usable in the same turn.
   expect((await bash("ls")).stdout).toBe("new");
-  expect(await fs.onGlob("**/*")).toEqual(["new"]);
+  expect(await fs.onProxy("/_sandbox/glob", { pattern: "**/*" })).toEqual({
+    label: "new",
+  });
 });

--- a/apps/api/src/harnesses/decopilot/built-in-tools/swappable-fs.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/swappable-fs.ts
@@ -1,16 +1,14 @@
 /**
  * A `SandboxFsHooks` whose backing target can be swapped at runtime.
  *
- * Why: the six VM file tools (read/write/edit/bash/grep/glob) are built ONCE
- * per run, closing over the fs hooks resolved from `vmContext.branch` at
- * run-start. When `load_repo` switches the thread's repo mid-run it provisions
- * a NEW sandbox on a new branch, but the already-built tools keep calling the
- * old (repo-less) fs — so `ls /app/repo` shows an empty checkout and the agent
- * loops waiting for files that live in a sandbox its tools aren't bound to.
+ * Why: VM tools are built once per run, closing over hooks resolved from
+ * `vmContext.branch` at run-start. When `load_repo` switches the thread's repo
+ * mid-run it provisions a new sandbox on a new branch, but the already-built
+ * tools would otherwise keep calling the old sandbox.
  *
  * The tools instead call through this thin forwarder. `load_repo` calls `swap`
  * with the freshly-built fs after the clone lands, so the SAME turn's next
- * bash/read/glob hits the new sandbox — no "wait for the next message" contract.
+ * daemon call hits the new sandbox — no "wait for the next message" contract.
  *
  * Pure: forwards every hook to the current target read at call time. No `@/` or
  * `@decocms/sandbox` imports, so it's trivially unit-testable.
@@ -28,14 +26,8 @@ export interface SwappableFs {
 export function createSwappableFs(initial: SandboxFsHooks): SwappableFs {
   let current = initial;
   const fs: SandboxFsHooks = {
-    onRead: (path) => current.onRead(path),
-    onWrite: (path, content) => current.onWrite(path, content),
-    onEdit: (path, edits) => current.onEdit(path, edits),
     onBash: (cmd, opts) => current.onBash(cmd, opts),
-    onGlob: (pattern) => current.onGlob(pattern),
-    onGrep: (pattern, opts) => current.onGrep(pattern, opts),
-    onProxy: (path, body, method, signal) =>
-      current.onProxy(path, body, method, signal),
+    onProxy: (path, body, signal) => current.onProxy(path, body, signal),
   };
   return {
     fs,

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/index.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/index.test.ts
@@ -4,8 +4,7 @@ import { createVmTools } from "./index";
 
 /**
  * Build a `SandboxFsHooks` stub whose `onProxy` records the last daemon path
- * and returns a canned response keyed by path. The richer fs ops delegate to
- * the same recorder so a single fixture covers every vm tool.
+ * and returns a canned response keyed by path.
  */
 function fakeFs(
   respond: (path: string, body: Record<string, unknown>) => unknown,
@@ -20,23 +19,12 @@ function fakeFs(
   };
   const fs: SandboxFsHooks = {
     onProxy,
-    onRead: async (path) =>
-      ((await onProxy("/_sandbox/read", { path })) as { content: string })
-        .content,
-    onWrite: async (path, content) => {
-      await onProxy("/_sandbox/write", { path, content });
-    },
-    onEdit: async () => {},
     onBash: async (command) =>
       (await onProxy("/_sandbox/bash", { command })) as {
         stdout: string;
         stderr: string;
         exitCode: number;
       },
-    onGlob: async (pattern) =>
-      ((await onProxy("/_sandbox/glob", { pattern })) as { files: string[] })
-        .files,
-    onGrep: async () => [],
   };
   return { fs, calls };
 }

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/index.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/index.ts
@@ -3,7 +3,7 @@
  *
  * Registers the six LLM-visible file tools (read/write/edit/grep/glob/bash)
  * on top of the injected `SandboxFsHooks`.
- * The hooks speak the unified `/_sandbox/*` surface with plain JSON bodies and
+ * The hooks speak the `/_sandbox/*` surface with plain JSON bodies and
  * own the handle resolution + auto-restart retry layer, so this module never
  * imports the sandbox-provider package directly (cycle-break, spec §4.3).
  */
@@ -42,16 +42,13 @@ export function createVmTools(params: VmToolsParams) {
   } = params;
   const approvalFor = (mutating: boolean) => (mutating ? needsApproval : false);
 
-  // Proxy an arbitrary `/_sandbox/*` route through the fs hooks' retry layer.
-  // Used by the tools whose daemon surface the typed flat ops don't model
-  // (image-read, html-buffer write/edit). `signal` is the run's abort signal
-  // (ToolCallOptions.abortSignal) so cancelling the run aborts the daemon call.
+  // Proxy a `/_sandbox/*` route through the hooks' retry layer. `signal` is the
+  // run's abort signal so cancelling the run aborts the daemon call.
   const call = (
     daemonPath: string,
     input: Record<string, unknown>,
     signal?: AbortSignal,
-    method: "POST" | "PUT" = "POST",
-  ): Promise<unknown> => fs.onProxy(daemonPath, input, method, signal);
+  ): Promise<unknown> => fs.onProxy(daemonPath, input, signal);
 
   const read = tool({
     needsApproval: approvalFor(TOOL_APPROVAL.read),

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/sandbox-fs-hooks-types.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/sandbox-fs-hooks-types.ts
@@ -1,27 +1,8 @@
 /**
- * Harness-owned filesystem-hook contract (option-b sandbox decoupling).
- *
- * MIRROR of the shape exported by
- * `packages/sandbox/server/provider/sandbox-fs-hooks.ts` (the `SandboxFsHooks` +
- * payload interfaces). `createSandboxFsHooks(provider, lifecycle)` over there
- * returns a value that stays STRUCTURALLY assignable to this interface, so the
- * portable harness VM tools consume the flat hooks WITHOUT importing
- * `@decocms/sandbox` — which would re-introduce the harness→sandbox cycle the
- * package extraction is breaking (spec 2026-06-11-harness-extraction-design.md
- * §4.3).
- *
- * The two definitions MUST stay structurally identical until the package move
- * (spec Phase 5) collapses them to one. `tsc` enforces this at the glue seams
- * (`agent-sandbox-fs.ts`, which annotates its return as this type while calling
- * the sandbox builder) plus a compile-time
- * drift assertion in `sandbox-fs-hooks-types.test.ts`.
+ * Harness-side mirror of the daemon hooks exported by `@decocms/sandbox`.
+ * Keeping the small structural contract here prevents the portable VM tools
+ * from importing the sandbox package and recreating an app/package cycle.
  */
-
-export interface SandboxFsEdit {
-  oldText: string;
-  newText: string;
-  replaceAll?: boolean;
-}
 
 export interface SandboxFsBashOpts {
   cwd?: string;
@@ -34,34 +15,11 @@ export interface SandboxFsBashResult {
   exitCode: number;
 }
 
-export interface SandboxFsGrepOpts {
-  path?: string;
-  glob?: string;
-  caseInsensitive?: boolean;
-}
-
-export interface SandboxFsGrepHit {
-  file: string;
-  line: number;
-  text: string;
-}
-
 export interface SandboxFsHooks {
-  onRead(path: string): Promise<string>;
-  onWrite(path: string, content: string): Promise<void>;
-  onEdit(path: string, edits: SandboxFsEdit[]): Promise<void>;
   onBash(cmd: string, opts?: SandboxFsBashOpts): Promise<SandboxFsBashResult>;
-  onGlob(pattern: string): Promise<string[]>;
-  onGrep(
-    pattern: string,
-    opts?: SandboxFsGrepOpts,
-  ): Promise<SandboxFsGrepHit[]>;
   /**
-   * Escape hatch — proxy an arbitrary `/_sandbox/*` daemon route and return its
-   * parsed JSON body, sharing the flat ops' handle-resolution + auto-restart
-   * retry layer. Used by the richer LLM-visible tools to cover daemon surfaces
-   * the typed flat ops intentionally don't model (image reads and html-buffer
-   * preview shapes).
+   * Proxy a `/_sandbox/*` daemon route and return its parsed JSON body, sharing
+   * `onBash`'s handle-resolution and restart behavior.
    *
    * `signal` is the run's abort signal (AI-SDK `ToolCallOptions.abortSignal`):
    * cancelling the run aborts the in-flight daemon request.
@@ -69,7 +27,6 @@ export interface SandboxFsHooks {
   onProxy(
     path: string,
     body: Record<string, unknown>,
-    method?: "POST" | "PUT",
     signal?: AbortSignal,
   ): Promise<unknown>;
 }

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/types.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/types.ts
@@ -22,11 +22,9 @@ export interface HtmlArtifactBuffer {
 
 export interface VmToolsParams {
   /**
-   * Flat sandbox filesystem hooks (read/write/edit/bash/glob/grep + the
-   * `onProxy` escape hatch). Handle resolution, daemon-reachability detection,
-   * and auto-restart retry all live inside these closures (built by
-   * `createSandboxFsHooks`), so the tools stay independent of sandbox
-   * lifecycle and transport details.
+   * Narrow daemon hooks. Handle resolution, daemon-reachability detection, and
+   * auto-restart retry live inside these closures, so the tools stay
+   * independent of sandbox lifecycle and transport details.
    */
   readonly fs: SandboxFsHooks;
   /** Optional HTML-artifact fast-path mirror (hosted-only; see `HtmlArtifactBuffer`). */

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.test.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.test.ts
@@ -49,15 +49,24 @@ describe("claim TTL renewal", () => {
     const hooks = createSandboxFsHooks(provider, lifecycle);
     // Without this a hosted-harness run holds no claim at all and the operator
     // reaps the pod 15 minutes in, mid-run (prod thread 38147122, 2026-08-16).
-    await hooks.onWrite("/app/a.ts", "a");
-    await hooks.onWrite("/app/b.ts", "b");
-    await hooks.onWrite("/app/c.ts", "c");
+    await hooks.onProxy("/_sandbox/write", {
+      path: "/app/a.ts",
+      content: "a",
+    });
+    await hooks.onProxy("/_sandbox/write", {
+      path: "/app/b.ts",
+      content: "b",
+    });
+    await hooks.onProxy("/_sandbox/write", {
+      path: "/app/c.ts",
+      content: "c",
+    });
     expect(renewed).toEqual(["handle-1"]);
   });
 });
 
 describe("createSandboxFsHooks", () => {
-  test("onRead proxies /_sandbox/read and returns content", async () => {
+  test("onProxy forwards the daemon path and body", async () => {
     const captured: { path?: string; body?: unknown } = {};
     const hooks = createSandboxFsHooks(
       fakeProvider(captured, {
@@ -67,38 +76,13 @@ describe("createSandboxFsHooks", () => {
       }),
       lifecycle,
     );
-    const out = await hooks.onRead("/app/x.ts");
+    const out = await hooks.onProxy("/_sandbox/read", { path: "/app/x.ts" });
     expect(captured.path).toBe("/_sandbox/read");
     expect(captured.body).toEqual({ path: "/app/x.ts" });
-    expect(out).toBe("file body");
-  });
-
-  test("onWrite proxies /_sandbox/write with path + content", async () => {
-    const captured: { path?: string; body?: unknown } = {};
-    const hooks = createSandboxFsHooks(
-      fakeProvider(captured, { ok: true, bytesWritten: 2 }),
-      lifecycle,
-    );
-    await hooks.onWrite("/app/y.ts", "hi");
-    expect(captured.path).toBe("/_sandbox/write");
-    expect(captured.body).toEqual({ path: "/app/y.ts", content: "hi" });
-  });
-
-  test("onEdit maps edits to the daemon's snake_case edit surface", async () => {
-    const captured: { path?: string; body?: unknown } = {};
-    const hooks = createSandboxFsHooks(
-      fakeProvider(captured, { ok: true, replacements: 1, content: "new" }),
-      lifecycle,
-    );
-    await hooks.onEdit("/app/z.ts", [
-      { oldText: "a", newText: "b", replaceAll: true },
-    ]);
-    expect(captured.path).toBe("/_sandbox/edit");
-    expect(captured.body).toEqual({
-      path: "/app/z.ts",
-      old_string: "a",
-      new_string: "b",
-      replace_all: true,
+    expect(out).toEqual({
+      kind: "text",
+      content: "file body",
+      lineCount: 1,
     });
   });
 
@@ -116,40 +100,6 @@ describe("createSandboxFsHooks", () => {
       timeout: 1000,
     });
     expect(r).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
-  });
-
-  test("onGlob proxies /_sandbox/glob and returns the files list", async () => {
-    const captured: { path?: string; body?: unknown } = {};
-    const hooks = createSandboxFsHooks(
-      fakeProvider(captured, { files: ["a.ts", "b.ts"] }),
-      lifecycle,
-    );
-    const files = await hooks.onGlob("**/*.ts");
-    expect(captured.path).toBe("/_sandbox/glob");
-    expect(captured.body).toEqual({ pattern: "**/*.ts" });
-    expect(files).toEqual(["a.ts", "b.ts"]);
-  });
-
-  test("onGrep proxies /_sandbox/grep and parses results into hits", async () => {
-    const captured: { path?: string; body?: unknown } = {};
-    const hooks = createSandboxFsHooks(
-      fakeProvider(captured, {
-        results: "a.ts:3:hello\nb.ts:7:hello",
-        matchCount: 2,
-      }),
-      lifecycle,
-    );
-    const hits = await hooks.onGrep("hello", { glob: "*.ts" });
-    expect(captured.path).toBe("/_sandbox/grep");
-    expect(captured.body).toEqual({
-      pattern: "hello",
-      glob: "*.ts",
-      output_mode: "content",
-    });
-    expect(hits).toEqual([
-      { file: "a.ts", line: 3, text: "hello" },
-      { file: "b.ts", line: 7, text: "hello" },
-    ]);
   });
 
   test("stamps x-thread-id on every daemon call when the lifecycle carries a threadId", async () => {
@@ -173,12 +123,18 @@ describe("createSandboxFsHooks", () => {
       ...lifecycle,
       threadId: "thread-42",
     });
-    await hooks.onWrite("org/output/plan.md", "hi");
+    await hooks.onProxy("/_sandbox/write", {
+      path: "org/output/plan.md",
+      content: "hi",
+    });
     expect(sawThreadHeader).toBe("thread-42" as never);
 
     // Without a threadId (e.g. a threadless probe) the header is absent.
     const bare = createSandboxFsHooks(provider, lifecycle);
-    await bare.onWrite("org/output/plan.md", "hi");
+    await bare.onProxy("/_sandbox/write", {
+      path: "org/output/plan.md",
+      content: "hi",
+    });
     expect(sawThreadHeader).toBe(null);
   });
 
@@ -201,12 +157,14 @@ describe("createSandboxFsHooks", () => {
       canAutoRestart: true,
       opTimeoutMs: 30,
     });
-    await expect(hooks.onRead("/app/x.ts")).rejects.toThrow(/timed out after/);
+    await expect(
+      hooks.onProxy("/_sandbox/read", { path: "/app/x.ts" }),
+    ).rejects.toThrow(/timed out after/);
     expect(invalidated).toBe(0);
   });
 
   test("op deadline follows the op's own budget: 45s default, budget+grace, clamped at the daemon cap", () => {
-    // No budget (read/write/edit/grep/glob): daemon default 30s + 15s grace.
+    // No budget: daemon default 30s + 15s grace.
     expect(opDeadlineMs({ path: "/x" })).toBe(45_000);
     // Bash with an explicit budget: budget + grace.
     expect(opDeadlineMs({ command: "x", timeout: 60_000 })).toBe(75_000);
@@ -238,7 +196,6 @@ describe("createSandboxFsHooks", () => {
     const pending = hooks.onProxy(
       "/_sandbox/bash",
       { command: "sleep 999" },
-      "POST",
       runAbort.signal,
     );
     runAbort.abort(new Error("run cancelled"));
@@ -270,8 +227,8 @@ describe("createSandboxFsHooks", () => {
       },
       canAutoRestart: true,
     });
-    const out = await hooks.onRead("/app/x.ts");
-    expect(out).toBe("ok");
+    const out = await hooks.onProxy("/_sandbox/read", { path: "/app/x.ts" });
+    expect(out).toEqual({ kind: "text", content: "ok", lineCount: 1 });
     expect(attempts).toBe(2);
     expect(invalidated).toBe(1);
   });
@@ -306,8 +263,12 @@ describe("createSandboxFsHooks", () => {
       },
       canAutoRestart: false,
     });
-    const out = await hooks.onRead("/app/x.ts");
-    expect(out).toBe("recovered");
+    const out = await hooks.onProxy("/_sandbox/read", { path: "/app/x.ts" });
+    expect(out).toEqual({
+      kind: "text",
+      content: "recovered",
+      lineCount: 1,
+    });
     expect(attempts).toBe(2);
     expect(forced).toBe(true);
   });
@@ -332,7 +293,9 @@ describe("createSandboxFsHooks", () => {
       },
       canAutoRestart: false,
     });
-    await expect(hooks.onRead("/app/x.ts")).rejects.toThrow(/not running/);
+    await expect(
+      hooks.onProxy("/_sandbox/read", { path: "/app/x.ts" }),
+    ).rejects.toThrow(/not running/);
     expect(attempts).toBe(1);
     expect(invalidated).toBe(0);
   });

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.ts
@@ -1,26 +1,9 @@
 /**
- * createSandboxFsHooks — the harness→sandbox cycle-breaker (spec
- * 2026-06-11-harness-extraction-design.md §4.3).
+ * Retrying adapter from the hosted harness to the in-sandbox daemon.
  *
- * Builds the flat filesystem hooks (`onRead`/`onWrite`/`onEdit`/`onBash`/
- * `onGlob`/`onGrep`) that the harness consumes through `HarnessDeps` (§5.1) over
- * an `AgentSandboxProvider.proxyDaemonRequest`. The harness calls
- * `deps.onRead(...)` and never sees the provider — the lifecycle (handle
- * resolution, daemon reachability, auto-restart) is hidden behind these
- * closures.
- *
- * The `DaemonUnreachableError` sentinel, the `daemonRequest` proxy wrapper, and
- * the call-level retry layer are moved verbatim from
- * `apps/api/src/harnesses/decopilot/built-in-tools/vm-tools/index.ts` (where
- * they used to live in-tool). The richer LLM-visible read/write/edit/grep/glob/
- * bash *tools* (truncation, image-queueing, html-buffer mirroring) stay in the
- * harness and call these flat hooks.
- *
- * The hook payload shapes mirror `HarnessDeps`'s `EditOp`/`BashOpts`/
- * `BashResult`/`GrepOpts`/`GrepHit` (`apps/api/src/harnesses/lib/harness-deps.ts`) so
- * hosted harness wiring can set `deps.onRead = hooks.onRead`, etc. They are
- * declared locally here because packages may not import an `apps/*` tree
- * (ban-cross-tree-imports).
+ * VM tools use `onProxy` for daemon routes while the few callers that execute
+ * commands directly use typed `onBash`. Handle resolution, TTL renewal,
+ * deadlines, and the one-shot restart retry stay hidden behind both hooks.
  */
 
 import type { AgentSandboxProvider } from "./agent-sandbox/runner";
@@ -29,12 +12,6 @@ type SandboxFsProvider = Pick<
   AgentSandboxProvider,
   "proxyDaemonRequest" | "renewTtl"
 >;
-
-export interface SandboxFsEdit {
-  oldText: string;
-  newText: string;
-  replaceAll?: boolean;
-}
 
 export interface SandboxFsBashOpts {
   cwd?: string;
@@ -47,36 +24,11 @@ export interface SandboxFsBashResult {
   exitCode: number;
 }
 
-export interface SandboxFsGrepOpts {
-  path?: string;
-  glob?: string;
-  caseInsensitive?: boolean;
-}
-
-export interface SandboxFsGrepHit {
-  file: string;
-  line: number;
-  text: string;
-}
-
 export interface SandboxFsHooks {
-  onRead(path: string): Promise<string>;
-  onWrite(path: string, content: string): Promise<void>;
-  onEdit(path: string, edits: SandboxFsEdit[]): Promise<void>;
   onBash(cmd: string, opts?: SandboxFsBashOpts): Promise<SandboxFsBashResult>;
-  onGlob(pattern: string): Promise<string[]>;
-  onGrep(
-    pattern: string,
-    opts?: SandboxFsGrepOpts,
-  ): Promise<SandboxFsGrepHit[]>;
   /**
-   * Escape hatch — proxy an arbitrary `/_sandbox/*` daemon route and return its
-   * parsed JSON body, sharing the same handle-resolution + auto-restart retry
-   * layer as the flat ops above. The richer LLM-visible read/write/edit/grep/
-   * glob/bash *tools* in the harness use this to preserve behavior that the flat
-   * ops intentionally drop (the image-read branch and the html-buffer preview
-   * shapes of write/edit). New harness code should prefer the typed flat ops;
-   * this exists only to cover the daemon surfaces those ops don't model.
+   * Proxy a `/_sandbox/*` daemon route and return its parsed JSON body, sharing
+   * the same handle-resolution and restart behavior as `onBash`.
    *
    * `signal` is the run's abort signal (AI-SDK `ToolCallOptions.abortSignal`):
    * cancelling the run aborts the in-flight daemon request instead of leaving
@@ -85,14 +37,13 @@ export interface SandboxFsHooks {
   onProxy(
     path: string,
     body: Record<string, unknown>,
-    method?: "POST" | "PUT",
     signal?: AbortSignal,
   ): Promise<unknown>;
 }
 
 export interface SandboxFsHooksLifecycle {
   /**
-   * Lazy handle resolver. Invoked on every fs op; the caller is expected to
+   * Lazy handle resolver. Invoked on every daemon call; the caller is expected to
    * memoise so the first invocation provisions and later calls reuse.
    */
   ensureHandle(): Promise<string>;
@@ -116,7 +67,7 @@ export interface SandboxFsHooksLifecycle {
    */
   canAutoRestart: boolean;
   /**
-   * Fixed per-op deadline override. Default derives from the op's own budget
+   * Fixed per-call deadline override. Default derives from the call's budget
    * (`opDeadlineMs`); tests override with a tiny value. Production callers
    * should not need to.
    */
@@ -133,7 +84,7 @@ export interface SandboxFsHooksLifecycle {
 }
 
 /**
- * HTTP deadline for one daemon op, enforced HERE (transport-agnostic) — the
+ * HTTP deadline for one daemon call, enforced HERE (transport-agnostic) — the
  * daemon's own bash timeout (30s default / 120s max) only protects when the
  * daemon is healthy enough to respond. Without this bound, a wedged daemon or
  * stalled org-fs mount left the harness awaiting silently past the 10-min
@@ -143,8 +94,7 @@ export interface SandboxFsHooksLifecycle {
  * body carries one (bash; clamped to the daemon's 120s cap), else the daemon's
  * 30s default — plus a grace window so a command the daemon kills at its cap
  * still delivers its stdout/stderr here instead of losing the race to the
- * client-side abort. Ops without a budget (read/write/edit/grep/glob) fail at
- * 45s.
+ * client-side abort. Calls without a budget fail at 45s.
  */
 const DAEMON_BASH_MAX_TIMEOUT_MS = 120_000; // daemon clamp (daemon/routes/bash.ts)
 const DAEMON_DEFAULT_TIMEOUT_MS = 30_000; // daemon default (daemon/routes/bash.ts)
@@ -217,11 +167,10 @@ async function daemonRequest(
   provider: SandboxFsProvider,
   handle: string,
   path: string,
-  body: Record<string, unknown> | null,
-  method: "GET" | "POST" | "PUT" = "POST",
+  body: Record<string, unknown>,
   opts?: { signal?: AbortSignal; timeoutMs?: number; threadId?: string },
 ): Promise<unknown> {
-  const timeoutMs = opts?.timeoutMs ?? opDeadlineMs(body ?? {});
+  const timeoutMs = opts?.timeoutMs ?? opDeadlineMs(body);
   const timeout = AbortSignal.timeout(timeoutMs);
   const reqSignal = opts?.signal
     ? AbortSignal.any([opts.signal, timeout])
@@ -236,19 +185,14 @@ async function daemonRequest(
     const init: {
       method: string;
       headers: Headers;
-      body: string | null;
+      body: string;
       signal: AbortSignal;
     } = {
-      method,
+      method: "POST",
       headers,
-      body: null,
+      body: JSON.stringify(body),
       signal: reqSignal,
     };
-    // GET/HEAD must not carry a body; the provider proxy strips it anyway,
-    // but constructing it is wasteful and obscures intent.
-    if (method !== "GET" && body !== null) {
-      init.body = JSON.stringify(body);
-    }
     // `abortable` (not just init.signal) so a transport that ignores the
     // signal — or a body read that stalls — still respects the deadline.
     ({ res, rawText } = await abortable(
@@ -266,7 +210,7 @@ async function daemonRequest(
     if (opts?.signal?.aborted) throw cause;
     if (timeout.aborted) {
       throw new Error(
-        `Sandbox ${method} ${path} timed out after ${Math.round(timeoutMs / 1000)}s — the sandbox may be overloaded or its filesystem stalled. Retry, or use a smaller operation.`,
+        `Sandbox POST ${path} timed out after ${Math.round(timeoutMs / 1000)}s — the sandbox may be overloaded or its filesystem stalled. Retry, or use a smaller operation.`,
       );
     }
     throw new DaemonUnreachableError(cause);
@@ -312,34 +256,7 @@ async function daemonRequest(
 }
 
 /**
- * Parse the daemon grep route's `output_mode: "content"` block — newline-
- * separated `file:line:text` rows (ripgrep `--line-number`) — into structured
- * hits. Rows that don't match the shape (e.g. ripgrep context separators) are
- * skipped.
- *
- * The file-explorer UI has an equivalent `parseGrepContent` in
- * `apps/web/src/components/sandbox/preview/file-explorer/utils.ts` —
- * same wire shape, kept separate because packages can't import app code.
- * Update both if the shape changes.
- */
-function parseGrepResults(results: string): SandboxFsGrepHit[] {
-  const hits: SandboxFsGrepHit[] = [];
-  for (const row of results.split("\n")) {
-    if (!row) continue;
-    const firstColon = row.indexOf(":");
-    if (firstColon < 0) continue;
-    const secondColon = row.indexOf(":", firstColon + 1);
-    if (secondColon < 0) continue;
-    const file = row.slice(0, firstColon);
-    const line = Number.parseInt(row.slice(firstColon + 1, secondColon), 10);
-    if (!Number.isFinite(line)) continue;
-    hits.push({ file, line, text: row.slice(secondColon + 1) });
-  }
-  return hits;
-}
-
-/**
- * Build the flat fs hooks over the two AgentSandboxProvider capabilities they
+ * Build the daemon hooks over the two AgentSandboxProvider capabilities they
  * need. Keeping this as a narrow Pick prevents filesystem helpers from growing
  * an implicit dependency on the full provisioning surface.
  */
@@ -384,11 +301,10 @@ export function createSandboxFsHooks(
   const call = async (
     daemonPath: string,
     input: Record<string, unknown>,
-    method: "POST" | "PUT" = "POST",
     signal?: AbortSignal,
   ): Promise<unknown> => {
     const tryOnce = async (handle: string) =>
-      daemonRequest(provider, handle, daemonPath, input, method, {
+      daemonRequest(provider, handle, daemonPath, input, {
         signal,
         timeoutMs: lifecycle.opTimeoutMs,
         threadId: lifecycle.threadId,
@@ -444,26 +360,7 @@ export function createSandboxFsHooks(
   };
 
   return {
-    onProxy: (path, body, method, signal) => call(path, body, method, signal),
-    onRead: async (path) => {
-      const r = (await call("/_sandbox/read", { path })) as { content: string };
-      return r.content;
-    },
-    onWrite: async (path, content) => {
-      await call("/_sandbox/write", { path, content });
-    },
-    onEdit: async (path, edits) => {
-      // The daemon edit route is single-edit (one old/new pair per call) and
-      // uses snake_case keys. Apply each edit in sequence.
-      for (const edit of edits) {
-        await call("/_sandbox/edit", {
-          path,
-          old_string: edit.oldText,
-          new_string: edit.newText,
-          replace_all: edit.replaceAll === true,
-        });
-      }
-    },
+    onProxy: (path, body, signal) => call(path, body, signal),
     onBash: async (cmd, opts) => {
       const r = (await call("/_sandbox/bash", {
         command: cmd,
@@ -471,22 +368,6 @@ export function createSandboxFsHooks(
         ...(opts?.timeoutMs !== undefined ? { timeout: opts.timeoutMs } : {}),
       })) as SandboxFsBashResult;
       return r;
-    },
-    onGlob: async (pattern) => {
-      const r = (await call("/_sandbox/glob", { pattern })) as {
-        files: string[];
-      };
-      return r.files;
-    },
-    onGrep: async (pattern, opts) => {
-      const r = (await call("/_sandbox/grep", {
-        pattern,
-        output_mode: "content",
-        ...(opts?.path !== undefined ? { path: opts.path } : {}),
-        ...(opts?.glob !== undefined ? { glob: opts.glob } : {}),
-        ...(opts?.caseInsensitive ? { ignore_case: true } : {}),
-      })) as { results: string };
-      return parseGrepResults(r.results);
     },
   };
 }


### PR DESCRIPTION
## Summary

- Remove five unused typed filesystem hooks: read, write, edit, glob, and grep.
- Delete their mirrored payload types and the orphan grep parser.
- Keep only typed bash plus the generic daemon proxy used by every VM tool.
- Remove the unused HTTP method selector and hard-code the surviving daemon calls to POST.
- Preserve cancellation, deadlines, TTL renewal, thread headers, and restart retry behavior.

## Verification

- Focused sandbox hook, swappable hook, and VM-tool tests
- bun run fmt:check
- bun run check
- bun run lint
- bun run knip

## Stack

5 of 6. Based on #6583; next: #6585.

No migration files changed.