### PR TITLE
fix(claude-code): retry a provider rejection instead of failing the run

### DIFF
--- a/apps/api/src/api/routes/decopilot/run-status-stage.ts
+++ b/apps/api/src/api/routes/decopilot/run-status-stage.ts
@@ -14,6 +14,8 @@ const RUN_STATUS_STAGES = [
   "preparing-tools",
   "starting-assistant",
   "analyzing-scope",
+  // Emitted by the in-sandbox harness runner, not from here.
+  "retrying-provider",
 ] as const;
 
 export type BackendRunStatusStage = (typeof RUN_STATUS_STAGES)[number];

--- a/apps/web/src/components/chat/run-status.test.ts
+++ b/apps/web/src/components/chat/run-status.test.ts
@@ -103,3 +103,23 @@ describe("starting-sandbox", () => {
     );
   });
 });
+
+describe("retrying-provider", () => {
+  test("supersedes every other stage, so the retry is never hidden", () => {
+    for (const stage of RUN_STATUS_STAGE_ORDER) {
+      expect(advanceRunStatusStage(stage, "retrying-provider")).toBe(
+        "retrying-provider",
+      );
+    }
+  });
+
+  test("parses the chunk the in-sandbox harness runner emits", () => {
+    expect(
+      parseRunStatusStageChunk({
+        type: "data-run-status",
+        id: "run-status",
+        data: { stage: "retrying-provider" },
+      }),
+    ).toBe("retrying-provider");
+  });
+});

--- a/apps/web/src/components/chat/run-status.ts
+++ b/apps/web/src/components/chat/run-status.ts
@@ -15,6 +15,9 @@ export const RUN_STATUS_STAGE_ORDER = [
   // monotonic.
   "starting-sandbox",
   "choosing-next-steps",
+  // Last on purpose: the harness retries a provider rejection only before the
+  // turn produces content, so this always supersedes the stage it interrupts.
+  "retrying-provider",
 ] as const;
 
 export type RunStatusStage = (typeof RUN_STATUS_STAGE_ORDER)[number];
