### PR TITLE
feat(cms): auto-switch stale session branches to a fresh one on CMS open

### DIFF
--- a/apps/api/src/api/routes/decofile.ts
+++ b/apps/api/src/api/routes/decofile.ts
@@ -431,20 +431,35 @@ export function createDecofileRoutes() {
     try {
       const client = await gitDataClientForScope(c);
       const baseBranch = await client.getDefaultBranch();
+      // Null lastCommitAt == "no age, never auto-switch off this branch".
       if (baseBranch === scope.branch) {
-        return c.json({ baseBranch, aheadBy: 0, behindBy: 0 });
+        return c.json({
+          baseBranch,
+          aheadBy: 0,
+          behindBy: 0,
+          lastCommitAt: null,
+        });
       }
       try {
-        const { aheadBy, behindBy } = await client.compare(
+        const [{ aheadBy, behindBy }, head] = await Promise.all([
+          client.compare(baseBranch, scope.branch),
+          client.getBranchHead(scope.branch),
+        ]);
+        return c.json({
           baseBranch,
-          scope.branch,
-        );
-        return c.json({ baseBranch, aheadBy, behindBy });
+          aheadBy,
+          behindBy,
+          lastCommitAt: head.committedAt,
+        });
       } catch (err) {
-        // A thread-minted branch that hasn't been materialized yet (first
-        // read/write creates it) trivially has no drift.
+        // A thread-minted branch not materialized yet has no drift and no age.
         if (err instanceof GitHubApiError && err.status === 404) {
-          return c.json({ baseBranch, aheadBy: 0, behindBy: 0 });
+          return c.json({
+            baseBranch,
+            aheadBy: 0,
+            behindBy: 0,
+            lastCommitAt: null,
+          });
         }
         throw err;
       }

--- a/apps/api/src/decofile/github-git-data.ts
+++ b/apps/api/src/decofile/github-git-data.ts
@@ -180,6 +180,15 @@ export interface GitDataClient {
   getDefaultBranch(): Promise<string>;
   getHeadSha(branch: string): Promise<string>;
   /**
+   * Branch head sha + the head commit's committer date, in one call. Git stores
+   * no ref-creation time, so this date is the branch's last-activity signal: a
+   * branch that was edited carries its last edit's date; a branch cut from the
+   * default branch and never touched carries the base commit's date (old the
+   * moment it lags behind an advancing default branch). The CMS staleness check
+   * reads it. Throws GitHubApiError(404) for a branch not yet on GitHub.
+   */
+  getBranchHead(branch: string): Promise<{ sha: string; committedAt: string }>;
+  /**
    * Gzipped tar of the repo at `ref`, as a stream — ONE request for every
    * file, vs one blob request per block. The preferred cold-read path. The
    * body is NEVER buffered here (golden rule 1: the archive must not touch
@@ -373,6 +382,16 @@ export function createGitDataClient(params: {
         `${repoBase}/git/ref/heads/${encodeRefPath(branch)}`,
       );
       return json.object.sha;
+    },
+
+    async getBranchHead(branch) {
+      const { json } = await call<{
+        commit: { sha: string; commit: { committer: { date: string } } };
+      }>("GET", `${repoBase}/branches/${encodeRefPath(branch)}`);
+      return {
+        sha: json.commit.sha,
+        committedAt: json.commit.commit.committer.date,
+      };
     },
 
     async getTarballStream(ref) {

--- a/apps/web/src/components/sections-editor/decofile-api.test.ts
+++ b/apps/web/src/components/sections-editor/decofile-api.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { CMS_STALE_BRANCH_MS, isBranchStale } from "./decofile-api";
+
+describe("isBranchStale", () => {
+  const now = new Date("2026-08-27T12:00:00.000Z").getTime();
+
+  it("is not stale when there is no commit date (default branch / unmaterialized)", () => {
+    expect(isBranchStale(null, now)).toBe(false);
+    expect(isBranchStale(undefined, now)).toBe(false);
+  });
+
+  it("is not stale for a fresh branch cut moments ago", () => {
+    const at = new Date(now - 60_000).toISOString();
+    expect(isBranchStale(at, now)).toBe(false);
+  });
+
+  it("is not stale exactly at the window boundary", () => {
+    const at = new Date(now - CMS_STALE_BRANCH_MS).toISOString();
+    expect(isBranchStale(at, now)).toBe(false);
+  });
+
+  it("is stale one ms past the window", () => {
+    const at = new Date(now - CMS_STALE_BRANCH_MS - 1).toISOString();
+    expect(isBranchStale(at, now)).toBe(true);
+  });
+
+  it("is stale for a branch untouched for 15 days", () => {
+    const at = new Date(now - 15 * 24 * 60 * 60 * 1000).toISOString();
+    expect(isBranchStale(at, now)).toBe(true);
+  });
+
+  it("honors a custom window", () => {
+    const at = new Date(now - 90 * 60 * 1000).toISOString();
+    expect(isBranchStale(at, now, 60 * 60 * 1000)).toBe(true);
+    expect(isBranchStale(at, now, 2 * 60 * 60 * 1000)).toBe(false);
+  });
+
+  it("treats an unparseable date as not stale", () => {
+    expect(isBranchStale("not-a-date", now)).toBe(false);
+  });
+});

--- a/apps/web/src/components/sections-editor/decofile-api.ts
+++ b/apps/web/src/components/sections-editor/decofile-api.ts
@@ -128,6 +128,59 @@ export async function fetchDecofile(
   return body.decofile;
 }
 
+/**
+ * A CMS branch is stale once its last commit is older than this. Git has no
+ * ref-creation time, so "last commit" doubles as "last touched" (an untouched
+ * side branch keeps the base commit it was cut from — old the moment the
+ * default branch advances). See {@link fetchDecofileStatus}.
+ */
+export const CMS_STALE_BRANCH_MS = 2 * 24 * 60 * 60 * 1000;
+
+interface DecofileStatus {
+  baseBranch: string;
+  aheadBy: number;
+  behindBy: number;
+  /**
+   * Head commit's committer date (ISO), or null when the branch is the default
+   * branch or not yet materialized on GitHub — either way, never auto-switch.
+   */
+  lastCommitAt: string | null;
+}
+
+/**
+ * Pure staleness predicate — kept side-effect-free so it unit-tests without a
+ * server. `null`/unparseable `lastCommitAt` is never stale (see DecofileStatus).
+ */
+export function isBranchStale(
+  lastCommitAt: string | null | undefined,
+  now: number,
+  windowMs: number = CMS_STALE_BRANCH_MS,
+): boolean {
+  if (!lastCommitAt) return false;
+  const at = new Date(lastCommitAt).getTime();
+  if (Number.isNaN(at)) return false;
+  return now - at > windowMs;
+}
+
+/** GET branch drift + head-commit age; the CMS auto-fresh-branch check reads it. */
+async function fetchDecofileStatus(
+  params: DecofileScopeParams,
+): Promise<DecofileStatus> {
+  const res = await fetch(`${decofileApiUrl(params)}/status`, {
+    cache: "no-store",
+  });
+  if (!res.ok) return throwResponseError(res, "Status");
+  return (await res.json()) as DecofileStatus;
+}
+
+export function decofileStatusQueryOptions(params: DecofileScopeParams) {
+  return {
+    queryKey: KEYS.decofileStatus(decofileCacheKey(params)),
+    queryFn: () => fetchDecofileStatus(params),
+    staleTime: 30_000,
+  };
+}
+
 /** PATCH blocks; resolves with the draft pointer of the carrying commit. */
 export async function patchDecofile(
   params: DecofileScopeParams,

--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -29,7 +29,13 @@ import {
   Suspense,
   type ReactNode,
 } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Chat, useChatTask } from "@/components/chat/index";
+import { useOrgFlag } from "@/hooks/use-organization-settings";
+import {
+  decofileStatusQueryOptions,
+  isBranchStale,
+} from "@/components/sections-editor/decofile-api";
 import { ChatSidePanel } from "@/components/chat/side-panel-chat";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { isModKey } from "@/lib/keyboard-shortcuts";
@@ -271,6 +277,53 @@ function VmEventsBridge({
       ),
     );
   }, [adoptBranchEligible, activeTask, session, setCurrentTaskBranch]);
+
+  /**
+   * Auto-fresh-branch (org-gated, off by default): opening the CMS on a branch
+   * whose last commit predates the staleness window moves the session to a
+   * freshly minted branch off the default branch. The stale branch is left on
+   * GitHub. One switch per thread per tab, mirroring the adopt guard above.
+   */
+  const { org } = useProjectContext();
+  const autoFreshBranchEnabled = useOrgFlag("cms_auto_fresh_branch");
+  const { runtime: cmsRuntime, resolved: cmsRuntimeResolved } =
+    useSessionRuntime(virtualMcpId);
+  const freshBranchForThreadRef = useRef<string | null>(null);
+  const staleCheckEnabled =
+    autoFreshBranchEnabled &&
+    cmsRuntimeResolved &&
+    cmsRuntime === "cms" &&
+    !!org?.slug &&
+    !!currentBranch &&
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only dedup probe; recorded inside the effect after firing
+    freshBranchForThreadRef.current !== (activeTask?.id ?? null);
+  const staleStatusQuery = useQuery({
+    ...decofileStatusQueryOptions({
+      orgSlug: org?.slug ?? "",
+      virtualMcpId,
+      branch: currentBranch ?? "",
+    }),
+    enabled: staleCheckEnabled,
+  });
+  const staleLastCommitAt = staleStatusQuery.data?.lastCommitAt ?? null;
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- one-shot branch switch gated on the resolved CMS status; no render-time equivalent
+  useEffect(() => {
+    if (!staleCheckEnabled || !activeTask) return;
+    if (!isBranchStale(staleLastCommitAt, Date.now())) return;
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- record the thread so a re-render can't switch twice
+    freshBranchForThreadRef.current = activeTask.id;
+    setCurrentTaskBranch(
+      generateBranchName(
+        session?.user?.name || session?.user?.email?.split("@")[0],
+      ),
+    );
+  }, [
+    staleCheckEnabled,
+    staleLastCommitAt,
+    activeTask,
+    session,
+    setCurrentTaskBranch,
+  ]);
 
   // Open the events stream only when a sandbox actually exists or a start is
   // in flight — NOT merely because the agent has a GitHub repo configured.

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -644,6 +644,8 @@ export const KEYS = {
   // Sandbox-less Fast Preview draft pointer: {version, token} for the current
   // branch head, populated by decofile API reads/writes (never fetched itself).
   decofileDraft: (cacheKey: string) => ["decofile-draft", cacheKey] as const,
+  // Branch drift + head-commit age for the CMS staleness check.
+  decofileStatus: (cacheKey: string) => ["decofile-status", cacheKey] as const,
   // Variadic so an invalidation call can pass just the org/vmid/branch prefix
   // and still partial-match the full org/vmid/branch/previewUrl query key.
   liveMeta: (...parts: string[]) => ["live-meta", ...parts] as const,

--- a/packages/e2e/fixtures/fast-preview.ts
+++ b/packages/e2e/fixtures/fast-preview.ts
@@ -29,7 +29,10 @@ export async function seedStubRepo(
     owner: string;
     repo: string;
     defaultBranch?: string;
-    branches?: Record<string, { files?: Record<string, string> } | null>;
+    branches?: Record<
+      string,
+      { files?: Record<string, string>; committedAt?: string } | null
+    >;
     mergeMode?: "merge" | "conflict" | "blocked";
   },
 ): Promise<void> {

--- a/packages/e2e/fixtures/github-stub.ts
+++ b/packages/e2e/fixtures/github-stub.ts
@@ -62,6 +62,8 @@ interface CommitRecord {
   treeSha: string;
   parents: string[];
   message: string;
+  /** Committer date (ISO); the branch head's drives the CMS staleness check. */
+  committedAt: string;
 }
 
 interface PullRecord {
@@ -101,7 +103,10 @@ interface SeedRepoBody {
    * (i.e. ahead-by-1). A branch entry WITHOUT a `files` key aliases the
    * default head instead (ahead-by-0) — handy for drift/status tests.
    */
-  branches?: Record<string, { files?: Record<string, string> } | null>;
+  branches?: Record<
+    string,
+    { files?: Record<string, string>; committedAt?: string } | null
+  >;
   mergeMode?: MergeMode;
 }
 
@@ -134,13 +139,14 @@ function putCommit(
   treeSha: string,
   parents: string[],
   message: string,
+  committedAt: string = new Date().toISOString(),
 ): string {
   // The counter keeps same-(tree,parents,message) commits distinct — this is
   // fixture code, not git; determinism-per-run is all the tests need.
   const sha = sha1(
     `commit:${treeSha}:${parents.join(",")}:${message}:${commitCounter++}`,
   );
-  repo.commits.set(sha, { sha, treeSha, parents, message });
+  repo.commits.set(sha, { sha, treeSha, parents, message, committedAt });
   repo.commitLog.push(sha);
   return sha;
 }
@@ -243,7 +249,13 @@ function seedRepo(body: SeedRepoBody): RepoState {
       ]),
     ),
   );
