### PR TITLE
fix(claude-code): mount the agent's own connections on a Code Agent chat

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -10,6 +10,7 @@ import {
   harnessRunsInSandbox,
   isRunSuperseded,
   isStudioOwnedConnection,
+  selectRunConnections,
   isUnreachableStatus,
   ndjsonLines,
   pushSandboxEnv,
@@ -57,6 +58,49 @@ describe("isStudioOwnedConnection", () => {
 
   test("does not exclude a real user-configured connection", () => {
     expect(isStudioOwnedConnection(orgId, "conn_abc123")).toBe(false);
+  });
+});
+
+describe("selectRunConnections", () => {
+  const organizationId = "org_1";
+  const connections = [
+    { id: "conn_github", status: "active" },
+    { id: "conn_vtex", status: "active" },
+    { id: "conn_broken", status: "error" },
+    { id: WellKnownOrgMCPId.SELF(organizationId), status: "active" },
+  ];
+
+  test("mounts the agent's own connections without the org-wide flag", () => {
+    expect(
+      selectRunConnections({
+        organizationId,
+        orgWide: false,
+        ownIds: new Set(["conn_github", "conn_broken"]),
+        connections,
+      }).map((c) => c.id),
+    ).toEqual(["conn_github"]);
+  });
+
+  test("mounts nothing when the agent aggregates nothing and the org opted out", () => {
+    expect(
+      selectRunConnections({
+        organizationId,
+        orgWide: false,
+        ownIds: new Set<string>(),
+        connections,
+      }),
+    ).toEqual([]);
+  });
+
+  test("the org-wide flag adds the rest, minus Studio's own and erroring ones", () => {
+    expect(
+      selectRunConnections({
+        organizationId,
+        orgWide: true,
+        ownIds: new Set<string>(),
+        connections,
+      }).map((c) => c.id),
+    ).toEqual(["conn_github", "conn_vtex"]);
   });
 });
 

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -306,12 +306,13 @@ export class SandboxDispatchClient {
 
   /**
    * The MCP surfaces one run gets: its own narrow Studio endpoint (`mcp`), plus
-   * — when the org opted in — every MCP connection in the org as its own server
-   * (`orgMcps`).
+   * the connections it mounts as servers of their own (`orgMcps`) — the agent's
+   * own aggregations always, the rest of the org's behind a flag. See
+   * {@link orgMcpConnections}.
    *
-   * Behind a flag because it is unbounded: each connection is one more server
-   * the harness connects to, and nothing here knows whether an org has three
-   * connections or thirty.
+   * The org-wide half is flagged because it is unbounded: each connection is one
+   * more server the harness connects to, and nothing here knows whether an org
+   * has three connections or thirty.
    *
    * The connections are resolved BEFORE the key is minted, because they are
    * part of its scope: every proxied tool call is authorized as
@@ -415,27 +416,46 @@ export class SandboxDispatchClient {
   }
 
   /**
-   * The org connections this run mounts, or none when the org has not opted in
-   * (or has no slug, without which the per-connection URL cannot be built).
+   * The connections this run mounts: the ones aggregated ON THE AGENT always,
+   * plus every other MCP connection in the org when it opted in
+   * (`coding_agent_org_mcps`). None without a slug, without which the
+   * per-connection URL cannot be built.
+   *
+   * The agent's own half is not flag-gated because it is not a fan-out: those
+   * connections are exactly what someone attached to this agent, and they are
+   * the toolset its chats had on hosted Decopilot (whose surface IS the agent's
+   * virtual MCP). This harness points at the narrow `task-run` surface instead,
+   * so without them a Code Agent chat lost every tool the agent was configured
+   * with — its GitHub MCP included.
    */
   private async orgMcpConnections(organization: {
     id: string;
     slug?: string;
   }): Promise<ConnectionEntity[]> {
     if (!organization.slug) return [];
-    const settings = await this.ctx.storage.organizationSettings.get(
-      organization.id,
+    const [settings, agent] = await Promise.all([
+      this.ctx.storage.organizationSettings.get(organization.id),
+      // Never throws the run: the synthetic super-agent has no row, and an
+      // unreadable one only costs this run its agent-attached tools.
+      this.ctx.storage.virtualMcps
+        .findById(this.virtualMcpId)
+        .catch(() => null),
+    ]);
+    const orgWide = orgFlagEnabled(settings?.flags, "coding_agent_org_mcps");
+    const ownIds = new Set(
+      (agent?.connections ?? []).map(
+        (aggregation) => aggregation.connection_id,
+      ),
     );
-    if (!orgFlagEnabled(settings?.flags, "coding_agent_org_mcps")) return [];
+    if (!orgWide && ownIds.size === 0) return [];
     // `list` excludes VIRTUAL connections (agents, not MCP servers) by default.
     const { items } = await this.ctx.storage.connections.list(organization.id);
-    return items.filter(
-      (connection) =>
-        // A connection Studio already knows is erroring only costs the session
-        // a failed connect at startup.
-        connection.status === "active" &&
-        !isStudioOwnedConnection(organization.id, connection.id),
-    );
+    return selectRunConnections({
+      organizationId: organization.id,
+      orgWide,
+      ownIds,
+      connections: items,
+    });
   }
 
   private async *stream(
@@ -1070,6 +1090,30 @@ export async function* ndjsonLines(
  * not something a coding agent should be handed. What the user actually
  * connected is everything else.
  */
+/**
+ * Which of the org's connections a run mounts. Pure — the flag/aggregation
+ * branch is the whole behaviour, so it is what the unit test pins.
+ */
+export function selectRunConnections<
+  T extends { id: string; status?: string | null },
+>(args: {
+  organizationId: string;
+  /** The org opted into every connection (`coding_agent_org_mcps`). */
+  orgWide: boolean;
+  /** Connections aggregated on the agent itself; always mounted. */
+  ownIds: ReadonlySet<string>;
+  connections: readonly T[];
+}): T[] {
+  return args.connections.filter(
+    (connection) =>
+      (args.orgWide || args.ownIds.has(connection.id)) &&
+      // A connection Studio already knows is erroring only costs the session
+      // a failed connect at startup.
+      connection.status === "active" &&
+      !isStudioOwnedConnection(args.organizationId, connection.id),
+  );
+}
+
 export function isStudioOwnedConnection(
   organizationId: string,
   connectionId: string,

--- a/apps/web/src/components/settings/review-settings.tsx
+++ b/apps/web/src/components/settings/review-settings.tsx
@@ -86,6 +86,20 @@ export function AgentToolsSettings() {
           titleKey="settings.agentTools.orgMcpsTitle"
           descriptionKey="settings.agentTools.orgMcpsDescription"
         />
+      </SettingsCard>
+    </SettingsSection>
+  );
+}
+
+/**
+ * Which coding agent backs Code Agent chats. Lives on General, not the board
+ * settings: it's about the org's agents, not about how tasks get reviewed.
+ */
+export function CodeAgentsSettings() {
+  const t = useT();
+  return (
+    <SettingsSection title={t("sidebar.agentsSection.codeAgents")}>
+      <SettingsCard>
         <FlagToggle
           flag="coding_agents_claude_code"
           icon={<Terminal size={16} />}

--- a/apps/web/src/views/settings/org-general.tsx
+++ b/apps/web/src/views/settings/org-general.tsx
@@ -2,6 +2,7 @@ import { Page } from "@/components/page";
 import { ConnectBanner } from "@/components/connect/connect-banner";
 import { OrganizationForm } from "@/components/settings/organization-form";
 import { MainAgentSettings } from "@/components/settings/main-agent-settings";
+import { CodeAgentsSettings } from "@/components/settings/review-settings";
 import { NavigationSettings } from "@/components/settings/navigation-settings";
 import { DomainSettings } from "@/components/settings/domain-settings";
 import { DeleteOrganizationSection } from "@/components/settings/delete-organization-section";
@@ -19,6 +20,7 @@ export function OrgGeneralPage() {
             <ConnectBanner />
             <OrganizationForm />
             <MainAgentSettings />
+            <CodeAgentsSettings />
             <NavigationSettings />
             <DomainSettings />
             <DeleteOrganizationSection />


### PR DESCRIPTION
## Problem

Code Agent chats now pin the `claude-code` harness (#6592). That client points at the narrow `task-run` MCP surface — deliberately, since the super-agent's virtual MCP aggregates nothing — so a **real** Code Agent's own connections (its GitHub MCP, VTEX, whatever is attached to it) stopped reaching the run. On hosted Decopilot those were the chat's toolset.

They could only come back via `orgMcps`, which is gated on the default-off `coding_agent_org_mcps` flag. Prod confirms the empty path: runs for `pedro-deco-systems` log no `[claude-code] org mcps:` line at all, which only happens on the zero-connection early return.

## Fix

`orgMcpConnections` now unions two sets:
- connections **aggregated on the agent** — always, no flag. Not a fan-out; exactly what someone attached to this agent. The synthetic super-agent has none, so task runs are unchanged.
- the rest of the org's — still behind `coding_agent_org_mcps`, since that half is unbounded.

Studio-owned well-knowns and erroring connections stay excluded either way. The filter is extracted as pure `selectRunConnections` and unit-tested (3 cases).

## Testing

`bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts` — 53 pass. `bun run --cwd=apps/api check` clean.

## Not in scope

An aggregation's `selected_tools` subset is ignored — a mounted connection is mounted whole, same as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Code Agent chats on the `claude-code` harness lost every connection attached to the agent itself (its GitHub MCP, VTEX, etc.) because the harness points at the narrow `task-run` MCP surface. The agent's own connections are now mounted unconditionally, while the org-wide set stays behind the `coding_agent_org_mcps` flag.

- Extracts the connection filter as pure `selectRunConnections` with unit tests.
- Excludes Studio-owned well-knowns and erroring connections in both cases.
- Moves the Claude Code toggle from board settings to Org General.

<sup>Written for commit 1cbed9f820f94f65579507ed27f7bc45ad2d141c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

