### PR TITLE
fix(sandbox): add a kill switch for the daemon's autosave checkpoint loop

### DIFF
--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -933,32 +933,39 @@ func main() {
 	// minutes. Without it, a pod killed with no grace period (OOM, node loss)
 	// loses everything the agent had not committed itself — the shutdown sync
 	// below only runs on SIGTERM.
-	d.autosave = gitx.NewAutosaver(gitx.AutosaveDeps{
-		Publish: gitx.PublishDeps{
-			RepoDir: repoDir,
-			GetCloneUrl: func() string {
-				if cfg := d.store.Read(); cfg != nil {
-					return cfg.CloneUrl()
-				}
-				return ""
+	//
+	// AUTOSAVE_DISABLED is the kill switch: this runs unattended on every
+	// sandbox's boot/dispatch path and pushes to the user's remote, so a
+	// surprise (e.g. GitHub rate-limiting the fleet, an unwanted branch
+	// history) needs to be turned off fleet-wide without a daemon redeploy.
+	if os.Getenv("AUTOSAVE_DISABLED") == "" {
+		d.autosave = gitx.NewAutosaver(gitx.AutosaveDeps{
+			Publish: gitx.PublishDeps{
+				RepoDir: repoDir,
+				GetCloneUrl: func() string {
+					if cfg := d.store.Read(); cfg != nil {
+						return cfg.CloneUrl()
+					}
+					return ""
+				},
+				GetOperator: d.operatorIdentity,
+				// Same disposition as the shutdown sync: one invalid block must not
+				// cost the user every other change in the checkpoint.
+				OnInvalidBlock: gitx.InvalidBlockSkip,
+				// Never force-push from a checkpoint. Losing one checkpoint beats
+				// clobbering a concurrent writer's commit.
+				ReconcileRemote: false,
 			},
-			GetOperator: d.operatorIdentity,
-			// Same disposition as the shutdown sync: one invalid block must not
-			// cost the user every other change in the checkpoint.
-			OnInvalidBlock: gitx.InvalidBlockSkip,
-			// Never force-push from a checkpoint. Losing one checkpoint beats
-			// clobbering a concurrent writer's commit.
-			ReconcileRemote: false,
-		},
-		Lock: &d.treeLock,
-		Configured: func() bool {
-			cfg := d.store.Read()
-			return cfg != nil && cfg.Branch() != ""
-		},
-		RunActive: func() bool { return d.dispatchReg.HasActiveRuns() },
-		Dirty:     func() bool { return gitx.IsDirty(repoDir) },
-	})
-	d.autosave.Start()
+			Lock: &d.treeLock,
+			Configured: func() bool {
+				cfg := d.store.Read()
+				return cfg != nil && cfg.Branch() != ""
+			},
+			RunActive: func() bool { return d.dispatchReg.HasActiveRuns() },
+			Dirty:     func() bool { return gitx.IsDirty(repoDir) },
+		})
+		d.autosave.Start()
+	}
 	d.dispatchDeps = dispatch.Deps{
 		DaemonToken:      d.getToken,
 		AppRoot:          appRoot,


### PR DESCRIPTION
Follows #6664 (autosave checkpointing).

#6664 added a periodic checkpoint loop that runs unattended on every sandbox pod's boot/dispatch path, pushing commits to the user's remote branch every 2 minutes while a run is active. Per this repo's own hardening checklist item 7 ("any change on a boot/install/dispatch hot path gets its own default-off flag"), it shipped with no way to turn it off short of a daemon redeploy. If it ever misbehaves at fleet scale — GitHub rate-limiting many pods pushing on the same cadence, an unwanted checkpoint commit pattern customers object to, a push failure loop — there was no lever to pull.

This adds `AUTOSAVE_DISABLED` as an env-var kill switch: when set (to any non-empty value), the daemon skips creating/starting the `Autosaver` entirely at boot. Default behavior (unset) is unchanged — autosave still starts exactly as #6664 shipped it. `d.autosave.Stop()` in `shutdown()` is already nil-checked, so leaving `d.autosave` nil when disabled is safe.

How to confirm: `cd packages/sandbox/daemon-go && go build ./... && go vet ./...` (both clean). Setting `AUTOSAVE_DISABLED=1` before boot means `d.autosave` stays nil and `Autosaver.Start()` is never called; unset, boot is identical to before this PR.

Locally ran: `go build ./...`, `go vet ./...`, `gofmt -l main.go` (no output) in `packages/sandbox/daemon-go`. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `AUTOSAVE_DISABLED` as an env-var kill switch for the autosave checkpoint loop added in #6664. Previously the loop ran on every sandbox boot and couldn’t be turned off short of a daemon redeploy; now setting the var to any non-empty value skips creating and starting the `Autosaver` entirely. Default behavior (unset) is unchanged, and the existing nil-check on `Stop()` covers the disabled path.

<sup>Written for commit ca65994feea2a9c24b31132e07a2a0a546935080. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

