### PR TITLE
fix(decopilot): bound the run-scoped tool-output map at 200 entries

### DIFF
--- a/apps/api/src/harnesses/decopilot/harness-deps.ts
+++ b/apps/api/src/harnesses/decopilot/harness-deps.ts
@@ -26,6 +26,7 @@ import { assembleDecopilotTools } from "./tools";
 import { buildClusterMcpToolHooks } from "@/api/routes/decopilot/cluster-mcp-tool-hooks";
 import { createHtmlArtifactBuffer } from "./built-in-tools/vm-tools/html-artifact-buffer";
 import { createHtmlArtifactWatcher } from "./built-in-tools/vm-tools/html-artifact-watcher";
+import { createToolOutputMap } from "@/harnesses/lib/decopilot/built-in-tools/read-tool-output";
 import type { PendingImage } from "./built-in-tools";
 import type {
   DecopilotToolRuntime,
@@ -125,7 +126,7 @@ export function buildClusterEnvironmentTools(args: {
   const toolRuntime: DecopilotToolRuntime = {
     buildEnvironmentTools: async ({ input: streamInput, onChildUsage }) => {
       const runContext = requireDecopilotRunContext(streamInput);
-      const toolOutputMap = new Map<string, string>();
+      const toolOutputMap = createToolOutputMap();
       const pendingImages: PendingImage[] = [];
       const { resolveArgs, onToolCalled, onPrOpened } =
         buildClusterMcpToolHooks(ctx, streamInput.threadId);

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { MAX_TOOL_OUTPUTS, createToolOutputMap } from "./read-tool-output";
+
+describe("createToolOutputMap", () => {
+  it("stays under the cap by evicting the oldest entry", () => {
+    const map = createToolOutputMap();
+    for (let i = 0; i < MAX_TOOL_OUTPUTS + 10; i++) {
+      map.set(`call_${i}`, `output ${i}`);
+    }
+    expect(map.size).toBe(MAX_TOOL_OUTPUTS);
+    expect(map.has("call_0")).toBe(false);
+    expect(map.has(`call_${MAX_TOOL_OUTPUTS + 9}`)).toBe(true);
+  });
+
+  it("re-setting an existing key doesn't evict anything", () => {
+    const map = createToolOutputMap();
+    for (let i = 0; i < MAX_TOOL_OUTPUTS; i++) {
+      map.set(`call_${i}`, `output ${i}`);
+    }
+    map.set("call_0", "updated");
+    expect(map.size).toBe(MAX_TOOL_OUTPUTS);
+    expect(map.get("call_0")).toBe("updated");
+  });
+});

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.ts
@@ -7,6 +7,27 @@ export interface ReadToolOutputParams {
   readonly toolOutputMap: Map<string, string>;
 }
 
+/** Every tool call whose output exceeds MAX_RESULT_TOKENS gets stashed here for
+ *  the life of the run — a long-running loop with many oversized outputs (bash,
+ *  grep, MCP calls) would otherwise grow this map without bound. Cap the entry
+ *  count, evicting the oldest (Map preserves insertion order) once a new entry
+ *  would exceed it; losing read_tool_output access to a very old, already-seen
+ *  output is a fair trade for a bounded memory footprint. */
+export const MAX_TOOL_OUTPUTS = 200;
+
+export function createToolOutputMap(): Map<string, string> {
+  const map = new Map<string, string>();
+  const set = map.set.bind(map);
+  map.set = (key, value) => {
+    if (!map.has(key) && map.size >= MAX_TOOL_OUTPUTS) {
+      const oldest = map.keys().next().value;
+      if (oldest !== undefined) map.delete(oldest);
+    }
+    return set(key, value);
+  };
+  return map;
+}
+
 export function createReadToolOutputTool(params: ReadToolOutputParams) {
   const { toolOutputMap } = params;
   return tool({


### PR DESCRIPTION
**Source:** resource-bound gap found while auditing `apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/` (recently-changed area) — not tied to a specific issue, same class as the `read-tool-output.ts`/`toolOutputMap` mechanism the repo already leans on for oversized tool output.

**Why:** `toolOutputMap` is created once per run (`harness-deps.ts`, `buildEnvironmentTools`) and every tool call whose output exceeds `MAX_RESULT_TOKENS` (32k tokens, easily 100KB+ serialized) gets stashed there so `read_tool_output` can page through it later. Nothing ever removes an entry, so a long agent run that repeatedly calls `bash`/`grep`/`glob` or an MCP tool producing oversized output keeps every one of those outputs in memory for as long as the run stays open — unbounded growth on a hot, long-lived path.

**Fix:** `createToolOutputMap()` (new, in `read-tool-output.ts`) returns a `Map` capped at `MAX_TOOL_OUTPUTS` (200) entries, evicting the oldest insertion (Map preserves insertion order) once a new entry would push it over. `harness-deps.ts` — the one production call site that creates this map for a real run — now uses it instead of a bare `new Map()`. Losing `read_tool_output` access to a very old, already-consumed output is a fair trade for a bounded per-run memory footprint. Behavior is otherwise identical: `get`/`has`/`delete`/`keys` are untouched, only `set` gained the eviction check.

**Regression test:** `apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.test.ts` (new) — asserts the map stays at the cap and evicts the oldest key once exceeded, and that re-setting an existing key doesn't evict.

**Reviewer command:** `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.test.ts`

**Local checks run:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (2 pass), `bunx oxlint` on all three touched files (0 warnings/errors), plus the pre-existing `vm-tools/common.test.ts` to confirm `maybeTruncate` (the map's other writer) is unaffected. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the per-run tool output map at 200 entries so long agent runs no longer accumulate unlimited oversized tool outputs in memory.

**Bug Fixes**
- Evicts the oldest entry when a new one would exceed the cap; re-setting an existing key doesn't evict.
- Losing `read_tool_output` access to a very old, already-consumed output is the trade-off for a bounded memory footprint.

<sup>Written for commit 68be5ef5551084660990eb03a9774fe77d0395c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

