### PR TITLE
fix(markdown-editor): a caret in a description is not an edit

### DIFF
--- a/apps/web/src/components/markdown-editor/caret-is-not-an-edit.test.ts
+++ b/apps/web/src/components/markdown-editor/caret-is-not-an-edit.test.ts
@@ -1,0 +1,58 @@
+import { setupComponentTest } from "../../../test/setup";
+setupComponentTest();
+import { describe, expect, test } from "bun:test";
+import { Editor } from "@tiptap/core";
+import { markdownEditorExtensions } from "./extensions";
+import { unwrapListContinuations } from "./unwrap-list-continuations";
+
+const WITH_TABLE = `## Contexto
+
+| Onde | String |
+| --- | --- |
+| Banner | aceitar |
+`;
+
+function updates(content: string, drive: (editor: Editor) => void) {
+  const seen: { docChanged: boolean; steps: number }[] = [];
+  const editor = new Editor({
+    extensions: markdownEditorExtensions(),
+    content: unwrapListContinuations(content),
+    contentType: "markdown",
+    onUpdate: ({ transaction }) =>
+      seen.push({
+        docChanged: transaction.docChanged,
+        steps: transaction.steps.length,
+      }),
+  });
+  drive(editor);
+  return seen;
+}
+
+describe("a caret is not an edit", () => {
+  test("focus fires onUpdate on content the schema had to reshape", () => {
+    expect(updates(WITH_TABLE, (e) => e.commands.focus())).toEqual([
+      { docChanged: false, steps: 0 },
+    ]);
+  });
+
+  test("and does not on content that parsed cleanly", () => {
+    expect(updates("hello", (e) => e.commands.focus())).toEqual([]);
+  });
+
+  test("a real edit always does", () => {
+    expect(updates("hello", (e) => e.commands.insertContent("!"))).toEqual([
+      { docChanged: true, steps: 1 },
+    ]);
+  });
+});
+
+describe("what the schema keeps", () => {
+  test("a table is already gone at parse, before anything is saved", () => {
+    const editor = new Editor({
+      extensions: markdownEditorExtensions(),
+      content: unwrapListContinuations(WITH_TABLE),
+      contentType: "markdown",
+    });
+    expect(editor.getMarkdown()).toBe("## Contexto");
+  });
+});

