### PR TITLE
refactor: replace ban-types Function with real call signatures

### DIFF
--- a/apps/api/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/index.ts
@@ -468,7 +468,10 @@ export function instrumentBuiltIns<T extends Record<string, unknown>>(
   const userId = ctx.auth?.user?.id;
   const result: Record<string, unknown> = {};
   for (const [name, tool] of Object.entries(tools)) {
-    const t = tool as { execute?: Function; [k: string]: unknown };
+    const t = tool as {
+      execute?: (input: unknown, options: unknown) => unknown;
+      [k: string]: unknown;
+    };
     const originalExecute = t.execute;
     if (typeof originalExecute !== "function") {
       result[name] = tool;

--- a/packages/mcp-utils/src/sandbox/run-code.ts
+++ b/packages/mcp-utils/src/sandbox/run-code.ts
@@ -1,4 +1,8 @@
-import type { QuickJSContext, QuickJSHandle } from "quickjs-emscripten-core";
+import type {
+  ExecutePendingJobsResult,
+  QuickJSContext,
+  QuickJSHandle,
+} from "quickjs-emscripten-core";
 import { scheduler } from "node:timers/promises";
 import { installConsole, type SandboxLog } from "./builtins/console.ts";
 import { createSandboxRuntime } from "./runtime.ts";
@@ -7,7 +11,9 @@ import { PendingPromiseTracker, toQuickJS } from "./utils/to-quickjs.ts";
 import type { IClient } from "../client-like.ts";
 
 function executePendingJobs(ctx: {
-  runtime: { executePendingJobs: Function };
+  runtime: {
+    executePendingJobs: (maxJobsToExecute?: number) => ExecutePendingJobsResult;
+  };
 }) {
   const res = ctx.runtime.executePendingJobs(100);
   try {


### PR DESCRIPTION
Two spots in the codebase type a callback as the bare `Function` type, which the repo's `ban-types` oxlint rule flags (a `warn`-level rule, not CI-enforced, so it accumulates as un-caught debt) — `Function` accepts any arity/argument types, so a caller can pass the wrong shape and only find out at runtime.

1. `packages/mcp-utils/src/sandbox/run-code.ts`: `executePendingJobs` on `QuickJSRuntime` already has a real exported signature, `(maxJobsToExecute?: number | void) => ExecutePendingJobsResult`, from `quickjs-emscripten-core`'s own `.d.ts`. Typed the inline `ctx.runtime` param against that instead of `Function`.
2. `apps/api/src/harnesses/decopilot/built-in-tools/index.ts`: `instrumentBuiltIns` casts each AI-SDK tool's `execute` to read it off before wrapping. Both call sites (`originalExecute.call(t, input, options)`) always pass exactly two arguments, so the cast is now `(input: unknown, options: unknown) => unknown` instead of `Function`.

Why a maintainer wants this: a real signature is what `bunx tsc --noEmit` can actually check a call against; `Function` is a no-op for that in both places.

Behavior-preserving — same runtime code, only annotations changed. No test needed (pure type-level change); a reviewer confirms with:
```
cd packages/mcp-utils && bunx tsc --noEmit
cd apps/api && bunx tsc --noEmit
bunx oxlint packages/mcp-utils/src/sandbox/run-code.ts apps/api/src/harnesses/decopilot/built-in-tools/index.ts
```

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in both `packages/mcp-utils` and `apps/api` (both clean), and `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces bare `Function` annotations with real call signatures in two spots so `tsc` can actually check callback shapes instead of accepting anything at compile time.

- In `packages/mcp-utils/src/sandbox/run-code.ts`, `executePendingJobs` now types the runtime callback as `(maxJobsToExecute?: number) => ExecutePendingJobsResult`, matching `quickjs-emscripten-core`'s exported signature.
- In `apps/api/src/harnesses/decopilot/built-in-tools/index.ts`, the `execute` cast is now `(input: unknown, options: unknown) => unknown`, matching the two call sites that pass exactly those arguments.

Behavior is unchanged; this is a pure type-level refactor, so no tests or runtime effects. Verify with `bunx tsc --noEmit` in `packages/mcp-utils` and `apps/api`, plus `bunx oxlint` on both touched files.

<sup>Written for commit 529fefa3e8ab13af5a379314e5ae74693f6cb1ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

