### PR TITLE
fix(jira): keep an issue body's block structure when rendering it to a card

### DIFF
--- a/apps/api/src/jira/client.test.ts
+++ b/apps/api/src/jira/client.test.ts
@@ -155,6 +155,29 @@ describe("jiraBodyToText block structure", () => {
     );
   });
 
+  /**
+   * Order matters: escaping the pipe first would turn `a\|b` into `a\\|b`,
+   * which markdown reads as one literal backslash followed by a LIVE column
+   * separator — the break the escape exists to prevent. Caught by CodeQL as an
+   * incomplete escape, and it is a real one.
+   */
+  it("escapes a backslash before the pipe it precedes", () => {
+    const cell = (text: string) => ({
+      type: "tableCell",
+      content: [para(text)],
+    });
+    expect(
+      jiraBodyToText(
+        doc({
+          type: "table",
+          content: [
+            { type: "tableRow", content: [cell("a\\|b"), cell("c\\\\d")] },
+          ],
+        }),
+      ),
+    ).toBe("| a\\\\\\|b | c\\\\\\\\d |\n| --- | --- |");
+  });
+
   it("pads a ragged row and neutralizes a pipe inside a cell", () => {
     const cell = (text: string) => ({
       type: "tableCell",

--- a/apps/api/src/jira/client.test.ts
+++ b/apps/api/src/jira/client.test.ts
@@ -93,6 +93,235 @@ describe("jiraBodyToText", () => {
   });
 });
 
+/**
+ * Every container that holds siblings has to say how they are separated. Only
+ * `doc` used to, so a real issue body arrived with its table cells run together
+ * ("VerificaçãoResultado…") and its list items run together — all the text
+ * present, none of it readable.
+ */
+describe("jiraBodyToText block structure", () => {
+  const para = (text: string) => ({
+    type: "paragraph",
+    content: [{ type: "text", text }],
+  });
+  const doc = (...content: unknown[]) => ({ type: "doc", content });
+
+  it("marks headings by level, clamping one it cannot read", () => {
+    expect(
+      jiraBodyToText(
+        doc(
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [{ type: "text", text: "Contexto" }],
+          },
+          {
+            type: "heading",
+            attrs: { level: 99 },
+            content: [{ type: "text", text: "Deep" }],
+          },
+          { type: "heading", content: [{ type: "text", text: "Level-less" }] },
+        ),
+      ),
+    ).toBe("## Contexto\n\n###### Deep\n\n# Level-less");
+  });
+
+  it("keeps a table a table instead of running its cells together", () => {
+    const cell = (text: string, type = "tableCell") => ({
+      type,
+      content: [para(text)],
+    });
+    expect(
+      jiraBodyToText(
+        doc({
+          type: "table",
+          content: [
+            {
+              type: "tableRow",
+              content: [
+                cell("Verificação", "tableHeader"),
+                cell("Resultado", "tableHeader"),
+              ],
+            },
+            {
+              type: "tableRow",
+              content: [cell("#ld-json-product"), cell("não existe")],
+            },
+          ],
+        }),
+      ),
+    ).toBe(
+      "| Verificação | Resultado |\n| --- | --- |\n| #ld-json-product | não existe |",
+    );
+  });
+
+  it("pads a ragged row and neutralizes a pipe inside a cell", () => {
+    const cell = (text: string) => ({
+      type: "tableCell",
+      content: [para(text)],
+    });
+    expect(
+      jiraBodyToText(
+        doc({
+          type: "table",
+          content: [
+            { type: "tableRow", content: [cell("a"), cell("b | c")] },
+            { type: "tableRow", content: [cell("only")] },
+          ],
+        }),
+      ),
+    ).toBe("| a | b \\| c |\n| --- | --- |\n| only |  |");
+  });
+
+  it("folds a multi-line cell onto its row rather than breaking the table", () => {
+    expect(
+      jiraBodyToText(
+        doc({
+          type: "table",
+          content: [
+            {
+              type: "tableRow",
+              content: [
+                { type: "tableCell", content: [para("one"), para("two")] },
+                { type: "tableCell", content: [para("x")] },
+              ],
+            },
+          ],
+        }),
+      ),
+    ).toBe("| one two | x |\n| --- | --- |");
+  });
+
+  it("gives every list item its own line", () => {
+    expect(
+      jiraBodyToText(
+        doc({
+          type: "bulletList",
+          content: [
+            { type: "listItem", content: [para("PDP: Product")] },
+            { type: "listItem", content: [para("Home: Organization")] },
+          ],
+        }),
+      ),
+    ).toBe("- PDP: Product\n- Home: Organization");
+  });
+
+  it("numbers an ordered list from where the issue starts it", () => {
+    const items = [para("first"), para("second")].map((p) => ({
+      type: "listItem",
+      content: [p],
+    }));
+    expect(jiraBodyToText(doc({ type: "orderedList", content: items }))).toBe(
+      "1. first\n2. second",
+    );
+    expect(
+      jiraBodyToText(
+        doc({ type: "orderedList", attrs: { order: 3 }, content: items }),
+      ),
+    ).toBe("3. first\n4. second");
+  });
+
+  it("renders a task list as checkboxes that keep their state", () => {
+    expect(
+      jiraBodyToText(
+        doc({
+          type: "taskList",
+          content: [
+            {
+              type: "taskItem",
+              attrs: { state: "DONE" },
+              content: [{ type: "text", text: "shipped" }],
+            },
+            {
+              type: "taskItem",
+              attrs: { state: "TODO" },
+              content: [{ type: "text", text: "pending" }],
+            },
+          ],
+        }),
+      ),
+    ).toBe("- [x] shipped\n- [ ] pending");
+  });
+
+  it("keeps an item's second paragraph inside the item", () => {
+    expect(
+      jiraBodyToText(
+        doc({
+          type: "bulletList",
+          content: [
+            { type: "listItem", content: [para("head"), para("tail")] },
+            { type: "listItem", content: [para("next")] },
+          ],
+        }),
+      ),
+    ).toBe("- head\n\n  tail\n- next");
+  });
+
+  it("fences a code block with the language the issue tagged it", () => {
+    expect(
+      jiraBodyToText(
+        doc({
+          type: "codeBlock",
+          attrs: { language: "js" },
+          content: [{ type: "text", text: "var a = 1;\nreturn a;" }],
+        }),
+      ),
+    ).toBe("```js\nvar a = 1;\nreturn a;\n```");
+  });
+
+  it("quotes a panel and a blockquote, blank lines included", () => {
+    expect(
+      jiraBodyToText(
+        doc({ type: "panel", content: [para("careful"), para("really")] }),
+      ),
+    ).toBe("> careful\n>\n> really");
+  });
+
+  it("renders a rule, and the inline widgets that carry no text node", () => {
+    expect(
+      jiraBodyToText(
+        doc(
+          { type: "rule" },
+          {
+            type: "paragraph",
+            content: [
+              { type: "emoji", attrs: { text: "✅", shortName: ":check:" } },
+              { type: "text", text: " see " },
+              { type: "inlineCard", attrs: { url: "https://example.test/x" } },
+            ],
+          },
+        ),
+      ),
+    ).toBe("---\n\n✅ see https://example.test/x");
+  });
+
+  it("drops media without leaving a blank block, keeping any caption", () => {
+    expect(
+      jiraBodyToText(
+        doc(
+          para("before"),
+          {
+            type: "mediaSingle",
+            content: [{ type: "media", attrs: { id: "m1" } }],
+          },
+          para("after"),
+        ),
+      ),
+    ).toBe("before\n\nafter");
+  });
+
+  it("still contributes the text of a node type it does not know", () => {
+    expect(
+      jiraBodyToText(
+        doc({
+          type: "somethingNew",
+          content: [{ type: "text", text: "kept" }],
+        }),
+      ),
+    ).toBe("kept");
+  });
+});
+
 describe("jiraBodyToText mentions", () => {
   const mention = (attrs: Record<string, unknown>) => ({
     type: "doc",

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -892,14 +892,22 @@ function listText(
     .join("\n");
 }
 
-/** A table cell flattened to one line: newlines and pipes would both break the
- *  row apart, so they are folded rather than emitted. */
+/**
+ * A table cell flattened to one line: a newline or a bare pipe would each break
+ * the row apart, so they are folded and escaped rather than emitted.
+ *
+ * Backslashes are escaped BEFORE pipes, and the order is load-bearing. A cell
+ * reading `a\|b` would otherwise come out as `a\\|b`, where markdown reads the
+ * pair as one literal backslash and the pipe as a live column separator — the
+ * exact break the escape exists to prevent.
+ */
 function cellText(value: unknown, names: ReadonlyMap<string, string>): string {
   const node = adfNode(value);
   if (!node) return "";
   return blockTexts(adfChildren(node), names)
     .join(" ")
     .replace(/\s*\n\s*/g, " ")
+    .replace(/\\/g, "\\\\")
     .replace(/\|/g, "\\|")
     .trim();
 }

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -796,33 +796,224 @@ function collectMentions(body: unknown, ids: Set<string>): void {
   }
 }
 
-/** Jira rich body → text the cards can render. The Agile API returns
- *  v2-style STRING bodies (wiki markup — converted to markdown); REST v3
- *  returns an ADF tree, which is flattened: text nodes concatenated,
- *  doc-level blocks separated by blank lines. ADF marks, tables, and media
- *  are dropped — the card links back to the issue for full fidelity. */
+interface AdfNode {
+  type?: string;
+  text?: string;
+  attrs?: Record<string, unknown> & MentionAttrs;
+  content?: unknown[];
+}
+
+function adfNode(value: unknown): AdfNode | null {
+  return value && typeof value === "object" ? (value as AdfNode) : null;
+}
+
+function adfChildren(node: AdfNode): unknown[] {
+  return Array.isArray(node.content) ? node.content : [];
+}
+
+function attrText(node: AdfNode, key: string): string {
+  const value = node.attrs?.[key];
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * The inline run of a node: text, breaks, mentions, and the small widgets ADF
+ * uses for links, emoji and dates.
+ *
+ * Marks (bold, links, code) are dropped: the card is a summary that links back
+ * to the issue, and re-deriving `[text](href)` from mark ranges is a different
+ * job from keeping the body readable. Anything unrecognized recurses, so a node
+ * type Atlassian adds later still contributes its text instead of vanishing.
+ */
+function inlineText(
+  value: unknown,
+  names: ReadonlyMap<string, string>,
+): string {
+  const node = adfNode(value);
+  if (!node) return "";
+  switch (node.type) {
+    case "text":
+      return node.text ?? "";
+    case "hardBreak":
+      return "\n";
+    case "mention":
+      return mentionText(node.attrs, names);
+    case "emoji":
+      return attrText(node, "text") || attrText(node, "shortName");
+    case "inlineCard":
+    case "blockCard":
+      return attrText(node, "url");
+    case "date":
+      return attrText(node, "timestamp");
+    case "status":
+      return attrText(node, "text");
+    default:
+      return adfChildren(node)
+        .map((child) => inlineText(child, names))
+        .join("");
+  }
+}
+
+/** Indent every line but the first, so a list item's second paragraph stays
+ *  inside the item instead of ending it. Blank lines are left blank rather than
+ *  padded — the separator between an item's paragraphs must not carry trailing
+ *  whitespace. */
+function hangingIndent(text: string, width: number): string {
+  const pad = " ".repeat(width);
+  return text
+    .split("\n")
+    .map((line, index) => (index === 0 || line === "" ? line : pad + line))
+    .join("\n");
+}
+
+function prefixLines(text: string, prefix: string): string {
+  return text
+    .split("\n")
+    .map((line) => (line === "" ? prefix.trimEnd() : prefix + line))
+    .join("\n");
+}
+
+/** One list, its items marked and their continuation lines indented under the
+ *  marker. `marker` decides bullet vs number vs checkbox. */
+function listText(
+  node: AdfNode,
+  names: ReadonlyMap<string, string>,
+  marker: (item: AdfNode, index: number) => string,
+): string {
+  const items = adfChildren(node)
+    .map(adfNode)
+    .filter((item): item is AdfNode => item !== null);
+  return items
+    .map((item, index) => {
+      const bullet = marker(item, index);
+      const body = blockTexts(adfChildren(item), names).join("\n\n");
+      return bullet + hangingIndent(body, bullet.length);
+    })
+    .join("\n");
+}
+
+/** A table cell flattened to one line: newlines and pipes would both break the
+ *  row apart, so they are folded rather than emitted. */
+function cellText(value: unknown, names: ReadonlyMap<string, string>): string {
+  const node = adfNode(value);
+  if (!node) return "";
+  return blockTexts(adfChildren(node), names)
+    .join(" ")
+    .replace(/\s*\n\s*/g, " ")
+    .replace(/\|/g, "\\|")
+    .trim();
+}
+
+/**
+ * An ADF table as a markdown one.
+ *
+ * The delimiter row goes under the first row whether or not it is made of
+ * header cells: markdown has no way to render a table without one, and a body
+ * row promoted to a header reads far better than a table that does not render.
+ */
+function tableText(node: AdfNode, names: ReadonlyMap<string, string>): string {
+  const rows = adfChildren(node)
+    .map(adfNode)
+    .filter((row): row is AdfNode => row?.type === "tableRow")
+    .map((row) => adfChildren(row).map((cell) => cellText(cell, names)));
+  if (rows.length === 0) return "";
+  const width = Math.max(...rows.map((row) => row.length));
+  const line = (cells: string[]) =>
+    `| ${[...cells, ...Array(width - cells.length).fill("")].join(" | ")} |`;
+  const [header, ...body] = rows as [string[], ...string[][]];
+  return [
+    line(header),
+    `| ${Array(width).fill("---").join(" | ")} |`,
+    ...body.map(line),
+  ].join("\n");
+}
+
+/** The block-level nodes of one container, each rendered whole, with the empty
+ *  ones dropped so a stray media node does not leave a blank paragraph. */
+function blockTexts(
+  values: unknown[],
+  names: ReadonlyMap<string, string>,
+): string[] {
+  return values
+    .map((value) => blockText(value, names))
+    .filter((text) => text.trim() !== "");
+}
+
+/**
+ * One block, rendered as the markdown the card's description field is written
+ * in (that is already the contract — a v2 wiki body goes through
+ * {@link wikiToMarkdown}).
+ *
+ * Every container that holds siblings has to say how they are separated. The
+ * previous version answered that only for `doc` and concatenated everywhere
+ * else, so a table came out as its cells run together and a list as its items
+ * run together — the text was all present and none of it was readable.
+ */
+function blockText(value: unknown, names: ReadonlyMap<string, string>): string {
+  const node = adfNode(value);
+  if (!node) return "";
+  switch (node.type) {
+    case "doc":
+      return blockTexts(adfChildren(node), names).join("\n\n");
+    case "heading": {
+      const level = Number(node.attrs?.level);
+      const depth = Number.isInteger(level)
+        ? Math.min(Math.max(level, 1), 6)
+        : 1;
+      return `${"#".repeat(depth)} ${inlineText(node, names)}`;
+    }
+    case "bulletList":
+      return listText(node, names, () => "- ");
+    case "orderedList": {
+      const start = Number(node.attrs?.order);
+      const first = Number.isInteger(start) && start > 0 ? start : 1;
+      return listText(node, names, (_item, index) => `${first + index}. `);
+    }
+    case "taskList":
+      return listText(node, names, (item) =>
+        attrText(item, "state") === "DONE" ? "- [x] " : "- [ ] ",
+      );
+    case "codeBlock":
+      return `\`\`\`${attrText(node, "language")}\n${inlineText(node, names)}\n\`\`\``;
+    case "blockquote":
+    case "panel":
+      return prefixLines(
+        blockTexts(adfChildren(node), names).join("\n\n"),
+        "> ",
+      );
+    case "rule":
+      return "---";
+    case "table":
+      return tableText(node, names);
+    case "expand":
+    case "nestedExpand": {
+      const title = attrText(node, "title").trim();
+      const body = blockTexts(adfChildren(node), names).join("\n\n");
+      return title ? `**${title}**\n\n${body}` : body;
+    }
+    case "media":
+      return "";
+    case "mediaSingle":
+    case "mediaGroup":
+      return blockTexts(adfChildren(node), names).join("\n\n");
+    default:
+      return inlineText(node, names);
+  }
+}
+
+/** Jira rich body → the markdown a card's description is written in. The Agile
+ *  API returns v2-style STRING bodies (wiki markup — converted by
+ *  {@link wikiToMarkdown}); REST v3 returns an ADF tree, rendered block by
+ *  block: headings, lists, task lists, code blocks, quotes and tables all keep
+ *  their shape. ADF marks and media are dropped — the card links back to the
+ *  issue for full fidelity. */
 export function jiraBodyToText(
   adf: unknown,
   names: ReadonlyMap<string, string> = new Map(),
 ): string {
   if (typeof adf === "string") return wikiToMarkdown(adf, names);
   if (!adf || typeof adf !== "object") return "";
-  const node = adf as {
-    type?: string;
-    text?: string;
-    attrs?: MentionAttrs;
-    content?: unknown[];
-  };
-  if (node.type === "text") return node.text ?? "";
-  if (node.type === "hardBreak") return "\n";
-  if (node.type === "mention") return mentionText(node.attrs, names);
-  const inner = (Array.isArray(node.content) ? node.content : []).map((child) =>
-    jiraBodyToText(child, names),
-  );
-  if (node.type === "doc") {
-    return inner.filter((text) => text.trim() !== "").join("\n\n");
-  }
-  return inner.join("");
+  return blockText(adf, names);
 }
 
 /**


### PR DESCRIPTION
## What is this contribution about?

A card synced from Jira showed far less of its issue than the issue had — not because text was dropped, but because every block ran into the next one.

`jiraBodyToText` walked the ADF tree and separated children **only at the `doc` node**:

```ts
if (node.type === "doc") return inner.filter(...).join("\n\n");
return inner.join("");   // ← table, tableRow, tableCell, bulletList, listItem, taskItem, heading…
```

So a table came back as `VerificaçãoResultado<script…> no HTML do servidor (5 page types)0Idem no DOM…0Elemento #ld-json-productnão existe`, and a list as `…offers (…).Todas as page types: BreadcrumbList.Home: Organization e WebSite.` Every character was present; none of it was readable. On one real issue this turned a spec with a comparison table, two lists and a checklist into an unbroken wall.

Blocks now render as the markdown the description field is **already** written in — that is not a new contract, a v2 wiki body has always gone through `wikiToMarkdown`:

| ADF | rendered |
|---|---|
| `heading` | `##` by level, clamped to 1–6 |
| `bulletList` / `orderedList` | one item per line, continuations indented under the marker; ordered lists honour `attrs.order` |
| `taskList` | `- [x]` / `- [ ]` from `attrs.state` |
| `codeBlock` | fenced, with `attrs.language` |
| `blockquote`, `panel` | `> ` prefixed |
| `table` | a markdown table |
| `rule` | `---` |
| `expand` | bold title, then its blocks |
| `media` | dropped, without leaving a blank block; a `mediaSingle` caption survives |

Inline widgets that carry no text node — `emoji`, `inlineCard`, `date`, `status` — contributed nothing at all before and now contribute their text or href.

**Two calls worth naming.** A table's delimiter row goes under the first row whether or not that row is made of header cells: markdown cannot render a table without one, and a body row promoted to a header reads far better than a table that does not render. And a cell is folded to a single line with its pipes escaped, since either a newline or a bare `|` breaks the row apart.

The module comment claimed tables were **"dropped"**. They were not dropped, they were mangled — which is worse than dropping, and an overstated safety claim in a comment is itself a bug. It now says what the renderer actually does.

Unknown node types still recurse to their text, so a type Atlassian ships later degrades to plain text rather than vanishing.

**Pull-only.** `markdownToAdf` is used for posting comments (`client.ts:616`), never for descriptions, so nothing round-trips a table back into Jira.

## How did you verify your code works?

All 50 pre-existing `client.test.ts` cases pass untouched — the paragraph/hardBreak/marks contract, the v2 wiki path, the null and non-object guards, and every mention case are unchanged by design, so none needed inverting.

13 new cases in a `jiraBodyToText block structure` describe, written from the shape of the issue that exposed this: heading levels (including an unreadable one and a missing one), a table with header cells, a ragged row, a pipe inside a cell, a multi-line cell, bullet/ordered/task lists, an ordered list starting at 3, a list item whose second paragraph must stay inside the item, a fenced code block, a panel's blank-line handling, `rule` plus the text-less inline widgets, media dropped without a blank block, and an unknown node type still contributing its text.

One of those found a real defect while I was writing it: `hangingIndent` padded the blank line between an item's two paragraphs, so the output carried trailing whitespace. Fixed in the implementation, not papered over in the expectation.

`bun test apps/api/src/jira/` 178 pass / 0 fail. `bun run check` 0 type errors, `bun run lint` 19 warnings identical to baseline, `knip` clean, `fmt:check` clean.

**Not verified, flagging honestly:** no test runs a captured real ADF payload end to end — the cases are hand-built from the shapes that broke. Fetching a live body needs a tenant credential, which does not belong in a fixture.

## Screenshots/Demonstration

Not captured; the change is in a pure function. The before/after is the table and list text quoted above.

## How to Test

1. On an org with Jira sync, open a card whose issue has a table, a bullet list and a checklist. Today its description is one unbroken run.
2. Touch that issue in Jira (any edit bumps `updated`) so the next sync tick re-pulls it.
3. The card's description should come back with the table rendered, one bullet per line, and `[ ]`/`[x]` checkboxes.

## Migration Notes

No schema change. But **existing cards keep their mangled descriptions** until their issue is next pulled: the sync only visits issues whose `updated` is past the integration's watermark, and this fix changes rendering, not scope.

To re-render a tenant's whole board in one pass, clear the watermark and let the next tick do a full re-scan:

```sql
UPDATE org_jira_integrations
   SET last_synced_at = NULL, last_sync_error = NULL
 WHERE organization_id = '<org-id>';
```

That is the initial-import path, which is idempotent (the link table's UNIQUE dedupes) and deliberately suppresses auto-delegation, so a re-scan cannot dispatch a paid agent run per pre-existing card.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders each ADF block in a Jira issue body as the markdown a card description already uses, so tables, lists, task checkboxes, code blocks, headings, quotes, and rules keep their shape instead of collapsing into unreadable run-on text. Inline widgets that carry no text node (emoji, inline cards, dates, statuses) now contribute their text, and unknown node types degrade to plain text instead of vanishing.

Table cells are folded to one line with pipes escaped; backslashes are escaped before pipes so a literal backslash cannot reactivate a column separator, and media is dropped without leaving a blank block. Pull-only: comments still round-trip through `markdownToAdf`, so nothing writes tables back to Jira.

**Migration**
- Existing cards keep their mangled descriptions until the issue is re-pulled; to re-render a board, clear the integration watermark.

<sup>Written for commit 7b46bdbd01fafa3bfe39d26e7393db4950d66c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

