### PR TITLE
fix(preview): stop scaled preview frame from scroll-clipping on section select

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -2012,7 +2012,8 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                   return () => observer.disconnect();
                 }}
                 className={cn(
-                  "h-full relative overflow-hidden flex justify-center",
+                  // `overflow-clip`, not `hidden`: the scaled frame's layout box outgrows this container, and a scroll port would let the browser scroll it to reveal a focused descendant (section select), jumping the preview up.
+                  "h-full relative overflow-clip flex justify-center",
                   previewSurfaceActive && !previewFluid && "bg-muted/30",
                 )}
               >


### PR DESCRIPTION
## Summary

In the sections/content editor's **scaled** preview mode (Fast Preview + Blocks open, or any time the canvas is narrower than the desktop logical width), the preview iframe would "jump up" — the site header got clipped at the top and an empty gap appeared at the bottom.

**Root cause:** the frame is rendered at the desktop logical width (1280px) and shrunk with `transform: scale()`. `transform` shrinks pixels, not layout, so the frame's **layout box stays taller than its container** (e.g. 1160px inside a 903px canvas). The canvas container had `overflow-hidden`, so `scrollHeight > clientHeight` turned it into a **scroll port**. `overflow: hidden` can't be scrolled by the user, but the browser still **auto-scrolls it to bring a focused descendant into view** — which fires when a section is selected (iframe focus / scroll-into-view). That set `scrollTop` to ~233px, pushing the frame up and clipping the header.

**Fix:** one line — switch the canvas container from `overflow-hidden` to `overflow-clip` (`apps/web/src/components/sandbox/preview/preview.tsx`). `overflow: clip` clips identically but creates **no scroll port**, so the browser can't displace the frame.

## Testing

Verified live in the Studio editor (als storefront):
- Repro (Blocks open, canvas 998px): container `top 54→957` (903px, `overflow:hidden`); scaled frame `top -179.5`; `container.scrollTop = 233.5`.
- `container.scrollTop = 0` → frame snaps back to `top: 54` (top-aligned, fills canvas).
- With `overflow: clip`, forcing `scrollTop = 300` stays `0`; frame stable at `top: 54`.

Affected area: sandbox preview canvas only. No behavior change in fluid (unscaled) desktop mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the scaled preview frame jumping up and clipping the site header when a section is selected. The container's `overflow-hidden` created a scroll port the browser auto-scrolled to reveal a focused descendant; switching to `overflow-clip` in `preview.tsx` keeps the same clipping but removes the scroll port. No behavior change in fluid (unscaled) desktop mode.

<sup>Written for commit a9bd826c3860f66fa6118cf5e44e7bbac7a78e20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

