### PR TITLE
fix(web): always run a repo-backed editor on a thread (#6667 follow-up)

### DIFF
--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -25,6 +25,8 @@ import {
   useEffect,
   useLayoutEffect,
   useRef,
+  useState,
+  useSyncExternalStore,
   use,
   Suspense,
   type ReactNode,
@@ -45,7 +47,10 @@ import { useProjectContext, useVirtualMCP, parseBranchMap } from "@/sdk";
 import type { VirtualMCPEntity, SandboxMap } from "@decocms/shared/sdk/types";
 import { agentHasClonableSource } from "@/lib/agent-capabilities";
 import { generateBranchName } from "@decocms/shared/branch-name";
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { defaultThreadRuntime } from "@decocms/shared/thread/session-runtime";
+import { useThreadManager } from "@/components/chat/store/hooks";
+import { findReusableNewChat } from "@/lib/reusable-new-chat";
+import { Navigate, useNavigate, useParams } from "@tanstack/react-router";
 import { useIsSandboxStartPending } from "@/components/sandbox/hooks/use-sandbox-start";
 import { useStatusSounds } from "../../hooks/use-status-sounds";
 import { authClient } from "@/lib/auth-client";
@@ -569,6 +574,17 @@ function AgentInsetProvider() {
   const routeThreadId = useRouteThreadId();
   /** The agent is the `{-$project}` segment on a destination, `?virtualmcpid=` on the legacy route. */
   const virtualMcpId = useRouteVirtualMcpId();
+  /** A stable thread id to mint when a repo-backed editor arrives with none and
+   *  the user has no idle empty chat to reuse, so a re-render before the URL
+   *  catches up reuses it instead of looping through fresh ones. Generated once
+   *  per mount; only used by the redirect below. */
+  const [generatedThreadId] = useState(() => crypto.randomUUID());
+  const { data: session } = authClient.useSession();
+  const threadManager = useThreadManager();
+  const threads = useSyncExternalStore(
+    threadManager.threads.subscribe,
+    threadManager.threads.get,
+  );
 
   // Ensure the thread row exists for this URL before rendering the chat. On
   // 404 the hook fires COLLECTION_THREADS_CREATE (idempotent) and surfaces a
@@ -614,6 +630,32 @@ function AgentInsetProvider() {
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
   }, []);
+
+  /**
+   * A repo-backed editor's branch is a thread field, so it must run on a thread;
+   * mint one into `?thread=` before mounting when the URL names none (#6667). The
+   * Super Agent (no repo) keeps its lazy threadless composer.
+   */
+  if (routeThreadId === null && hasActiveGithubRepo) {
+    // Focus the user's idle empty chat for this agent, else mint one — as useNavigateToAgent does.
+    const threadId =
+      findReusableNewChat(
+        threads,
+        virtualMcpId,
+        session?.user?.id,
+        defaultThreadRuntime(entity.metadata),
+      )?.id ?? generatedThreadId;
+    return (
+      <Navigate
+        to="."
+        replace
+        search={(prev: Record<string, unknown>) => ({
+          ...prev,
+          thread: threadId,
+        })}
+      />
+    );
+  }
 
   const chatVirtualMcpId = virtualMcpId;
 


### PR DESCRIPTION
## Summary

After #6667 started addressing destinations by path, a **repo-backed agent editor could open with no thread** in the URL (`?thread=` absent — a deep link, `choose-editor`, or any navigation that didn't carry it, since the shell deliberately doesn't retain `thread` across navigations).

The branch is a **thread field** (`activeTask.branch`), so a threadless editor left the branch picker stranded on **"Select branch…"**, with both *selecting* a branch and *New* silently doing nothing (`setCurrentTaskBranch` is gated on an active thread), and the adopt / auto-fresh-stale effects never firing.

`AgentInsetProvider` now **guarantees a thread for repo-backed agents**: when the URL names none it mints one into `?thread=` **before mounting**, reusing the user's idle empty "New chat" for that agent when one exists — exactly what `useNavigateToAgent` does (`findReusableNewChat ?? fresh id`). This restores the pre-#6667 behavior where the client minted the thread id and the ensure-fallback created the row on landing.

Scoped to repo-backed agents on purpose — the Super Agent (no repo, no branch pill) keeps its lazy threadless empty composer that #6667 designed.

## Why it happens

- `resolveRouteThreadId` returns `null` on a destination with no `?thread=` → `currentBranch = activeTask?.branch ?? null` → picker falls back to "Select branch…".
- `setCurrentTaskBranch` is `if (effectiveTaskId) …` → no-op without a thread → selecting/`New` do nothing.
- `VmEventsBridge`'s adopt-branch and auto-fresh-stale both require `activeTask`, so neither runs.

## Relationship to #6639

Complementary, not conflicting (same file, different function — `AgentInsetProvider` vs `VmEventsBridge`; #6639 is already an ancestor). With a thread guaranteed, adopt mints a fresh **unmaterialized (non-stale)** branch and #6639's auto-fresh-stale check evaluates correctly instead of sitting dead on a threadless entry. No double-switch: `isBranchStale(null)` is `false` and both effects are one-shot per thread/tab.

## Testing

- `bun run --cwd=apps/web check` ✅
- `bun run lint` ✅
- `bun run fmt` ✅
- unit: `thread-route.test.ts` + `use-layout-state.test.ts` → 57 pass / 0 fail

Not yet added: an e2e that enters a repo-backed destination without `?thread=` and asserts the URL gains `?thread=` + a real branch (reusing an idle empty chat when present). Happy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes repo-backed agent editors opening without a thread in the URL, which stranded the branch picker on “Select branch…” and made selecting a branch or New silently do nothing. `AgentInsetProvider` now guarantees a thread before mounting by minting `?thread=` into the URL, reusing the user’s idle empty chat for that agent when one exists. Scoped to repo-backed agents, the Super Agent keeps its lazy threadless composer.

<sup>Written for commit 50380be8f55b370b39f009cc66ce8cd56738eab3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

