### PR TITLE
refactor(decopilot): replace ban-types Function with a real call signature

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/studio-provider.ts
+++ b/apps/api/src/harnesses/lib/decopilot/studio-provider.ts
@@ -181,10 +181,14 @@ export function createLanguageModel(
   // Provider-specific settings (reasoning / models fallback) are not part of
   // the generic ProviderV3 interface, so we cast to pass them through.
   const make = (id: string, s?: Record<string, unknown>): LanguageModelV3 =>
-    (s && Object.keys(s).length > 0
-      ? // biome-ignore lint/complexity/noBannedTypes: pass-through provider settings
-        (provider.aiSdk.languageModel as Function)(id, s)
-      : provider.aiSdk.languageModel(id)) as LanguageModelV3;
+    s && Object.keys(s).length > 0
+      ? (
+          provider.aiSdk.languageModel as (
+            id: string,
+            settings: Record<string, unknown>,
+          ) => LanguageModelV3
+        )(id, s)
+      : provider.aiSdk.languageModel(id);
 
   const primary = make(model.id, settings);
   // Free model is plain (no reasoning, no nested models array) so the retry is


### PR DESCRIPTION
**Source:** C-DEBT — a `ban-types`-violating `Function` cast in `studio-provider.ts` (this repo's `no-explicit-any`/`ban-types` rules are `warn`-level, not CI-enforced, so this kind of thing accumulates uncaught). Distinct file from #6671 (which covers `built-in-tools/index.ts` and `run-code.ts`) — not a duplicate.

**What/why:** `createLanguageModel`'s `make()` helper calls `provider.aiSdk.languageModel` with a provider-specific second `settings` argument that isn't part of the declared `ProviderV3` interface (which only takes `(modelId: string)`). It reached for the banned `Function` type to bypass this, wrapped in a `biome-ignore` suppression comment. Replaced the cast with the real call signature `(id: string, settings: Record<string, unknown>) => LanguageModelV3` — same runtime behavior, but now a signature drift on the underlying provider is a compile-time error instead of silently swallowed by `Function`, and the suppression comment is gone.

**Confirms behavior is unchanged:** pure type-level change — the call site and its two branches (with/without settings) are untouched, only the cast's declared type changed. `bunx tsc --noEmit` in apps/api is green on the file, no runtime logic touched.

**Reviewer check:** `cd apps/api && bunx tsc --noEmit` (green), `bunx oxlint apps/api/src/harnesses/lib/decopilot/studio-provider.ts` (0 warnings/errors).

**Locally verified:** `bun run fmt`, targeted `tsc --noEmit` in apps/api, `oxlint` on the changed file. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the banned `Function` cast in `studio-provider.ts` with the real call signature `(id: string, settings: Record<string, unknown>) => LanguageModelV3`, so provider signature drift is caught at compile time instead of being silently swallowed.

This is a pure type-level refactor—the call site and runtime behavior are unchanged.

<sup>Written for commit 5f5cbdede952533d02dd1db43cf6583861a6bafb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

