### PR TITLE
fix(mcp-clients): broadcast the list-revalidation throttle clear to every pod

### DIFF
--- a/apps/api/src/mcp-clients/mcp-cache-invalidation.test.ts
+++ b/apps/api/src/mcp-clients/mcp-cache-invalidation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import {
+  fetchWithCache,
+  type McpListCache,
+  type McpListType,
+} from "./mcp-list-cache";
+import { invalidateConnectionCaches } from "./mcp-cache-invalidation";
+
+const makeTool = (name: string): Tool => ({
+  name,
+  description: `Tool ${name}`,
+  inputSchema: { type: "object", properties: {} },
+});
+
+/** Minimal Map-based McpListCache for testing. */
+class TestMcpListCache implements McpListCache {
+  private readonly cache = new Map<string, unknown[]>();
+  async get(type: McpListType, connectionId: string) {
+    return this.cache.get(`${type}.${connectionId}`) ?? null;
+  }
+  async set(type: McpListType, connectionId: string, data: unknown[]) {
+    this.cache.set(`${type}.${connectionId}`, data);
+  }
+  async invalidate(connectionId: string) {
+    for (const type of ["tools", "resources", "prompts"] as McpListType[]) {
+      this.cache.delete(`${type}.${connectionId}`);
+    }
+  }
+  teardown() {}
+}
+
+describe("invalidateConnectionCaches", () => {
+  it("also lifts the list-revalidation throttle, not just the read cache", async () => {
+    const conn = "conn_invalidated_via_cache_bus";
+    const cache = new TestMcpListCache();
+    await cache.set("tools", conn, [makeTool("stale")]);
+
+    let callCount = 0;
+    const fetchLive = async () => {
+      callCount++;
+      return [makeTool("fresh")];
+    };
+
+    await fetchWithCache("tools", conn, fetchLive, cache, undefined, 10_000);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(callCount).toBe(1);
+
+    // No NATS connection registered here — exercises the local-eviction path.
+    invalidateConnectionCaches(conn);
+
+    await fetchWithCache("tools", conn, fetchLive, cache, undefined, 10_000);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(callCount).toBe(2);
+  });
+});

--- a/apps/api/src/mcp-clients/mcp-cache-invalidation.ts
+++ b/apps/api/src/mcp-clients/mcp-cache-invalidation.ts
@@ -16,6 +16,7 @@
 
 import type { NatsConnection, Subscription } from "@nats-io/nats-core";
 import { getMcpReadCache } from "./mcp-read-cache";
+import { clearRevalidationState } from "./mcp-list-cache";
 
 const INVALIDATE_SUBJECT = "studio.mcp-cache.invalidate";
 
@@ -26,9 +27,18 @@ const decoder = new TextDecoder();
 let getConnection: (() => NatsConnection | null) | undefined;
 let sub: Subscription | null = null;
 
-/** Drop this connection's per-pod cached read results (content + tool calls). */
+/**
+ * Drop this connection's per-pod cached read results (content + tool calls)
+ * and its list-revalidation throttle bookkeeping.
+ *
+ * The throttle map has no TTL, so a replica that never handles the delete
+ * request itself would otherwise keep that connection's entry forever —
+ * this broadcast is the only signal every OTHER pod gets that the connection
+ * is gone.
+ */
 function evictLocal(connectionId: string): void {
   getMcpReadCache()?.invalidate(connectionId);
+  clearRevalidationState(connectionId);
 }
 
 /**

--- a/apps/api/src/tools/connection/delete.ts
+++ b/apps/api/src/tools/connection/delete.ts
@@ -16,10 +16,7 @@ import {
   requireAuth,
   requireOrganization,
 } from "../../core/studio-context";
-import {
-  clearRevalidationState,
-  getMcpListCache,
-} from "../../mcp-clients/mcp-list-cache";
+import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
 import { invalidateConnectionCaches } from "../../mcp-clients/mcp-cache-invalidation";
 import { ConnectionEntitySchema } from "./schema";
 
@@ -116,10 +113,7 @@ export const COLLECTION_CONNECTIONS_DELETE = defineTool({
     getMcpListCache()
       ?.invalidate(input.id)
       .catch(() => {});
-    // Drop this pod's revalidation-throttle bookkeeping for the deleted connection.
-    clearRevalidationState(input.id);
-    // Drop cached read content and tool results for this connection across ALL
-    // replicas (per-pod caches → NATS broadcast).
+    // Drops caches and revalidation state across ALL replicas (NATS broadcast).
     invalidateConnectionCaches(input.id);
 
     const userId = getUserId(ctx);


### PR DESCRIPTION
Follows #6652, which cleared a deleted connection's list-revalidation throttle bookkeeping (`lastRevalidatedAt`/`revalidating` maps in `mcp-list-cache.ts`, which have no TTL) — but only on the pod that handled the `COLLECTION_CONNECTIONS_DELETE` call. Every other replica in a multi-pod deployment never gets that signal and keeps the deleted connection's throttle entries forever, which is exactly the unbounded-growth failure #6652 set out to fix, just reduced from N pods to N-1.

The fix broadcasts the clear the same way the codebase already broadcasts read-cache eviction: `mcp-cache-invalidation.ts`'s `evictLocal` (called locally and via the existing NATS `studio.mcp-cache.invalidate` subject) now also calls `clearRevalidationState`. `delete.ts` no longer needs its own direct call since `invalidateConnectionCaches` already covers the local pod too — removed to avoid the duplicate.

Failure scenario: two-pod deployment, a connection is deleted on pod A. Pod A's throttle map is clear, but pod B — which may still route revalidation traffic for other connections — keeps a `tools:<deleted-id>` / `resources:<deleted-id>` / `prompts:<deleted-id>` entry in its in-memory map for the rest of the pod's life.

Regression test: `apps/api/src/mcp-clients/mcp-cache-invalidation.test.ts` — populates the throttle via `fetchWithCache`, calls `invalidateConnectionCaches` (the cross-pod entry point, exercised here without a live NATS connection so it hits the same local-eviction path every pod's subscriber hits), then asserts a subsequent fetch is NOT throttled. Fails on the pre-fix code (`Expected: 2, Received: 1`), passes after.

Reviewer: `bun test apps/api/src/mcp-clients/mcp-cache-invalidation.test.ts`.

Verified locally: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test above (fails pre-fix, passes post-fix), and `bunx oxlint` on the three changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broadcasts the list-revalidation throttle clear on connection delete so every pod drops deleted connections' throttle bookkeeping, fixing unbounded memory growth in multi-pod deployments where only the handling pod previously cleared it.

- `evictLocal` in `mcp-cache-invalidation.ts` now also calls `clearRevalidationState`, reusing the existing NATS invalidation broadcast.
- Removes the now-redundant direct call in `delete.ts` since the broadcast already covers the local pod.
- Adds a regression test that populates the throttle, calls `invalidateConnectionCaches` (exercising the local-eviction path without a live NATS connection), and asserts the next fetch isn't throttled.

<sup>Written for commit 87fb9fada92c33d0a144d21c8071eae330844772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

