### PR TITLE
feat(task-board): show a synced card under its tracker's key, not a second one

### DIFF
--- a/apps/api/src/storage/jira-integrations.integration.test.ts
+++ b/apps/api/src/storage/jira-integrations.integration.test.ts
@@ -190,4 +190,41 @@ describe("linked issues still on the board", () => {
       [],
     );
   });
+
+  /**
+   * The card read has to carry the tracker's key, because that is what the
+   * card shows. Real Postgres rather than a fake: the value is attached by a
+   * batched second query over the link table, not selected off the item row,
+   * so a fake that simply returns the item would agree with a version that
+   * attaches nothing.
+   */
+  it("attaches the tracker key to a synced card, and null to one Studio owns", async () => {
+    const synced = await linkedCard("9100", "todo");
+    const own = await taskBoard.create({
+      organizationId: ORG_R,
+      title: "written in Studio",
+      status: "todo",
+      by: USER_R,
+    });
+
+    expect((await taskBoard.getById(synced.id, ORG_R))?.jiraIssueKey).toBe(
+      "OS-9100",
+    );
+    expect((await taskBoard.getById(own.id, ORG_R))?.jiraIssueKey).toBe(null);
+
+    const listed = await taskBoard.list(ORG_R);
+    const byId = new Map(listed.map((i) => [i.id, i.jiraIssueKey]));
+    expect(byId.get(synced.id)).toBe("OS-9100");
+    expect(byId.get(own.id)).toBe(null);
+  });
+
+  it("leaves a fresh create's key null, before any link exists", async () => {
+    const created = await taskBoard.create({
+      organizationId: ORG_R,
+      title: "fresh",
+      status: "todo",
+      by: USER_R,
+    });
+    expect(created.jiraIssueKey).toBe(null);
+  });
 });

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1583,6 +1583,7 @@ export class TaskBoardStorage {
     await this.inTransaction(async (db) => {
       await this.attachThreads(db, items, organizationId);
       await this.attachTags(db, items);
+      await this.attachJiraKeys(db, items);
       await this.attachReviewVerdicts(db, items);
     });
   }