-  const defaultHead = putCommit(repo, defaultTree, [], `seed ${defaultBranch}`);
+  const defaultHead = putCommit(
+    repo,
+    defaultTree,
+    [],
+    `seed ${defaultBranch}`,
+    branches[defaultBranch]?.committedAt,
+  );
   repo.refs.set(defaultBranch, defaultHead);
 
   for (const [branch, spec] of Object.entries(branches)) {
@@ -263,7 +275,7 @@ function seedRepo(body: SeedRepoBody): RepoState {
     );
     repo.refs.set(
       branch,
-      putCommit(repo, tree, [defaultHead], `seed ${branch}`),
+      putCommit(repo, tree, [defaultHead], `seed ${branch}`, spec.committedAt),
     );
   }
   repos.set(repoKey(body.owner, body.repo), repo);
@@ -395,6 +407,25 @@ async function handleRepos(
       full_name: repoKey(repo.owner, repo.name),
       default_branch: repo.defaultBranch,
       owner: { login: repo.owner },
+    });
+    return;
+  }
+
+  // GET /repos/{o}/{r}/branches/{branch...}
+  if (req.method === "GET" && rest[0] === "branches" && rest.length >= 2) {
+    const branch = rest.slice(1).join("/");
+    const sha = repo.refs.get(branch);
+    const commit = sha ? repo.commits.get(sha) : undefined;
+    if (!sha || !commit) {
+      notFound(res);
+      return;
+    }
+    json(res, 200, {
+      name: branch,
+      commit: {
+        sha,
+        commit: { committer: { date: commit.committedAt } },
+      },
     });
     return;
   }

