### PR TITLE
feat(admin): edit the hardcoded agent prompts and ship them as a PR

### DIFF
--- a/apps/api/src/api/routes/admin-prompt-region.test.ts
+++ b/apps/api/src/api/routes/admin-prompt-region.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import {
+  extractPromptRegion,
+  replacePromptRegion,
+} from "./admin-prompt-region";
+
+const SOURCE = [
+  "const X = {",
+  "  // prompt-region:start qa-agent",
+  '  qa: "be thorough",',
+  "  // prompt-region:end qa-agent",
+  "};",
+  "",
+].join("\n");
+
+describe("prompt regions", () => {
+  it("extracts only the marked body", () => {
+    expect(extractPromptRegion(SOURCE, "qa-agent")).toBe(
+      '  qa: "be thorough",\n',
+    );
+  });
+
+  it("returns null for an unknown region", () => {
+    expect(extractPromptRegion(SOURCE, "nope")).toBeNull();
+  });
+
+  it("replaces the body and leaves the markers and the rest intact", () => {
+    const next = replacePromptRegion(SOURCE, "qa-agent", '  qa: "be quick",');
+    expect(next).toBe(
+      [
+        "const X = {",
+        "  // prompt-region:start qa-agent",
+        '  qa: "be quick",',
+        "  // prompt-region:end qa-agent",
+        "};",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("round-trips an extracted body unchanged", () => {
+    const body = extractPromptRegion(SOURCE, "qa-agent");
+    expect(replacePromptRegion(SOURCE, "qa-agent", body!)).toBe(SOURCE);
+  });
+
+  it("refuses to splice when the markers drifted away", () => {
+    expect(() => replacePromptRegion(SOURCE, "gone", "x")).toThrow(
+      'prompt region "gone" not found',
+    );
+  });
+});
+
+/**
+ * The registry in `admin-prompts.ts` addresses prompts by marker id. A marker
+ * deleted or renamed in a refactor turns the editor into "content: null" for
+ * that prompt — silently, since nothing else reads these comments. This is the
+ * test that fails instead.
+ */
+describe("the real prompt regions", () => {
+  const REGIONS: Array<[string, string]> = [
+    ["qa-agent", "../../tools/task-board/enqueue-reviewer.ts"],
+    ["code-reviewer", "../../tools/task-board/enqueue-reviewer.ts"],
+    ["super-agent", "../../tools/task-board/enqueue-super-agent.ts"],
+    ["super-agent-sandbox", "../../tools/task-board/claude-code-task-run.ts"],
+  ];
+
+  for (const [id, relativePath] of REGIONS) {
+    it(`round-trips ${id}`, async () => {
+      const source = await Bun.file(
+        new URL(relativePath, import.meta.url),
+      ).text();
+      const body = extractPromptRegion(source, id);
+      expect(body).toBeTruthy();
+      expect(replacePromptRegion(source, id, body!)).toBe(source);
+    });
+  }
+});

--- a/apps/api/src/api/routes/admin-prompt-region.ts
+++ b/apps/api/src/api/routes/admin-prompt-region.ts
@@ -1,0 +1,58 @@
+/**
+ * The agent prompts stay HARDCODED in TypeScript — the admin prompt editor
+ * never moves them into the database. What it edits is the source region
+ * between a pair of marker comments, read from and written back to
+ * `decocms/studio` over the GitHub API.
+ *
+ * A marked region is the only thing that makes that safe: without it the editor
+ * would have to round-trip a 600-line source file through a textarea, and any
+ * stray keystroke outside the prompt would ship as a code change.
+ *
+ * Pure (no I/O) so the splice — the part that can silently corrupt a source
+ * file — is unit-tested. See `admin-prompts.ts` for the registry and the
+ * commit/PR flow.
+ */
+
+const START = (id: string) => `// prompt-region:start ${id}`;
+const END = (id: string) => `// prompt-region:end ${id}`;
+
+/** Marker line bounds of `id` within `source`, or null when either is absent. */
+function regionBounds(
+  source: string,
+  id: string,
+): { from: number; to: number } | null {
+  const start = source.indexOf(START(id));
+  if (start === -1) return null;
+  const from = source.indexOf("\n", start);
+  if (from === -1) return null;
+  const to = source.indexOf(END(id), from);
+  if (to === -1) return null;
+  // Back up to the newline ending the region's last content line, so the
+  // marker's own indentation is never part of the body.
+  const lineStart = source.lastIndexOf("\n", to);
+  return { from: from + 1, to: lineStart + 1 };
+}
+
+/** The source text between `id`'s markers, or null when the region is gone. */
+export function extractPromptRegion(source: string, id: string): string | null {
+  const bounds = regionBounds(source, id);
+  return bounds ? source.slice(bounds.from, bounds.to) : null;
+}
+
+/**
+ * `source` with `id`'s region replaced by `body`. Throws when the region is
+ * absent: a missing marker means the registry and the repo have drifted, and
+ * appending the edit somewhere would be worse than refusing it.
+ */
+export function replacePromptRegion(
+  source: string,
+  id: string,
+  body: string,
+): string {
+  const bounds = regionBounds(source, id);
+  if (!bounds) {
+    throw new Error(`prompt region "${id}" not found in source`);
+  }
+  const normalized = body.endsWith("\n") ? body : `${body}\n`;
+  return source.slice(0, bounds.from) + normalized + source.slice(bounds.to);
+}

--- a/apps/api/src/api/routes/admin-prompts.ts
+++ b/apps/api/src/api/routes/admin-prompts.ts
@@ -32,20 +32,6 @@ import {
 const PROMPT_REPO = { owner: "decocms", repo: "studio" } as const;
 
 /**
- * The branch the editor reads and targets. Defaults to the repo's default
- * branch, which is what a deployment wants.
- *
- * The override exists because the markers this whole surface addresses only
- * reach the default branch once the PR adding them merges — without it the
- * feature cannot be exercised before that, which is exactly when you want to.
- * Read per call so a long-lived dev server and its env agree.
- */
-function promptBranch(gh: GitDataClient): Promise<string> {
-  const override = process.env.ADMIN_PROMPTS_BRANCH?.trim();
-  return override ? Promise.resolve(override) : gh.getDefaultBranch();
-}
-
-/**
  * The editable prompts, each addressed by the marker pair that fences it in its
  * source file (see `admin-prompt-region.ts`). Two entries share
  * `enqueue-reviewer.ts`: QA and Code Review are one builder with a per-reviewer
@@ -187,7 +173,7 @@ export function createAdminPromptRoutes(): Hono<Env> {
 
   app.get("/prompts", async (c) => {
     const { gh, org } = await clientForActor(c.get("studioContext"));
-    const branch = await promptBranch(gh);
+    const branch = await gh.getDefaultBranch();
     // Pin the read to the commit, not the branch: the sha goes back to the
     // client and is what a save is written against, so a push landing between
     // the two can be reported as a conflict instead of silently reverted.
@@ -235,7 +221,7 @@ export function createAdminPromptRoutes(): Hono<Env> {
     }
 
     const { gh } = await clientForActor(c.get("studioContext"));
-    const base = await promptBranch(gh);
+    const base = await gh.getDefaultBranch();
     const baseSha = await gh.getHeadSha(base);
     if (typeof body.baseSha === "string" && body.baseSha !== baseSha) {
       // The editor loaded an older HEAD; committing its text would revert

--- a/apps/api/src/api/routes/admin-prompts.ts
+++ b/apps/api/src/api/routes/admin-prompts.ts
@@ -7,10 +7,11 @@
  * review + deploy); this surface only removes the "open an editor, find the
  * template literal" step for the people who tune these prompts.
  *
- * Credentials are the acting admin's own: the org GitHub connection of their
- * active organization, the same one the task board uses. So the PR is authored
- * by whoever pressed the button, and an admin without GitHub connected gets a
- * 400 rather than a shared service identity writing on their behalf.
+ * Credentials are the acting admin's own: a GitHub connection from one of their
+ * own organizations (see `resolveActorOrg`), resolved the same way the task
+ * board resolves one. So the PR is authored by whoever pressed the button, and
+ * an admin with no GitHub connected anywhere gets a 400 rather than a shared
+ * service identity writing on their behalf.
  *
  * Mounted by `admin.ts`, therefore already behind `requireDeploymentAdmin`.
  */
@@ -29,6 +30,20 @@ import {
 
 /** The repo the prompts live in — this one. */
 const PROMPT_REPO = { owner: "decocms", repo: "studio" } as const;
+
+/**
+ * The branch the editor reads and targets. Defaults to the repo's default
+ * branch, which is what a deployment wants.
+ *
+ * The override exists because the markers this whole surface addresses only
+ * reach the default branch once the PR adding them merges — without it the
+ * feature cannot be exercised before that, which is exactly when you want to.
+ * Read per call so a long-lived dev server and its env agree.
+ */
+function promptBranch(gh: GitDataClient): Promise<string> {
+  const override = process.env.ADMIN_PROMPTS_BRANCH?.trim();
+  return override ? Promise.resolve(override) : gh.getDefaultBranch();
+}
 
 /**
  * The editable prompts, each addressed by the marker pair that fences it in its
@@ -72,18 +87,62 @@ class PromptEditorError extends Error {
   }
 }
 
-/** A GitHub client on the acting admin's own connection. */
-async function clientForActor(
-  ctx: Env["Variables"]["studioContext"],
-): Promise<GitDataClient> {
-  const orgId = ctx.organization?.id;
-  if (!orgId) {
+type Ctx = Env["Variables"]["studioContext"];
+
+/**
+ * The acting admin's organization to borrow a GitHub connection from.
+ *
+ * `ctx.organization` is NOT usable here: this surface is instance-level, so
+ * there is no org slug in the path for `resolveOrgFromPath` to read, and a
+ * browser session's `activeOrganizationId` is frequently null (it is on every
+ * local-mode session). So resolve it from the admin's own memberships instead,
+ * picking the oldest org that actually has an active GitHub connection.
+ *
+ * Deterministic rather than chosen: an admin in several connected orgs gets the
+ * same one every time, and the response names it so the page can show whose
+ * GitHub is about to author the PR. A picker can come when someone needs one.
+ */
+async function resolveActorOrg(
+  ctx: Ctx,
+): Promise<{ id: string; slug: string; name: string }> {
+  const userId = ctx.auth.user?.id;
+  if (!userId) {
+    throw new PromptEditorError("Unauthorized", 400);
+  }
+  const row = await ctx.db
+    .selectFrom("member")
+    .innerJoin("organization", "organization.id", "member.organizationId")
+    .innerJoin("connections", "connections.organization_id", "organization.id")
+    .select([
+      "organization.id as id",
+      "organization.slug as slug",
+      "organization.name as name",
+    ])
+    .where("member.userId", "=", userId)
+    .where("connections.slug", "=", "mcp-github")
+    .where("connections.status", "=", "active")
+    .orderBy("organization.createdAt", "asc")
+    .limit(1)
+    .executeTakeFirst();
+  if (!row) {
     throw new PromptEditorError(
-      "No active organization — open Studio in an organization first",
+      "None of your organizations has GitHub connected — connect it, then reload",
       400,
     );
   }
-  const connection = await resolveGithubConnection(ctx, orgId, null, {
+  return row;
+}
+
+/** A GitHub client on the acting admin's own connection. */
+async function clientForActor(
+  ctx: Ctx,
+): Promise<{ gh: GitDataClient; org: { slug: string; name: string } }> {
+  const org = await resolveActorOrg(ctx);
+  // The mint path for a repo-scoped child connection reads `ctx.organization`,
+  // which is exactly what this route doesn't have — bind the resolved org so
+  // both the lookup and the token agree on one scope.
+  const orgCtx: Ctx = { ...ctx, organization: org };
+  const connection = await resolveGithubConnection(orgCtx, org.id, null, {
     owner: PROMPT_REPO.owner,
     name: PROMPT_REPO.repo,
   });
@@ -93,11 +152,14 @@ async function clientForActor(
       400,
     );
   }
-  const accessToken = await githubConnectionAccessToken(ctx, connection);
+  const accessToken = await githubConnectionAccessToken(orgCtx, connection);
   if (!accessToken) {
     throw new PromptEditorError("Reconnect GitHub to edit prompts", 400);
   }
-  return createGitDataClient({ ...PROMPT_REPO, accessToken });
+  return {
+    gh: createGitDataClient({ ...PROMPT_REPO, accessToken }),
+    org: { slug: org.slug, name: org.name },
+  };
 }
 
 /** Every distinct source file the registry touches, read once at `ref`. */
@@ -124,8 +186,8 @@ export function createAdminPromptRoutes(): Hono<Env> {
   const app = new Hono<Env>();
 
   app.get("/prompts", async (c) => {
-    const gh = await clientForActor(c.get("studioContext"));
-    const branch = await gh.getDefaultBranch();
+    const { gh, org } = await clientForActor(c.get("studioContext"));
+    const branch = await promptBranch(gh);
     // Pin the read to the commit, not the branch: the sha goes back to the
     // client and is what a save is written against, so a push landing between
     // the two can be reported as a conflict instead of silently reverted.
@@ -136,6 +198,9 @@ export function createAdminPromptRoutes(): Hono<Env> {
       repo: `${PROMPT_REPO.owner}/${PROMPT_REPO.repo}`,
       branch,
       baseSha,
+      // Whose GitHub connection will author the PR — the page shows it, since
+      // the org was resolved here rather than chosen by the operator.
+      org: org.slug || org.name,
       prompts: PROMPTS.map((prompt) => ({
         ...prompt,
         content: extractPromptRegion(sources.get(prompt.path) ?? "", prompt.id),
@@ -169,8 +234,8 @@ export function createAdminPromptRoutes(): Hono<Env> {
       return c.json({ error: "No prompt edits to commit" }, 400);
     }
 
-    const gh = await clientForActor(c.get("studioContext"));
-    const base = await gh.getDefaultBranch();
+    const { gh } = await clientForActor(c.get("studioContext"));
+    const base = await promptBranch(gh);
     const baseSha = await gh.getHeadSha(base);
     if (typeof body.baseSha === "string" && body.baseSha !== baseSha) {
       // The editor loaded an older HEAD; committing its text would revert

--- a/apps/api/src/api/routes/admin-prompts.ts
+++ b/apps/api/src/api/routes/admin-prompts.ts
@@ -1,0 +1,234 @@
+/**
+ * Deployment-admin prompt editor: read the hardcoded agent prompts from
+ * `decocms/studio` HEAD, edit them, and ship the edit as a pull request.
+ *
+ * The prompts STAY hardcoded — nothing here makes the running deployment read a
+ * prompt from the database. The edit path is the ordinary one (commit + PR +
+ * review + deploy); this surface only removes the "open an editor, find the
+ * template literal" step for the people who tune these prompts.
+ *
+ * Credentials are the acting admin's own: the org GitHub connection of their
+ * active organization, the same one the task board uses. So the PR is authored
+ * by whoever pressed the button, and an admin without GitHub connected gets a
+ * 400 rather than a shared service identity writing on their behalf.
+ *
+ * Mounted by `admin.ts`, therefore already behind `requireDeploymentAdmin`.
+ */
+import { Hono } from "hono";
+import type { Env } from "@/api/hono-env";
+import {
+  createGitDataClient,
+  type GitDataClient,
+} from "@/decofile/github-git-data";
+import { githubConnectionAccessToken } from "@/oauth/github-mint";
+import { resolveGithubConnection } from "@/tools/task-board/prs-get";
+import {
+  extractPromptRegion,
+  replacePromptRegion,
+} from "./admin-prompt-region";
+
+/** The repo the prompts live in — this one. */
+const PROMPT_REPO = { owner: "decocms", repo: "studio" } as const;
+
+/**
+ * The editable prompts, each addressed by the marker pair that fences it in its
+ * source file (see `admin-prompt-region.ts`). Two entries share
+ * `enqueue-reviewer.ts`: QA and Code Review are one builder with a per-reviewer
+ * persona, and the persona is the part worth editing.
+ *
+ * Adding a prompt here = wrapping it in a marker pair + one line below.
+ */
+const PROMPTS = [
+  {
+    id: "qa-agent",
+    label: "QA Agent",
+    path: "apps/api/src/tools/task-board/enqueue-reviewer.ts",
+  },
+  {
+    id: "code-reviewer",
+    label: "Code Reviewer",
+    path: "apps/api/src/tools/task-board/enqueue-reviewer.ts",
+  },
+  {
+    id: "super-agent-sandbox",
+    label: "Super Agent (sandbox)",
+    path: "apps/api/src/tools/task-board/claude-code-task-run.ts",
+  },
+  {
+    id: "super-agent",
+    label: "Super Agent (hosted)",
+    path: "apps/api/src/tools/task-board/enqueue-super-agent.ts",
+  },
+] as const;
+
+type PromptId = (typeof PROMPTS)[number]["id"];
+
+class PromptEditorError extends Error {
+  constructor(
+    message: string,
+    readonly status: 400 | 404 | 409,
+  ) {
+    super(message);
+  }
+}
+
+/** A GitHub client on the acting admin's own connection. */
+async function clientForActor(
+  ctx: Env["Variables"]["studioContext"],
+): Promise<GitDataClient> {
+  const orgId = ctx.organization?.id;
+  if (!orgId) {
+    throw new PromptEditorError(
+      "No active organization — open Studio in an organization first",
+      400,
+    );
+  }
+  const connection = await resolveGithubConnection(ctx, orgId, null, {
+    owner: PROMPT_REPO.owner,
+    name: PROMPT_REPO.repo,
+  });
+  if (!connection) {
+    throw new PromptEditorError(
+      "Connect GitHub in this organization to edit prompts",
+      400,
+    );
+  }
+  const accessToken = await githubConnectionAccessToken(ctx, connection);
+  if (!accessToken) {
+    throw new PromptEditorError("Reconnect GitHub to edit prompts", 400);
+  }
+  return createGitDataClient({ ...PROMPT_REPO, accessToken });
+}
+
+/** Every distinct source file the registry touches, read once at `ref`. */
+async function readSources(
+  gh: GitDataClient,
+  ref: string,
+): Promise<Map<string, string>> {
+  const paths = [...new Set(PROMPTS.map((p) => p.path))];
+  const texts = await Promise.all(
+    paths.map((path) => gh.getFileTextAtRef(ref, path)),
+  );
+  const sources = new Map<string, string>();
+  paths.forEach((path, i) => {
+    const text = texts[i];
+    if (text == null) {
+      throw new PromptEditorError(`${path} no longer exists at ${ref}`, 409);
+    }
+    sources.set(path, text);
+  });
+  return sources;
+}
+
+export function createAdminPromptRoutes(): Hono<Env> {
+  const app = new Hono<Env>();
+
+  app.get("/prompts", async (c) => {
+    const gh = await clientForActor(c.get("studioContext"));
+    const branch = await gh.getDefaultBranch();
+    // Pin the read to the commit, not the branch: the sha goes back to the
+    // client and is what a save is written against, so a push landing between
+    // the two can be reported as a conflict instead of silently reverted.
+    const baseSha = await gh.getHeadSha(branch);
+    const sources = await readSources(gh, baseSha);
+
+    return c.json({
+      repo: `${PROMPT_REPO.owner}/${PROMPT_REPO.repo}`,
+      branch,
+      baseSha,
+      prompts: PROMPTS.map((prompt) => ({
+        ...prompt,
+        content: extractPromptRegion(sources.get(prompt.path) ?? "", prompt.id),
+      })),
+    });
+  });
+
+  app.post("/prompts/pull-request", async (c) => {
+    const body = (await c.req.json().catch(() => ({}))) as {
+      title?: unknown;
+      baseSha?: unknown;
+      edits?: unknown;
+    };
+    const title =
+      typeof body.title === "string" && body.title.trim()
+        ? body.title.trim()
+        : "chore(prompts): edit agent prompts";
+    const known = new Set<string>(PROMPTS.map((p) => p.id));
+    const edits = (Array.isArray(body.edits) ? body.edits : [])
+      .filter(
+        (e): e is { id: PromptId; content: string } =>
+          !!e &&
+          typeof e === "object" &&
+          typeof (e as { id?: unknown }).id === "string" &&
+          known.has((e as { id: string }).id) &&
+          typeof (e as { content?: unknown }).content === "string" &&
+          (e as { content: string }).content.trim().length > 0,
+      )
+      .map((e) => ({ id: e.id, content: e.content }));
+    if (edits.length === 0) {
+      return c.json({ error: "No prompt edits to commit" }, 400);
+    }
+
+    const gh = await clientForActor(c.get("studioContext"));
+    const base = await gh.getDefaultBranch();
+    const baseSha = await gh.getHeadSha(base);
+    if (typeof body.baseSha === "string" && body.baseSha !== baseSha) {
+      // The editor loaded an older HEAD; committing its text would revert
+      // whatever landed since. The client reloads and the operator re-applies.
+      return c.json(
+        {
+          error:
+            "The prompts changed on GitHub since this page loaded — reload and re-apply your edit",
+        },
+        409,
+      );
+    }
+
+    // Splice against the exact parent commit's content so an unedited prompt in
+    // the same file is carried over verbatim rather than reverted.
+    const sources = await readSources(gh, baseSha);
+    for (const edit of edits) {
+      const prompt = PROMPTS.find((p) => p.id === edit.id)!;
+      sources.set(
+        prompt.path,
+        replacePromptRegion(sources.get(prompt.path)!, prompt.id, edit.content),
+      );
+    }
+
+    const changedPaths = [
+      ...new Set(edits.map((e) => PROMPTS.find((p) => p.id === e.id)!.path)),
+    ];
+    const entries = await Promise.all(
+      changedPaths.map(async (path) => ({
+        path,
+        mode: "100644",
+        type: "blob" as const,
+        sha: await gh.createBlob(sources.get(path)!),
+      })),
+    );
+
+    const treeSha = await gh.createTree(
+      await gh.getCommitTreeSha(baseSha),
+      entries,
+    );
+    const commitSha = await gh.createCommit({
+      message: title,
+      treeSha,
+      parentShas: [baseSha],
+    });
+    const branch = `admin/prompts-${Date.now().toString(36)}`;
+    await gh.createRef(branch, commitSha);
+    const pr = await gh.createPullRequest({ base, head: branch, title });
+
+    return c.json({ number: pr.number, url: pr.html_url, branch });
+  });
+
+  app.onError((error, c) => {
+    if (error instanceof PromptEditorError) {
+      return c.json({ error: error.message }, error.status);
+    }
+    throw error;
+  });
+
+  return app;
+}

--- a/apps/api/src/api/routes/admin.ts
+++ b/apps/api/src/api/routes/admin.ts
@@ -27,6 +27,7 @@ import { getDb } from "@/database";
 import { posthog } from "@/posthog";
 import { getSettings } from "@/settings";
 import type { Env } from "@/api/hono-env";
+import { createAdminPromptRoutes } from "./admin-prompts";
 
 /**
  * Mount path for the deployment-admin surface. Single source of truth: app.ts
@@ -377,6 +378,10 @@ export function createAdminRoutes(): Hono<Env> {
 
     return c.json({ ok: true });
   });
+
+  // The agent-prompt editor (reads/writes decocms/studio over GitHub) — its own
+  // module, mounted here so it inherits this router's admin fence.
+  app.route("/", createAdminPromptRoutes());
 
   return app;
 }

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -179,6 +179,7 @@ export function buildClaudeCodeTaskPrompt(
   repo: TaskRepo | null,
   opts?: SuperAgentPromptOpts & { repoChoices?: TaskRepoChoiceOption[] },
 ): string {
+  // prompt-region:start super-agent-sandbox
   const lines: string[] = [
     "You've been assigned this task. Complete it and finish with a pull request if it makes sense (like a coding task) or is explicitly requested.",
     "",
@@ -278,4 +279,5 @@ export function buildClaudeCodeTaskPrompt(
     `(task id: ${task.id})`,
   );
   return lines.join("\n");
+  // prompt-region:end super-agent-sandbox
 }

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -73,6 +73,7 @@ export const REVIEWER_DISALLOWED_TOOLS: Record<ReviewerKind, string[]> = {
 /** The review instructions unique to each reviewer. Shared scaffolding (load
  *  the PR, don't push code, end with a decision) lives in the prompt builder. */
 const REVIEWER_FOCUS: Record<ReviewerKind, string> = {
+  // prompt-region:start qa-agent
   qa:
     "You are the QA Agent. Your job is to confirm the task ACTUALLY SOLVED THE " +
     "PROBLEM — not to review code style. Exercise the feature/behavior the task " +
@@ -95,6 +96,8 @@ const REVIEWER_FOCUS: Record<ReviewerKind, string> = {
     "criteria / scenarios you checked with a pass/fail on each, a before→after " +
     "pointer to the screenshots, the exact URL(s) and viewport you exercised, and " +
     "anything you could not verify and why.",
+  // prompt-region:end qa-agent
+  // prompt-region:start code-reviewer
   code_review:
     "You are the Code Reviewer. Review the code changes for correctness, " +
     "security, and quality. FIRST look for a review skill/command appropriate " +
@@ -102,6 +105,7 @@ const REVIEWER_FOCUS: Record<ReviewerKind, string> = {
     "`security-review` skill, or the repo's CONTRIBUTING/review guidelines) and " +
     "use it. Read the diff critically and flag concrete issues with file/line " +
     "references.",
+  // prompt-region:end code-reviewer
 };
 
 /**

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -93,6 +93,7 @@ export function buildSuperAgentTaskPrompt(
   // repo does the commit/push/PR flow apply. Then keep it direct: don't hunt for
   // the dev-server port, don't chase incidental symbols. Keep it tight — a
   // bloated prompt costs tokens every step.
+  // prompt-region:start super-agent
   return [
     "You've been assigned this task. Complete it.",
     "",
@@ -154,6 +155,7 @@ export function buildSuperAgentTaskPrompt(
     "",
     `(task id: ${task.id})`,
   ].join("\n");
+  // prompt-region:end super-agent
 }
 
 /**

--- a/apps/web/src/i18n/en/admin.ts
+++ b/apps/web/src/i18n/en/admin.ts
@@ -28,7 +28,7 @@ export const admin = {
   "admin.orgs.organization": "Organization",
   "admin.orgs.searchPlaceholder": "Search organizations by name or slug...",
   "admin.prompts.description":
-    "These prompts are hardcoded in {repo}. Edits here are read from and committed back to {branch} as a pull request, using your own GitHub connection.",
+    "These prompts are hardcoded in {repo}. Edits here are read from {branch} and committed back as a pull request, using the GitHub connection of your {org} organization.",
   "admin.prompts.failedToLoadDescription":
     "Check that GitHub is connected in your active organization, then try again.",
   "admin.prompts.failedToLoadTitle": "Failed to load prompts",

--- a/apps/web/src/i18n/en/admin.ts
+++ b/apps/web/src/i18n/en/admin.ts
@@ -5,6 +5,7 @@ export const admin = {
     "Verify your email address to access the admin dashboard.",
   "admin.layout.goHome": "Go home",
   "admin.layout.organizationsTab": "Organizations",
+  "admin.layout.promptsTab": "Agent prompts",
   "admin.layout.restrictedToDashboard":
     "This dashboard is restricted to deployment admins.",
   "admin.layout.usersTab": "Users",
@@ -26,6 +27,22 @@ export const admin = {
   "admin.orgs.noOrgsYet": "No organizations exist yet.",
   "admin.orgs.organization": "Organization",
   "admin.orgs.searchPlaceholder": "Search organizations by name or slug...",
+  "admin.prompts.description":
+    "These prompts are hardcoded in {repo}. Edits here are read from and committed back to {branch} as a pull request, using your own GitHub connection.",
+  "admin.prompts.failedToLoadDescription":
+    "Check that GitHub is connected in your active organization, then try again.",
+  "admin.prompts.failedToLoadTitle": "Failed to load prompts",
+  "admin.prompts.markerMissing":
+    'The prompt-region markers for "{id}" are missing from this file — fix the markers in the repo before editing here.',
+  "admin.prompts.openPr": "Open pull request ({count})",
+  "admin.prompts.opening": "Opening...",
+  "admin.prompts.prFailed": "Failed to open the pull request",
+  "admin.prompts.prOpened": "Pull request #{number} opened",
+  "admin.prompts.prTitleLabel": "Pull request title",
+  "admin.prompts.prTitlePlaceholder":
+    "chore(prompts): tighten the QA Agent persona",
+  "admin.prompts.retry": "Try again",
+  "admin.prompts.viewPr": "View",
   "admin.users.columnCreated": "Created",
   "admin.users.columnEmail": "Email",
   "admin.users.columnUser": "User",

--- a/apps/web/src/i18n/pt-br/admin.ts
+++ b/apps/web/src/i18n/pt-br/admin.ts
@@ -31,7 +31,7 @@ export const admin = {
   "admin.orgs.organization": "Organização",
   "admin.orgs.searchPlaceholder": "Procure organizações por nome ou slug...",
   "admin.prompts.description":
-    "Estes prompts são fixos no código em {repo}. As edições aqui são lidas de {branch} e enviadas de volta como um pull request, usando sua própria conexão do GitHub.",
+    "Estes prompts são fixos no código em {repo}. As edições aqui são lidas de {branch} e enviadas de volta como um pull request, usando a conexão do GitHub da sua organização {org}.",
   "admin.prompts.failedToLoadDescription":
     "Verifique se o GitHub está conectado na sua organização ativa e tente novamente.",
   "admin.prompts.failedToLoadTitle": "Falha ao carregar os prompts",

--- a/apps/web/src/i18n/pt-br/admin.ts
+++ b/apps/web/src/i18n/pt-br/admin.ts
@@ -7,6 +7,7 @@ export const admin = {
     "Verifique seu endereço de e-mail para acessar o painel de administração.",
   "admin.layout.goHome": "Voltar para início",
   "admin.layout.organizationsTab": "Organizações",
+  "admin.layout.promptsTab": "Prompts dos agentes",
   "admin.layout.restrictedToDashboard":
     "Este painel é restrito a administradores de implantação.",
   "admin.layout.usersTab": "Usuários",
@@ -29,6 +30,22 @@ export const admin = {
   "admin.orgs.noOrgsYet": "Nenhuma organização existe ainda.",
   "admin.orgs.organization": "Organização",
   "admin.orgs.searchPlaceholder": "Procure organizações por nome ou slug...",
+  "admin.prompts.description":
+    "Estes prompts são fixos no código em {repo}. As edições aqui são lidas de {branch} e enviadas de volta como um pull request, usando sua própria conexão do GitHub.",
+  "admin.prompts.failedToLoadDescription":
+    "Verifique se o GitHub está conectado na sua organização ativa e tente novamente.",
+  "admin.prompts.failedToLoadTitle": "Falha ao carregar os prompts",
+  "admin.prompts.markerMissing":
+    'Os marcadores prompt-region de "{id}" não estão neste arquivo — corrija os marcadores no repositório antes de editar aqui.',
+  "admin.prompts.openPr": "Abrir pull request ({count})",
+  "admin.prompts.opening": "Abrindo...",
+  "admin.prompts.prFailed": "Falha ao abrir o pull request",
+  "admin.prompts.prOpened": "Pull request #{number} aberto",
+  "admin.prompts.prTitleLabel": "Título do pull request",
+  "admin.prompts.prTitlePlaceholder":
+    "chore(prompts): ajustar a persona do QA Agent",
+  "admin.prompts.retry": "Tentar novamente",
+  "admin.prompts.viewPr": "Ver",
   "admin.users.columnCreated": "Criado",
   "admin.users.columnEmail": "E-mail",
   "admin.users.columnUser": "Usuário",

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -633,6 +633,7 @@ export const KEYS = {
     ["deployment-admin", "orgs", search] as const,
   // Prefix key: invalidates every orgs query regardless of the search term.
   deploymentAdminOrgsList: () => ["deployment-admin", "orgs"] as const,
+  deploymentAdminPrompts: () => ["deployment-admin", "prompts"] as const,
 
   // Brand context (scoped by organization)
   defaultBrand: (organizationId: string) =>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -134,10 +134,17 @@ const adminOrgsRoute = createRoute({
   component: lazyRouteComponent(() => import("./routes/admin/orgs.tsx")),
 });
 
+const adminPromptsRoute = createRoute({
+  getParentRoute: () => adminLayout,
+  path: "/prompts",
+  component: lazyRouteComponent(() => import("./routes/admin/prompts.tsx")),
+});
+
 const adminLayoutWithChildren = adminLayout.addChildren([
   adminIndexRoute,
   adminUsersRoute,
   adminOrgsRoute,
+  adminPromptsRoute,
 ]);
 
 // ============================================

--- a/apps/web/src/routes/admin/layout.tsx
+++ b/apps/web/src/routes/admin/layout.tsx
@@ -10,6 +10,7 @@ import { useT } from "@/i18n/use-t.ts";
 const TABS = [
   { to: "/_admin/users", labelKey: "admin.layout.usersTab" },
   { to: "/_admin/orgs", labelKey: "admin.layout.organizationsTab" },
+  { to: "/_admin/prompts", labelKey: "admin.layout.promptsTab" },
 ] as const;
 
 function AdminTabs() {

--- a/apps/web/src/routes/admin/prompts.tsx
+++ b/apps/web/src/routes/admin/prompts.tsx
@@ -25,6 +25,8 @@ interface AdminPromptsResponse {
   repo: string;
   branch: string;
   baseSha: string;
+  /** Slug of the org whose GitHub connection authors the PR. */
+  org: string;
   prompts: AdminPrompt[];
 }
 
@@ -36,7 +38,7 @@ export default function AdminPromptsPage() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [title, setTitle] = useState("");
 
-  const { data, isLoading, isError, refetch } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: KEYS.deploymentAdminPrompts(),
     queryFn: () => adminFetch<AdminPromptsResponse>("/api/_admin/prompts"),
   });
@@ -94,7 +96,14 @@ export default function AdminPromptsPage() {
     return (
       <EmptyState
         title={t("admin.prompts.failedToLoadTitle")}
-        description={t("admin.prompts.failedToLoadDescription")}
+        // The server's own message names the actual cause (no GitHub
+        // connection, a moved file, a rate limit); a canned string here sent
+        // the first person who hit this off debugging the wrong thing.
+        description={
+          error instanceof Error && error.message
+            ? error.message
+            : t("admin.prompts.failedToLoadDescription")
+        }
         actions={
           <Button variant="outline" size="sm" onClick={() => refetch()}>
             {t("admin.prompts.retry")}
@@ -115,6 +124,7 @@ export default function AdminPromptsPage() {
               {t("admin.prompts.description", {
                 repo: data?.repo ?? "",
                 branch: data?.branch ?? "",
+                org: data?.org ?? "",
               })}
             </p>
 

--- a/apps/web/src/routes/admin/prompts.tsx
+++ b/apps/web/src/routes/admin/prompts.tsx
@@ -1,0 +1,187 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Loading01 } from "@untitledui/icons";
+import { Page } from "@/components/page";
+import { EmptyState } from "@/components/empty-state.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { adminFetch } from "@/lib/admin-fetch";
+import { KEYS } from "@/lib/query-keys";
+import { useT } from "@/i18n/use-t.ts";
+
+interface AdminPrompt {
+  id: string;
+  label: string;
+  path: string;
+  /** Null when the marker pair is gone from the file — nothing to edit. */
+  content: string | null;
+}
+
+interface AdminPromptsResponse {
+  repo: string;
+  branch: string;
+  baseSha: string;
+  prompts: AdminPrompt[];
+}
+
+export default function AdminPromptsPage() {
+  const t = useT();
+  // Edits keyed by prompt id; a prompt absent here is unedited, which is what
+  // the save sends (only edited prompts are committed).
+  const [edits, setEdits] = useState<Record<string, string>>({});
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: KEYS.deploymentAdminPrompts(),
+    queryFn: () => adminFetch<AdminPromptsResponse>("/api/_admin/prompts"),
+  });
+
+  const prompts = data?.prompts ?? [];
+  const selected = prompts.find((p) => p.id === selectedId) ?? prompts[0];
+  const editedIds = Object.keys(edits).filter(
+    (id) => edits[id] !== prompts.find((p) => p.id === id)?.content,
+  );
+
+  const pullRequest = useMutation({
+    mutationFn: () =>
+      adminFetch<{ number: number; url: string }>(
+        "/api/_admin/prompts/pull-request",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: title.trim() || undefined,
+            baseSha: data?.baseSha,
+            edits: editedIds.map((id) => ({ id, content: edits[id] })),
+          }),
+        },
+      ),
+    onSuccess: (pr) => {
+      toast.success(
+        t("admin.prompts.prOpened", { number: String(pr.number) }),
+        {
+          action: {
+            label: t("admin.prompts.viewPr"),
+            onClick: () => window.open(pr.url, "_blank"),
+          },
+        },
+      );
+      setEdits({});
+      setTitle("");
+      refetch();
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error ? error.message : t("admin.prompts.prFailed"),
+      );
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loading01 size={20} className="animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (isError || !selected) {
+    return (
+      <EmptyState
+        title={t("admin.prompts.failedToLoadTitle")}
+        description={t("admin.prompts.failedToLoadDescription")}
+        actions={
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            {t("admin.prompts.retry")}
+          </Button>
+        }
+      />
+    );
+  }
+
+  const value = edits[selected.id] ?? selected.content ?? "";
+
+  return (
+    <Page>
+      <Page.Content>
+        <Page.Body>
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-muted-foreground">
+              {t("admin.prompts.description", {
+                repo: data?.repo ?? "",
+                branch: data?.branch ?? "",
+              })}
+            </p>
+
+            <div className="flex flex-wrap gap-1">
+              {prompts.map((prompt) => (
+                <button
+                  type="button"
+                  key={prompt.id}
+                  onClick={() => setSelectedId(prompt.id)}
+                  className={cn(
+                    "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                    prompt.id === selected.id
+                      ? "bg-muted text-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {prompt.label}
+                  {editedIds.includes(prompt.id) ? " •" : ""}
+                </button>
+              ))}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="prompt-source">{selected.path}</Label>
+              <Textarea
+                id="prompt-source"
+                className="min-h-[420px] font-mono text-xs"
+                spellCheck={false}
+                value={value}
+                disabled={selected.content === null}
+                onChange={(e) =>
+                  setEdits({ ...edits, [selected.id]: e.target.value })
+                }
+              />
+              {selected.content === null ? (
+                <p className="text-sm text-destructive">
+                  {t("admin.prompts.markerMissing", { id: selected.id })}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+              <div className="flex w-full flex-col gap-2 md:max-w-md">
+                <Label htmlFor="pr-title">
+                  {t("admin.prompts.prTitleLabel")}
+                </Label>
+                <Input
+                  id="pr-title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder={t("admin.prompts.prTitlePlaceholder")}
+                />
+              </div>
+              <Button
+                disabled={editedIds.length === 0 || pullRequest.isPending}
+                onClick={() => pullRequest.mutate()}
+              >
+                {pullRequest.isPending
+                  ? t("admin.prompts.opening")
+                  : t("admin.prompts.openPr", {
+                      count: String(editedIds.length),
+                    })}
+              </Button>
+            </div>
+          </div>
+        </Page.Body>
+      </Page.Content>
+    </Page>
+  );
+}


### PR DESCRIPTION
## Summary

A new **Agent prompts** tab on `/_admin` that reads the hardcoded QA Agent /
Code Reviewer / Super Agent prompts from `decocms/studio` HEAD, lets an operator
edit them, and ships the edit as a pull request using the acting admin's own
GitHub connection.

The prompts stay **hardcoded in TypeScript** — nothing here makes a running
deployment read a prompt from the database. The edit path is still commit → PR →
review → deploy; this only removes the "open an editor, find the template
literal" step.

## How it works

- Each editable prompt is fenced by a `// prompt-region:start <id>` /
  `// prompt-region:end <id>` comment pair in its source file. That fence is what
  makes the editor safe: without it the page would have to round-trip a 600-line
  source file through a textarea, and a stray keystroke outside the prompt would
  ship as a code change.
- `GET /api/_admin/prompts` reads every registered file once at the current HEAD
  **commit** (not the branch) and returns each marked region plus that sha.
- `POST /api/_admin/prompts/pull-request` re-reads HEAD, **409s** if it moved
  since the page loaded, splices the edits into the parent commit's own content
  (so an unedited prompt in the same file is carried over verbatim, never
  reverted), then blob → tree → commit → branch → PR via the existing
  `GitDataClient`.
- Credentials are the acting admin's: the org GitHub connection of their active
  organization, resolved with the same `resolveGithubConnection` the task board
  uses. No GitHub connected → 400, never a shared service identity.
- Registry today: QA Agent, Code Reviewer (both the per-reviewer persona in
  `enqueue-reviewer.ts`), Super Agent sandbox, Super Agent hosted. Adding one =
  a marker pair + one line.

## Testing

- `bun test apps/api/src/api/routes/admin-prompt-region.test.ts` — extract /
  splice / round-trip / refuses-on-drift, plus a test that reads the **real**
  source files and round-trips all four regions. That last one is the guard for
  the actual failure mode: a marker deleted in a refactor would otherwise turn a
  prompt into `content: null` silently.
- `bun test apps/api/src/api/app.test.ts` and the task-board prompt-builder
  tests pass (markers are comments, prompt output is byte-identical).
- `bun run check`, `bun run lint` (0 errors), `bun run fmt` clean.
- Not exercised end-to-end against GitHub — the commit/PR path is the existing
  `GitDataClient`, but the first real save is worth watching.

## Notes

- Editing a region means editing TypeScript, including its `${}`
  interpolations — deliberate, since the prompts stay hardcoded. A syntax error
  fails CI on the PR rather than in production.
- Scoped to `decocms/studio` by constant; no env override until something needs
  one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an **Agent prompts** tab on `/_admin` that edits the hardcoded QA Agent, Code Reviewer, and Super Agent prompts and ships the edit as a pull request on the acting admin's GitHub connection. Prompts stay hardcoded in TypeScript — this only removes the "find the template literal" step, so edits still go through the normal commit → PR → review → deploy path.

- **New Features**
  - Editable prompts are fenced by `// prompt-region:start/:end <id>` comment pairs, so edits splice into the source without round-tripping the whole file through a textarea.
  - Saving re-reads `decocms/studio` HEAD, splices into the parent commit's content, and opens a PR via the existing `GitDataClient`; a 409 is returned if HEAD moved since the page loaded.
  - The PR is authored by the admin's oldest org with an active GitHub connection since the session's active org is usually null; no connected org returns a 400.
  - Registered prompts: QA Agent, Code Reviewer, Super Agent (sandbox and hosted); adding one is a marker pair plus a registry line.
  - The splice is unit-tested, including a round-trip over the real source files so a deleted marker fails CI instead of silently nulling a prompt.

<sup>Written for commit a04d2269267d63342bfaa833e7a484feb373cff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

