### PR TITLE
fix(sandbox): invalidate live meta when the dev server comes up

### DIFF
--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.test.ts
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   buildDirectDaemonEventsUrl,
   isDirectDaemonEventsGoneStatus,
-  isLiveMetaKeyForScope,
   isWorkingTreeReadyPhase,
 } from "./sandbox-events-context";
 
@@ -34,38 +33,6 @@ describe("isDirectDaemonEventsGoneStatus", () => {
     expect(isDirectDaemonEventsGoneStatus(429)).toBe(false);
     expect(isDirectDaemonEventsGoneStatus(502)).toBe(false);
     expect(isDirectDaemonEventsGoneStatus(503)).toBe(false);
-  });
-});
-
-describe("isLiveMetaKeyForScope", () => {
-  test("matches a live-meta key regardless of its previewUrl suffix", () => {
-    expect(
-      isLiveMetaKeyForScope(
-        ["live-meta", "acme", "vmid-1", "main", "https://preview.example.com"],
-        "acme",
-        "vmid-1",
-        "main",
-      ),
-    ).toBe(true);
-  });
-
-  test("does not match a different org, vmid, or branch", () => {
-    const scope = [
-      "live-meta",
-      "acme",
-      "vmid-1",
-      "main",
-      "https://x.example.com",
-    ];
-    expect(isLiveMetaKeyForScope(scope, "other-org", "vmid-1", "main")).toBe(
-      false,
-    );
-    expect(isLiveMetaKeyForScope(scope, "acme", "other-vmid", "main")).toBe(
-      false,
-    );
-    expect(isLiveMetaKeyForScope(scope, "acme", "vmid-1", "other-branch")).toBe(
-      false,
-    );
   });
 });
 

--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
@@ -137,21 +137,6 @@ const DAEMON_EVENT_TYPES: readonly DaemonEventName[] = [
 // `log` is broadcast separately — same SSE stream, different shape.
 const LOG_EVENT = "log" as const;
 
-/** True when `queryKey` is a cached live-meta entry for this org/vmid/branch, regardless of its previewUrl suffix. */
-export function isLiveMetaKeyForScope(
-  queryKey: readonly unknown[],
-  orgSlug: string,
-  virtualMcpId: string,
-  branch: string,
-): boolean {
-  return (
-    queryKey[0] === "live-meta" &&
-    queryKey[1] === orgSlug &&
-    queryKey[2] === virtualMcpId &&
-    queryKey[3] === branch
-  );
-}
-
 export function buildDirectDaemonEventsUrl(
   previewUrl: string | null | undefined,
 ): string | null {
@@ -390,11 +375,9 @@ export function SandboxEventsProvider({
               void queryClient.invalidateQueries({
                 queryKey: KEYS.decofile(cacheKeyForBranch),
               });
+              // Prefix key — the entry also carries preview/production URL suffixes.
               void queryClient.invalidateQueries({
-                predicate: (query) =>
-                  query.queryKey[0] === "live-meta" &&
-                  typeof query.queryKey[1] === "string" &&
-                  query.queryKey[1].startsWith(`${cacheKeyForBranch}/`),
+                queryKey: KEYS.liveMeta(org.slug, virtualMcpId, branch),
               });
             }
             prevLifecyclePhase = lp.state.phase;
@@ -504,13 +487,7 @@ export function SandboxEventsProvider({
               liveMetaDebounceTimer = setTimeout(() => {
                 liveMetaDebounceTimer = null;
                 void queryClient.invalidateQueries({
-                  predicate: (query) =>
-                    isLiveMetaKeyForScope(
-                      query.queryKey,
-                      org.slug,
-                      virtualMcpId,
-                      branch,
-                    ),
+                  queryKey: KEYS.liveMeta(org.slug, virtualMcpId, branch),
                 });
               }, 1_000);
             }

--- a/apps/web/src/components/sections-editor/use-live-meta.test.ts
+++ b/apps/web/src/components/sections-editor/use-live-meta.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { metaSourceOrder } from "./use-live-meta";
+import { KEYS } from "@/lib/query-keys";
+import { liveMetaQueryKey, metaSourceOrder } from "./use-live-meta";
 
 const PREVIEW = "https://sandbox.example.deco.host";
 const PROD = "https://www.example.com";
@@ -96,5 +97,49 @@ describe("metaSourceOrder", () => {
         fastPreviewActive: true,
       }),
     ).toEqual([{ kind: "committed" }]);
+  });
+});
+
+describe("liveMetaQueryKey", () => {
+  const params = {
+    orgSlug: "acme",
+    virtualMcpId: "vmid-1",
+    branch: "feature-branch",
+  };
+
+  // The sandbox lifecycle invalidates live meta with the (org, vmid, branch)
+  // prefix when the dev server comes up. If the head of this key ever stops
+  // matching that prefix, the invalidation silently no-ops and the CMS keeps
+  // rendering forms from the committed/production schema for the whole
+  // session — on a Deno site (no committed meta.gen.json) that means the
+  // form shows main's fields, not the branch's.
+  it("keeps KEYS.liveMeta(org, vmid, branch) as a prefix", () => {
+    const key = liveMetaQueryKey({
+      ...params,
+      previewUrl: PREVIEW,
+      productionUrl: PROD,
+    });
+    const scope = KEYS.liveMeta(
+      params.orgSlug,
+      params.virtualMcpId,
+      params.branch,
+    );
+    expect(key.slice(0, scope.length)).toEqual([...scope]);
+  });
+
+  it("keeps the prefix when no URLs are known yet", () => {
+    const key = liveMetaQueryKey(params);
+    const scope = KEYS.liveMeta(
+      params.orgSlug,
+      params.virtualMcpId,
+      params.branch,
+    );
+    expect(key.slice(0, scope.length)).toEqual([...scope]);
+  });
+
+  it("varies by URL tail so a settings edit re-fetches", () => {
+    expect(liveMetaQueryKey({ ...params, productionUrl: PROD })).not.toEqual(
+      liveMetaQueryKey({ ...params, productionUrl: "https://other.example" }),
+    );
   });
 });

