### PR TITLE
fix(task-board): resolve a short-link key by its tracker key first

### DIFF
--- a/apps/web/src/layouts/task-key-redirect/resolve.test.ts
+++ b/apps/web/src/layouts/task-key-redirect/resolve.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { findTaskByKeyOrId } from "./resolve";
 
 const items = [
-  { id: "board_abc", keySeq: 1 },
-  { id: "board_def", keySeq: 12 },
-  { id: "board_ghi", keySeq: null },
+  { id: "board_abc", keySeq: 1, jiraIssueKey: null },
+  { id: "board_def", keySeq: 12, jiraIssueKey: null },
+  { id: "board_ghi", keySeq: null, jiraIssueKey: null },
+  { id: "board_jkl", keySeq: 333, jiraIssueKey: null },
+  { id: "board_mno", keySeq: 5, jiraIssueKey: "OS-333" },
 ];
 
 describe("findTaskByKeyOrId", () => {
@@ -16,6 +18,17 @@ describe("findTaskByKeyOrId", () => {
 
   test("resolves a raw id — what a keyless card's share link carries", () => {
     expect(findTaskByKeyOrId(items, "board_ghi")?.id).toBe("board_ghi");
+  });
+
+  /**
+   * Regression for the collision `matchesTaskKey` was hardened against in
+   * task-filters.tsx: a synced card's tracker key must resolve to the card
+   * that actually wears it, not to whichever unrelated card happens to hold
+   * the same number as a Studio `keySeq`.
+   */
+  test("resolves a synced card by its tracker key, not by a same-numbered keySeq", () => {
+    expect(findTaskByKeyOrId(items, "OS-333")?.id).toBe("board_mno");
+    expect(findTaskByKeyOrId(items, "os-333")?.id).toBe("board_mno");
   });
 
   test("misses cleanly", () => {

--- a/apps/web/src/layouts/task-key-redirect/resolve.ts
+++ b/apps/web/src/layouts/task-key-redirect/resolve.ts
@@ -1,19 +1,30 @@
-import { parseTaskKeySeq } from "@decocms/shared/task-key";
+import { matchesTaskKey } from "@/layouts/task-board/task-filters";
 
 /**
- * The card a short link names: by human key (`DECO-01`, `deco-1`, `1`) or by
- * raw id.
+ * The card a short link names: by human key (`DECO-01`, a synced card's
+ * tracker key like `OS-333`, `deco-1`, `1`) or by raw id.
  *
- * Both, because a card written before the key backfill has no key and the
- * share button falls back to its id — and because a link, once pasted
- * somewhere, has to keep working.
+ * The exact tracker key is checked first, ahead of `matchesTaskKey`'s looser
+ * keySeq fallback, so an exact `OS-333` always wins over an unrelated card
+ * that merely shares its number.
+ *
+ * The id fallback exists because a card written before the key backfill has
+ * no key and the share button falls back to its id — and because a link,
+ * once pasted somewhere, has to keep working.
  */
 export function findTaskByKeyOrId<
-  T extends { id: string; keySeq: number | null },
+  T extends {
+    id: string;
+    keySeq: number | null;
+    jiraIssueKey?: string | null;
+  },
 >(items: T[], term: string | undefined): T | undefined {
-  if (!term) return undefined;
-  const seq = parseTaskKeySeq(term);
-  return seq === null
-    ? items.find((item) => item.id === term)
-    : items.find((item) => item.keySeq === seq);
+  const raw = term?.trim();
+  if (!raw) return undefined;
+  const lower = raw.toLowerCase();
+  return (
+    items.find((item) => item.jiraIssueKey?.trim().toLowerCase() === lower) ??
+    items.find((item) => matchesTaskKey(raw, item.keySeq, item.jiraIssueKey)) ??
+    items.find((item) => item.id === raw)
+  );
 }


### PR DESCRIPTION
Follows #6648.

#6648 added `jiraIssueKey` to `TaskBoardItem` and hardened `matchesTaskKey` (task-filters.tsx) so board search matches a synced card by its tracker key (`OS-333`) instead of quietly falling back to `parseTaskKeySeq`, which strips any letter prefix and matches by number alone. It missed a second consumer of the same identifier: `findTaskByKeyOrId` in `apps/web/src/layouts/task-key-redirect/resolve.ts`, which backs the `/$org/t/:taskKey` short link (also the link the notification digest email builds via `taskKey()`).

**Failure scenario:** an org has a Studio-only card with `keySeq: 333` and, separately, a card synced from Jira issue `OS-333` (a different `keySeq`). Opening `/$org/t/OS-333` — e.g. from a digest email or a pasted short link — resolved to the unrelated Studio card with `keySeq === 333` instead of the actual `OS-333` card, because `findTaskByKeyOrId` parsed the term with `parseTaskKeySeq` (letter-prefix-agnostic) rather than going through the tracker-key-aware `matchesTaskKey`.

Fix: reuse `matchesTaskKey`, and check an exact tracker-key match first so it always wins over a same-numbered unrelated card. Added a regression test (`resolve.test.ts`) that fails on the old code (asserts the term resolves to the Jira-synced card, not the Studio card sharing its number) and passes after the fix.

Reviewer check: `bun test apps/web/src/layouts/task-key-redirect/resolve.test.ts`.

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (no new errors), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `/$org/t/:taskKey` short-link resolver so a synced card's tracker key (e.g. `OS-333`) opens that card. Previously the term was parsed by number alone, so `OS-333` could land on an unrelated Studio card with `keySeq` 333. This resolver also backs the notification digest email links.

**Bug Fixes**
- Checks an exact tracker-key match before falling back to the looser keySeq match.
- Reuses the same `matchesTaskKey` logic as board search so both consumers stay consistent.
- Adds a regression test asserting `OS-333` and `os-333` resolve to the tracker-synced card.

<sup>Written for commit a82fc5ff5ddb732ea54bb07a6725194ba8ead39e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

