### PR TITLE
fix(harness): discard the delta coalescer's held text on a provider-retry restart

### DIFF
--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -499,4 +499,14 @@ describe("createDeltaCoalescer", () => {
     const odd = { type: "text-delta", id: "a" };
     expect(c.push([odd])).toEqual([odd]);
   });
+
+  test("discard drops what is held instead of emitting it", () => {
+    const c = createDeltaCoalescer(100);
+    c.push([delta("a", "abandoned")]);
+    c.discard();
+    expect(c.drain()).toEqual([]);
+    // A later push starts clean, not merged into the discarded text.
+    expect(c.push([delta("a", "fresh")])).toEqual([]);
+    expect(c.drain()).toEqual([delta("a", "fresh")]);
+  });
 });

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -475,6 +475,7 @@ function retryingProviderChunk(): Record<string, unknown> {
 export function createDeltaCoalescer(flushChars = 200): {
   push(chunks: unknown[]): unknown[];
   drain(): unknown[];
+  discard(): void;
 } {
   let held: { type: string; id: string; delta: string } | null = null;
 
@@ -524,6 +525,9 @@ export function createDeltaCoalescer(flushChars = 200): {
       const chunk = held;
       held = null;
       return [chunk];
+    },
+    discard() {
+      held = null;
     },
   };
 }
@@ -636,6 +640,8 @@ export async function runClaudeCode(
           emit({ chunks: [retryingProviderChunk()] });
           // What the dead attempt buffered is not part of the next one.
           pending.length = 0;
+          // Nor is a delta it left half-coalesced — discard it, don't drain it.
+          coalescer.discard();
           await Bun.sleep(waitMs);
           if (!resumeSession) sessionId = crypto.randomUUID();
           attempt = 0;


### PR DESCRIPTION
Follows #6664 (token-level streaming, merged today), hardening the retry path it added.

On a transient provider rejection, `runClaudeCode` restarts the attempt and clears `pending` (`pending.length = 0`) since the dead attempt's buffered chunks aren't part of the next one. The `createDeltaCoalescer` added in the same PR can independently be holding an un-flushed text/reasoning delta at that exact point (deltas can accumulate before the turn's first assistant message, i.e. before `started` flips — the same window `canRestartCleanly()` checks) — nothing cleared it. A later `drain()` on the *new* attempt would then splice the dead attempt's partial, abandoned text into the new attempt's stream, or worse, merge it into an unrelated delta if the new attempt reuses the same block id.

Failure scenario: provider rejects the request mid-stream after emitting a partial (<200 char) text delta that never got flushed; the retry restarts a fresh SDK session, and the abandoned delta text reappears prefixed onto (or merged into) the first delta of the successful retry.

Fix: added `discard()` to the coalescer (drops the held delta without emitting it) and call it right next to `pending.length = 0` in the transient-provider-rejection retry branch.

Regression test: `discard drops what is held instead of emitting it` in `packages/harness-runner/claude-code.test.ts` — pushes a delta, discards, drains (expects empty), then verifies a fresh push after discard is not merged with the discarded text.

To confirm: `bun test packages/harness-runner/claude-code.test.ts`.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (packages/harness-runner), the targeted test file above (39 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the delta coalescer retaining abandoned text across provider-retry restarts, which could splice a dead attempt's partial delta into the new attempt's stream or merge it with an unrelated delta.

- Adds `discard()` to `createDeltaCoalescer` and calls it alongside the `pending` reset during retry.
- Includes a regression test verifying discarded text is not emitted or merged.

<sup>Written for commit e496ce81e6d8c3d46cc04e2c38f7a644ebb9712e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

