### PR TITLE
feat(auth): claim pre-authorized invitations at signup

### DIFF
--- a/apps/api/migrations/188-invitation-auto-accept.ts
+++ b/apps/api/migrations/188-invitation-auto-accept.ts
@@ -1,0 +1,20 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Marks an invitation as safe to claim on the invitee's behalf at signup.
+ *
+ * Default false: a normal invitation must still be accepted deliberately, so
+ * inviting an arbitrary address cannot silently place that person in an org the
+ * first time they sign up. Only trusted bulk backfills (migrating members from
+ * a prior system, where the membership already existed) set this true.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE invitation
+      ADD COLUMN "autoAccept" boolean NOT NULL DEFAULT false
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE invitation DROP COLUMN "autoAccept"`.execute(db);
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -186,6 +186,7 @@ import * as migration184jirarescanafterscopechange from "./184-jira-rescan-after
 import * as migration185jirarescanexistingcards from "./185-jira-rescan-existing-cards.ts";
 import * as migration186jirarescanpendingflag from "./186-jira-rescan-pending-flag.ts";
 import * as migration187taskboardcommentthread from "./187-task-board-comment-thread.ts";
+import * as migration188invitationautoaccept from "./188-invitation-auto-accept.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -403,6 +404,7 @@ const migrations: Record<string, Migration> = {
   "185-jira-rescan-existing-cards": migration185jirarescanexistingcards,
   "186-jira-rescan-pending-flag": migration186jirarescanpendingflag,
   "187-task-board-comment-thread": migration187taskboardcommentthread,
+  "188-invitation-auto-accept": migration188invitationautoaccept,
 };
 
 export default migrations;

--- a/apps/api/src/auth/ensure-user-organization.ts
+++ b/apps/api/src/auth/ensure-user-organization.ts
@@ -83,6 +83,19 @@ export type EnsureOrganizationResult =
       createdVia: string;
     }
   | {
+      /**
+       * The user had one or more pending invitations addressed to their email
+       * and was placed into those orgs at signup. Takes precedence over every
+       * domain rule below — an explicit invitation is a stronger signal of
+       * intent than an email domain ever is.
+       */
+      status: "joined_via_invitation";
+      organization: EnsuredOrganization;
+      organizations: EnsuredOrganization[];
+      domain: string | null;
+      createdVia: string;
+    }
+  | {
       status: "ambiguous";
       domain: string;
       organizations: DomainOrganizationCandidate[];
@@ -155,6 +168,18 @@ async function ensureUserOrganizationInTransaction(options: {
 }): Promise<EnsureOrganizationResult> {
   const { db, authApi, user, allowCreate, createdVia, domain } = options;
 
+  // Only pre-authorized (bulk-migrated) invitations; see migration 188.
+  const invited = await acceptPendingInvitations(db, authApi, user);
+  if (invited.length > 0) {
+    return {
+      status: "joined_via_invitation",
+      organization: invited[0]!,
+      organizations: invited,
+      domain,
+      createdVia,
+    };
+  }
+
   if (isVerifiedCorporateUser(user) && domain) {
     const domainStorage = new OrganizationDomainStorage(db);
     const domainRecords = await domainStorage.getAllByDomain(domain);
@@ -165,10 +190,7 @@ async function ensureUserOrganizationInTransaction(options: {
 
     if (candidates.length === 1 && candidates[0]?.joinMode === "auto") {
       const organization = candidates[0]!;
-      // An explicit invitation to this org already governs membership. Skip the
-      // domain auto-join so accepting the invitation is the single membership
-      // path — otherwise the user gets a member row here AND a second one when
-      // acceptInvitation unconditionally creates a member, showing up twice.
+      // Accepting it is the single membership path; joining here too duplicates.
       if (await hasPendingInvitationToOrg(db, user.email, organization.id)) {
         return { status: "skipped", reason: "pending-invitation", domain };
       }
@@ -408,8 +430,6 @@ async function hasPendingInvitationToOrg(
   email: string,
   organizationId: string,
 ): Promise<boolean> {
-  // The invitation table is managed by Better Auth and isn't in the Kysely
-  // Database type, so query it with raw SQL (camelCase columns need quoting).
   const result = await sql<{ exists: boolean }>`
     select exists(
       select 1 from invitation
@@ -422,14 +442,74 @@ async function hasPendingInvitationToOrg(
   return result.rows[0]?.exists ?? false;
 }
 
+/**
+ * Claim every auto-accept invitation for this email; oldest first becomes active.
+ *
+ * Member row is written before the invitation is marked accepted, because
+ * `addMember` runs outside `db`'s transaction: a rollback then leaves a
+ * membership with a pending invitation, which the next call re-accepts.
+ *
+ * Raw SQL because Better Auth owns `invitation` and it is not in the Kysely types.
+ */
+async function acceptPendingInvitations(
+  db: DatabaseExecutor,
+  authApi: AuthOrganizationApi,
+  user: AssuredUser,
+): Promise<EnsuredOrganization[]> {
+  const pending = await sql<{
+    invitationId: string;
+    role: string | null;
+    id: string;
+    name: string;
+    slug: string;
+    logo: string | null;
+    metadata: unknown;
+  }>`
+    select i.id as "invitationId", i.role,
+           o.id, o.name, o.slug, o.logo, o.metadata
+    from invitation i
+    join organization o on o.id = i."organizationId"
+    where lower(i.email) = lower(${user.email})
+      and i.status = 'pending'
+      and i."autoAccept" = true
+      and i."expiresAt" > now()
+    order by i."createdAt" asc
+  `.execute(db);
+
+  const joined: EnsuredOrganization[] = [];
+
+  for (const row of pending.rows) {
+    if (isOrgArchived(row)) {
+      continue;
+    }
+
+    const { invitationId, role, metadata: _metadata, ...organization } = row;
+    await addMemberIdempotent(
+      authApi,
+      user.id,
+      organization.id,
+      role ?? "user",
+    );
+
+    await sql`
+      update invitation set status = 'accepted' where id = ${invitationId}
+    `.execute(db);
+
+    joined.push(organization);
+  }
+
+  return joined;
+}
+
 async function addMemberIdempotent(
   authApi: AuthOrganizationApi,
   userId: string,
   organizationId: string,
+  role = "user",
 ): Promise<void> {
   try {
     await authApi.addMember({
-      body: { userId, role: "user", organizationId },
+      body: { userId, role, organizationId },
     });
   } catch (error) {
     if (!isAlreadyMemberError(error)) {

--- a/apps/api/src/auth/index.ts
+++ b/apps/api/src/auth/index.ts
@@ -631,6 +631,23 @@ export const auth = betterAuth({
               });
             }
 
+            if (result.status === "joined_via_invitation") {
+              for (const organization of result.organizations) {
+                posthog.capture({
+                  distinctId: user.id,
+                  event: "organization_invitation_auto_accepted",
+                  groups: { organization: organization.id },
+                  properties: {
+                    organization_id: organization.id,
+                    organization_slug: organization.slug,
+                    email_domain: result.domain,
+                    joined_via: result.createdVia,
+                    invitation_count: result.organizations.length,
+                  },
+                });
+              }
+            }
+
             if (result.status === "joined") {
               posthog.capture({
                 distinctId: user.id,

--- a/packages/e2e/tests/invite-auto-accept.spec.ts
+++ b/packages/e2e/tests/invite-auto-accept.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * `invitation."autoAccept"` is claimed at signup; a plain invitation is not.
+ *
+ * Guards the consent boundary: inviting an arbitrary address must not place
+ * that person in an org the first time they sign up. Only bulk backfills of
+ * memberships that already existed elsewhere set the flag.
+ *
+ * The org is seeded directly and no domain is claimed, so the only thing that
+ * can produce a membership here is the invitation itself.
+ */
+
+import { type Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUp } from "../fixtures/auth";
+import { expect, test } from "../fixtures/test";
+
+const RUN = `${Date.now()}`;
+const TEST_DOMAIN = `autoaccept-e2e-${RUN}.test`;
+const ORG_ID = `e2e_autoaccept_org_${RUN}`;
+
+const INVITER_ID = `e2e_autoaccept_inviter_${RUN}`;
+
+async function seedInvitation(
+  db: Client,
+  email: string,
+  autoAccept: boolean,
+): Promise<void> {
+  await db.query(
+    `INSERT INTO invitation
+       (id, "organizationId", email, role, status, "expiresAt", "inviterId",
+        "createdAt", "autoAccept")
+     VALUES (gen_random_uuid()::text, $1, $2, 'admin', 'pending',
+             timestamptz '2099-12-31 23:59:59+00', $3, now(), $4)`,
+    [ORG_ID, email, INVITER_ID, autoAccept],
+  );
+}
+
+async function memberCount(db: Client, userId: string): Promise<string> {
+  const result = await db.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM "member"
+     WHERE "userId" = $1 AND "organizationId" = $2`,
+    [userId, ORG_ID],
+  );
+  return result.rows[0]!.count;
+}
+
+test.describe("Invite: only an autoAccept invitation is claimed at signup", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+    await db.query(
+      `INSERT INTO "organization" (id, name, slug, "createdAt")
+       VALUES ($1, $2, $3, now())
+       ON CONFLICT (id) DO NOTHING`,
+      [ORG_ID, "AutoAccept E2E Org", `e2e-autoaccept-org-${RUN}`],
+    );
+  });
+
+  test.afterAll(async () => {
+    if (!db) return;
+    await db.query(`DELETE FROM invitation WHERE "organizationId" = $1`, [
+      ORG_ID,
+    ]);
+    await db.query(`DELETE FROM "member" WHERE "organizationId" = $1`, [
+      ORG_ID,
+    ]);
+    await db.query(`DELETE FROM "organization" WHERE id = $1`, [ORG_ID]);
+    await db.end();
+  });
+
+  test("autoAccept invitation places the user in the org with its role", async ({
+    page,
+  }) => {
+    const email = `flagged-${RUN}-${Math.floor(Math.random() * 100000)}@${TEST_DOMAIN}`;
+    await seedInvitation(db, email, true);
+    await signUp(page, { email });
+
+    const userRow = await db.query<{ id: string }>(
+      `SELECT id FROM "user" WHERE email = $1`,
+      [email],
+    );
+    const userId = userRow.rows[0]!.id;
+
+    expect(await memberCount(db, userId)).toBe("1");
+
+    const membership = await db.query<{ role: string | null }>(
+      `SELECT role FROM "member" WHERE "userId" = $1 AND "organizationId" = $2`,
+      [userId, ORG_ID],
+    );
+    expect(membership.rows[0]!.role).toBe("admin");
+
+    const invitation = await db.query<{ status: string }>(
+      `SELECT status FROM invitation WHERE lower(email) = lower($1)`,
+      [email],
+    );
+    expect(invitation.rows[0]!.status).toBe("accepted");
+  });
+
+  test("a plain invitation leaves the user out of the org until they accept", async ({
+    page,
+  }) => {
+    const email = `plain-${RUN}-${Math.floor(Math.random() * 100000)}@${TEST_DOMAIN}`;
+    await seedInvitation(db, email, false);
+    await signUp(page, { email });
+
+    const userRow = await db.query<{ id: string }>(
+      `SELECT id FROM "user" WHERE email = $1`,
+      [email],
+    );
+    const userId = userRow.rows[0]!.id;
+
+    expect(await memberCount(db, userId)).toBe("0");
+
+    const invitation = await db.query<{ status: string }>(
+      `SELECT status FROM invitation WHERE lower(email) = lower($1)`,
+      [email],
+    );
+    expect(invitation.rows[0]!.status).toBe("pending");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `invitation."autoAccept"`. When set, the invitation is claimed on the
invitee's first signup — ahead of every email-domain rule — placing them
directly in the inviting org with the invitation's role.

**Why.** `ensureUserOrganization` only ever consulted invitations in one narrow
spot: when the user's email domain resolved to exactly one `auto` org, it
checked for a pending invitation *to that same org* and skipped the auto-join
so accepting the invitation stayed the single membership path. Everywhere else
— domain unclaimed, generic domain (gmail and friends), or an invitation to an
org other than the one the domain points at — invitations were never looked at,
and the user fell through to a freshly auto-created personal org. The
invitation they were actually sent is then only reachable from the org
switcher, which is a poor landing for a membership that already existed in a
prior system and is being backfilled.

**Consent boundary.** The column defaults to `false` and nothing in app code
writes it — the only reference in `apps/` and `packages/` is the read filter in
`acceptPendingInvitations`. `createInvitation` doesn't know the column exists,
so every invitation created through the UI is unaffected. Pre-authorizing one
requires an operator writing to the database directly, which deliberately keeps
"place someone in an org without their action" off the product surface. If this
ever becomes a product feature, the column alone is not sufficient and will
need an explicit permission gate on top.

## Behaviour

Resolution order in `ensureUserOrganizationInTransaction`:

1. `autoAccept` invitations → join each one with its own role, mark `accepted`, return.
2. Otherwise a plain pending invitation to the domain-matched org → `skipped` /
   `pending-invitation`, exactly as before.
3. Otherwise → existing domain rules.

Notes:

- **All** matching invitations are claimed, not just the first — one person can
  be backfilled into several orgs at once. Oldest invitation wins as the active org.
- The invitation's role is honoured. `addMemberIdempotent` previously hardcoded
  `"user"`; it now takes the role, defaulting to `"user"` for the domain path.
- No `emailVerified` requirement, unlike the domain path: an invitation names an
  exact address, so there is no domain to infer trust from.
- Archived orgs are skipped.
- The member row is written *before* the invitation is marked accepted.
  `addMember` runs on Better Auth's own connection rather than this
  transaction, so a rollback leaves a membership with a still-pending
  invitation, which the next call re-accepts idempotently. The reverse order
  would strand an accepted invitation with no membership.
- New PostHog event `organization_invitation_auto_accepted`, one per org joined.

## Testing

- `packages/e2e/tests/invite-auto-accept.spec.ts` (new) — two cases that are the
  consent boundary itself: an `autoAccept` invitation yields exactly one member
  with role `admin` and flips the invitation to `accepted`; a plain invitation
  yields **zero** members and stays `pending`. The test org claims no domain, so
  the invitation is the only thing that can produce a membership.
- `packages/e2e/tests/invite-no-duplicate-member.spec.ts` unchanged — it pins
  plain-invitation behaviour, which this PR preserves.
- `bun run check`, `bun run lint` (0 errors), `bun run fmt:check`, `knip` clean.
- `bun test apps/api/src/auth apps/api/migrations` → 140 pass, 0 fail.
- Full `bun test apps/api/` is 4025 pass / 56 fail both with and without this
  change — the 56 are pre-existing on `main` (vault, task board, S3, MCP proxy;
  they need infra this environment lacks), verified by re-running with the diff
  reverted in place.
- The e2e suite itself was **not** run: it needs Postgres + NATS + both servers up.

## Deploy

Migration 188 runs via the chart's `post-install,post-upgrade` migrate job, so
it applies on the next deploy with no manual step.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Claims pre-authorized invitations at signup so invited users with unclaimed or generic email domains land in their inviting org with the invitation’s role, instead of a fresh personal org. Invitations with `autoAccept` set are claimed before any email-domain rule.

**Migration**

- Adds `invitation."autoAccept"` column defaulting to `false`; only direct DB writes set it, so regular invitations still require manual acceptance.
- Applies automatically via the chart’s post-install/post-upgrade migrate job on next deploy.

<sup>Written for commit 445e2333d15f0b12d38d9e0cc6b98db7cf45ef17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

