### PR TITLE
refactor(task-board): dedupe isDeliveryLane into packages/shared

### DIFF
--- a/apps/api/src/tools/task-board/lanes.ts
+++ b/apps/api/src/tools/task-board/lanes.ts
@@ -11,8 +11,10 @@
  * too, and those importing `run-reactions` for a constant would be a cycle.
  */
 
-import { DELIVERY_LANES } from "@decocms/shared/task-board";
+import { DELIVERY_LANES, isDeliveryLane } from "@decocms/shared/task-board";
 import type { TaskBoardItemStatus } from "@/storage/types";
+
+export { isDeliveryLane };
 
 export const LANE_RANK: Record<TaskBoardItemStatus, number> = {
   triage: 0,
@@ -29,14 +31,6 @@ export const LANE_RANK: Record<TaskBoardItemStatus, number> = {
 /** The delivery lanes, as board statuses — the assertion that the shared
  *  literal union stays a subset of this side's lane vocabulary. */
 export const DELIVERY_LANE_STATUSES: TaskBoardItemStatus[] = DELIVERY_LANES;
-
-/** True for one of the post-merge delivery lanes (Approved, Merged, Post-deploy
- *  Validation) — the statuses that only exist for an org running
- *  `delivery_lanes_enabled`. Mirrors the web-side `isDeliveryLane` in
- *  `layouts/task-board/config.tsx`. */
-export function isDeliveryLane(status: TaskBoardItemStatus): boolean {
-  return DELIVERY_LANE_STATUSES.includes(status);
-}
 
 /**
  * True when moving `from` → `to` advances the card.

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -19,7 +19,7 @@ import {
 } from "@untitledui/icons";
 import { Bug } from "lucide-react";
 import type { StudioToolOutput as ToolOutput } from "@decocms/shared/tools/tool-io";
-import { DEFAULT_TAG_COLOR, DELIVERY_LANES } from "@decocms/shared/task-board";
+import { DEFAULT_TAG_COLOR, isDeliveryLane } from "@decocms/shared/task-board";
 import { isResolvedRunFailure } from "@decocms/shared/entities";
 import type { Sprint } from "@decocms/shared/sprints";
 import type { ComponentType } from "react";
@@ -28,6 +28,7 @@ import type { TranslationKey } from "@/i18n/use-t.ts";
 export {
   DEFAULT_TASK_TYPE,
   SUPER_AGENT_ASSIGNEE_ID,
+  isDeliveryLane,
   nextTagColor,
 } from "@decocms/shared/task-board";
 
@@ -307,11 +308,6 @@ export const TASK_TYPE_CONFIG: Record<
     iconClassName: "text-purple-500",
   },
 };
-
-/** True for one of the post-merge delivery lanes. */
-export function isDeliveryLane(status: TaskBoardItemStatus): boolean {
-  return (DELIVERY_LANES as string[]).includes(status);
-}
 
 /**
  * Lanes a card may be MOVED to — "Move to", the status dropdown, drag targets.

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -155,6 +155,15 @@ export const DELIVERY_LANES: DeliveryLane[] = [
   "post_deploy_validation",
 ];
 
+/** True for one of the post-merge delivery lanes (Approved, Merged, Post-deploy
+ *  Validation) — the statuses that only exist for an org running
+ *  `delivery_lanes_enabled`. Single home for both api (`tools/task-board/lanes.ts`)
+ *  and web (`layouts/task-board/config.tsx`), which used to define this
+ *  identically on each side. */
+export function isDeliveryLane(status: string): boolean {
+  return (DELIVERY_LANES as string[]).includes(status);
+}
+
 /** True when this org runs the delivery lanes. Off by default. */
 export function deliveryLanesEnabled(
   flags: Record<string, unknown> | null | undefined,


### PR DESCRIPTION
**Source:** C1 code reduction found while auditing the delivery-lanes area (recently touched by #6634/#6635/#6643).

`apps/api/src/tools/task-board/lanes.ts` and `apps/web/src/layouts/task-board/config.tsx` each independently defined an identical `isDeliveryLane(status)` — both bodies were `DELIVERY_LANES.includes(status)`, and both files already imported `DELIVERY_LANES` from `@decocms/shared/task-board`. The api file's own comment even said "Mirrors the web-side `isDeliveryLane`", flagging the duplication itself. Moved the function into `packages/shared/src/task-board.ts` (the array's existing home) and made both sides import it instead of redefining it — one source of truth for a check `TASK_BOARD_ITEM_UPDATE`'s gate, the board's move-target filter, and the Jira column mapper all depend on agreeing on.

**Net:** -15 / +9 lines. Behavior-preserving — same `DELIVERY_LANES` array, same `.includes()` check, just one definition instead of two; every call site (`lanes.ts`, `config.tsx`, `update.ts`, `jira.tsx`) keeps working via re-export/import.

**Reviewer check:** `bun test apps/api/src/tools/task-board/lanes.test.ts packages/shared/src/task-board.test.ts apps/web/src/layouts/task-board/config.test.ts` (all pass, 75 assertions across the three files).

**Verified locally:** `bun run fmt`, `bunx tsc --noEmit` in `packages/shared`, `apps/api`, and `apps/web` (all clean), `bunx oxlint` on the three touched files (0 warnings/errors), and the three targeted test files above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the identical `isDeliveryLane` helper that existed in both `apps/api` and `apps/web` by moving it to `packages/shared`. Behavior is unchanged—same logic and same `DELIVERY_LANES` constant—but now there's a single source of truth for the delivery-lane check used across the API and web.

<sup>Written for commit a40c6a52375092c073ac718e3b8e6aca83e9c0be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

