### PR TITLE
fix(api-keys): bound the permissions allowlist accepted at create/update

### DIFF
--- a/apps/api/src/tools/apiKeys/schema.test.ts
+++ b/apps/api/src/tools/apiKeys/schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { ApiKeyCreateInputSchema } from "./schema";
+
+/**
+ * `checkApiKeyPermission` (auth/api-key-permissions.ts) rebuilds a `Set` from
+ * a key's stored `permissions` allowlist on every tool call the key makes.
+ * Before this bound, `API_KEY_CREATE`/`API_KEY_UPDATE` accepted an unbounded
+ * `permissions` record, so a caller could mint a key whose allowlist costs
+ * real CPU/memory on every future request that key makes.
+ */
+describe("ApiKeyCreateInputSchema permissions bound", () => {
+  const base = { name: "k" };
+
+  it("accepts a normal-sized allowlist", () => {
+    const result = ApiKeyCreateInputSchema.safeParse({
+      ...base,
+      permissions: { self: ["ORGANIZATION_GET"], conn_abc: ["*"] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects more resources than the cap", () => {
+    const permissions: Record<string, string[]> = {};
+    for (let i = 0; i < 1001; i++) permissions[`conn_${i}`] = ["*"];
+    const result = ApiKeyCreateInputSchema.safeParse({
+      ...base,
+      permissions,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects more actions on one resource than the cap", () => {
+    const result = ApiKeyCreateInputSchema.safeParse({
+      ...base,
+      permissions: { self: Array.from({ length: 501 }, (_, i) => `T${i}`) },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/tools/apiKeys/schema.ts
+++ b/apps/api/src/tools/apiKeys/schema.ts
@@ -30,6 +30,21 @@ const PermissionSchema = z.record(z.string(), z.array(z.string()));
 
 export type Permission = z.infer<typeof PermissionSchema>;
 
+/** `checkApiKeyPermission` rebuilds a `Set` from the stored allowlist on every
+ *  tool call the key makes — bound it here so an unbounded grant at create/
+ *  update time can't become a per-request cost multiplier. */
+const MAX_PERMISSION_RESOURCES = 1000;
+const MAX_ACTIONS_PER_RESOURCE = 500;
+
+/** Same shape as {@link PermissionSchema}, bounded — only for CREATE/UPDATE
+ *  input. Output schemas stay on the unbounded `PermissionSchema` so an
+ *  already-stored key (from before this cap existed) still reads back fine. */
+const PermissionInputSchema = z
+  .record(z.string(), z.array(z.string()).max(MAX_ACTIONS_PER_RESOURCE))
+  .refine((p) => Object.keys(p).length <= MAX_PERMISSION_RESOURCES, {
+    message: `Permissions cannot grant more than ${MAX_PERMISSION_RESOURCES} resources`,
+  });
+
 // ============================================================================
 // API Key Entity Schema (for list operations - no key value)
 // ============================================================================
@@ -73,7 +88,7 @@ export const ApiKeyCreateInputSchema = z.object({
     .min(1)
     .max(64)
     .describe("Human-readable name for the API key"),
-  permissions: PermissionSchema.describe(
+  permissions: PermissionInputSchema.describe(
     'Permissions to grant (REQUIRED — there is no implicit default). Format: { resource: [actions] }. Resource is "self" for management tools or "conn_<UUID>" for connection-specific tools. Actions are tool names (e.g., ["ORGANIZATION_GET"]) or ["*"] for all. Example: { "self": ["ORGANIZATION_GET", "COLLECTION_CONNECTIONS_LIST"] }. The key is authorized solely by this allowlist; the creator\'s role does not widen it.',
   ),
   expiresIn: z
@@ -159,7 +174,7 @@ export const ApiKeyUpdateInputSchema = z.object({
     .max(64)
     .optional()
     .describe("New name for the API key"),
-  permissions: PermissionSchema.optional().describe(
+  permissions: PermissionInputSchema.optional().describe(
     'New permissions. Format: { resource: [actions] } where resource is "self" for management tools or "conn_<UUID>" for connection-specific tools. Actions are tool names or "*" for all. Example: { "self": ["API_KEY_CREATE"] }. Replaces existing permissions.',
   ),
   metadata: z


### PR DESCRIPTION
**Source**: reduction/hardening — same DoS-bounds pattern already applied broadly this week to other tool inputs feeding a per-request check (#6566 tagIds, #6567 virtual-mcp ids, #6558 mark-read ids, #6570 mentions).

**Why a maintainer wants this**: `checkApiKeyPermission` (apps/api/src/auth/api-key-permissions.ts) rebuilds a `Set` from the key's stored `permissions` allowlist on *every single tool call that key makes*. `API_KEY_CREATE`/`API_KEY_UPDATE` accepted an unbounded `{ resource: [actions] }` record, so any authenticated org member could mint or update a key with an arbitrarily large allowlist (e.g. thousands of resources, each with thousands of action strings) — that blob is stored once but re-parsed into a fresh `Set` on every request the key makes afterward, making it a per-request CPU/memory cost multiplier, not just a one-time storage cost.

**Fix**: added `PermissionInputSchema` — the same `{ resource: [actions] }` shape, capped at 1000 resources and 500 actions per resource (comfortably above any real key's scope: `self` plus a handful of `conn_<uuid>` resources) — and used it only for the CREATE/UPDATE input schemas. The output schemas (list/create/update responses) stay on the original unbounded `PermissionSchema` so a key created before this cap existed still reads back fine.

**Regression test**: `apps/api/src/tools/apiKeys/schema.test.ts` — asserts a normal-sized allowlist still parses, and that exceeding either cap (1001 resources, or 501 actions on one resource) is rejected.

**To confirm**: `cd apps/api && bun test src/tools/apiKeys/schema.test.ts`

**Locally verified**: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test above, and `bunx oxlint` on both changed files — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the permissions allowlist accepted at API key create/update so a stored grant can't become a per-request CPU/memory cost on every tool call that key makes.

- `checkApiKeyPermission` rebuilds a `Set` from the stored allowlist on every tool call, so the previously unbounded record was a per-request cost multiplier rather than a one-time storage cost.
- Create/update input schemas now cap the allowlist at 1000 resources and 500 actions per resource; output schemas stay unbounded so pre-existing keys still read back correctly.
- Adds regression tests covering a normal-sized allowlist and both cap violations.

<sup>Written for commit f20625003b17cdc8916f3a86a7fdfa14235afbc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

