### PR TITLE
fix(task-board): timestamp dispatched user messages so they sort first

### DIFF
--- a/apps/api/src/tools/task-board/enqueue-task-run.ts
+++ b/apps/api/src/tools/task-board/enqueue-task-run.ts
@@ -158,6 +158,11 @@ export async function enqueueAgentRunForTask(
     id: crypto.randomUUID(),
     role: "user" as const,
     parts: [{ type: "text" as const, text: opts.prompt }],
+    // The chat POST path gets this from the browser; a dispatched run has no
+    // browser, so stamp it here. It rides the mirrored `data-user-message`
+    // chunk, which is otherwise timestamp-less — a viewer replaying the stream
+    // then sorts this turn by arrival time, i.e. after the reply it triggered.
+    metadata: { created_at: new Date().toISOString() },
   };
 
   // Persist the user turn BEFORE dispatch (as POST /messages does) so it lands

--- a/apps/api/src/tools/task-board/nudge-thread.ts
+++ b/apps/api/src/tools/task-board/nudge-thread.ts
@@ -47,6 +47,9 @@ export async function nudgeThreadTurn(
     id: opts.messageId,
     role: "user" as const,
     parts: [{ type: "text" as const, text: opts.prompt }],
+    // Same reason as `enqueueAgentRunForTask`: the mirrored stream chunk needs
+    // its own timestamp or replaying viewers order this turn by arrival.
+    metadata: { created_at: new Date().toISOString() },
   };
 
   // Persist the user turn before dispatch, for the same ordering reason as

--- a/apps/web/src/components/chat/store/thread-connection.test.ts
+++ b/apps/web/src/components/chat/store/thread-connection.test.ts
@@ -905,6 +905,38 @@ describe("applyLocalMessage", () => {
     expect(conn.messages.get().map((m) => m.id)).toEqual(["flip-1"]);
   });
 
+  test("a server-dispatched message keeps its metadata.created_at, so it sorts before the reply it triggered", async () => {
+    globalThis.fetch = makeFetchMock() as unknown as typeof globalThis.fetch;
+
+    const conn = getOrOpenStream("acme", "thread-apply-local-metadata-ts", {
+      client: null,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    // A task-board run replays: the assistant chunks land first, then the
+    // mirrored user-message chunk. Its timestamp lives in `metadata`.
+    conn.messages.set([
+      {
+        id: "reply",
+        role: "assistant",
+        parts: [{ type: "text", text: "on it" }],
+        created_at: "2026-01-01T00:00:05.000Z",
+      } as UIMessage,
+    ]);
+
+    conn.applyLocalMessage({
+      id: "dispatched",
+      role: "user",
+      parts: [{ type: "text", text: "You've been assigned this task." }],
+      metadata: { created_at: "2026-01-01T00:00:01.000Z" },
+    } as UIMessage);
+
+    expect(conn.messages.get().map((m) => m.id)).toEqual([
+      "dispatched",
+      "reply",
+    ]);
+  });
+
   test("dedupes by id when the row is already in the body (refetch raced the flip)", async () => {
     globalThis.fetch = makeFetchMock() as unknown as typeof globalThis.fetch;
 

--- a/apps/web/src/components/chat/store/thread-connection.ts
+++ b/apps/web/src/components/chat/store/thread-connection.ts
@@ -164,8 +164,17 @@ function applyLocally(
     // that earlier assistant. A persisted refetch (incoming carries the DB
     // `created_at`) overwrites this via `preserveCreatedAt`. No-op if a
     // `created_at` is already present.
-    const msg = action.message as UIMessage & { created_at?: string };
+    const msg = action.message as UIMessage & {
+      created_at?: string;
+      metadata?: { created_at?: string };
+    };
     if (msg.created_at != null) return [...prev, msg];
+    // A server-dispatched turn (task board, nudge) carries its timestamp in
+    // `metadata` — promote it rather than stamping arrival time.
+    const fromMetadata = msg.metadata?.created_at;
+    if (fromMetadata != null) {
+      return [...prev, { ...msg, created_at: fromMetadata } as UIMessage];
+    }
     let maxMs = 0;
     for (const m of prev) {
       const ts = (m as { created_at?: string | number | Date }).created_at;


### PR DESCRIPTION
## Problem

The assigned-task user message renders *below* the tool calls it triggered, with a later clock time (screenshot: Bash calls at 7:05 PM, the "You've been assigned this task" bubble at 7:07 PM).

A task-board run builds its user message server-side (`enqueue-task-run.ts`), with no `created_at` on the object. The persisted DB row is fine — the part emitter derives one — but the same object is mirrored onto the run stream verbatim as a `data-user-message` chunk. JetStream replays with `deliverPolicy: "all"`, so a viewer opening the thread mid- or post-run receives that timestamp-less chunk *after* the assistant chunks. `applyLocally` then stamps it `Date.now()`, and `mergeAndSort` puts it last.

Confirmed against prod (`thrd_d05CRpblUJ0G8zPusVq0O`): the user text part is `seq 0`, `created_at` 22:05:51.432 — earliest in the thread. The DB order is right; only the live/replayed view is wrong.

## Fix

- Stamp `metadata.created_at` on the dispatched message in `enqueue-task-run.ts` and `nudge-thread.ts` — the same field the browser sets on the chat POST path, so it rides the mirrored chunk.
- Client: promote `metadata.created_at` before falling back to arrival time. Fixes threads dispatched before this ships, since their chunks are already in JetStream without one.

## Testing

- One test in `thread-connection.test.ts`: a replayed dispatched message arriving after the reply still sorts ahead of it. Verified it fails with the client change reverted.
- `bun test apps/web/src/components/chat/store/thread-connection.test.ts` → 72 pass.
- `bun run check` clean in `apps/api` and `apps/web`; `bun run fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task-board and nudge dispatched user messages rendering below the tool calls they triggered: their mirrored stream chunk carried no `created_at`, so replaying viewers got arrival-time stamps that sorted the message last.

**Bug Fixes**
- Both dispatch sites now set `metadata.created_at` at send, matching the browser chat POST path.
- The client promotes `metadata.created_at` before falling back to arrival time, which also corrects threads dispatched before this change.
- Adds a regression test covering a replayed dispatched message arriving after its reply.

<sup>Written for commit cb795bfd9ed4303e94c49432a6bbd1748a182c5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

