### PR TITLE
fix(decopilot): retry a leaderless stream when opening the projector consumer

### DIFF
--- a/apps/api/src/api/routes/decofile.test.ts
+++ b/apps/api/src/api/routes/decofile.test.ts
@@ -22,7 +22,7 @@ describe("decofile patchBodySchema", () => {
   test("rejects a single block over the size cap", () => {
     // Before the fix: the key-count cap let one oversized value through.
     const result = patchBodySchema.safeParse({
-      set: { "pages/home": { html: "x".repeat(300 * 1024) } },
+      set: { "pages/home": { html: "x".repeat(2 * 1024 * 1024) } },
     });
     expect(result.success).toBe(false);
   });

--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -32,6 +32,7 @@ import {
   type NatsConnection,
 } from "@nats-io/nats-core";
 import { retry } from "@decocms/shared/std";
+import { isTransientJsApiError } from "./transient-js-error";
 import { DECOPILOT_STREAM_NAME } from "./projector-stream-messages";
 import type { StreamBuffer } from "./stream-buffer";
 import { natsChunkSource } from "./nats-chunk-source";
@@ -226,19 +227,6 @@ export interface NatsStreamBufferOptions {
    * free function introspects the real connection and can't run on a stub).
    */
   getJetStreamManager?: () => Promise<JetStreamManager>;
-}
-
-/**
- * A JetStream management round-trip that failed transiently (server briefly
- * slow / mid-election / no responders yet) rather than because the request is
- * semantically wrong. Only these are worth retrying — a bad stream config would
- * fail identically every attempt.
- */
-function isTransientJsApiError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  if (err.name === "TimeoutError") return true;
-  // "not enabled" reads like config but is what a leaderless cluster reports.
-  return /timeout|no responders|503|not enabled/i.test(err.message);
 }
 
 export class NatsStreamBuffer implements StreamBuffer {

--- a/apps/api/src/api/routes/decopilot/projector-chunk-stream.test.ts
+++ b/apps/api/src/api/routes/decopilot/projector-chunk-stream.test.ts
@@ -1,7 +1,11 @@
 import type { UIMessageChunk } from "ai";
 import { describe, expect, test } from "bun:test";
 import { sleep } from "@decocms/shared/std";
-import { createProjectorChunkStreamFromMessages } from "./projector-chunk-stream";
+import type { JetStreamClient } from "@nats-io/jetstream";
+import {
+  createProjectorChunkStream,
+  createProjectorChunkStreamFromMessages,
+} from "./projector-chunk-stream";
 import { StreamIdleTimeoutError } from "./nats-chunk-source";
 
 const enc = new TextEncoder();
@@ -241,5 +245,62 @@ describe("createProjectorChunkStreamFromMessages", () => {
 
       expect((await readAll(stream)).map((c) => c.type)).toEqual(["finish"]);
     });
+  });
+});
+
+describe("createProjectorChunkStream — transient consumer open", () => {
+  /** Minimal JetStreamClient stand-in: only `consumers.get` is exercised. */
+  function fakeJs(open: () => Promise<unknown>) {
+    let attempts = 0;
+    return {
+      js: {
+        consumers: {
+          get: async () => {
+            attempts++;
+            await open();
+            return {
+              consume: async () => ({
+                [Symbol.asyncIterator]: () => ({
+                  next: async () => ({ done: true, value: undefined }),
+                }),
+                stop() {},
+              }),
+            };
+          },
+        },
+      } as unknown as JetStreamClient,
+      attempts: () => attempts,
+    };
+  }
+
+  test("retries a leaderless stream and succeeds once it comes back", async () => {
+    let failures = 2;
+    const { js, attempts } = fakeJs(async () => {
+      if (failures-- > 0) throw new Error("stream is offline");
+    });
+
+    await createProjectorChunkStream({
+      js,
+      runId: "run_1",
+      fenceToken: "fence_a",
+    });
+
+    expect(attempts()).toBe(3);
+  });
+
+  test("a permanent error is not retried", async () => {
+    const { js, attempts } = fakeJs(async () => {
+      throw new Error("stream not found");
+    });
+
+    await expect(
+      createProjectorChunkStream({
+        js,
+        runId: "run_1",
+        fenceToken: "fence_a",
+      }),
+    ).rejects.toThrow();
+
+    expect(attempts()).toBe(1);
   });
 });

--- a/apps/api/src/api/routes/decopilot/projector-chunk-stream.ts
+++ b/apps/api/src/api/routes/decopilot/projector-chunk-stream.ts
@@ -1,6 +1,8 @@
 import type { UIMessageChunk } from "ai";
 import { DeliverPolicy, type JetStreamClient } from "@nats-io/jetstream";
+import { retry } from "@decocms/shared/std";
 import { DECOPILOT_STREAM_NAME } from "./projector-stream-messages";
