### PR TITLE
refactor(home): use the destructive token for the overdue task date

### DIFF
--- a/apps/web/src/components/home/home-tasks.tsx
+++ b/apps/web/src/components/home/home-tasks.tsx
@@ -99,7 +99,7 @@ function TaskRow({
           <span
             className={cn(
               "hidden items-center gap-1 @xl:inline-flex",
-              due.overdue ? "text-red-600" : "",
+              due.overdue ? "text-destructive" : "",
             )}
           >
             <Calendar className="size-3" />


### PR DESCRIPTION
C-DEBT: design-token drift in a file bordering the task-board lane.

The Home overview's task row hardcodes `text-red-600` for an overdue due-date, while the task board's own row (`apps/web/src/layouts/task-board/index.tsx`, both `formatDueDate`'s urgency pill and the due-date badge) already renders the identical "overdue" meaning with the design-system `text-destructive` token. Same concept, same app, unambiguous mapping — not a judgment call about shade or brand.

Maintainer payoff: keeps the overdue color themeable (dark mode, future brand tweaks) and consistent with the board it summarizes, instead of a magic Tailwind palette class drifting from the token everywhere else uses.

This aligns the shade to the design-system `destructive` token — it is not guaranteed to be pixel-identical to the old `red-600`, but is the correct semantic color for "overdue" per the rest of the codebase.

To confirm: open the Home overview with a task whose due date is in the past and check the date pill renders in the destructive (red) color, matching the task board's own overdue badge.

Checks run locally: `bun run fmt` (clean), `bunx oxlint apps/web/src/components/home/home-tasks.tsx` (0 warnings/errors). No types touched, so no targeted `tsc` run was needed. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hardcoded `text-red-600` with the design-system `text-destructive` token for the overdue due date in the home task row. This aligns the color with the task board's overdue badge and keeps it themeable. The shade may differ slightly from the old red.

<sup>Written for commit aa537a6f3c7e4516b1738fc35de1e2bbaa5d717a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

