### PR TITLE
fix(sections-editor): drop the standalone nested-section breadcrumb crumb

### DIFF
--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -12,6 +12,7 @@ import {
   isArrayDrillDownField,
   normalizeBreadcrumbLabel,
   prependCrumbIfAbsent,
+  recordContainerOwner,
   siblingsNeedingAncestorCrumb,
   resolveActiveFieldKey,
   resolveArrayItemSelection,
@@ -130,6 +131,61 @@ describe("prependCrumbIfAbsent", () => {
     const trail = ["café", "Free shipping"];
     // Same crumb in composed form must be recognized as already present.
     expect(prependCrumbIfAbsent("café", trail)).toBe(trail);
+  });
+});
+
+describe("recordContainerOwner", () => {
+  test("prepends the container key to an item crumb's ownerPath, no visible crumb", () => {
+    const trail: Crumb[] = [{ label: "CASA5", itemIndex: 0 }];
+    expect(recordContainerOwner("children", trail)).toEqual([
+      { label: "CASA5", itemIndex: 0, ownerPath: ["children"] },
+    ]);
+  });
+
+  test("preserves the item crumb's other fields", () => {
+    const trail: Crumb[] = [
+      {
+        label: "CASA5",
+        itemIndex: 2,
+        arrayLabel: "Cupons da PDP",
+        fieldKey: "pdpCupons",
+      },
+    ];
+    expect(recordContainerOwner("children", trail)).toEqual([
+      {
+        label: "CASA5",
+        itemIndex: 2,
+        arrayLabel: "Cupons da PDP",
+        fieldKey: "pdpCupons",
+        ownerPath: ["children"],
+      },
+    ]);
+  });
+
+  test("leaves plain string crumbs untouched", () => {
+    const trail: Crumb[] = ["Some Object", { label: "CASA5", itemIndex: 0 }];
+    expect(recordContainerOwner("children", trail)).toEqual([
+      "Some Object",
+      { label: "CASA5", itemIndex: 0, ownerPath: ["children"] },
+    ]);
+  });
+
+  test("is idempotent — re-stamping the same head container is a no-op", () => {
+    const trail: Crumb[] = [
+      { label: "CASA5", itemIndex: 0, ownerPath: ["children"] },
+    ];
+    const once = recordContainerOwner("children", trail);
+    expect(once[0]).toEqual(trail[0]!);
+  });
+
+  test("nests outermost-first as the trail bubbles up through containers", () => {
+    const inner = recordContainerOwner("inner", [
+      { label: "CASA5", itemIndex: 0 },
+    ]);
+    const outer = recordContainerOwner("outer", inner);
+    expect(outer).toEqual([
+      { label: "CASA5", itemIndex: 0, ownerPath: ["outer", "inner"] },
+    ]);
   });
 });
 
@@ -797,6 +853,12 @@ describe("resolveActiveFieldKey", () => {
         crumb,
       ]),
     ).not.toBe("fallback");
