### PR TITLE
fix(decopilot): fall back to an unreplicated stream on a single-node NATS

### DIFF
--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts
@@ -99,6 +99,11 @@ test("decopilot stream is replicated so one node loss keeps the run streaming", 
   expect(decopilotStreamConfig().num_replicas).toBe(3);
 });
 
+test("decopilot stream config honours an explicit replica count", () => {
+  // The single-node fallback in `init()` re-issues the config with 1.
+  expect(decopilotStreamConfig(1).num_replicas).toBe(1);
+});
+
 describe("NatsStreamBuffer", () => {
   it("purge is a no-op when jsm is not initialized (no throw)", () => {
     const buffer = new NatsStreamBuffer({
@@ -241,6 +246,70 @@ describe("NatsStreamBuffer", () => {
     } as never);
     expect(ok).toBe(true);
     expect(publishMock).toHaveBeenCalled();
+  });
+
+  it("init falls back to an unreplicated stream on a single-node NATS", async () => {
+    // Regression: a replicated default made `streams.update` reject on any
+    // non-clustered JetStream (local dev, self-hosts, the multi-pod test
+    // cluster), leaving `js` null so every chunk of every run was dropped.
+    const configs: Array<{ num_replicas: number }> = [];
+    const streamUpdateMock = mock(
+      (_name: string, config: { num_replicas: number }) => {
+        configs.push(config);
+        if (config.num_replicas > 1) {
+          return Promise.reject(
+            new Error("replicas > 1 not supported in non-clustered mode"),
+          );
+        }
+        return Promise.resolve({});
+      },
+    );
+    const mockJsm = {
+      streams: {
+        info: mock(() => Promise.resolve({})),
+        update: streamUpdateMock,
+        add: mock(() => Promise.resolve({})),
+      },
+    };
+    const publishMock = mock(() => Promise.resolve({ seq: 1 }));
+
+    const buffer = new NatsStreamBuffer({
+      getConnection: () => ({}) as never,
+      getJetStream: () => ({ publish: publishMock }) as never,
+      getJetStreamManager: (() => Promise.resolve(mockJsm)) as never,
+    });
+
+    await buffer.init();
+
+    expect(configs.map((c) => c.num_replicas)).toEqual([3, 1]);
+    // Degraded to unreplicated, but streaming — not wedged at js=null.
+    expect(
+      await buffer.publishRawChunk("thrd_x", { type: "text" } as never),
+    ).toBe(true);
+  });
+
+  it("init does NOT fall back to 1 replica on an unrelated update failure", async () => {
+    // The fallback is scoped to replica rejections; a real config error must
+    // still surface instead of silently shipping an unreplicated stream.
+    const streamUpdateMock = mock(() =>
+      Promise.reject(new Error("invalid stream config: bad subject")),
+    );
+    const mockJsm = {
+      streams: {
+        info: mock(() => Promise.resolve({})),
+        update: streamUpdateMock,
+        add: mock(() => Promise.resolve({})),
+      },
+    };
+
+    const buffer = new NatsStreamBuffer({
+      getConnection: () => ({}) as never,
+      getJetStream: () => ({}) as never,
+      getJetStreamManager: (() => Promise.resolve(mockJsm)) as never,
+    });
+
+    await expect(buffer.init()).rejects.toThrow("invalid stream config");
+    expect(streamUpdateMock).toHaveBeenCalledTimes(1);
   });
 
   it("init does NOT retry a non-transient (semantic) error", async () => {

--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -87,6 +87,12 @@ const MAX_BYTES = 4 * 1024 * 1024 * 1024; // 4GB stream cap
  * how one NATS pod restart darkened chat cluster-wide on 2026-08-26. 3 matches
  * the cluster size so a single node loss keeps quorum.
  *
+ * This is the *requested* count, not a guarantee: a single-node JetStream
+ * rejects anything above 1 outright, and `init()` then falls back to an
+ * unreplicated stream — see `isReplicaUnsupportedError`. Local `bun run dev`,
+ * self-hosts and the multi-pod/resilience test clusters all run one NATS node,
+ * so without that fallback a replicated default darkens streaming there.
+ *
  * Env-overridable for rollback without a deploy — `init()` applies the value
  * through `streams.update`, and JetStream scales replicas online, so setting
  * `DECOPILOT_STREAM_REPLICAS=1` reverts on the next pod start.
@@ -102,7 +108,7 @@ const MAX_MSGS_PER_SUBJECT = 500_000; // headroom for multi-hour non-stop stream
  * stream survives a NATS restart, with a retention SLA and a time-based dedup
  * window. Extracted from `init()` so it can be unit-tested without a connection.
  */
-export function decopilotStreamConfig() {
+export function decopilotStreamConfig(replicas: number = STREAM_REPLICAS) {
   return {
     name: DECOPILOT_STREAM_NAME,
     subjects: [`${DECOPILOT_STREAM_SUBJECT_PREFIX}.>`],
@@ -113,7 +119,7 @@ export function decopilotStreamConfig() {
     discard: DiscardPolicy.Old,
     retention: RetentionPolicy.Limits,
     duplicate_window: DUPLICATE_WINDOW_NS, // time-based Nats-Msg-Id dedup (spec §10.2)
-    num_replicas: STREAM_REPLICAS,
+    num_replicas: replicas,
   };
 }
 
@@ -229,6 +235,23 @@ export interface NatsStreamBufferOptions {
   getJetStreamManager?: () => Promise<JetStreamManager>;
 }
 
+/**
+ * The server cannot satisfy the requested replica count. A single-node
+ * (non-clustered) JetStream rejects `replicas > 1` outright; a cluster with
+ * fewer peers than requested rejects it as insufficient resources. Both are
+ * legitimate deployments — local dev, self-hosts and the test clusters all run
+ * one NATS node — so the stream must still be created there, just unreplicated.
+ * Anything else is a real config error and has to surface.
+ */
+function isReplicaUnsupportedError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (/non-clustered/i.test(err.message)) return true;
+  return (
+    /replicas?\b/i.test(err.message) &&
+    /not supported|can ?not|exceed|insufficient|greater than/i.test(err.message)
+  );
+}
+
 export class NatsStreamBuffer implements StreamBuffer {
   private js: JetStreamClient | null = null;
   private jsm: JetStreamManager | null = null;
@@ -246,43 +269,62 @@ export class NatsStreamBuffer implements StreamBuffer {
       );
       return;
     }
-    const config = decopilotStreamConfig();
-
     // The JS-API round-trips below (manager handshake + stream ensure) can time
     // out transiently if JetStream is briefly slow at boot. Init only re-runs on
     // a NATS `onReady` (reconnect); when the connection stays up, a single
     // startup timeout would otherwise leave `this.js` null for the pod's whole
     // life — every run then fails at `publishRawChunk`. Retry the transient
     // failures in place instead of relying on a reconnect that may never come.
+    const ensureStream = async (
+      mgr: JetStreamManager,
+      replicas: number,
+    ): Promise<void> => {
+      const config = decopilotStreamConfig(replicas);
+      try {
+        await mgr.streams.info(DECOPILOT_STREAM_NAME);
+        await mgr.streams.update(DECOPILOT_STREAM_NAME, config);
+      } catch (err: unknown) {
+        const isNotFound =
+          err instanceof Error && err.message.includes("stream not found");
+        if (isNotFound) {
+          await mgr.streams.add(config);
+        } else {
+          // JetStream cannot change a stream's `storage` in place, so flipping
+          // the legacy Memory stream to File makes `update` reject. The stream
+          // is ephemeral run-scratch (it only holds in-flight chunks), so a
+          // one-time delete + add at deploy is safe: drop the old stream and
+          // recreate it file-backed. Any other error is real — rethrow.
+          const isStorageMismatch =
+            err instanceof Error &&
+            /can ?not change.*storage|storage type/i.test(err.message);
+          if (isStorageMismatch) {
+            await mgr.streams.delete(DECOPILOT_STREAM_NAME);
+            await mgr.streams.add(config);
+          } else {
+            throw err;
+          }
+        }
+      }
+    };
+
     const jsm = await retry(
       async () => {
         const mgr = this.options.getJetStreamManager
           ? await this.options.getJetStreamManager()
           : await jetstreamManager(nc);
         try {
-          await mgr.streams.info(DECOPILOT_STREAM_NAME);
-          await mgr.streams.update(DECOPILOT_STREAM_NAME, config);
+          await ensureStream(mgr, STREAM_REPLICAS);
         } catch (err: unknown) {
-          const isNotFound =
-            err instanceof Error && err.message.includes("stream not found");
-          if (isNotFound) {
-            await mgr.streams.add(config);
-          } else {
-            // JetStream cannot change a stream's `storage` in place, so flipping
-            // the legacy Memory stream to File makes `update` reject. The stream
-            // is ephemeral run-scratch (it only holds in-flight chunks), so a
-            // one-time delete + add at deploy is safe: drop the old stream and
-            // recreate it file-backed. Any other error is real — rethrow.
-            const isStorageMismatch =
-              err instanceof Error &&
-              /can ?not change.*storage|storage type/i.test(err.message);
-            if (isStorageMismatch) {
-              await mgr.streams.delete(DECOPILOT_STREAM_NAME);
-              await mgr.streams.add(config);
-            } else {
-              throw err;
-            }
-          }
+          // A single-node NATS can't hold a replicated stream. Streaming at all
+          // beats streaming with failover: retry unreplicated rather than leave
+          // `js` null, which silently drops every chunk of every run.
+          if (STREAM_REPLICAS <= 1 || !isReplicaUnsupportedError(err))
+            throw err;
+          console.warn(
+            `[Decopilot] StreamBuffer: NATS rejected num_replicas=${STREAM_REPLICAS} ` +
+              `(${(err as Error).message}); falling back to an unreplicated stream`,
+          );
+          await ensureStream(mgr, 1);
         }
         return mgr;
       },


### PR DESCRIPTION
## Why main is red

Multi-Pod Tests has failed on **every** main commit since `f50027065` (#6600) — 4 of 11 tests, ~3 hours of red. Last green was `bd0df9e29`.

#6600 raised `DECOPILOT_STREAMS` to `num_replicas: 3` so the stream survives a NATS node loss on the 3-node production cluster. That value is applied unconditionally, and a non-clustered JetStream rejects it outright. From the failing job's pod logs:

```
mesh-1-1 | [Decopilot] StreamBuffer init failed (late-join disabled):
           JetStreamApiError: replicas > 1 not supported in non-clustered mode
mesh-1-1 | [Decopilot] createTailStream: JetStream client unavailable for thread ...; no live tail
mesh-1-1 | [decopilot] stream error: publishRawChunk failed
```

`init()` throws, `js` stays `null`, and every chunk of every run is dropped silently — healthy pods, dead chat. The four failures are all downstream of that one cause:

| test | symptom |
|---|---|
| `attach-cross-pod` | `expect(pod2Joined).toContain("chunk-1")` → received `""` |
| `automation-webhook` ×2 | run never completes (30s timeout) |
| `rollout-churn` | `run-dispatched` never observed (30s timeout) |

This is not test-only. **Every deployment that runs a single NATS node hits it**: local `bun run dev`, self-hosts, and the resilience cluster. Only the production 3-node cluster was exercised before merge.

## The fix

`init()` retries with `num_replicas: 1` when — and only when — the server rejects the replica count itself (`isReplicaUnsupportedError`: non-clustered, or too few peers). The downgrade is logged loudly. Any other stream-config error still surfaces and still fails init, as before.

Streaming unreplicated beats not streaming. Production is unaffected and still gets 3; `DECOPILOT_STREAM_REPLICAS` still works as #6600's no-deploy rollback lever.

The multi-pod suite deliberately keeps its single NATS node and does **not** set `DECOPILOT_STREAM_REPLICAS=1` — pinning the env there would have hidden the bug from CI instead of fixing it, and would leave local dev and self-hosts broken. The suite stays the regression guard.

## Testing

- `bun test apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts` — 36 pass, including two new cases: the single-node fallback re-issues the config as `[3, 1]` and still publishes, and an unrelated `invalid stream config` error still rejects without downgrading.
- `bun run --cwd=apps/api check`, `bun run lint` (0 errors), `bun run fmt` clean.
- Multi-Pod Tests on this PR is the real proof — it reproduces the failure on the default branch exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Decopilot streaming on single-node NATS deployments. The default replica count of 3 (set for the production cluster) made non-clustered JetStream reject stream setup, which threw from `init()` and left the JetStream client null — silently dropping every chunk of every run on local dev, self-hosts, and test clusters. Now `init()` retries with `num_replicas: 1` specifically when the server rejects the replica count, and logs the downgrade loudly.

- The fallback is scoped to replica rejections only — any other stream-config error still fails init.
- Production is unaffected and still gets 3 replicas; `DECOPILOT_STREAM_REPLICAS=1` remains a manual rollback lever.
- Added tests for both paths: fallback re-issues the config as `[3, 1]` and still publishes, and an unrelated invalid config error still rejects without downgrading.

<sup>Written for commit 9762d1d632ab41e3b633eecf194de15c2f9e6aa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