@@ -71,6 +74,10 @@ const RUN_STATUS_I18N_KEYS: Record<
   "choosing-next-steps": {
     label: "chat.runStatus.choosingNextStepsLabel",
     detail: "chat.runStatus.choosingNextStepsDetail",
+  },
+  "retrying-provider": {
+    label: "chat.runStatus.retryingProviderLabel",
+    detail: "chat.runStatus.retryingProviderDetail",
   },
 };
 

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -355,6 +355,9 @@ export const chat = {
   "chat.runStatus.choosingNextStepsLabel": "Thinking",
   "chat.runStatus.startingSandboxDetail":
     "Booting the machine and checking out the repository",
+  "chat.runStatus.retryingProviderDetail":
+    "The model provider was unavailable — trying another one",
+  "chat.runStatus.retryingProviderLabel": "Waiting for the model provider",
   "chat.runStatus.startingSandboxLabel": "Starting the sandbox",
   "chat.runStatus.gatheringContextDetail":
     "Looking through the history, files, and notes",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -365,6 +365,9 @@ export const chat = {
   "chat.runStatus.choosingNextStepsLabel": "Pensando",
   "chat.runStatus.startingSandboxDetail":
     "Ligando a m\u00e1quina e fazendo checkout do reposit\u00f3rio",
+  "chat.runStatus.retryingProviderDetail":
+    "O provedor do modelo estava indisponível — tentando outro",
+  "chat.runStatus.retryingProviderLabel": "Aguardando o provedor do modelo",
   "chat.runStatus.startingSandboxLabel": "Iniciando o sandbox",
   "chat.runStatus.gatheringContextDetail":
     "Analisando o histórico, arquivos e notas",

--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -3,6 +3,7 @@ import type { HarnessStreamInputWire } from "@decocms/sandbox/dispatch/schemas";
 import {
   brokenStudioMcp,
   buildOptions,
+  isTransientProviderRejection,
   mcpServersFor,
   promptForRun,
   promptFromUserMessage,
@@ -364,5 +365,40 @@ describe("mcpServersFor", () => {
         ),
       ),
     ).toEqual(["linear"]);
+  });
+});
+
+describe("isTransientProviderRejection", () => {
+  test("matches OpenRouter's upstream relay, whatever the status", () => {
+    expect(
+      isTransientProviderRejection("API Error: 400 Provider returned error"),
+    ).toBe(true);
+    expect(
+      isTransientProviderRejection("API Error: 502 Provider returned error"),
+    ).toBe(true);
+  });
+
+  test("a 400 that describes the request stays fatal", () => {
+    expect(
+      isTransientProviderRejection(
+        "API Error: 400 messages.0: text content blocks must be non-empty",
+      ),
+    ).toBe(false);
+    expect(
+      isTransientProviderRejection(
+        "API Error: 400 max_tokens: must be less than or equal to 64000",
+      ),
+    ).toBe(false);
+  });
+
+  test("does not swallow the credit and session errors that have own paths", () => {
+    expect(
+      isTransientProviderRejection(
+        "API Error: 402 requires more credits, requested up to 64000 tokens",
+      ),
+    ).toBe(false);
+    expect(
+      isTransientProviderRejection("Session ID abc is already in use"),
+    ).toBe(false);
   });
 });

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -352,6 +352,72 @@ const MCP_ATTEMPTS = 8;
 const MCP_BACKOFF_BASE_MS = 2_000;
 
 /**
+ * Retries allowed against a rejecting upstream model provider, and the base of
+ * the equal-jittered backoff between them (0.5-1s, 1-2s, 2-4s).
+ *
+ * OpenRouter fronts one Claude model with several upstreams (Anthropic, Bedrock,
+ * Vertex, Azure) and picks one per request, so a request it relays as
+ * `400 Provider returned error` is a property of the upstream it happened to
+ * pick, not of the request: on production threads the SAME prompt in the SAME
+ * pod failed and then completed 87 seconds later, untouched. The SDK will not
+ * retry it for us — a 400 is a permanent client error by every Anthropic SDK's
+ * rules, which is the right default and the wrong one here.
+ *
+ * Three retries because one is only worth anything if it lands on a different
+ * upstream, which it does immediately; waiting longer buys nothing.
+ * The jitter is not decoration — these failures arrive in bursts (14 threads in
+ * one hour on one org), so an unjittered backoff would retry them in lockstep.
+ */
+const PROVIDER_RETRIES = 3;
+const PROVIDER_BACKOFF_BASE_MS = 1_000;
+
+/**
+ * Whether an SDK throw is the upstream provider failing rather than the request
+ * being wrong.
+ *
+ * Matched on OpenRouter's own relay wording, not on the status code: a 400 whose
+ * body describes the request (`messages.0: text content blocks must be
+ * non-empty`) is a bug a retry would only repeat, and must stay fatal. Exported
+ * for the unit test — pure.
+ */
+export function isTransientProviderRejection(message: string): boolean {
+  return /provider returned error/i.test(message);
+}
+
+/**
+ * Equal-jitter exponential backoff for {@link PROVIDER_RETRIES}.
+ *
+ * Hand-rolled rather than `exponentialBackoffWithJitter` from
+ * `@decocms/shared/std`, which every other retry in the repo uses: this package
+ * is installed into the sandbox image from a tarball and so can only depend on
+ * published packages, which a private workspace module is not. Same reason
+ * `Bun.sleep` stands in for `sleep` here and on the MCP path above.
+ */
+function providerBackoffMs(attempt: number): number {
+  const exponential = PROVIDER_BACKOFF_BASE_MS * 2 ** (attempt - 1);
+  return Math.round(exponential * (0.5 + Math.random() / 2));
+}
+
+/**
+ * A live-only progress chunk telling the UI what this pause is.
+ *
+ * The shape is the `data-run-status` contract owned by
+ * `apps/api/src/api/routes/decopilot/run-status-stage.ts`, restated here rather
+ * than imported: this package is installed into the sandbox image from a tarball
+ * (`packages/sandbox/image/Dockerfile`) and can only depend on published
+ * packages, so the process boundary is the wall. Studio drops these from the
+ * durable projection (`isTransientControlChunk`), so a retry the user watched
+ * happen leaves nothing behind in the thread.
+ */
+function retryingProviderChunk(): Record<string, unknown> {
+  return {
+    type: "data-run-status",
+    id: "run-status",
+    data: { stage: "retrying-provider" },
+  };
+}
+
+/**
  * Run one turn, emitting its chunks as the SDK produces them. An SDK throw
  * becomes a final `error` frame after whatever the turn had already emitted, so
  * a crash mid-turn still shows the work instead of an empty message.
@@ -385,6 +451,16 @@ export async function runClaudeCode(
     started = true;
     emit({ chunks: [...turnStartChunks(id), ...pending.splice(0)] });
   };
+  /**
+   * Whether a failed attempt can be restarted without duplicating work.
+   *
+   * `started` flips on the turn's first assistant message, and a tool call is
+   * part of one — so an un-started turn has run no tool and side-effected
+   * nothing, and restarting it loses only the request that failed. Past that
+   * point a restart would re-run work and splice two generations into one
+   * message, which is a worse failure than the one it recovers from.
+   */
+  const canRestartCleanly = () => !started;
   const push = (chunks: unknown[]) => {
     if (chunks.length === 0) return;
     if (started) emit({ chunks });
@@ -394,6 +470,7 @@ export async function runClaudeCode(
   try {
     let forkedForSession = false;
     let restartedWithoutResume = false;
+    let providerRetries = 0;
     for (let attempt = 1; ; attempt++) {
       let broken: string | null;
       try {
@@ -423,6 +500,26 @@ export async function runClaudeCode(
           );
           sessionId = crypto.randomUUID();
           resumeSession = false;
+          attempt = 0;
+          continue;
+        }
+        if (
+          canRestartCleanly() &&
+          providerRetries < PROVIDER_RETRIES &&
+          isTransientProviderRejection(msg)
+        ) {
+          providerRetries++;
+          const waitMs = providerBackoffMs(providerRetries);
+          console.error(
+            `[claude-code] provider rejected the request (${msg}) — retrying ` +
+              `in ${waitMs}ms (attempt ${providerRetries}/${PROVIDER_RETRIES})`,
+          );
+          // Straight to `emit`: `push` buffers until the turn starts.
+          emit({ chunks: [retryingProviderChunk()] });
+          // What the dead attempt buffered is not part of the next one.
+          pending.length = 0;
+          await Bun.sleep(waitMs);
+          if (!resumeSession) sessionId = crypto.randomUUID();
           attempt = 0;
           continue;
         }


### PR DESCRIPTION
## Summary

A `claude-code` run died on `API Error: 400 Provider returned error` and the thread was permanently `failed`. That string is OpenRouter's, and it means *the upstream it picked* failed — not that our request was wrong.

OpenRouter fronts one Claude model with 9 endpoints across 5 upstreams (Anthropic, Bedrock, Vertex, Azure, Claude Platform on AWS) and picks one per request:

```
$ GET /api/v1/models/anthropic/claude-opus-5/endpoints
Anthropic | Amazon Bedrock (x2) | Azure (x2) | Google (x3) | Claude Platform on AWS
```

The Agent SDK won't retry a 400 — a permanent client error by every Anthropic SDK's rules, which is the right default and the wrong one here. So one unlucky pick killed the run.

This retries it, and shows the user the wait.

## Evidence it's routing, not the request

From prod (`montecarlo`, org `Iu7iG4yE…`), same user, same agent, same sandbox, same env:

```
15:26:02Z  vir_2rQmJ5jTyTAdjz9-2Tchs  failed  model_error
15:27:29Z  vir_2rQmJ5jTyTAdjz9-2Tchs  completed
```

87 seconds apart. Nothing request-shaped varies across those two — only routing. 26 `model_error` parts in 14 days, all but two this exact string, all `claude-code`, ramping from 08-24. One thread was a user typing `oi`.

## What changed

- **`packages/harness-runner/claude-code.ts`** — a third transient class in the attempt loop that already restarts for "session in use" and "session not found". Emits a live `data-run-status` chunk, then jittered backoff (0.5–1s, 1–2s, 2–4s; jitter because these arrive in bursts — 14 threads in one hour), up to 3 retries.
- **`run-status-stage.ts` / `run-status.ts` / `en`+`pt-br` chat dicts** — a `retrying-provider` stage, ranked last so it always supersedes the stage it interrupts. Reads "Waiting for the model provider".

## Safety

- **Only before the turn emits anything.** `started` flips on the first assistant message and a tool call *is* part of one, so an un-started turn has run no tool and side-effected nothing. Past that a restart would re-run work and splice two generations into one message (cf. #4409). This mirrors `fail()`'s own `!started && pending.length === 0` guard.
- **Matched on OpenRouter's relay wording, not the status code.** A 400 that describes the request (`messages.0: text content blocks must be non-empty`) stays fatal — a retry would only repeat it. Tested both ways.
- **No new mechanism.** The status chunk rides `ingest-run`'s existing `publishRawChunk` (no type filter) to the UI, and `isTransientControlChunk` already excludes `data-run-status` from the durable projection — so a retry the user watched leaves nothing in the thread. That's the case that filter's comment anticipated.
- **Bounded.** 3 retries per run, not per attempt; the counter never resets.

## Notes for review

- **Why the backoff is hand-rolled** instead of `@decocms/shared/std`, against the house rule: `harness-runner` is `npm install -g`'d into the sandbox image from a tarball (`packages/sandbox/image/Dockerfile:182`), so it can only depend on *published* packages — a `workspace:*` dep on a private module would break the image at runtime. Same reason `Bun.sleep` stands in for `sleep`, as it already does on the MCP path in this file.
- **The `data-run-status` shape is restated** in the harness rather than imported, for the same tarball reason. The process boundary is the wall.
- **This does not eliminate the 400s**, it survives them. The upstream pin (`provider.only`) is request-body-only and Claude Code owns the body; there is no routing header (I checked all 26 documented `x-*` headers) and `@preset/` would break BYOK keys. Setting **Allowed Providers = `anthropic`** on the OpenRouter account behind the `deco` keys is the complementary, zero-code mitigation.

## Testing

- `bun test packages/harness-runner/` — 52 pass
- Every test file referencing the stage contract across all tiers (grepped `data-run-status` / `RUN_STATUS_STAGE` / `analyzing-scope`): 158 pass
- `bun run --workspaces check` — clean, all 16 workspaces (incl. `studio-web`, which is what proves pt-br dictionary completeness)
- `bun run lint` — 0 errors, none of the 19 pre-existing warnings in touched files
- `bun run fmt`, `knip` — clean
- `bun test apps/api/src apps/web/src` — 383 failures, **identical on a clean `origin/main` tree** (service-dependent tests, no local Postgres); this branch adds +2 passing and changes no failure

Not covered: no e2e. The retry path needs a provider that rejects on demand, which the test org has no way to produce. The decision logic is unit-tested pure; the loop wiring is not.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A `claude-code` run now retries when OpenRouter's chosen upstream rejects the request, instead of failing the thread permanently. `400 Provider returned error` means the upstream picked for that request failed, not that the request was wrong — the same prompt in the same pod failed and then completed 87 seconds later, untouched.

Retries happen in the harness runner's existing attempt loop (which already restarts for "session in use" and "session not found"), with equal-jittered backoff (0.5–1s, 1–2s, 2–4s) and up to 3 retries per run. A `retrying-provider` run-status stage shows "Waiting for the model provider" in the UI during the wait.

**Safety**
- Retries only before the turn emits anything, so no tool has run and nothing side-effected.
- Matched on OpenRouter's relay wording, not the status code, so a 400 that describes the request stays fatal.
- The status chunk is live-only; `isTransientControlChunk` already excludes it from the durable projection.

**Implementation notes**
- Backoff is hand-rolled instead of `@decocms/shared/std` because `harness-runner` is installed into the sandbox image from a tarball and can only depend on published packages.
- This doesn't eliminate the 400s; setting Allowed Providers = `anthropic` on the OpenRouter account is the complementary zero-code mitigation.

<sup>Written for commit 3f9cf432f52a60fce98fc52431d740c5014d5d2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

