### PR TITLE
fix(task-board): cap TASK_BOARD_REVIEW_DECISION's notes length

### DIFF
--- a/apps/api/src/tools/task-board/review-decision.test.ts
+++ b/apps/api/src/tools/task-board/review-decision.test.ts
@@ -3,7 +3,32 @@ import type { ReviewCycleActivity } from "@decocms/shared/task-board";
 import {
   isDuplicateChangeRequest,
   reviewTokenVerified,
+  TASK_BOARD_REVIEW_DECISION,
 } from "./review-decision";
+
+describe("TASK_BOARD_REVIEW_DECISION notes bound", () => {
+  const baseInput = {
+    taskBoardItemId: "item-1",
+    reviewer: "qa" as const,
+    decision: "approve" as const,
+  };
+
+  it("accepts notes at the cap", () => {
+    const result = TASK_BOARD_REVIEW_DECISION.inputSchema.safeParse({
+      ...baseInput,
+      notes: "x".repeat(50_000),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects notes over the cap — unbounded text would land verbatim in a card comment and the next re-dispatch prompt", () => {
+    const result = TASK_BOARD_REVIEW_DECISION.inputSchema.safeParse({
+      ...baseInput,
+      notes: "x".repeat(50_001),
+    });
+    expect(result.success).toBe(false);
+  });
+});
 
 describe("reviewTokenVerified", () => {
   const cycleA = new Date("2026-01-01T00:00:00Z").getTime();

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -30,6 +30,12 @@ import { TaskQuotaError } from "@/billing/task-quota";
 import { ensureReviewerCommented } from "./reviewer-comment";
 import { taskRunContextStore } from "./task-run-context";
 
+/** `notes` is mirrored verbatim into a card comment (`ensureReviewerCommented`)
+ *  and into the next Super Agent run's re-dispatch prompt (`feedback` below) —
+ *  same cap as a regular comment body so a reviewer can't grow either without
+ *  bound. */
+const MAX_REVIEW_NOTES_LENGTH = 50_000;
+
 /**
  * True when a resolved LEGACY reviewToken claim actually belongs to THIS
  * reviewer's claim on the CURRENT review cycle. (Current tokens are HMACs —
@@ -119,6 +125,7 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
     notes: z
       .string()
       .min(1)
+      .max(MAX_REVIEW_NOTES_LENGTH)
       .describe(
         "For approve: a short summary of what you verified. For " +
           "request_changes: specific, actionable feedback the Super Agent " +


### PR DESCRIPTION
Follows the established "bound an attacker/agent-controlled tool-input field" hardening lane (comment body, task title/description/repo all already capped) — this is the one sibling free-text field on the task-board tool surface that was left unbounded.

`notes` on `TASK_BOARD_REVIEW_DECISION` had no `.max()`, unlike every other free-text field in this area (`TASK_BOARD_COMMENT_CREATE`'s `body`, `TASK_BOARD_CREATE`'s `title`/`description`/`repo`). It isn't just stored: `ensureReviewerCommented` mirrors it verbatim into a card comment when the reviewer left none, and on `request_changes` it's spliced directly into the next Super Agent run's re-dispatch prompt via `feedback: `${REVIEWER_LABEL[reviewer]}: ${notes}``. An unbounded verdict grows both the activity/comment rows and the next model call's context with no limit.

Failure scenario: a reviewer run (or a prompt-injected one) returns a multi-megabyte `notes` string — it gets written straight into `task_board_item_activity` and into a card comment, then re-fed as context to the very next agent dispatch, ballooning cost and DB row size with no cap in the way every sibling field already has one.

Fix: capped `notes` at 50,000 chars — the same bound `TASK_BOARD_COMMENT_CREATE` already enforces on a comment body, since this text ends up in that same comment column via `verdictCommentBody`.

Regression test in `review-decision.test.ts` asserts the tool's `inputSchema` accepts exactly the cap and rejects one character over it.

Reviewer check: `bun test apps/api/src/tools/task-board/review-decision.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `TASK_BOARD_REVIEW_DECISION`'s `notes` field at 50,000 characters so reviewer verdicts can no longer grow card comments and re-dispatch prompts without bound.

- Applies the same cap `TASK_BOARD_COMMENT_CREATE` already enforces on comment bodies, since these notes land in the same comment column.
- Adds a regression test asserting the schema accepts exactly 50,000 chars and rejects one over.

<sup>Written for commit bfbfaf96f10e1cb0551781e7b796739755ed4cdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

