### PR TITLE
fix(settings): make the unmapped-columns warning readable in light mode

### DIFF
--- a/apps/web/src/views/settings/jira.tsx
+++ b/apps/web/src/views/settings/jira.tsx
@@ -286,7 +286,7 @@ function ColumnMappingRows({ integration }: { integration: JiraIntegration }) {
   return (
     <div className="flex flex-col mt-3">
       {unmapped.length > 0 && (
-        <p className="mb-2 rounded-md bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
+        <p className="mb-2 rounded-md bg-warning/10 px-3 py-2 text-xs text-warning">
           {t("settings.jira.unmappedWarning", {
             columns: unmapped.map((column) => column.name).join(", "),
           })}


### PR DESCRIPTION
## Summary

The unmapped-columns warning in the task board's Jira settings was unreadable in the light theme — white text on a cream background.

`apps/web/src/views/settings/jira.tsx` paired `text-warning-foreground` with `bg-warning/10`. But `--warning-foreground` is near-white (`oklch(0.99 0.02 95)`): it's the *on-solid* pairing, meant for text sitting on a filled `bg-warning`. Over a 10% tint it disappears.

Swapped to `text-warning` — the pattern every other tinted state banner in the app already uses (`components/account-popover.tsx`, `components/chat/credits-eyebrow.tsx`, `components/chat/tiptap/file/uploader.tsx`). Both themes define `--warning` at a mid lightness (`0.62` light / `0.65` dark), so it reads in either.

This was the only `*-foreground`-on-tint misuse in `apps/web/src` — `grep` for `warning-foreground|success-foreground` turns up nothing else outside the token definitions themselves.

## Testing

One-token CSS class change, no logic touched. Verified by reading the token definitions in `packages/ui/src/styles/global.css` (both `:root` and the dark block) and by comparing against the existing tinted-banner call sites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the unmapped-columns warning in the Jira settings so it's readable in light mode. The banner previously paired `text-warning-foreground` (near-white) with a 10% warning tint, making the text invisible against the cream background; it now uses `text-warning`, matching every other tinted banner in the app.

<sup>Written for commit d705161c2806c5c099ef163cf6b2f69be347ea25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

