### PR TITLE
feat(preview): force __deco_ssr=1 on the preview iframe

### DIFF
--- a/apps/api/src/api/routes/decofile.test.ts
+++ b/apps/api/src/api/routes/decofile.test.ts
@@ -22,7 +22,7 @@ describe("decofile patchBodySchema", () => {
   test("rejects a single block over the size cap", () => {
     // Before the fix: the key-count cap let one oversized value through.
     const result = patchBodySchema.safeParse({
-      set: { "pages/home": { html: "x".repeat(300 * 1024) } },
+      set: { "pages/home": { html: "x".repeat(2 * 1024 * 1024) } },
     });
     expect(result.success).toBe(false);
   });

--- a/apps/web/src/components/sandbox/preview/preview.test.ts
+++ b/apps/web/src/components/sandbox/preview/preview.test.ts
@@ -21,9 +21,9 @@ describe("withDecoFBT", () => {
     expect(withDecoFBT(null)).toBe(null);
   });
 
-  it("sets __decoFBT=0 on a well-formed URL", () => {
+  it("sets __decoFBT=0 and __deco_ssr=1 on a well-formed URL", () => {
     expect(withDecoFBT("https://example.com/foo")).toBe(
-      "https://example.com/foo?__decoFBT=0",
+      "https://example.com/foo?__decoFBT=0&__deco_ssr=1",
     );
   });
 

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -212,17 +212,20 @@ export function withDeviceHint(url: string, device: PreviewDeviceSize): string {
 }
 
 /**
- * Force `__decoFBT=0` on the preview URL — disables deco's loader/block-tree
- * cache so edits render immediately in the iframe (same param the "Open result
- * in new tab" invoke path sets, see `buildInvokeRunUrl`). Passes `null` through
- * so it can wrap the whole `iframeSrc` computation regardless of mode, and
- * falls back to the unmodified `url` on a malformed input instead of throwing.
+ * Force `__decoFBT=0` and `__deco_ssr=1` on the preview URL — `__decoFBT=0`
+ * disables deco's loader/block-tree cache so edits render immediately in the
+ * iframe (same param the "Open result in new tab" invoke path sets, see
+ * `buildInvokeRunUrl`); `__deco_ssr=1` forces server-side rendering for the
+ * iframe. Passes `null` through so it can wrap the whole `iframeSrc`
+ * computation regardless of mode, and falls back to the unmodified `url` on a
+ * malformed input instead of throwing.
  */
 export function withDecoFBT(url: string | null): string | null {
   if (!url) return null;
   try {
     const parsed = new URL(url, window.location.href);
     parsed.searchParams.set("__decoFBT", "0");
+    parsed.searchParams.set("__deco_ssr", "1");
     return parsed.href;
   } catch {
     return url;


### PR DESCRIPTION
## Summary

The preview iframe already forces `__decoFBT=0` (disables deco's loader/block-tree cache so edits render immediately). This adds `__deco_ssr=1` to the same iframe URL so the preview renders server-side.

Change is scoped to `withDecoFBT` in `preview.tsx`, which wraps the `iframeSrc` computation — so the iframe now loads with `?__decoFBT=0&__deco_ssr=1`.

**Not touched:** the "Open result in new tab" invoke path (`buildInvokeRunUrl` in `use-run-block.ts`) — that's a separate flow.

## Testing

- Updated `preview.test.ts` to assert both params; `bun test apps/web/src/components/sandbox/preview/preview.test.ts` → 7 pass.
- `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forces the preview iframe to render server-side by adding `__deco_ssr=1` to the iframe URL, alongside the existing `__decoFBT=0` cache-disable param; the "Open result in new tab" flow is untouched.

- Updates preview tests to assert both params.
- Bumps the `decofile` size-cap test fixture over 1 MiB to match the per-block cap raised in #6603.

<sup>Written for commit edb990be65f540cc5961180a5093677cb30bbdfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

