### PR TITLE
fix(task-board): don't dispatch a reviewer while the author run is live

### DIFF
--- a/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from "bun:test";
 import type { TaskBoardItem } from "@/storage/types";
 import {
+  authorRunLive,
   MAX_REVIEWER_ATTEMPTS,
   reviewerAttemptsExhausted,
   pinnedRepoConnectionId,
@@ -442,5 +443,55 @@ describe("stalePreviewHandoffDue", () => {
     expect(stalePreviewHandoffDue(0, at("2026-08-13T17:00:00.000Z"))).toBe(
       true,
     );
+  });
+});
+
+describe("authorRunLive", () => {
+  it("is true while the Super Agent's own thread is still running", () => {
+    const task = taskWith([
+      thread({
+        title: "Super Agent: fix",
+        status: "in_progress",
+        createdAt: "2026-01-01T10:00:00Z",
+        lastActiveAt: "2026-01-01T10:09:00Z",
+      }),
+    ]);
+    expect(authorRunLive(task, NOW)).toBe(true);
+  });
+
+  it("is false once the Super Agent's thread is terminal", () => {
+    const task = taskWith([
+      thread({
+        title: "Super Agent: fix",
+        status: "completed",
+        createdAt: "2026-01-01T10:00:00Z",
+        lastActiveAt: "2026-01-01T10:09:00Z",
+      }),
+    ]);
+    expect(authorRunLive(task, NOW)).toBe(false);
+  });
+
+  it("is false for an author that went silent — a dead run must not strand the card", () => {
+    const task = taskWith([
+      thread({
+        title: "Super Agent: fix",
+        status: "in_progress",
+        createdAt: "2026-01-01T08:00:00Z",
+        lastActiveAt: "2026-01-01T08:00:00Z",
+      }),
+    ]);
+    expect(authorRunLive(task, NOW)).toBe(false);
+  });
+
+  it("does not count a live reviewer thread as the author", () => {
+    const task = taskWith([
+      thread({
+        title: "Reviewer: fix",
+        status: "in_progress",
+        createdAt: "2026-01-01T10:00:00Z",
+        lastActiveAt: "2026-01-01T10:09:00Z",
+      }),
+    ]);
+    expect(authorRunLive(task, NOW)).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -6,6 +6,7 @@ import {
   isReviewerThreadTitle,
   PR_DIFF_RECIPE,
   NO_VISUAL_SURFACE,
+  REVIEWER_KINDS,
   REVIEWER_LABEL,
   reviewCycleStart,
   SHALLOW_CHECKOUT_NOTE,
@@ -28,8 +29,8 @@ import type { ClaudeCodeModelClass } from "@/harnesses/claude-code-env";
 const TERMINAL_THREAD_STATUSES = new Set(["completed", "failed", "expired"]);
 
 /**
- * True when a reviewer thread is genuinely still running: non-terminal status
- * AND a heartbeat inside the stall window.
+ * True when a run thread is genuinely still running: non-terminal status AND a
+ * heartbeat inside the stall window.
  *
  * Status alone is not liveness. A reviewer whose pod died mid-run stays
  * `in_progress` forever — the in-memory idle reaper is per-pod, and
@@ -38,7 +39,7 @@ const TERMINAL_THREAD_STATUSES = new Set(["completed", "failed", "expired"]);
  * reaped by nobody. Uses the same heartbeat and window as the rest of the
  * codebase (`isThreadRunStale`), so "how long is too long" has one definition.
  */
-function isReviewerThreadLive(
+function isThreadRunLive(
   thr: TaskBoardItem["threads"][number],
   now: number,
 ): boolean {
@@ -48,6 +49,25 @@ function isReviewerThreadLive(
   return !isThreadRunStale(
     { updated_at: thr.lastActiveAt, last_progress_at: null },
     now,
+  );
+}
+
+/**
+ * True while the task's author — the Super Agent, i.e. any run thread that
+ * isn't a reviewer's — is still going.
+ *
+ * The Super Agent is told to link the PR and set In Review *while still
+ * running* (`claude-code-task-run.ts`), so the card is reviewable long before
+ * the run that owns the branch is finished. Title is the discriminator the rest
+ * of the board already uses (`resolveReviewRunToolNames`); liveness is
+ * {@link isThreadRunLive}, so a dead author's stall window releases the card
+ * rather than stranding it.
+ */
+export function authorRunLive(task: TaskBoardItem, now: number): boolean {
+  return task.threads.some(
+    (thr) =>
+      !REVIEWER_KINDS.some((kind) => isReviewerThreadTitle(thr.title, kind)) &&
+      isThreadRunLive(thr, now),
   );
 }
 
@@ -161,6 +181,8 @@ export async function enqueueEnabledReviewers(
   );
   const enabled = enabledReviewerKinds(settings?.flags);
   if (enabled.length === 0) return;
+  // Deferred, not dropped — both callers re-poll; above the hand-offs on purpose.
+  if (authorRunLive(task, Date.now())) return;
   const modelClass: ClaudeCodeModelClass = orgFlagEnabled(
     settings?.flags,
     "cheap_reviewer_model",
@@ -312,7 +334,7 @@ function isSpentAttempt(
   return (
     thr.status !== null &&
     !TERMINAL_THREAD_STATUSES.has(thr.status) &&
-    !isReviewerThreadLive(thr, now)
+    !isThreadRunLive(thr, now)
   );
 }
 
@@ -328,7 +350,7 @@ function reviewerThreadsThisCycle(
   return task.threads.filter((thr) => {
     if (!isReviewerThreadTitle(thr.title, kind)) return false;
     return (
-      isReviewerThreadLive(thr, now) ||
+      isThreadRunLive(thr, now) ||
       new Date(thr.createdAt).getTime() >= lastInReviewAt
     );
   });
@@ -400,7 +422,7 @@ export function reviewerHandledThisCycle(
   // nothing re-dispatches, and the merge gate waits on a verdict that will
   // never come. One sat that way while its co-reviewer had approved in 68
   // seconds.
-  if (thisCycle.some((thr) => isReviewerThreadLive(thr, now))) return true;
+  if (thisCycle.some((thr) => isThreadRunLive(thr, now))) return true;
   const spent = thisCycle.filter((thr) => isSpentAttempt(thr, now));
   // Every attempt spent and the budget is gone — stop, a human owns it now.
   if (spent.length >= MAX_REVIEWER_ATTEMPTS) return true;


### PR DESCRIPTION
## Problem

The Super Agent is instructed to link the PR and set `in_review` **while it is still running** (`claude-code-task-run.ts:276-278`), so a card becomes reviewable well before the run that owns the branch has finished.

Neither reviewer dispatch site checks for that. Both `prs-get.ts:1215` (the task modal's ~10s poll) and `review-sweeper.ts:541` (the boot sweeper) gate on `status === "in_review"` && `assigneeId === SUPER_AGENT_ASSIGNEE_ID` && `prReadyForReview(prs)` — nothing about the producing run. The file already had a liveness helper, `isReviewerThreadLive`, but it was only ever pointed at *reviewer* threads.

Observed in prod on `osklen` / OS-336: the Super Agent wrote `in_review` at seq 46 and kept working through seq 59 (verifying the deploy preview and posting a second comment). The modal's poll dispatched the Reviewer 12s later, against a branch the author was still checking.

## Change

- `isReviewerThreadLive` → **`isThreadRunLive`**. Pure rename; it never touched anything reviewer-specific.
- New **`authorRunLive(task, now)`** — any thread on the task that isn't a reviewer's (title discriminator, the same one `resolveReviewRunToolNames` uses) and is live.
- One gate at the top of `enqueueEnabledReviewers`, above the `handTaskToHuman` branches so none of those fire mid-run either.

It's a **defer, not a dead end**: both call sites are reconcilers that re-poll, so the next tick dispatches. And liveness reuses `isThreadRunStale`, so a dead author is released by the existing stall window rather than stranding the card — no new timeout, no new state, no pending column.

Both dispatch sites and any future one are covered, since everything funnels through `enqueueEnabledReviewers`.

## Trade-off worth a look

`isThreadRunStale` uses `THREAD_EXPIRY_MS = 30 min`. An author whose pod dies mid-run now delays the reviewer by up to 30 minutes instead of dispatching on the next poll. Bounded and self-healing, but it's a real cost in the crash path traded for correctness in the normal path. If it's too slow the fix isn't a second timeout here — it's writing the author's terminal status faster, since the status check short-circuits ahead of the staleness window.

## Testing

- Four cases on `authorRunLive` in the existing suite (live author defers, terminal author dispatches, silent author dispatches, a live *reviewer* doesn't count as the author). Existing `thread()`/`taskWith()` fixtures, no new scaffolding.
- `bun test apps/api/src/tools/task-board/` → 398 pass / 9 fail. Baseline with the diff stashed → 394 pass / 9 fail: the same 9, all `*.integration.test.ts` needing real Postgres.
- Mutation check: dropping the `!` on the reviewer exclusion fails `does not count a live reviewer thread as the author`.
- `bun run check` clean; `bun run lint` 0 errors (19 pre-existing warnings, none in touched files); `bun run fmt` run.

## Not in scope

The other half of the OS-336 trace: the agent had no way to hand a **partially** fixable task to a human. `handTaskToHuman` (`run-reactions.ts:454`) does exactly the right thing and has six internal callers, but no MCP tool exposes it, and both prompt regions only branch "code → PR → in_review" or "no code → comment → done". Separate PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers reviewer dispatch until the author's run is no longer live, so the Reviewer won't start against a branch the Super Agent is still checking.

- The card can be marked `in_review` while the author run is live; dispatch now waits for the author's thread to be terminal or stale.
- Renames `isReviewerThreadLive` to `isThreadRunLive` and adds `authorRunLive`, which treats any live non-reviewer thread on the task as the author.
- Both dispatch paths — the task-modal poll and the boot sweeper — route through `enqueueEnabledReviewers`, so the gate covers all present and future callers.
- Dispatch is deferred, not dropped: both callers re-poll, so the next tick dispatches.

**Trade-off**
- An author pod that dies mid-run now delays the reviewer up to 30 minutes (the stall window) instead of dispatching on the next poll. Bounded and self-healing; faster recovery would mean writing the author's terminal status sooner.

<sup>Written for commit 193e88e8c2bbb45dace4699575dfabe59d5b74c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

