### PR TITLE
feat: stream claude-code tokens, show elapsed on running tools, checkpoint agent work to its branch

### DIFF
--- a/apps/web/src/components/chat/message/parts/tool-call-part/bash-wait.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/bash-wait.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useT } from "@/i18n/use-t.ts";
 import { useClockTick } from "@/lib/use-clock-tick.ts";
 
 const STORAGE_PREFIX = "bash-sleep-start:";
@@ -35,15 +36,12 @@ function firstSeenStart(toolCallId: string): number {
  * the first time this browser observed the call running, persisted in
  * sessionStorage so it survives a page refresh instead of resetting.
  */
-function useSleepStartedAt(
-  toolCallId: string,
-  anchorMs: number | null,
-): number {
+function useCallStartedAt(toolCallId: string, anchorMs: number | null): number {
   const fallback = useState(() => firstSeenStart(toolCallId))[0];
   return anchorMs ?? fallback;
 }
 
-function formatCountdown(ms: number): string {
+function formatDuration(ms: number): string {
   const secs = Math.ceil(ms / 1000);
   if (secs < 60) return `${secs}s`;
   const mins = Math.floor(secs / 60);
@@ -70,11 +68,48 @@ export function BashWaitSummary({
   anchorMs: number | null;
 }) {
   useClockTick(1000);
-  const startedAt = useSleepStartedAt(toolCallId, anchorMs);
+  const startedAt = useCallStartedAt(toolCallId, anchorMs);
   const remaining = startedAt + durationMs - Date.now();
   return (
     <span className="tabular-nums">
-      {remaining > 0 ? `Waiting ${formatCountdown(remaining)}` : "Wrapping up…"}
+      {remaining > 0 ? `Waiting ${formatDuration(remaining)}` : "Wrapping up…"}
+    </span>
+  );
+}
+
+/**
+ * Below this, a running tool is just latency and a counter is noise. Past it,
+ * the run looks frozen without one.
+ */
+const ELAPSED_VISIBLE_AFTER_MS = 10_000;
+
+/**
+ * Live "running for Ns" readout for any still-running tool call.
+ *
+ * The sibling countdown above needs a known duration; this one does not, which
+ * is what makes it usable for the calls that actually read as a hang — a
+ * multi-minute `deno test`, a build, an MCP tool waiting on a deploy. Anchored
+ * the same way (`anchorMs`, else the sessionStorage-backed first-observed time)
+ * so a reload keeps counting from when the call really fired.
+ *
+ * Under `ELAPSED_VISIBLE_AFTER_MS` it renders the plain "Preparing…" copy: a
+ * counter on every fast tool call would be worse than no counter at all.
+ */
+export function ToolElapsedSummary({
+  toolCallId,
+  anchorMs,
+}: {
+  toolCallId: string;
+  anchorMs: number | null;
+}) {
+  const t = useT();
+  useClockTick(1000);
+  const startedAt = useCallStartedAt(toolCallId, anchorMs);
+  const elapsed = Date.now() - startedAt;
+  if (elapsed < ELAPSED_VISIBLE_AFTER_MS) return t("chat.generic.preparing");
+  return (
+    <span className="tabular-nums">
+      {t("chat.generic.runningFor", { elapsed: formatDuration(elapsed) })}
     </span>
   );
 }

--- a/apps/web/src/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/generic.tsx
@@ -376,10 +376,12 @@ export function GenericToolCallPart({
         durationMs={sleepDurationMs}
         anchorMs={partCreatedAtMs(part)}
       />
-    ) : effectiveState === "loading" && !isStaleApproval && !isOutputError ? (
+    ) : effectiveState === "loading" ? (
       // Any other still-running call: count up. A multi-minute build or test
       // is the case that reads as a dead run, and it has no duration to count
       // down from — "Preparing…" alone is what made it look frozen.
+      // A stale approval and an output error both resolve to another
+      // `effectiveState` above, so "loading" already excludes them.
       <ToolElapsedSummary
         toolCallId={toolCallId}
         anchorMs={partCreatedAtMs(part)}

--- a/apps/web/src/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/generic.tsx
@@ -46,7 +46,7 @@ import {
   XClose,
 } from "@untitledui/icons";
 import { TOOL_DISPLAY_MAP } from "./tool-display-map.ts";
-import { BashWaitSummary } from "./bash-wait.tsx";
+import { BashWaitSummary, ToolElapsedSummary } from "./bash-wait.tsx";
 import { parseSleepMs } from "./bash-sleep.ts";
 import { toEpochMs } from "@/lib/format-time.ts";
 import type { DynamicToolUIPart, ToolUIPart } from "ai";
@@ -374,6 +374,14 @@ export function GenericToolCallPart({
       <BashWaitSummary
         toolCallId={toolCallId}
         durationMs={sleepDurationMs}
+        anchorMs={partCreatedAtMs(part)}
+      />
+    ) : effectiveState === "loading" && !isStaleApproval && !isOutputError ? (
+      // Any other still-running call: count up. A multi-minute build or test
+      // is the case that reads as a dead run, and it has no duration to count
+      // down from — "Preparing…" alone is what made it look frozen.
+      <ToolElapsedSummary
+        toolCallId={toolCallId}
         anchorMs={partCreatedAtMs(part)}
       />
     ) : isStaleApproval ? (

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -189,6 +189,7 @@ export const chat = {
   "chat.generic.loadingApp": "Loading app...",
   "chat.generic.openInPanel": "Open in panel",
   "chat.generic.preparing": "Preparing...",
+  "chat.generic.runningFor": "Running for {elapsed}",
   "chat.generic.retry": "Retry",
   "chat.generic.waitingForApproval": "Waiting for your approval",
   "chat.highlight.continue": "Continue",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -195,6 +195,7 @@ export const chat = {
   "chat.generic.loadingApp": "Carregando app...",
   "chat.generic.openInPanel": "Abrir no painel",
   "chat.generic.preparing": "Preparando...",
+  "chat.generic.runningFor": "Executando há {elapsed}",
   "chat.generic.retry": "Tentar novamente",
   "chat.generic.waitingForApproval": "Aguardando sua aprovação",
   "chat.highlight.continue": "Continuar",

--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -3,6 +3,7 @@ import type { HarnessStreamInputWire } from "@decocms/sandbox/dispatch/schemas";
 import {
   brokenStudioMcp,
   buildOptions,
+  createDeltaCoalescer,
   isTransientProviderRejection,
   mcpServersFor,
   promptForRun,
@@ -158,6 +159,12 @@ describe("brokenStudioMcp", () => {
 });
 
 describe("buildOptions", () => {
+  test("asks the SDK for partial messages", () => {
+    // Without this the SDK yields only complete assistant messages and a
+    // paragraph reaches the UI as one frame after the model finished writing.
+    expect(options().includePartialMessages).toBe(true);
+  });
+
   test("bypasses permissions — the pod is the isolation boundary", () => {
     expect(options().permissionMode).toBe("bypassPermissions");
   });
@@ -425,5 +432,71 @@ describe("isTransientProviderRejection", () => {
     expect(
       isTransientProviderRejection("Session ID abc is already in use"),
     ).toBe(false);
+  });
+});
+
+describe("createDeltaCoalescer", () => {
+  const delta = (id: string, text: string) => ({
+    type: "text-delta",
+    id,
+    delta: text,
+  });
+
+  test("holds a short delta until something forces it out", () => {
+    const c = createDeltaCoalescer(10);
+    expect(c.push([delta("a", "hi")])).toEqual([]);
+    expect(c.drain()).toEqual([delta("a", "hi")]);
+    // Drained once; nothing left to emit twice.
+    expect(c.drain()).toEqual([]);
+  });
+
+  test("concatenates same-block deltas and flushes at the threshold", () => {
+    const c = createDeltaCoalescer(5);
+    expect(c.push([delta("a", "ab")])).toEqual([]);
+    expect(c.push([delta("a", "cd")])).toEqual([]);
+    expect(c.push([delta("a", "ef")])).toEqual([delta("a", "abcdef")]);
+    expect(c.drain()).toEqual([]);
+  });
+
+  test("a non-delta chunk flushes what is held, before itself", () => {
+    const c = createDeltaCoalescer(100);
+    // Ordering is the contract: text-end must never overtake its own text.
+    expect(c.push([delta("a", "hi"), { type: "text-end", id: "a" }])).toEqual([
+      delta("a", "hi"),
+      { type: "text-end", id: "a" },
+    ]);
+  });
+
+  test("a different block flushes the previous one rather than merging", () => {
+    const c = createDeltaCoalescer(100);
+    c.push([delta("a", "one")]);
+    expect(c.push([delta("b", "two")])).toEqual([delta("a", "one")]);
+    expect(c.drain()).toEqual([delta("b", "two")]);
+  });
+
+  test("reasoning and text deltas are not merged into each other", () => {
+    const c = createDeltaCoalescer(100);
+    c.push([{ type: "reasoning-delta", id: "a", delta: "think" }]);
+    // Same id, different kind — merging would put reasoning into a text part.
+    expect(c.push([delta("a", "say")])).toEqual([
+      { type: "reasoning-delta", id: "a", delta: "think" },
+    ]);
+  });
+
+  test("chunks that are not deltas pass through untouched", () => {
+    const c = createDeltaCoalescer(100);
+    const chunks = [
+      { type: "text-start", id: "a" },
+      { type: "tool-input-available", toolCallId: "t", toolName: "Bash" },
+      { type: "finish-step" },
+    ];
+    expect(c.push(chunks)).toEqual(chunks);
+  });
+
+  test("a malformed delta is passed through, not swallowed", () => {
+    const c = createDeltaCoalescer(100);
+    // No `delta` string: not coalescable, but dropping it would lose output.
+    const odd = { type: "text-delta", id: "a" };
+    expect(c.push([odd])).toEqual([odd]);
   });
 });

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -266,6 +266,13 @@ export function buildOptions(args: {
     ...(maxTurns === undefined ? {} : { maxTurns }),
     // ponytail: fixed, not configurable — raise it here if runs come back thin.
     effort: "low",
+    // Token-level streaming. Without this the SDK yields only COMPLETE
+    // assistant messages, so a paragraph reaches the UI as one 5KB frame after
+    // the model finished writing it — the run reads as frozen while it is in
+    // fact mid-sentence. `to-ui-chunks.ts` folds the resulting `stream_event`
+    // deltas into the same chunk vocabulary, and `push` coalesces them, so
+    // nothing downstream sees a per-token frame.
+    includePartialMessages: true,
     // Per-dispatch tool subtraction (a reviewer run is read-only; the Super
     // Agent's is not). `disallowedTools` is enforced by the harness itself, so
     // it holds under `bypassPermissions`.
@@ -449,6 +456,79 @@ function retryingProviderChunk(): Record<string, unknown> {
 }
 
 /**
+ * Coalesces adjacent text/reasoning deltas so token-level streaming does not
+ * become token-level *framing*.
+ *
+ * `includePartialMessages` makes the SDK yield one message per token, and the
+ * caller turns every emission into one dispatch frame — forwarding them 1:1
+ * would push tens of thousands of ~60-byte frames per run through the daemon,
+ * JetStream and every open SSE connection. Deltas on the same block concatenate
+ * losslessly, so they are held until they are worth a frame.
+ *
+ * Ordering is preserved exactly: a non-delta chunk flushes whatever is held
+ * before it goes out, so `text-end` can never overtake its own text.
+ *
+ * ponytail: size-based, no timer. ~200 chars is well under a second at model
+ * output rates, and a timer would need a flush race at every turn exit for no
+ * visible gain. If a slow model ever feels chunky, add the timer here.
+ */
+export function createDeltaCoalescer(flushChars = 200): {
+  push(chunks: unknown[]): unknown[];
+  drain(): unknown[];
+} {
+  let held: { type: string; id: string; delta: string } | null = null;
+
+  const asDelta = (
+    chunk: unknown,
+  ): { type: string; id: string; delta: string } | null => {
+    if (typeof chunk !== "object" || chunk === null) return null;
+    const record = chunk as Record<string, unknown>;
+    if (record.type !== "text-delta" && record.type !== "reasoning-delta") {
+      return null;
+    }
+    if (typeof record.id !== "string" || typeof record.delta !== "string") {
+      return null;
+    }
+    return { type: record.type, id: record.id, delta: record.delta };
+  };
+
+  return {
+    push(chunks) {
+      const out: unknown[] = [];
+      for (const chunk of chunks) {
+        const delta = asDelta(chunk);
+        if (!delta) {
+          if (held) out.push(held);
+          held = null;
+          out.push(chunk);
+          continue;
+        }
+        // Both type AND id: ids are minted distinctly today, but merging a
+        // reasoning delta into a text part on an id collision would corrupt
+        // the part rather than just misorder it.
+        if (held && held.type === delta.type && held.id === delta.id) {
+          held.delta += delta.delta;
+        } else {
+          if (held) out.push(held);
+          held = delta;
+        }
+        if (held.delta.length >= flushChars) {
+          out.push(held);
+          held = null;
+        }
+      }
+      return out;
+    },
+    drain() {
+      if (!held) return [];
+      const chunk = held;
+      held = null;
+      return [chunk];
+    },
+  };
+}
+
+/**
  * Run one turn, emitting its chunks as the SDK produces them. An SDK throw
  * becomes a final `error` frame after whatever the turn had already emitted, so
  * a crash mid-turn still shows the work instead of an empty message.
@@ -492,11 +572,18 @@ export async function runClaudeCode(
    * message, which is a worse failure than the one it recovers from.
    */
   const canRestartCleanly = () => !started;
-  const push = (chunks: unknown[]) => {
+  const coalescer = createDeltaCoalescer();
+  const send = (chunks: unknown[]) => {
     if (chunks.length === 0) return;
     if (started) emit({ chunks });
     else pending.push(...chunks);
   };
+  const push = (chunks: unknown[]) => {
+    if (chunks.length === 0) return;
+    send(coalescer.push(chunks));
+  };
+  /** Emit whatever the coalescer is still holding. Every turn exit owes this. */
+  const drain = () => send(coalescer.drain());
 
   try {
     let forkedForSession = false;
@@ -710,6 +797,7 @@ export async function runClaudeCode(
       // which fails the whole run instead of just forgetting.
       await Bun.write(file, sessionId);
       startTurn(messageId ?? `msg_${message.uuid}`);
+      drain();
       emit({
         chunks: [
           ...turnFinishChunks(
@@ -727,6 +815,7 @@ export async function runClaudeCode(
   /** Close whatever the turn had emitted, then report what ended it. */
   function fail(message: string) {
     const error = { code: "harness_crashed", message };
+    drain();
     if (!started && pending.length === 0) {
       emit({ chunks: [], error });
       return;

--- a/packages/harness-runner/to-ui-chunks.test.ts
+++ b/packages/harness-runner/to-ui-chunks.test.ts
@@ -137,8 +137,236 @@ describe("UiChunkTranslator", () => {
   test("unknown message types and blocks are ignored", () => {
     const t = new UiChunkTranslator();
     expect(t.translate({ type: "system" })).toEqual([]);
+    // A stream_event with no `event` payload is still nothing to render — but a
+    // populated one is NOT ignored any more; see the streaming tests below.
     expect(t.translate({ type: "stream_event" })).toEqual([]);
     expect(t.translate(assistant([{ type: "future_block" }]))).toEqual([]);
+  });
+});
+
+/** One raw Anthropic streaming event, as the SDK forwards it. */
+const streamEvent = (event: unknown) => ({
+  type: "stream_event" as const,
+  event,
+});
+
+describe("UiChunkTranslator — token streaming (includePartialMessages)", () => {
+  test("a text block streams start/delta/end as the events arrive", () => {
+    const t = new UiChunkTranslator();
+    expect(t.translate(streamEvent({ type: "message_start" }))).toEqual([]);
+    const start = t.translate(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+    );
+    expect(start).toEqual([{ type: "text-start", id: "stream-1" }]);
+    expect(
+      t.translate(
+        streamEvent({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "Hel" },
+        }),
+      ),
+    ).toEqual([{ type: "text-delta", id: "stream-1", delta: "Hel" }]);
+    expect(
+      t.translate(
+        streamEvent({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "lo" },
+        }),
+      ),
+    ).toEqual([{ type: "text-delta", id: "stream-1", delta: "lo" }]);
+    expect(
+      t.translate(streamEvent({ type: "content_block_stop", index: 0 })),
+    ).toEqual([{ type: "text-end", id: "stream-1" }]);
+  });
+
+  test("thinking streams as reasoning; signature deltas emit nothing", () => {
+    const t = new UiChunkTranslator();
+    t.translate(streamEvent({ type: "message_start" }));
+    expect(
+      t.translate(
+        streamEvent({
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "thinking", thinking: "" },
+        }),
+      ),
+    ).toEqual([{ type: "reasoning-start", id: "stream-1" }]);
+    expect(
+      t.translate(
+        streamEvent({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "thinking_delta", thinking: "hmm" },
+        }),
+      ),
+    ).toEqual([{ type: "reasoning-delta", id: "stream-1", delta: "hmm" }]);
+    // Not renderable text — and it must not be appended to the reasoning part.
+    expect(
+      t.translate(
+        streamEvent({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "signature_delta", signature: "sig" },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  test("the assistant message does not restate a block it already streamed", () => {
+    const t = new UiChunkTranslator();
+    t.translate(streamEvent({ type: "message_start" }));
+    t.translate(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+    );
+    t.translate(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Hello" },
+      }),
+    );
+    t.translate(streamEvent({ type: "content_block_stop", index: 0 }));
+    // The SDK now restates the finished message. The text is already on the
+    // wire; emitting it again is the duplication this guards.
+    expect(t.translate(assistant([{ type: "text", text: "Hello" }]))).toEqual(
+      [],
+    );
+  });
+
+  test("tool calls still come from the assistant message, not the deltas", () => {
+    const t = new UiChunkTranslator();
+    t.translate(streamEvent({ type: "message_start" }));
+    // A tool_use block streams its input as partial JSON — unusable, so the
+    // start and the deltas yield nothing.
+    expect(
+      t.translate(
+        streamEvent({
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "tool_use", id: "call-1", name: "Bash" },
+        }),
+      ),
+    ).toEqual([]);
+    expect(
+      t.translate(
+        streamEvent({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: '{"cmd' },
+        }),
+      ),
+    ).toEqual([]);
+    // The complete input arrives with the assistant message, which is what
+    // satisfies the tool-input-before-output contract.
+    expect(
+      t.translate(
+        assistant([
+          {
+            type: "tool_use",
+            id: "call-1",
+            name: "Bash",
+            input: { cmd: "ls" },
+          },
+        ]),
+      ),
+    ).toEqual([
+      {
+        type: "tool-input-available",
+        toolCallId: "call-1",
+        toolName: "Bash",
+        input: { cmd: "ls" },
+      },
+    ]);
+  });
+
+  test("a streamed text block mixed with a tool call keeps both", () => {
+    const t = new UiChunkTranslator();
+    t.translate(streamEvent({ type: "message_start" }));
+    t.translate(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+    );
+    t.translate(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Running it" },
+      }),
+    );
+    t.translate(streamEvent({ type: "content_block_stop", index: 0 }));
+    // Index 0 was streamed, index 1 was not — only the tool call is restated.
+    expect(
+      t.translate(
+        assistant([
+          { type: "text", text: "Running it" },
+          { type: "tool_use", id: "call-1", name: "Bash", input: {} },
+        ]),
+      ),
+    ).toEqual([
+      {
+        type: "tool-input-available",
+        toolCallId: "call-1",
+        toolName: "Bash",
+        input: {},
+      },
+    ]);
+  });
+
+  test("a block left open by an interrupted stream is closed, not leaked", () => {
+    const t = new UiChunkTranslator();
+    t.translate(streamEvent({ type: "message_start" }));
+    t.translate(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+    );
+    t.translate(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "half a sen" },
+      }),
+    );
+    // No content_block_stop. The next message must close it, or the part is
+    // reassembled as unfinished forever.
+    expect(t.translate(streamEvent({ type: "message_start" }))).toEqual([
+      { type: "text-end", id: "stream-1" },
+    ]);
+  });
+
+  test("a second message's indices are not skipped by the first's", () => {
+    const t = new UiChunkTranslator();
+    t.translate(streamEvent({ type: "message_start" }));
+    t.translate(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+    );
+    t.translate(streamEvent({ type: "content_block_stop", index: 0 }));
+    t.translate(assistant([{ type: "text", text: "first" }]));
+    // A message the SDK did NOT stream (index 0 again) must still be emitted.
+    expect(t.translate(assistant([{ type: "text", text: "second" }]))).toEqual([
+      { type: "text-start", id: "u1-2" },
+      { type: "text-delta", id: "u1-2", delta: "second" },
+      { type: "text-end", id: "u1-2" },
+    ]);
   });
 });
 

--- a/packages/harness-runner/to-ui-chunks.ts
+++ b/packages/harness-runner/to-ui-chunks.ts
@@ -14,11 +14,13 @@
  *  - text/reasoning ids are per-block, not per-message: two text blocks in one
  *    assistant turn are two parts.
  *
- * Block-granular, not token-granular: the caller emits a frame per SDK message
- * (see `claude-code.ts`), so a text block arrives as start+delta+end back to
- * back rather than as deltas. The chunk vocabulary is identical either way, so
- * moving to token deltas later is a change of *when* these are yielded, not
- * *what*.
+ * Token-granular when the SDK streams, block-granular when it does not. With
+ * `includePartialMessages` on (see `claude-code.ts`) text and thinking arrive as
+ * `stream_event` deltas and are emitted as they land; the `assistant` message
+ * that follows then re-states those same blocks, so the indices already
+ * streamed are skipped there rather than emitted twice. Tool calls are always
+ * taken from the `assistant` message: `input_json_delta` is partial JSON, and
+ * the ordering contract above needs a COMPLETE input before the output.
  */
 
 import type { UIMessageChunk } from "ai";
@@ -70,10 +72,21 @@ export interface SdkResultMessage {
   total_cost_usd?: number;
 }
 
+/**
+ * A raw Anthropic streaming event, forwarded by the SDK under
+ * `includePartialMessages`. Only the content-block events matter here; `event`
+ * is `unknown` because every field read off it is guarded.
+ */
+export interface SdkStreamEventMessage {
+  type: "stream_event";
+  event: unknown;
+}
+
 export type TranslatableSdkMessage =
   | SdkAssistantMessage
   | SdkUserMessage
   | SdkResultMessage
+  | SdkStreamEventMessage
   | { type: string };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -110,6 +123,22 @@ export class UiChunkTranslator {
   private readonly announcedToolCalls = new Set<string>();
   private blockSeq = 0;
   /**
+   * Text/reasoning blocks opened from `stream_event` and not yet closed, keyed
+   * by the Anthropic content-block index. Holds the minted chunk id so the
+   * deltas and the end land on the part the start opened.
+   */
+  private readonly openStreamBlocks = new Map<
+    number,
+    { id: string; kind: "text" | "reasoning" }
+  >();
+  /**
+   * Content-block indices of the message currently streaming that were already
+   * emitted as deltas. The `assistant` message restates every block, so these
+   * are skipped there — the same index is positional in both, which is what
+   * makes the skip safe.
+   */
+  private readonly streamedIndices = new Set<number>();
+  /**
    * Prompt tokens of the most recent API call — how full the model's context
    * actually was. Read by `turnFinishChunks`; `result.usage` cannot supply it
    * because it sums every call of the session (a long turn's cached prompts
@@ -129,7 +158,91 @@ export class UiChunkTranslator {
     if (message.type === "user" && "message" in message) {
       return this.translateToolResults(message as SdkUserMessage);
     }
+    if (message.type === "stream_event" && "event" in message) {
+      return this.translateStreamEvent(
+        (message as SdkStreamEventMessage).event,
+      );
+    }
     return [];
+  }
+
+  /**
+   * One raw Anthropic streaming event → chunks. Text and thinking deltas are
+   * forwarded as they arrive; everything else (tool input deltas, message
+   * envelopes, signatures) yields nothing, because the `assistant` message is
+   * the authority for those.
+   */
+  private translateStreamEvent(event: unknown): UIMessageChunk[] {
+    if (!isRecord(event)) return [];
+    // A new message: nothing from the previous one may still be open, and its
+    // skip set does not apply to this one's indices.
+    if (event.type === "message_start") {
+      const chunks = this.closeOpenStreamBlocks();
+      this.streamedIndices.clear();
+      return chunks;
+    }
+    const index = event.index;
+    if (typeof index !== "number") return [];
+    if (event.type === "content_block_start") {
+      const block = event.content_block;
+      if (!isRecord(block)) return [];
+      const kind =
+        block.type === "text"
+          ? ("text" as const)
+          : block.type === "thinking"
+            ? ("reasoning" as const)
+            : null;
+      // tool_use blocks are announced from the `assistant` message instead.
+      if (!kind) return [];
+      const id = this.nextBlockId("stream");
+      this.openStreamBlocks.set(index, { id, kind });
+      this.streamedIndices.add(index);
+      return [{ type: `${kind}-start`, id } as UIMessageChunk];
+    }
+    if (event.type === "content_block_delta") {
+      const open = this.openStreamBlocks.get(index);
+      const delta = event.delta;
+      if (!open || !isRecord(delta)) return [];
+      const text =
+        open.kind === "text" && typeof delta.text === "string"
+          ? delta.text
+          : open.kind === "reasoning" && typeof delta.thinking === "string"
+            ? delta.thinking
+            : null;
+      // `signature_delta` on a thinking block, `input_json_delta` on a tool
+      // call: both arrive here and neither is renderable text.
+      if (text === null || text.length === 0) return [];
+      return [
+        {
+          type: `${open.kind}-delta`,
+          id: open.id,
+          delta: text,
+        } as UIMessageChunk,
+      ];
+    }
+    if (event.type === "content_block_stop") {
+      const open = this.openStreamBlocks.get(index);
+      if (!open) return [];
+      this.openStreamBlocks.delete(index);
+      return [{ type: `${open.kind}-end`, id: open.id } as UIMessageChunk];
+    }
+    return [];
+  }
+
+  /**
+   * End every block still open from `stream_event`. A stream that stops without
+   * `content_block_stop` (an interrupt, a crash mid-block) would otherwise
+   * leave a part that never closes, which the projector reassembles as
+   * unfinished forever.
+   */
+  private closeOpenStreamBlocks(): UIMessageChunk[] {
+    if (this.openStreamBlocks.size === 0) return [];
+    const chunks: UIMessageChunk[] = [];
+    for (const open of this.openStreamBlocks.values()) {
+      chunks.push({ type: `${open.kind}-end`, id: open.id } as UIMessageChunk);
+    }
+    this.openStreamBlocks.clear();
+    return chunks;
   }
 
   private nextBlockId(uuid: string): string {
@@ -145,10 +258,15 @@ export class UiChunkTranslator {
         (usage.cache_read_input_tokens ?? 0) +
         (usage.cache_creation_input_tokens ?? 0);
     }
-    const chunks: UIMessageChunk[] = [];
-    for (const block of message.message.content) {
+    // Anything the stream left open belongs to this message and must close
+    // before its blocks are restated.
+    const chunks: UIMessageChunk[] = this.closeOpenStreamBlocks();
+    for (const [index, block] of message.message.content.entries()) {
       if (!isRecord(block)) continue;
+      // Already emitted as deltas — restating it here would duplicate the text.
+      const streamed = this.streamedIndices.has(index);
       if (block.type === "text" && typeof block.text === "string") {
+        if (streamed) continue;
         // Empty text blocks are real in the SDK stream (a turn that only made
         // a tool call). Emitting start/end for them would create empty parts.
         if (block.text.length === 0) continue;
@@ -159,6 +277,7 @@ export class UiChunkTranslator {
         continue;
       }
       if (block.type === "thinking" && typeof block.thinking === "string") {
+        if (streamed) continue;
         if (block.thinking.length === 0) continue;
         const id = this.nextBlockId(message.uuid);
         chunks.push({ type: "reasoning-start", id });
@@ -180,6 +299,8 @@ export class UiChunkTranslator {
         });
       }
     }
+    // This message is fully accounted for; the next one's indices are its own.
+    this.streamedIndices.clear();
     return chunks;
   }
 

--- a/packages/sandbox/daemon-go/README.md
+++ b/packages/sandbox/daemon-go/README.md
@@ -16,7 +16,8 @@ implementation — the TypeScript daemon it replaced was deleted.
 Clone and set up the repo, install dependencies, run the dev script and other
 project tasks under a PTY, serve filesystem and Git operations, dispatch agent
 harness runs and stream their output as SSE, proxy preview HTTP/WebSocket traffic
-to the dev server, publish work back to git on shutdown, and report health so
+to the dev server, publish work back to git on shutdown and periodically
+mid-run, and report health so
 Studio can tell a live sandbox from a dead one.
 
 ### Dispatch is single-writer per run
@@ -46,7 +47,7 @@ Two properties the consumer depends on, both asserted in `daemon-e2e/`:
 | `internal/routes/` | HTTP surface: `/health`, `/_sandbox/*`, fs, git, bash, exec, tasks, tools, events |
 | `internal/setup/` | Clone, install, golden cache, dep metrics, orchestration |
 | `internal/dispatch/` | Agent run dispatch and harness runner |
-| `internal/gitx/` | Git: checkout, rebase, publish, branch status, protected-branch guard |
+| `internal/gitx/` | Git: checkout, rebase, publish, autosave checkpoints, branch status, protected-branch guard |
 | `internal/proc/` | PTY spawn, task manager, log tee, ring buffer, port sniffer |
 | `internal/config/` | Tenant config store: classify, merge, validate, persist |
 | `internal/events/` | SSE broadcast and replay |

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
@@ -162,6 +162,15 @@ func (reg *Registry) claim(runId string, cancel context.CancelFunc) (*activeRun,
 // CancelAll kills every in-flight run. Used on daemon shutdown: a running
 // harness holds CLIs writing into the tree the shutdown publish is about to
 // commit.
+// HasActiveRuns reports whether any harness run is in flight. Read by the
+// daemon's autosave loop: checkpoints exist to bound a run's loss window, and an
+// idle sandbox already syncs its tree on shutdown.
+func (reg *Registry) HasActiveRuns() bool {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	return len(reg.activeRuns) > 0
+}
+
 func (reg *Registry) CancelAll() {
 	reg.mu.Lock()
 	entries := make([]*activeRun, 0, len(reg.activeRuns))

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
@@ -159,9 +159,6 @@ func (reg *Registry) claim(runId string, cancel context.CancelFunc) (*activeRun,
 	}
 }
 
-// CancelAll kills every in-flight run. Used on daemon shutdown: a running
-// harness holds CLIs writing into the tree the shutdown publish is about to
-// commit.
 // HasActiveRuns reports whether any harness run is in flight. Read by the
 // daemon's autosave loop: checkpoints exist to bound a run's loss window, and an
 // idle sandbox already syncs its tree on shutdown.
@@ -171,6 +168,9 @@ func (reg *Registry) HasActiveRuns() bool {
 	return len(reg.activeRuns) > 0
 }
 
+// CancelAll kills every in-flight run. Used on daemon shutdown: a running
+// harness holds CLIs writing into the tree the shutdown publish is about to
+// commit.
 func (reg *Registry) CancelAll() {
 	reg.mu.Lock()
 	entries := make([]*activeRun, 0, len(reg.activeRuns))

--- a/packages/sandbox/daemon-go/internal/gitx/autosave.go
+++ b/packages/sandbox/daemon-go/internal/gitx/autosave.go
@@ -1,0 +1,185 @@
+package gitx
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// AutosaveInterval is how often a run's working tree is checkpointed to its
+// branch.
+//
+// The window it bounds is data loss, not latency: on a hard pod death
+// (OOMKill, node loss, SIGKILL) the daemon's shutdown sync never runs, so
+// whatever is uncommitted is gone and the replacement pod clones only what was
+// pushed. A long agent run that edits for many turns without committing had an
+// unbounded window before this existed.
+const AutosaveInterval = 2 * time.Minute
+
+// AutosaveMessage is the commit subject for every checkpoint. Fixed on purpose:
+// a reader scanning a branch's history needs to tell the agent's own deliberate
+// commits from the daemon's periodic ones at a glance.
+const AutosaveMessage = "chore(daemon): checkpoint work in progress"
+
+// AutosaveDeps is what the checkpoint loop needs from the daemon. Injected
+// rather than reached for, so the loop is testable without a daemon, a repo or
+// a network.
+type AutosaveDeps struct {
+	// Publish carries the same PublishDeps the shutdown sync uses. Its
+	// ReconcileRemote MUST stay false: a checkpoint that force-pushed could
+	// clobber a concurrent writer, and losing a checkpoint is strictly better
+	// than losing someone else's commit.
+	Publish PublishDeps
+	// Interval between checks. Zero means AutosaveInterval.
+	Interval time.Duration
+	// Lock is the daemon's working-tree lock. Held only for the publish itself.
+	Lock interface{ Acquire() func() }
+	// Configured reports whether a branch is known yet. False before the clone
+	// lands, when there is nothing to push to.
+	Configured func() bool
+	// RunActive reports whether a harness run is in flight. Checkpoints exist
+	// for runs; an idle sandbox already syncs on shutdown and does not need its
+	// tree committed under someone who is just browsing.
+	RunActive func() bool
+	// Dirty reports whether the tree has uncommitted changes. Checked WITHOUT
+	// the tree lock: it is a read, and a wrong answer only costs one skipped or
+	// one wasted cycle, whereas taking the lock every interval would stall
+	// writers for nothing on a clean tree.
+	Dirty func() bool
+	// publishFn is the publish to call. nil means the real Publish; set by tests.
+	publishFn func(PublishDeps, string) error
+}
+
+// Autosaver periodically commits and pushes a running agent's working tree to
+// its own branch, so a pod that dies without a grace period loses minutes of
+// work instead of the whole run.
+//
+// Non-blocking by construction: it owns a goroutine and never runs on a request
+// path. It takes the tree lock only around the publish, and the health probe
+// reads none of that state, so a slow push cannot make the pod look dead.
+//
+// Idempotent by construction: Publish stages the tree, commits ONLY when the
+// index is non-empty, and pushes; a tick that finds nothing new commits nothing
+// and pushes a no-op. Two ticks in a row on an unchanged tree leave one commit,
+// not two.
+//
+// ponytail: whole-tree checkpoint on a timer, no coalescing with the agent's own
+// commits and no attempt to squash the checkpoints afterwards. They are cheap and
+// they are on a feature branch that gets squash-merged. If the noise ever matters,
+// squash them at PR time — not by making the daemon clever about it.
+type Autosaver struct {
+	deps AutosaveDeps
+	stop chan struct{}
+	mu   sync.Mutex
+	// done is closed when the loop exits, so Stop can be called from shutdown
+	// without racing a publish already in flight.
+	done    chan struct{}
+	started bool
+}
+
+func NewAutosaver(deps AutosaveDeps) *Autosaver {
+	if deps.Interval <= 0 {
+		deps.Interval = AutosaveInterval
+	}
+	if deps.publishFn == nil {
+		deps.publishFn = Publish
+	}
+	return &Autosaver{
+		deps: deps,
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+}
+
+// Start runs the checkpoint loop until Stop. Safe to call once; later calls are
+// no-ops.
+func (a *Autosaver) Start() {
+	a.mu.Lock()
+	if a.started {
+		a.mu.Unlock()
+		return
+	}
+	a.started = true
+	a.mu.Unlock()
+	go a.loop()
+}
+
+// Stop ends the loop and waits for an in-flight checkpoint to finish, so the
+// shutdown sync that follows never races it for the tree lock.
+func (a *Autosaver) Stop() {
+	a.mu.Lock()
+	if !a.started {
+		a.mu.Unlock()
+		return
+	}
+	a.mu.Unlock()
+	select {
+	case <-a.stop:
+		// already stopping
+	default:
+		close(a.stop)
+	}
+	<-a.done
+}
+
+func (a *Autosaver) loop() {
+	defer close(a.done)
+	t := time.NewTicker(a.deps.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-a.stop:
+			return
+		case <-t.C:
+			a.Tick()
+		}
+	}
+}
+
+// Tick performs one checkpoint if the tree warrants it. Exported for the test:
+// the decision is the part worth asserting on, and driving it directly beats
+// waiting on a timer.
+func (a *Autosaver) Tick() {
+	if a.deps.Configured != nil && !a.deps.Configured() {
+		return
+	}
+	if a.deps.RunActive != nil && !a.deps.RunActive() {
+		return
+	}
+	// Cheap read, no lock. A clean tree is the common case and must cost nothing.
+	if a.deps.Dirty != nil && !a.deps.Dirty() {
+		return
+	}
+	if a.deps.Lock != nil {
+		release := a.deps.Lock.Acquire()
+		defer release()
+	}
+	// The tree lock serializes the daemon's own writers, NOT the agent: its
+	// edits go through Bash straight to the filesystem. So a checkpoint can
+	// capture a half-written file. That is acceptable for a checkpoint and only
+	// for a checkpoint — it is superseded by the next one and by the agent's own
+	// commit, and the alternative (cancelling the run to get a quiet tree, which
+	// is what shutdown does) is not available to a periodic save.
+	if err := a.deps.publishFn(a.deps.Publish, AutosaveMessage); err != nil {
+		// Never fatal. A checkpoint is best-effort: a detached HEAD mid-rebase, a
+		// protected branch, a transient push failure all mean "not this time",
+		// and the next tick tries again.
+		slog.Warn("autosave checkpoint failed", "err", err)
+		return
+	}
+	slog.Info("autosave checkpoint pushed")
+}
+
+// IsDirty reports whether the working tree has anything uncommitted. A cheap
+// porcelain read, deliberately not the full ComputeWorkingTreeStatus: the
+// checkpoint loop only needs the boolean, and it asks every interval.
+//
+// An error reads as clean. A tree whose status cannot be read is not one to
+// commit blind.
+func IsDirty(repoDir string) bool {
+	out, ok := tryReadGit(repoDir, []string{"status", "--porcelain=v1", "-z"})
+	if !ok {
+		return false
+	}
+	return len(ParsePorcelainZ(out)) > 0
+}

--- a/packages/sandbox/daemon-go/internal/gitx/autosave_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/autosave_test.go
@@ -1,0 +1,200 @@
+package gitx
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeLock records whether the checkpoint took the tree lock, and whether it
+// gave it back. A checkpoint that leaks the lock deadlocks every fs write and
+// the shutdown sync behind it.
+type fakeLock struct {
+	acquired int
+	released int
+}
+
+func (l *fakeLock) Acquire() func() {
+	l.acquired++
+	return func() { l.released++ }
+}
+
+type recorder struct {
+	mu       sync.Mutex
+	messages []string
+	err      error
+}
+
+func (r *recorder) publish(_ PublishDeps, msg string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.messages = append(r.messages, msg)
+	return r.err
+}
+
+func (r *recorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.messages)
+}
+
+// harness builds an Autosaver whose every gate is on and whose publish is
+// recorded. Each test flips the one gate it is about.
+func harness(t *testing.T, rec *recorder) (*Autosaver, *fakeLock) {
+	t.Helper()
+	lock := &fakeLock{}
+	a := NewAutosaver(AutosaveDeps{
+		Lock:       lock,
+		Configured: func() bool { return true },
+		RunActive:  func() bool { return true },
+		Dirty:      func() bool { return true },
+		publishFn:  rec.publish,
+	})
+	return a, lock
+}
+
+func TestTickPublishesWhenRunningAndDirty(t *testing.T) {
+	rec := &recorder{}
+	a, lock := harness(t, rec)
+	a.Tick()
+	if rec.count() != 1 {
+		t.Fatalf("want 1 publish, got %d", rec.count())
+	}
+	if rec.messages[0] != AutosaveMessage {
+		t.Fatalf("want fixed checkpoint message, got %q", rec.messages[0])
+	}
+	if lock.acquired != 1 || lock.released != 1 {
+		t.Fatalf("tree lock acquired %d released %d, want 1/1", lock.acquired, lock.released)
+	}
+}
+
+func TestTickSkipsWhenTreeIsClean(t *testing.T) {
+	rec := &recorder{}
+	lock := &fakeLock{}
+	a := NewAutosaver(AutosaveDeps{
+		Lock:       lock,
+		Configured: func() bool { return true },
+		RunActive:  func() bool { return true },
+		Dirty:      func() bool { return false },
+		publishFn:  rec.publish,
+	})
+	a.Tick()
+	if rec.count() != 0 {
+		t.Fatalf("clean tree must not publish, got %d", rec.count())
+	}
+	// The whole point of checking dirty first: a clean tree must not stall
+	// writers behind the tree lock every interval.
+	if lock.acquired != 0 {
+		t.Fatalf("clean tree must not take the tree lock, took it %d times", lock.acquired)
+	}
+}
+
+func TestTickSkipsWhenNoRunIsActive(t *testing.T) {
+	rec := &recorder{}
+	a := NewAutosaver(AutosaveDeps{
+		Configured: func() bool { return true },
+		RunActive:  func() bool { return false },
+		Dirty:      func() bool { return true },
+		publishFn:  rec.publish,
+	})
+	a.Tick()
+	if rec.count() != 0 {
+		t.Fatalf("idle sandbox must not checkpoint, got %d", rec.count())
+	}
+}
+
+func TestTickSkipsBeforeABranchIsConfigured(t *testing.T) {
+	rec := &recorder{}
+	a := NewAutosaver(AutosaveDeps{
+		Configured: func() bool { return false },
+		RunActive:  func() bool { return true },
+		Dirty:      func() bool { return true },
+		publishFn:  rec.publish,
+	})
+	a.Tick()
+	if rec.count() != 0 {
+		t.Fatalf("no branch means nothing to push to, got %d", rec.count())
+	}
+}
+
+func TestTickSurvivesAPublishFailure(t *testing.T) {
+	rec := &recorder{err: errors.New("detached HEAD mid-rebase")}
+	a, lock := harness(t, rec)
+	// A failed checkpoint must not panic, must not abort the loop, and must give
+	// the tree lock back — the next tick has to be able to run.
+	a.Tick()
+	a.Tick()
+	if rec.count() != 2 {
+		t.Fatalf("want a retry on the next tick, got %d publishes", rec.count())
+	}
+	if lock.released != 2 {
+		t.Fatalf("failed checkpoint leaked the tree lock: released %d of 2", lock.released)
+	}
+}
+
+func TestTickIsIdempotentOnAnUnchangedTree(t *testing.T) {
+	// Publish itself commits only when the index is non-empty, so a second tick
+	// over the same content is a no-op commit and a no-op push. What this pins is
+	// that the loop does not invent extra work of its own: same tree, same fixed
+	// message, no accumulating state between ticks.
+	rec := &recorder{}
+	a, _ := harness(t, rec)
+	a.Tick()
+	a.Tick()
+	if rec.count() != 2 {
+		t.Fatalf("want 2 publish calls, got %d", rec.count())
+	}
+	if rec.messages[0] != rec.messages[1] {
+		t.Fatalf("checkpoint message drifted: %q then %q", rec.messages[0], rec.messages[1])
+	}
+}
+
+func TestStopWaitsForTheLoopToExit(t *testing.T) {
+	rec := &recorder{}
+	a := NewAutosaver(AutosaveDeps{
+		Interval:   time.Millisecond,
+		Configured: func() bool { return true },
+		RunActive:  func() bool { return true },
+		Dirty:      func() bool { return true },
+		publishFn:  rec.publish,
+	})
+	a.Start()
+	// Shutdown calls Stop before its own publish; if Stop returned early the two
+	// would race for the tree lock.
+	done := make(chan struct{})
+	go func() {
+		a.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not return")
+	}
+	// Idempotent: shutdown can be reached twice.
+	a.Stop()
+}
+
+func TestStopBeforeStartIsANoOp(t *testing.T) {
+	a := NewAutosaver(AutosaveDeps{})
+	// A daemon that dies during boot reaches shutdown without ever starting the
+	// loop; Stop must not block on a `done` no goroutine will close.
+	done := make(chan struct{})
+	go func() {
+		a.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop blocked on an unstarted autosaver")
+	}
+}
+
+func TestDefaultIntervalIsApplied(t *testing.T) {
+	a := NewAutosaver(AutosaveDeps{})
+	if a.deps.Interval != AutosaveInterval {
+		t.Fatalf("want default %v, got %v", AutosaveInterval, a.deps.Interval)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/gitx/exclude_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/exclude_test.go
@@ -110,3 +110,42 @@ func TestEnsureExcludeHidesAlreadyCommittedDaemonPaths(t *testing.T) {
 		t.Fatalf("`git add -A` staged a daemon-managed path: %q", staged)
 	}
 }
+
+// A `.env` the agent wrote is a live credential, and the autosave loop publishes
+// unattended — so publish must never carry one to the branch, wherever it sits.
+func TestPublishNeverCommitsDotenv(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature/x")
+	if err := os.MkdirAll(filepath.Join(repo, "apps", "api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, rel := range []string{".env", ".env.local", "apps/api/.env"} {
+		if err := os.WriteFile(filepath.Join(repo, filepath.FromSlash(rel)), []byte("TOKEN=synthetic-not-a-real-token\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// `.envrc` is committed on purpose by plenty of repos; the guard must not eat it.
+	if err := os.WriteFile(filepath.Join(repo, ".envrc"), []byte("use flake\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "app.ts"), []byte("export const x = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fails at the push (no remote); the commit it builds first is the artifact.
+	_ = Publish(PublishDeps{RepoDir: repo}, "sync")
+
+	committed := gitIn(t, repo, "show", "--pretty=format:", "--name-only", "HEAD")
+	for _, rel := range []string{".env", ".env.local", "apps/api/.env"} {
+		for _, line := range strings.Split(committed, "\n") {
+			if strings.TrimSpace(line) == rel {
+				t.Fatalf("publish committed %s: %q", rel, committed)
+			}
+		}
+	}
+	if !strings.Contains(committed, ".envrc") {
+		t.Fatalf("publish dropped .envrc, which is not a secret: %q", committed)
+	}
+	if !strings.Contains(committed, "app.ts") {
+		t.Fatalf("publish dropped the user's work too: %q", committed)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/gitx/publish.go
+++ b/packages/sandbox/daemon-go/internal/gitx/publish.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -106,20 +107,38 @@ func changedPaths(status WorkingTreeStatus) []string {
 // run's MCP bearer token, which a push would leak into the repo's history.
 var NeverCommit = []string{".deco/tools/"}
 
+// dotenvName reports whether a file name is a `.env` variant — `.env` itself or
+// `.env.<anything>` (`.env.local`, `.env.production`). NOT `.envrc`, which repos
+// commit on purpose.
+func dotenvName(base string) bool {
+	return base == ".env" || strings.HasPrefix(base, ".env.")
+}
+
 // dropNeverCommit filters {@link NeverCommit} paths out of a publish's file list.
+//
+// Also drops `.env` files anywhere in the tree. They only reach this list when
+// the repo forgot to ignore them, but then they hold live credentials and the
+// autosave loop (autosave.go) pushes unattended every couple of minutes — so a
+// secret the agent wrote and would have deleted before finishing reaches the
+// branch, and GitHub, first. A push is irreversible (a force-push does not undo
+// a leak), which is what makes dropping them the safe default even though it
+// means a repo that genuinely tracks a `.env` cannot change it from a sandbox.
 func dropNeverCommit(paths []string) []string {
 	out := make([]string, 0, len(paths))
 	for _, p := range paths {
 		rel := strings.TrimPrefix(filepath.ToSlash(p), "./")
-		skip := false
+		reason := ""
+		if dotenvName(path.Base(rel)) {
+			reason = "dotenv file"
+		}
 		for _, deny := range NeverCommit {
 			if rel == strings.TrimSuffix(deny, "/") || strings.HasPrefix(rel, deny) {
-				skip = true
+				reason = "daemon-managed path"
 				break
 			}
 		}
-		if skip {
-			slog.Warn("skipping from sync", "reason", "daemon-managed path", "path", rel)
+		if reason != "" {
+			slog.Warn("skipping from sync", "reason", reason, "path", rel)
 			continue
 		}
 		out = append(out, p)

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -83,6 +83,7 @@ type daemon struct {
 	phases       *proc.PhaseManager
 	tasks        *proc.TaskManager
 	branchStatus *gitx.BranchStatusMonitor
+	autosave     *gitx.Autosaver
 	orchestrator *setup.Orchestrator
 	prober       *probe.Prober
 	proxyHandler *proxy.Handler
@@ -584,6 +585,11 @@ func (d *daemon) shutdown() {
 
 	d.tasks.Shutdown()
 	d.branchStatus.Stop()
+	// Before the sync below: Stop waits out an in-flight checkpoint, so the two
+	// publishes cannot interleave on the tree lock.
+	if d.autosave != nil {
+		d.autosave.Stop()
+	}
 	// Before the publish, and unconditionally: a running harness holds CLIs that
 	// would otherwise keep writing into the tree the publish is about to commit.
 	d.dispatchReg.CancelAll()
@@ -923,6 +929,36 @@ func main() {
 	)
 
 	d.dispatchReg = dispatch.NewRegistry()
+	// Checkpoint a running agent's tree to its own branch every couple of
+	// minutes. Without it, a pod killed with no grace period (OOM, node loss)
+	// loses everything the agent had not committed itself — the shutdown sync
+	// below only runs on SIGTERM.
+	d.autosave = gitx.NewAutosaver(gitx.AutosaveDeps{
+		Publish: gitx.PublishDeps{
+			RepoDir: repoDir,
+			GetCloneUrl: func() string {
+				if cfg := d.store.Read(); cfg != nil {
+					return cfg.CloneUrl()
+				}
+				return ""
+			},
+			GetOperator: d.operatorIdentity,
+			// Same disposition as the shutdown sync: one invalid block must not
+			// cost the user every other change in the checkpoint.
+			OnInvalidBlock: gitx.InvalidBlockSkip,
+			// Never force-push from a checkpoint. Losing one checkpoint beats
+			// clobbering a concurrent writer's commit.
+			ReconcileRemote: false,
+		},
+		Lock: &d.treeLock,
+		Configured: func() bool {
+			cfg := d.store.Read()
+			return cfg != nil && cfg.Branch() != ""
+		},
+		RunActive: func() bool { return d.dispatchReg.HasActiveRuns() },
+		Dirty:     func() bool { return gitx.IsDirty(repoDir) },
+	})
+	d.autosave.Start()
 	d.dispatchDeps = dispatch.Deps{
 		DaemonToken:      d.getToken,
 		AppRoot:          appRoot,


### PR DESCRIPTION
## Why

A super-agent run on the task board looked dead for 30+ minutes while it was in fact working normally. Investigating it in prod turned up three separate causes, none of which was a crash.

## What

### 1. Stream claude-code tokens instead of whole messages

`buildOptions` never set `includePartialMessages`, so the SDK yielded only **complete** assistant messages. A paragraph reached the UI as one ~5KB frame after the model had finished writing it — a run mid-sentence was indistinguishable from a run that had died. The pod log showed it plainly: `bytes=57` envelope, then `bytes=5404`.

Enables partial messages and translates the resulting `stream_event` content-block events into the same `UIMessageChunk` vocabulary. The `assistant` message still restates every block, so indices already streamed are skipped there rather than emitted twice. Tool calls continue to come from the `assistant` message: `input_json_delta` is partial JSON, and the tool-input-before-output contract the projector enforces needs a complete input.

Deltas are coalesced before becoming dispatch frames (`createDeltaCoalescer`, ~200 chars, size-based, no timer). One frame per token would push tens of thousands of ~60-byte frames per run through the daemon, JetStream and every open SSE connection. Postgres was never at risk — parts persist per `finish-step` and deltas fold into a single part.

No flag. On for everyone.

### 2. Count up on a long-running tool call

Most of the run's wall-clock was multi-minute `Bash` calls. The existing live countdown needs a known duration, so it only covered bash `sleep`; everything else showed `"Preparing…"` for its entire duration, which is the frame that reads as a hang.

`ToolElapsedSummary` reuses that component's anchor resolution (the part's server-stamped `created_at`, else a `sessionStorage`-backed first-observed time) so a reload keeps counting from when the call actually fired. Hidden under 10s — a counter on every fast call is worse than none. Both locales.

### 3. Checkpoint a running agent's work to its branch

The daemon only published the working tree on SIGTERM (`main.go` `shutdown()`). A pod killed with **no** grace period — OOMKill, node loss, SIGKILL — lost everything the agent had not committed itself, and the replacement pod clones only what reached the branch. A long run editing across many turns had an unbounded loss window. The recovery path already assumes "last state pushed to the branch"; the only thing missing was branch freshness.

Adds a background checkpoint loop: every 2 min, if a harness run is in flight and the tree is dirty, `gitx.Publish` to the run's own branch — same branch, same PR the agent is working on.

- **Non-blocking**: own goroutine, never on a request path. Tree lock held only around the publish; the health probe reads none of that state, so a slow push cannot make the pod look dead. The dirty check is deliberately *outside* the lock so a clean tree never stalls writers.
- **Idempotent**: `Publish` commits only when the index is non-empty, so a tick over unchanged content commits nothing and pushes a no-op.
- **Bounded blast radius**: `ReconcileRemote` stays off, so a checkpoint can never force-push over a concurrent writer. `OnInvalidBlock: skip` matches the shutdown sync.
- Shutdown stops the loop and waits for an in-flight checkpoint before its own sync, so the two never race for the tree lock.

## Deliberately not in scope

**Reconnect backfill was already built.** `routes.ts` sets `deliverPolicy = thread.status === "in_progress" ? "all" : "new"`, replaying the whole per-thread JetStream subject; the client dedupes by id and calls `refetchLatestPage()` on every reconnect. Nothing to add — it was on the original plan until the code said otherwise.

A `499` in the access log initially looked like a browser SSE drop. It was `claude-code/2.1.220` on `/mcp/task-run/…` — the in-sandbox agent's own MCP client, unrelated to the UI.

## Known ceiling

A checkpoint can capture a half-written file: the tree lock serializes the *daemon's* writers, not the agent, whose edits go through Bash straight to the filesystem. Acceptable for a checkpoint specifically — it is superseded by the next one and by the agent's own commit — and the alternative (cancelling the run for a quiet tree, which is what shutdown does) isn't available to a periodic save. Called out in the code comment.

**A checkpoint pushes to the PR branch, so it re-triggers whatever watches that branch** — CI, cubic, review notifications — at up to one per `AutosaveInterval` (2 min) for as long as a run keeps editing. That is the cost of the branch being the recovery contract; `AutosaveInterval` is the knob if the noise outweighs the loss window it bounds.

Publish drops `.env` / `.env.<x>` anywhere in the tree (`dropNeverCommit`). Unattended two-minute pushes are what makes that load-bearing: a secret the agent wrote and would have deleted before finishing would otherwise reach the branch, and GitHub, first — and a push is irreversible.

## Testing

- `packages/harness-runner`: 68 tests. New coverage for stream-event translation, the no-double-emit guard, interrupted blocks left open, and 8 coalescer cases. One of them caught a real latent bug — the coalescer merged on `id` alone, so a reasoning delta could merge into a text part on an id collision; now keyed on type + id.
- Inverted the test that asserted `stream_event` → `[]`.
- `daemon-go`: 12 new tests covering each gate, lock acquire/release (including on failure), idempotency, and `Stop` before `Start`. `go test ./...` and `-race` clean.
- `apps/web`: 416 chat tests pass.
- `bun run check` clean across all 14 workspaces. `bun run lint` 0 errors (19 warnings, all pre-existing, none in touched files). `knip` clean. `bun run fmt` applied.

**Not run:** Playwright e2e and the resilience suite (need Docker/Postgres). Worth a run before merge, e2e especially for the chat stream.

## Review notes

Frame volume is the thing to watch after deploy — the coalescer threshold is the knob (`DELTA_FLUSH_CHARS`), and `AutosaveInterval` is the other. Neither is configurable by design; both are one-line changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three causes of a super-agent run appearing dead: token streaming, an elapsed counter for long-running tools, and periodic git checkpoints.

- Enables `includePartialMessages` in the Claude Code SDK.
- Translates `stream_event` content-block deltas into the same `UIMessageChunk` vocabulary.
- Coalesces adjacent deltas before dispatch so token streaming doesn't become per-token frames.
- Skips blocks already streamed when the assistant message restates them; tool calls still come from the complete message.
- Shows "Running for Ns" on any still-running tool call after 10 seconds, using the call's server timestamp or a `sessionStorage` fallback so a reload keeps counting.
- Adds an autosave loop to `daemon-go` that commits and pushes a dirty working tree to the run's branch every 2 minutes while a run is active.
- Autosave is non-blocking, idempotent, never force-pushes, and stops before shutdown sync.
- Publish also refuses `.env` / `.env.<x>` files anywhere in the tree, since the loop pushes unattended and a push is irreversible.

<sup>Written for commit deb824a70363ba4a9e032af2436b4f1ac4576118. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

