### PR TITLE
fix(monitoring): fall back to the coarsest interval bucket, not the finest

### DIFF
--- a/apps/web/src/routes/orgs/monitoring/utils.test.ts
+++ b/apps/web/src/routes/orgs/monitoring/utils.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { computeHeatmapView } from "./utils.ts";
+import { computeHeatmapView, getIntervalFromRange } from "./utils.ts";
+
+describe("getIntervalFromRange", () => {
+  test("falls back to the coarsest bucket for a range wider than any of them", () => {
+    // ~5 years — wider than the largest configured bucket (7d at 40 steps).
+    const range = {
+      startDate: new Date("2020-01-01T00:00:00Z"),
+      endDate: new Date("2026-01-01T00:00:00Z"),
+    };
+    expect(getIntervalFromRange(range)).toBe("7d");
+  });
+
+  test("picks the smallest bucket that keeps steps near the target for an in-range span", () => {
+    const range = {
+      startDate: new Date("2026-01-01T00:00:00Z"),
+      endDate: new Date("2026-01-02T00:00:00Z"),
+    };
+    expect(getIntervalFromRange(range)).toBe("1h");
+  });
+});
 
 describe("computeHeatmapView", () => {
   test("maxValue only reflects cells for agents actually rendered", () => {

--- a/apps/web/src/routes/orgs/monitoring/utils.ts
+++ b/apps/web/src/routes/orgs/monitoring/utils.ts
@@ -38,7 +38,8 @@ export function getIntervalFromRange(range: DateRange): string {
   const durationMs = range.endDate.getTime() - range.startDate.getTime();
   const rawInterval = durationMs / TARGET_STEPS;
   const nice = NICE_INTERVALS.find((b) => b.ms >= rawInterval);
-  return nice?.label ?? "1d";
+  // A range wider than the largest bucket has no match — fall back to it, not "1d".
+  return nice?.label ?? NICE_INTERVALS[NICE_INTERVALS.length - 1]!.label;
 }
 
 function intervalToMs(interval: string): number {


### PR DESCRIPTION
**Source:** bug found while auditing the monitoring dashboard's timeseries bucketing (`apps/web/src/routes/orgs/monitoring/utils.ts`), part of RECENTLY-CHANGED-FILES creative sweep.

**Why it matters:** `getIntervalFromRange` picks a Grafana-style auto-interval by scanning `NICE_INTERVALS` (1m … 7d) for the smallest bucket that still keeps the range around ~40 steps. When a range is wider than the largest configured bucket (7d covers up to ~280 days at 40 steps), `Array.find` returns `undefined` and the code fell back to `"1d"` — the *smallest* bucket in the table, not the largest. The monitoring page's absolute time-range picker lets an org pick an arbitrary custom range (months or years), so a multi-year range would silently render thousands of daily buckets in `buildFilledStatsData` instead of the intended handful of weekly ones — the opposite of what a coarser fallback should do.

**Fix:** fall back to `NICE_INTERVALS[NICE_INTERVALS.length - 1]` (7d, the coarsest bucket) instead of the hardcoded `"1d"`.

**Regression test:** `apps/web/src/routes/orgs/monitoring/utils.test.ts` adds a `getIntervalFromRange` describe block: a ~5-year range now resolves to `"7d"` (was `"1d"`), plus a same-day range asserting the normal in-table path still resolves to `"1h"`.

**To confirm:** `bun test apps/web/src/routes/orgs/monitoring/utils.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the monitoring dashboard's interval fallback so multi-year time ranges render weekly buckets instead of thousands of daily ones.

`getIntervalFromRange` previously fell back to `"1d"`—the smallest bucket—when a range exceeded the largest configured bucket (`7d` at ~40 steps). It now falls back to `"7d"`, and the tests cover both the wide-range fallback and a normal same-day range.

<sup>Written for commit 46238d1a529b024db8cc23e12e80a40c3b03ecc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

