### PR TITLE
fix(decopilot): replicate DECOPILOT_STREAMS across the RAFT cluster

### DIFF
--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts
@@ -95,6 +95,10 @@ test("decopilot stream is file-backed with a dedup window and SLA retention", ()
   expect(c.max_bytes).toBeGreaterThanOrEqual(4 * 1024 * 1024 * 1024); // >= 4GB
 });
 
+test("decopilot stream is replicated so one node loss keeps the run streaming", () => {
+  expect(decopilotStreamConfig().num_replicas).toBe(3);
+});
+
 describe("NatsStreamBuffer", () => {
   it("purge is a no-op when jsm is not initialized (no throw)", () => {
     const buffer = new NatsStreamBuffer({

--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -80,6 +80,20 @@ const MAX_AGE_NS = 24 * 60 * 60 * 1_000_000_000; // 24h — outlasts day-long ru
 // the same UI part.
 const DUPLICATE_WINDOW_NS = 2 * 60 * 1_000_000_000; // 2 min
 const MAX_BYTES = 4 * 1024 * 1024 * 1024; // 4GB stream cap
+/**
+ * RAFT replicas for `DECOPILOT_STREAMS`. At 1 the stream has no failover: the
+ * node holding it going down takes every live run's stream with it, which is
+ * how one NATS pod restart darkened chat cluster-wide on 2026-08-26. 3 matches
+ * the cluster size so a single node loss keeps quorum.
+ *
+ * Env-overridable for rollback without a deploy — `init()` applies the value
+ * through `streams.update`, and JetStream scales replicas online, so setting
+ * `DECOPILOT_STREAM_REPLICAS=1` reverts on the next pod start.
+ */
+const STREAM_REPLICAS = Math.max(
+  1,
+  Number(process.env.DECOPILOT_STREAM_REPLICAS ?? 3) || 3,
+);
 const MAX_MSGS_PER_SUBJECT = 500_000; // headroom for multi-hour non-stop streams
 
 /**
@@ -98,7 +112,7 @@ export function decopilotStreamConfig() {
     discard: DiscardPolicy.Old,
     retention: RetentionPolicy.Limits,
     duplicate_window: DUPLICATE_WINDOW_NS, // time-based Nats-Msg-Id dedup (spec §10.2)
-    num_replicas: 1,
+    num_replicas: STREAM_REPLICAS,
   };
 }
 


### PR DESCRIPTION
`DECOPILOT_STREAMS` was created with **`num_replicas: 1`** on a 3-node NATS RAFT cluster. A single-replica stream has no failover: whichever node holds it going down takes **every live run's stream** with it.

That is why one NATS pod restart on 2026-08-26 surfaced as chats hanging cluster-wide instead of a blip. Reported case: thread `9354a20c-…` (org `montecarlo`) stuck 17m on "Isso está levando mais tempo que o usual".

## Change

`num_replicas: 1` → `3`, matching the `cluster.replicas: 3` we already run. JetStream scales replicas online and `init()` already applies config via `streams.update`, so it takes effect on the next pod start — no manual stream surgery.

## On the default-off convention

CLAUDE.md asks for risky hot-path changes behind a default-off flag. I deliberately did **not** do that here: defaulting to 1 ships the outage. Instead the value is env-overridable, so rollback needs no deploy —

```
DECOPILOT_STREAM_REPLICAS=1
```

restores the old behaviour on the next pod start. Flagging the deviation explicitly rather than burying it.

## ⚠️ Land order

R3 costs more per-node memory and CPU for replication, and the three NATS nodes are currently **0.98 GiB / 0.94 CPU allocatable** (they are that small precisely because the NATS container declares no resource requests, so Karpenter provisions the minimum node). **Merge decocms/deco-apps-cd#394 first**, then this.

## Related

- decocms/studio#6597 — retry transient JetStream publish failures (the run-level recovery)
- decocms/deco-apps-cd#394 — NATS resource requests (must land first)

## Testing

`bun test apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts` → 31 pass / 0 fail, including a new assertion that the stream config is replicated.

`bun run fmt`, `bun run --cwd=apps/api check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replicates `DECOPILOT_STREAMS` across all 3 NATS cluster nodes instead of a single replica. Previously, the node holding the one replica going down took every live run's stream with it, which is why one NATS pod restart on 2026-08-26 hung chats cluster-wide.

**Rollout**
- Merge the `deco-apps-cd#394` resource requests first — replication costs extra per-node memory and CPU.
- Rollback needs no deploy: `DECOPILOT_STREAM_REPLICAS=1` reverts on the next pod start.
- Defaults to 3 replicas on purpose; defaulting to 1 would ship the outage the change fixes.

<sup>Written for commit 80c06926c441340347c488c7e34bd51f069650b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

