### PR TITLE
fix(virtual-mcp): drop pinned views for detached connections

### DIFF
--- a/apps/web/src/layouts/main-panel-tabs/attached-pinned-views.test.ts
+++ b/apps/web/src/layouts/main-panel-tabs/attached-pinned-views.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { keepAttachedPinnedViews } from "./attached-pinned-views";
+
+const pins = [
+  { connectionId: "conn_a", toolName: "dashboard" },
+  { connectionId: "conn_gone", toolName: "dashboard" },
+];
+
+describe("keepAttachedPinnedViews", () => {
+  it("drops pins for detached connections", () => {
+    expect(keepAttachedPinnedViews(pins, ["conn_a"])).toEqual([pins[0]!]);
+  });
+
+  it("keeps everything while the connection list is still loading", () => {
+    expect(keepAttachedPinnedViews(pins, [])).toEqual(pins);
+  });
+
+  it("keeps pins for attached connections that are erroring", () => {
+    expect(keepAttachedPinnedViews(pins, ["conn_a", "conn_gone"])).toEqual(
+      pins,
+    );
+  });
+});

--- a/apps/web/src/layouts/main-panel-tabs/attached-pinned-views.ts
+++ b/apps/web/src/layouts/main-panel-tabs/attached-pinned-views.ts
@@ -1,0 +1,15 @@
+/**
+ * Drop pinned views whose connection is no longer attached to the agent.
+ *
+ * The agent settings panel only lists attached connections, so a pin left
+ * behind by a detached one renders a tab with no toggle to turn it off.
+ * An empty `attachedConnectionIds` means "not loaded yet" — keep everything.
+ */
+export function keepAttachedPinnedViews<T extends { connectionId: string }>(
+  pinnedViews: T[],
+  attachedConnectionIds: Iterable<string>,
+): T[] {
+  const attached = new Set(attachedConnectionIds);
+  if (attached.size === 0) return pinnedViews;
+  return pinnedViews.filter((pv) => attached.has(pv.connectionId));
+}

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -51,6 +51,7 @@ import {
 } from "./tab-id";
 import { resolveTabIcon, type TabIcon, type TabKind } from "./resolve-tab-icon";
 import { useTaskMetadata } from "./use-task-metadata";
+import { keepAttachedPinnedViews } from "./attached-pinned-views";
 import { resolvePreviewSource } from "./preview-source";
 import {
   getSourceSystemTabs,
@@ -227,7 +228,12 @@ export function useMainPanelTabs(ctx: {
           }))
       : [];
   const firstDevView = devViews[0];
-  const pinnedViews = firstDevView ? devViews : (entityUI?.pinnedViews ?? []);
+  const pinnedViews = firstDevView
+    ? devViews
+    : keepAttachedPinnedViews(
+        entityUI?.pinnedViews ?? [],
+        (entity?.connections ?? []).map((c) => c.connection_id),
+      );
   const effectiveDefaultMainView =
     firstDevView && devConnId
       ? { type: "ext-apps", id: devConnId, toolName: firstDevView.toolName }

--- a/apps/web/src/views/virtual-mcp/layout-tab-content.tsx
+++ b/apps/web/src/views/virtual-mcp/layout-tab-content.tsx
@@ -175,9 +175,9 @@ export function LayoutTabContent({
   };
 
   // Reconcile orphaned pinned views once tool data is available.
-  // Only remove pins whose connection was successfully fetched but no longer
-  // exposes the pinned tool. Pins for connections that failed to fetch are
-  // kept to avoid permanent deletion from transient errors.
+  // Drop pins whose connection is detached from the agent, or which fetched
+  // OK but no longer expose the pinned tool. Pins for attached connections
+  // that failed to fetch are kept to survive transient errors.
   const reconciledRef = useRef(false);
   if (
     connectionsWithTools &&
@@ -195,10 +195,12 @@ export function LayoutTabContent({
       connectionsData.flatMap((c) => c.uiTools.map((t) => `${c.id}:${t.name}`)),
     );
 
+    const attachedIds = new Set(connectionIds);
     const validPinned = pinnedViews.filter(
       (pv) =>
-        !fetchedOkIds.has(pv.connectionId) ||
-        validKeys.has(`${pv.connectionId}:${pv.toolName}`),
+        attachedIds.has(pv.connectionId) &&
+        (!fetchedOkIds.has(pv.connectionId) ||
+          validKeys.has(`${pv.connectionId}:${pv.toolName}`)),
     );
 
     if (validPinned.length !== pinnedViews.length) {


### PR DESCRIPTION
## Problem

A pinned view whose connection is no longer aggregated on the agent renders a **tab that cannot be removed**.

Reported on `farmrio` / agent `vir_H62GklSGy4YowOaV06okW` ("Visual Merchandising"): a `PLP optimizer` tab pointing at `conn_4xFJaZfgju0VCZSH4quts`, which is not in `connection_aggregations` for that agent. The settings panel lists only attached connections, so it rendered no toggle for it — but the tab bar renders straight from `metadata.ui.pinnedViews`, orphan included.

The existing orphan reconcile in `layout-tab-content.tsx` didn't catch it: it only drops a pin whose connection **fetched OK** but no longer exposes the tool. A detached connection is never fetched, so `fetchedOkIds.has(...)` is false and the pin is kept — forever.

## Fix

`keepAttachedPinnedViews()` — drop pins whose `connectionId` isn't among the agent's attached connections. Applied in two places:

- `use-main-panel-tabs.ts` — the tab disappears immediately, no visit to settings required.
- `layout-tab-content.tsx` — the reconcile now persists the prune.

An empty attached-connection list means "not loaded yet" and keeps everything, so the bar never blanks mid-load. Pins for **attached** connections that fail to fetch are still kept, preserving the transient-error guard.

## Testing

- `apps/web/src/layouts/main-panel-tabs/attached-pinned-views.test.ts` — 3 cases: detached dropped, loading keeps all, attached-but-erroring kept.
- Prod row for `vir_H62GklSGy4YowOaV06okW` was manually corrected (orphan removed from `metadata.ui.pinnedViews`, 4 → 3) so the customer is unblocked; this PR prevents recurrence and cleans up any other org's orphans on next agent load.

## Not in scope

`metadata.ui.homeTiles` / `homeTile` have the same orphan class and are not pruned by `cleanOrphanedPinnedViews` in `apps/api/src/storage/virtual.ts` either. No reported breakage, left for a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unremovable pinned tabs when a pinned view's connection is no longer attached to the agent.

**Bug Fixes**
- Filters pinned views against the agent's attached connections in both the tab bar and the settings reconcile.
- An empty attached-connection list means "not loaded yet" and keeps everything, so the tab bar never blanks mid-load.
- Keeps pins for attached connections that fail to fetch, preserving the transient-error guard.
- Existing orphans are pruned on the next agent load; the reported row was already corrected manually.

<sup>Written for commit dc8b356c1d6fbc2f817650beb2aab62c43ee11e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

