### PR TITLE
fix(decopilot): retry transient JetStream publish failures

### DIFF
--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts
@@ -629,6 +629,46 @@ describe("NatsStreamBuffer", () => {
       );
     });
 
+    it("rides out a transient JetStreamNotEnabled and still resolves true", async () => {
+      let attempts = 0;
+      const mockJs = {
+        publish: mockOf(() => {
+          attempts += 1;
+          if (attempts < 3) {
+            const err = new Error("jetstream is not enabled");
+            err.name = "JetStreamNotEnabled";
+            return Promise.reject(err);
+          }
+          return Promise.resolve({ seq: 1 });
+        }),
+      };
+      const buffer = new NatsStreamBuffer({
+        getConnection: () => ({}) as never,
+        getJetStream: () => mockJs as never,
+      });
+      (buffer as unknown as { js: unknown }).js = mockJs;
+      expect(await buffer.publishRawChunk("run_1", { type: "start" })).toBe(
+        true,
+      );
+      expect(attempts).toBe(3);
+    });
+
+    it("resolves false (never throws) once the transient window is exhausted", async () => {
+      const mockJs = {
+        publish: mockOf(() =>
+          Promise.reject(new Error("no responders: decopilot.stream.run_1")),
+        ),
+      };
+      const buffer = new NatsStreamBuffer({
+        getConnection: () => ({}) as never,
+        getJetStream: () => mockJs as never,
+      });
+      (buffer as unknown as { js: unknown }).js = mockJs;
+      expect(await buffer.publishRawChunk("run_1", { type: "start" })).toBe(
+        false,
+      );
+    }, 30_000); // exhaustion costs ~13s of real backoff
+
     it("forwards an explicit msgId for JetStream dedup", async () => {
       const published: Array<{ subj: string; opts?: unknown }> = [];
       const mockJs = {

--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -223,7 +223,8 @@ export interface NatsStreamBufferOptions {
 function isTransientJsApiError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   if (err.name === "TimeoutError") return true;
-  return /timeout|no responders|503/i.test(err.message);
+  // "not enabled" reads like config but is what a leaderless cluster reports.
+  return /timeout|no responders|503|not enabled/i.test(err.message);
 }
 
 export class NatsStreamBuffer implements StreamBuffer {
@@ -427,6 +428,54 @@ export class NatsStreamBuffer implements StreamBuffer {
    * caller knows the publish is confirmed. Returns `false` when JetStream is
    * unavailable so the caller does NOT advance its cursor.
    */
+  /**
+   * Publish ONE already-serialized message, riding out a transient JetStream
+   * outage (leader election, brief no-responders, the node holding the stream
+   * restarting) instead of failing the run. Retried PER MESSAGE, not per
+   * fragment set, so a multi-fragment chunk keeps its order and a mid-loop
+   * failure never republishes the fragments already acked.
+   *
+   * Safe to retry: every publish on the ingest path carries a `msgId` keyed by
+   * `(fenceToken, seq)` and the stream's `duplicate_window` is 2 min, so a
+   * republish inside that window is dropped server-side rather than
+   * double-writing a UI part. Returns `false` once the transient window is
+   * exhausted, preserving this class's "never advance the caller's cursor on a
+   * failed publish" contract rather than throwing a new error shape at callers.
+   */
+  private async publishSerialized(
+    js: JetStreamClient,
+    m: {
+      subject: string;
+      data: Uint8Array;
+      headers?: Record<string, string>;
+      msgId?: string;
+    },
+  ): Promise<boolean> {
+    try {
+      await retry(
+        () =>
+          js.publish(m.subject, m.data, {
+            ...(m.headers ? { headers: toMsgHdrs(m.headers) } : {}),
+            ...(m.msgId ? { msgID: m.msgId } : {}),
+          }),
+        {
+          maxAttempts: 6,
+          minTimeout: 250,
+          maxTimeout: 5000,
+          jitter: 0.5,
+          isRetriable: isTransientJsApiError,
+        },
+      );
+      return true;
+    } catch (err) {
+      console.error(
+        `[Decopilot] publish failed after retries subject=${m.subject}`,
+        err,
+      );
+      return false;
+    }
+  }
+
   async publishRawChunk(
     taskId: string,
     chunk: unknown,
@@ -442,10 +491,7 @@ export class NatsStreamBuffer implements StreamBuffer {
     encodeMsHistogram().record(performance.now() - t0);
     publishedChunksCounter().add(1);
     for (const m of msgs) {
-      await js.publish(m.subject, m.data, {
-        ...(m.headers ? { headers: toMsgHdrs(m.headers) } : {}),
-        ...(m.msgId ? { msgID: m.msgId } : {}),
-      });
+      if (!(await this.publishSerialized(js, m))) return false;
     }
     return true;
   }
@@ -458,8 +504,7 @@ export class NatsStreamBuffer implements StreamBuffer {
     const js = this.js;
     if (!js) return false;
     const m = serializeDone({ runId: taskId, fenceToken, finalSeq });
-    await js.publish(m.subject, m.data, { msgID: m.msgId });
-    return true;
+    return await this.publishSerialized(js, m);
   }
 
   async createTailStream(


### PR DESCRIPTION
A JetStream publish that fails during a leader election kills the whole run. `publishRawChunk`/`publishDone` called `js.publish()` bare, while `init()` already wraps its JS-API round-trips in `retry(...)`.

## What happened in prod

Thread `9354a20c-deb9-4832-abfb-6c1f64f97b76` (org `montecarlo`), 2026-08-26 14:34:57Z — reported as a chat stuck on "Isso está levando mais tempo que o usual" for 17m:

1. The run died inside `runHostedHarness` with `JetStreamNotEnabled: jetstream is not enabled`, thrown from `publishRawChunk`.
2. The workflow's failure path then tried to publish the terminal error and got `NoResponders: 'decopilot.stream.9354a20c-…'`.
3. `hosted-harness-workflow.ts:531-543` swallows that by design, so the thread was left with **no fence-scoped terminal at all** — nothing for the projector to fold, and the UI spins forever.

Root cause of the JetStream unavailability: the NATS cluster was flapping — `nats-2` OOMKilled (exit 137), `nats-0` killed by its `/healthz?js-enabled-only=true` liveness probe, meta-leader lost.

## The fix

- Widen `isTransientJsApiError` to match `not enabled`. The old regex was `/timeout|no responders|503/i`, which does **not** match `jetstream is not enabled` — so even the one retry that existed classified this outage as permanent.
- Add `publishSerialized()`: per-message `retry` (6 attempts, 250ms→5s, ~13s total), shared by `publishRawChunk` and `publishDone`.

Retry is idempotent **by construction, not by luck**: every ingest publish carries a `msgId` of `(runId, fenceToken, seq)` and the stream's `duplicate_window` is 2 min, so a republish is dropped server-side. `ingestRun` already depends on this (see its `initialAckSeq` comment).

Retried per message rather than per fragment set, so a mid-loop failure never re-sends fragments already acked. Returns `false` on exhaustion rather than throwing a new error shape, preserving the class's "never advance the caller's cursor on a failed publish" contract.

13s rides out a leader election but not a full pod restart — deliberate. A run should not block a minute on one chunk.

## Why not recover at the workflow layer

`runHostedHarness` is `retriesAllowed: false` on purpose — re-running an agent-loop step splices generations (#4409). Recovery has to live at the publish boundary.

## Testing

`bun test apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts` → 30 pass / 0 fail.

Two new cases:
- transient `JetStreamNotEnabled` twice then success → resolves `true`, 3 attempts
- sustained `no responders` → resolves `false`, never throws

The 16 failures in the wider `decopilot/` + `dispatch-queue/` suites are pre-existing (real-Postgres tests, no local PG) — identical set on a stashed tree.

`bun run fmt`, `bun run lint` (0 errors), `bun run --cwd=apps/api check` all pass.

## Follow-ups (config, not code — not in this PR)

1. **`DECOPILOT_STREAMS` is `num_replicas: 1`** on a 3-node RAFT cluster (`nats-stream-buffer.ts:104`). Losing the node holding that replica takes streaming down globally with no failover — this is why one pod restart brakes chat for everyone. `init()` already calls `streams.update`, so raising it to 3 applies online.
2. **NATS containers declare no resource requests/limits** (`resources: {}` on all three). Actual usage is 10-130MiB all day, so they are not growing — with no request, the node OOM killer just picks them first under co-tenant pressure.

Happy to send those as a second PR against `deco-apps-cd` if this looks right.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient JetStream publish failures so a leader election or brief no-responders no longer kills a run or leaves the thread stuck.

**Bug Fixes**
- Widens `isTransientJsApiError` to treat `not enabled` as transient.
- Adds `publishSerialized` for per-message retry (6 attempts, 250ms–5s backoff) and returns `false` on exhaustion, preserving the "never advance cursor" contract.
- Retries are safe because every ingest publish carries a `msgId` deduped by the stream's 2-minute `duplicate_window`.

<sup>Written for commit be78c1826a1001ebc589616c9979acfc779f8ecf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

