### PR TITLE
perf(task-board): mint secondary-repo clone credentials concurrently

### DIFF
--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -239,31 +239,30 @@ async function secondaryRepoConfigs(
   { cloneUrl: string; repoName: string; submoduleCredentials: never[] }[]
 > {
   const dirNames = secondaryRepoDirNames(repos);
-  const out: {
-    cloneUrl: string;
-    repoName: string;
-    submoduleCredentials: never[];
-  }[] = [];
-  for (const [i, repo] of repos.entries()) {
-    if (!repo.connectionId) continue;
-    try {
-      const { cloneUrl } = await buildCloneInfo(
-        repo.connectionId,
-        repo.owner,
-        repo.name,
-        ctx.db,
-        ctx.vault,
-        { bufferMs: CLONE_TOKEN_MIN_TTL_MS },
-      );
-      out.push({ cloneUrl, repoName: dirNames[i]!, submoduleCredentials: [] });
-    } catch (err) {
-      console.warn(
-        `[TASK_ADD_REPO] skipping secondary ${repo.owner}/${repo.name}:`,
-        err instanceof Error ? err.message : err,
-      );
-    }
-  }
-  return out;
+  // Independent per-repo credential mints — run concurrently, not in series.
+  const settled = await Promise.all(
+    repos.map(async (repo, i) => {
+      if (!repo.connectionId) return null;
+      try {
+        const { cloneUrl } = await buildCloneInfo(
+          repo.connectionId,
+          repo.owner,
+          repo.name,
+          ctx.db,
+          ctx.vault,
+          { bufferMs: CLONE_TOKEN_MIN_TTL_MS },
+        );
+        return { cloneUrl, repoName: dirNames[i]!, submoduleCredentials: [] };
+      } catch (err) {
+        console.warn(
+          `[TASK_ADD_REPO] skipping secondary ${repo.owner}/${repo.name}:`,
+          err instanceof Error ? err.message : err,
+        );
+        return null;
+      }
+    }),
+  );
+  return settled.filter((entry) => entry !== null);
 }
 
 export const TASK_ADD_REPO = defineTool({


### PR DESCRIPTION
**Source:** optimization found while auditing the recently-landed multi-repo task-run feature (#6557) and its follow-up fix (#6596, secondary-repo dir-name collisions).

**Why:** `TASK_ADD_REPO`'s `secondaryRepoConfigs` awaited `buildCloneInfo` (a DB + vault-backed GitHub App installation-token mint) one repo at a time in a `for` loop. Since #6557 lets one run accumulate several secondary repos, and this function re-mints every secondary's credential on *every* `TASK_ADD_REPO` call (by design — tokens live only an hour), a run with several secondaries now pays each repo's mint latency in series, even though the mints share no state and are already isolated per-repo with their own try/catch.

**Fix:** switched the loop to `Promise.all(repos.map(...))`. Same skip-on-failure behavior (a repo whose connection has since gone is dropped, logged, and doesn't affect siblings) and the same output order — `Promise.all` resolves in input order regardless of completion order, and each entry still keys off its own index into `dirNames`.

**Reviewer check:** `bun test apps/api/src/tools/task-board/add-repo.test.ts` — the 6 existing tests (including the multi-repo cases) pass unchanged.

**Verified locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace, clean), `bun test apps/api/src/tools/task-board/add-repo.test.ts` (6 pass), `bunx oxlint` on the changed file (0 warnings). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelizes the secondary-repo credential minting in `TASK_ADD_REPO` so multi-repo runs no longer pay each repo's token fetch latency in series.

The old behavior awaited `buildCloneInfo` for each secondary repo one at a time. The new code uses `Promise.all` over the repos, keeping the same per-repo skip-on-failure behavior and output order (results still align with input order). No migration steps or rollback actions are needed.

<sup>Written for commit e0d4fee761f3510d6f4e8a1797a971236f347974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

