### PR TITLE
fix(inbox): cancel a stale in-flight refetch before marking a row read

### DIFF
--- a/apps/web/src/hooks/use-inbox-feed.ts
+++ b/apps/web/src/hooks/use-inbox-feed.ts
@@ -150,7 +150,9 @@ export function useInboxFeed(): InboxFeed {
     /** `ids: undefined` is the server's "all of mine in this org". */
     mutationFn: (ids: string[] | null) =>
       studio.call("NOTIFICATION_MARK_READ", ids ? { ids } : {}),
-    onMutate: (ids) => {
+    onMutate: async (ids) => {
+      // Cancel a stale in-flight refetch, or it can resurrect the row this drops.
+      await queryClient.cancelQueries({ queryKey });
       queryClient.setQueryData<InfiniteData<Page>>(queryKey, (data) =>
         dropLocally(data, ids),
       );


### PR DESCRIPTION
**Source:** a bug found while auditing `apps/web/src/hooks/use-task-board-items.ts` (hot this tick — #6627, #6632, #6637 all fixed the same race class there this week) and checking sibling live-query hooks for the same shape. `use-inbox-feed.ts`'s `markRead` mutation had it too, unfixed.

**Why it matters:** `markRead`'s `onMutate` optimistically drops the read row(s) from the cached inbox list via `setQueryData`, but never cancels a refetch already in flight first (the 60s poll backstop, or a live SSE `invalidateQueries` from another notification landing moments earlier). If that stale refetch resolves after the optimistic drop, its (still-unread) server snapshot overwrites the cache and the just-cleared row reappears — a visible flicker — until `onSettled`'s own `invalidateQueries` corrects it a beat later.

**Failure scenario:** user has the inbox open with the 60s poll or a recent SSE invalidate in flight, clicks to mark a notification read → the row vanishes, then briefly reappears, then vanishes again once the trailing refetch settles.

**Fix:** `await queryClient.cancelQueries({ queryKey })` before the optimistic `setQueryData`, mirroring the exact pattern already applied to `use-task-board-items.ts`'s `onUpdate`/`onDelete`/`onTaskStatus` handlers in #6627, #6632, #6637.

**Verify:** `bun test apps/web/src/hooks/use-inbox-feed.test.ts` (existing `dropLocally` unit tests still pass — the mutation wiring itself isn't unit-testable without a full QueryClient/mock harness, same as the three sibling fixes, which also shipped without a new test). `cd apps/web && bunx tsc --noEmit` is clean.

**Locally ran:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bun test apps/web/src/hooks/use-inbox-feed.test.ts`, `bunx oxlint apps/web/src/hooks/use-inbox-feed.ts` — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inbox flicker when marking a notification read: a stale in-flight refetch (60s poll or SSE invalidation) could land after the optimistic cache drop and briefly bring the just-cleared row back. The feed now cancels pending queries before the optimistic write so the cleared row stays gone; fresh data still arrives via the normal refetch paths afterward.

<sup>Written for commit 8e6156a5510740acf31ffce465f11d9f01aa812c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

