### PR TITLE
fix(oauth): don't discard a successfully refreshed OAuth token on a persist failure

### DIFF
--- a/apps/api/src/oauth/token-refresh-persist-failure.test.ts
+++ b/apps/api/src/oauth/token-refresh-persist-failure.test.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
 });
 
 describe("refreshAndStore — storage failures don't throw", () => {
-  it("returns null instead of rejecting when persisting a fresh token fails", async () => {
+  it("returns the freshly refreshed token instead of discarding it when persisting fails", async () => {
     mockRefreshAccessToken.mockResolvedValue({
       success: true,
       accessToken: "new-access",
@@ -54,7 +54,9 @@ describe("refreshAndStore — storage failures don't throw", () => {
       upsert: vi.fn().mockRejectedValue(new Error("db unavailable")),
     });
 
-    await expect(refreshAndStore(baseToken, storage)).resolves.toBeNull();
+    await expect(refreshAndStore(baseToken, storage)).resolves.toBe(
+      "new-access",
+    );
   });
 
   it("returns null instead of rejecting when deleting a dead token fails", async () => {

--- a/apps/api/src/oauth/token-refresh.ts
+++ b/apps/api/src/oauth/token-refresh.ts
@@ -124,12 +124,12 @@ async function refreshAndStoreOnce(
       tokenEndpoint: token.tokenEndpoint,
     });
   } catch (error) {
-    // Persisting the refreshed token failed — report a transient failure.
+    // A cache miss, not a failure — the token is already valid on the upstream.
     console.warn("[TokenRefresh] failed to persist refreshed token", {
       connectionId: token.connectionId,
       message: error instanceof Error ? error.message : String(error),
     });
-    return { accessToken: null, permanent: false };
+    return { accessToken: result.accessToken, permanent: false };
   }
   return { accessToken: result.accessToken, permanent: false };
 }


### PR DESCRIPTION
Follows #6511, which fixed this exact discard-on-persist-failure bug in the sibling `github-mint.ts` path (the two files are explicitly documented as siblings — `token-refresh.ts` reuses `PROACTIVE_REFRESH_BUFFER_MS`/`RECONNECT_ERROR` from it).

`token-refresh.ts` had the identical bug: `refreshAndStoreOnce` already catches a `tokenStorage.upsert()` failure so it doesn't throw, but it returned `{ accessToken: null, permanent: false }` — discarding the token it just successfully refreshed.

This is worse than the mint case: many OAuth providers rotate (single-use) refresh tokens, so once the refresh call succeeds, the old `refreshToken` is already dead upstream. Discarding the new `accessToken` on a transient DB/vault write blip doesn't just cost a retry — `getValidDownstreamAccessToken` surfaces `state: "refresh_failed"` even though a perfectly valid token exists, and the *next* refresh attempt would replay the now-consumed refresh token and fail for real (heading toward a forced manual reconnect).

**Fix**: return the freshly refreshed `accessToken` even when `tokenStorage.upsert()` throws, matching the just-merged `github-mint.ts` fix. The warning log is unchanged; only the return value changes.

**Regression test**: `token-refresh-persist-failure.test.ts` had a pre-existing test that explicitly asserted the *old* behavior ("returns null instead of rejecting when persisting a fresh token fails") — inverted it to assert the refreshed token is returned instead of discarded.

Reviewer command: `bun test apps/api/src/oauth/token-refresh-persist-failure.test.ts`

Checked locally: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OAuth token refresh path so a successfully refreshed access token is returned even when persisting it to storage fails. Previously, a persist failure discarded the fresh token, which caused downstream calls to report `refresh_failed` and made the next refresh attempt fail with the already-consumed refresh token (since many providers rotate them). The regression test now asserts the refreshed token is returned instead of `null`.

<sup>Written for commit a698ea6e161e1f2c34720b83b918d706a33b3c1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

