### PR TITLE
feat(sidebar): opt-in project settings shortcut on nav destinations

### DIFF
--- a/apps/web/src/components/sidebar/nav-destinations.tsx
+++ b/apps/web/src/components/sidebar/nav-destinations.tsx
@@ -9,6 +9,7 @@
  *
  * The org's coding agents (GitHub-backed virtual MCPs) trail the list, one row
  * per repo — those DO switch agents, since each owns its own codebase.
+ * Agent rows also carry a `showProjectSettingsGear`-gated gear onto settings.
  *
  * Inbox is in the design but has no backing surface yet, so it is deliberately
  * not listed.
@@ -16,13 +17,21 @@
 
 import type { ReactNode } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { BarChartSquare02, Columns03, Folder, Home02 } from "@untitledui/icons";
+import {
+  BarChartSquare02,
+  Columns03,
+  Folder,
+  Home02,
+  Settings02,
+} from "@untitledui/icons";
 import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
   useSidebar,
 } from "@decocms/ui/components/sidebar.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
   getWellKnownDecopilotVirtualMCP,
@@ -45,6 +54,7 @@ import { defaultThreadRuntime } from "@decocms/shared/thread/session-runtime";
 import { authClient } from "@/lib/auth-client";
 import { formatPinnedViewTabId } from "@/layouts/main-panel-tabs/tab-id";
 import { useCommerceDiagnostic } from "@/hooks/use-commerce-diagnostic";
+import { usePreferences } from "@/hooks/use-preferences.ts";
 import { track } from "@/lib/posthog-client";
 import { useT } from "@/i18n/use-t.ts";
 
@@ -54,6 +64,10 @@ interface NavDestination {
   icon: ReactNode;
   isActive: boolean;
   onSelect: () => void;
+  /** When set, the row grows a hover-revealed gear opening this destination's
+   *  settings. Only the agent rows have one — the fixed destinations are
+   *  views, not configurable entities. */
+  onOpenSettings?: () => void;
 }
 
 /** The well-known Decopilot (Super Agent) id for the current org. */
