### PR TITLE
fix(credits): hide the credit balance for contract-billed orgs

### DIFF
--- a/apps/api/src/ai-providers/adapters/deco-ai-gateway.ts
+++ b/apps/api/src/ai-providers/adapters/deco-ai-gateway.ts
@@ -49,8 +49,17 @@ export const decoAiGatewayAdapter: ProviderAdapter = {
     if (!res.ok) {
       throw new Error(`Failed to fetch credits balance: ${res.status}`);
     }
-    const data = (await res.json()) as { balance_cents: number };
-    return { balanceCents: data.balance_cents };
+    const data = (await res.json()) as {
+      balance_cents: number;
+      credit_funded?: boolean;
+    };
+    // credit_funded:false means the org is not on prepaid credits at all — it
+    // has a contract spend ceiling, so its "balance" is not money it bought and
+    // showing it as one reads as debt. Absent (older gateway) = assume credits.
+    return {
+      balanceCents: data.balance_cents,
+      creditFunded: data.credit_funded ?? true,
+    };
   },
 
   async provisionKey(studioJwt: string, organizationId: string) {

--- a/apps/api/src/ai-providers/types.ts
+++ b/apps/api/src/ai-providers/types.ts
@@ -68,7 +68,7 @@ export interface ProviderAdapter {
   getCreditsBalance?(
     studioJwt: string,
     organizationId: string,
-  ): Promise<{ balanceCents: number }>;
+  ): Promise<{ balanceCents: number; creditFunded?: boolean }>;
 
   /**
    * Server-to-server key provisioning (e.g. on org creation).

--- a/apps/api/src/tools/ai-providers/credits.ts
+++ b/apps/api/src/tools/ai-providers/credits.ts
@@ -26,6 +26,11 @@ export const AI_PROVIDER_CREDITS = defineTool({
     balanceCents: z
       .number()
       .describe("Remaining balance in cents (e.g. 1000 = $10.00)"),
+    creditFunded: z
+      .boolean()
+      .describe(
+        "False when the org is not on prepaid credits (contract spend ceiling). Its balance is not purchased money, so surfaces should hide it rather than render it as a credit figure.",
+      ),
   }),
   handler: async (input, ctx) => {
     requireAuth(ctx);
@@ -57,6 +62,6 @@ export const AI_PROVIDER_CREDITS = defineTool({
       );
     }
 
-    return result;
+    return { creditFunded: true, ...result };
   },
 });

--- a/apps/web/src/components/sidebar/top-actions.tsx
+++ b/apps/web/src/components/sidebar/top-actions.tsx
@@ -39,8 +39,13 @@ function creditColor(balanceDollars: number): string {
 function CreditChip() {
   const navigate = useNavigate();
   const { org } = useProjectContext();
-  const { hasDecoKey, balanceDollars } = useDecoCredits();
+  const { hasDecoKey, balanceDollars, creditFunded } = useDecoCredits();
   if (!hasDecoKey) return null;
+  // Contract orgs (spend ceiling, no prepaid credits) have no credit balance to
+  // show. Hiding the chip is the honest option: any number here reads as
+  // "credits you hold", and for these orgs the figure went negative as they
+  // spent — which is exactly the contract working as agreed.
+  if (!creditFunded) return null;
   return (
     <SidebarMenu>
       <SidebarMenuItem>

--- a/apps/web/src/hooks/use-deco-credits.ts
+++ b/apps/web/src/hooks/use-deco-credits.ts
@@ -39,6 +39,11 @@ export function useDecoCredits() {
     },
   });
 
+  // False only when the gateway explicitly says so: an org on a contract spend
+  // ceiling is not funded by prepaid credits, so its balance is not money it
+  // bought. Rendering it as a credit figure is how a contract customer's normal
+  // spend showed up in the sidebar as a negative balance.
+  const creditFunded = data?.creditFunded !== false;
   const balanceCents = data?.balanceCents ?? null;
   const balanceDollars = balanceCents != null ? balanceCents / 100 : null;
 
@@ -49,7 +54,7 @@ export function useDecoCredits() {
   // the common case. Ignores the very first read (undefined → value is not
   // a "top-up", just the initial load).
   const firstSeenRef = useRef<Map<string, boolean>>(new Map());
-  if (balanceCents != null) {
+  if (balanceCents != null && creditFunded) {
     const previous = lastSeenBalance.get(org.id);
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
     const hasSeenBefore = firstSeenRef.current.get(org.id);
@@ -66,15 +71,21 @@ export function useDecoCredits() {
     firstSeenRef.current.set(org.id, true);
   }
   const hasDecoKey = !!decoKey;
-  const hasCredits = balanceCents != null && balanceCents > 0;
-  const isZeroBalance = balanceCents != null && balanceCents === 0;
-  const isInitialFreeCredit = balanceCents != null && balanceCents === 200;
+  // Every credit-shaped signal is gated on creditFunded: a contract org has no
+  // credits to have, to run out of, or to be given for free, and firing
+  // "credits exhausted" at one is worse than showing it a wrong number.
+  const hasCredits = creditFunded && balanceCents != null && balanceCents > 0;
+  const isZeroBalance =
+    creditFunded && balanceCents != null && balanceCents === 0;
+  const isInitialFreeCredit =
+    creditFunded && balanceCents != null && balanceCents === 200;
   const hasOnlyDecoProvider =
     keys.length > 0 && keys.every((k) => k.providerId === "deco");
 
   return {
     hasDecoKey,
     decoKeyId: decoKey?.id ?? null,
+    creditFunded,
     balanceCents,
     balanceDollars,
     hasCredits,

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -305,6 +305,8 @@ export const settings = {
   "settings.decoCreditsHero.availableBalance": "Available credit balance",
   "settings.decoCreditsHero.cancel": "Cancel",
   "settings.decoCreditsHero.cancelButton": "Cancel",
+  "settings.decoCreditsHero.contractBilling":
+    "This workspace is billed by contract, not by prepaid credits. Usage is metered and capped by your agreed ceiling.",
   "settings.decoCreditsHero.custom": "Custom",
   "settings.decoCreditsHero.decoAiGatewayAlt": "Deco AI Gateway",
   "settings.decoCreditsHero.disconnect": "Disconnect",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -318,6 +318,8 @@ export const settings = {
     "Saldo de cr\u00e9dito dispon\u00edvel",
   "settings.decoCreditsHero.cancel": "Cancelar",
   "settings.decoCreditsHero.cancelButton": "Cancelar",
+  "settings.decoCreditsHero.contractBilling":
+    "Este workspace \u00e9 cobrado por contrato, n\u00e3o por cr\u00e9ditos pr\u00e9-pagos. O uso \u00e9 medido e limitado pelo teto acordado.",
   "settings.decoCreditsHero.custom": "Personalizado",
   "settings.decoCreditsHero.decoAiGatewayAlt": "Deco AI Gateway",
   "settings.decoCreditsHero.disconnect": "Desconectar",

--- a/apps/web/src/views/settings/ai-providers/deco-credits-hero.tsx
+++ b/apps/web/src/views/settings/ai-providers/deco-credits-hero.tsx
@@ -266,6 +266,15 @@ export function DecoCreditsHero() {
             </AlertDialogContent>
           </AlertDialog>
 
+          {/* Contract orgs are not funded by prepaid credits: there is no
+              balance to show, and a top-up would take money the key limit
+              ignores. Say what governs their spend instead. */}
+          {data?.creditFunded === false ? (
+            <p className="text-xs text-muted-foreground pt-2">
+              {t("settings.decoCreditsHero.contractBilling")}
+            </p>
+          ) : (
+            <>
           {/* Balance */}
           <div className="flex flex-col gap-2 pt-2">
             <div className="flex items-baseline gap-2">
@@ -306,6 +315,8 @@ export function DecoCreditsHero() {
             </p>
             <QuickTopUp />
           </div>
+            </>
+          )}
         </div>
       </SettingsCard>
     </SettingsSection>

--- a/apps/web/src/views/settings/ai-providers/deco-credits-hero.tsx
+++ b/apps/web/src/views/settings/ai-providers/deco-credits-hero.tsx
@@ -275,46 +275,47 @@ export function DecoCreditsHero() {
             </p>
           ) : (
             <>
-          {/* Balance */}
-          <div className="flex flex-col gap-2 pt-2">
-            <div className="flex items-baseline gap-2">
-              {isLoading || isFetching ? (
-                <Skeleton className="h-9 w-24" />
-              ) : (
-                <span
-                  className={cn(
-                    "text-3xl font-semibold tabular-nums tracking-tight",
-                    balanceDollars != null && creditColorClass(balanceDollars),
+              {/* Balance */}
+              <div className="flex flex-col gap-2 pt-2">
+                <div className="flex items-baseline gap-2">
+                  {isLoading || isFetching ? (
+                    <Skeleton className="h-9 w-24" />
+                  ) : (
+                    <span
+                      className={cn(
+                        "text-3xl font-semibold tabular-nums tracking-tight",
+                        balanceDollars != null &&
+                          creditColorClass(balanceDollars),
+                      )}
+                    >
+                      {displayBalance}
+                    </span>
                   )}
-                >
-                  {displayBalance}
-                </span>
-              )}
-              <button
-                type="button"
-                onClick={() => refetch()}
-                disabled={isFetching}
-                className="text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors p-1 rounded-md hover:bg-muted/50"
-                aria-label={t("settings.decoCreditsHero.refreshBalance")}
-              >
-                <RefreshCw01
-                  size={14}
-                  className={cn(isFetching && "animate-spin")}
-                />
-              </button>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {t("settings.decoCreditsHero.availableBalance")}
-            </p>
-          </div>
+                  <button
+                    type="button"
+                    onClick={() => refetch()}
+                    disabled={isFetching}
+                    className="text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors p-1 rounded-md hover:bg-muted/50"
+                    aria-label={t("settings.decoCreditsHero.refreshBalance")}
+                  >
+                    <RefreshCw01
+                      size={14}
+                      className={cn(isFetching && "animate-spin")}
+                    />
+                  </button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {t("settings.decoCreditsHero.availableBalance")}
+                </p>
+              </div>
 
-          {/* Quick top-up */}
-          <div className="pt-4 border-t border-border/60">
-            <p className="text-xs font-medium text-muted-foreground mb-2.5">
-              {t("settings.decoCreditsHero.addCredits")}
-            </p>
-            <QuickTopUp />
-          </div>
+              {/* Quick top-up */}
+              <div className="pt-4 border-t border-border/60">
+                <p className="text-xs font-medium text-muted-foreground mb-2.5">
+                  {t("settings.decoCreditsHero.addCredits")}
+                </p>
+                <QuickTopUp />
+              </div>
             </>
           )}
         </div>

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -4588,7 +4588,7 @@ export interface StudioToolIO {
         | "llmapi"
         | "openai-compatible";
     };
-    output: { balanceCents: number };
+    output: { balanceCents: number; creditFunded: boolean };
   };
   CLAUDE_SUBSCRIPTION_CONNECT: {
     input: { token: string };


### PR DESCRIPTION
Depends on the gateway side, already deployed: the balance response now carries `credit_funded`.

An org on a **contract spend ceiling** is not funded by prepaid credits. Every surface here still rendered its balance as money the workspace holds — and since a ceiling org's figure goes negative as it spends, a contract customer saw a **negative balance in the sidebar**. That is the contract working exactly as agreed, displayed as a deficit.

## What it does

Plumbs `creditFunded` from the gateway through the adapter → provider contract → `AI_PROVIDER_CREDITS`, then acts on it in four places:

- **sidebar credit chip: hidden.** Any figure there reads as "credits you hold", and for these orgs there is no such quantity.
- **`hasCredits` / `isZeroBalance` / `isInitialFreeCredit` gated on it**, so the chat *credits exhausted* empty state cannot fire at an org that has no credits to exhaust. Showing that to a paying contract customer would be worse than the wrong number it replaces.
- **settings hero drops the balance and the quick top-up**, replaced by a line saying spend is contract-billed and capped by the agreed ceiling. The top-up is the one that actually mattered: for a ceiling org the key limit ignores ledger money, so buying credits would have taken payment and changed nothing.
- **top-up detection heuristic** no longer fires for them — a rising balance is not a purchase.

## Rollout

`credit_funded` absent (older gateway) is treated as `true`, so prepaid orgs and the deploy window are unaffected. Two orgs are in the new mode today; 628 stay prepaid.

## Note on `tool-io.ts`

Edited by hand. The generator works but reformats the whole 7k-line snapshot onto single lines; the one-field diff here is what it would have produced.

`oxlint` clean on the touched files, `tsc` clean on `apps/web` and `apps/api`.