### PR TITLE
fix(decofile): raise per-block cap to 1 MiB

### DIFF
--- a/apps/api/src/api/routes/decofile.ts
+++ b/apps/api/src/api/routes/decofile.ts
@@ -70,8 +70,8 @@ function isValidBranch(branch: string): boolean {
 // Bounds the tree write GitHub does for one commit.
 const MAX_PATCH_KEYS = 500;
 
-// Bounds one block's own size — a block count cap alone still lets one oversized value through.
-const MAX_BLOCK_BYTES = 256 * 1024;
+// Bounds one block's own size — fits real multivariate page blocks that inline a section tree per variant.
+const MAX_BLOCK_BYTES = 1024 * 1024;
 
 // Bounds one block key's length — a key becomes a GitHub tree path.
 const MAX_BLOCK_KEY_LENGTH = 1024;


### PR DESCRIPTION
## Summary

The `PATCH /api/:org/decofile/:virtualMcpId/:branch` endpoint caps each block at 256 KiB (`JSON.stringify(value).length`). That cap is too tight for real multivariate page blocks: a `website/pages/Page.tsx` block wraps its sections in a `website/flags/multivariate.ts` with N variants, and **each variant inlines a full copy of the page's section tree**. With ~6 variants a single page routinely serializes to 340–650 KiB.

Observed in one org (347 blocks total): **26 blocks already exceed 256 KiB** (largest 652 KiB, then 405 KiB, then a cluster at ~350 KiB). The `GET` doesn't enforce the cap, so these were already persisted — but any edit that re-saves one hits `"Each block must be at most 262144 bytes"` and the whole patch is rejected, making those pages **uneditable**.

This raises `MAX_BLOCK_BYTES` from 256 KiB → **1 MiB**, which clears all 26. A 1 MiB file is unremarkable for the underlying GitHub tree write, and the endpoint keeps its other guards:
- `MAX_PATCH_BODY_BYTES` = 8 MiB (raw body)
- `MAX_PATCH_KEYS` = 500 (blocks per patch)
- `MAX_BLOCK_KEY_LENGTH` = 1024

## Follow-up (not in this PR)

The real bloat is the multivariate variant duplication — every variant, including `always`/`never` matchers, inlines the entire section tree. Variants should `$ref` shared section blocks instead of duplicating the layout ~6×. Tracked separately as a content-model cleanup.

## Testing

- `bun run fmt` — clean
- No unit/e2e test asserts the old 256 KiB value (grepped both tiers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the per-block size cap for the decofile patch endpoint from 256 KiB to 1 MiB so multivariate page blocks that inline section trees per variant can be saved again. The old cap rejected any re-save of blocks above 256 KiB, making those pages uneditable; the new cap accommodates all currently observed blocks (largest 652 KiB).

<sup>Written for commit 51c574a946d18616990b05e82e6c90c3f81e3323. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