@@ -188,12 +202,34 @@ function useAgentNavRows(
   const devAgentIds = getDevAgentIds(agents);
   const { threads } = useThreads();
   const { data: session } = authClient.useSession();
-  const { setTaskId, createNewTask } = usePanelActions();
+  const { setTaskId, createNewTask, openTab } = usePanelActions();
+
+  /**
+   * Open the agent's chat, optionally landing on a specific main view. Reuses
+   * the agent's existing empty "New chat" so repeat clicks don't pile up
+   * threads; `opts.main` beats that thread's remembered layout (see
+   * resolveTaskSwitchSearch), so the gear always lands on Settings.
+   */
+  const openAgent = (
+    agent: VirtualMCPEntity,
+    opts?: { main?: string },
+  ): void => {
+    onNavigate?.();
+    const existing = findReusableNewChat(
+      threads,
+      agent.id,
+      session?.user?.id,
+      defaultThreadRuntime(agent.metadata),
+    );
+    if (existing) setTaskId(existing.id, agent.id, opts);
+    else void createNewTask(agent.id, undefined, opts);
+  };
 
   return agents
     .filter((agent) => predicate(agent, devAgentIds))
     .map((agent) => {
       const repo = getActiveGithubRepo(agent);
+      const isActive = search.virtualmcpid === agent.id;
       return {
         key: agent.id,
         label: agent.title || repo?.name || "",
@@ -205,18 +241,23 @@ function useAgentNavRows(
             className="shrink-0"
           />
         ),
-        isActive: search.virtualmcpid === agent.id,
+        isActive,
         onSelect: () => {
           track("nav_destination_clicked", { destination: "coding_agent" });
-          onNavigate?.();
-          const existing = findReusableNewChat(
-            threads,
-            agent.id,
-            session?.user?.id,
-            defaultThreadRuntime(agent.metadata),
-          );
-          if (existing) setTaskId(existing.id, agent.id);
-          else void createNewTask(agent.id);
+          openAgent(agent);
+        },
+        onOpenSettings: () => {
+          track("nav_destination_clicked", {
+            destination: "coding_agent_settings",
+          });
+          // `?main=settings` — the target the agents list's row menu opens too.
+          if (isActive) {
+            // Already on this agent: swap the view, keep the open thread.
+            onNavigate?.();
+            openTab("settings");
+          } else {
+            openAgent(agent, { main: "settings" });
+          }
         },
       };
     });
@@ -233,6 +274,7 @@ export function NavDestinationsContent({
 }: {
   onNavigate?: () => void;
 }) {
+  const t = useT();
   const destinations = useNavDestinations({ onNavigate });
   const codingAgents = useAgentNavRows(
     (agent) => agentHasClonableSource(agent.metadata),
@@ -244,23 +286,53 @@ export function NavDestinationsContent({
     { onNavigate },
   );
   const agentRows = [...codingAgents, ...pinnedAgents];
+  const [{ showProjectSettingsGear }] = usePreferences();
   // Expanded, the label is right there — a tooltip repeating it is noise.
   const { state, isMobile } = useSidebar();
-  const showTooltip = state === "collapsed" && !isMobile;
+  const isCollapsed = state === "collapsed" && !isMobile;
 
-  const row = (item: NavDestination) => (
-    <SidebarMenuItem key={item.key}>
-      <SidebarMenuButton
-        onClick={item.onSelect}
-        isActive={item.isActive}
-        aria-current={item.isActive ? "page" : undefined}
-        tooltip={showTooltip ? item.label : undefined}
-      >
-        {item.icon}
-        <span className="truncate">{item.label}</span>
-      </SidebarMenuButton>
-    </SidebarMenuItem>
-  );
+  const row = (item: NavDestination) => {
+    // Opt-in per person; the icon rail has no room for a second control.
+    const gear = item.onOpenSettings && showProjectSettingsGear && !isCollapsed;
+    return (
+      <SidebarMenuItem key={item.key}>
+        <SidebarMenuButton
+          onClick={item.onSelect}
+          isActive={item.isActive}
+          aria-current={item.isActive ? "page" : undefined}
+          tooltip={isCollapsed ? item.label : undefined}
+          className={cn(
+            gear &&
+              "group-hover/menu-item:bg-sidebar-accent group-hover/menu-item:text-sidebar-accent-foreground",
+          )}
+        >
+          {item.icon}
+          {/* Reserve the overlaid gear's width so the ellipsis clears it. */}
+          <span className={cn("truncate", gear && "pr-7")}>{item.label}</span>
+        </SidebarMenuButton>
+        {gear && (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={t("sidebar.navDestinations.projectSettings", {
+              name: item.label,
+            })}
+            onClick={item.onOpenSettings}
+            className={cn(
+              // One tint throughout — only ghost's background reacts to hover.
+              "absolute right-1 top-1/2 -translate-y-1/2 text-sidebar-foreground/60 hover:text-sidebar-foreground/60",
+              // Hover-to-reveal has no touch equivalent.
+              isMobile
+                ? "opacity-100"
+                : "opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100",
+            )}
+          >
+            <Settings02 />
+          </Button>
+        )}
+      </SidebarMenuItem>
+    );
+  };
 
   return (
     <SidebarMenu className="gap-1">

--- a/apps/web/src/hooks/use-preferences.ts
+++ b/apps/web/src/hooks/use-preferences.ts
@@ -12,6 +12,12 @@ interface Preferences {
   theme: ThemeMode;
   language: Locale;
   /**
+   * Reveal a settings shortcut on each sidebar project row on hover. Off by
+   * default — the row is a navigation target first, and the shortcut is a
+   * second control competing for the same space.
+   */
+  showProjectSettingsGear: boolean;
+  /**
    * Task-board lanes hidden by default (`HIDDEN_STATUSES`) that this person has
    * pulled back onto the board. Statuses, not lane indexes, so a reordered or
    * renamed lane can't resurrect the wrong column.
@@ -25,6 +31,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   enableSounds: false,
   theme: "system",
   language: detectLocale(),
+  showProjectSettingsGear: false,
   shownTaskBoardLanes: [],
 };
 

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -140,6 +140,9 @@ export const settings = {
   "settings.preferences.soundsDescription":
     "Play sounds for agent actions and notifications.",
   "settings.preferences.soundsPreview": "Preview notification sound",
+  "settings.preferences.projectSettingsGear": "Project settings shortcut",
+  "settings.preferences.projectSettingsGearDescription":
+    "Reveal a settings shortcut when you hover a project in the sidebar.",
   "settings.preferences.toolApproval": "Tool Approval",
   "settings.preferences.toolApprovalDescription":
     "Control how tools are approved before execution.",

--- a/apps/web/src/i18n/en/sidebar.ts
+++ b/apps/web/src/i18n/en/sidebar.ts
@@ -19,6 +19,7 @@ export const sidebar = {
   "sidebar.agentsSection.selectAnExistingAgent": "Select an existing agent",
   "sidebar.navDestinations.home": "Home",
   "sidebar.navDestinations.library": "Library",
+  "sidebar.navDestinations.projectSettings": "{name} settings",
   "sidebar.navDestinations.reports": "Reports",
   "sidebar.navDestinations.tasks": "Tasks",
   "sidebar.navigationMobile.closeSidebar": "Close sidebar",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -146,6 +146,9 @@ export const settings = {
   "settings.preferences.soundsDescription":
     "Reproduza sons para ações de agentes e notificações.",
   "settings.preferences.soundsPreview": "Ouvir som de notificação",
+  "settings.preferences.projectSettingsGear": "Atalho de configurações",
+  "settings.preferences.projectSettingsGearDescription":
+    "Mostrar um atalho de configurações ao passar o mouse sobre um projeto na barra lateral.",
   "settings.preferences.toolApproval": "Aprovação de ferramentas",
   "settings.preferences.toolApprovalDescription":
     "Controle como as ferramentas são aprovadas antes da execução.",

--- a/apps/web/src/i18n/pt-br/sidebar.ts
+++ b/apps/web/src/i18n/pt-br/sidebar.ts
@@ -22,6 +22,7 @@ export const sidebar = {
     "Selecione um agente existente",
   "sidebar.navDestinations.home": "Início",
   "sidebar.navDestinations.library": "Biblioteca",
+  "sidebar.navDestinations.projectSettings": "Configurações de {name}",
   "sidebar.navDestinations.reports": "Relatórios",
   "sidebar.navDestinations.tasks": "Tarefas",
   "sidebar.navigationMobile.closeSidebar": "Fechar barra lateral",

--- a/apps/web/src/views/settings/profile-preferences.tsx
+++ b/apps/web/src/views/settings/profile-preferences.tsx
@@ -293,6 +293,34 @@ function PreferencesSection() {
           }
         />
         <SettingsCardItem
+          title={t("settings.preferences.projectSettingsGear")}
+          description={t("settings.preferences.projectSettingsGearDescription")}
+          onClick={() => {
+            track("preferences_project_settings_gear_toggled", {
+              enabled: !preferences.showProjectSettingsGear,
+            });
+            setPreferences((prev) => ({
+              ...prev,
+              showProjectSettingsGear: !prev.showProjectSettingsGear,
+            }));
+          }}
+          action={
+            <Switch
+              aria-label={t("settings.preferences.projectSettingsGear")}
+              checked={preferences.showProjectSettingsGear}
+              onCheckedChange={(checked) => {
+                track("preferences_project_settings_gear_toggled", {
+                  enabled: checked,
+                });
+                setPreferences((prev) => ({
+                  ...prev,
+                  showProjectSettingsGear: checked,
+                }));
+              }}
+            />
+          }
+        />
+        <SettingsCardItem
           title={t("settings.preferences.toolApproval")}
           description={t("settings.preferences.toolApprovalDescription")}
           action={

--- a/packages/e2e/tests/nav-v2.spec.ts
+++ b/packages/e2e/tests/nav-v2.spec.ts
@@ -101,6 +101,32 @@ async function clearSeededNavV2(orgId: string): Promise<void> {
  *  from every agent title below so the sidebar's label source is unambiguous. */
 const CODING_AGENT_REPO = "nav-v2-e2e";
 
+/**
+ * Wire contract: the per-user preferences blob, and the opt-in that reveals the
+ * settings shortcut on project rows. It is OFF by default, so every spec that
+ * wants the shortcut has to ask for it — that default is itself asserted below.
+ *
+ * `addInitScript` re-runs on each document, which survives `expandSidebar`'s
+ * reloads. localStorage throws on opaque origins (about:blank), hence the catch.
+ */
+const PREFERENCES_KEY = "studio:user:preferences";
+
+async function enableProjectSettingsGear(page: Page): Promise<void> {
+  await page.addInitScript(
+    ([key, value]) => {
+      try {
+        window.localStorage.setItem(key, value);
+      } catch {
+        /* opaque origin — the real navigation re-runs this */
+      }
+    },
+    [PREFERENCES_KEY, JSON.stringify({ showProjectSettingsGear: true })] as [
+      string,
+      string,
+    ],
+  );
+}
+
 /** A repo-backed ("coding") agent — the sidebar lists one row per repo. */
 async function createCodingAgent(
   request: APIRequestContext,
@@ -440,5 +466,120 @@ test.describe("first-class navigation", () => {
     });
     await expect(row("before rename")).toHaveCount(0);
     await expect(row(CODING_AGENT_REPO)).toHaveCount(0);
+  });
+
+  test("a coding agent's row gear opens that agent's settings", async ({
+    authedPage: { page, orgSlug },
+  }) => {
+    const request = page.context().request;
+    const agent = await createCodingAgent(request, orgSlug, "gear agent");
+
+    await enableProjectSettingsGear(page);
+    await page.goto(`/${orgSlug}`);
+    await expandSidebar(page, "Home");
+
+    const sidebar = page.locator('[data-sidebar="content"]');
+    const row = sidebar.getByRole("button", {
+      name: "gear agent",
+      exact: true,
+    });
+    await expect(row).toBeVisible({ timeout: SHELL_TIMEOUT_MS });
+
+    // The gear only reveals on hover; its label is the wire contract asserted here.
+    await row.hover();
+    await sidebar
+      .getByRole("button", { name: "gear agent settings", exact: true })
+      .click();
+
+    await expect(page).toHaveURL(
+      new RegExp(`[?&]virtualmcpid=${agent.item.id}\\b`),
+    );
+    await expect(page).toHaveURL(/[?&]main=settings\b/);
+    await expect(page.getByPlaceholder("Agent name")).toHaveValue(
+      "gear agent",
+      { timeout: SHELL_TIMEOUT_MS },
+    );
+  });
+
+  test("the gear keeps the open thread when already on that agent", async ({
+    authedPage: { page, orgSlug },
+  }) => {
+    const request = page.context().request;
+    const agent = await createCodingAgent(request, orgSlug, "same thread");
+    const thread = await callSelfMcpTool<{ item: { id: string } }>(
+      request,
+      orgSlug,
+      "COLLECTION_THREADS_CREATE",
+      { data: { virtual_mcp_id: agent.item.id } },
+    );
+
+    await enableProjectSettingsGear(page);
+    await page.goto(
+      `/${orgSlug}/${thread.item.id}?virtualmcpid=${agent.item.id}`,
+    );
+    await expandSidebar(page, "Home");
+
+    const sidebar = page.locator('[data-sidebar="content"]');
+    const row = sidebar.getByRole("button", {
+      name: "same thread",
+      exact: true,
+    });
+    await expect(row).toBeVisible({ timeout: SHELL_TIMEOUT_MS });
+    await row.hover();
+    await sidebar
+      .getByRole("button", { name: "same thread settings", exact: true })
+      .click();
+
+    await expect(page).toHaveURL(/[?&]main=settings\b/);
+    await expect(page).toHaveURL(new RegExp(`/${thread.item.id}\\?`));
+  });
+
+  test("the settings shortcut is off until the preference is turned on", async ({
+    authedPage: { page, orgSlug },
+  }) => {
+    const request = page.context().request;
+    await createCodingAgent(request, orgSlug, "opt in");
+
+    // No enableProjectSettingsGear() — a fresh person gets the default.
+    await page.goto(`/${orgSlug}`);
+    await expandSidebar(page, "Home");
+
+    const sidebar = page.locator('[data-sidebar="content"]');
+    await expect(
+      sidebar.getByRole("button", { name: "opt in", exact: true }),
+    ).toBeVisible({ timeout: SHELL_TIMEOUT_MS });
+    await expect(
+      sidebar.getByRole("button", { name: "opt in settings", exact: true }),
+    ).toHaveCount(0);
+
+    // Flip it in Settings → Preferences, the way a person would.
+    await page.goto(`/${orgSlug}/settings/profile`);
+    const toggle = page.getByRole("switch", {
+      name: /project settings shortcut/i,
+    });
+    await toggle.waitFor({ state: "visible", timeout: SHELL_TIMEOUT_MS });
+    await expect(toggle).not.toBeChecked();
+    await toggle.click();
+    await expect(toggle).toBeChecked();
+
+    await page.goto(`/${orgSlug}`);
+    await expandSidebar(page, "Home");
+    await expect(
+      sidebar.getByRole("button", { name: "opt in settings", exact: true }),
+    ).toHaveCount(1, { timeout: SHELL_TIMEOUT_MS });
+  });
+
+  test("the fixed destinations carry no settings gear", async ({
+    authedPage: { page, orgSlug },
+  }) => {
+    // Even with the shortcut opted in, only projects get one.
+    await enableProjectSettingsGear(page);
+    await page.goto(`/${orgSlug}`);
+    await expandSidebar(page, "Home");
+
+    const sidebar = page.locator('[data-sidebar="content"]');
+    await expect(
+      sidebar.getByRole("button", { name: /^(Home|Tasks|Library) settings$/ }),
+    ).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

Under the first-class navigation (`nav_v2`), the sidebar lists the org's projects — GitHub-backed virtual MCPs — below the fixed destinations. Hovering one now reveals a gear that opens that project's settings (`?main=settings`), the same view the agents list's row menu opens.

It ships **opt-in**: a new per-user `showProjectSettingsGear` preference, **default off**, with a toggle in **Settings → Profile & Preferences**. The row is a navigation target first, so a second control competing for the same space is something you ask for rather than something imposed.

## Behaviour

| | |
|---|---|
| Preference off (default) | Sidebar unchanged — no gear, label truncates as before |
| Preference on, hover a project | Gear fades in at the row's right edge |
| Click, from elsewhere | Reuse-or-create that project's chat, landing on Settings |
| Click, already on that project | Keeps the open thread, only swaps the view |
| Collapsed icon rail | No gear (no room for a second control) |
| Mobile | Gear stays visible (hover has no touch equivalent) |

## Notes for review

- **The already-on-this-project case is deliberately not the agents-list behaviour.** The `⋮ → Settings` item on `/settings/agents` always reuse-or-creates a thread. Doing that from the sidebar would bounce you off an in-progress conversation onto an empty new chat, so the gear calls `openTab("settings")` instead when the project is already active.
- **Label padding is on the truncating span, not the button.** `pr-8` on `SidebarMenuButton` loses to the sidebar's own `group-data-[state=expanded]/sidebar:px-2` in the cascade, so a long project name's ellipsis ran underneath the gear. Caught in the browser, not by types.
- **The new `Switch` sets an explicit `aria-label`**, following `NavigationSettings` (the `nav_v2` switch). The neighbouring Notifications and Sounds switches have **no accessible name** — verified in the live DOM. That pre-existing gap is left alone as out of scope; worth a follow-up.
- No coercion branch was added for the new boolean in `usePreferences`' initializer — it matches `enableSounds` / `enableNotifications`, where the `{ ...DEFAULT_PREFERENCES, ...existing }` merge already supplies the default for existing stored blobs.

## Testing

Verified end to end in a local dev org with a repo-backed project:

- Default off → sidebar renders `Home / Reports / Tasks / Library / storefront`, no gear.
- Flip the toggle in Settings → Profile & Preferences → persists (`showProjectSettingsGear: true` in `studio:user:preferences`).
- Back to the sidebar → the gear is present and opens the project's settings form.
- Already on the project: `…/<thread>?…&main=git` → click gear → `…/<thread>?…&main=settings`, **same thread id**.
- Collapsed rail renders six destination icons and zero gears.
- Computed styles checked hovered vs not: icon colour is `oklab(0.2 0.005 0.0087 / 0.6)` in both states — the ghost background is the only thing that reacts. Checked in light and dark, with a short and a long project name.

`bun run fmt`, `bun run check` (web + e2e), and `bun run lint` pass (0 errors).

**e2e:** `packages/e2e/tests/nav-v2.spec.ts` — the three gear specs added earlier assumed the shortcut was unconditional, so they are **rewritten**, not appended to: they now opt in via an `addInitScript` helper seeding the preferences blob (the "fixed destinations carry no gear" spec included, which would otherwise have passed vacuously). One new spec covers the gate itself: default off → flip the switch in Settings → shortcut appears.

⚠️ The e2e suite was **not run locally** — this machine hits port 3000/5432 collisions and auth rate limiting. Relying on CI for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hover-revealed settings gear to sidebar project rows, gated behind a new per-user preference that defaults to off.

- The toggle lives in Settings → Profile & Preferences; the gear opens that project's `?main=settings` view.
- When already on that project, the gear keeps the open thread and swaps only the view via `openTab("settings")`, unlike the agents list which always reuse-or-creates a new chat.
- The collapsed icon rail shows no gear; on mobile the gear stays visible because hover has no touch equivalent.
- The new Switch sets an explicit `aria-label`; the neighboring switches lack one, which is pre-existing and out of scope.
- The e2e specs were rewritten to opt in by seeding the preference blob via `addInitScript`; the suite wasn't run locally and relies on CI.

<sup>Written for commit e295f5a90aa0a03ed2796c557041b9c9e680a0d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