--- a/apps/web/src/components/sections-editor/use-live-meta.ts
+++ b/apps/web/src/components/sections-editor/use-live-meta.ts
@@ -62,6 +62,29 @@ export function metaSourceOrder(input: {
   return sources;
 }
 
+/**
+ * Cache key for one meta read. The `(orgSlug, virtualMcpId, branch)` head is
+ * the invalidation scope — `KEYS.liveMeta(org, vmid, branch)` must stay a
+ * prefix of it, since that is how the sandbox lifecycle swaps the CMS off the
+ * committed/production schema once the dev server is up. The URL tail is what
+ * makes a settings edit re-fetch.
+ */
+export function liveMetaQueryKey(params: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  previewUrl?: string | null;
+  productionUrl?: string | null;
+}) {
+  return KEYS.liveMeta(
+    params.orgSlug,
+    params.virtualMcpId,
+    params.branch,
+    params.previewUrl ?? "",
+    params.productionUrl ?? "",
+  );
+}
+
 export function useLiveMeta(
   params: UseLiveMetaParams | null,
   options?: {
@@ -83,16 +106,8 @@ export function useLiveMeta(
   );
   const fastPreviewActive = runtime === "cms";
   return useQuery({
-    // productionUrl is appended so a settings edit re-fetches; invalidators key
-    // on the (org, vm, branch) prefix, which still matches (variadic key).
     queryKey: params
-      ? KEYS.liveMeta(
-          params.orgSlug,
-          params.virtualMcpId,
-          params.branch,
-          previewUrl ?? "",
-          productionUrl ?? "",
-        )
+      ? liveMetaQueryKey({ ...params, previewUrl, productionUrl })
       : KEYS.liveMeta(""),
     queryFn: async () => {
       const fetchMeta = async (baseUrl: string): Promise<LiveMeta | null> => {


### PR DESCRIPTION
## What is this contribution about?

Rework Jira task-board synchronization to use board issue and backlog APIs, keeping board visibility accurate while simplifying sprint handling. This removes the obsolete JQL-based scope and sprint persistence paths, updates task-board filtering and settings, and fixes live metadata invalidation when the sandbox dev server starts.

## How did you verify your code works?

- Updated task-board, sprint, Jira integration, and live-meta tests to cover the revised behavior.
- Added coverage for sprint filters, task-board configuration, task updates, and sandbox live-meta refresh behavior.
- Ran the relevant Bun test suites for the changed API, shared, and web modules.

## Screenshots/Demonstration

Not applicable; the changes do not require new UI screenshots.

## How to Test

1. Configure a Jira integration connected to a board containing active, future, closed, and backlog issues.
2. Run a Jira synchronization and open the task board.
3. Verify that visible board issues appear, backlog issues are excluded, and sprint filters reflect the available sprint data.
4. Update task-board settings and task fields, then reload the board.
5. Start the sandbox development server and verify that live metadata refreshes when the server becomes available.

## Migration Notes

No new database migration is required. Obsolete sprint and Jira-scope migrations and storage paths were removed as part of the model simplification.

## Review Checklist

- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox live-meta cache invalidation so the CMS switches to the branch's schema once the dev server is up, instead of silently serving the committed or production schema for the whole session.

**Bug Fixes**

- Replaced the hand-rolled invalidation predicate, which expected a key shape live-meta keys never had, with the `KEYS.liveMeta(org, vmid, branch)` prefix key at both invalidation sites.
- Extracted `liveMetaQueryKey` in `use-live-meta` so the key head is shared between the builder and its invalidators, and pinned the prefix contract with unit tests.
- Removed the now-unused `isLiveMetaKeyForScope` helper.

<sup>Written for commit e99e510b8fe83bdae4742efa3b0356335562d9d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

