### PR TITLE
fix(jira): gate reconciliation on either sync-run truncation reason

### DIFF
--- a/apps/api/src/jira/sync.test.ts
+++ b/apps/api/src/jira/sync.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import type { OrgJiraIntegration } from "@/storage/types";
-import { buildJql, isUnchanged, rescanContinues, vanishedLinks } from "./sync";
+import {
+  buildJql,
+  isUnchanged,
+  rescanContinues,
+  runTruncated,
+  vanishedLinks,
+} from "./sync";
 
 /**
  * The pull's query. Worth pinning because it is the whole definition of which
@@ -184,5 +190,25 @@ describe("rescanContinues", () => {
 
   it("never claims a rescan for a plain incremental run", () => {
     expect(rescanContinues(false, 500, 25)).toBe(false);
+  });
+});
+
+/**
+ * `reconcileVanishedIssues` (which archives cards outside Jira's live scope)
+ * gates on this same truncation check — a run that hit the PAGE cap on many
+ * empty-but-tokened pages, with `processed` still low, is just as incomplete
+ * as one that hit the issue cap, and must not be read as "finished".
+ */
+describe("runTruncated", () => {
+  it("is truncated once the issue cap is hit", () => {
+    expect(runTruncated(500, 3)).toBe(true);
+  });
+
+  it("is truncated once the page cap is hit, even with few issues processed", () => {
+    expect(runTruncated(10, 25)).toBe(true);
+  });
+
+  it("is not truncated when a run finishes under both caps", () => {
+    expect(runTruncated(42, 1)).toBe(false);
   });
 });

--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -174,6 +174,18 @@ export function isUnchanged(
 }
 
 /**
+ * Whether this run stopped short of the full incremental scope — either cap
+ * can be why: `MAX_ISSUES_PER_RUN` on a page full of mapped issues, or
+ * `MAX_PAGES_PER_RUN` on a filter that returns many empty-but-tokened pages
+ * (an issue-sparse JQL still burns a page per call). Shared by every caller
+ * that needs to know "did this run actually finish", so the two truncation
+ * reasons can't drift apart again.
+ */
+export function runTruncated(processed: number, pages: number): boolean {
+  return processed >= MAX_ISSUES_PER_RUN || pages >= MAX_PAGES_PER_RUN;
+}
+
+/**
  * Whether the rescan must keep forcing a full re-read on the NEXT run.
  *
  * A run only advances as far as `MAX_ISSUES_PER_RUN`/`MAX_PAGES_PER_RUN` let
@@ -190,9 +202,7 @@ export function rescanContinues(
   processed: number,
   pages: number,
 ): boolean {
-  const truncated =
-    processed >= MAX_ISSUES_PER_RUN || pages >= MAX_PAGES_PER_RUN;
-  return isRescan && truncated;
+  return isRescan && runTruncated(processed, pages);
 }
 
 /** Epics (hierarchyLevel 1) and anything above are containers, not cards. */
@@ -671,10 +681,9 @@ async function runSync(
   }
 
   counts.unmappedStatuses = [...unmapped].sort();
-  // Reconciliation reads the WHOLE scope, so it waits for a run that finished
-  // the incremental pass — mid-backfill, most of the board is legitimately
-  // not linked yet.
-  if (processed < MAX_ISSUES_PER_RUN) {
+  // Reconciliation reads the WHOLE scope, so it waits for a run that actually finished the incremental pass.
+  const truncated = runTruncated(processed, pages);
+  if (!truncated) {
     counts.archived = await reconcileVanishedIssues(
       ctx,
       integration,
@@ -687,7 +696,7 @@ async function runSync(
   // `last_synced_at` stays NULL: the UI would sit on "waiting for the first
   // sync" forever and every later run would count as the initial import, which
   // is exactly the state that suppresses auto-delegation.
-  const rescanPending = rescanContinues(isRescan, processed, pages);
+  const rescanPending = isRescan && truncated;
   if (watermark === undefined && processed === 0) {
     return { counts, watermark: runStartedAt, rescanPending };
   }


### PR DESCRIPTION
Follows #6613 (the `rescanContinues` fix) in the same file.

`reconcileVanishedIssues` (archives task-board cards whose Jira issue left the board's scope) reads the WHOLE scope, so it deliberately skips itself when the incremental pass this tick was truncated and hasn't caught up. That gate was `processed < MAX_ISSUES_PER_RUN` — only one of the two ways a run truncates. A JQL filter that returns many empty-but-tokened pages (Jira can do this on sparse matches) hits `MAX_PAGES_PER_RUN` while `processed` stays low, which the old check read as "finished", firing an extra whole-board `searchIssueIds` scan on every such tick instead of waiting for the incremental pass to actually catch up — needless load on a large/sparse board's Jira API budget, the exact class of problem #6613 fixed for the rescan-pending flag in this same file.

Extracted the shared `runTruncated(processed, pages)` check (`processed >= MAX_ISSUES_PER_RUN || pages >= MAX_PAGES_PER_RUN`) and used it for both the reconciliation gate and `rescanContinues`, so the two can't drift apart again — `rescanPending` is now just `isRescan && truncated`.

Regression test: `runTruncated` is unit-tested for both truncation reasons (issue-cap, page-cap) and the non-truncated case, mirroring the existing `rescanContinues` tests.

Reviewer check: `bun test apps/api/src/jira/sync.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Jira reconciliation gate so it waits for the incremental sync to fully finish, including when the run hits the page cap on sparse JQL filters, avoiding needless full-board scans.

<sup>Written for commit aec5a97575168313e931fbdc5c09cd863ac153b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

