### PR TITLE
fix(admin): don't let a prompt-region id match as a prefix of a longer id's marker

### DIFF
--- a/apps/api/src/api/routes/admin-prompt-region.test.ts
+++ b/apps/api/src/api/routes/admin-prompt-region.test.ts
@@ -51,6 +51,45 @@ describe("prompt regions", () => {
 });
 
 /**
+ * A shorter id that is a prefix of a longer one's marker (e.g. "super-agent" /
+ * "super-agent-sandbox", both real ids in the registry today) must not match
+ * the longer marker's line — or an edit to the short id would splice into the
+ * long id's region instead.
+ */
+describe("prompt regions with a prefix-colliding id", () => {
+  const PREFIX_SOURCE = [
+    "const X = {",
+    "  // prompt-region:start super-agent-sandbox",
+    '  sandbox: "be careful",',
+    "  // prompt-region:end super-agent-sandbox",
+    "  // prompt-region:start super-agent",
+    '  hosted: "be quick",',
+    "  // prompt-region:end super-agent",
+    "};",
+    "",
+  ].join("\n");
+
+  it("extracts the exact-id region, not the prefix-matching one", () => {
+    expect(extractPromptRegion(PREFIX_SOURCE, "super-agent")).toBe(
+      '  hosted: "be quick",\n',
+    );
+    expect(extractPromptRegion(PREFIX_SOURCE, "super-agent-sandbox")).toBe(
+      '  sandbox: "be careful",\n',
+    );
+  });
+
+  it("replaces only the exact-id region", () => {
+    const next = replacePromptRegion(
+      PREFIX_SOURCE,
+      "super-agent",
+      '  hosted: "be quick and safe",',
+    );
+    expect(next).toContain('sandbox: "be careful"');
+    expect(next).toContain('hosted: "be quick and safe"');
+  });
+});
+
+/**
  * The registry in `admin-prompts.ts` addresses prompts by marker id. A marker
  * deleted or renamed in a refactor turns the editor into "content: null" for
  * that prompt — silently, since nothing else reads these comments. This is the

--- a/apps/api/src/api/routes/admin-prompt-region.ts
+++ b/apps/api/src/api/routes/admin-prompt-region.ts
@@ -16,16 +16,36 @@
 const START = (id: string) => `// prompt-region:start ${id}`;
 const END = (id: string) => `// prompt-region:end ${id}`;
 
+/**
+ * `source.indexOf(marker)`, but rejecting a hit where `marker` is only a
+ * prefix of a longer id's marker (e.g. id "super-agent" must not match the
+ * "super-agent-sandbox" marker line) — the line has to end right after it.
+ */
+function indexOfExactMarker(
+  source: string,
+  marker: string,
+  fromIndex: number,
+): number {
+  let idx = fromIndex;
+  for (;;) {
+    idx = source.indexOf(marker, idx);
+    if (idx === -1) return -1;
+    const after = source[idx + marker.length];
+    if (after === undefined || after === "\n" || after === "\r") return idx;
+    idx += marker.length;
+  }
+}
+
 /** Marker line bounds of `id` within `source`, or null when either is absent. */
 function regionBounds(
   source: string,
   id: string,
 ): { from: number; to: number } | null {
-  const start = source.indexOf(START(id));
+  const start = indexOfExactMarker(source, START(id), 0);
   if (start === -1) return null;
   const from = source.indexOf("\n", start);
   if (from === -1) return null;
-  const to = source.indexOf(END(id), from);
+  const to = indexOfExactMarker(source, END(id), from);
   if (to === -1) return null;
   // Back up to the newline ending the region's last content line, so the
   // marker's own indentation is never part of the body.


### PR DESCRIPTION
The admin prompt editor (#6610, merged today) addresses each hardcoded agent prompt by a marker pair (`// prompt-region:start <id>` / `:end <id>`), located in `admin-prompt-region.ts` via a plain `source.indexOf(marker)`. That match isn't anchored to the end of the marker line, so an id that is a string prefix of another id's marker matches the longer marker's line instead of its own — and the registry already has this shape today: `"super-agent"` is a prefix of `"super-agent-sandbox"`.

**Why it matters:** if `super-agent` and `super-agent-sandbox` regions ever land in the same source file (or any future id is added that prefixes an existing one — the registry's own comment invites exactly that: "Adding a prompt here = wrapping it in a marker pair + one line below"), editing the shorter id would silently splice its new content into the longer id's region, corrupting the source file the admin's PR gets built from — with no error, since `regionBounds` still finds *a* match.

**Fix:** `indexOfExactMarker` now walks forward past any prefix hit and only accepts a match where the marker line ends right after it (next char is `\n`, `\r`, or EOF).

**Regression test:** added a `PREFIX_SOURCE` fixture with both a `super-agent-sandbox` and a `super-agent` region in the same file (mirroring the real-world near-collision) and confirmed:
- with the fix, `extractPromptRegion`/`replacePromptRegion` for `"super-agent"` only ever touch the `super-agent` region, never the `-sandbox` one.
- traced through the old code, the same fixture would have returned the `-sandbox` region's content for the `super-agent` id — this is not a hypothetical.

**To confirm:** `bun test apps/api/src/api/routes/admin-prompt-region.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (no new errors), `bunx oxlint` on both changed files (0 warnings/errors), and the full targeted test file (11 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the admin prompt editor so a shorter id like `super-agent` no longer matches the marker line for `super-agent-sandbox`, preventing edits from silently splicing into the wrong region.

**Bug Fixes**
- Marker search now only accepts a match when the line ends right after the id (next char is newline, carriage return, or EOF).
- Added a regression test covering both colliding ids in the same file.

<sup>Written for commit a3013a35625b45006afe19a7cd6f4167440d3ce8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

