### PR TITLE
fix(task-board): don't re-apply the progress-note length floor to a mirrored verdict

### DIFF
--- a/apps/api/src/tools/task-board/reviewer-comment.test.ts
+++ b/apps/api/src/tools/task-board/reviewer-comment.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import { NO_VISUAL_SURFACE } from "@decocms/shared/task-board";
-import { reviewerCommentGap, verdictCommentBody } from "./reviewer-comment";
+import {
+  nextGapAfterMirror,
+  reviewerCommentGap,
+  verdictCommentBody,
+} from "./reviewer-comment";
 
 const THREAD = "thrd_qa";
 /** Long enough to clear the progress-note floor. */
@@ -68,6 +72,29 @@ describe("reviewerCommentGap", () => {
     expect(
       reviewerCommentGap([{ threadId: THREAD, body }], THREAD, "qa"),
     ).toBeNull();
+  });
+});
+
+describe("nextGapAfterMirror", () => {
+  it("accepts a short-but-real mirrored code-review verdict", () => {
+    // A one-word verdict mirrors under the progress-note floor.
+    expect(
+      nextGapAfterMirror(
+        "code_review",
+        verdictCommentBody("code_review", "approve", "LGTM"),
+      ),
+    ).toBeNull();
+  });
+
+  it("still asks QA for screenshots when the mirrored notes are prose only", () => {
+    expect(
+      nextGapAfterMirror("qa", verdictCommentBody("qa", "approve", RECORD)),
+    ).toBe("no_screenshots");
+  });
+
+  it("accepts a mirrored QA verdict that already embeds a screenshot", () => {
+    const body = verdictCommentBody("qa", "approve", `${RECORD}\n![before](x)`);
+    expect(nextGapAfterMirror("qa", body)).toBeNull();
   });
 });
 

--- a/apps/api/src/tools/task-board/reviewer-comment.ts
+++ b/apps/api/src/tools/task-board/reviewer-comment.ts
@@ -84,7 +84,7 @@ export function reviewerCommentGap(
 
 /** Does this one comment carry the visual evidence QA owes? `![` opens a
  *  markdown image either side of `embedOrgOutputImages`. Pure — unit-tested. */
-export function hasVisualEvidence(body: string): boolean {
+function hasVisualEvidence(body: string): boolean {
   return body.includes("![") || body.includes(NO_VISUAL_SURFACE);
 }
 

--- a/apps/api/src/tools/task-board/reviewer-comment.ts
+++ b/apps/api/src/tools/task-board/reviewer-comment.ts
@@ -79,10 +79,30 @@ export function reviewerCommentGap(
   );
   if (own.length === 0) return "missing";
   if (kind !== "qa") return null;
-  // `![` opens a markdown image either side of `embedOrgOutputImages`.
-  const shown = own.some((c) => c.body.includes("!["));
-  const justified = own.some((c) => c.body.includes(NO_VISUAL_SURFACE));
-  return shown || justified ? null : "no_screenshots";
+  return own.some((c) => hasVisualEvidence(c.body)) ? null : "no_screenshots";
+}
+
+/** Does this one comment carry the visual evidence QA owes? `![` opens a
+ *  markdown image either side of `embedOrgOutputImages`. Pure — unit-tested. */
+export function hasVisualEvidence(body: string): boolean {
+  return body.includes("![") || body.includes(NO_VISUAL_SURFACE);
+}
+
+/**
+ * What's still owed right after mirroring the verdict notes into a comment —
+ * checked directly against that one comment, NOT through `reviewerCommentGap`.
+ * The mirrored text IS the reviewer's definitive record regardless of length
+ * (a one-word "LGTM" verdict is still a real verdict, not a progress note),
+ * so re-applying `MIN_RECORD_LENGTH` here would keep flagging a short-but-real
+ * code-review approval as "missing" forever and send it the QA-only
+ * screenshots follow-up meant for a different reviewer kind entirely.
+ */
+export function nextGapAfterMirror(
+  kind: ReviewerKind,
+  mirroredBody: string,
+): ReviewerCommentGap | null {
+  if (kind !== "qa") return null;
+  return hasVisualEvidence(mirroredBody) ? null : "no_screenshots";
 }
 
 /** The mirrored comment's body: the reviewer's own verdict text, headed by which
@@ -152,9 +172,8 @@ export async function ensureReviewerCommented(
       `[task-board] ${kind} reviewer on ${item.id} recorded no comment — ` +
         `mirrored its verdict notes`,
     );
-    // A mirrored verdict is a record, but for QA it is not evidence: the notes
-    // are prose, and the screenshots live in the run's outputs. Re-check.
-    gap = reviewerCommentGap([...comments, { threadId, body }], threadId, kind);
+    // A mirrored verdict is a record, but for QA it is not evidence.
+    gap = nextGapAfterMirror(kind, body);
     if (!gap) return;
   }
 


### PR DESCRIPTION
Follows #6611.

`ensureReviewerCommented` mirrors a reviewer's verdict `notes` into a card comment when the run left none, then re-checks whether more is owed by running the just-mirrored comment back through `reviewerCommentGap`. That function enforces an 80-char `MIN_RECORD_LENGTH` floor meant to filter out progress notes ("starting review") from a reviewer's own comments — but the mirrored text IS the definitive verdict regardless of length. A short-but-real `code_review` approval like `"LGTM"` mirrors to `"**Code Reviewer** approved:\n\nLGTM"` (33 chars), which still reads as `"missing"`. The code then falls through unconditionally to the QA-only "post your before/after screenshots" follow-up nudge — dispatching a wasted extra agent run on a code reviewer's thread, with a prompt that's nonsensical for that reviewer kind.

Fix: `nextGapAfterMirror(kind, mirroredBody)` checks the one just-written comment directly (screenshot markers / `NO_VISUAL_SURFACE` for QA, nothing for other kinds) instead of re-running it through the progress-note filter.

Regression test in `reviewer-comment.test.ts` (`nextGapAfterMirror` describe block) reproduces the bug: I confirmed the old `reviewerCommentGap`-based re-check returns `"missing"` for a mirrored `"LGTM"` code-review verdict (ran it standalone against the pre-fix code), and the new test suite passes against the fix.

Reviewer: run `bun test apps/api/src/tools/task-board/reviewer-comment.test.ts`.

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), targeted test file (12/12 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full suite runs in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mirroring a short-but-real code-review verdict like "LGTM" from being re-flagged as missing, which previously triggered a QA-only screenshots follow-up on a code reviewer's thread.

- Mirrored comments are now checked directly via `nextGapAfterMirror` instead of re-running `reviewerCommentGap` and its 80-char floor.
- QA verdicts still get the screenshot nudge when the mirrored notes carry no visual evidence.
- Adds regression tests covering short code-review verdicts and QA verdicts with and without screenshots.

<sup>Written for commit 4db114ebb53b1c8f6d20d62602a713d08facc9d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

