### PR TITLE
fix(task-board): reject a direct create into a delivery lane when the flag is off

### DIFF
--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { getUserId, requireAuth } from "@/core/studio-context";
+import { orgFlagEnabled } from "@decocms/shared/organization/schema";
 import {
   MAX_TASK_DESCRIPTION_LENGTH,
   MAX_TASK_REPO_LENGTH,
@@ -16,6 +17,7 @@ import { reactToSuperAgentDelegation } from "./enqueue-super-agent";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { extractPrFromText } from "./pr-extract";
+import { rejectsUngatedDeliveryLane } from "./update";
 
 export const TASK_BOARD_ITEM_CREATE = defineTool({
   name: "TASK_BOARD_ITEM_CREATE",
@@ -71,6 +73,23 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
         `Not a GitHub pull request URL: ${input.prUrl} (expected ` +
           "https://github.com/<owner>/<repo>/pull/<number>)",
       );
+    }
+
+    if (input.status !== undefined) {
+      const settings =
+        await ctx.storage.organizationSettings.get(organizationId);
+      if (
+        rejectsUngatedDeliveryLane(
+          input.status,
+          orgFlagEnabled(settings?.flags, "delivery_lanes_enabled"),
+        )
+      ) {
+        throw new Error(
+          "Delivery lanes are not enabled for this organization — enable " +
+            "them in Settings before creating a task in Approved, Merged, " +
+            "or Post-deploy Validation.",
+        );
+      }
     }
 
     if (input.assigneeId) {

--- a/packages/e2e/tests/task-board-delivery-lanes.spec.ts
+++ b/packages/e2e/tests/task-board-delivery-lanes.spec.ts
@@ -123,10 +123,14 @@ test.describe("task board delivery lanes", () => {
       callSelfMcpTool<T>(request, orgSlug, name, args);
     const orgId = await findOrgId(request, orgSlug);
 
-    // No reviewers enabled, so the readiness gate reduces to the lane alone.
+    // No reviewers enabled, and the flag lets CREATE below land straight in "approved".
     await call("ORGANIZATION_SETTINGS_UPDATE", {
       organizationId: orgId,
-      flags: { qa_agent_enabled: false, code_reviewer_enabled: false },
+      flags: {
+        qa_agent_enabled: false,
+        code_reviewer_enabled: false,
+        delivery_lanes_enabled: true,
+      },
     });
 
     const { item: early } = await call<{ item: TaskBoardItem }>(


### PR DESCRIPTION
Follows #6634, which gated TASK_BOARD_ITEM_UPDATE against writing a delivery-lane status (`approved`/`merged`/`post_deploy_validation`) when the org's `delivery_lanes_enabled` flag is off, but left the sibling entry point — TASK_BOARD_ITEM_CREATE — ungated. That tool accepts `status` directly at create time with no check, so any MCP client, script, or stale agent could still park a brand-new card straight in a delivery lane the flag's own description promises "behaves exactly as if it did not exist".

This reuses #6634's own `rejectsUngatedDeliveryLane` helper (imported from `update.ts`, already unit-tested there) and wires it into `TASK_BOARD_ITEM_CREATE` the same way.

While fixing this I found the existing e2e spec (`task-board-delivery-lanes.spec.ts`, "the ship gate accepts Approved...") was itself relying on the gap: it created an item directly with `status: "approved"` without enabling `delivery_lanes_enabled` first. Updated that test to enable the flag, matching the pattern the sibling test in the same file already uses for TASK_BOARD_ITEM_UPDATE.

Failure scenario before this fix: with `delivery_lanes_enabled` off (the default), `TASK_BOARD_ITEM_CREATE({ title: "x", status: "approved" })` succeeds and creates a card in a lane the UI is supposed to treat as nonexistent — same bug class #6634 fixed for updates, just on the other entry point.

Reviewer check: `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/tools/task-board/create.ts packages/e2e/tests/task-board-delivery-lanes.spec.ts`. The e2e assertion itself needs Docker/Postgres (not available in this environment) — CI's e2e job covers it.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api and packages/e2e), `bunx oxlint` on the three changed files — all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates `TASK_BOARD_ITEM_CREATE` so it rejects writing directly to a delivery lane when the `delivery_lanes_enabled` flag is off, matching the existing gate on `TASK_BOARD_ITEM_UPDATE`. Previously, create accepted `status: "approved"`/`merged`/`post_deploy_validation` regardless of the flag, letting any client park a new card in a lane the UI treats as nonexistent.

- Reuses the `rejectsUngatedDeliveryLane` helper from `update.ts`, which is already unit-tested.
- Updates the e2e spec to enable `delivery_lanes_enabled` before creating a card with status `approved`, since the test previously relied on the gap.

<sup>Written for commit e71ecf6d145cab1a62293e458327f661d959e600. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

