### PR TITLE
feat(settings): move the Claude Code toggle to General

### DIFF
--- a/apps/web/src/components/settings/review-settings.tsx
+++ b/apps/web/src/components/settings/review-settings.tsx
@@ -86,6 +86,20 @@ export function AgentToolsSettings() {
           titleKey="settings.agentTools.orgMcpsTitle"
           descriptionKey="settings.agentTools.orgMcpsDescription"
         />
+      </SettingsCard>
+    </SettingsSection>
+  );
+}
+
+/**
+ * Which coding agent backs Code Agent chats. Lives on General, not the board
+ * settings: it's about the org's agents, not about how tasks get reviewed.
+ */
+export function CodeAgentsSettings() {
+  const t = useT();
+  return (
+    <SettingsSection title={t("sidebar.agentsSection.codeAgents")}>
+      <SettingsCard>
         <FlagToggle
           flag="coding_agents_claude_code"
           icon={<Terminal size={16} />}

--- a/apps/web/src/views/settings/org-general.tsx
+++ b/apps/web/src/views/settings/org-general.tsx
@@ -2,6 +2,7 @@ import { Page } from "@/components/page";
 import { ConnectBanner } from "@/components/connect/connect-banner";
 import { OrganizationForm } from "@/components/settings/organization-form";
 import { MainAgentSettings } from "@/components/settings/main-agent-settings";
+import { CodeAgentsSettings } from "@/components/settings/review-settings";
 import { NavigationSettings } from "@/components/settings/navigation-settings";
 import { DomainSettings } from "@/components/settings/domain-settings";
 import { DeleteOrganizationSection } from "@/components/settings/delete-organization-section";
@@ -19,6 +20,7 @@ export function OrgGeneralPage() {
             <ConnectBanner />
             <OrganizationForm />
             <MainAgentSettings />
+            <CodeAgentsSettings />
             <NavigationSettings />
             <DomainSettings />
             <DeleteOrganizationSection />


### PR DESCRIPTION
The "Run Code Agent chats with Claude Code" toggle sat under board/task settings next to the reviewer flags, but it's an org-agent setting, not a review one. Moved it to Settings → General as its own "Code Agents" section; `coding_agent_org_mcps` stays on the tasks page.

No new i18n keys (reuses the existing toggle copy + `sidebar.agentsSection.codeAgents` for the section title).

Testing: `bun run check`, `bun run fmt`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the Claude Code agent toggle from board/task settings to Settings → General, where it belongs as an org-agent setting.

- The toggle now appears under a new "Code Agents" section in Settings → General.
- `coding_agent_org_mcps` stays on the tasks page.
- Reuses existing i18n keys, so no new translations are added.

<sup>Written for commit 8d9bb124670b858b4c29ed6e45138b9b38c69f7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

