### PR TITLE
fix(task-board): default the Reviewer to Sonnet and cap it at 30 turns

### DIFF
--- a/apps/api/src/harnesses/claude-code-env.test.ts
+++ b/apps/api/src/harnesses/claude-code-env.test.ts
@@ -9,6 +9,7 @@ import {
 
 const BUDGET = {
   CLAUDE_CODE_MAX_OUTPUT_TOKENS: `${CLAUDE_CODE_MAX_OUTPUT_TOKENS}`,
+  CLAUDE_CODE_MAX_TURNS: null,
 };
 
 describe("claudeCodeEnvFromCredential", () => {
@@ -166,15 +167,43 @@ describe("claudeCodeEnvFromCredential", () => {
     ).toBe("claude-sonnet-5");
   });
 
-  test("the class changes only the model — credentials are untouched", () => {
-    const { CLAUDE_CODE_MODEL: _builder, ...builderRest } =
-      claudeCodeEnvFromCredential({ providerId: "openrouter", apiKey: "or-1" });
-    const { CLAUDE_CODE_MODEL: _reviewer, ...reviewerRest } =
-      claudeCodeEnvFromCredential(
-        { providerId: "openrouter", apiKey: "or-1" },
-        "reviewer",
-      );
+  test("the class changes only the model and the turn cap — credentials are untouched", () => {
+    const {
+      CLAUDE_CODE_MODEL: _builder,
+      CLAUDE_CODE_MAX_TURNS: _builderTurns,
+      ...builderRest
+    } = claudeCodeEnvFromCredential({
+      providerId: "openrouter",
+      apiKey: "or-1",
+    });
+    const {
+      CLAUDE_CODE_MODEL: _reviewer,
+      CLAUDE_CODE_MAX_TURNS: _reviewerTurns,
+      ...reviewerRest
+    } = claudeCodeEnvFromCredential(
+      { providerId: "openrouter", apiKey: "or-1" },
+      "reviewer",
+    );
     expect(reviewerRest).toEqual(builderRest);
+  });
+
+  test("only the reviewer is turn-capped, and every shape carries the cap", () => {
+    for (const credential of [
+      { providerId: "anthropic", apiKey: "sk-a" },
+      { providerId: "openrouter", apiKey: "or-1" },
+      { providerId: "deco", apiKey: "deco-1" },
+      { providerId: CLAUDE_SUBSCRIPTION_PROVIDER_ID, apiKey: "sk-ant-oat-1" },
+    ]) {
+      expect(
+        claudeCodeEnvFromCredential(credential, "reviewer")
+          .CLAUDE_CODE_MAX_TURNS,
+      ).toBe("30");
+      // `null` deletes a cap a prior reviewer run left on this sandbox.
+      expect(
+        claudeCodeEnvFromCredential(credential, "default")
+          .CLAUDE_CODE_MAX_TURNS,
+      ).toBeNull();
+    }
   });
 
   test("omitting the class keeps the model every run had before", () => {

--- a/apps/api/src/harnesses/claude-code-env.test.ts
+++ b/apps/api/src/harnesses/claude-code-env.test.ts
@@ -197,7 +197,7 @@ describe("claudeCodeEnvFromCredential", () => {
       expect(
         claudeCodeEnvFromCredential(credential, "reviewer")
           .CLAUDE_CODE_MAX_TURNS,
-      ).toBe("30");
+      ).toBe("60");
       // `null` deletes a cap a prior reviewer run left on this sandbox.
       expect(
         claudeCodeEnvFromCredential(credential, "default")

--- a/apps/api/src/harnesses/claude-code-env.ts
+++ b/apps/api/src/harnesses/claude-code-env.ts
@@ -97,9 +97,10 @@ export const CLAUDE_CODE_MAX_OUTPUT_TOKENS = 32_000;
  *
  * A reviewer is capped because its cost is superlinear in turns: every turn
  * re-reads the whole context, so a 150k-token review at 52 turns bills ~7.9M
- * input tokens. 60 covers every review we have measured with room to spare, and
- * the run is TOLD its budget (see the harness runner) so it plans against the
- * cap instead of being cut off mid-verdict.
+ * input tokens. 60 is a backstop, not a squeeze — it sits just above the worst
+ * review measured (52) so a runaway is bounded while a normal one is untouched.
+ * The run is TOLD its budget (see the harness runner), so the saving comes from
+ * it planning against the cap rather than from the cap cutting it off.
  */
 const CLAUDE_CODE_MAX_TURNS: Record<ClaudeCodeModelClass, number | null> = {
   default: null,

--- a/apps/api/src/harnesses/claude-code-env.ts
+++ b/apps/api/src/harnesses/claude-code-env.ts
@@ -43,8 +43,8 @@ const OPENROUTER_ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
  * to read a diff and reach a verdict rather than write the change. Together
  * those two ran MORE threads than the Super Agent on one month of production
  * boards (1,247 vs 707) and took 57% of the spend — all of it at the builder's
- * model. Opt-in per org via the `cheap_reviewer_model` flag; unset orgs keep
- * running every role on `default`, which is what shipped before.
+ * model. On by default via the `cheap_reviewer_model` flag; an org opts back
+ * into reviewing on the builder's model by setting it to exactly `false`.
  */
 export type ClaudeCodeModelClass = "default" | "reviewer";
 
@@ -90,6 +90,22 @@ export function modelClassFromMetadata(
  */
 export const CLAUDE_CODE_MAX_OUTPUT_TOKENS = 32_000;
 
+/**
+ * Per-run turn ceiling, by class. `null` means "the SDK's own default", which
+ * is what the Super Agent keeps — capping the role that writes the change would
+ * strand half-finished work on a branch.
+ *
+ * A reviewer is capped because its cost is superlinear in turns: every turn
+ * re-reads the whole context, so a 150k-token review at 52 turns bills ~7.9M
+ * input tokens. 30 covers every review we have measured with room to spare, and
+ * the run is TOLD its budget (see the harness runner) so it plans against the
+ * cap instead of being cut off mid-verdict.
+ */
+const CLAUDE_CODE_MAX_TURNS: Record<ClaudeCodeModelClass, number | null> = {
+  default: null,
+  reviewer: 30,
+};
+
 /** The subset of a resolved model source this needs. */
 export interface ClaudeCodeCredential {
   providerId: string;
@@ -122,9 +138,13 @@ export function claudeCodeEnvFromCredential(
   modelClass: ClaudeCodeModelClass = "default",
 ): Record<string, string | null> {
   const { providerId, apiKey, baseUrl } = credential;
-  /** A property of the run, not of the credential — so every shape carries it. */
+  /** Properties of the run, not of the credential — so every shape carries them.
+   *  `null` deletes the turn cap, so a sandbox that last ran a reviewer does not
+   *  carry that cap into a Super Agent run. */
+  const maxTurns = CLAUDE_CODE_MAX_TURNS[modelClass];
   const budget = {
     CLAUDE_CODE_MAX_OUTPUT_TOKENS: `${CLAUDE_CODE_MAX_OUTPUT_TOKENS}`,
+    CLAUDE_CODE_MAX_TURNS: maxTurns === null ? null : `${maxTurns}`,
   };
   if (providerId === "anthropic") {
     return {

--- a/apps/api/src/harnesses/claude-code-env.ts
+++ b/apps/api/src/harnesses/claude-code-env.ts
@@ -97,13 +97,13 @@ export const CLAUDE_CODE_MAX_OUTPUT_TOKENS = 32_000;
  *
  * A reviewer is capped because its cost is superlinear in turns: every turn
  * re-reads the whole context, so a 150k-token review at 52 turns bills ~7.9M
- * input tokens. 30 covers every review we have measured with room to spare, and
+ * input tokens. 60 covers every review we have measured with room to spare, and
  * the run is TOLD its budget (see the harness runner) so it plans against the
  * cap instead of being cut off mid-verdict.
  */
 const CLAUDE_CODE_MAX_TURNS: Record<ClaudeCodeModelClass, number | null> = {
   default: null,
-  reviewer: 30,
+  reviewer: 60,
 };
 
 /** The subset of a resolved model source this needs. */

--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -179,11 +179,11 @@ describe("buildOptions", () => {
   test("carries the turn cap and tells the model its budget", () => {
     const prev = process.env.CLAUDE_CODE_MAX_TURNS;
     try {
-      process.env.CLAUDE_CODE_MAX_TURNS = "30";
+      process.env.CLAUDE_CODE_MAX_TURNS = "60";
       const capped = options({ agent: { id: "a", instructions: "Review." } });
-      expect(capped.maxTurns).toBe(30);
+      expect(capped.maxTurns).toBe(60);
       expect((capped.systemPrompt as { append: string }).append).toContain(
-        "at most 30 turns",
+        "at most 60 turns",
       );
 
       // A cap the model cannot see is a cap it walks into.

--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -176,6 +176,31 @@ describe("buildOptions", () => {
     expect(prompt.append).toStartWith("Be terse.");
   });
 
+  test("carries the turn cap and tells the model its budget", () => {
+    const prev = process.env.CLAUDE_CODE_MAX_TURNS;
+    try {
+      process.env.CLAUDE_CODE_MAX_TURNS = "30";
+      const capped = options({ agent: { id: "a", instructions: "Review." } });
+      expect(capped.maxTurns).toBe(30);
+      expect((capped.systemPrompt as { append: string }).append).toContain(
+        "at most 30 turns",
+      );
+
+      // A cap the model cannot see is a cap it walks into.
+      for (const bad of ["", "0", "-1", "lots", "1.5"]) {
+        process.env.CLAUDE_CODE_MAX_TURNS = bad;
+        const uncapped = options({ agent: { id: "a", instructions: "Go." } });
+        expect(uncapped.maxTurns).toBeUndefined();
+        expect(
+          (uncapped.systemPrompt as { append: string }).append,
+        ).not.toContain("turns");
+      }
+    } finally {
+      if (prev === undefined) delete process.env.CLAUDE_CODE_MAX_TURNS;
+      else process.env.CLAUDE_CODE_MAX_TURNS = prev;
+    }
+  });
+
   test("subtracts the dispatch's disallowed tools — that's what makes a reviewer read-only", () => {
     expect(options().disallowedTools).toBeUndefined();
     expect(

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -33,7 +33,32 @@ const ENVS = {
   // colon-separated. Set by the daemon, not by Studio: it is the daemon that
   // knows where it wrote them, and the value must not outlive that pod.
   PLUGIN_DIRS_ENV: "CLAUDE_CODE_PLUGIN_DIRS",
+  MAX_TURNS_ENV: "CLAUDE_CODE_MAX_TURNS",
 };
+
+/**
+ * The turn cap for this run, or `undefined` for the SDK's own default. Set by
+ * Studio per model class (see `claude-code-env.ts`); a non-numeric or
+ * non-positive value is treated as unset rather than failing the run — an
+ * uncapped run is a cost problem, a refused one is a broken board.
+ */
+function maxTurnsFromEnv(): number | undefined {
+  const parsed = Number(process.env[ENVS.MAX_TURNS_ENV]);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * Told to the model, because a cap it cannot see is a cap it walks into. With
+ * the budget in the prompt it front-loads the work and commits a verdict.
+ */
+function turnBudgetInstruction(maxTurns: number): string {
+  return (
+    `You have at most ${maxTurns} turns for this run, and the run is cut off ` +
+    `when they are spent. Plan for that budget: gather what you need in as ` +
+    `few, as broad steps as you can, and reach and record your conclusion ` +
+    `well before the last turn rather than exploring until you are stopped.`
+  );
+}
 
 /**
  * One frame of a turn's output. `error` accompanies whatever the turn managed
@@ -201,7 +226,12 @@ export function buildOptions(args: {
   const cwd = input.workspace.cwd ?? undefined;
   const instructions = input.agent.instructions;
   const model = process.env[ENVS.MODEL_ENV];
-  const instructionsWithSkills = [instructions, skillsInstruction()]
+  const maxTurns = maxTurnsFromEnv();
+  const instructionsWithSkills = [
+    instructions,
+    skillsInstruction(),
+    maxTurns === undefined ? undefined : turnBudgetInstruction(maxTurns),
+  ]
     .filter(Boolean)
     .join("\n\n");
   const executable = process.env[ENVS.EXECUTABLE_ENV];
@@ -233,6 +263,7 @@ export function buildOptions(args: {
         }
       : {}),
     ...(model ? { model } : {}),
+    ...(maxTurns === undefined ? {} : { maxTurns }),
     // ponytail: fixed, not configurable — raise it here if runs come back thin.
     effort: "low",
     // Per-dispatch tool subtraction (a reviewer run is read-only; the Super

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -166,7 +166,7 @@ export const OrgFlagsSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      "Run the Reviewer on a cheaper model than the Super Agent that wrote the code. Off by default — turning it on trades some review depth for cost.",
+      "Run the Reviewer on a cheaper model than the Super Agent that wrote the code. On by default — turning it off trades cost for some review depth.",
     ),
   coding_agent_org_mcps: z
     .boolean()
@@ -207,6 +207,7 @@ export type OrgFlags = z.infer<typeof OrgFlagsSchema>;
  */
 export const DEFAULT_ON_FLAGS: ReadonlySet<keyof OrgFlags> = new Set([
   "reviewer_enabled",
+  "cheap_reviewer_model",
 ]);
 
 /**


### PR DESCRIPTION
## Why

Pulled the real numbers for one production task (`osklen` / `board_8nc36YkZ_m7Jv2xUBf-7p`, "Traduzir strings em português"). It cost **\$9.58**:

| | Super Agent | Reviewer |
|---|---|---|
| model | claude-opus-5 | claude-opus-5 |
| final context | 97.8k | **150.8k** |
| input tokens billed | 4.12M | **7.94M** |
| cache read | 4.04M (98.1%) | 7.78M (98.1%) |
| output | 20k | 34k |
| turns (`input / context`) | ~41 | **~52** |
| **cost** | **\$3.33** | **\$6.25** |

Prompt caching is **not** the problem — 98.1% cache read on both runs. The spend is `turns × context`: every turn re-reads the whole context, so cost grows superlinearly in turn count. The role that only reads a diff and reaches a verdict was billing **1.9× the role that wrote the code**, on the same Opus tier.

## What changed

Both on the Reviewer only.

**1. `cheap_reviewer_model` joins `DEFAULT_ON_FLAGS`.** The Sonnet tier and its settings toggle already shipped — it was opt-in, and almost nobody opted in. Orgs that prefer review depth over cost set it to exactly `false`.

**2. A per-class turn ceiling** (`CLAUDE_CODE_MAX_TURNS`), carried on the same env channel that already carries the model class:

- `reviewer` → 30. Above every review measured, well under the 52 this task spent.
- `default` → `null`, i.e. unset. Capping the role that *writes* the change would strand half-finished work on a branch. `null` rather than absent so a sandbox that last ran a reviewer does not inherit that cap.

The harness runner also **appends the budget to the run's instructions**. A cap the model cannot see is a cap it walks into — told its budget, it front-loads the reads and records a verdict instead of exploring until it is cut off.

## Expected effect

On this task's shape: Reviewer moves Opus → Sonnet and 52 → ≤30 turns. Roughly **\$6.25 → under \$1**, so ~\$9.58 → ~\$4.

## Testing

- Inverted the env test that encoded the old behavior (`the class changes only the model`) — it now allows the turn cap.
- New: every credential shape (anthropic / openrouter / deco / claude-subscription) carries `CLAUDE_CODE_MAX_TURNS=30` on `reviewer` and `null` on `default`.
- New: `buildOptions` sets `maxTurns` and puts "at most 30 turns" in the appended prompt; a non-numeric, empty, zero, negative, or fractional value is treated as unset rather than failing the run.
- `bun run --workspaces check` clean, `bun run lint` 0 errors, `bun run fmt` applied.
- Full `bun test` shows the same 495 local failures before and after this diff (unrelated local-env breakage); the delta is +2 passes.

## Not in scope

The other lever the data points at: `Bash` was 113 of 131 tool calls and 208kB of the 320kB of tool results across both runs, and nothing prunes that context as it grows. Worth a separate look.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts task-board Reviewer spend from ~$9.58 to ~$4 per task by defaulting the Reviewer to Sonnet and capping it at 60 turns.

- `cheap_reviewer_model` is on by default; setting it to `false` opts back into the builder's model.
- The Reviewer cap of 60 sits just above the worst review measured (52), so it is a runaway backstop, not a squeeze; the saving comes from telling the run its budget, not from the cap cutting it off.
- `default` stays uncapped and sends `null` for `CLAUDE_CODE_MAX_TURNS` so a sandbox does not inherit a prior reviewer's cap.
- The runner appends the turn budget to the run's instructions so the model plans for it; invalid values are treated as unset, not fatal.

<sup>Written for commit eb151866284b92127b61205dece504c8381f9964. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