+    // Structural ownership (what the editor now stamps): resolves to `children` by KEY alone — no visible "Children" crumb, no meta, no title heuristic.
+    expect(
+      resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
+        { label: couponUrl, itemIndex: 0, ownerPath: ["children"] },
+      ]),
+    ).toBe("children");
   });
 
   test("narrows to a PLP loader whose selectedFacets[] item is labelled by key", () => {
@@ -920,7 +982,18 @@ describe("resolveActiveFieldKey", () => {
         { label: "category-1", itemIndex: 0 },
       ]),
     ).toBeNull();
-    // The ancestor crumb (stamped by siblingsNeedingAncestorCrumb) pins the owner.
+    // Structural `ownerPath` (recordContainerOwner) pins the owner by KEY, invisibly.
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, [
+        { label: "category-1", itemIndex: 0, ownerPath: ["page"] },
+      ]),
+    ).toBe("page");
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, [
+        { label: "category-1", itemIndex: 0, ownerPath: ["RangePriceProps"] },
+      ]),
+    ).toBe("RangePriceProps");
+    // A legacy VISIBLE ancestor crumb still resolves (back-compat for persisted trails).
     expect(
       resolveActiveFieldKey(keys, properties, objValue, [
         "Page",

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -859,6 +859,32 @@ describe("resolveActiveFieldKey", () => {
         { label: couponUrl, itemIndex: 0, ownerPath: ["children"] },
       ]),
     ).toBe("children");
+    // Collision guard: a deeper container key that also names a sibling here makes ownership ambiguous. `fallback` is FIRST in key order, so a naive first-match fast-path would wrongly pick it; the guard must fall through so the schema owner still pins `children` via meta.
+    const collidingProps = {
+      fallback: properties.fallback,
+      children: properties.children,
+    };
+    const collidingValue = {
+      fallback: objValue.fallback,
+      children: objValue.children,
+    };
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(collidingProps),
+        collidingProps,
+        collidingValue,
+        [
+          {
+            label: couponUrl,
+            itemIndex: 0,
+            arrayLabel: "Cupons da PDP",
+            ownerPath: ["children", "fallback"],
+          },
+        ],
+        undefined,
+        meta,
+      ),
+    ).toBe("children");
   });
 
   test("narrows to a PLP loader whose selectedFacets[] item is labelled by key", () => {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -30,6 +30,17 @@ interface ItemCrumb {
   arrayLabel?: string;
   /** The array's own property key, recorded at drill-in for exact ownership resolution (no label guessing). */
   fieldKey?: string;
+  /**
+   * The chain of block-ref (section/loader) CONTAINER keys this item lives
+   * inside, outermost first — recorded as the trail bubbles up through each
+   * confusable container ({@link recordContainerOwner}). It's the block-ref
+   * analogue of {@link arrayLabel}: an INVISIBLE structural disambiguator that
+   * rides on the item crumb instead of a standalone "Children"-style crumb, so
+   * two sibling sections (e.g. `children` = MountedPDP vs `fallback` = NotFound)
+   * resolve deterministically by KEY — no schema-title/value guessing — and
+   * WITHOUT an extra navigation stop the user must click back through.
+   */
+  ownerPath?: string[];
 }
 
 export type Crumb = string | ItemCrumb;
@@ -52,6 +63,11 @@ function crumbArrayLabel(crumb: Crumb): string | undefined {
 /** The array's own property key recorded on an item crumb at drill-in, if any. */
 function crumbFieldKey(crumb: Crumb): string | undefined {
   return isItemCrumb(crumb) ? crumb.fieldKey : undefined;
+}
+
+/** The block-ref container ownership chain recorded on an item crumb, if any. */
+function crumbOwnerPath(crumb: Crumb): string[] | undefined {
+  return isItemCrumb(crumb) ? crumb.ownerPath : undefined;
 }
 
 /**
@@ -97,6 +113,33 @@ export function prependCrumbIfAbsent(label: string, trail: Crumb[]): Crumb[] {
     return trail;
   }
   return [label, ...trail];
+}
+
+/**
+ * Record `containerKey` as the block-ref CONTAINER that owns every array item in
+ * `trail`, by prepending it to each item crumb's {@link ItemCrumb.ownerPath}. Used
+ * in place of {@link prependCrumbIfAbsent} for block-ref (section/loader) fields:
+ * where {@link prependCrumbIfAbsent} stamps a VISIBLE ancestor crumb the user has
+ * to click back through, this hangs the same ownership signal on the item crumb
+ * INVISIBLY (like `arrayLabel`), so the trail flattens to `[section, item]` and
+ * back from the item lands on the parent section, never on a bare nested-section
+ * stop.
+ *
+ * Prepend keeps the chain outermost-first as the trail bubbles up through nested
+ * containers; it's idempotent per key (re-stamping on a maintenance render — the
+ * item crumb already names this container at the head — is a no-op), so it never
+ * duplicates. Plain string crumbs pass through untouched.
+ */
+export function recordContainerOwner(
+  containerKey: string,
+  trail: Crumb[],
+): Crumb[] {
+  return trail.map((crumb) => {
+    if (!isItemCrumb(crumb)) return crumb;
+    const owner = crumb.ownerPath ?? [];
+    if (owner[0] === containerKey) return crumb;
+    return { ...crumb, ownerPath: [containerKey, ...owner] };
+  });
 }
 
 function labelsMatch(a: string, b: string): boolean {
@@ -558,6 +601,15 @@ function resolveActiveFieldKeyInScope(
       const schema = properties[key];
       if (!schema || !isArrayDrillDownField(schema, objValue[key])) continue;
       if (key === headFieldKey) return key;
+    }
+  }
+
+  // Structural block-ref fast-path: an item carries its section container's key in `ownerPath` (see recordContainerOwner), so the owning block-ref resolves by exact key — the invisible replacement for the old standalone ancestor crumb. One sibling per level can be in the chain, so a match is unambiguous; older crumbs without it fall through to the heuristics below.
+  const owners = breadcrumbPath.flatMap((crumb) => crumbOwnerPath(crumb) ?? []);
+  if (owners.length > 0) {
+    for (const key of keys) {
+      if (properties[key]?.type !== "block-ref") continue;
+      if (owners.includes(key)) return key;
     }
   }
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -604,13 +604,13 @@ function resolveActiveFieldKeyInScope(
     }
   }
 
-  // Structural block-ref fast-path: an item carries its section container's key in `ownerPath` (see recordContainerOwner), so the owning block-ref resolves by exact key — the invisible replacement for the old standalone ancestor crumb. One sibling per level can be in the chain, so a match is unambiguous; older crumbs without it fall through to the heuristics below.
+  // Structural block-ref fast-path: an item carries its section container's key in `ownerPath` (see recordContainerOwner), so the owning block-ref resolves by exact key — the invisible replacement for the old standalone ancestor crumb. Only ONE of this scope's block-refs can legitimately be an owner (an item lives in one container); if a deeper container's key collides with a sibling's here, resolution is ambiguous, so fall through to the heuristics rather than guess by key order. Older crumbs without ownerPath fall through too.
   const owners = breadcrumbPath.flatMap((crumb) => crumbOwnerPath(crumb) ?? []);
   if (owners.length > 0) {
-    for (const key of keys) {
-      if (properties[key]?.type !== "block-ref") continue;
-      if (owners.includes(key)) return key;
-    }
+    const ownedHere = keys.filter(
+      (key) => properties[key]?.type === "block-ref" && owners.includes(key),
+    );
+    if (ownedHere.length === 1) return ownedHere[0]!;
   }
 
   for (const key of keys) {

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -32,6 +32,7 @@ import {
   fieldDisplayLabel,
   isArrayDrillDownField,
   prependCrumbIfAbsent,
+  recordContainerOwner,
   siblingsNeedingAncestorCrumb,
   resolveActiveFieldKey,
   siblingFieldLabel,
@@ -636,10 +637,14 @@ export function SchemaForm({
         const needsAncestorCrumb =
           collidesWithSibling ||
           (consumedPrefix.length === 0 && ancestorCrumbSiblings.has(key));
+        // A block-ref container records ownership structurally on the item crumb (invisible, no back-through stop); object siblings keep the visible label crumb.
         const fieldOnBreadcrumbChangeForKey =
           needsAncestorCrumb && fieldOnBreadcrumbChange
-            ? (next: Crumb[]) =>
-                fieldOnBreadcrumbChange(prependCrumbIfAbsent(label, next))
+            ? propSchema.type === "block-ref"
+              ? (next: Crumb[]) =>
+                  fieldOnBreadcrumbChange(recordContainerOwner(key, next))
+              : (next: Crumb[]) =>
+                  fieldOnBreadcrumbChange(prependCrumbIfAbsent(label, next))
             : fieldOnBreadcrumbChange;
 
         return renderField({


### PR DESCRIPTION
## Summary

Drilling into an array item inside a **block-ref section container** stamped a standalone, clickable ancestor crumb (e.g. `NotFoundChallenge › Children › ‹coupon›`). That crumb existed **only** so the resolver could tell two sibling sections apart (casaevideo `NotFoundChallenge`: `children` = `MountedPDP.pdpCupons` beside `fallback` = `NotFound.categories`) — but it turned into a navigation stop, so clicking **back** landed the user on an isolated nested-section block, which reads as strange (the nested section is already shown inline in its parent).

This replaces the **visible string crumb** with an **invisible structural disambiguator** carried on the item crumb — the real "Phase 2" of the strangler-fig fix started in #6346. It's the block-ref analogue of the `arrayLabel` fold that arrays already use.

## What changed

- **`schema-form-breadcrumb.ts`**
  - `ItemCrumb` gains `ownerPath?: string[]` — the outermost-first chain of block-ref container keys the item lives inside.
  - New `recordContainerOwner(key, trail)` prepends a container key to each item crumb's `ownerPath` (idempotent, dedup at head; string crumbs untouched).
  - Resolver gets an `ownerPath` fast-path: a block-ref whose key is in the chain wins by **exact key** — deterministic, no schema-title/value guessing. One container per level ⇒ unambiguous.
- **`schema-form.tsx`** — block-ref (`type === "block-ref"`) container fields route to `recordContainerOwner` (invisible) instead of `prependCrumbIfAbsent`. **Object siblings keep the visible label crumb** (unchanged).
- Back-compat kept: `blockRefSchemaOwnsArrayLabel` (#6337) and the string-crumb resolver path still resolve legacy/persisted trails.

## Result

- The standalone nested-section crumb is **gone** — the trail flattens to `[section, item]`.
- **Back** from the item lands on the parent section, never on a bare nested-section stop.
- Sibling-section ownership is now resolved **by structural key**, which is more robust than the previous title/value heuristics.

## Testing

- `bun test apps/web/src/components/sections-editor/` — **727 pass, 0 fail** (100 in the breadcrumb file).
  - Added `recordContainerOwner` unit tests (prepend, field preservation, string pass-through, idempotence, nested order).
  - Added `ownerPath` resolution assertions to the exact casaevideo `NotFoundChallenge` fixture and the montecarlo `page`/`RangePriceProps` fixture (identical data-derived labels — proves the disambiguator is load-bearing).
  - **Inverted** the test that encoded the old visible-crumb behavior to assert structural ownership, keeping the legacy string-crumb path as a back-compat assertion.
- `bun run check` (typecheck) clean · `bun run fmt`/`lint` clean (0 errors).

## Notes / follow-up

- **Object siblings** (`shelfProps`/`shelfPropsOffer`) still use the visible string crumb. Giving them `ownerPath` too would let us delete the remaining label-guessing + `blockRefSchemaOwnsArrayLabel` — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drilling into an array item inside a `block-ref` section container no longer stamps a clickable ancestor crumb — the trail now flattens to `[section, item]`, so back from the item lands on the parent section instead of a bare nested-section stop.

- Ownership is carried invisibly on the item crumb via an `ownerPath` key chain, the block-ref analogue of `arrayLabel`.
- The resolver picks the owning block-ref by exact key, but only when the chain names exactly one block-ref at that scope; key collisions fall through to the schema-pinned heuristics instead of guessing by key order.
- Object siblings keep the visible label crumb; legacy string-crumb trails still resolve for back-compat.

<sup>Written for commit f6c2c7e2439b0fad98ad7d62a953527962ac285b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