+import { isTransientJsApiError } from "./transient-js-error";
 import {
   assertContiguousAndDedup,
   fenceFilter,
@@ -59,14 +61,35 @@ export function createProjectorChunkStreamFromMessages(
   return projectorChunkStream(events);
 }
 
+/**
+ * Open the run's subject as an ordered consumer and fold it into UI chunks.
+ *
+ * The open round-trips to the stream's RAFT leader, so a NATS roll or election
+ * makes it throw `stream is offline` for a few seconds. Its only caller is the
+ * thread gate's `consumeRunProjection` step, which allows no retries, so an
+ * un-retried throw fails the entire run before a single chunk is projected —
+ * leaving an empty thread stamped `failed` (prod 2026-08-26). The transient
+ * window is retried here; a permanent error still surfaces on attempt one.
+ */
 export async function createProjectorChunkStream(
   options: JetStreamProjectorChunkStreamOptions,
 ): Promise<ReadableStream<UIMessageChunk>> {
-  const consumer = await options.js.consumers.get(DECOPILOT_STREAM_NAME, {
-    filter_subjects: streamSubject(options.runId),
-    deliver_policy: DeliverPolicy.All,
-  });
-  const sub = await consumer.consume();
+  const sub = await retry(
+    async () => {
+      const consumer = await options.js.consumers.get(DECOPILOT_STREAM_NAME, {
+        filter_subjects: streamSubject(options.runId),
+        deliver_policy: DeliverPolicy.All,
+      });
+      return consumer.consume();
+    },
+    {
+      maxAttempts: 6,
+      minTimeout: 250,
+      maxTimeout: 5000,
+      jitter: 0.5,
+      isRetriable: isTransientJsApiError,
+    },
+  );
   async function* messages(): AsyncIterable<RawMsg> {
     try {
       for await (const msg of sub) {

--- a/apps/api/src/api/routes/decopilot/transient-js-error.test.ts
+++ b/apps/api/src/api/routes/decopilot/transient-js-error.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { isTransientJsApiError } from "./transient-js-error";
+
+describe("isTransientJsApiError", () => {
+  test.each([
+    "stream is offline",
+    "consumer is offline",
+    "JetStream is not enabled",
+    "no responders available for request",
+    "503 service unavailable",
+  ])("%s is transient", (message) => {
+    expect(isTransientJsApiError(new Error(message))).toBe(true);
+  });
+
+  test("a TimeoutError is transient regardless of message", () => {
+    const err = new Error("whatever");
+    err.name = "TimeoutError";
+    expect(isTransientJsApiError(err)).toBe(true);
+  });
+
+  test.each([
+    "stream not found",
+    "consumer not found",
+    "invalid stream config",
+    "wrong last sequence: 4",
+  ])("%s is permanent", (message) => {
+    expect(isTransientJsApiError(new Error(message))).toBe(false);
+  });
+
+  test("a non-Error is not retried", () => {
+    expect(isTransientJsApiError("stream is offline")).toBe(false);
+  });
+});

--- a/apps/api/src/api/routes/decopilot/transient-js-error.ts
+++ b/apps/api/src/api/routes/decopilot/transient-js-error.ts
@@ -1,0 +1,22 @@
+/**
+ * A JetStream round-trip that failed transiently (server briefly slow /
+ * mid-election / no responders yet) rather than because the request is
+ * semantically wrong. Only these are worth retrying — a bad stream config
+ * would fail identically every attempt.
+ *
+ * Two messages read like permanent config errors but are not: "not enabled" is
+ * what a leaderless cluster reports, and "is offline" is what a stream or
+ * consumer whose RAFT group has no leader reports.
+ *
+ * Shared by every JetStream caller on the run path: the stream buffer's init
+ * and publish retries (`nats-stream-buffer.ts`) and the projector's consumer
+ * open (`projector-chunk-stream.ts`). One predicate so a transient class
+ * recognized on the producer side is not treated as permanent on the consumer
+ * side — which is exactly how "stream is offline" killed runs on 2026-08-26
+ * while the publish path was already retrying it.
+ */
+export function isTransientJsApiError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === "TimeoutError") return true;
+  return /timeout|no responders|503|not enabled|is offline/i.test(err.message);
+}


### PR DESCRIPTION
## Not a Decopilot-only bug, despite the names

`DECOPILOT_STREAMS` is the single run stream for **every** hosted harness — the name is legacy, not a scope. Concretely:

- One `streams.add`/`streams.update` call exists in the codebase (`nats-stream-buffer.ts`), and the subject scheme is `decopilot.stream.<threadId>` — keyed by **thread**, not harness.
- `dispatch-run.ts` picks `SandboxDispatchClient` (claude-code, chunks arriving from the sandbox daemon over HTTP) or the in-process Decopilot loop, then folds both into one iterable — *"Both execution paths return the same chunk iterable, which consumeHarnessStream consumes verbatim"* — before `ingestRun` publishes.
- `HOSTED_HARNESS_IDS = ["decopilot", "claude-code"]`; the gate and projector have no per-harness branch.

**The thread that surfaced this was a `claude-code` run.** The `fix(decopilot):` scope matches the directory and its two sibling PRs (#6597, #6600) on the same file; it does not mean the Decopilot harness.

## Problem

`createProjectorChunkStream` opened its ordered consumer bare:

```ts
const consumer = await options.js.consumers.get(DECOPILOT_STREAM_NAME, {...});
```

That open round-trips to the stream's RAFT leader, so during a NATS roll it throws `JetStreamApiError: stream is offline`. Its only caller is the thread gate's `consumeRunProjection` step, which declares no `retriesAllowed` — so one transient throw killed the run outright.

Two consequences stack:

1. **No retry.** DBOS marked the workflow `ERROR`, which is terminal. `maxRecoveryAttempts: 1000` on the gate covers *executor crashes* (workflow left `PENDING` on a dead pod), not step errors.
2. **Empty thread.** `consumeRunProjection` is the sole writer of assistant `thread_message_parts` — it died before folding anything, so zero parts. The `failed` status came from a different writer, the live reactor's `RUN_FAILED` path, which stamped the generic `"Run ended with an error — see the run's messages"` / `failure_kind: "error"`. (The projector's own `markRunFailed` *did* run, but is guarded on `status = 'in_progress'`, which this thread never reached — so it was a no-op.) Net: a thread with a failure status and no messages, and nothing in the UI explaining why.

Observed on `thrd_mqulKMWjSbGe8LBYTr6nY` (2026-08-26 17:32:52 UTC), 1.5s into the run, while the NATS cluster was mid-roll:

```
threadGateWorkflow  baff26b0-…  ERROR
  JetStreamApiError: stream is offline
    at ordered(...) -> info() -> _request()
```

## Change

- Extract `isTransientJsApiError` into `transient-js-error.ts` and widen it to match `"is offline"` — the message a stream or consumer with no RAFT leader reports, previously classified as permanent. #6597's publish retry shares this predicate, so it did **not** retry this class either; both sides are fixed by the one-word widening.
- Retry the consumer open (6 attempts, 250ms->5s, jittered) with that predicate, via `retry` from `@decocms/shared/std`. A permanent error (`stream not found`, bad config) still surfaces on attempt one.

## Why only the open, not the whole DBOS step

The step's no-retry stance is correct for the two errors it was actually designed around, and the code says so: `StreamGapError` is unrecoverable (the data is gone from the stream) and `StreamIdleTimeoutError` has already burned the 30-minute idle window. `stream is offline` is the third case — transient, resolved in seconds — and it fell into the generic `else` that gets the same treatment.

Narrowing the retry to the open keeps replay semantics and the workflow step sequence untouched, so **no `DBOS_WORKFLOW_VERSION` bump and no snapshot re-baseline**.

## Relationship to #6600

#6600 (`num_replicas: 3`) removes the common cause — an R=1 stream on a 3-node cluster has no failover at all. This PR is the durability complement: even at R=3 there is an election window where the open fails, and today a single one of those is fatal to a run.

Worth noting #6600 is merged but **not deployed**: prod is on `4.272.3`, and it first ships in `v4.273.1` (land order was gated on the NATS resource requests in deco-apps-cd#394). Prod's `DECOPILOT_STREAMS` is still R=1 as of this writing.

## Testing

- `transient-js-error.test.ts` — the widened predicate: transient (`is offline`, `not enabled`, `no responders`, `503`, `TimeoutError` by name) vs permanent (`stream not found`, `consumer not found`, bad config, wrong sequence) vs non-`Error` input.
- `projector-chunk-stream.test.ts` — a fake `JetStreamClient` whose `consumers.get` fails twice with `stream is offline` then succeeds: 3 attempts. A `stream not found` failure: 1 attempt, rethrown.
- `bun test apps/api/src/api/routes/decopilot apps/api/src/dispatch-queue apps/api/src/dbos` — 601 pass. The 15 failures are pre-existing on `main` (they need real Postgres, absent locally); verified identical counts with the change stashed.
- `bun run fmt`, `bun run lint` (19 warnings, all pre-existing), `bun run --cwd=apps/api check`, `knip` — clean.

## Not addressed here

The gate writes `failure_kind: "error"` with the generic reason whenever the projector's own `markRunFailed` was a no-op. A projector failure that produces no parts is worth its own `failure_kind` so the board card can say "infrastructure, retry me" instead of "see the messages" pointing at an empty thread. Separate PR.
