### PR TITLE
fix(billing): collect CPF/CNPJ via a required custom field on Checkout

### DIFF
--- a/apps/api/src/billing/stripe-api.test.ts
+++ b/apps/api/src/billing/stripe-api.test.ts
@@ -42,18 +42,33 @@ describe("toStripeForm", () => {
 });
 
 describe("taxAndAddressParams", () => {
-  test("collects address + tax ID, and writes back only for a saved customer", () => {
+  test("collects address + a required CPF/CNPJ custom field", () => {
     const guest = toStripeForm(taxAndAddressParams(null));
     expect(guest.get("billing_address_collection")).toBe("required");
-    expect(guest.get("tax_id_collection[enabled]")).toBe("true");
-    // Without `required`, `enabled` alone lets the buyer submit blank.
-    expect(guest.get("tax_id_collection[required]")).toBe("if_supported");
+
+    // A no-op for BR buyers: the country isn't in Checkout's supported list.
+    expect(guest.has("tax_id_collection[enabled]")).toBe(false);
+    expect(guest.has("tax_id_collection[required]")).toBe(false);
+
+    expect(guest.get("custom_fields[0][key]")).toBe("taxid");
+    expect(guest.get("custom_fields[0][type]")).toBe("text");
+    expect(guest.get("custom_fields[0][label][type]")).toBe("custom");
+    expect(guest.get("custom_fields[0][label][custom]")).toBe("CPF / CNPJ");
+    // Pinned rather than left to Stripe's `false` default — it gates payment.
+    expect(guest.get("custom_fields[0][optional]")).toBe("false");
+    // Bare CPF (11 digits) through formatted CNPJ (18 chars).
+    expect(guest.get("custom_fields[0][text][minimum_length]")).toBe("11");
+    expect(guest.get("custom_fields[0][text][maximum_length]")).toBe("18");
+
     // Stripe rejects customer_update without a `customer` on the session.
     expect(guest.has("customer_update[address]")).toBe(false);
+  });
 
+  test("writes back to the customer only when one is saved", () => {
     const saved = toStripeForm(taxAndAddressParams("cus_1"));
     expect(saved.get("billing_address_collection")).toBe("required");
-    expect(saved.get("tax_id_collection[required]")).toBe("if_supported");
+    expect(saved.get("custom_fields[0][key]")).toBe("taxid");
+    expect(saved.get("custom_fields[0][optional]")).toBe("false");
     // Required by Stripe once a saved customer meets address collection.
     expect(saved.get("customer_update[address]")).toBe("auto");
     expect(saved.get("customer_update[name]")).toBe("auto");

--- a/apps/api/src/billing/stripe-api.ts
+++ b/apps/api/src/billing/stripe-api.ts
@@ -83,12 +83,31 @@ async function stripeRequest<T>(
   return parsed as T;
 }
 
+/** Custom-field key carrying the buyer's CPF/CNPJ. Stripe requires the key to
+ *  be alphanumeric, hence no separator. */
+const TAX_ID_FIELD_KEY = "taxid";
+
+/** A bare CPF is the shortest accepted value (11 digits), a formatted CNPJ the
+ *  longest (`00.000.000/0000-00`). */
+const TAX_ID_MIN_LENGTH = 11;
+const TAX_ID_MAX_LENGTH = 18;
+
 /**
- * Collect the buyer's billing address + tax ID (CPF/CNPJ, VAT, …) on every
- * Checkout — both are API-only params with no Dashboard fallback, so omitting
- * them means we never see either.
+ * Collect the buyer's billing address + CPF/CNPJ on every Checkout — both are
+ * API-only params with no Dashboard fallback, so omitting them means we never
+ * see either.
  *
- * `required` defaults to `never` — `enabled` alone renders a skippable field.
+ * The tax ID rides a required `custom_fields` entry rather than
+ * `tax_id_collection`, because Brazil is absent from Checkout's supported
+ * billing countries: `br_cnpj`/`br_cpf` exist on the Customer Tax ID API but
+ * not in Checkout, so `tax_id_collection[required]=if_supported` resolves to
+ * "not supported, therefore not required" for a BR buyer and the field never
+ * renders. The submitted value lands on `session.custom_fields[].text.value`,
+ * on `checkout.session.completed`, and in the Dashboard payment export.
+ *
+ * Required unconditionally: Checkout can't vary a custom field by country, and
+ * `adaptive_pricing` means a USD session doesn't imply a foreign buyer — every
+ * completed session on this account bills to a BR address, USD ones included.
  *
  * `customer_update` is mandatory, not cosmetic: with a saved `customer` and
  * address collection on, Stripe 400s the session unless we explicitly allow
@@ -100,7 +119,18 @@ export function taxAndAddressParams(
 ): Record<string, unknown> {
   return {
     billing_address_collection: "required",
-    tax_id_collection: { enabled: true, required: "if_supported" },
+    custom_fields: [
+      {
+        key: TAX_ID_FIELD_KEY,
+        label: { type: "custom", custom: "CPF / CNPJ" },
+        type: "text",
+        optional: false,
+        text: {
+          minimum_length: TAX_ID_MIN_LENGTH,
+          maximum_length: TAX_ID_MAX_LENGTH,
+        },
+      },
+    ],
     ...(customerId && { customer_update: { address: "auto", name: "auto" } }),
   };
 }


### PR DESCRIPTION
## Summary

`tax_id_collection[required]=if_supported` never collects anything from a Brazilian buyer. Brazil is **absent from Checkout's supported billing countries**, so Stripe resolves `if_supported` to "not supported, therefore not required" and the tax ID field is never rendered at all.

`br_cnpj`/`br_cpf` do exist — but on the **Customer Tax ID API**, which is a different and broader list than Checkout's. That mismatch is why the two previous attempts (#5933, #6588) read correctly and still collected nothing.

This swaps the tax ID onto a required `custom_fields` entry, which is the supported way to collect it for countries outside Checkout's list.

## Root cause, verified against live data

The params were reaching Stripe intact — this was never a serialization or an API-version problem. On completed live sessions:

| Field | Value |
| --- | --- |
| `billing_address_collection` | `required` — worked, full address collected |
| `tax_id_collection` | `{ enabled: true, required: "if_supported" }` — stored as sent |
| `customer_details.tax_ids` | `[]` — empty |
| `charge.billing_details.tax_id` | `null` |

Cross-referencing the two Stripe docs tables confirms it:

| List | BR present? |
| --- | --- |
| Customer Tax IDs API (`/v1/tax_ids`) | yes — `br_cnpj`, `br_cpf` |
| Checkout `tax_id_collection` | **no** — the table goes `BJ` → `BS` → `BY` |

## What changed

`taxAndAddressParams` now sends:

```ts
custom_fields: [
  {
    key: "taxid",                                   // Stripe requires alphanumeric keys
    label: { type: "custom", custom: "CPF / CNPJ" },
    type: "text",
    optional: false,
    text: { minimum_length: 11, maximum_length: 18 },
  },
]
```

The bounds span a bare CPF (11 digits) through a formatted CNPJ (`00.000.000/0000-00`, 18 chars). The value lands on `session.custom_fields[].text.value`, on `checkout.session.completed`, and in the Dashboard payment export.

Both call sites (org subscription and AI-credit top-up) go through this helper, and custom fields are unavailable only in `mode: setup` — neither flow uses it.

**Required unconditionally**, because Checkout can't vary a custom field by country and `adaptive_pricing` means a USD session doesn't imply a foreign buyer. Every completed session on this account bills to a BR address, the USD ones included — so this doesn't block any real buyer today. If non-BR customers are onboarded later, the escape hatch is to branch the helper on a caller-supplied country.

`billing_address_collection` is untouched — it was already working.

## Testing

- `bun test apps/api/src/billing/` — 79 pass. The existing test encoded the old behavior, so it was **inverted** rather than appended to: it now asserts `tax_id_collection` is no longer sent, so the no-op can't creep back.
- `bun run fmt` (no changes), `bun run lint` (0 errors), `bun run check` (green across all 14 workspaces), `knip` (nothing new).

## Follow-ups, deliberately not in this PR

1. **The value isn't persisted as a real Tax ID.** It's on the session and in payment exports — enough for finance — but it doesn't become a Tax ID object on the Customer, so it won't render in the invoice header. Doing that means reading the field in the `checkout.session.completed` handler and calling `POST /v1/tax_ids`. It has a prerequisite: top-ups run with `customer_creation: "if_required"` and currently produce sessions with `customer: null`, so there's no Customer to attach it to.
2. **No format validation.** Custom fields are free text; Stripe only enforces the length bounds.
3. **Unrelated but worth flagging:** this repo sends no `Stripe-Version` header, so every request runs on the account default version. Other services on the same Stripe account are pinned to their own versions (several at `2022-11-15`, one at `2026-02-25.clover`), which is what makes the request log look inconsistent. Pinning is a one-line addition to `stripeRequest`, but it's a behavior change on the billing hot path and belongs in its own PR.

Stripe's docs also advise against using custom fields for personal or protected data; CPF arguably qualifies, even though collecting it is standard practice and required for nota fiscal in Brazil. Worth a legal sign-off before this ships.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Checkout never collecting a CPF/CNPJ from Brazilian buyers: `tax_id_collection[required]=if_supported` is a no-op because Brazil isn't in Checkout's supported billing countries, so Stripe never renders the field. Swaps it for a required `custom_fields` text entry that lands on the session, on `checkout.session.completed`, and in the Dashboard payment export.

**Notes**
- The field is required for every session: Checkout can't vary custom fields by country, and `adaptive_pricing` means a USD session doesn't imply a foreign buyer.
- The value doesn't become a Tax ID object on the Customer, so it won't render in invoice headers; wiring that into the `checkout.session.completed` handler has a prerequisite — top-ups currently create sessions with `customer: null`.
- Stripe only enforces the 11–18 character bounds, not format; Stripe advises against custom fields for protected data like CPF, so a legal sign-off is worth getting.
- The test that asserted the old behavior now asserts `tax_id_collection` is no longer sent, so the no-op can't creep back.

<sup>Written for commit a8cfca51630b2739b5c567040db8d758d0d0333e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

