### PR TITLE
fix(jira): make a rescan actually refresh the cards it already had

### DIFF
--- a/apps/api/migrations/185-jira-rescan-existing-cards.ts
+++ b/apps/api/migrations/185-jira-rescan-existing-cards.ts
@@ -1,0 +1,29 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Clear every Jira integration's watermark again, because migration 184's
+ * rescan only did half the job.
+ *
+ * 184 cleared the watermark so the widened scope would be re-read, and it
+ * worked for the cards that were MISSING: 50 arrived on the first tick. But
+ * the pull's "nothing to do" shortcut fires before any field is written — an
+ * issue whose link already recorded its `updated` was skipped outright — so
+ * every card that already existed kept the `sprint_id` it never had. The board
+ * came out of the rescan showing 253 issues that Jira has in a sprint as
+ * backlog.
+ *
+ * `isUnchanged` now refuses that shortcut on a rescan, which makes clearing the
+ * watermark mean what 184 assumed it meant. This is the second clear, the one
+ * that actually refreshes the cards.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    UPDATE org_jira_integrations
+       SET last_synced_at = NULL,
+           last_sync_error = NULL
+     WHERE last_synced_at IS NOT NULL
+  `.execute(db);
+}
+
+/** Nothing to restore — see 184. */
+export async function down(): Promise<void> {}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -183,6 +183,7 @@ import * as migration181taskboarditemtyperequired from "./181-task-board-item-ty
 import * as migration182taskboardsprintsentities from "./182-task-board-sprints-entities.ts";
 import * as migration183dropjirajqlfilter from "./183-drop-jira-jql-filter.ts";
 import * as migration184jirarescanafterscopechange from "./184-jira-rescan-after-scope-change.ts";
+import * as migration185jirarescanexistingcards from "./185-jira-rescan-existing-cards.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -397,6 +398,7 @@ const migrations: Record<string, Migration> = {
   "182-task-board-sprints-entities": migration182taskboardsprintsentities,
   "183-drop-jira-jql-filter": migration183dropjirajqlfilter,
   "184-jira-rescan-after-scope-change": migration184jirarescanafterscopechange,
+  "185-jira-rescan-existing-cards": migration185jirarescanexistingcards,
 };
 
 export default migrations;

--- a/apps/api/src/jira/sync.test.ts
+++ b/apps/api/src/jira/sync.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { OrgJiraIntegration } from "@/storage/types";
-import { buildJql, vanishedLinks } from "./sync";
+import { buildJql, isUnchanged, vanishedLinks } from "./sync";
 
 /**
  * The pull's query. Worth pinning because it is the whole definition of which
@@ -127,5 +127,36 @@ describe("vanishedLinks", () => {
 
   it("has nothing to do on a board with no linked cards", () => {
     expect(vanishedLinks(new Set(["1"]), [])).toEqual([]);
+  });
+});
+
+/**
+ * The "nothing to do" shortcut. It fires BEFORE any field is written, which is
+ * why a rescan must not take it: migration 184 cleared the watermark to re-read
+ * a widened scope, and the run created the 50 cards it was missing while
+ * leaving 274 existing ones with the `sprint_id` they never had — 253 issues
+ * that Jira has in a sprint read as backlog on the board.
+ */
+describe("isUnchanged", () => {
+  const seen = "2026-03-02T12:00:00.000Z";
+
+  it("skips an issue no newer than what the link recorded", () => {
+    expect(isUnchanged(seen, new Date(seen), false)).toBe(true);
+    expect(isUnchanged(seen, new Date("2026-03-02T11:00:00.000Z"), false)).toBe(
+      true,
+    );
+  });
+
+  it("processes an issue that moved on", () => {
+    expect(isUnchanged(seen, new Date("2026-03-02T12:00:01.000Z"), false)).toBe(
+      false,
+    );
+  });
+
+  it("never skips on a rescan, however old the issue looks", () => {
+    expect(isUnchanged(seen, new Date(seen), true)).toBe(false);
+    expect(isUnchanged(seen, new Date("2020-01-01T00:00:00.000Z"), true)).toBe(
+      false,
+    );
   });
 });

--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -146,6 +146,29 @@ export function buildJql(
   return `${conditions} ORDER BY updated ASC`;
 }
 
+/**
+ * Whether a linked issue can be skipped without re-reading its fields.
+ *
+ * Normally yes: the link records the `updated` we last processed, so an issue
+ * no newer than that has nothing to tell us, and this shortcut is what keeps a
+ * tick cheap.
+ *
+ * NEVER on a rescan. A rescan happens because the shape of what we mirror
+ * changed, which makes every existing card stale by definition — and the
+ * shortcut fires BEFORE any field is written, so the rescan would create the
+ * cards it was missing and leave every card it already had untouched. That is
+ * exactly what happened when sprints shipped: 50 cards arrived, 274 kept a null
+ * sprint, and the board showed 253 issues that Jira had in a sprint as backlog.
+ */
+export function isUnchanged(
+  linkUpdatedAt: string,
+  issueUpdated: Date,
+  isRescan: boolean,
+): boolean {
+  if (isRescan) return false;
+  return new Date(linkUpdatedAt) >= issueUpdated;
+}
+
 /** Epics (hierarchyLevel 1) and anything above are containers, not cards. */
 function isCardIssue(issue: JiraIssue): boolean {
   const level = issue.fields.issuetype?.hierarchyLevel;
@@ -431,8 +454,12 @@ async function runSync(
     throw new Error("No status mapping configured");
   }
 
-  // The first import is a backfill, not activity — never its auto-delegate trigger (it would dispatch one run per pre-existing To Do issue).
-  const isInitialImport = integration.lastSyncedAt === null;
+  // A null watermark means "mirror everything from scratch" — a first connect,
+  // or a scope change that cleared it (see migration 184). Both are a backfill
+  // rather than activity, so neither triggers auto-delegation (it would
+  // dispatch one paid run per pre-existing To Do issue), and both must re-read
+  // every card rather than trust what the links already say.
+  const isRescan = integration.lastSyncedAt === null;
   const client = new JiraClient(
     integration.siteUrl,
     integration.email,
@@ -506,7 +533,7 @@ async function runSync(
       }
 
       const link = links.get(issue.id);
-      if (link && new Date(link.jiraUpdatedAt) >= issueUpdated) {
+      if (link && isUnchanged(link.jiraUpdatedAt, issueUpdated, isRescan)) {
         counts.unchanged++;
         watermark = issueUpdated;
         continue;
@@ -541,7 +568,7 @@ async function runSync(
             data: { from: before.status, to: status },
           });
         }
-        if (statusChangedOnJira && !isInitialImport) {
+        if (statusChangedOnJira && !isRescan) {
           item = await maybeAutoDelegate(ctx, integration, item);
         }
         await pullComments(
@@ -592,7 +619,7 @@ async function runSync(
           }
           throw err;
         }
-        if (!isInitialImport) {
+        if (!isRescan) {
           item = await maybeAutoDelegate(ctx, integration, item);
         }
         await pullComments(


### PR DESCRIPTION
Follow-up to #6589, found by watching that PR's own rescan land in production.

## What happened

Migration 184 cleared the watermark so the widened scope would be re-read. In production it worked for what was **missing** — 50 cards arrived on the first tick, including the whole batch that had been invisible in the board's Backlog tab — and did nothing at all for what was already there.

Numbers from the real board after that rescan:

| | |
|---|---|
| links created | 50 |
| existing links touched | **2** |
| cards carrying a sprint | **4** |
| issues Jira has in a sprint | **253** |

So the board came out of the rescan with 253 issues that live in a sprint reading as backlog.

## Why

The pull's "nothing to do" shortcut:

```ts
if (link && new Date(link.jiraUpdatedAt) >= issueUpdated) {
  counts.unchanged++;
  continue;   // ← before any field is written
}
```

For an existing card the link already recorded the issue's `updated`, so every one of them hit `continue` and no field — `sprint_id` included — was ever written. The shortcut is right in steady state and wrong for a rescan, and nothing distinguished the two.

## The fix

`isUnchanged` refuses the shortcut whenever the watermark is null, which is precisely the state that means "mirror everything from scratch": a first connect, or a scope change that cleared it. That makes clearing the watermark mean what 184 already assumed it meant.

`isInitialImport` is renamed `isRescan` in the same commit, because reading it as "the first import" is what hid this — it has been "any full re-mirror" since 184 shipped.

Migration 185 clears the watermark once more, this time against a pull that refreshes existing cards. Same safety as 184: a null watermark suppresses auto-delegation, so re-reading 300+ issues cannot dispatch a paid agent run per pre-existing To Do card, and `MAX_ISSUES_PER_RUN` paces the run.

## Testing

`isUnchanged` is exported and unit-tested: skips an issue no newer than the link, processes one that moved on, and never skips on a rescan however old the issue looks. Migration applied against real Postgres; `bun run check`, `lint` (0 errors), `knip` clean, 160 jira/migration tests pass.

## Expected effect on deploy

One rescan that re-reads the board's scope and writes `sprint_id` onto every card, so the sprint filter stops reporting a board of pure backlog. No new cards expected — #6589's rescan already created those.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Jira rescan so it refreshes existing cards instead of only creating missing ones: migration 184's rescan added 50 cards but left every existing one with a null `sprint_id`, and migration 185 re-runs it with the unchanged-check disabled to backfill sprint data. No new cards are expected — the previous rescan already created them.

**Migration**
- 185 clears the integration watermark again, now against a sync that re-reads existing cards.
- A null watermark suppresses auto-delegation and `MAX_ISSUES_PER_RUN` paces the run, so the backfill dispatches no paid agent runs.

**Bug Fixes**
- `isUnchanged` skips the no-op shortcut only when the watermark isn't null, since a null watermark means "mirror everything from scratch" (first connect or scope change).
- `isInitialImport` is renamed `isRescan`, and `isUnchanged` now has unit tests.

<sup>Written for commit cd89094304759a2f7205670afc84884cc4be9809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