--- a/apps/web/src/components/markdown-editor/index.tsx
+++ b/apps/web/src/components/markdown-editor/index.tsx
@@ -77,7 +77,9 @@ function insertUpload(
  * and the string stays legible wherever it's read outside the editor.
  *
  * Uncontrolled by design — the initial markdown seeds the document and
- * `onChange` reports every edit. Remount (via `key`) to load a different value.
+ * `onChange` reports every edit, and ONLY an edit: a caret landing in the text
+ * must not hand the caller a value to save. Remount (via `key`) to load a
+ * different value.
  */
 export function MarkdownEditor({
   defaultValue,
@@ -168,7 +170,12 @@ export function MarkdownEditor({
         return uploadInto(view, files, at);
       },
     },
-    onUpdate: ({ editor }) => onChangeRef.current(editor.getMarkdown()),
+    onUpdate: ({ editor, transaction }) => {
+      // Selection-only transactions carry no steps, and TipTap fires onUpdate
+      // for them anyway — clicking into a description was enough to save it.
+      if (!transaction.docChanged) return;
+      onChangeRef.current(editor.getMarkdown());
+    },
   });
 
   if (!editor) return null;


### PR DESCRIPTION
## What is this contribution about?

**Opening a task and clicking into its description was enough to overwrite it.** No typing required.

```ts
onUpdate: ({ editor }) => onChangeRef.current(editor.getMarkdown()),
```

TipTap fires `onUpdate` for selection-only transactions too. I instrumented the one behind a focus:

```
onUpdate on create : 0 calls
after focus()      : 1 call  → docChanged: false, steps: 0
```

Zero steps. Nothing about the document had changed — and the value was written back anyway, straight into the caller's save.

### Why that destroys rather than just churns

The editor's schema is **narrower than the markdown it is handed**. `extensions.ts` loads StarterKit, image, link, placeholder, text-align and mention — there is no table node. So a table does not survive being parsed, let alone edited:

```
in  : ## Contexto \n\n | Onde | String | \n | --- | --- | \n | Banner | aceitar |
out : ## Contexto
```

A card whose description had a table lost it to being **read**. Checklists degrade too — `- [ ] tarefa` comes back as `- tarefa`, state dropped.

This is not theoretical. Two synced cards were destroyed this way in production this afternoon, each with a `description_changed` activity entry naming a human who had only opened them and clicked "see more". One went from 2105 characters to 1226.

### The sharpest part of it

The trigger and the loss are the *same content*. Focus fires `onUpdate` only on markdown the schema had to reshape on the way in — a description that parsed cleanly never fires it at all. So the write happens exactly and only on the descriptions that have something to lose.

### The fix

Guard on `transaction.docChanged`. A caret landing in the text is not an edit and must not hand the caller a value to save.

**Scoped out, deliberately:** the schema gap is untouched. Reading is now safe, but the first genuine keystroke in a description with a table still costs the table. Closing that needs `@tiptap/extension-table` (not currently a dependency) plus task-list support — a change to the editor's schema, with its own round-trip contract to pin. It belongs in its own PR, not smuggled into the one that stops the bleeding.

## How did you verify your code works?

Four unit cases in `caret-is-not-an-edit.test.ts`, all driving a real `Editor` built from the app's own `markdownEditorExtensions()`:

- focus on content the schema reshaped fires `onUpdate` with exactly `{ docChanged: false, steps: 0 }` — the regression, pinned by its signature rather than by "it fired";
- focus on content that parsed cleanly fires nothing, which is what makes the two indistinguishable from the caller's side and is why the guard has to be on `docChanged` and not on some content check;
- a real edit fires `{ docChanged: true, steps: 1 }`, so the guard cannot be satisfied by simply never calling back;
- `getMarkdown()` on the table fixture returns `"## Contexto"`, pinning the schema gap as a known, currently-accepted loss rather than leaving it undocumented.

22 pass / 0 fail across `apps/web/src/components/markdown-editor/`. `bun run check` 0 type errors, `bun run lint` 19 warnings identical to baseline, `knip` clean, `fmt:check` clean.

**Not verified, flagging honestly:** I tried this first as a component test rendering `<MarkdownEditor>` and dropped it. It needs `QueryClientProvider` **and** `ProjectContextProvider`, and a test that needs stubbed context is not a unit test by this repo's own rule — it would have belonged in e2e. So nothing here asserts that `index.tsx` actually *applies* the guard; what is pinned is the discriminator it relies on, which is the part a TipTap upgrade could silently change underneath us. The guard itself is one line. An e2e that opens a task with a table, clicks the description, and asserts the row is unchanged would close that gap and is worth adding.

## Screenshots/Demonstration

Not captured — the change is a one-line condition. The before/after is the two production descriptions quoted above.

## How to Test

1. Create a task whose description contains a markdown table and a `- [ ]` checklist.
2. Open the task, click into the description, click elsewhere, close the dialog.
3. Re-open it. The description must be byte-identical. On `main` the table is gone.
4. Now actually type a character and save — the description still loses its table. That is the known remaining gap, not a regression from this PR.

## Migration Notes

None. No schema change, no API change.

Descriptions already destroyed are not recoverable from Studio. For Jira-synced cards the next full re-scan rewrites them from the issue (`JIRA_RESYNC_REQUEST`); for cards Studio owns, the content is gone.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the markdown editor from saving a description when the user only clicks into it. Previously focus alone fired `onUpdate` and wrote the serialized markdown back to the caller's save — destructive because the editor's schema is narrower than the markdown it handles (no table or task-list nodes), so a table is already gone at parse time. Two synced cards were destroyed this way in production.

The fix guards on `transaction.docChanged`, so a caret landing in the text never triggers a write. The schema gap is deliberately out of scope: a first genuine edit in a table-bearing description still costs the table, and closing that needs the table and task-list extensions in their own change.

Four new unit tests in `caret-is-not-an-edit.test.ts` drive a real `Editor` built from `markdownEditorExtensions()` — pinning the focus regression by its signature (`docChanged: false`, zero steps), confirming clean parses fire nothing, confirming real edits still report, and documenting the table loss at parse time as known behavior.

<sup>Written for commit 8420368307c6fb48258f5da5cd875d60062b75b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

