### PR TITLE
refactor(agent-shell): dedupe the duplicate useSessionRuntime(virtualMcpId) call

### DIFF
--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -286,13 +286,12 @@ function VmEventsBridge({
    */
   const { org } = useProjectContext();
   const autoFreshBranchEnabled = useOrgFlag("cms_auto_fresh_branch");
-  const { runtime: cmsRuntime, resolved: cmsRuntimeResolved } =
-    useSessionRuntime(virtualMcpId);
+  const sessionState = useSessionRuntime(virtualMcpId);
   const freshBranchForThreadRef = useRef<string | null>(null);
   const staleCheckEnabled =
     autoFreshBranchEnabled &&
-    cmsRuntimeResolved &&
-    cmsRuntime === "cms" &&
+    sessionState.resolved &&
+    sessionState.runtime === "cms" &&
     !!org?.slug &&
     !!currentBranch &&
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only dedup probe; recorded inside the effect after firing
@@ -331,7 +330,6 @@ function VmEventsBridge({
   // SANDBOX_START (covers the booting window; SandboxLifecycleProvider's
   // auto-start shares this mutation key, so `useIsSandboxStartPending`
   // observes it).
-  const sessionState = useSessionRuntime(virtualMcpId);
   /** `null` until the answer is real — never act on the project default. */
   const sessionRuntime = sessionState.resolved ? sessionState.runtime : null;
   const isStartPending = useIsSandboxStartPending(


### PR DESCRIPTION
Follows #6639, which added the auto-fresh-branch staleness check to `VmEventsBridge` in `apps/web/src/layouts/agent-shell-layout/index.tsx`.

That PR's new code calls `useSessionRuntime(virtualMcpId)` for the CMS-runtime check, and the pre-existing code further down in the same component calls `useSessionRuntime(virtualMcpId)` again with the identical argument, to gate the sandbox-events subscription. Both calls resolve to the exact same `SessionRuntime` answer for the same render (same `virtualMcpId`, same underlying `useVirtualMCP`/`useOptionalChatTask` reads) — the second call is pure redundant recompute inside a component that already fires on every branch/task/session change.

Net: -5 / +3. Single call site, both usages now read from the same `sessionState` result — behavior is unchanged (verified the two derivations, `cmsRuntime`/`cmsRuntimeResolved` and `sessionRuntime`, are structurally identical reads off the same object).

A reviewer can confirm by diffing: both former call sites reduce to reads of one `useSessionRuntime(virtualMcpId)` result.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web — no new errors; one pre-existing, unrelated prosemirror-model version-skew error is present on main and untouched by this diff), `bunx oxlint apps/web/src/layouts/agent-shell-layout/index.tsx` (0 warnings/errors). No test file changes needed since this is a pure behavior-preserving call dedupe, not new logic. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dedupes the duplicate `useSessionRuntime(virtualMcpId)` call in `VmEventsBridge` so the same session state is no longer recomputed twice per render. Behavior is unchanged: both the auto-fresh-branch staleness check and the sandbox-events gate now read from the single `sessionState` result.

<sup>Written for commit 0f32ee785201c8b9d7edcfb79dfeefd72d5b9852. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

