### PR TITLE
fix(decopilot): retry a leaderless stream when opening the tail consumer

### DIFF
--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts
@@ -361,6 +361,54 @@ describe("NatsStreamBuffer", () => {
       expect(result).toBeNull();
     });
 
+    it("retries a leaderless stream when opening the tail consumer", async () => {
+      const { sub, end } = createControlledSubscription();
+      let attempts = 0;
+      let failures = 2;
+      const mockJs = {
+        consumers: {
+          get: async () => {
+            attempts++;
+            if (failures-- > 0) throw new Error("stream is offline");
+            return { consume: () => Promise.resolve(sub) };
+          },
+        },
+      };
+      const buffer = new NatsStreamBuffer({
+        getConnection: () => ({}) as never,
+        getJetStream: () => mockJs as never,
+      });
+      (buffer as unknown as { js: unknown }).js = mockJs;
+
+      const stream = await buffer.createTailStream("task-1");
+      end();
+
+      expect(attempts).toBe(3);
+      expect(stream).not.toBeNull();
+    });
+
+    it("does not retry a permanent consumer-open error", async () => {
+      let attempts = 0;
+      const mockJs = {
+        consumers: {
+          get: async () => {
+            attempts++;
+            throw new Error("stream not found");
+          },
+        },
+      };
+      const buffer = new NatsStreamBuffer({
+        getConnection: () => ({}) as never,
+        getJetStream: () => mockJs as never,
+      });
+      (buffer as unknown as { js: unknown }).js = mockJs;
+
+      const result = await buffer.createTailStream("task-1");
+
+      expect(attempts).toBe(1);
+      expect(result).toBeNull();
+    });
+
     it("yields buffered chunks and closes when the subscription ends", async () => {
       const { sub, push, end } = createControlledSubscription();
       const buffer = bufferWith(() => Promise.resolve(sub));

--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -535,14 +535,23 @@ export class NatsStreamBuffer implements StreamBuffer {
 
     let sub;
     try {
-      // v3 ordered (ephemeral, no-ack) consumer over this run's subject. The
-      // replacement for v2's removed `js.subscribe(..., {ordered:true})` push
-      // consumer: same delivery semantics, but driven via the consumer API.
-      const consumer = await js.consumers.get(DECOPILOT_STREAM_NAME, {
-        filter_subjects: subj,
-        deliver_policy: deliverPolicy,
-      });
-      sub = await consumer.consume();
+      // v3 ordered consumer, retried across a transient leader-election window.
+      sub = await retry(
+        async () => {
+          const consumer = await js.consumers.get(DECOPILOT_STREAM_NAME, {
+            filter_subjects: subj,
+            deliver_policy: deliverPolicy,
+          });
+          return consumer.consume();
+        },
+        {
+          maxAttempts: 6,
+          minTimeout: 250,
+          maxTimeout: 5000,
+          jitter: 0.5,
+          isRetriable: isTransientJsApiError,
+        },
+      );
     } catch (err) {
       console.warn(
         "[Decopilot] JetStream tail unavailable (non-critical):",


### PR DESCRIPTION
Follows #6605 (merged earlier today), which retried the transient NATS JetStream leader-election window (`stream is offline` / no-responders / timeout) when the *projector* opens its consumer (`createProjectorChunkStream`). `NatsStreamBuffer.createTailStream` — the sibling call that opens the *live UI tail* consumer via the exact same `js.consumers.get(DECOPILOT_STREAM_NAME, ...)` call — was left un-retried. A NATS roll or leader election during that window now throws once, and `createTailStream` treats any thrown error as "non-critical, no live tail" (catches it and returns `null`), silently killing the run's live stream for its whole duration instead of riding out a few seconds of transient unavailability.

**Why it matters**: this is the exact bug class #6605 just fixed one hop away — a transient JetStream hiccup shouldn't cost an entire run's live UI stream when a few retries would ride it out.

**Fix**: wrap the `consumers.get` + `.consume()` open in the same `retry(...)` + `isTransientJsApiError` already used by `NatsStreamBuffer.init` and `createProjectorChunkStream` (maxAttempts 6, 250ms–5000ms backoff, jitter 0.5). A permanent error (e.g. "stream not found") still surfaces on the first attempt, unchanged.

**Regression tests** (`nats-stream-buffer.test.ts`): "retries a leaderless stream when opening the tail consumer" (2 transient failures then success → 3 attempts, stream opens) and "does not retry a permanent consumer-open error" (1 attempt, returns null) — mirroring the tests #6605 added for the projector side.

**To verify**: `bun test apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts`

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/api, no new errors), targeted test file above (33/33 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries the live UI tail consumer open (`createTailStream`) when NATS JetStream is temporarily leaderless, matching the retry already added for the projector consumer.

- Wraps the `consumers.get` and `consume` calls in the same `retry` helper used by `init` and `createProjectorChunkStream` (6 attempts, 250ms–5000ms backoff, 0.5 jitter).
- Permanent errors like "stream not found" still abort on the first attempt and `createTailStream` returns `null` as before.
- Adds two regression tests: one for two transient failures followed by success, one for a permanent error resulting in a single attempt.

<sup>Written for commit 68343cbc396d0e0a02d87bca1f9c5f27c87c3e2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

