### PR TITLE
feat(task-board): open a sprint board on the running sprint

### DIFF
--- a/apps/web/src/layouts/task-board/task-filters.test.ts
+++ b/apps/web/src/layouts/task-board/task-filters.test.ts
@@ -29,33 +29,58 @@ function item(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
 }
 
 /**
- * A sprint filter arrives from the URL, which outlives the sprint it names.
- * Left in place, an unknown id hides every card behind a chip that reads
- * exactly like "no sprint filter".
+ * A board that runs sprints opens on the running one, so an absent param means
+ * "nobody has chosen yet" rather than "no filter". The URL also outlives the
+ * sprint it names, and an unknown id left in place would hide every card behind
+ * a chip that reads exactly like "no sprint filter".
  */
 describe("resolveSprintFilter", () => {
-  const sprints = [
-    {
-      id: "sprint_a",
-      name: "Sprint 12",
-      state: "active" as const,
-      startsAt: null,
-      endsAt: null,
-    },
-  ];
+  const sprint = (id: string, state: "active" | "future" | "closed") => ({
+    id,
+    name: id,
+    state,
+    startsAt: null,
+    endsAt: null,
+  });
+  const sprints = [sprint("sprint_a", "active"), sprint("sprint_b", "future")];
 
   test("keeps a sprint the board actually has", () => {
-    expect(resolveSprintFilter("sprint_a", sprints)).toBe("sprint_a");
+    expect(resolveSprintFilter("sprint_b", sprints)).toBe("sprint_b");
   });
 
-  test("drops one it does not, including on a board with no sprints", () => {
-    expect(resolveSprintFilter("sprint_gone", sprints)).toBe(null);
-    expect(resolveSprintFilter("sprint_a", [])).toBe(null);
+  test("opens on the running sprint when the URL says nothing", () => {
+    expect(resolveSprintFilter(null, sprints)).toBe("sprint_a");
   });
 
-  test("leaves the backlog sentinel and 'any sprint' alone", () => {
+  /** Inverts the pre-default behaviour: both used to resolve to "any sprint". */
+  test("falls back to the running sprint for an id the board lost", () => {
+    expect(resolveSprintFilter("sprint_gone", sprints)).toBe("sprint_a");
+  });
+
+  test("shows every sprint only when asked", () => {
+    expect(resolveSprintFilter("all", sprints)).toBe(null);
+  });
+
+  test("has no default to apply without a running sprint", () => {
+    expect(resolveSprintFilter(null, [])).toBe(null);
+    expect(resolveSprintFilter(null, [sprint("sprint_b", "future")])).toBe(
+      null,
+    );
+    expect(resolveSprintFilter("sprint_gone", [])).toBe(null);
+  });
+
+  test("picks one running sprint when the tracker has several", () => {
+    expect(
+      resolveSprintFilter(null, [
+        sprint("sprint_z", "active"),
+        sprint("sprint_a", "active"),
+      ]),
+    ).toBe("sprint_a");
+  });
+
+  test("leaves the backlog sentinel alone, default or not", () => {
     expect(resolveSprintFilter("backlog", [])).toBe("backlog");
-    expect(resolveSprintFilter(null, sprints)).toBe(null);
+    expect(resolveSprintFilter("backlog", sprints)).toBe("backlog");
   });
 });
 

--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -7,6 +7,7 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { useT, type TranslationKey } from "@/i18n/use-t.ts";
+import { currentSprintId } from "@decocms/shared/sprints";
 import { parseTaskKeySeq } from "@decocms/shared/task-key";
 import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import { Button } from "@decocms/ui/components/button.tsx";
@@ -77,6 +78,11 @@ const NO_REPO_FILTER = "__no_repo__";
  *  namespace with sprint ids, which are `sprint_`-prefixed, so it can't collide. */
 const BACKLOG_FILTER = "backlog";
 
+/** Sentinel for "every sprint", which has to be SAID rather than implied by an
+ *  absent param: absence is what selects the running sprint, so without this the
+ *  Any-sprint option would drop out of the URL and default straight back. */
+const ALL_SPRINTS_FILTER = "all";
+
 /** Radix `RadioGroup` needs a string value — this stands in for `null` (any). */
 const ANY_FILTER = "__any__";
 
@@ -108,42 +114,72 @@ export const EMPTY_FILTERS: TaskFilters = {
 };
 
 /**
- * Drop a sprint filter naming a sprint this board does not have.
+ * The sprint filter this board should apply, given what the URL says.
  *
- * The value comes from the URL, which outlives the sprint it names — a shared
- * link, a bookmark, a sprint deleted in Jira. Left in place it hides every card
- * while its chip reads exactly like "no sprint filter", so the board looks
- * empty for no stated reason. Call it only once the sprints have loaded, or an
- * in-flight read would drop a filter that is about to be valid.
+ * A board that runs sprints opens on the running one, the way Jira does, so an
+ * absent param is not "no filter" — it is "nobody has chosen yet". Every sprint
+ * is reachable only through {@link ALL_SPRINTS_FILTER}, which is the whole
+ * reason that sentinel exists.
+ *
+ * An unresolvable id resolves like an absent one. The URL outlives the sprint it
+ * names — a shared link, a bookmark, a sprint deleted in Jira — and left in
+ * place it hides every card behind a chip that reads like "no filter". Falling
+ * back to the default keeps a single rule: you see every sprint only by asking.
+ *
+ * Call it only once the sprints have loaded, or an in-flight read would drop a
+ * filter that is about to be valid.
  */
 export function resolveSprintFilter(
   value: string | null,
   sprints: readonly Sprint[],
 ): string | null {
-  if (value === null || value === BACKLOG_FILTER) return value;
-  return sprints.some((sprint) => sprint.id === value) ? value : null;
+  if (value === ALL_SPRINTS_FILTER) return null;
+  if (value === BACKLOG_FILTER) return value;
+  if (value !== null && sprints.some((sprint) => sprint.id === value)) {
+    return value;
+  }
+  return currentSprintId(sprints);
 }
 
-function hasActiveFilters(f: TaskFilters): boolean {
+/**
+ * Whether the sprint scope is one the user narrowed to, as opposed to the board
+ * opening on its running sprint. The default must not count: it would light up
+ * "Clear" on a board nobody filtered, and clearing cannot remove it — the reset
+ * writes an absent param, which is exactly what re-selects the default.
+ *
+ * Picking the running sprint by hand lands on the same state and so reads as
+ * the default. Indistinguishable and harmless: the board shows the same cards.
+ */
+function sprintNarrowed(f: TaskFilters, defaultSprint: string | null): boolean {
+  return f.sprint !== null && f.sprint !== defaultSprint;
+}
+
+function hasActiveFilters(
+  f: TaskFilters,
+  defaultSprint: string | null,
+): boolean {
   return (
     f.assignee !== null ||
     f.priority !== null ||
     f.due !== null ||
     f.tags.length > 0 ||
     f.repo !== null ||
-    f.sprint !== null ||
+    sprintNarrowed(f, defaultSprint) ||
     f.search.trim() !== ""
   );
 }
 
-function activeFilterCount(f: TaskFilters): number {
+function activeFilterCount(
+  f: TaskFilters,
+  defaultSprint: string | null,
+): number {
   return (
     (f.assignee !== null ? 1 : 0) +
     (f.priority !== null ? 1 : 0) +
     (f.due !== null ? 1 : 0) +
     (f.tags.length > 0 ? 1 : 0) +
     (f.repo !== null ? 1 : 0) +
-    (f.sprint !== null ? 1 : 0) +
+    (sprintNarrowed(f, defaultSprint) ? 1 : 0) +
     (f.search.trim() !== "" ? 1 : 0)
   );
 }
@@ -655,7 +691,8 @@ function SprintFilter({
   value: string | null;
   /** Sprints to offer, in reading order (running → next → past). */
   sprints: Sprint[];
-  onChange: (next: string | null) => void;
+  /** Always a stored value — `ALL_SPRINTS_FILTER`, never a bare null. */
+  onChange: (next: string) => void;
   block?: boolean;
 }) {
   const t = useT();
@@ -684,7 +721,9 @@ function SprintFilter({
       >
         <DropdownMenuRadioGroup
           value={value === null ? ANY_FILTER : value}
-          onValueChange={(next) => onChange(next === ANY_FILTER ? null : next)}
+          onValueChange={(next) =>
+            onChange(next === ANY_FILTER ? ALL_SPRINTS_FILTER : next)
+          }
         >
           <DropdownMenuRadioItem value={ANY_FILTER}>
             {t("taskBoard.taskFilters.sprintAnySprint")}
@@ -888,7 +927,7 @@ export function TaskFiltersBar({
         sprints={sprints}
         onChange={onChange}
       />
-      {hasActiveFilters(filters) && (
+      {hasActiveFilters(filters, currentSprintId(sprints)) && (
         <button
           type="button"
           onClick={() => onChange(EMPTY_FILTERS)}
@@ -923,7 +962,7 @@ export function TaskFiltersDrawer({
 }) {
   const t = useT();
   const [open, setOpen] = useState(false);
-  const count = activeFilterCount(filters);
+  const count = activeFilterCount(filters, currentSprintId(sprints));
   const triggerClass = chipClass(count > 0);
   return (
     <Drawer open={open} onOpenChange={setOpen} direction="bottom">

--- a/packages/shared/src/sprints.test.ts
+++ b/packages/shared/src/sprints.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   compareSprints,
+  currentSprintId,
   isSprintState,
   type Sprint,
   type SprintState,
@@ -79,5 +80,37 @@ describe("isSprintState", () => {
     for (const state of ["ACTIVE", "backlog", "", null, 1, undefined]) {
       expect(isSprintState(state)).toBe(false);
     }
+  });
+});
+
+describe("currentSprintId", () => {
+  it("names the running sprint", () => {
+    expect(
+      currentSprintId([sprint("closed", "closed"), sprint("now", "active")]),
+    ).toBe("now");
+  });
+
+  it("has no answer when nothing is running", () => {
+    expect(currentSprintId([])).toBe(null);
+    expect(
+      currentSprintId([sprint("next", "future"), sprint("old", "closed")]),
+    ).toBe(null);
+  });
+
+  /** A board can run parallel sprints; reading order breaks the tie so the
+   *  board opens on the same one every time. */
+  it("picks deterministically when several are running", () => {
+    const both = [
+      sprint("b", "active", "2026-02-01T00:00:00Z"),
+      sprint("a", "active", "2026-01-01T00:00:00Z"),
+    ];
+    expect(currentSprintId(both)).toBe("a");
+    expect(currentSprintId([...both].reverse())).toBe("a");
+  });
+
+  it("does not reorder the caller's list", () => {
+    const list = [sprint("b", "future"), sprint("a", "active")];
+    currentSprintId(list);
+    expect(list.map((s) => s.id)).toEqual(["b", "a"]);
   });
 });

--- a/packages/shared/src/sprints.ts
+++ b/packages/shared/src/sprints.ts
@@ -67,3 +67,19 @@ export function compareSprints(a: Sprint, b: Sprint): number {
   }
   return a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
 }
+
+/**
+ * The sprint a board opens on: the one that is running.
+ *
+ * Reads the tracker's `state` rather than asking which window today falls in —
+ * a sprint that started three days late is still the current one, and the board
+ * has to agree with what Jira shows. Jira allows several sprints running on one
+ * board, so this takes the first in reading order. Null when nothing is
+ * running, which leaves the board showing every sprint.
+ */
+export function currentSprintId(sprints: readonly Sprint[]): string | null {
+  const running = sprints
+    .filter((sprint) => sprint.state === "active")
+    .sort(compareSprints);
+  return running[0]?.id ?? null;
+}


### PR DESCRIPTION
## What is this contribution about?

A board that mirrors sprints from Jira opened showing every card in every sprint, so the first thing anyone did each morning was reach for the sprint filter. Jira opens on the running sprint; this makes the board do the same.

The change is one rule in `resolveSprintFilter`, which is already the single place a URL param becomes a filter: an absent `sprint` param now means **"nobody has chosen yet"**, not "no filter", and resolves to the sprint the tracker reports as `active`. Never to whichever window today's date falls in — a sprint that started three days late is still the current one, and the board has to agree with what Jira shows.

**Every sprint is still reachable, but it has to be said.** The Any-sprint option now writes an explicit `all` sentinel instead of a bare null, because null drops out of the URL and an absent param is exactly what re-selects the default — without the sentinel, "Any sprint" would be unselectable.

Two smaller consequences, both deliberate:

- **An id the board no longer has falls back to the default**, where it used to fall back to "any". The URL outlives the sprint it names (a shared link, a bookmark, a sprint deleted in Jira), and either fallback fixes the old symptom of a board that looks empty behind a chip reading like "no filter". Defaulting keeps one rule instead of two.
- **The default does not count towards the active-filter badge, and "Clear" leaves it alone.** Counting it would light up Clear on a board nobody filtered, and clearing writes an absent param — which re-selects the default, so the button would visibly do nothing. Picking the running sprint by hand lands on the same state and reads as the default; indistinguishable and harmless, since the cards shown are identical.

`currentSprintId` lives in `packages/shared/src/sprints.ts` next to `compareSprints`, and sorts before picking so a board with parallel sprints (Jira allows them) opens on the same one every time.

## How did you verify your code works?

Per the repo's inversion rule I **inverted** the two assertions that encoded the old behaviour rather than appending beside them: `resolveSprintFilter(null, sprints)` and `resolveSprintFilter("sprint_gone", sprints)` both used to expect `null` and now expect the running sprint.

New unit coverage in `task-filters.test.ts` (opens on the running sprint, falls back for a lost id, `all` shows everything, no default without a running sprint, deterministic with several running, backlog sentinel untouched) and `packages/shared/src/sprints.test.ts` (`currentSprintId`, including that it does not reorder the caller's list).

`bun run check` 0 type errors, `bun run lint` 19 warnings identical to baseline, `knip` clean, `fmt:check` clean. The board suite goes **118 → 122** passing, with the same two pre-existing order-dependent failures (`task-filters-search`, which pass standalone) present on baseline and after — verified by stashing the change and re-running.

**Not verified, flagging honestly:** no live browser check, and no e2e was added. `packages/e2e/tests/task-board-sprints.spec.ts` exercises an org with no sprints, which is unaffected (no running sprint → no default), so it stays valid but does not cover this. Asserting the default needs a board with a sprint, and nothing in Studio can currently write a card into one — that is the same gap the existing spec documents.

## Screenshots/Demonstration

Not captured. On an org with no sprints, or none running, the board is byte-for-byte unchanged.

## How to Test

1. On an org with **no** sprints, confirm the board opens exactly as before and the Sprint chip reads "Sprint".
2. On an org whose Jira board has a running sprint, open the board with no `sprint` in the URL — it should open scoped to that sprint, with its name on the chip.
3. Pick **Any sprint** — the URL should gain `sprint=all` and every card should appear. Refresh: it must stay on Any sprint, not snap back.
4. Pick a different sprint, then hit **Clear** — the other filters clear and the board returns to the running sprint.
5. Hand-edit the URL to `sprint=sprint_doesnotexist` — the board should fall back to the running sprint rather than showing an empty board.
6. With the board scoped to its default, confirm the active-filter badge/Clear button is **not** shown until you actually narrow something.

## Migration Notes

None. No schema change, no API change — this is entirely how the web client reads its own URL. Existing links carrying an explicit `sprint=<id>` keep working unchanged; links that relied on an absent param to mean "all sprints" will now open on the running sprint, which is the intended change.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes sprint boards open scoped to the running sprint when the URL has no `sprint` param, instead of showing every sprint.

- The running sprint comes from the tracker's active state, not today's date, so it agrees with what Jira shows.
- "Any sprint" now writes an explicit `all` sentinel, since an absent param is what re-selects the default.
- A sprint id the board no longer has falls back to the default instead of showing an empty board.
- The default sprint doesn't count toward the active-filter badge, and "Clear" leaves it alone.
- Boards with no running sprint, and orgs with no sprints, are unchanged.

<sup>Written for commit f02b793c1a3d6f0d5ebb02715fe9fd9acba2210d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

