### PR TITLE
feat(jira): let an operator queue a full re-scan of the board

### DIFF
--- a/apps/api/src/storage/jira-integrations.integration.test.ts
+++ b/apps/api/src/storage/jira-integrations.integration.test.ts
@@ -108,6 +108,39 @@ describe("jira integration status mapping", () => {
     ]);
   });
 
+  /**
+   * The watermark is what makes a repair reach nothing: an issue behind it is
+   * never asked for again, so a widened mapping or a fixed renderer only
+   * touches issues that happen to change afterwards. Clearing it has to leave
+   * the row in the initial-import state — which is also the state that
+   * suppresses auto-delegation, so a re-scan cannot dispatch a paid run per
+   * pre-existing card.
+   */
+  it("clears the watermark without disturbing the rest of the row", async () => {
+    const mapping = { in_review: ["QA", "Code Review"] };
+    const written = await write(mapping);
+    await storage.recordSyncResult(written.id, {
+      error: "boom",
+      watermark: new Date("2026-01-01T00:00:00Z"),
+      rescanPending: true,
+    });
+
+    await storage.clearWatermark(written.id);
+
+    const after = await storage.getByOrg(ORG);
+    expect(after?.lastSyncedAt).toBe(null);
+    expect(after?.lastSyncError).toBe(null);
+    expect(after?.rescanPending).toBe(false);
+    expect(after?.statusMapping).toEqual(mapping);
+    expect(after?.boardId).toBe("1");
+  });
+
+  it("is a no-op on an id that is not this org's integration", async () => {
+    const before = await storage.getByOrg(ORG);
+    await storage.clearWatermark("jira_does_not_exist");
+    expect(await storage.getByOrg(ORG)).toEqual(before);
+  });
+
   it("reads an empty mapping as empty rather than throwing", async () => {
     await write({});
     expect((await storage.getByOrg(ORG))?.statusMapping).toEqual({});

--- a/apps/api/src/storage/jira-integrations.ts
+++ b/apps/api/src/storage/jira-integrations.ts
@@ -207,6 +207,33 @@ export class JiraIntegrationStorage {
   }
 
   /**
+   * Drop the watermark, so the next run re-scans the board from the start.
+   *
+   * `last_synced_at` means "every issue in scope up to here has been
+   * processed", which stops being true whenever what we do with an issue
+   * changes — a widened status mapping, a fixed renderer — rather than only
+   * when the scope does. Issues already behind the watermark are never asked
+   * for again, so those repairs reach nothing without this.
+   *
+   * Safe to call: a null watermark is the initial-import path, which is
+   * idempotent (the link table's UNIQUE dedupes every issue) and deliberately
+   * suppresses auto-delegation, so a re-scan cannot dispatch a paid agent run
+   * per pre-existing card. `MAX_ISSUES_PER_RUN` paces the rest.
+   */
+  async clearWatermark(id: string): Promise<void> {
+    await this.db
+      .updateTable("org_jira_integrations")
+      .set({
+        last_synced_at: null,
+        last_sync_error: null,
+        rescan_pending: false,
+        updated_at: new Date(),
+      })
+      .where("id", "=", id)
+      .execute();
+  }
+
+  /**
    * Every linked issue in the org, for the reconciliation pass — the cards
    * whose issue is no longer in the board's scope.
    *

--- a/apps/api/src/tools/index.ts
+++ b/apps/api/src/tools/index.ts
@@ -225,6 +225,7 @@ export const CORE_TOOLS = [
   JiraTools.JIRA_BOARDS_LIST,
   JiraTools.JIRA_BOARD_COLUMNS_LIST,
   JiraTools.JIRA_SYNC_RUN,
+  JiraTools.JIRA_RESYNC_REQUEST,
 
   // Object Storage tools
   ObjectStorageTools.LIST_OBJECTS,

--- a/apps/api/src/tools/jira/index.ts
+++ b/apps/api/src/tools/jira/index.ts
@@ -315,3 +315,30 @@ export const JIRA_SYNC_RUN = defineTool({
     return { result };
   },
 });
+
+export const JIRA_RESYNC_REQUEST = defineTool({
+  name: "JIRA_RESYNC_REQUEST",
+  description:
+    "Mark the whole board for a re-scan. Does NOT sync — it drops the sync's " +
+    "watermark, so the next scheduled run re-reads every issue in scope " +
+    "instead of only what changed. Use it after changing what the sync DOES " +
+    "with an issue (a widened status mapping, a fixed body renderer), since " +
+    "issues behind the watermark are otherwise never asked for again. Use " +
+    "JIRA_SYNC_RUN to pull the recent changes right now.",
+  inputSchema: z.object({}),
+  outputSchema: z.object({ queued: z.literal(true) }),
+  handler: async (_input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const organization = requireOrganization(ctx);
+    const integration = await requireIntegration(ctx, organization.id);
+    // Deliberately does not run the scan. A full board is thousands of Jira
+    // reads paced across ticks by MAX_ISSUES_PER_RUN and `rescan_pending`,
+    // which is the scheduler's job — holding an HTTP request open for it would
+    // time out on exactly the boards big enough to need it, and a run dropped
+    // by a recycled process would leave no trace that a re-scan was wanted.
+    // The cleared watermark IS the durable record of the request.
+    await ctx.storage.jiraIntegrations.clearWatermark(integration.id);
+    return { queued: true as const };
+  },
+});

--- a/apps/web/src/hooks/use-jira-integration.ts
+++ b/apps/web/src/hooks/use-jira-integration.ts
@@ -84,3 +84,19 @@ export function useRunJiraSync() {
       queryClient.invalidateQueries({ queryKey: KEYS.jiraIntegration(org.id) }),
   });
 }
+
+/**
+ * Ask for a full re-scan. Returns as soon as the request is recorded — the
+ * scan itself is the scheduler's, paced across ticks, because a whole board is
+ * far more Jira reads than a request should hold open.
+ */
+export function useRequestJiraResync() {
+  const { org } = useProjectContext();
+  const studio = useStudioTools();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => await studio.call("JIRA_RESYNC_REQUEST", {}),
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: KEYS.jiraIntegration(org.id) }),
+  });
+}

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -56,7 +56,13 @@ export const settings = {
   "settings.jira.enableRequirements":
     "Pick a project and map at least one status before enabling the sync",
   "settings.jira.lastSynced": "Last synced {ago}",
-  "settings.jira.waitingFirstSync": "Waiting for the first sync",
+  "settings.jira.waitingFirstSync": "Waiting for the next sync",
+  "settings.jira.resyncAll": "Resync everything",
+  "settings.jira.resyncAllTitle": "Re-scan the whole board?",
+  "settings.jira.resyncAllQueued":
+    "Re-scan requested — the next sync will start it.",
+  "settings.jira.resyncAllDescription":
+    '"Sync now" only pulls issues changed since the last run. This marks every issue on the board to be re-read \u2014 what you want after changing the status mapping, or when cards look wrong. It starts on the next scheduled sync rather than now, can span several runs on a large board, and never assigns an agent to a card.',
   "settings.jira.syncNow": "Sync now",
   "settings.jira.syncing": "Syncing…",
   "settings.jira.syncDone":

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -59,7 +59,13 @@ export const settings = {
   "settings.jira.enableRequirements":
     "Escolha um projeto e mapeie pelo menos um status antes de ativar a sincronização",
   "settings.jira.lastSynced": "Última sincronização {ago}",
-  "settings.jira.waitingFirstSync": "Aguardando a primeira sincronização",
+  "settings.jira.waitingFirstSync": "Aguardando a próxima sincronização",
+  "settings.jira.resyncAll": "Resincronizar tudo",
+  "settings.jira.resyncAllTitle": "Reler o board inteiro?",
+  "settings.jira.resyncAllQueued":
+    "Releitura solicitada — a próxima sincronização vai começá-la.",
+  "settings.jira.resyncAllDescription":
+    'O "Sincronizar agora" só puxa issues alteradas desde a última execução. Esta opção marca todas as issues do board para serem relidas — é o que você quer depois de mudar o mapeamento de status, ou quando os cards estão errados. Ela começa na próxima sincronização agendada, não agora, pode se estender por várias execuções num board grande, e nunca delega um card para um agente.',
   "settings.jira.syncNow": "Sincronizar agora",
   "settings.jira.syncing": "Sincronizando…",
   "settings.jira.syncDone":

--- a/apps/web/src/views/settings/jira.tsx
+++ b/apps/web/src/views/settings/jira.tsx
@@ -61,6 +61,7 @@ import {
   useJiraBoardColumns,
   useJiraBoards,
   useJiraIntegration,
+  useRequestJiraResync,
   useRunJiraSync,
   useUpsertJiraIntegration,
 } from "@/hooks/use-jira-integration";
@@ -544,6 +545,8 @@ function SyncRow({ integration }: { integration: JiraIntegration }) {
   const t = useT();
   const upsert = useUpsertJiraIntegration();
   const runSync = useRunJiraSync();
+  const requestResync = useRequestJiraResync();
+  const [resyncOpen, setResyncOpen] = useState(false);
   const hasMapping = Object.keys(integration.statusMapping).length > 0;
 
   return (
@@ -552,6 +555,49 @@ function SyncRow({ integration }: { integration: JiraIntegration }) {
       description={<SyncStatusLine integration={integration} />}
       action={
         <div className="flex items-center gap-3">
+          <AlertDialog open={resyncOpen} onOpenChange={setResyncOpen}>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={
+                !integration.enabled ||
+                runSync.isPending ||
+                requestResync.isPending
+              }
+              onClick={() => setResyncOpen(true)}
+            >
+              {t("settings.jira.resyncAll")}
+            </Button>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  {t("settings.jira.resyncAllTitle")}
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  {t("settings.jira.resyncAllDescription")}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>
+                  {t("settings.jira.cancel")}
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() =>
+                    requestResync.mutate(undefined, {
+                      onSuccess: () =>
+                        toast.success(t("settings.jira.resyncAllQueued")),
+                      onError: (err) =>
+                        toast.error(
+                          errorMessage(err, t("settings.jira.syncFailed")),
+                        ),
+                    })
+                  }
+                >
+                  {t("settings.jira.resyncAll")}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
           <Button
             variant="outline"
             size="sm"

--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -194,6 +194,7 @@ const ALL_TOOL_NAMES = [
   "JIRA_BOARDS_LIST",
   "JIRA_BOARD_COLUMNS_LIST",
   "JIRA_SYNC_RUN",
+  "JIRA_RESYNC_REQUEST",
 
   // Object Storage tools
   "LIST_OBJECTS",
@@ -916,6 +917,12 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     category: "Jira",
   },
   {
+    name: "JIRA_RESYNC_REQUEST",
+    description:
+      "Mark the whole Jira board to be re-read on the next scheduled sync",
+    category: "Jira",
+  },
+  {
     name: "FILE_CONFIG_UPDATE",
     description:
       "Update an S3 bucket configuration, optionally rotating credentials",
@@ -1440,6 +1447,7 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "JIRA_BOARDS_LIST",
       "JIRA_BOARD_COLUMNS_LIST",
       "JIRA_SYNC_RUN",
+      "JIRA_RESYNC_REQUEST",
     ],
   },
   {

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -5026,6 +5026,10 @@ export interface StudioToolIO {
         | { error: string };
     };
   };
+  JIRA_RESYNC_REQUEST: {
+    input: { [x: string]: never };
+    output: { queued: true };
+  };
   LIST_OBJECTS: {
     input: {
       prefix?: string | undefined;


### PR DESCRIPTION
## What is this contribution about?

`last_synced_at` means *"every issue in scope up to here has been processed"*, and the pull asks Jira only for `updated >= watermark`. That is exactly right when the **issues** change. It is wrong whenever what the sync *does with* an issue changes — a widened status mapping, a fixed body renderer — because every issue behind the watermark is already "done" and never gets re-read.

We have hit that twice in a week, and both times the only fix was a hand-written `UPDATE` against production. Migration 184 exists on precisely this argument: a repair "whose repair depends on someone remembering a SQL statement is a scope change that silently doesn't apply."

### It queues, it does not sync

`JIRA_RESYNC_REQUEST` drops the watermark and returns. It deliberately does **not** run the scan:

- A whole board is thousands of Jira reads. `MAX_ISSUES_PER_RUN` and `rescan_pending` already pace that across scheduler ticks — that is the scheduler's job, and it already does it correctly.
- Holding an HTTP request open for a full scan would time out on exactly the boards big enough to need one.
- A run kicked off fire-and-forget and then lost to a recycled process would leave **no trace** that a re-scan was ever wanted. The cleared watermark *is* the durable record of the request; the next tick picks it up and carries it across as many ticks as it takes.

**That is also why it is its own tool rather than a `full` flag on `JIRA_SYNC_RUN`.** One performs a sync and reports created/updated/archived; the other records an intent and has nothing to report. Folding both into one tool means a union output that every caller — including an agent reading the description — has to disambiguate. Two verbs, two tools.

- **Storage**: `clearWatermark` also clears `last_sync_error` and `rescan_pending`, so the row lands in a coherent initial-import state rather than a half-one.
- **UI**: "Resync everything" beside "Sync now", behind a confirm that says it starts on the *next scheduled sync* rather than now, can span several runs, and never assigns an agent to a card. "Sync now" is untouched.
- **Copy**: `waitingFirstSync` now reads "waiting for the **next** sync". With a queued re-scan, a null watermark no longer implies the org has never synced, and the old string would have been actively wrong right after pressing the button.

**Why it is safe, and why the confirm can say so.** A null watermark is the initial-import path: idempotent (the link table's `UNIQUE` dedupes every issue) and it deliberately suppresses auto-delegation, so a re-scan cannot dispatch a paid agent run per pre-existing card.

## How did you verify your code works?

Two new **real-Postgres** cases in `jira-integrations.integration.test.ts` — the tier the repo requires for a storage change, since an in-memory fake would accept columns the `update()` whitelist silently drops:

- clearing leaves `lastSyncedAt`, `lastSyncError` and `rescanPending` reset **and** the rest of the row (status mapping, board id) untouched — written against a row first dirtied with an error, a watermark and a pending rescan;
- an id that is not this org's integration is a no-op, so the row is byte-identical after.

1062 pass across `apps/api/src/jira/`, `apps/api/src/tools/` and the storage suite, with 2 pre-existing failures (`hosted AI provider schemas`, OAuth URL generation) confirmed identical on baseline by stashing the change and re-running. `bun run check` 0 type errors (which also proves the pt-BR dictionary mirrors en, per the `satisfies` contract), `bun run lint` 19 warnings identical to baseline, `knip` clean, `fmt:check` clean. Tool contracts regenerated, and the tool registered in `registry-metadata.ts` — the name list, its Jira category entry, and the `integrations:manage` permission group, so it is not invisible to the consent UI.

**Not verified, flagging honestly:** no e2e — the existing Jira suite does not spin a fake Jira, and the handler is thin orchestration over the storage call that *is* pinned. No live browser check of the new button.

## Screenshots/Demonstration

Not captured. The UI change is one outline button in Settings → Tasks → Jira, next to "Sync now", plus its confirm dialog.

## How to Test

1. Settings → Tasks → Jira on an org with a connected, **enabled** integration. Both buttons should be disabled when the integration is off.
2. **Sync now** — behaviour unchanged, toast still reports created/updated/archived.
3. Add a Jira column to a lane in the mapping, then **Sync now**. Issues in that column that have not changed in Jira will **not** appear — that is the bug this exists for.
4. **Resync everything** → confirm. It should return immediately with "Re-scan requested — the next sync will start it", and the status line should read "Waiting for the next sync".
5. Wait for the next tick (the cron is every 10 minutes) and confirm those issues appear, without anyone pressing anything else.
6. Confirm the dialog cancels cleanly without recording anything.

## Migration Notes

None — no schema change. `JIRA_SYNC_RUN` is untouched, so existing callers are unaffected.

The equivalent by hand, for anyone who needs it before this ships:

```sql
UPDATE org_jira_integrations
   SET last_synced_at = NULL, last_sync_error = NULL, rescan_pending = false
 WHERE organization_id = '<org-id>';
```

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes
