### PR TITLE
fix(e2e): seed the inviter the invite spec's foreign key requires

### DIFF
--- a/packages/e2e/tests/invite-auto-accept.spec.ts
+++ b/packages/e2e/tests/invite-auto-accept.spec.ts
@@ -55,6 +55,14 @@ test.describe("Invite: only an autoAccept invitation is claimed at signup", () =
        ON CONFLICT (id) DO NOTHING`,
       [ORG_ID, "AutoAccept E2E Org", `e2e-autoaccept-org-${RUN}`],
     );
+    // The inviter has to exist: `invitation."inviterId"` is a foreign key into
+    // `user`, so seeding an invitation without one fails the insert outright.
+    await db.query(
+      `INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+       VALUES ($1, $2, false, $3, now(), now())
+       ON CONFLICT (id) DO NOTHING`,
+      [INVITER_ID, `inviter-${RUN}@${TEST_DOMAIN}`, "AutoAccept E2E Inviter"],
+    );
   });
 
   test.afterAll(async () => {
@@ -66,6 +74,7 @@ test.describe("Invite: only an autoAccept invitation is claimed at signup", () =
       ORG_ID,
     ]);
     await db.query(`DELETE FROM "organization" WHERE id = $1`, [ORG_ID]);
+    await db.query(`DELETE FROM "user" WHERE id = $1`, [INVITER_ID]);
     await db.end();
   });
 


### PR DESCRIPTION
## What is this contribution about?

`main` is red, and every branch cut from it inherits the failure. Both tests in `invite-auto-accept.spec.ts` die in `beforeAll`:

```
insert or update on table "invitation" violates foreign key constraint "invitation_inviterId_fkey"
  at seedInvitation (packages/e2e/tests/invite-auto-accept.spec.ts:28:3)
```

The spec declares `INVITER_ID` and seeds every invitation with it, but `beforeAll` only inserts the **organization** — the inviter row is never created, and `invitation."inviterId"` is a foreign key into `user`.

**It has never passed.** #6644's own e2e was already failing when it merged, so this landed red rather than regressing afterwards.

The fix is to seed that user, and to delete it in `afterAll` alongside the rest.

## How did you verify your code works?

Against real Postgres, rather than by reading the schema. I probed the constraint and both paths directly:

```
FK: invitation_inviterId_fkey  FOREIGN KEY ("inviterId") REFERENCES "user"(id) ON DELETE CASCADE
without inviter: REJECTED -> insert or update on table "invitation" violates foreign key constraint "invitation_inviterId_fkey"
with inviter:    inserted OK
```

The rejection is byte-for-byte the CI error, which is what makes this the cause rather than a plausible-looking neighbour.

That probe also corrected me mid-fix. I had written a comment claiming the delete order mattered "or the same foreign key blocks the delete". It does not — the key is `ON DELETE CASCADE`. I removed the comment rather than ship one that asserts something false.

Tenant-scoped per the e2e rules: `INVITER_ID` and the seeded email both carry the per-run suffix the spec already generates, so `fullyParallel` stays safe.

`bun run lint` 19 warnings identical to baseline, `bun run check` 0 type errors, `fmt` clean.

**Not verified, flagging honestly:** I did not run the Playwright suite end to end locally — that needs the full harness (embedded Postgres, Better Auth keys, both servers up). What is proven is the exact insert that was failing, against a real database. CI on this PR is the real check.

## Screenshots/Demonstration

Not applicable — test-only change.

## How to Test

CI. The two `invite-auto-accept` tests should go green; nothing else changes.

## Migration Notes

None. Test-only, no product code touched.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `invite-auto-accept` e2e spec so its two tests no longer fail in `beforeAll` due to a missing inviter user for the seeded invitation's foreign key. Seeds the inviter in setup and deletes it in teardown; test-only change.

<sup>Written for commit 10e382d00a9472007d71f32fdf4d7a6b623c86bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

