### PR TITLE
fix(settings): keep a Jira column's mapped delivery lane selectable when the flag turns off

### DIFF
--- a/apps/web/src/views/settings/jira.test.ts
+++ b/apps/web/src/views/settings/jira.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { boardStatusOptions } from "./jira.tsx";
+
+describe("boardStatusOptions", () => {
+  it("offers every lane once delivery lanes are on", () => {
+    expect(boardStatusOptions(true, undefined).map((o) => o.value)).toContain(
+      "merged",
+    );
+  });
+
+  it("drops the delivery lanes once the flag is off", () => {
+    const values = boardStatusOptions(false, undefined).map((o) => o.value);
+    expect(values).not.toContain("merged");
+    expect(values).not.toContain("approved");
+    expect(values).not.toContain("post_deploy_validation");
+  });
+
+  // A row already mapped to a delivery lane must keep showing it once the flag is off.
+  it("keeps the row's current delivery lane even with the flag off", () => {
+    const values = boardStatusOptions(false, "merged").map((o) => o.value);
+    expect(values).toContain("merged");
+    expect(values).not.toContain("approved");
+  });
+});

--- a/apps/web/src/views/settings/jira.tsx
+++ b/apps/web/src/views/settings/jira.tsx
@@ -106,13 +106,19 @@ const BOARD_STATUS_OPTIONS: Array<{
 ];
 
 /** The lanes this org can map a Jira status onto — offering an unrun delivery
- *  lane would route issues into a column the board never draws. */
-function boardStatusOptions(
+ *  lane would route issues into a column the board never draws. `current` is
+ *  this row's already-mapped value: if it's a delivery lane saved while the
+ *  flag was on, it must stay in the list even after the flag turns off, or the
+ *  Select's value stops matching any item and the row silently renders blank
+ *  while the mapping underneath is untouched. */
+export function boardStatusOptions(
   deliveryEnabled: boolean,
+  current: BoardStatus | undefined,
 ): typeof BOARD_STATUS_OPTIONS {
-  return deliveryEnabled
-    ? BOARD_STATUS_OPTIONS
-    : BOARD_STATUS_OPTIONS.filter((o) => !isDeliveryLane(o.value));
+  if (deliveryEnabled) return BOARD_STATUS_OPTIONS;
+  return BOARD_STATUS_OPTIONS.filter(
+    (o) => !isDeliveryLane(o.value) || o.value === current,
+  );
 }
 
 /** Radix Select forbids empty item values — sentinel for "not synced". */
@@ -336,7 +342,10 @@ function ColumnMappingRows({ integration }: { integration: JiraIntegration }) {
               <SelectItem value={DONT_SYNC}>
                 {t("settings.jira.dontSync")}
               </SelectItem>
-              {boardStatusOptions(deliveryEnabled).map((option) => (
+              {boardStatusOptions(
+                deliveryEnabled,
+                laneOfColumn(mapping, column),
+              ).map((option) => (
                 <SelectItem key={option.value} value={option.value}>
                   {t(option.labelKey)}
                 </SelectItem>


### PR DESCRIPTION
Follows #6457 (delivery lanes). #6457 filters delivery-lane statuses (`approved`/`merged`/`post_deploy_validation`) out of the Jira column-mapping Select whenever `delivery_lanes_enabled` is off — mirroring the same pattern it applied to the board's own lane visibility (`laneVisibility`'s `occupied` override) everywhere except this one call site.

Failure scenario: an org maps a Jira column to "Merged" while the flag is on, then turns the flag off. The saved mapping (`statusMapping`) is untouched, but Radix Select's `value` no longer matches any `SelectItem` in the now-filtered option list, so that row silently renders blank instead of "Merged" — an admin sees an unmapped-looking column even though sync still routes to it correctly underneath.

Fix: `boardStatusOptions` now takes the row's current mapped value and always keeps it in the list even when it's a delivery lane and the flag is off, same as the board already does for an occupied lane. Added `apps/web/src/views/settings/jira.test.ts` covering: lanes on, lanes off, and a row currently mapped to a delivery lane with the flag off.

A reviewer can confirm with `bun test apps/web/src/views/settings/jira.test.ts`.

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (no jira-related errors), `bunx oxlint` on both changed files (clean), and the targeted test above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps a Jira column's mapped delivery lane selectable when the `delivery_lanes_enabled` flag turns off. Previously the row rendered blank once the flag was off because the dropdown no longer contained the mapped value, even though the underlying mapping stayed intact.

- `boardStatusOptions` now takes the row's current mapped value and keeps it in the list even when it's a disabled delivery lane.
- Adds `apps/web/src/views/settings/jira.test.ts` covering lanes on, lanes off, and a row currently mapped to a delivery lane with the flag off.

<sup>Written for commit ac62a33a21f3fb7436514efddcd5f8b1b7e88676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

