### PR TITLE
fix(admin): return 409 instead of 500 when a prompt's marker region drifted away

### DIFF
--- a/apps/api/src/api/routes/admin-prompts.test.ts
+++ b/apps/api/src/api/routes/admin-prompts.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import { applyPromptEdits, PromptEditorError } from "./admin-prompts";
+
+const REVIEWER_PATH = "apps/api/src/tools/task-board/enqueue-reviewer.ts";
+const SUPER_AGENT_PATH = "apps/api/src/tools/task-board/enqueue-super-agent.ts";
+
+const REVIEWER_SOURCE = [
+  "const X = {",
+  "  // prompt-region:start qa-agent",
+  '  qa: "be thorough",',
+  "  // prompt-region:end qa-agent",
+  "  // prompt-region:start code-reviewer",
+  '  review: "be picky",',
+  "  // prompt-region:end code-reviewer",
+  "};",
+  "",
+].join("\n");
+
+describe("applyPromptEdits", () => {
+  it("splices an edit into its own region and leaves siblings sharing the file untouched", () => {
+    const sources = new Map([[REVIEWER_PATH, REVIEWER_SOURCE]]);
+    applyPromptEdits(sources, [
+      { id: "qa-agent", content: '  qa: "be fast",' },
+    ]);
+    const next = sources.get(REVIEWER_PATH)!;
+    expect(next).toContain('qa: "be fast"');
+    expect(next).toContain('review: "be picky"');
+  });
+
+  // Reachable via a direct POST, bypassing the editor UI's own guard.
+  it("throws a 409 PromptEditorError when the region drifted out of the source instead of a raw splice error", () => {
+    const drifted = [
+      "const X = {",
+      "  // prompt-region:start code-reviewer",
+      '  review: "be picky",',
+      "  // prompt-region:end code-reviewer",
+      "};",
+      "",
+    ].join("\n");
+    const sources = new Map([[REVIEWER_PATH, drifted]]);
+
+    let caught: unknown;
+    try {
+      applyPromptEdits(sources, [{ id: "qa-agent", content: "x" }]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(PromptEditorError);
+    expect((caught as InstanceType<typeof PromptEditorError>).status).toBe(409);
+  });
+
+  it("applies edits across different files independently", () => {
+    const sources = new Map([
+      [REVIEWER_PATH, REVIEWER_SOURCE],
+      [
+        SUPER_AGENT_PATH,
+        [
+          "// prompt-region:start super-agent",
+          'hosted: "be quick",',
+          "// prompt-region:end super-agent",
+          "",
+        ].join("\n"),
+      ],
+    ]);
+    applyPromptEdits(sources, [
+      { id: "code-reviewer", content: '  review: "be lenient",' },
+      { id: "super-agent", content: 'hosted: "be slow",' },
+    ]);
+    expect(sources.get(REVIEWER_PATH)).toContain('review: "be lenient"');
+    expect(sources.get(SUPER_AGENT_PATH)).toContain('hosted: "be slow"');
+  });
+});

--- a/apps/api/src/api/routes/admin-prompts.ts
+++ b/apps/api/src/api/routes/admin-prompts.ts
@@ -64,7 +64,7 @@ const PROMPTS = [
 
 type PromptId = (typeof PROMPTS)[number]["id"];
 
-class PromptEditorError extends Error {
+export class PromptEditorError extends Error {
   constructor(
     message: string,
     readonly status: 400 | 404 | 409,
@@ -146,6 +146,35 @@ async function clientForActor(
     gh: createGitDataClient({ ...PROMPT_REPO, accessToken }),
     org: { slug: org.slug, name: org.name },
   };
+}
+
+/**
+ * Splice every edit into `sources` (mutated in place). A region can vanish
+ * between the GET that populated the editor and this POST — the file itself
+ * was reverted, or the registry and the source drifted — and `baseSha`
+ * doesn't catch every such case (a caller can post an edit without ever
+ * having loaded the current HEAD). `replacePromptRegion` throws a plain
+ * `Error` for that; surface it the same way `readSources` already does for
+ * a moved file, instead of letting it fall through to a generic 500.
+ */
+export function applyPromptEdits(
+  sources: Map<string, string>,
+  edits: { id: PromptId; content: string }[],
+): void {
+  for (const edit of edits) {
+    const prompt = PROMPTS.find((p) => p.id === edit.id)!;
+    try {
+      sources.set(
+        prompt.path,
+        replacePromptRegion(sources.get(prompt.path)!, prompt.id, edit.content),
+      );
+    } catch {
+      throw new PromptEditorError(
+        `Prompt "${edit.id}" no longer has a marked region in ${prompt.path} — reload and re-apply your edit`,
+        409,
+      );
+    }
+  }
 }
 
 /** Every distinct source file the registry touches, read once at `ref`. */
@@ -238,13 +267,7 @@ export function createAdminPromptRoutes(): Hono<Env> {
     // Splice against the exact parent commit's content so an unedited prompt in
     // the same file is carried over verbatim rather than reverted.
     const sources = await readSources(gh, baseSha);
-    for (const edit of edits) {
-      const prompt = PROMPTS.find((p) => p.id === edit.id)!;
-      sources.set(
-        prompt.path,
-        replacePromptRegion(sources.get(prompt.path)!, prompt.id, edit.content),
-      );
-    }
+    applyPromptEdits(sources, edits);
 
     const changedPaths = [
       ...new Set(edits.map((e) => PROMPTS.find((p) => p.id === e.id)!.path)),


### PR DESCRIPTION
Follows #6610 (deployment-admin prompt editor, merged this same day). `POST /api/_admin/prompts/pull-request` takes an untrusted `edits` array from the request body and splices each entry into the source file via `replacePromptRegion`, which then gets committed and opened as a PR against `decocms/studio`. `replacePromptRegion` throws a plain `Error` when a prompt's marker pair is gone from the file — the route's sibling failure mode (`readSources`, a moved/deleted file) is already mapped to a clean `PromptEditorError` 409, but this one wasn't, so it fell through to the generic 500 handler.

The editor UI already disables an unmarked prompt (`content: null`) so a normal click-through can't hit this, but the endpoint takes raw JSON — a direct POST for a prompt id whose marker was removed/renamed between the GET and the POST (or just crafted by hand) 500s instead of getting the same structured, reload-and-retry 409 every other drift case in this route gets.

**Fix**: extracted the edit-splicing loop into `applyPromptEdits` (pure, no I/O) and wrapped `replacePromptRegion` in a try/catch that rethrows as `PromptEditorError(409)`, matching `readSources`'s existing pattern.

**Regression test**: `apps/api/src/api/routes/admin-prompts.test.ts` — new file, 3 cases: normal splice leaves a sibling region in the same file untouched, a drifted region now throws `PromptEditorError` with `status: 409` instead of a raw `Error`, and edits across two different files apply independently. No mocks needed since `applyPromptEdits` is pure.

Reviewer check: `bun test apps/api/src/api/routes/admin-prompts.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (14 pass across both prompt-region test files), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the admin prompt pull-request endpoint returning a generic 500 when a marker region drifts away, so direct POSTs get the same structured 409 reload-and-retry error as other drift cases.

- Extracts the edit-splicing loop into `applyPromptEdits` and rethrows `replacePromptRegion` errors as `PromptEditorError` with status 409.
- Adds regression tests for sibling regions in the same file, drifted regions, and edits across multiple files.

<sup>Written for commit 33a2a6afbc42e126c72a880e36c0d5d63571ab0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

