### PR TITLE
fix(task-board): drop run count and plan qualifier from cost chip

### DIFF
--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -172,10 +172,7 @@ export const taskBoard = {
   "taskBoard.taskDialog.resolveConflictSuccess":
     "Agent dispatched to resolve the conflicts",
   "taskBoard.taskDialog.resolveConflictError": "Couldn't start the agent",
-  "taskBoard.taskDialog.costRunCountSingular": "in {runs} run",
-  "taskBoard.taskDialog.costRunCountPlural": "in {runs} runs",
   "taskBoard.taskDialog.costEstimatePrefix": "~{amount}",
-  "taskBoard.taskDialog.costOnSubscription": "· on your Claude plan",
   "taskBoard.taskDialog.costTooltipSingular":
     "Estimated AI cost of this task, across its only run — the Super Agent plus every reviewer and re-run round. Calculated from the model provider's list prices; it is not a billed amount and your actual invoice may differ.",
   "taskBoard.taskDialog.costTooltipPlural":

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -182,10 +182,7 @@ export const taskBoard = {
     "Agente acionado para resolver os conflitos",
   "taskBoard.taskDialog.resolveConflictError":
     "Não foi possível acionar o agente",
-  "taskBoard.taskDialog.costRunCountSingular": "em {runs} execução",
-  "taskBoard.taskDialog.costRunCountPlural": "em {runs} execuções",
   "taskBoard.taskDialog.costEstimatePrefix": "~{amount}",
-  "taskBoard.taskDialog.costOnSubscription": "· no seu plano Claude",
   "taskBoard.taskDialog.costTooltipSingular":
     "Custo estimado de IA desta tarefa, somando sua única execução — o Super Agent mais cada rodada de revisão e reexecução. Calculado a partir da tabela de preços do provedor; não é um valor cobrado e sua fatura real pode diferir.",
   "taskBoard.taskDialog.costTooltipPlural":

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -209,9 +209,9 @@ const EMPTY_PROPERTY = "opacity-50";
 
 /**
  * What this task has cost, summed over every run linked to it. A bare dollar
- * sign next to a task reads as an invoice, so the chip says on its face that
- * the figure is the provider's list-price estimate, and — on a linked Claude
- * plan — that nobody is billed it at all.
+ * sign next to a task reads as an invoice, so it's prefixed with `~` to read
+ * as an estimate; run count, provider list-price basis, and subscription
+ * status (if any) move to the hover tooltip instead of the chip face.
  *
  * The task, not the run, is the unit that matters: a card is a Super Agent run
  * plus however many reviewer and re-run rounds it took, and until now that
@@ -249,19 +249,6 @@ function TaskCost({ threads }: { threads?: TaskBoardItemThread[] }) {
           }),
         })}
       </span>
-      <span className="text-muted-foreground">
-        {t(
-          isSingular
-            ? "taskBoard.taskDialog.costRunCountSingular"
-            : "taskBoard.taskDialog.costRunCountPlural",
-          { runs: String(runCount) },
-        )}
-      </span>
-      {onSubscription ? (
-        <span className="text-muted-foreground">
-          {t("taskBoard.taskDialog.costOnSubscription")}
-        </span>
-      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- The task cost chip on the task dialog showed three things at once: `~$13.49`, `in 8 runs`, `· on your Claude plan` — cluttered and the "on your Claude plan" qualifier was confusing (unclear if included/extra/overage).
- Removed the run-count and subscription-qualifier text from the chip face. That context (run count, provider list-price basis, subscription usage) still lives in the hover tooltip, which already had the full explanation.

## Test plan
- [x] `bun run --cwd=apps/web check` passes
- [x] `bun run lint` — no new warnings/errors introduced
- [x] `bun run fmt` applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up the task cost chip so it now shows only the estimated cost. The chip previously crammed the cost, run count, and “· on your Claude plan” qualifier into one line, which read as noise and made it unclear whether the amount is included, extra, or overage.

- Removes the run-count and subscription-qualifier text from the chip face.
- Hover tooltip still shows the full context: run count, provider list-price basis, and subscription usage.
- Removes the now-unused translation strings from the English and Portuguese locale files.

<sup>Written for commit f7728a8314292be5abeb6b10eb08faf4208f97f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