@@ -1709,6 +1710,32 @@ export class TaskBoardStorage {
 
   /** Populate each item's `tags`, name ascending. One batched query. Items are
    *  already org-scoped by the caller, so the join needs no org filter. */
+  /**
+   * Populate each item's `jiraIssueKey` — the key the issue wears in the
+   * tracker, which is what people say out loud about a synced card.
+   *
+   * One batched query, not a join on the item read: the link is one-to-one but
+   * lives in its own table, and every other ref on a card is attached here for
+   * the same reason. Cards Studio owns have no row and stay null.
+   */
+  private async attachJiraKeys(
+    db: Kysely<Database>,
+    items: TaskBoardItem[],
+  ): Promise<void> {
+    const ids = items.map((i) => i.id);
+
+    const rows = await db
+      .selectFrom("task_board_item_jira_links")
+      .select(["item_id as itemId", "jira_issue_key as jiraIssueKey"])
+      .where("item_id", "in", ids)
+      .execute();
+
+    const byItem = new Map(rows.map((row) => [row.itemId, row.jiraIssueKey]));
+    for (const item of items) {
+      item.jiraIssueKey = byItem.get(item.id) ?? null;
+    }
+  }
+
   private async attachTags(
     db: Kysely<Database>,
     items: TaskBoardItem[],
@@ -2212,7 +2239,8 @@ export class TaskBoardStorage {
       sortOrder: row.sort_order,
       keySeq: row.key_seq,
       retryAttempts: row.retry_attempts ?? 0,
-      // Populated by attachRefs for reads; empty for a fresh create.
+      // Populated by attachRefs for reads; null/empty for a fresh create.
+      jiraIssueKey: null,
       threads: [],
       tags: [],
       reviewVerdicts: [],

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1907,6 +1907,9 @@ export interface TaskBoardItem {
   sortOrder: number;
   /** Per-org sequence behind the card's human key (`DECO-01`), never null. */
   keySeq: number;
+  /** The key this card's issue wears in the tracker (`OS-333`), for a card that
+   *  came from one — attached on reads, null for a card Studio owns. */
+  jiraIssueKey: string | null;
   /** Infrastructure retries already spent on this card's runs — the budget
    *  `reactToFailedTaskRun` spends against `MAX_RUN_RETRIES`. */
   retryAttempts: number;

--- a/apps/api/src/tools/task-board/run-reactions.test.ts
+++ b/apps/api/src/tools/task-board/run-reactions.test.ts
@@ -211,6 +211,7 @@ function makeItem(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
     dueDate: null,
     sortOrder: 0,
     keySeq: 1,
+    jiraIssueKey: null,
     retryAttempts: 0,
     threads: [],
     tags: [],

--- a/apps/api/src/tools/task-board/schema.test.ts
+++ b/apps/api/src/tools/task-board/schema.test.ts
@@ -42,6 +42,7 @@ describe("TaskBoardItemSchema – proxy round-trip validation", () => {
     sprintId: null,
     sortOrder: 0,
     keySeq: 1,
+    jiraIssueKey: null,
     retryAttempts: 0,
     threads: [],
     tags: [],

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -184,6 +184,10 @@ export const TaskBoardItemSchema = z.object({
   sortOrder: z.number(),
   // Per-org sequence behind the card's human key (`DECO-01`); null pre-backfill.
   keySeq: z.number().nullable(),
+  // The key this card's issue wears in the tracker (`OS-333`), for a card that
+  // came from one. It is what the card shows, because it is what people say
+  // out loud about it. Null for a card Studio owns.
+  jiraIssueKey: z.string().nullable(),
   // Infrastructure retries already spent on this card's runs — the budget
   // `reactToFailedTaskRun` spends against `MAX_RUN_RETRIES`. Present on every
   // `TaskBoardItem` (see storage/types.ts), so it must be modeled here too:

--- a/apps/api/src/tools/task-board/update.test.ts
+++ b/apps/api/src/tools/task-board/update.test.ts
@@ -32,6 +32,7 @@ function item(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
     dueDate: null,
     sortOrder: 0,
     keySeq: 1,
+    jiraIssueKey: null,
     retryAttempts: 0,
     threads: [],
     tags: [],

--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -31,6 +31,7 @@ function item(id: string, sortOrder: number): TaskBoardItem {
     dueDate: null,
     sortOrder,
     keySeq: 1,
+    jiraIssueKey: null,
     retryAttempts: 0,
     threads: [],
     tags: [],

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -489,7 +489,7 @@ function CardFooter({
   onDueDateChange?: (iso: string) => void;
 }) {
   const { org } = useProjectContext();
-  const key = taskKey(org.slug, item.keySeq);
+  const key = taskKey(org.slug, item.keySeq, item.jiraIssueKey);
   return (
     // No inset of its own: the footer shares the card's padding, so the type glyph starts on the same left edge as the title and the labels.
     <div className="mt-auto flex shrink-0 items-center justify-between gap-2 pt-1">

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -617,7 +617,7 @@ function TaskBoardItemEditor({
     item && onRerun && item.assigneeId === SUPER_AGENT_ASSIGNEE_ID;
 
   /** The card's human key (`DECO-01`), the one identity a person can quote. */
-  const key = item ? taskKey(org.slug, item.keySeq) : null;
+  const key = item ? taskKey(org.slug, item.keySeq, item.jiraIssueKey) : null;
   const assignee = members.find((m) => m.userId === assigneeId);
   const assignedBy = item?.assignedBy
     ? members.find((m) => m.userId === item.assignedBy)

--- a/apps/web/src/layouts/task-board/task-filters.test.ts
+++ b/apps/web/src/layouts/task-board/task-filters.test.ts
@@ -324,3 +324,39 @@ describe("matchesTaskKey", () => {
     expect(matchesTaskKey("7", null)).toBe(false);
   });
 });
+
+/**
+ * The collision this exists to prevent: `parseTaskKeySeq` ignores a term's
+ * prefix, so before the tracker key was consulted, searching `OS-333` resolved
+ * to the number 333 and quietly matched whichever unrelated card held Studio
+ * sequence 333 — while missing the card actually named OS-333.
+ */
+describe("matchesTaskKey with a tracker key", () => {
+  test("finds a synced card by the key it shows, any case", () => {
+    expect(matchesTaskKey("OS-333", 320, "OS-333")).toBe(true);
+    expect(matchesTaskKey("os-333", 320, "OS-333")).toBe(true);
+    expect(matchesTaskKey("  OS-333  ", 320, "OS-333")).toBe(true);
+  });
+
+  test("does not match a synced card by the sequence it no longer shows", () => {
+    expect(matchesTaskKey("OSKL-320", 320, "OS-333")).toBe(false);
+  });
+
+  test("never lets a tracker key match an unrelated card's sequence", () => {
+    expect(matchesTaskKey("OS-333", 333, "OS-999")).toBe(false);
+    expect(matchesTaskKey("OS-333", 333, null)).toBe(true);
+  });
+
+  test("takes a bare number against either vocabulary, ambiguity included", () => {
+    expect(matchesTaskKey("333", 320, "OS-333")).toBe(true);
+    expect(matchesTaskKey("0333", 320, "OS-333")).toBe(true);
+    expect(matchesTaskKey("320", 320, "OS-333")).toBe(false);
+    expect(matchesTaskKey("333", 333, null)).toBe(true);
+  });
+
+  test("an empty or unparseable term names nothing", () => {
+    expect(matchesTaskKey("", 320, "OS-333")).toBe(false);
+    expect(matchesTaskKey("   ", 320, "OS-333")).toBe(false);
+    expect(matchesTaskKey("schema", 320, "OS-333")).toBe(false);
+  });
+});

--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -196,13 +196,35 @@ function isSameDay(a: number, b: number): boolean {
   );
 }
 
-/** True when the term names this card by its human key (see `taskKey`). */
+/** A term written as a bare number — the shorthand both key vocabularies take. */
+const BARE_SEQ = /^0*(\d+)$/;
+
+/**
+ * True when the term names this card by the key it SHOWS (see `taskKey`).
+ *
+ * A card synced from a tracker shows the tracker's key, so that is the only
+ * lettered key it answers to. Falling through to the sequence would be worse
+ * than useless: `parseTaskKeySeq` ignores the prefix, so searching `OS-333`
+ * would quietly match whichever unrelated card happens to hold Studio sequence
+ * 333, and miss the one actually named that.
+ *
+ * A bare number still works either way, since it is ambiguous by construction
+ * and a search returning both readings of it is the honest answer.
+ */
 export function matchesTaskKey(
   search: string,
   keySeq: number | null | undefined,
+  trackerKey?: string | null,
 ): boolean {
-  if (keySeq == null) return false;
-  return parseTaskKeySeq(search) === keySeq;
+  const term = search.trim();
+  if (term === "") return false;
+  const tracker = trackerKey?.trim();
+  if (tracker) {
+    if (term.toLowerCase() === tracker.toLowerCase()) return true;
+    const bare = BARE_SEQ.exec(term)?.[1];
+    return bare !== undefined && Number(bare) === parseTaskKeySeq(tracker);
+  }
+  return keySeq != null && parseTaskKeySeq(term) === keySeq;
 }
 
 export function taskMatchesFilters(
@@ -212,7 +234,10 @@ export function taskMatchesFilters(
   const search = f.search.trim().toLowerCase();
   if (search !== "") {
     const haystack = `${item.title} ${item.description ?? ""}`.toLowerCase();
-    if (!haystack.includes(search) && !matchesTaskKey(search, item.keySeq)) {
+    if (
+      !haystack.includes(search) &&
+      !matchesTaskKey(search, item.keySeq, item.jiraIssueKey)
+    ) {
       return false;
     }
   }

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -171,6 +171,9 @@ export interface TaskBoardItem {
   sortOrder: number;
   /** Per-org sequence behind the card's human key (`DECO-01`). */
   keySeq: number | null;
+  /** The key this card's issue wears in the tracker (`OS-333`), for a card
+   *  synced from one — what `taskKey` shows. Null for a card Studio owns. */
+  jiraIssueKey: string | null;
   /** Infrastructure retries already spent on this card's runs — the budget
    *  `reactToFailedTaskRun` spends against `MAX_RUN_RETRIES`. */
   retryAttempts: number;

--- a/packages/shared/src/task-key.test.ts
+++ b/packages/shared/src/task-key.test.ts
@@ -33,3 +33,30 @@ describe("taskKey", () => {
     expect(taskKey("deco", undefined)).toBeNull();
   });
 });
+
+/**
+ * A synced card wears the tracker's key because that is the name it already
+ * has — in the issue, the branch, the PR title and everything anyone says
+ * about it. The Studio sequence is untouched underneath; it just stops being
+ * the thing on screen.
+ */
+describe("taskKey with a tracker key", () => {
+  test("shows the tracker's key instead of the Studio one", () => {
+    expect(taskKey("osklen", 320, "OS-333")).toBe("OS-333");
+  });
+
+  test("keeps the Studio key for a card Studio owns", () => {
+    expect(taskKey("osklen", 320, null)).toBe("OSKL-320");
+    expect(taskKey("osklen", 320, undefined)).toBe("OSKL-320");
+  });
+
+  test("treats a blank tracker key as absent rather than showing nothing", () => {
+    expect(taskKey("osklen", 320, "")).toBe("OSKL-320");
+    expect(taskKey("osklen", 320, "   ")).toBe("OSKL-320");
+  });
+
+  test("shows a tracker key even for a card from before the backfill", () => {
+    expect(taskKey("osklen", null, "OS-333")).toBe("OS-333");
+    expect(taskKey("osklen", null, null)).toBe(null);
+  });
+});

--- a/packages/shared/src/task-key.ts
+++ b/packages/shared/src/task-key.ts
@@ -17,7 +17,15 @@ export function taskKeyPrefix(orgSlug: string): string {
 }
 
 /**
- * A card's human key: `DECO-01`.
+ * A card's human key: `DECO-01`, or the tracker's own key for a card synced
+ * from one.
+ *
+ * A synced card wears the tracker's key because that is the name it already
+ * has: the issue is `OS-333` in Jira, in the branch, in the PR title and in
+ * everything anyone says about it, and a second Studio-only number is one
+ * translation step every reader has to make. The internal `keySeq` is
+ * unaffected — it is still allocated, still unique per org, and still what the
+ * card is ordered and addressed by.
  *
  * `keySeq` is null only for a row written before the backfill migration ran,
  * which has no key to show — the caller falls back to whatever it showed
@@ -26,7 +34,10 @@ export function taskKeyPrefix(orgSlug: string): string {
 export function taskKey(
   orgSlug: string,
   keySeq: number | null | undefined,
+  trackerKey?: string | null,
 ): string | null {
+  const tracker = trackerKey?.trim();
+  if (tracker) return tracker;
   if (keySeq == null) return null;
   return `${taskKeyPrefix(orgSlug)}-${String(keySeq).padStart(2, "0")}`;
 }

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -361,6 +361,7 @@ export interface StudioToolIO {
         sprintId: string | null;
         sortOrder: number;
         keySeq: number | null;
+        jiraIssueKey: string | null;
         retryAttempts: number;
         threads: {
           threadId: string;
@@ -428,6 +429,7 @@ export interface StudioToolIO {
         sprintId: string | null;
         sortOrder: number;
         keySeq: number | null;
+        jiraIssueKey: string | null;
         retryAttempts: number;
         threads: {
           threadId: string;
@@ -527,6 +529,7 @@ export interface StudioToolIO {
         sprintId: string | null;
         sortOrder: number;
         keySeq: number | null;
+        jiraIssueKey: string | null;
         retryAttempts: number;
         threads: {
           threadId: string;


### PR DESCRIPTION
## What is this contribution about?

A card pulled from Jira showed `OSKL-320` while the issue it mirrors is `OS-333`. The tracker's key is the name the work already has — it is in the issue, the branch, the PR title, the standup, and every message anyone writes about it. The Studio number appears in exactly one place: the card. So the card is the thing that should give way.

**This is display, not identity.** `OSKL-320` was never an id — it is `taskKey(orgSlug, keySeq)`, four letters off the org slug plus a per-org sequence. The row's id (`board_…`) and its `keySeq` are untouched: still allocated, still unique per org, still what the card is ordered and addressed by. There is no migration and nothing to backfill; the Jira key has been stored in `task_board_item_jira_links` all along, it just never reached the read.

- `jiraIssueKey` rides the card read via **`attachJiraKeys`**, batched alongside the other refs rather than joined onto the item row — the link lives in its own table and every other ref on a card is attached the same way.
- `taskKey(orgSlug, keySeq, trackerKey?)` prefers the tracker key. A blank one is treated as absent, so a bad row degrades to the Studio key instead of to nothing.

### The part that was a bug waiting to happen

`parseTaskKeySeq` **ignores a term's prefix** — deliberately, and correctly, back when an org had exactly one. With two vocabularies on the board that becomes a silent mismatch: searching `OS-333` resolves to the number `333`, which would have matched whichever unrelated card holds Studio sequence 333, *and missed the card actually named OS-333*.

So `matchesTaskKey` now takes the tracker key, and the rule is: **a card answers to the key it shows.** A synced card matches its tracker key (any case), not its hidden sequence. A bare number still matches either vocabulary — that term is ambiguous by construction, and a search returning both readings of it is the honest answer rather than a guess.

### Two things I want a reviewer to push back on if they disagree

1. **`jiraIssueKey` is required (nullable), not optional**, on `TaskBoardItem`. That made adding it a compile error at every construction site — four fixtures and one optimistic-update path — instead of an optional field that silently reads `undefined` in whichever spot got missed. It is the same shape `keySeq` already has.
2. **The sidebar inbox still shows the Studio key**, and I left it that way on purpose rather than quietly half-doing it. The inbox key is *denormalized into the notification payload at write time* (`notify.ts:106` writes `taskKeySeq` into the row's jsonb), so carrying the tracker key there means changing what gets written **and** deciding what happens to notifications already stored. That is its own PR with its own question, not a line in this one.

## How did you verify your code works?

**Real Postgres** for the read, in `jira-integrations.integration.test.ts` — the tier the repo requires here, because the value is attached by a batched second query rather than selected off the item row, so an in-memory fake that returns the item would happily agree with a version that attaches nothing. Covered: a synced card gets its key and a Studio-owned card gets `null`, through both `getById` **and** `list`; and a fresh `create` is null before any link exists.

**Unit** for the two pure functions. `task-key.test.ts`: the tracker key wins, a card Studio owns keeps its own, a blank/whitespace tracker key falls back rather than rendering nothing, and a pre-backfill row (`keySeq: null`) still shows a tracker key. `task-filters.test.ts`: the collision above pinned directly — `matchesTaskKey("OS-333", 333, "OS-999")` must be `false`, and `matchesTaskKey("OS-333", 333, null)` must still be `true` so Studio cards are unaffected — plus case-insensitivity, whitespace, the bare-number cases including zero-padding, and terms that name nothing.

508 pass / 0 fail across the touched suites. `bun run check` 0 type errors, `bun run lint` 19 warnings identical to baseline, `knip` clean, `fmt:check` clean. Tool contracts regenerated.

**Not verified, flagging honestly:** no live browser check, and no e2e. The board e2e does not have a Jira-linked card to assert against — nothing in the suite can create the link — which is the same gap `task-board-sprints.spec.ts` already documents for sprints.

## Screenshots/Demonstration

Not captured. The visible change is the key on the card and in the task dialog header: `OSKL-320` → `OS-333` for synced cards, unchanged for every other card.

## How to Test

1. On an org with **no** Jira integration, confirm cards still show `DECO-01`-style keys and that searching by number and by full key both still work.
2. On an org with Jira sync, open a synced card — the key on the card and in the dialog header should be the Jira key.
3. Search that key (`OS-333`, `os-333`) — it should find that card and **only** that card. Specifically: if another card's Studio sequence is 333, it must not appear.
4. Search the bare number (`333`) — it should find it, and also any Studio card whose sequence is 333. That is intended.
5. Search a synced card's old Studio key (`OSKL-320`) — it should no longer match, because that key is no longer shown anywhere.

## Migration Notes

None. No schema change, no backfill — `jira_issue_key` has been populated by the sync since the link table existed. `TaskBoardItem` gains a required nullable field, which is a wire-shape addition; the generated `tool-io.ts` diff is committed.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cards synced from Jira now display the tracker's key (e.g., `OS-333`) instead of the Studio-generated one, and search matches the key a card shows.

**Bug Fixes**  
- Searching a tracker key previously fell through to its numeric part and could match an unrelated card; a card now only answers to the key it displays, and bare numbers still match either vocabulary.
- `jiraIssueKey` is attached on reads via a batched query over the link table, and `taskKey` prefers it when non-blank, falling back to the Studio key otherwise.
- `jiraIssueKey` is a required nullable field on `TaskBoardItem`, so every construction site fails the compile if the field is missed.
- The sidebar inbox still shows the Studio key; its key is denormalized into notification payloads at write time, so that change is deliberately left out here.
- No migration is needed; the Jira key was already stored in the link table.

<sup>Written for commit b8f219c72ee613a9e9ea29111eefbbcc6876bf11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

