### PR TITLE
fix(task-board): cancel a stale in-flight refetch before a thread-status push

### DIFF
--- a/apps/web/src/hooks/use-task-board-items.ts
+++ b/apps/web/src/hooks/use-task-board-items.ts
@@ -118,6 +118,8 @@ export function useTaskBoardItems() {
     onTaskStatus: (event) => {
       const threadId = event.subject;
       const status = event.data.status;
+      // Same race as onUpdate/onDelete above: cancel a stale in-flight refetch first.
+      queryClient.cancelQueries({ queryKey });
       queryClient.setQueryData<TaskBoardData>(queryKey, (prev) =>
         prev
           ? {


### PR DESCRIPTION
Follows #6632, which hardened `onUpdate`/`onDelete` in `use-task-board-items.ts` against a real race — a list refetch issued before a live SSE push lands after it and clobbers the pushed state — by calling `queryClient.cancelQueries` before writing. `onTaskStatus` (the linked-thread `requires_action`/`in_progress` status handler, which flips a card's "blocked, waiting for input" flag) was left out of that hardening pass and still writes with `setQueryData` alone, so it's exposed to the identical bug: open a task dialog, a thread flips to `requires_action` via SSE, a refetch already in flight from before the push resolves after it and reverts the card's blocked flag until the 60s backstop poll catches up.

Fix: call `queryClient.cancelQueries({ queryKey })` before `setQueryData` in `onTaskStatus`, matching the pattern already used in `onUpdate`/`onDelete` right above it.

No new test — same precedent as #6632 itself, which shipped this exact hardening pattern with no test (the hook's dependencies — `useProjectContext`, `useStudioTools`, `useTaskBoardEvents`, `useDecopilotEvents` — make it e2e territory, not a pure-logic unit).

Reviewer check: read `apps/web/src/hooks/use-task-board-items.ts` — `onTaskStatus` now mirrors the same cancel-then-write shape as `onUpdate`/`onDelete`.

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/web, no new errors on this file), `bunx oxlint apps/web/src/hooks/use-task-board-items.ts` (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `onTaskStatus` from clobbering an SSE thread-status push with a stale refetch, matching the cancel-then-write pattern already in `onUpdate`/`onDelete`. Previously, a refetch in flight before the push could resolve after it and revert the card's blocked flag until the 60s backstop poll.

<sup>Written for commit 65f882a7486dc0534921fc5e2d742300e4697099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

