### PR TITLE
fix(billing): require tax ID on Stripe Checkout

### DIFF
--- a/apps/api/src/billing/stripe-api.test.ts
+++ b/apps/api/src/billing/stripe-api.test.ts
@@ -46,11 +46,14 @@ describe("taxAndAddressParams", () => {
     const guest = toStripeForm(taxAndAddressParams(null));
     expect(guest.get("billing_address_collection")).toBe("required");
     expect(guest.get("tax_id_collection[enabled]")).toBe("true");
+    // Without `required`, `enabled` alone lets the buyer submit blank.
+    expect(guest.get("tax_id_collection[required]")).toBe("if_supported");
     // Stripe rejects customer_update without a `customer` on the session.
     expect(guest.has("customer_update[address]")).toBe(false);
 
     const saved = toStripeForm(taxAndAddressParams("cus_1"));
     expect(saved.get("billing_address_collection")).toBe("required");
+    expect(saved.get("tax_id_collection[required]")).toBe("if_supported");
     // Required by Stripe once a saved customer meets address collection.
     expect(saved.get("customer_update[address]")).toBe("auto");
     expect(saved.get("customer_update[name]")).toBe("auto");

--- a/apps/api/src/billing/stripe-api.ts
+++ b/apps/api/src/billing/stripe-api.ts
@@ -88,6 +88,8 @@ async function stripeRequest<T>(
  * Checkout — both are API-only params with no Dashboard fallback, so omitting
  * them means we never see either.
  *
+ * `required` defaults to `never` — `enabled` alone renders a skippable field.
+ *
  * `customer_update` is mandatory, not cosmetic: with a saved `customer` and
  * address collection on, Stripe 400s the session unless we explicitly allow
  * Checkout to write back to the customer — and a customer whose address is
@@ -98,7 +100,7 @@ export function taxAndAddressParams(
 ): Record<string, unknown> {
   return {
     billing_address_collection: "required",
-    tax_id_collection: { enabled: true },
+    tax_id_collection: { enabled: true, required: "if_supported" },
     ...(customerId && { customer_update: { address: "auto", name: "auto" } }),
   };
 }


### PR DESCRIPTION
Someone completed a subscription with no tax ID (CPF/CNPJ) on the Checkout form.

## Cause

#5933 turned on tax ID collection, but only half of it:

```ts
tax_id_collection: { enabled: true },
```

Per the [Stripe API reference](https://docs.stripe.com/api/checkout/sessions/create?query=tax_id_collection), `tax_id_collection` has a second field:

> `tax_id_collection.required` (enum, optional) — Describes whether a tax ID is required during checkout. **Defaults to `never`.**

So `enabled: true` only *renders* the field. It stays optional, the buyer submits it blank, and Stripe accepts the session. The `billing_address_collection: "required"` sitting next to it is genuinely required, which is what made this look already-handled.

## Fix

One line in `taxAndAddressParams()`:

```ts
tax_id_collection: { enabled: true, required: "if_supported" },
```

`if_supported` makes the field mandatory whenever Stripe supports a tax ID for the billing address country — which covers BR (`br_cpf` / `br_cnpj`) — and leaves it optional elsewhere. There is no "always required" option; the enum is only `if_supported` or `never`, and `if_supported` is the right behavior anyway: it does not block checkout in a country where Stripe has nothing to validate against.

Both Checkout sessions (`createOrgCheckoutSession` for the org subscription and `createTopUpCheckoutSession` for credit top-ups) go through `taxAndAddressParams()`, so this covers both.

## Testing

`bun test apps/api/src/billing/stripe-api.test.ts` — 7 pass. The existing `taxAndAddressParams` test now asserts `tax_id_collection[required]=if_supported` on both paths (guest and saved customer).

## Not covered by this PR

- **Existing subscribers keep their blank tax ID.** No retroaction — those Customers need the tax ID filled in manually in Stripe, or the buyer re-prompted.
- **The Customer Portal is a separate surface.** `createBillingPortalSession` uses the default Dashboard configuration; if tax IDs are not marked editable under Settings → Billing → Customer portal, a customer cannot self-correct after the fact. That is Dashboard config, not something this repo can set.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires a tax ID on Stripe Checkout instead of only rendering the field, so buyers can no longer complete a subscription without one. `required: "if_supported"` makes the field mandatory wherever Stripe supports a tax ID for the billing address country and leaves it optional elsewhere; both org subscription and credit top-up sessions are covered since they share `taxAndAddressParams()`.

- Existing subscribers with a blank tax ID are not retroactively updated; that must be handled manually in Stripe.
- Customer Portal sessions are not covered, since tax ID editability there is Dashboard configuration outside this repo.

<sup>Written for commit 326715a261e92ba9da3f85f2dcc537f71947a046. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

