### PR TITLE
fix(harness): close a stream_event's open block before finish-step on error

### DIFF
--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -4,11 +4,13 @@ import {
   brokenStudioMcp,
   buildOptions,
   createDeltaCoalescer,
+  errorFinishChunks,
   isTransientProviderRejection,
   mcpServersFor,
   promptForRun,
   promptFromUserMessage,
 } from "./claude-code";
+import { UiChunkTranslator } from "./to-ui-chunks";
 
 /** A minimal valid wire input; each test overrides what it cares about. */
 function input(
@@ -498,5 +500,45 @@ describe("createDeltaCoalescer", () => {
     // No `delta` string: not coalescable, but dropping it would lose output.
     const odd = { type: "text-delta", id: "a" };
     expect(c.push([odd])).toEqual([odd]);
+  });
+});
+
+describe("errorFinishChunks", () => {
+  test("closes a block stream_event left open before finish-step", () => {
+    const translator = new UiChunkTranslator();
+    translator.translate({
+      type: "stream_event",
+      event: { type: "message_start" },
+    });
+    translator.translate({
+      type: "stream_event",
+      event: {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      },
+    });
+    translator.translate({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "hi" },
+      },
+    });
+    // No `content_block_stop` — the SDK threw mid-block.
+    expect(errorFinishChunks(translator)).toEqual([
+      { type: "text-end", id: "stream-1" },
+      { type: "finish-step" },
+      { type: "finish", finishReason: "error" },
+    ]);
+  });
+
+  test("nothing left open: just finish-step and finish", () => {
+    const translator = new UiChunkTranslator();
+    expect(errorFinishChunks(translator)).toEqual([
+      { type: "finish-step" },
+      { type: "finish", finishReason: "error" },
+    ]);
   });
 });

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -830,11 +830,28 @@ export async function runClaudeCode(
     }
     startTurn(messageId ?? `msg_${Date.now()}`);
     emit({
-      chunks: [
-        { type: "finish-step" },
-        { type: "finish", finishReason: "error" },
-      ],
+      chunks: errorFinishChunks(translator),
       error,
     });
   }
+}
+
+/**
+ * Chunks for an aborted turn: close whatever `stream_event` left open, then
+ * finish the step and the run.
+ *
+ * Same orphan-end hazard the step boundary above guards against — the AI SDK
+ * reducer clears its open text/reasoning parts on `finish-step`, so an end
+ * emitted after it throws and drops the stream. An SDK throw mid-block (a
+ * network drop, a crash) reaches `fail()` with a block `stream_event` opened
+ * and never closed; without this, `finish-step` went out first and the part
+ * was left open forever instead of throwing — no crash, but a message that
+ * reads as still streaming after the run has already failed.
+ */
+export function errorFinishChunks(translator: UiChunkTranslator): unknown[] {
+  return [
+    ...translator.closeOpenStreamBlocks(),
+    { type: "finish-step" },
+    { type: "finish", finishReason: "error" },
+  ];
 }


### PR DESCRIPTION
Follows #6670.

#6670 added token-level streaming and, in a same-PR follow-up fix, closes a `stream_event`-opened text/reasoning block before the `finish-step` boundary between assistant messages — because the AI SDK's reducer clears its open parts on `finish-step`, so an `-end` emitted after it targets a part the reducer no longer knows and throws, killing the run mid-stream.

That same fix was applied at the multi-step boundary (`claude-code.ts`, inside the `message.type === "assistant"` branch) but missed the other place a turn ends: `fail()`, called when the SDK throws mid-turn (a network drop, a crash). `fail()` emitted `finish-step` directly, without first calling `translator.closeOpenStreamBlocks()`. If the SDK throws while a `stream_event` block is still open (no `content_block_stop` arrived), that part never gets its `-end` chunk — no crash this time, but the message reads as still streaming forever in the UI even though the run has already failed and reported an error.

Fix: extracted the step-boundary's "close what's open, then finish" pattern into a small exported helper (`errorFinishChunks`) and used it in `fail()` too.

**Regression test**: `packages/harness-runner/claude-code.test.ts` — `errorFinishChunks` with a block left open by `stream_event` (no `content_block_stop`) now closes it (`text-end`) before `finish-step`/`finish`; confirmed this fails on the pre-fix code (the export doesn't exist there) and passes after.

Reviewer check: `cd packages/harness-runner && bun test claude-code.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (packages/harness-runner), `bun test packages/harness-runner/claude-code.test.ts` (40 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the harness error path so a message no longer reads as still streaming after a mid-turn crash. Previously, `fail()` emitted `finish-step` without closing any `stream_event`-opened block; now it reuses the same close-then-finish logic as the assistant-message step boundary.

- Extracts the close-open-blocks-then-finish pattern into an exported `errorFinishChunks` helper and uses it in `fail()`.
- Adds a regression test for an open block with no `content_block_stop`.

<sup>Written for commit 1adca812839c72621bf205a173c87c3ad6b06174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

