### PR TITLE
fix(sections-editor): surface saved blocks whose name contains "/"

### DIFF
--- a/apps/web/src/components/sandbox/content/runnable-catalog.test.ts
+++ b/apps/web/src/components/sandbox/content/runnable-catalog.test.ts
@@ -163,13 +163,20 @@ describe("runnable-catalog", () => {
       MySubmit: { __resolveType: "site/actions/submit.ts" },
       // Not a runnable — should be ignored.
       Header: { __resolveType: "site/sections/Header/Header.tsx" },
-      // Nested path keys and non-objects are skipped.
-      "pages/home": { __resolveType: "site/loaders/products.ts" },
+      // Module-key defaults and non-objects are skipped.
+      "site/loaders/products.ts": { __resolveType: "site/loaders/products.ts" },
       plain: "value",
+      // User-named block whose name contains "/" is KEPT.
+      "Estampas / Flags": { __resolveType: "site/loaders/products.ts" },
     };
 
     const savedLoaders = listSavedRunnables(meta, decofile, "loaders");
     expect(savedLoaders).toEqual([
+      {
+        key: "Estampas / Flags",
+        resolveType: "site/loaders/products.ts",
+        title: "Estampas / Flags",
+      },
       {
         key: "MyProducts",
         resolveType: "site/loaders/products.ts",

--- a/apps/web/src/components/sandbox/content/runnable-catalog.ts
+++ b/apps/web/src/components/sandbox/content/runnable-catalog.ts
@@ -60,6 +60,22 @@ export function isManifestRunnableResolveType(
 }
 
 /**
+ * Whether a decofile key is a module resolveType rather than a user-given block
+ * name — i.e. a system default resolvable (`site/loaders/products.ts`) or a
+ * Tanstack bare invoke-by-key alias (`site/loaders/CheckStock`). These are not
+ * saved blocks the user created, so the catalog skips them. Arbitrary display
+ * names — even ones containing "/" like `Estampas / Flags` — return false.
+ */
+function isModuleResolveTypeKey(
+  meta: LiveMeta,
+  key: string,
+  kind: RunnableKind,
+): boolean {
+  if (/\.tsx?$/.test(key)) return true;
+  return isManifestRunnableResolveType(meta, key, kind);
+}
+
+/**
  * All manifest resolveTypes of the given runnable kind (loaders/actions). Unlike
  * {@link listAvailableRunnables} this is the raw set — no hidden/preview
  * filtering — for callers that need to pattern-match against every registered
@@ -197,7 +213,8 @@ export function listSavedRunnables(
   const entries: SavedRunnableEntry[] = [];
 
   for (const [key, val] of Object.entries(decofile)) {
-    if (key.includes("/")) continue;
+    // Skip module-key defaults/aliases; keep user names with "/" ("Estampas / Flags").
+    if (isModuleResolveTypeKey(meta, key, kind)) continue;
     if (isAutoPreviewBlockKey(key)) continue;
     if (!val || typeof val !== "object" || Array.isArray(val)) continue;
 

--- a/apps/web/src/components/sections-editor/block-ref-field-utils.test.ts
+++ b/apps/web/src/components/sections-editor/block-ref-field-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { LiveMeta, SchemaProperty } from "./resolve-schema";
 import {
   blockRefLoaderConfigHasData,
+  blockRefOptionLabel,
   detectBlockRefType,
   enrichBlockRefOptions,
   lazyWrappedInner,
@@ -146,6 +147,33 @@ describe("detectBlockRefType", () => {
         cardRefs,
       ),
     ).toBe("image-card");
+  });
+});
+
+describe("blockRefOptionLabel", () => {
+  test("keeps a saved-block name containing '/' (from the #module@name title)", () => {
+    // Regression: labelFromResolveType split "Estampas / Flags" into " Flags".
+    expect(
+      blockRefOptionLabel({
+        resolveType: "Estampas / Flags",
+        title: "#site/loaders/Layouts/Stamps.tsx@Estampas / Flags",
+      }),
+    ).toBe("Estampas / Flags");
+  });
+
+  test("uses a plain title verbatim (module option)", () => {
+    expect(
+      blockRefOptionLabel({
+        resolveType: "site/loaders/Layouts/Stamps.tsx",
+        title: "Estampas",
+      }),
+    ).toBe("Estampas");
+  });
+
+  test("falls back to the path-derived label when there is no title", () => {
+    expect(
+      blockRefOptionLabel({ resolveType: "site/loaders/products.ts" }),
+    ).toBe("Products");
   });
 });
 

--- a/apps/web/src/components/sections-editor/block-ref-field-utils.ts
+++ b/apps/web/src/components/sections-editor/block-ref-field-utils.ts
@@ -1,7 +1,9 @@
 import { labelFromResolveType } from "./section-types";
 import { isLazyResolveType } from "./section-lazy";
 import {
+  embeddedUnionBlockId,
   isSavedBlockResolveType,
+  parseSavedBlockSchemaTitle,
   unionRefMatchesValue,
 } from "./block-type-utils";
 import {
@@ -38,6 +40,26 @@ function isMultivariateFlagResolveType(resolveType: string): boolean {
 
 function titleFromResolveType(resolveType: string): string {
   return labelFromResolveType(resolveType);
+}
+
+/**
+ * Human label for a block-ref option in the selector. Saved-block references
+ * carry a `#<module>@<name>` title whose `<name>` is the user-given block name
+ * and may contain "/" (e.g. "Estampas / Flags"). Splitting the title/resolveType
+ * on "/" truncates such names (→ " Flags"), making the option unfindable by
+ * typing. Prefer the parsed block name, then the module title, then the
+ * path-derived label.
+ */
+export function blockRefOptionLabel(ref: BlockRefOption): string {
+  const savedName = ref.title
+    ? parseSavedBlockSchemaTitle(ref.title)?.blockId
+    : undefined;
+  if (savedName) return savedName;
+  if (ref.title && !ref.title.includes("/")) return ref.title;
+  return (
+    embeddedUnionBlockId(ref.resolveType) ??
+    labelFromResolveType(ref.resolveType)
+  );
 }
 
 /** Ensure saved blocks and concrete module types appear in the anyOf selector. */

--- a/apps/web/src/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/any-of-field.tsx
@@ -28,16 +28,14 @@ import {
 import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   blockRefLoaderConfigHasData,
+  blockRefOptionLabel,
   detectBlockRefType,
   enrichBlockRefOptions,
   lazyWrappedInner,
   resolveNestedBlockRefSchema,
   schemaWithoutDiscriminator,
 } from "../block-ref-field-utils";
-import {
-  embeddedUnionBlockId,
-  isEmbeddedUnionResolveType,
-} from "../block-type-utils";
+import { isEmbeddedUnionResolveType } from "../block-type-utils";
 import { labelFromResolveType } from "../section-types";
 import { crumbLabel, type Crumb } from "../schema-form-breadcrumb";
 import { suggestBlockId, validateBlockId } from "../page-sections";
@@ -447,13 +445,7 @@ export function AnyOfField({
             </SelectTrigger>
             <SelectContent>
               {refs.map((ref) => {
-                // If title is a file path (contains "/"), derive a human label
-                // from the resolveType instead (e.g. "DeliveryPromiseProductListingPage").
-                const displayTitle =
-                  ref.title && !ref.title.includes("/")
-                    ? ref.title
-                    : (embeddedUnionBlockId(ref.resolveType) ??
-                      labelFromResolveType(ref.resolveType));
+                const displayTitle = blockRefOptionLabel(ref);
                 return (
                   <SelectItem key={ref.resolveType} value={ref.resolveType}>
                     {displayTitle}


### PR DESCRIPTION
## Summary

Deco saves global loader/action blocks keyed by their **user-given name**, which may contain `/`. Two places in Studio treated that `/` as a path separator and dropped or truncated such blocks, so a block named e.g. **"Estampas / Flags"** (farmrio) was effectively invisible.

Reported on farmrio: the "Estampas / Flags" loader (the estampas/flags shown on product cards) had **no "Ver salvos"** under the `Estampas` loader, didn't show in the Loaders list, and searching "estampas"/"flags" returned nothing.

## Fixes

1. **Loaders/Actions list — `listSavedRunnables`** (`runnable-catalog.ts`)
   Was `if (key.includes("/")) continue;`, dropping every saved block whose name has `/`. Replaced with `isModuleResolveTypeKey`, which skips only keys that are genuinely a module resolveType (`.ts`/`.tsx` default resolvables, or a Tanstack bare invoke-by-key alias). User-named blocks with `/` are kept; Preview stubs and non-runnable `__resolveType`s are still filtered as before.

2. **Section block-ref picker label — `blockRefOptionLabel`** (`block-ref-field-utils.ts`, used by `any-of-field.tsx`)
   The option label was derived by splitting the `#module@name` title / resolveType on `/`, collapsing "Estampas / Flags" → " Flags" (unfindable by typing). New helper prefers the parsed saved-block name (`parseSavedBlockSchemaTitle`).

## Testing

- Unit tests added for both (`runnable-catalog.test.ts`, `block-ref-field-utils.test.ts`).
- Verified against the **real** farmrio `/live/_meta` + `.deco/blocks`: `listSavedRunnables` now returns `Estampas / Flags` grouped under `site > Layouts`, and the picker labels it `Estampas / Flags`.
- `bun run check`, `bun test` (affected files), and `bun run fmt` pass.

## Affected areas

Studio Content editor: Carregadores/Ações list (search + "Ver salvos") and the block-ref selector inside section forms. Also fixes the sibling "vitrine 30/09" block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes saved blocks named with "/" (like "Estampas / Flags") being invisible in the Studio Loaders/Actions list and unsearchable in the section block-ref picker. The previous logic treated "/" as a path separator, dropping those keys entirely and truncating their labels.

**Bug Fixes**
- `listSavedRunnables` now skips only module resolveType keys (`.ts`/`.tsx` defaults and Tanstack bare aliases), keeping user-named blocks with "/".
- The block-ref picker now derives labels from the parsed saved-block name in the `#module@name` title instead of splitting on "/".

<sup>Written for commit 60743802fc7d5b5064c5bc9e3f755ed7a7217fde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

