### PR TITLE
fix(mcp-clients): clear the list-cache revalidation throttle on connection delete

### DIFF
--- a/apps/api/src/mcp-clients/mcp-list-cache.test.ts
+++ b/apps/api/src/mcp-clients/mcp-list-cache.test.ts
@@ -15,6 +15,7 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import {
+  clearRevalidationState,
   fetchWithCache,
   isRevalidationStale,
   type McpListCache,
@@ -300,6 +301,29 @@ describe("fetchWithCache", () => {
 
     await new Promise((r) => setTimeout(r, 30)); // exceed the 20ms window
     await fetchWithCache("tools", conn, fetchLive, cache, undefined, 20);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(callCount).toBe(2);
+  });
+
+  it("clearRevalidationState lifts the throttle for a deleted connection", async () => {
+    const conn = "conn_cleared_on_delete";
+    const cache = new TestMcpListCache();
+    await cache.set("tools", conn, [makeTool("stale")]);
+
+    let callCount = 0;
+    const fetchLive = async () => {
+      callCount++;
+      return [makeTool("fresh")];
+    };
+
+    await fetchWithCache("tools", conn, fetchLive, cache, undefined, 10_000);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(callCount).toBe(1);
+
+    clearRevalidationState(conn);
+
+    // Not throttled: the pre-delete clock is gone, not just stale.
+    await fetchWithCache("tools", conn, fetchLive, cache, undefined, 10_000);
     await new Promise((r) => setTimeout(r, 5));
     expect(callCount).toBe(2);
   });

--- a/apps/api/src/mcp-clients/mcp-list-cache.ts
+++ b/apps/api/src/mcp-clients/mcp-list-cache.ts
@@ -134,6 +134,24 @@ export function isRevalidationStale(
   return nowMs - lastMs >= minIntervalMs;
 }
 
+/**
+ * Drop a deleted connection's throttle bookkeeping.
+ *
+ * `lastRevalidatedAt` has no TTL and nothing else ever removes an entry — a
+ * long-lived pod that revalidates a connection's lists once accumulates one
+ * key per (type, connection) for the rest of its life, even after the
+ * connection is gone. Call this once the connection itself is deleted, the
+ * one point a key is guaranteed to never be read again.
+ */
+export function clearRevalidationState(connectionId: string): void {
+  const types: McpListType[] = ["tools", "resources", "prompts"];
+  for (const type of types) {
+    const key = `${type}:${connectionId}`;
+    lastRevalidatedAt.delete(key);
+    revalidating.delete(key);
+  }
+}
+
 function isMethodNotFound(err: unknown): boolean {
   return err instanceof McpError && err.code === ErrorCode.MethodNotFound;
 }

--- a/apps/api/src/tools/connection/delete.ts
+++ b/apps/api/src/tools/connection/delete.ts
@@ -16,7 +16,10 @@ import {
   requireAuth,
   requireOrganization,
 } from "../../core/studio-context";
-import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
+import {
+  clearRevalidationState,
+  getMcpListCache,
+} from "../../mcp-clients/mcp-list-cache";
 import { invalidateConnectionCaches } from "../../mcp-clients/mcp-cache-invalidation";
 import { ConnectionEntitySchema } from "./schema";
 
@@ -113,6 +116,8 @@ export const COLLECTION_CONNECTIONS_DELETE = defineTool({
     getMcpListCache()
       ?.invalidate(input.id)
       .catch(() => {});
+    // Drop this pod's revalidation-throttle bookkeeping for the deleted connection.
+    clearRevalidationState(input.id);
     // Drop cached read content and tool results for this connection across ALL
     // replicas (per-pod caches → NATS broadcast).
     invalidateConnectionCaches(input.id);


### PR DESCRIPTION
**Source:** a real gap found while reading `apps/api/src/mcp-clients/mcp-list-cache.ts` (a recently-touched connection-tooling area) — not tied to an issue or a recent PR.

**The gap:** `fetchWithCache`'s background-revalidation throttle is a module-level `Map<string, number>` (`lastRevalidatedAt`) keyed by `${type}:${connectionId}`. Nothing ever deletes an entry — `McpListCache.invalidate()` only clears the NATS KV list cache, not this in-memory throttle bookkeeping. On a long-lived pod, every connection that is ever revalidated (which happens on essentially every cache hit past the 30s throttle window) leaves 3 keys (`tools`/`resources`/`prompts`) in the map forever, including for connections that are later deleted. It's a slow, unbounded per-pod memory leak scoped to org connection churn over the pod's lifetime.

**Fix:** added `clearRevalidationState(connectionId)` to `mcp-list-cache.ts`, which drops a connection's 3 throttle keys from both `lastRevalidatedAt` and the transient `revalidating` set. Wired it into `connection/delete.ts`, right next to the existing `getMcpListCache()?.invalidate(id)` call — the one point a connection id is guaranteed to never be read again.

**Verification:** added a unit test (`clearRevalidationState lifts the throttle for a deleted connection`) proving a post-clear `fetchWithCache` call for the same id revalidates immediately instead of being throttled by the pre-clear clock — the direct regression proof for the leak/staleness this closes. Reviewer command: `bun test apps/api/src/mcp-clients/mcp-list-cache.test.ts`.

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/mcp-clients/mcp-list-cache.test.ts` (35 pass), `bunx oxlint` on the 3 touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an unbounded per-pod memory leak in the MCP list cache revalidation throttle by clearing a deleted connection's bookkeeping on connection delete.

- Adds `clearRevalidationState(connectionId)` to `mcp-list-cache.ts` to drop the connection's `tools`/`resources`/`prompts` throttle entries from both the revalidation clock and the in-flight set.
- Calls it in `connection/delete.ts` alongside the existing cache invalidation, the one point a connection is guaranteed to never be read again.
- Adds a unit test proving a post-delete `fetchWithCache` revalidates immediately instead of being throttled by the stale clock.

<sup>Written for commit a0309bbca7b14e10e09fee740ca94925894cc62c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

