### PR TITLE
fix(sandbox): cap a single unterminated NDJSON dispatch line

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -222,6 +222,26 @@ describe("ndjsonLines", () => {
     expect(seen).toEqual([{ chunks: [], note: "日本語" }]);
   });
 
+  test("a runaway line without a newline is refused instead of buffered forever", async () => {
+    // No trailing newline — the whole thing is one buffered, unterminated tail.
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(`{"x":"${"a".repeat(70_000_000)}`),
+        );
+        controller.close();
+      },
+    });
+    let thrown: unknown;
+    try {
+      for await (const _ of ndjsonLines(body)) void _;
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(/without a newline/);
+  });
+
   test("a non-transport read failure stays terminal", async () => {
     const body = new ReadableStream<Uint8Array>({
       pull(controller) {

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -129,6 +129,17 @@ const MAX_TOTAL_DISPATCH_ATTEMPTS = 5;
 const DAEMON_SILENCE_TIMEOUT_MS = 90_000;
 
 /**
+ * Ceiling on one buffered-but-unterminated NDJSON line, in UTF-16 code units
+ * (~bytes for the JSON this stream carries). The daemon writes one frame per
+ * `Write` + trailing `\n` with no per-frame size cap of its own, so a run that
+ * emits one huge tool output (a giant file cat, an unbounded log dump) as a
+ * single frame would otherwise make `ndjsonLines` grow `buffer` without limit
+ * until the newline finally arrives — a slow memory exhaustion on the API pod
+ * shared by every concurrent sandbox run, not just the offending one.
+ */
+const MAX_NDJSON_LINE_CHARS = 64 * 1024 * 1024; // 64MB
+
+/**
  * The sandbox, not the harness, is what failed — so the turn can be continued
  * on a replacement pod. A harness that crashes reports through its own terminal
  * frame instead, and that is a real terminal we must not paper over by re-running
@@ -1069,6 +1080,11 @@ export async function* ndjsonLines(
       if (step.done) break;
       buffer += decoder.decode(step.value, { stream: true });
       yield* drain(true);
+      if (buffer.length > MAX_NDJSON_LINE_CHARS) {
+        throw new Error(
+          `sandbox dispatch produced a line over ${MAX_NDJSON_LINE_CHARS} chars without a newline — refusing to buffer it further`,
+        );
+      }
     }
     // Flush a multi-byte character `{ stream: true }` held back mid-sequence.
     buffer += decoder.decode();


### PR DESCRIPTION
**Source:** a reduction/hardening found while auditing `apps/api/src/harnesses/sandbox-dispatch-client.ts` (recently churned by the dispatch-continuation work) — not tied to an open issue.

**Payoff:** `ndjsonLines` reads the daemon's dispatch response one NDJSON frame at a time by accumulating bytes in a `buffer` string until it sees a `\n`. The daemon (`packages/sandbox/daemon-go/internal/dispatch/dispatch.go`) writes one `json.Marshal`'d frame + `\n` per `Write` call with no per-frame size cap of its own — so a run that emits one huge tool output (a large file cat, an unbounded log dump) as a single frame makes Studio's `buffer` grow without limit until that newline finally shows up. That's unbounded memory growth on the API pod, and it's shared: every concurrent sandbox run on that pod pays for the one offending run's buffer.

**Fix:** after each read+drain, if the still-unterminated tail exceeds 64MB, throw a clear error instead of continuing to accumulate. This only fires on a single runaway line — normal multi-line traffic (however large in aggregate) drains its complete lines every iteration and never hits the check.

**Regression test:** `sandbox-dispatch-client.test.ts` — "a runaway line without a newline is refused instead of buffered forever" feeds `ndjsonLines` a 70MB single line with no trailing newline and asserts it throws rather than hanging/OOMing.

**To verify:** `bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts`

**Checked locally:** `bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts` (54 pass), `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors), `bun run fmt`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the buffer in `ndjsonLines` so a single unterminated NDJSON frame from the daemon can't grow without limit. Previously a run emitting one huge tool output as a single frame would buffer indefinitely until a newline arrived, causing unbounded memory growth on the API pod that every concurrent run pays for. Now a line over 64MB with no trailing newline throws a clear error instead of accumulating; normal multi-line traffic is unaffected.

- Adds a regression test that feeds a 70MB unterminated line and asserts it throws.

<sup>Written for commit d0aeed5c3870369b4f28243c7a26a6d23004725f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

