### PR TITLE
fix(jira): keep forcing a rescan across truncated runs on large boards

### DIFF
--- a/apps/api/migrations/186-jira-rescan-pending-flag.ts
+++ b/apps/api/migrations/186-jira-rescan-pending-flag.ts
@@ -1,0 +1,42 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Tracks whether a rescan (migration 184's scope change, 185's existing-card
+ * fix, or a plain first import) is still in progress across runs — not just
+ * within one.
+ *
+ * `isRescan` in sync.ts was `last_synced_at === null`, but a run only advances
+ * the watermark as far as `MAX_ISSUES_PER_RUN`/`MAX_PAGES_PER_RUN` let it get
+ * (that pacing is deliberate — see sync.ts). The FIRST run of a rescan on a
+ * board with more mapped issues than one run's cap sets a non-null watermark
+ * before the scope is fully re-read, so every following run reads
+ * `last_synced_at !== null` and treats itself as a normal incremental sync —
+ * silently reverting to `isUnchanged`'s shortcut for the issues the rescan
+ * never got to. On a board over the cap, 185's fix would only have reached
+ * its first ~500 issues.
+ *
+ * `rescan_pending` survives across runs independently of the watermark, so
+ * sync.ts can keep forcing a full re-read (and keep suppressing
+ * auto-delegate) until a run finishes the scope without hitting a cap.
+ *
+ * Backfilled true for every integration already mid-rescan (185's WHERE
+ * clause put those at `last_synced_at IS NULL`) so a deploy doesn't drop them
+ * out of the rescan they're already in.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE org_jira_integrations
+      ADD COLUMN rescan_pending boolean NOT NULL DEFAULT false
+  `.execute(db);
+  await sql`
+    UPDATE org_jira_integrations
+       SET rescan_pending = true
+     WHERE last_synced_at IS NULL
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE org_jira_integrations DROP COLUMN rescan_pending`.execute(
+    db,
+  );
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -184,6 +184,7 @@ import * as migration182taskboardsprintsentities from "./182-task-board-sprints-
 import * as migration183dropjirajqlfilter from "./183-drop-jira-jql-filter.ts";
 import * as migration184jirarescanafterscopechange from "./184-jira-rescan-after-scope-change.ts";
 import * as migration185jirarescanexistingcards from "./185-jira-rescan-existing-cards.ts";
+import * as migration186jirarescanpendingflag from "./186-jira-rescan-pending-flag.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -399,6 +400,7 @@ const migrations: Record<string, Migration> = {
   "183-drop-jira-jql-filter": migration183dropjirajqlfilter,
   "184-jira-rescan-after-scope-change": migration184jirarescanafterscopechange,
   "185-jira-rescan-existing-cards": migration185jirarescanexistingcards,
+  "186-jira-rescan-pending-flag": migration186jirarescanpendingflag,
 };
 
 export default migrations;

--- a/apps/api/src/jira/sync.test.ts
+++ b/apps/api/src/jira/sync.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { OrgJiraIntegration } from "@/storage/types";
-import { buildJql, isUnchanged, vanishedLinks } from "./sync";
+import { buildJql, isUnchanged, rescanContinues, vanishedLinks } from "./sync";
 
 /**
  * The pull's query. Worth pinning because it is the whole definition of which
@@ -27,6 +27,7 @@ function integration(
     enabled: true,
     lastSyncedAt: null,
     lastSyncError: null,
+    rescanPending: false,
     createdBy: "user-1",
     createdAt: NOW.toISOString(),
     updatedAt: NOW.toISOString(),
@@ -158,5 +159,30 @@ describe("isUnchanged", () => {
     expect(isUnchanged(seen, new Date("2020-01-01T00:00:00.000Z"), true)).toBe(
       false,
     );
+  });
+});
+
+/**
+ * A rescan run only advances as far as its per-run caps allow. If the flag
+ * that forces the rescan doesn't survive a truncated run, the NEXT run reads
+ * a non-null watermark, stops treating itself as a rescan, and silently skips
+ * every issue past the cap as "unchanged" — the exact bug 185 fixed, just
+ * past 500 issues instead of at the watermark.
+ */
+describe("rescanContinues", () => {
+  it("keeps forcing a rescan when a run hit the issue cap", () => {
+    expect(rescanContinues(true, 500, 3)).toBe(true);
+  });
+
+  it("keeps forcing a rescan when a run hit the page cap", () => {
+    expect(rescanContinues(true, 10, 25)).toBe(true);
+  });
+
+  it("clears once a rescan run finishes the scope under both caps", () => {
+    expect(rescanContinues(true, 42, 1)).toBe(false);
+  });
+
+  it("never claims a rescan for a plain incremental run", () => {
+    expect(rescanContinues(false, 500, 25)).toBe(false);
   });
 });

--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -98,10 +98,14 @@ export async function syncJiraIntegrationSafe(
   integration: OrgJiraIntegration,
 ): Promise<JiraSyncResult> {
   try {
-    const { counts, watermark } = await runSync(ctx, integration);
+    const { counts, watermark, rescanPending } = await runSync(
+      ctx,
+      integration,
+    );
     await ctx.storage.jiraIntegrations.recordSyncResult(integration.id, {
       error: null,
       watermark,
+      rescanPending,
     });
     return counts;
   } catch (err) {
@@ -167,6 +171,28 @@ export function isUnchanged(
 ): boolean {
   if (isRescan) return false;
   return new Date(linkUpdatedAt) >= issueUpdated;
+}
+
+/**
+ * Whether the rescan must keep forcing a full re-read on the NEXT run.
+ *
+ * A run only advances as far as `MAX_ISSUES_PER_RUN`/`MAX_PAGES_PER_RUN` let
+ * it (deliberate pacing, see below) — so a rescan on a board with more mapped
+ * issues than one run's cap sets a non-null `last_synced_at` before the scope
+ * is fully re-read. Without this, the next run would read `lastSyncedAt !==
+ * null`, stop treating itself as a rescan, and silently go back to
+ * `isUnchanged`'s shortcut for every issue the first run never reached — the
+ * same bug migration 185 fixed, just past the 500-issue mark instead of at
+ * `updated === lastSyncedAt`.
+ */
+export function rescanContinues(
+  isRescan: boolean,
+  processed: number,
+  pages: number,
+): boolean {
+  const truncated =
+    processed >= MAX_ISSUES_PER_RUN || pages >= MAX_PAGES_PER_RUN;
+  return isRescan && truncated;
 }
 
 /** Epics (hierarchyLevel 1) and anything above are containers, not cards. */
@@ -442,7 +468,11 @@ async function reconcileVanishedIssues(
 async function runSync(
   ctx: StudioContext,
   integration: OrgJiraIntegration,
-): Promise<{ counts: JiraSyncCounts; watermark?: Date }> {
+): Promise<{
+  counts: JiraSyncCounts;
+  watermark?: Date;
+  rescanPending?: boolean;
+}> {
   const orgId = integration.organizationId;
   const boardId = integration.boardId;
   if (!boardId) {
@@ -454,12 +484,9 @@ async function runSync(
     throw new Error("No status mapping configured");
   }
 
-  // A null watermark means "mirror everything from scratch" — a first connect,
-  // or a scope change that cleared it (see migration 184). Both are a backfill
-  // rather than activity, so neither triggers auto-delegation (it would
-  // dispatch one paid run per pre-existing To Do issue), and both must re-read
-  // every card rather than trust what the links already say.
-  const isRescan = integration.lastSyncedAt === null;
+  // First connect / scope change (migration 184) or an unfinished rescan (migration 186).
+  const isRescan =
+    integration.lastSyncedAt === null || integration.rescanPending;
   const client = new JiraClient(
     integration.siteUrl,
     integration.email,
@@ -660,9 +687,10 @@ async function runSync(
   // `last_synced_at` stays NULL: the UI would sit on "waiting for the first
   // sync" forever and every later run would count as the initial import, which
   // is exactly the state that suppresses auto-delegation.
+  const rescanPending = rescanContinues(isRescan, processed, pages);
   if (watermark === undefined && processed === 0) {
-    return { counts, watermark: runStartedAt };
+    return { counts, watermark: runStartedAt, rescanPending };
   }
 
-  return { counts, watermark };
+  return { counts, watermark, rescanPending };
 }

--- a/apps/api/src/storage/jira-integrations.ts
+++ b/apps/api/src/storage/jira-integrations.ts
@@ -32,6 +32,7 @@ type Row = {
   enabled: boolean;
   last_synced_at: Date | string | null;
   last_sync_error: string | null;
+  rescan_pending: boolean;
   created_by: string;
   created_at: Date | string;
   updated_at: Date | string;
@@ -73,6 +74,7 @@ export class JiraIntegrationStorage {
       enabled: row.enabled,
       lastSyncedAt: row.last_synced_at ? toIso(row.last_synced_at) : null,
       lastSyncError: row.last_sync_error,
+      rescanPending: row.rescan_pending,
       createdBy: row.created_by,
       createdAt: toIso(row.created_at),
       updatedAt: toIso(row.updated_at),
@@ -183,16 +185,21 @@ export class JiraIntegrationStorage {
 
   /** Record a sync outcome. `watermark` (the max issue `updated` fully
    *  processed) only advances on success — an errored run keeps the old one
-   *  so the next run re-covers the gap. */
+   *  so the next run re-covers the gap. `rescanPending` left unset (an error,
+   *  or a run that hasn't decided) leaves the flag as it was — only a run
+   *  that actually ran the rescan/incremental decision gets to change it. */
   async recordSyncResult(
     id: string,
-    result: { error: string | null; watermark?: Date },
+    result: { error: string | null; watermark?: Date; rescanPending?: boolean },
   ): Promise<void> {
     await this.db
       .updateTable("org_jira_integrations")
       .set({
         last_sync_error: result.error,
         ...(result.watermark ? { last_synced_at: result.watermark } : {}),
+        ...(result.rescanPending !== undefined
+          ? { rescan_pending: result.rescanPending }
+          : {}),
         updated_at: new Date(),
       })
       .where("id", "=", id)

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -2034,6 +2034,11 @@ export interface OrgJiraIntegrationTable {
    *  as it got, so the next run resumes instead of skipping. */
   last_synced_at: ColumnType<Date | null, never, Date | string | null>;
   last_sync_error: ColumnType<string | null, never, string | null>;
+  /** Set while a rescan (scope change, existing-card fix, or first import)
+   *  hasn't yet finished re-reading the whole scope — survives across the
+   *  multiple runs a large board needs, independent of `last_synced_at`
+   *  (see migration 186). */
+  rescan_pending: ColumnType<boolean, boolean | undefined, boolean>;
   created_by: string;
   created_at: ColumnType<Date, Date | string | undefined, never>;
   updated_at: ColumnType<Date, Date | string | undefined, Date | string>;
@@ -2054,6 +2059,7 @@ export interface OrgJiraIntegration {
   enabled: boolean;
   lastSyncedAt: string | null;
   lastSyncError: string | null;
+  rescanPending: boolean;
   createdBy: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
Follows #6612.

#6612 fixed the rescan's "nothing to do" shortcut by deriving `isRescan` from `integration.lastSyncedAt === null`. That works for a board small enough to finish in one run, but a run only advances the watermark as far as `MAX_ISSUES_PER_RUN` (500) / `MAX_PAGES_PER_RUN` (25) let it (deliberate pacing, per sync.ts's own docs). On a board with more mapped issues than that, the first run of a rescan sets a non-null `last_synced_at` before the scope is fully re-read — so the *next* run reads `lastSyncedAt !== null`, stops treating itself as a rescan, and silently falls back to `isUnchanged`'s shortcut for every remaining issue. That's exactly the bug #6612 fixed, just past the 500-issue mark instead of at the watermark: on a board over the cap, migration 185's fix would only have reached its first batch.

Fix: a `rescan_pending` column (migration 186) that survives across runs independently of the watermark. `rescanContinues(isRescan, processed, pages)` decides whether a run finished the scope or was truncated by a cap; `runSync` now OR's it into `isRescan` and persists it via `recordSyncResult`. Backfilled `true` for any integration already mid-rescan under #6612 (WHERE `last_synced_at IS NULL`) so deployment doesn't drop them out of it.

Regression test: `rescanContinues` in sync.test.ts — asserts it stays true when either cap is hit and clears only once a rescan run finishes the scope under both.

Reviewer check: `bun test apps/api/src/jira/sync.test.ts`.

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/jira/sync.test.ts` (18 pass) and `apps/api/migrations/index.test.ts` (2 pass), `bunx oxlint` on every changed file (0 warnings/errors). Full CI (including the jira-integrations Postgres integration test) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Jira rescans on large boards so they don't silently skip issues past a run's caps. `isRescan` used to derive from `lastSyncedAt === null`, but a run capped at 500 issues / 25 pages sets a non-null watermark before fully reading the scope, so the next run stops treating itself as a rescan and marks every remaining issue as unchanged. A new `rescan_pending` column survives across runs; `rescanContinues()` detects a truncated run and keeps forcing the full re-read until the scope finishes.

**Migration**
- Migration 186 adds `rescan_pending` to `org_jira_integrations`, defaulting to `false`.
- Backfills it to `true` for integrations with `last_synced_at IS NULL` so a rescan already in progress isn't dropped on deploy.

<sup>Written for commit 80fe3fd241129f6fdd170af312a713eea91b32d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

