### PR TITLE
fix(decopilot): stop a replicated stream config from bricking a single-node NATS

### DIFF
--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts
@@ -248,19 +248,16 @@ describe("NatsStreamBuffer", () => {
     expect(publishMock).toHaveBeenCalled();
   });
 
-  it("init falls back to an unreplicated stream on a single-node NATS", async () => {
-    // Regression: a replicated default made `streams.update` reject on any
-    // non-clustered JetStream (local dev, self-hosts, the multi-pod test
-    // cluster), leaving `js` null so every chunk of every run was dropped.
+  it("init never writes a replicated config to a non-clustered NATS", async () => {
+    // Regression: `streams.update` ACCEPTS num_replicas>1 on a single node and
+    // persists it to the stream's on-disk meta.inf, which the server then
+    // cannot recover on its next boot (503 from /healthz forever). No error is
+    // raised, so the error-driven fallback below can't catch it — the count
+    // must be clamped from the connection's topology before anything is written.
     const configs: Array<{ num_replicas: number }> = [];
     const streamUpdateMock = mock(
       (_name: string, config: { num_replicas: number }) => {
         configs.push(config);
-        if (config.num_replicas > 1) {
-          return Promise.reject(
-            new Error("replicas > 1 not supported in non-clustered mode"),
-          );
-        }
         return Promise.resolve({});
       },
     );
@@ -274,18 +271,75 @@ describe("NatsStreamBuffer", () => {
     const publishMock = mock(() => Promise.resolve({ seq: 1 }));
 
     const buffer = new NatsStreamBuffer({
-      getConnection: () => ({}) as never,
+      // A single-node server sends no `cluster` in its INFO.
+      getConnection: () => ({ info: {} }) as never,
       getJetStream: () => ({ publish: publishMock }) as never,
       getJetStreamManager: (() => Promise.resolve(mockJsm)) as never,
     });
 
     await buffer.init();
 
-    expect(configs.map((c) => c.num_replicas)).toEqual([3, 1]);
-    // Degraded to unreplicated, but streaming — not wedged at js=null.
+    expect(configs.map((c) => c.num_replicas)).toEqual([1]);
+    // Unreplicated, but streaming — not wedged at js=null.
     expect(
       await buffer.publishRawChunk("thrd_x", { type: "text" } as never),
     ).toBe(true);
+  });
+
+  it("init requests a replicated stream on a clustered NATS", async () => {
+    const configs: Array<{ num_replicas: number }> = [];
+    const streamUpdateMock = mock(
+      (_name: string, config: { num_replicas: number }) => {
+        configs.push(config);
+        return Promise.resolve({});
+      },
+    );
+    const mockJsm = {
+      streams: {
+        info: mock(() => Promise.resolve({})),
+        update: streamUpdateMock,
+        add: mock(() => Promise.resolve({})),
+      },
+    };
+
+    const buffer = new NatsStreamBuffer({
+      getConnection: () => ({ info: { cluster: "deco-nats" } }) as never,
+      getJetStream: () => ({}) as never,
+      getJetStreamManager: (() => Promise.resolve(mockJsm)) as never,
+    });
+
+    await buffer.init();
+
+    expect(configs.map((c) => c.num_replicas)).toEqual([3]);
+  });
+
+  it("init rewrites a stale meta.inf by following add with update", async () => {
+    // `add` onto the directory left behind by an unrecoverable stream reuses it
+    // and keeps the old meta.inf, so without the trailing `update` the very next
+    // NATS boot fails to recover the stream again.
+    const streamAddMock = mock(() => Promise.resolve({}));
+    const streamUpdateMock = mock((_name: string, _config: unknown) =>
+      Promise.resolve({}),
+    );
+    const mockJsm = {
+      streams: {
+        info: mock(() => Promise.reject(new Error("stream not found"))),
+        update: streamUpdateMock,
+        add: streamAddMock,
+      },
+    };
+
+    const buffer = new NatsStreamBuffer({
+      getConnection: () => ({ info: {} }) as never,
+      getJetStream: () => ({}) as never,
+      getJetStreamManager: (() => Promise.resolve(mockJsm)) as never,
+    });
+
+    await buffer.init();
+
+    expect(streamAddMock).toHaveBeenCalledTimes(1);
+    expect(streamUpdateMock).toHaveBeenCalledTimes(1);
+    expect(streamUpdateMock.mock.calls[0]?.[0]).toBe("DECOPILOT_STREAMS");
   });
 
   it("init does NOT fall back to 1 replica on an unrelated update failure", async () => {
@@ -303,7 +357,9 @@ describe("NatsStreamBuffer", () => {
     };
 
     const buffer = new NatsStreamBuffer({
-      getConnection: () => ({}) as never,
+      // Clustered, so the clamp keeps 3 and the replica predicate is what
+      // decides — which is the branch this test is about.
+      getConnection: () => ({ info: { cluster: "deco-nats" } }) as never,
       getJetStream: () => ({}) as never,
       getJetStreamManager: (() => Promise.resolve(mockJsm)) as never,
     });

--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -87,11 +87,9 @@ const MAX_BYTES = 4 * 1024 * 1024 * 1024; // 4GB stream cap
  * how one NATS pod restart darkened chat cluster-wide on 2026-08-26. 3 matches
  * the cluster size so a single node loss keeps quorum.
  *
- * This is the *requested* count, not a guarantee: a single-node JetStream
- * rejects anything above 1 outright, and `init()` then falls back to an
- * unreplicated stream — see `isReplicaUnsupportedError`. Local `bun run dev`,
- * self-hosts and the multi-pod/resilience test clusters all run one NATS node,
- * so without that fallback a replicated default darkens streaming there.
+ * This is the *requested* count, not a guarantee: `init()` clamps it to what
+ * the connected server can host (`supportedReplicas`). Local `bun run dev`,
+ * self-hosts and the multi-pod/resilience test clusters all run one NATS node.
  *
  * Env-overridable for rollback without a deploy — `init()` applies the value
  * through `streams.update`, and JetStream scales replicas online, so setting
@@ -236,6 +234,27 @@ export interface NatsStreamBufferOptions {
 }
 
 /**
+ * Clamp the requested replica count to what the connected server can host.
+ *
+ * `streams.add` rejects `num_replicas > 1` on a non-clustered server, but
+ * `streams.update` ACCEPTS it: it persists `num_replicas: 3` into the stream's
+ * on-disk `meta.inf` and reports success. The server then cannot recover that
+ * stream on its next boot and serves 503 from `/healthz` forever, which in
+ * Kubernetes means the startup probe never passes, so the pod never joins the
+ * Service and no client can reach it to undo the damage. Because `update`
+ * returns no error, `isReplicaUnsupportedError` cannot catch this — the count
+ * has to be clamped before any config is written.
+ *
+ * `ServerInfo.cluster` carries the cluster name and is only present when the
+ * server runs a `cluster{}` block; a single node reports nothing. Peer counts
+ * are deliberately not used: `connect_urls` is empty whenever `advertise` is
+ * off, which is the norm behind a Service.
+ */
+function supportedReplicas(nc: NatsConnection, requested: number): number {
+  return nc.info?.cluster ? requested : 1;
+}
+
+/**
  * The server cannot satisfy the requested replica count. A single-node
  * (non-clustered) JetStream rejects `replicas > 1` outright; a cluster with
  * fewer peers than requested rejects it as insufficient resources. Both are
@@ -288,6 +307,10 @@ export class NatsStreamBuffer implements StreamBuffer {
           err instanceof Error && err.message.includes("stream not found");
         if (isNotFound) {
           await mgr.streams.add(config);
+          // `add` onto a directory left by an unrecoverable stream reuses it
+          // and leaves the old `meta.inf`, so the next boot fails to recover
+          // again. `update` is what rewrites it.
+          await mgr.streams.update(DECOPILOT_STREAM_NAME, config);
         } else {
           // JetStream cannot change a stream's `storage` in place, so flipping
           // the legacy Memory stream to File makes `update` reject. The stream
@@ -312,16 +335,16 @@ export class NatsStreamBuffer implements StreamBuffer {
         const mgr = this.options.getJetStreamManager
           ? await this.options.getJetStreamManager()
           : await jetstreamManager(nc);
+        const replicas = supportedReplicas(nc, STREAM_REPLICAS);
         try {
-          await ensureStream(mgr, STREAM_REPLICAS);
+          await ensureStream(mgr, replicas);
         } catch (err: unknown) {
           // A single-node NATS can't hold a replicated stream. Streaming at all
           // beats streaming with failover: retry unreplicated rather than leave
           // `js` null, which silently drops every chunk of every run.
-          if (STREAM_REPLICAS <= 1 || !isReplicaUnsupportedError(err))
-            throw err;
+          if (replicas <= 1 || !isReplicaUnsupportedError(err)) throw err;
           console.warn(
-            `[Decopilot] StreamBuffer: NATS rejected num_replicas=${STREAM_REPLICAS} ` +
+            `[Decopilot] StreamBuffer: NATS rejected num_replicas=${replicas} ` +
               `(${(err as Error).message}); falling back to an unreplicated stream`,
           );
           await ensureStream(mgr, 1);

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -591,6 +591,17 @@ s3Sync:
 # unless overridden via configMap.meshConfig.NATS_URL
 nats:
   enabled: true
+  # The subchart's startup probe uses the full /healthz, which reports 503 when
+  # any single stream fails to recover. Kubernetes suppresses the readiness and
+  # liveness probes until the startup probe passes, so one bad stream keeps the
+  # pod out of the Service permanently — and that is exactly what stops a client
+  # from connecting to repair it. js-server-only matches the readiness probe:
+  # the pod serves traffic once JetStream itself is up.
+  container:
+    merge:
+      startupProbe:
+        httpGet:
+          path: /healthz?js-server-only=true
   clusterCreds:
     # Enable when Studio's internal NATS_URL connection must authenticate with
     # a creds file.


### PR DESCRIPTION
## Summary

`deco-studio-stg`'s NATS pod has been in a 15-minute crashloop since 2026-08-26 (166 restarts), with the API logging `createTailStream: JetStream client unavailable` for every run — Decopilot streaming is dark in staging.

Root cause: **`streams.update` does not reject `num_replicas > 1` on a non-clustered server.** It accepts the call, persists `num_replicas: 3` into the stream's on-disk `meta.inf`, and reports success. The server then fails to recover that stream on its *next* boot and serves 503 from `/healthz` forever.

In Kubernetes that is terminal. The NATS subchart's startup probe uses the full `/healthz`, and Kubernetes suppresses the readiness and liveness probes until the startup probe passes — so the pod never becomes Ready, never joins the Service, and **no client can reach it to repair the stream**:

```
$ kubectl get endpoints -n deco-studio-stg deco-studio-stg-nats
subsets:
- notReadyAddresses:          # <- zero ready addresses
  - ip: 10.3.110.133
```

The single-node fallback added in #6625 cannot catch this: it is error-driven, and `update` raises no error. It only ever covered the `streams.add` path. Staging has been running a build that contains #6625 (it shipped in v4.279.1; stg is on 4.290.1) and is broken anyway.

## Changes

- **Clamp the replica count to what the connected server can host, before any config is written.** `ServerInfo.cluster` is present only when the server runs a `cluster{}` block. Verified against both real deployments — prod reports `"deco-studio-nats"`, a single node reports nothing. Peer counts are deliberately not used: `connect_urls` is empty whenever `advertise` is off, which is the norm behind a Service.
- **Follow `streams.add` with `streams.update`.** `add` onto the directory left behind by an unrecoverable stream reuses it and keeps the stale `meta.inf` — the runtime looks healthy while the next boot fails to recover again. `update` is what rewrites the file. This makes an **already-poisoned volume self-heal**, so staging recovers on deploy with no manual `rm -rf` on the PVC.
- **Point the NATS startup probe at `js-server-only`**, matching the readiness probe, so one unrecoverable stream can no longer strand the pod outside the Service — the state that blocks the repair above.

## Testing

Verified against `nats-server` **2.12.5** (the deployed build) on a real JetStream store, reproducing staging's exact state:

| step | result |
|---|---|
| `update(R=3)` on a single node | returns **OK**, writes `"num_replicas":3` to `meta.inf` |
| restart | `Error recreating stream ... replicas > 1 not supported in non-clustered mode (10074)` → `/healthz` **503** |
| `add(R=1)` alone (old fallback) | runtime healthy, `meta.inf` still 3 → **re-breaks on next restart** |
| patched `init()` | `meta.inf` repaired to 1, `/healthz` **200**, still 200 after restart |

`/healthz?js-server-only=true` returns `{"status":"ok"}` on the poisoned server, confirming the probe change lets the pod join the Service.

Unit tests: the test asserting the old `[3, 1]` behavior is inverted to assert a non-clustered server is never sent a replicated config at all; added coverage for the clustered path and for the `add`-then-`update` repair. The "unrelated failure must surface" test now uses a clustered connection so it still exercises `isReplicaUnsupportedError` rather than short-circuiting on the clamp.

```
bun test apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts   38 pass, 0 fail
bun run check    clean
bun run lint     0 errors
bun run knip     clean
helm template    startupProbe -> /healthz?js-server-only=true (port: monitor preserved)
```

## Affected areas / risk

**Prod is unaffected by the bug** — it is clustered (`cluster_size: 3`) and already runs `DECOPILOT_STREAMS` at R=3 with all peers current, so the clamp is a no-op there and it keeps requesting 3.

The behavior change is limited to non-clustered servers (staging, local `bun run dev`, self-hosts, the resilience/e2e clusters), which cannot host a replicated stream in the first place. The shipped chart defaults to a single NATS node (`nats.config.cluster.enabled: false` upstream, not overridden here), so **every self-hosted install on ≥ v4.273.1 is exposed to this** — they get the fix too.

The startup-probe change makes NATS join the Service slightly earlier, on the same condition readiness already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a NATS stream config bug that could permanently brick a single-node NATS. `streams.update` accepted `num_replicas: 3` on a non-clustered server and persisted it to the stream's on-disk config; the server then couldn't recover that stream on its next boot, served 503 from `/healthz` forever, and stayed out of the Kubernetes Service with no client able to reach it to repair the stream.

**Bug Fixes**
- Replica count is clamped to what the connected server can host before any config is written.
- `streams.add` is now followed by `streams.update` so an already-poisoned volume self-heals instead of re-breaking on the next boot.
- NATS startup probe points at `js-server-only` so one unrecoverable stream can't strand the pod outside the Service.

Clustered prod is unaffected and keeps requesting 3 replicas; the fix applies to single-node installs (staging, local dev, self-hosts).

<sup>Written for commit f7ebbc2c960854ff8f9a8374f8b1e84323990f67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

