### PR TITLE
fix(web): don't crash reading a non-object thread-layout entry

### DIFF
--- a/apps/web/src/lib/thread-layout-memory.test.ts
+++ b/apps/web/src/lib/thread-layout-memory.test.ts
@@ -29,6 +29,16 @@ describe("sanitizeThreadLayout", () => {
     } as unknown as Parameters<typeof sanitizeThreadLayout>[0];
     expect(sanitizeThreadLayout(dirty)).toEqual({});
   });
+
+  test("doesn't throw on a non-object entry (tampered sessionStorage)", () => {
+    for (const dirty of [null, undefined, "chat", 5, ["a"]] as unknown[]) {
+      expect(
+        sanitizeThreadLayout(
+          dirty as unknown as Parameters<typeof sanitizeThreadLayout>[0],
+        ),
+      ).toEqual({});
+    }
+  });
 });
 
 describe("upsertThreadLayoutEntries", () => {

--- a/apps/web/src/lib/thread-layout-memory.ts
+++ b/apps/web/src/lib/thread-layout-memory.ts
@@ -42,6 +42,7 @@ type StoredEntry = [taskId: string, layout: ThreadLayout];
  */
 export function sanitizeThreadLayout(layout: ThreadLayout): ThreadLayout {
   const clean: ThreadLayout = {};
+  if (layout === null || typeof layout !== "object") return clean;
   if (typeof layout.tab === "string") clean.tab = layout.tab;
   if (typeof layout.mainpanel === "boolean") clean.mainpanel = layout.mainpanel;
   if (typeof layout.sidepanel === "boolean") {


### PR DESCRIPTION
**Source:** a bug found reading `apps/web/src/lib/thread-layout-memory.ts` (recently touched by #6667, the destination-by-path work).

**Why:** `sanitizeThreadLayout` (the boundary the module's own comment claims sanitizes every read of tampered/untrusted `sessionStorage` JSON) assumes its argument is an object. `readStore`'s validation only checks the stored tuple's shape (`[id, layout]`, `id` a string) — it never checks that `layout` itself is an object. A malformed entry such as `["a", null]` (privacy-mode quirks, a manual tamper, or a future format bug) passes that filter, and `sanitizeThreadLayout(null)` throws a `TypeError` on `layout.tab`, which propagates out of `readThreadLayout` — called on every thread switch (`resolveTaskSwitchSearch`) — crashing that flow instead of degrading to "no memory" as the module promises.

**Fix:** `sanitizeThreadLayout` now returns `{}` for `null`/non-object input instead of throwing, matching every other tampered-value case it already handles.

**Regression test:** `thread-layout-memory.test.ts` — new case feeds `null`/`undefined`/a string/a number/an array into `sanitizeThreadLayout` and asserts it returns `{}` instead of throwing.

**Reviewer command:** `bun test apps/web/src/lib/thread-layout-memory.test.ts`

**Local checks run:** `bun run fmt`, `bunx oxlint apps/web/src/lib/thread-layout-memory.ts apps/web/src/lib/thread-layout-memory.test.ts` (clean), and the targeted test file above (8 pass). Skipped the workspace `tsc --noEmit` — it fails on a pre-existing, unrelated prosemirror version-mismatch error in `mention-suggestion.tsx` that predates this change. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when reading a tampered or malformed thread-layout entry from `sessionStorage`. `sanitizeThreadLayout` now returns `{}` for non-object input instead of throwing, so `readThreadLayout` no longer blows up on entries like `["a", null]` and degrades to "no memory" as the module promises. Adds a regression test covering `null`, `undefined`, strings, numbers, and arrays.

<sup>Written for commit 0364f79a4dc51eab58eb9d6f990a10ab6d58fa24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