--- a/packages/e2e/tests/decofile-api.spec.ts
+++ b/packages/e2e/tests/decofile-api.spec.ts
@@ -509,6 +509,7 @@ test.describe("decofile API", () => {
         baseBranch: "main",
         aheadBy: 0,
         behindBy: 0,
+        lastCommitAt: expect.any(String),
       });
 
       const commitsBefore = (await inspectStubRepo(ctx, owner, repo)).commits
@@ -553,6 +554,7 @@ test.describe("decofile API", () => {
         baseBranch: "main",
         aheadBy: 1,
         behindBy: 0,
+        lastCommitAt: expect.any(String),
       });
     } finally {
       await ctx.dispose();
@@ -941,6 +943,68 @@ test.describe("decofile API", () => {
         },
       ).catch((error: unknown) => error);
       expect(String(refused)).toMatch(/CMS session/i);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test("status exposes the branch head's last-commit date; null for the default branch and unmaterialized branches", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    try {
+      const user = await signUpViaApi(ctx);
+      const org = user.orgSlug;
+      const owner = uniqueOwner();
+      const repo = "site";
+
+      const staleAt = new Date(
+        Date.now() - 15 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      await seedStubRepo(ctx, {
+        owner,
+        repo,
+        defaultBranch: "main",
+        branches: {
+          main: { files: { ".deco/blocks/Hero.json": '{"n":1}\n' } },
+          // A side branch whose only commit is 15 days old (stale-shaped).
+          stale: {
+            files: { ".deco/blocks/Hero.json": '{"n":2}\n' },
+            committedAt: staleAt,
+          },
+        },
+      });
+      const project = await createFastPreviewProject(ctx, org, { owner, repo });
+      const statusUrl = (branch: string) =>
+        `${decofileUrl(project, branch)}/status`;
+
+      // Side branch: its own old commit date comes back verbatim.
+      const stale = await ctx.get(statusUrl("stale"));
+      expect(stale.status()).toBe(200);
+      expect(await stale.json()).toEqual({
+        baseBranch: "main",
+        aheadBy: 1,
+        behindBy: 0,
+        lastCommitAt: staleAt,
+      });
+
+      // Editing the default branch itself is never a stale side branch.
+      const onMain = await ctx.get(statusUrl("main"));
+      expect(await onMain.json()).toEqual({
+        baseBranch: "main",
+        aheadBy: 0,
+        behindBy: 0,
+        lastCommitAt: null,
+      });
+
+      // A branch not yet materialized on GitHub has no age — never stale.
+      const unmaterialized = await ctx.get(statusUrl("thread-minted-branch"));
+      expect(await unmaterialized.json()).toEqual({
+        baseBranch: "main",
+        aheadBy: 0,
+        behindBy: 0,
+        lastCommitAt: null,
+      });
     } finally {
       await ctx.dispose();
     }

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -192,6 +192,12 @@ export const OrgFlagsSchema = z.object({
     .describe(
       "Board lanes for shipping: Approved, Merged and Post-deploy Validation sit between In Review and Done, and a merged pull request lands on Merged instead of Done. For teams whose release process continues after the merge. Off by default — with it off the board and the state machine behave exactly as if the lanes did not exist.",
     ),
+  cms_auto_fresh_branch: z
+    .boolean()
+    .optional()
+    .describe(
+      "When a user opens the CMS on a branch whose last commit is older than the staleness window (2 days), move the session to a freshly minted branch cut from the default branch. The stale branch is left intact on GitHub. Off by default.",
+    ),
 });
 
 export type OrgFlags = z.infer<typeof OrgFlagsSchema>;

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -130,6 +130,7 @@ export interface StudioToolIO {
             coding_agents_claude_code?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
             delivery_lanes_enabled?: boolean | undefined;
+            cms_auto_fresh_branch?: boolean | undefined;
           }
         | null
         | undefined;
@@ -201,6 +202,7 @@ export interface StudioToolIO {
             coding_agents_claude_code?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
             delivery_lanes_enabled?: boolean | undefined;
+            cms_auto_fresh_branch?: boolean | undefined;
           }
         | undefined;
       main_agent_id?: string | null | undefined;
@@ -272,6 +274,7 @@ export interface StudioToolIO {
             coding_agents_claude_code?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
             delivery_lanes_enabled?: boolean | undefined;
+            cms_auto_fresh_branch?: boolean | undefined;
           }
         | null
         | undefined;


### PR DESCRIPTION
## O que é

Quando alguém abre o **CMS** numa branch de sessão cujo **último commit** é mais antigo que a janela de staleness (**2 dias**), a sessão troca automaticamente para uma **branch nova cortada da default branch**. A branch velha **não é apagada nem alterada** — continua no GitHub, recuperável.

Motivação: alguém some por ~15 dias e volta pra uma branch defasada/quebrada; em vez disso passa a cair numa branch limpa e atual.

- Gated pela flag de org **`cms_auto_fresh_branch` (default OFF)** — nada muda até uma org ligar explicitamente.
- Uma troca por thread/aba (guarda por `ref`, mesmo padrão do branch-adopt que já existia).
- Dispara só em `runtime === "cms"`.

## Por que "data do último commit" e não "data de criação"

Git não guarda quando um ref nasceu e a API do GitHub não expõe isso de forma confiável. O sinal robusto — sem depender do nome da branch — é a data do commit para o qual o head aponta. Isso pega inclusive a branch **nunca editada**: o ref fica congelado no commit da main de quando nasceu, então uma branch de 15 dias tem head com data velha e é detectada como stale, mesmo sem nenhum commit próprio.

## Mudanças

- **api**: `getBranchHead` no git-data client; `decofile /status` agora devolve `lastCommitAt` (`null` para a default branch e branches ainda não materializadas → nunca troca).
- **web**: predicado puro `isBranchStale` + query de status do decofile; efeito one-shot de troca no `VmEventsBridge`.
- **shared**: flag `cms_auto_fresh_branch` + contratos regenerados.
- **e2e**: stub do GitHub ganhou datas de commit + rota `/branches/{branch}`; novo teste de contrato do `/status`; asserts antigos do status atualizados para o campo novo.
- **unit**: `isBranchStale`.

## Como ligar

```
ORGANIZATION_SETTINGS_UPDATE { flags: { cms_auto_fresh_branch: true } }
```

## Testing

- ✅ `tsc` (api/web/shared/e2e), `fmt`, `lint` (0 erros), `knip` limpo
- ✅ unit `isBranchStale` (7/7)
- ⚠️ e2e escrito e type-checa; não rodado localmente (harness e2e exige Postgres em `:5432`) — roda no CI.

## Caveat

Se a própria `main` ficar parada +2 dias, trocar uma branch limpa-porém-antiga geraria outra branch limpa (churn inofensivo, sem perda de dado) — irrelevante em repo ativo. Se incomodar, o passo seguinte é o servidor gravar `branchCreatedAt` no momento de criação do ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-switches the CMS session to a fresh branch when the current branch's last commit is older than 2 days, so returning users don't keep working on a lagging branch. The stale branch stays intact on GitHub; the behavior is off by default behind the `cms_auto_fresh_branch` org flag.

**Changes**
- Adds `getBranchHead` to the git-data client and `lastCommitAt` to the decofile `/status` response (null for default/unmaterialized branches).
- Adds a pure `isBranchStale` check and a one-shot switch effect in `VmEventsBridge`, gated on `runtime === "cms"`.
- Extends the GitHub e2e stub with commit dates and a `/branches/{branch}` route; adds a `/status` contract test and unit tests for `isBranchStale`.
- Orgs opt in via `ORGANIZATION_SETTINGS_UPDATE` with `cms_auto_fresh_branch: true`.

<sup>Written for commit 6d5c9d1a56bbb83e90c41a8f6e66d41d778c8d2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

