### PR TITLE
feat(content): edit page JSON in a side panel instead of a read-only modal

### DIFF
--- a/apps/web/src/components/sandbox/blocks/blocks-panel.tsx
+++ b/apps/web/src/components/sandbox/blocks/blocks-panel.tsx
@@ -33,6 +33,7 @@ const SectionsEditor = lazy(() =>
 export function BlocksPanel({
   virtualMcpId,
   externalSelection = null,
+  onViewJsonFile,
 }: {
   virtualMcpId: string;
   /**
@@ -41,6 +42,11 @@ export function BlocksPanel({
    * distinct selections, so re-clicking one reopens its form.
    */
   externalSelection?: { index: number; seq: number } | null;
+  /**
+   * Open the page's raw JSON in a side panel (Preview owns the slot). When
+   * omitted the editor falls back to its local modal.
+   */
+  onViewJsonFile?: (pageKey: string) => void;
 }) {
   const { org } = useProjectContext();
   const { currentBranch, taskId } = useChatTask();
@@ -169,6 +175,7 @@ export function BlocksPanel({
           }
           onExitSeo={workspace.consumeEditSeo}
           onVariantPreviewOverride={workspace.setVariantOverride}
+          onViewJsonFile={onViewJsonFile}
         />
       </Suspense>
     </div>

--- a/apps/web/src/components/sandbox/blocks/page-json-panel.tsx
+++ b/apps/web/src/components/sandbox/blocks/page-json-panel.tsx
@@ -1,0 +1,130 @@
+import { type Ref, useImperativeHandle } from "react";
+import { Loading01, X } from "@untitledui/icons";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { MonacoCodeEditor } from "@/components/monaco-editor";
+import { useProjectContext } from "@/sdk";
+import { useChatTask } from "@/components/chat/context";
+import { useSandboxLifecycle } from "@/components/sandbox/hooks/sandbox-lifecycle-context";
+import { useDecofile } from "@/components/sections-editor/use-decofile";
+import { useDebouncedSaveBlock } from "@/components/sections-editor/use-save-block";
+import { useT } from "@/i18n/use-t.ts";
+
+/**
+ * Editable Page JSON side panel. Renders alongside the CMS (Blocks) panel — same
+ * width — instead of a modal, so the raw decofile entry can be edited in place
+ * while the preview stays visible. Mirrors {@link BlocksPanel}'s data wiring
+ * (decofile read + debounced block write): edits autosave once they settle, the
+ * same way the section forms do — no explicit Save button. Invalid JSON mid-edit
+ * is skipped silently until it parses again.
+ */
+export interface PageJsonPanelHandle {
+  /** Persist any edit still inside the autosave debounce window. */
+  flush: () => void;
+}
+
+export function PageJsonPanel({
+  virtualMcpId,
+  pageKey,
+  onClose,
+  ref,
+}: {
+  virtualMcpId: string;
+  pageKey: string;
+  onClose: () => void;
+  ref?: Ref<PageJsonPanelHandle>;
+}) {
+  const t = useT();
+  const { org } = useProjectContext();
+  const { currentBranch, taskId } = useChatTask();
+  const lifecycle = useSandboxLifecycle();
+  const previewUrl = lifecycle.previewUrl;
+
+  const fetchParams = currentBranch
+    ? {
+        orgSlug: org.slug,
+        virtualMcpId,
+        branch: currentBranch,
+        threadId: taskId ?? null,
+        previewUrl,
+      }
+    : null;
+
+  const decofile = useDecofile(fetchParams);
+  const { save, flush } = useDebouncedSaveBlock({
+    orgSlug: org.slug,
+    virtualMcpId,
+    branch: currentBranch ?? "",
+  });
+
+  const pageData = decofile.data?.[pageKey];
+  const loading = decofile.data === undefined && decofile.isLoading;
+  const missing = decofile.data !== undefined && pageData === undefined;
+  const readOnly = !currentBranch || missing || loading;
+  const initialJson =
+    pageData === undefined ? "" : JSON.stringify(pageData, null, 2);
+
+  const scheduleSave = (raw: string) => {
+    if (readOnly) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      return;
+    }
+    save(pageKey, parsed as Record<string, unknown>);
+  };
+
+  // Parent close paths flush through this so a debounce-window edit still saves.
+  useImperativeHandle(ref, () => ({ flush }));
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
+      <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2.5">
+        <div className="min-w-0 flex-1 truncate text-sm font-semibold">
+          {t("sectionsEditor.pageJsonDialog.titleShort")}
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          aria-label={t("sectionsEditor.pageJsonDialog.close")}
+          className="size-7 shrink-0"
+        >
+          <X size={14} />
+        </Button>
+      </div>
+      {loading ? (
+        <div className="flex flex-1 items-center justify-center">
+          <Loading01 size={20} className="animate-spin text-muted-foreground" />
+        </div>
+      ) : missing ? (
+        <div className="p-4 text-xs font-mono text-foreground/60">
+          // {t("sectionsEditor.pageJsonDialog.pageNotFound")}
+        </div>
+      ) : (
+        <div className="min-h-0 flex-1">
+          <MonacoCodeEditor
+            // Remount from the freshest snapshot once the decofile read lands.
+            key={`${pageKey}:${decofile.data === undefined ? "loading" : "ready"}`}
+            code={initialJson}
+            language="json"
+            readOnly={readOnly}
+            height="100%"
+            onChange={(v) => scheduleSave(v ?? "")}
+            onSave={(v) => {
+              scheduleSave(v);
+              flush();
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -145,6 +145,10 @@ import { useSandboxRepoDir } from "../hooks/use-sandbox-repo-dir";
 import { useBlocksPreviewWorkspace } from "@/components/sandbox/blocks/blocks-preview-workspace-context";
 import { BlocksPanel } from "@/components/sandbox/blocks/blocks-panel";
 import {
+  PageJsonPanel,
+  type PageJsonPanelHandle,
+} from "@/components/sandbox/blocks/page-json-panel";
+import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
@@ -362,6 +366,21 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   } | null>(null);
   const previewIframeRef = useRef<HTMLIFrameElement>(null);
   const blocksPanelRef = useRef<PanelImperativeHandle>(null);
+  // Page key whose raw JSON is open in the side panel next to Blocks (null = closed).
+  const [jsonPageKey, setJsonPageKey] = useState<string | null>(null);
+  const jsonPanelHandleRef = useRef<PageJsonPanelHandle>(null);
+  const closeJsonPanel = () => {
+    jsonPanelHandleRef.current?.flush();
+    setJsonPageKey(null);
+  };
+  const toggleJsonPanel = (pageKey: string) =>
+    setJsonPageKey((current) => {
+      if (current === pageKey) {
+        jsonPanelHandleRef.current?.flush();
+        return null;
+      }
+      return pageKey;
+    });
   // Live canvas size, used to scale the fixed-width frame to fit.
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
   /** Origin most recently confirmed registered with the native shell via
@@ -1095,6 +1114,8 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
       if (mode === "blocks") blocksPanelRef.current?.resize("30%");
       else blocksPanelRef.current?.collapse();
     }
+    // The JSON side panel only makes sense next to the Blocks editor.
+    if (mode !== "blocks") closeJsonPanel();
     setEditingMode(mode);
     setVisualElement(null);
     setCmsSelectedSection(null);
@@ -1960,7 +1981,18 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             <BlocksPanel
               virtualMcpId={virtualMcpId}
               externalSelection={cmsSelectedSection}
+              onViewJsonFile={toggleJsonPanel}
             />
+            {jsonPageKey && (
+              <div className="absolute inset-0 z-10">
+                <PageJsonPanel
+                  ref={jsonPanelHandleRef}
+                  virtualMcpId={virtualMcpId}
+                  pageKey={jsonPageKey}
+                  onClose={closeJsonPanel}
+                />
+              </div>
+            )}
             {isMobile && floatingPreviewControls}
           </div>
         ) : (
@@ -1981,6 +2013,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                 <BlocksPanel
                   virtualMcpId={virtualMcpId}
                   externalSelection={cmsSelectedSection}
+                  onViewJsonFile={toggleJsonPanel}
                 />
               )}
             </ResizablePanel>
@@ -1993,189 +2026,222 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
               minSize="35%"
               className="min-w-0 overflow-hidden"
             >
-              <div
-                ref={(node) => {
-                  if (!node) return;
-                  const measure = () =>
-                    setCanvasSize((prev) =>
-                      prev.width === node.clientWidth &&
-                      prev.height === node.clientHeight
-                        ? prev
-                        : {
-                            width: node.clientWidth,
-                            height: node.clientHeight,
-                          },
-                    );
-                  measure();
-                  const observer = new ResizeObserver(measure);
-                  observer.observe(node);
-                  return () => observer.disconnect();
-                }}
-                className={cn(
-                  // `overflow-clip`, not `hidden`: the scaled frame's layout box outgrows this container, and a scroll port would let the browser scroll it to reveal a focused descendant (section select), jumping the preview up.
-                  "h-full relative overflow-clip flex justify-center",
-                  previewSurfaceActive && !previewFluid && "bg-muted/30",
-                )}
+              <ResizablePanelGroup
+                orientation="horizontal"
+                disabled={!jsonPageKey}
               >
-                {/* Asymptotic "commit ramp" progress: brand lime fill over a
+                {jsonPageKey && (
+                  <>
+                    <ResizablePanel
+                      id="preview-json-editor"
+                      defaultSize="43%"
+                      minSize="20%"
+                      className="min-w-0 overflow-hidden"
+                    >
+                      <PageJsonPanel
+                        ref={jsonPanelHandleRef}
+                        virtualMcpId={virtualMcpId}
+                        pageKey={jsonPageKey}
+                        onClose={closeJsonPanel}
+                      />
+                    </ResizablePanel>
+                    <ResizableHandle withHandle />
+                  </>
+                )}
+                <ResizablePanel
+                  id="preview-canvas-inner"
+                  minSize="30%"
+                  className="min-w-0 overflow-hidden"
+                >
+                  <div
+                    ref={(node) => {
+                      if (!node) return;
+                      const measure = () =>
+                        setCanvasSize((prev) =>
+                          prev.width === node.clientWidth &&
+                          prev.height === node.clientHeight
+                            ? prev
+                            : {
+                                width: node.clientWidth,
+                                height: node.clientHeight,
+                              },
+                        );
+                      measure();
+                      const observer = new ResizeObserver(measure);
+                      observer.observe(node);
+                      return () => observer.disconnect();
+                    }}
+                    className={cn(
+                      // `overflow-clip`, not `hidden`: the scaled frame's layout box outgrows this container, and a scroll port would let the browser scroll it to reveal a focused descendant (section select), jumping the preview up.
+                      "h-full relative overflow-clip flex justify-center",
+                      previewSurfaceActive && !previewFluid && "bg-muted/30",
+                    )}
+                  >
+                    {/* Asymptotic "commit ramp" progress: brand lime fill over a
                     transparent track — no strip across the site, just the
                     moving edge itself, with a soft same-color glow for
                     presence on busy content. */}
-                {(navigating || decofileWriting) && previewSurfaceActive && (
-                  <div className="absolute inset-x-0 top-0 z-40 h-1 overflow-hidden">
-                    <div className="absolute inset-y-0 left-0 rounded-r-full bg-brand shadow-[0_0_6px] shadow-brand/60 animate-preview-ramp" />
-                  </div>
-                )}
+                    {(navigating || decofileWriting) &&
+                      previewSurfaceActive && (
+                        <div className="absolute inset-x-0 top-0 z-40 h-1 overflow-hidden">
+                          <div className="absolute inset-y-0 left-0 rounded-r-full bg-brand shadow-[0_0_6px] shadow-brand/60 animate-preview-ramp" />
+                        </div>
+                      )}
 
-                {display.showBlockingOverlay && (
-                  <div className="absolute inset-0 z-30">
-                    <SandboxStateCard
-                      kind="starting"
-                      progress={progress}
-                      claimPhase={claimPhase}
-                    />
-                  </div>
-                )}
-
-                {previewState.kind === "suspended" && (
-                  <div className="absolute inset-0 z-30">
-                    <SandboxStateCard
-                      kind="suspended"
-                      onResume={lifecycle.resume}
-                    />
-                  </div>
-                )}
-
-                {previewState.kind === "errored" && (
-                  <div className="absolute inset-0 z-30">
-                    <SandboxStateCard
-                      kind="errored"
-                      error={previewState.error}
-                      onRetry={lifecycle.retry}
-                      connectionsHref={`/${org.slug}/settings/connections`}
-                    />
-                  </div>
-                )}
-
-                {display.showWakingPill && (
-                  <div className="absolute top-4 left-1/2 z-20 flex max-w-md -translate-x-1/2 items-start gap-3 rounded-xl border border-border bg-muted px-4 py-3 shadow-lg pointer-events-none select-none">
-                    <Loading01
-                      size={18}
-                      className="mt-0.5 shrink-0 animate-spin text-muted-foreground"
-                    />
-                    <div className="flex flex-col gap-0.5">
-                      <span className="text-sm font-medium text-foreground">
-                        {t("sandbox.preview.startingPreview")}
-                      </span>
-                      <span className="text-xs text-muted-foreground">
-                        {t("sandbox.preview.startingPreviewHint")}
-                      </span>
-                    </div>
-                  </div>
-                )}
-
-                {effectiveEditingMode === "visual" && !visualElement && (
-                  <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 rounded-full border border-violet-400/40 bg-violet-500/90 px-3 py-1 text-xs font-medium text-white shadow-md backdrop-blur-sm pointer-events-none select-none">
-                    <CursorClick01 size={12} />
-                    {t("sandbox.preview.clickElementToAsk")}
-                  </div>
-                )}
-                {effectiveEditingMode === "visual" && visualElement && (
-                  <VisualEditorPrompt
-                    element={visualElement}
-                    onDismiss={() => setVisualElement(null)}
-                  />
-                )}
-
-                {floatingPreviewControls}
-
-                {previewSurfaceActive && iframeSrc && (
-                  <div
-                    className={cn(
-                      "shrink-0",
-                      !previewFluid &&
-                        "border-x border-border bg-background shadow-sm",
+                    {display.showBlockingOverlay && (
+                      <div className="absolute inset-0 z-30">
+                        <SandboxStateCard
+                          kind="starting"
+                          progress={progress}
+                          claimPhase={claimPhase}
+                        />
+                      </div>
                     )}
-                    style={previewFrameStyle}
-                  >
-                    <iframe
-                      // Key on the iframe base: remount when the base URL changes
-                      // (branch switch, or the production→sandbox swap once the dev
-                      // server is up). Path navigation is driven by `iframeSrc`.
-                      key={display.iframeBase}
-                      ref={previewIframeRef}
-                      src={iframeSrc}
-                      className="w-full h-full border-0"
-                      title={t("sandbox.preview.devServerPreviewTitle")}
-                      onError={iframeRecovery.handleError}
-                      onLoad={() => {
-                        // A load reached the frame — cancel the recovery watchdog
-                        // and reset its backoff before anything else.
-                        iframeRecovery.handleLoad();
-                        // The page finished loading — always clear the navigation
-                        // indicator first, before any of the early returns below.
-                        endNavigation();
-                        // Production (Fast Preview) frame is cross-origin: skip the sandbox-only load handling, but the site's real pages still take the CMS overlay via the framework's `editor::inject` listener.
-                        if (display.mode !== "sandbox") {
-                          if (
-                            display.mode === "production" &&
-                            !display.showWakingPill &&
-                            editingMode === "blocks"
-                          ) {
-                            injectCmsEditor();
-                          }
-                          return;
-                        }
-                        // This is the VM dev-server preview (sandboxed running app),
-                        // NOT an MCP app. MCP apps render via <MCPAppRenderer/>.
-                        track("vm_preview_loaded", {
-                          view_mode: editingMode,
-                          vm_id: vmEntry?.sandboxHandle ?? null,
-                          // Intentionally excluding the full previewUrl — it can contain
-                          // ephemeral tokens / user data in the query string.
-                        });
-                        // Sync currentPath when the user navigates inside the iframe.
-                        // Skip while a programmatic navigation is pending — stale
-                        // onLoad events from the previous URL would reset us to "/".
-                        if (!activeGlobalSection) {
-                          try {
-                            const iframePath =
-                              previewIframeRef.current?.contentWindow?.location
-                                ?.pathname;
-                            if (!iframePath) return;
-                            const intended = intendedPathRef.current;
-                            if (intended !== null) {
-                              intendedPathRef.current = null;
-                              // Stale onLoad from the previous URL — ignore.
-                              if (normPath(iframePath) !== normPath(intended)) {
-                                return;
+
+                    {previewState.kind === "suspended" && (
+                      <div className="absolute inset-0 z-30">
+                        <SandboxStateCard
+                          kind="suspended"
+                          onResume={lifecycle.resume}
+                        />
+                      </div>
+                    )}
+
+                    {previewState.kind === "errored" && (
+                      <div className="absolute inset-0 z-30">
+                        <SandboxStateCard
+                          kind="errored"
+                          error={previewState.error}
+                          onRetry={lifecycle.retry}
+                          connectionsHref={`/${org.slug}/settings/connections`}
+                        />
+                      </div>
+                    )}
+
+                    {display.showWakingPill && (
+                      <div className="absolute top-4 left-1/2 z-20 flex max-w-md -translate-x-1/2 items-start gap-3 rounded-xl border border-border bg-muted px-4 py-3 shadow-lg pointer-events-none select-none">
+                        <Loading01
+                          size={18}
+                          className="mt-0.5 shrink-0 animate-spin text-muted-foreground"
+                        />
+                        <div className="flex flex-col gap-0.5">
+                          <span className="text-sm font-medium text-foreground">
+                            {t("sandbox.preview.startingPreview")}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {t("sandbox.preview.startingPreviewHint")}
+                          </span>
+                        </div>
+                      </div>
+                    )}
+
+                    {effectiveEditingMode === "visual" && !visualElement && (
+                      <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 rounded-full border border-violet-400/40 bg-violet-500/90 px-3 py-1 text-xs font-medium text-white shadow-md backdrop-blur-sm pointer-events-none select-none">
+                        <CursorClick01 size={12} />
+                        {t("sandbox.preview.clickElementToAsk")}
+                      </div>
+                    )}
+                    {effectiveEditingMode === "visual" && visualElement && (
+                      <VisualEditorPrompt
+                        element={visualElement}
+                        onDismiss={() => setVisualElement(null)}
+                      />
+                    )}
+
+                    {floatingPreviewControls}
+
+                    {previewSurfaceActive && iframeSrc && (
+                      <div
+                        className={cn(
+                          "shrink-0",
+                          !previewFluid &&
+                            "border-x border-border bg-background shadow-sm",
+                        )}
+                        style={previewFrameStyle}
+                      >
+                        <iframe
+                          // Key on the iframe base: remount when the base URL changes
+                          // (branch switch, or the production→sandbox swap once the dev
+                          // server is up). Path navigation is driven by `iframeSrc`.
+                          key={display.iframeBase}
+                          ref={previewIframeRef}
+                          src={iframeSrc}
+                          className="w-full h-full border-0"
+                          title={t("sandbox.preview.devServerPreviewTitle")}
+                          onError={iframeRecovery.handleError}
+                          onLoad={() => {
+                            // A load reached the frame — cancel the recovery watchdog
+                            // and reset its backoff before anything else.
+                            iframeRecovery.handleLoad();
+                            // The page finished loading — always clear the navigation
+                            // indicator first, before any of the early returns below.
+                            endNavigation();
+                            // Production (Fast Preview) frame is cross-origin: skip the sandbox-only load handling, but the site's real pages still take the CMS overlay via the framework's `editor::inject` listener.
+                            if (display.mode !== "sandbox") {
+                              if (
+                                display.mode === "production" &&
+                                !display.showWakingPill &&
+                                editingMode === "blocks"
+                              ) {
+                                injectCmsEditor();
                               }
-                            }
-                            // Keep the template as currentPath when the loaded
-                            // path is just the template with params filled in —
-                            // otherwise the page match and param inputs are lost.
-                            if (
-                              normPath(iframePath) === normPath(resolvedPath)
-                            ) {
                               return;
                             }
-                            setCurrentPath(iframePath);
-                            persistLastPage({
-                              path: iframePath,
-                              pageKey: pinnedPageKey,
-                              params: pathParamValues,
+                            // This is the VM dev-server preview (sandboxed running app),
+                            // NOT an MCP app. MCP apps render via <MCPAppRenderer/>.
+                            track("vm_preview_loaded", {
+                              view_mode: editingMode,
+                              vm_id: vmEntry?.sandboxHandle ?? null,
+                              // Intentionally excluding the full previewUrl — it can contain
+                              // ephemeral tokens / user data in the query string.
                             });
-                          } catch {
-                            // Cross-origin — can't read, keep current value
-                          }
-                        }
-                        if (editingMode === "visual") injectVisualEditor();
-                        if (editingMode === "blocks") injectCmsEditor();
-                      }}
-                    />
+                            // Sync currentPath when the user navigates inside the iframe.
+                            // Skip while a programmatic navigation is pending — stale
+                            // onLoad events from the previous URL would reset us to "/".
+                            if (!activeGlobalSection) {
+                              try {
+                                const iframePath =
+                                  previewIframeRef.current?.contentWindow
+                                    ?.location?.pathname;
+                                if (!iframePath) return;
+                                const intended = intendedPathRef.current;
+                                if (intended !== null) {
+                                  intendedPathRef.current = null;
+                                  // Stale onLoad from the previous URL — ignore.
+                                  if (
+                                    normPath(iframePath) !== normPath(intended)
+                                  ) {
+                                    return;
+                                  }
+                                }
+                                // Keep the template as currentPath when the loaded
+                                // path is just the template with params filled in —
+                                // otherwise the page match and param inputs are lost.
+                                if (
+                                  normPath(iframePath) ===
+                                  normPath(resolvedPath)
+                                ) {
+                                  return;
+                                }
+                                setCurrentPath(iframePath);
+                                persistLastPage({
+                                  path: iframePath,
+                                  pageKey: pinnedPageKey,
+                                  params: pathParamValues,
+                                });
+                              } catch {
+                                // Cross-origin — can't read, keep current value
+                              }
+                            }
+                            if (editingMode === "visual") injectVisualEditor();
+                            if (editingMode === "blocks") injectCmsEditor();
+                          }}
+                        />
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
+                </ResizablePanel>
+              </ResizablePanelGroup>
             </ResizablePanel>
           </ResizablePanelGroup>
         )}

--- a/apps/web/src/i18n/en/sections-editor.ts
+++ b/apps/web/src/i18n/en/sections-editor.ts
@@ -114,6 +114,7 @@ export const sectionsEditor = {
   "sectionsEditor.multivariateFieldWrapper.addVariant": "Add variant",
   "sectionsEditor.multivariateFieldWrapper.ruleLabel": "Rule",
   "sectionsEditor.multivariateFieldWrapper.variantN": "Variant {n}",
+  "sectionsEditor.pageJsonDialog.close": "Close",
   "sectionsEditor.pageJsonDialog.copied": "Copied",
   "sectionsEditor.pageJsonDialog.copy": "Copy",
   "sectionsEditor.pageJsonDialog.invalidJsonError":
@@ -124,6 +125,7 @@ export const sectionsEditor = {
   "sectionsEditor.pageJsonDialog.saveSuccess": "Page JSON saved.",
   "sectionsEditor.pageJsonDialog.saving": "Saving…",
   "sectionsEditor.pageJsonDialog.title": "Page JSON",
+  "sectionsEditor.pageJsonDialog.titleShort": "JSON",
   "sectionsEditor.pageTemplateSelect.blankPageDefaultLabel": "Blank page",
   "sectionsEditor.pageTemplateSelect.blankPageLabel": "Blank page",
   "sectionsEditor.pageTemplateSelect.noPagesFoundMessage": "No pages found.",

--- a/apps/web/src/i18n/pt-br/sections-editor.ts
+++ b/apps/web/src/i18n/pt-br/sections-editor.ts
@@ -118,6 +118,7 @@ export const sectionsEditor = {
   "sectionsEditor.multivariateFieldWrapper.addVariant": "Adicionar variante",
   "sectionsEditor.multivariateFieldWrapper.ruleLabel": "Regra",
   "sectionsEditor.multivariateFieldWrapper.variantN": "Variante {n}",
+  "sectionsEditor.pageJsonDialog.close": "Fechar",
   "sectionsEditor.pageJsonDialog.copied": "Copiado",
   "sectionsEditor.pageJsonDialog.copy": "Copiar",
   "sectionsEditor.pageJsonDialog.invalidJsonError":
@@ -128,6 +129,7 @@ export const sectionsEditor = {
   "sectionsEditor.pageJsonDialog.saveSuccess": "Page JSON salvo.",
   "sectionsEditor.pageJsonDialog.saving": "Salvando…",
   "sectionsEditor.pageJsonDialog.title": "Page JSON",
+  "sectionsEditor.pageJsonDialog.titleShort": "JSON",
   "sectionsEditor.pageTemplateSelect.blankPageDefaultLabel": "Página em branco",
   "sectionsEditor.pageTemplateSelect.blankPageLabel": "Página em branco",
   "sectionsEditor.pageTemplateSelect.noPagesFoundMessage":


### PR DESCRIPTION
## Summary

The `<>` toolbar action in the CMS (Blocks) editor used to open the page's raw JSON in a **read-only modal**. This replaces it with an **editable side panel** that opens next to the CMS — inside the preview area — so it can be written to and the CMS panel keeps its width.

## Behavior

- **Editable** — Monaco JSON editor with **debounced autosave** (no Save button, mirroring how the section forms persist). Invalid JSON mid-edit is skipped silently until it parses again; `Cmd/Ctrl+S` forces an immediate save.
- **Opens beside the CMS, preview shrinks** — the panel lives in a nested resizable split *inside* the preview canvas, so opening it takes width from the preview, **never from the CMS**. The preview iframe stays mounted (no reload) when toggling.
- **Toggle** — clicking the `<>` icon again closes the panel; the header **✕** closes it too. Both close paths **flush** any pending autosave via an imperative `flush()` handle, so no edit inside the debounce window is lost.
- Minimal header: just **"JSON"** + close, sized to line up with the CMS header.

The read-only modal (`PageJsonDialog`) is still used from the standalone Content tab; only the preview/CMS `<>` action changed.

## Files

- `components/sandbox/blocks/page-json-panel.tsx` — new editable side panel
- `components/sandbox/blocks/blocks-panel.tsx` — forwards `onViewJsonFile` to the editor
- `components/sandbox/preview/preview.tsx` — toggle state + nested resizable slot in the canvas
- `i18n/en|pt-br/sections-editor.ts` — `titleShort` ("JSON") + `close` keys

## Testing

- `bun run --cwd=apps/web check` (tsc) ✅
- `bun run lint` ✅ (0 errors)
- `bun run fmt` ✅
- ⚠️ Not verified visually in a running app — the local agent sandbox is disabled in this environment, so the live CMS/preview couldn't be launched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The `<>` action in the CMS (Blocks) editor now opens the page's raw JSON in an editable side panel instead of a read-only modal. The panel lives inside the preview area, so opening it shrinks the preview but never the CMS, and the preview iframe stays mounted when toggling.

Edits persist via debounced autosave with no Save button; invalid JSON is skipped silently until it parses again. `Cmd/Ctrl+S` forces an immediate save, and both close paths (the `<>` icon and the header ✕) flush any pending debounced edit. The read-only modal is still used from the standalone Content tab.

Not visually verified in a running app — the local agent sandbox is disabled in this environment.

<sup>Written for commit 8fdc4dc4ff6eb2a69bcd5cd16c306720d47ef3cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

