### PR TITLE
fix(task-board): reject a direct write into a delivery lane when the flag is off

### DIFF
--- a/apps/api/src/tools/task-board/lanes.ts
+++ b/apps/api/src/tools/task-board/lanes.ts
@@ -30,6 +30,14 @@ export const LANE_RANK: Record<TaskBoardItemStatus, number> = {
  *  literal union stays a subset of this side's lane vocabulary. */
 export const DELIVERY_LANE_STATUSES: TaskBoardItemStatus[] = DELIVERY_LANES;
 
+/** True for one of the post-merge delivery lanes (Approved, Merged, Post-deploy
+ *  Validation) — the statuses that only exist for an org running
+ *  `delivery_lanes_enabled`. Mirrors the web-side `isDeliveryLane` in
+ *  `layouts/task-board/config.tsx`. */
+export function isDeliveryLane(status: TaskBoardItemStatus): boolean {
+  return DELIVERY_LANE_STATUSES.includes(status);
+}
+
 /**
  * True when moving `from` → `to` advances the card.
  *

--- a/apps/api/src/tools/task-board/update.test.ts
+++ b/apps/api/src/tools/task-board/update.test.ts
@@ -12,6 +12,7 @@ import {
   closesOwnReview,
   delegatesToSuperAgent,
   diffTaskActivityEntries,
+  rejectsUngatedDeliveryLane,
   updatesAnyField,
 } from "./update";
 
@@ -233,5 +234,32 @@ describe("closesOwnReview", () => {
 
   it("never catches a person", () => {
     expect(closesOwnReview("done", "in_review", false)).toBe(false);
+  });
+});
+
+describe("rejectsUngatedDeliveryLane", () => {
+  it("refuses a direct write into a delivery lane when the flag is off", () => {
+    expect(rejectsUngatedDeliveryLane("approved", false)).toBe(true);
+    expect(rejectsUngatedDeliveryLane("merged", false)).toBe(true);
+    expect(rejectsUngatedDeliveryLane("post_deploy_validation", false)).toBe(
+      true,
+    );
+  });
+
+  it("allows it once the org runs the delivery lanes", () => {
+    expect(rejectsUngatedDeliveryLane("approved", true)).toBe(false);
+    expect(rejectsUngatedDeliveryLane("merged", true)).toBe(false);
+  });
+
+  it("leaves every other status alone regardless of the flag", () => {
+    for (const status of [
+      "todo",
+      "in_progress",
+      "in_review",
+      "done",
+    ] as const) {
+      expect(rejectsUngatedDeliveryLane(status, false)).toBe(false);
+    }
+    expect(rejectsUngatedDeliveryLane(undefined, false)).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { getUserId, requireAuth } from "@/core/studio-context";
+import { orgFlagEnabled } from "@decocms/shared/organization/schema";
 import type {
   TaskBoardActivityAction,
   TaskBoardItem,
@@ -16,6 +17,7 @@ import {
   TaskBoardItemSchema,
   TaskBoardItemStatusSchema,
 } from "./schema";
+import { isDeliveryLane } from "./lanes";
 import { assertValidAssignee } from "./validate-assignee";
 import { reactToSuperAgentDelegation } from "./enqueue-super-agent";
 import { recordTaskActivities } from "./activity";
@@ -164,6 +166,28 @@ export function closesOwnReview(
   return isTaskRun && completesTask && awaitingReview;
 }
 
+/**
+ * A delivery lane (Approved, Merged, Post-deploy Validation) is a status that
+ * only exists for an org running `delivery_lanes_enabled` — the schema still
+ * accepts it unconditionally (adding a lane is a compile-time exhaustiveness
+ * concern, not a runtime one), so this tool is the one place that has to
+ * refuse it directly when the flag is off. Without this, any raw
+ * TASK_BOARD_ITEM_UPDATE call (an MCP client, a script, a stale agent) could
+ * park a card in a lane the flag's own description promises "behaves exactly
+ * as if it did not exist" — the board's `moveTargets`/`laneVisibility` only
+ * gate the UI's own drag/dropdown, not the tool underneath them.
+ */
+export function rejectsUngatedDeliveryLane(
+  inputStatus: TaskBoardItemStatus | undefined,
+  deliveryLanesEnabled: boolean,
+): boolean {
+  return (
+    inputStatus !== undefined &&
+    isDeliveryLane(inputStatus) &&
+    !deliveryLanesEnabled
+  );
+}
+
 export const TASK_BOARD_ITEM_UPDATE = defineTool({
   name: "TASK_BOARD_ITEM_UPDATE",
   description:
@@ -265,6 +289,23 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     // longer org-scoped itself (the join table has no organization_id).
     if (hasFieldUpdate && !previous) {
       throw new Error(`Task board item not found: ${input.id}`);
+    }
+
+    if (input.status !== undefined && isDeliveryLane(input.status)) {
+      const settings =
+        await ctx.storage.organizationSettings.get(organizationId);
+      if (
+        rejectsUngatedDeliveryLane(
+          input.status,
+          orgFlagEnabled(settings?.flags, "delivery_lanes_enabled"),
+        )
+      ) {
+        throw new Error(
+          "Delivery lanes are not enabled for this organization — enable " +
+            "them in Settings before moving a task to Approved, Merged, or " +
+            "Post-deploy Validation.",
+        );
+      }
     }
 
     const isTaskRun = taskRunContextStore.getStore() !== undefined;

--- a/packages/e2e/tests/task-board-delivery-lanes.spec.ts
+++ b/packages/e2e/tests/task-board-delivery-lanes.spec.ts
@@ -71,6 +71,13 @@ test.describe("task board delivery lanes", () => {
     const request = page.context().request;
     const call = <T>(name: string, args: unknown) =>
       callSelfMcpTool<T>(request, orgSlug, name, args);
+    const orgId = await findOrgId(request, orgSlug);
+
+    // A direct write into a delivery lane is gated behind the flag.
+    await call("ORGANIZATION_SETTINGS_UPDATE", {
+      organizationId: orgId,
+      flags: { delivery_lanes_enabled: true },
+    });
 
     const { item } = await call<{ item: TaskBoardItem }>(
       "TASK_BOARD_ITEM_CREATE",


### PR DESCRIPTION
Follows #6457 (delivery lanes behind `delivery_lanes_enabled`).

`TASK_BOARD_ITEM_UPDATE`'s `status` input validated only against `TaskBoardItemStatusSchema`, not against the org's `delivery_lanes_enabled` flag. So any raw caller of the tool — an MCP client, a script, a stale decopilot agent — could set `status: "approved"`, `"merged"`, or `"post_deploy_validation"` even on an org that never turned the lanes on.

That breaks the invariant #6457 itself documents: the flag's `OrgFlagsSchema` description says the board "behave[s] exactly as if the lanes did not exist" with it off. #6457 already gated every UI entry point (`moveTargets`, `laneVisibility`, the Jira status-mapping options) on the flag, but the tool underneath those UI gates had no server-side check — the UI gate is advisory only, same class of gap the file's own `isReadyToShip` comment warns about ("that's client-side gating only").

Fix: `TASK_BOARD_ITEM_UPDATE` now looks up the org's flag before accepting a delivery-lane status, and throws if it's off. Added `isDeliveryLane` to `lanes.ts` (mirrors the existing web-side helper) and a pure `rejectsUngatedDeliveryLane` gate, unit-tested in `update.test.ts` (asserts the block for `false`, the pass-through for `true`, and that every non-lane status is untouched either way).

Reviewer: `bun test apps/api/src/tools/task-board/update.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on the three changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `TASK_BOARD_ITEM_UPDATE` so it rejects writes into delivery-lane statuses when the org's `delivery_lanes_enabled` flag is off. Previously the tool only validated the status against the enum, letting raw callers (an MCP client, a script, a stale agent) set `approved`, `merged`, or `post_deploy_validation` on any org. Now it checks the org flag and throws instead.

- Adds `isDeliveryLane` in `lanes.ts`, mirroring the web-side helper.
- Adds the pure `rejectsUngatedDeliveryLane` gate in `update.ts`; unit tests cover the flag off, flag on, and non-lane statuses.
- Updates the e2e delivery-lane spec to enable the flag before the direct-write test.
- Callers on orgs with the flag off that set these statuses will now get an error pointing them to Settings.

<sup>Written for commit 6963edbff6091105f3f54bb3c8e691b21239e6b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

