### PR TITLE
fix(sandbox): only announce 'starting sandbox' on a cold start

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -548,21 +548,24 @@ export class SandboxDispatchClient {
       resume: { reason: string } | null,
     ): AsyncIterable<UIMessageChunk> =>
       (async function* () {
-        // The longest silence in the run: pod boot, clone, and (interactive)
-        // install. The chat has no per-thread stream here, so this rides
-        // the org `/watch`.
-        await publishRunStatusStage({
-          streamBuffer,
-          harnessId: SANDBOX_HOSTED_HARNESS,
-          taskId: runId,
-          stage: "starting-sandbox",
-        });
         const sandbox = await ensureSandbox(
           {
             virtualMcpId,
             branch,
             // Headless loop, no preview — unless someone is watching it.
             purpose: interactive ? "interactive" : "harness-run",
+            // The longest silence in the run: pod boot, clone, and
+            // (interactive) install. The chat has no per-thread stream here, so
+            // this rides the org `/watch`. Only on a cold start — an
+            // interactive agent keeps its pod between turns, and announcing a
+            // boot on every message made a warm resume look like a re-boot.
+            onColdStart: () =>
+              publishRunStatusStage({
+                streamBuffer,
+                harnessId: SANDBOX_HOSTED_HARNESS,
+                taskId: runId,
+                stage: "starting-sandbox",
+              }),
           },
           ctx,
         );

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -239,6 +239,13 @@ export async function ensureSandbox(
      * agent-run SandboxTemplate + warm pool. Defaults to `interactive`.
      */
     purpose?: SandboxPurpose;
+    /**
+     * Fired only when this call actually has to provision a pod — i.e. the
+     * resume fast path below did NOT hit. Callers that show a "booting the
+     * sandbox" status use this so a warm resume doesn't announce a boot that
+     * isn't happening. Best-effort: a throw here must not fail the ensure.
+     */
+    onColdStart?: () => Promise<void>;
   },
   ctx: StudioContext,
 ): Promise<SandboxRecord> {
@@ -301,6 +308,8 @@ export async function ensureSandbox(
   const threadRepo = await getThreadGithubRepo(ctx, provisioningThreadId);
   const githubRepo =
     threadRepo ?? (metadata as GithubRepoMeta).githubRepo ?? null;
+  // Past the resume fast path: this call is a real boot, so tell the caller.
+  await input.onColdStart?.().catch(() => {});
   const { entry } = await provisionSandbox({
     ctx,
     userId,


### PR DESCRIPTION
## Summary

A Code Agent chat showed **"Starting the sandbox / Booting the machine and checking out the repository"** on *every* message, even though the pod was already up.

`SandboxDispatchClient` published the `starting-sandbox` run-status stage unconditionally, before calling `ensureSandbox`. For an interactive agent (one with `metadata.githubRepo.url` → `interactive: true`) the pod is never released at run end, so `ensureSandbox` takes its live-pod fast path and returns in milliseconds — but the boot copy had already been streamed.

This moves the publish into an optional `onColdStart` callback that `ensureSandbox` fires only *after* the fast path misses, i.e. only when it is genuinely about to provision.

No behavior change for headless task runs: those release their pod at run end (`SANDBOX_RELEASE_ON_RUN_END=1` in prod), so the next dispatch really is a cold start and still shows the stage.

## Testing notes

- `bun run check` (apps/api) clean, `bun run fmt` clean.
- Confirmed against prod for thread `ff4e48e7…` / agent `vir_OJPvdPUqkyb3318ccCeuY`: one `sandbox_runner_state` row (`agentic-cms-blog-post-8c8e38b1ec8488b5`), pod alive across turns — so every turn after the first was a warm resume mislabelled as a boot.
- No new test: the change is where an existing side effect is invoked, not new logic.

## Affected areas

- `apps/api/src/harnesses/sandbox-dispatch-client.ts`
- `apps/api/src/tools/sandbox/start.ts` (`ensureSandbox` gains an optional callback)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Code Agent chat showing "Starting the sandbox" on every message instead of only when the machine actually boots.

- `SandboxDispatchClient` now passes an `onColdStart` callback that `ensureSandbox` fires only when its live-pod fast path misses.
- Interactive agents keep their pod between turns, so warm resumes no longer announce a boot.
- Headless task runs are unaffected: their pods release at run end, so the next run is still a cold start.

<sup>Written for commit cac7aeac1dee31c0b11a87d9d95a2a46ffc9230b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

