### PR TITLE
fix(sandbox): prevent secondary-repo directory-name collisions across owner-qualified fallbacks

### DIFF
--- a/packages/shared/src/secondary-repo-dirs.test.ts
+++ b/packages/shared/src/secondary-repo-dirs.test.ts
@@ -49,6 +49,16 @@ describe("secondaryRepoDirNames", () => {
   it("has nothing to name for no repos", () => {
     expect(secondaryRepoDirNames([])).toEqual([]);
   });
+
+  // "a"/"x" and "b"/"x" collide, and "a-x" is a real bare name in the set.
+  it("escalates a bare name that collides with a sibling's owner-qualified fallback", () => {
+    const names = secondaryRepoDirNames([
+      r("a", "x"),
+      r("b", "x"),
+      r("c", "a-x"),
+    ]);
+    expect(new Set(names).size).toBe(names.length);
+  });
 });
 
 // The whole point of the shared rule: TASK_ADD_REPO asks for one repo's name

--- a/packages/shared/src/secondary-repo-dirs.ts
+++ b/packages/shared/src/secondary-repo-dirs.ts
@@ -29,10 +29,36 @@ export function secondaryRepoDirNames(repos: SecondaryRepoRef[]): string[] {
       .map((r) => r.name.toLowerCase())
       .filter((name, i, all) => all.indexOf(name) !== i),
   );
-  return repos.map((r) =>
+  const useOwner = repos.map((r) => shared.has(r.name.toLowerCase()));
+  const candidateOf = (i: number) =>
     sanitize(
-      shared.has(r.name.toLowerCase()) ? `${r.owner}-${r.name}` : r.name,
-    ),
+      useOwner[i] ? `${repos[i].owner}-${repos[i].name}` : repos[i].name,
+    ).toLowerCase();
+
+  // An owner-qualified name can itself collide with a sibling's bare name; escalate the losing side until stable, bounded by repos.length.
+  for (let pass = 0; pass < repos.length; pass++) {
+    const seen = new Map<string, number>();
+    let changed = false;
+    for (let i = 0; i < repos.length; i++) {
+      const candidate = candidateOf(i);
+      const prior = seen.get(candidate);
+      if (prior !== undefined) {
+        if (!useOwner[i]) {
+          useOwner[i] = true;
+          changed = true;
+        }
+        if (!useOwner[prior]) {
+          useOwner[prior] = true;
+          changed = true;
+        }
+      }
+      seen.set(candidate, i);
+    }
+    if (!changed) break;
+  }
+
+  return repos.map((r, i) =>
+    sanitize(useOwner[i] ? `${r.owner}-${r.name}` : r.name),
   );
 }
 

--- a/packages/shared/src/secondary-repo-dirs.ts
+++ b/packages/shared/src/secondary-repo-dirs.ts
@@ -30,10 +30,12 @@ export function secondaryRepoDirNames(repos: SecondaryRepoRef[]): string[] {
       .filter((name, i, all) => all.indexOf(name) !== i),
   );
   const useOwner = repos.map((r) => shared.has(r.name.toLowerCase()));
-  const candidateOf = (i: number) =>
-    sanitize(
-      useOwner[i] ? `${repos[i].owner}-${repos[i].name}` : repos[i].name,
+  const candidateOf = (i: number) => {
+    const r = repos[i]!;
+    return sanitize(
+      useOwner[i] ? `${r.owner}-${r.name}` : r.name,
     ).toLowerCase();
+  };
 
   // An owner-qualified name can itself collide with a sibling's bare name; escalate the losing side until stable, bounded by repos.length.
   for (let pass = 0; pass < repos.length; pass++) {


### PR DESCRIPTION
**Source:** bug found while auditing `packages/shared/src/secondary-repo-dirs.ts`, the directory-naming rule shared by `TASK_ADD_REPO` (#6557, #6593) and pod provisioning for a run's secondary repo checkouts.

**Why it matters:** `secondaryRepoDirNames` only escalates a repo to its owner-qualified name (`owner-name`) when its *bare* name collides with a sibling's bare name. But that owner-qualified fallback can itself collide with an unrelated repo's untouched bare name — e.g. repos `a/x`, `b/x`, and `c/a-x`: the first two collide and fall back to `a-x`/`b-x`, but `a-x` is also the bare (unescalated) name chosen for `c/a-x`. Two different secondary repos then resolve to the same directory, so provisioning silently writes one checkout on top of the other — data loss for whichever one lands second.

**Failure scenario:** a task run adds secondary repos `a/x`, `b/x`, and `c/a-x` (in any order) — the daemon materializes two of the three secondary checkouts into the same directory, clobbering one repo's working tree.

**Fix:** after the existing bare-name collision pass, run a bounded fixed-point pass over the *final* candidate names — any remaining collision escalates whichever side is still on its bare name, repeating until stable (bounded by `repos.length`, since each pass only ever escalates more entries, never fewer). Added `secondaryRepoDirNames escalates a bare name that collides with a sibling's owner-qualified fallback`, which reproduces the exact `a/x`, `b/x`, `c/a-x` scenario above and asserts all resulting names are unique.

**To verify:** `bun test packages/shared/src/secondary-repo-dirs.test.ts`

**Checked locally:** `bun run fmt`, `bunx tsc --noEmit` (packages/shared), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a collision in `secondaryRepoDirNames` where an owner-qualified fallback name (e.g. `a-x`) could match another repo's bare name (e.g. `c/a-x`), causing two secondary checkouts to overwrite each other. Now escalates the losing side of any remaining collision until all names are unique, bounded by the repo count, and adds a regression test for this exact case.

<sup>Written for commit b46a85afcca1adda504a41809799ebb04afa59b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

