### PR TITLE
fix(task-board): cancel a stale in-flight refetch before a live task delete

### DIFF
--- a/apps/web/src/hooks/use-task-board-items.ts
+++ b/apps/web/src/hooks/use-task-board-items.ts
@@ -99,8 +99,9 @@ export function useTaskBoardItems() {
     onResync: () => {
       queryClient.invalidateQueries({ queryKey });
     },
-    // Live deletes: drop the removed card so it clears on every open board.
+    // Live deletes: drop the removed card, canceling a stale in-flight refetch first (same race as onUpdate above).
     onDelete: (id) => {
+      queryClient.cancelQueries({ queryKey });
       queryClient.setQueryData<TaskBoardData>(queryKey, (prev) =>
         prev ? { ...prev, items: prev.items.filter((t) => t.id !== id) } : prev,
       );


### PR DESCRIPTION
Follows #6627 (`fix(task-board): stop a raced refetch from bouncing an Auto-fixed card back to To Do`), which added `queryClient.cancelQueries({ queryKey })` before the optimistic patch in `onUpdate` because a list refetch issued before a live push can resolve after it and overwrite the transition.

`onDelete`, right below it in the same file, has the identical race and was left unfixed: a refetch already in flight when a live delete event lands still resolves with the (pre-delete) full list, and its response overwrites the just-applied deletion — the card reappears on the board until the 60s refetch backstop (or an F5) catches up.

This mirrors the exact fix #6627 applied to `onUpdate`: cancel the in-flight query before writing the delete into the cache, so a stale response can't win the race.

To confirm: read `apps/web/src/hooks/use-task-board-items.ts` — `onUpdate` and `onDelete` in `useTaskBoardItems()` now both cancel before patching, where only `onUpdate` did before.

Locally verified: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bunx oxlint apps/web/src/hooks/use-task-board-items.ts` (0 errors/warnings). No existing unit test covers this hook (it's SSE + react-query wiring, exercised in e2e); full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition where a stale in-flight refetch could overwrite a live task delete, causing the deleted card to reappear until the next refetch. Now cancels the in-flight query before applying the delete to the cache, matching the existing fix for task updates.

<sup>Written for commit de454e003713422ebb2ffb54be5feb91954e5a92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

