### PR TITLE
fix(decopilot): cap the fallback tool-output map used by subagents

### DIFF
--- a/apps/api/src/harnesses/decopilot/assemble-agent-tools.ts
+++ b/apps/api/src/harnesses/decopilot/assemble-agent-tools.ts
@@ -22,6 +22,7 @@ import {
   type ToolCallAnalytics,
 } from "@/harnesses/lib/decopilot/mcp-tools";
 import { MCP_TOOL_CALL_TIMEOUT_MS } from "@/harnesses/lib/decopilot/harness-constants";
+import { createToolOutputMap } from "@/harnesses/lib/decopilot/built-in-tools/read-tool-output";
 import {
   buildBuiltInTools,
   getBuiltInTools,
@@ -81,7 +82,7 @@ export interface AssembleAgentToolsResult {
 export async function assembleAgentTools(
   opts: AssembleAgentToolsOptions,
 ): Promise<AssembleAgentToolsResult> {
-  const toolOutputMap = opts.toolOutputMap ?? new Map<string, string>();
+  const toolOutputMap = opts.toolOutputMap ?? createToolOutputMap();
 
   // 1. MCP tools — truncation always on.
   const { tools: mcpTools, nameMap } = await toolsFromMCP(


### PR DESCRIPTION
Follows #6601, which capped the cluster's main-loop `toolOutputMap` at 200 entries because nothing else bounded it.

`assembleAgentTools` (`apps/api/src/harnesses/decopilot/assemble-agent-tools.ts`) has its own fallback: whenever a caller doesn't pass in a `toolOutputMap`, it builds one itself with a plain `new Map<string, string>()`. That fallback is exactly the path every subagent run takes — both interactive `subtask` delegations (`built-in-tools/subtask.ts`) and backgrounded ones (`background-tool-workflow.ts`) omit `toolOutputMap` on purpose (each subagent gets its own map), so they all hit the unbounded branch #6601 didn't touch. A subagent run with many oversized tool outputs (bash/grep/MCP calls across parallel tool calls within a step, up to `SUBAGENT_STEP_LIMIT`) grows this map without the same cap the main loop now has.

Fix: reuse the already-capped `createToolOutputMap()` helper from `read-tool-output.ts` for this fallback branch too, so subagents get the identical eviction behavior instead of a plain unbounded `Map`.

How to confirm: `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.test.ts` (the helper's own eviction test, unchanged — this PR is a one-line wiring fix reusing it) and a read of `assemble-agent-tools.ts:84`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/harnesses/decopilot/assemble-agent-tools.ts` (0 warnings/errors), and the targeted test above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the fallback tool‑output map used by subagents so it gets the same 200‑entry cap as the main‑loop map, preventing unbounded memory growth during subagent runs with many oversized tool outputs.

Subagents (interactive subtasks and backgrounded workflows) always hit the fallback path in `assembleAgentTools`; the fix reuses the existing `createToolOutputMap()` helper instead of a plain `Map`, matching the eviction behavior already applied to the main loop.

<sup>Written for commit d67227e2f2baa10d9d735b52d2fd43ab78355af8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

