### PR TITLE
feat(task-board): let the board decide, instead of comparing status to literals

### DIFF
--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -24,6 +24,7 @@
  * its issue is next updated in Jira.
  */
 
+import { boardHandler } from "@/tools/task-board/board-handler";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import type { StudioContext } from "@/core/studio-context";
 import type {
@@ -240,8 +241,11 @@ async function maybeAutoDelegate(
   item: TaskBoardItem,
 ): Promise<TaskBoardItem> {
   if (!integration.autoDelegate) return item;
-  if (item.status !== "todo" || item.assigneeId) return item;
+  if (item.assigneeId) return item;
   const orgId = integration.organizationId;
+  // The board decides whether its own column starts work; one nobody set up
+  // that way is uneventful.
+  if (!(await boardHandler(orgId).startsWorkOn(item.status))) return item;
   // Conditional claim, not a plain update: the cron, a webhook wake-up (its
   // debounce is per-pod) and a manual JIRA_SYNC_RUN can all be mid-sync on the
   // same issue, and a read-then-write would dispatch two paid agent runs on it.

--- a/apps/api/src/tools/task-board/board-handler.test.ts
+++ b/apps/api/src/tools/task-board/board-handler.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { CANONICAL_COLUMN_KEYS } from "@decocms/shared/task-board";
+import { boardHandler } from "./board-handler";
+import { LANE_RANK } from "./lanes";
+
+/**
+ * The seam automation asks instead of comparing `status` to a literal.
+ *
+ * One board is behind it today; what these pin is the contract the second one
+ * has to honour. Above all that a column can be uneventful — a board mirrored
+ * from someone else's tracker will have mostly columns nobody configured, and
+ * a caller that assumes every column means something is the bug.
+ */
+describe("boardHandler — the board Studio ships with", () => {
+  const board = boardHandler("org_1");
+
+  it("renders every canonical column, left to right", async () => {
+    expect((await board.columns()).map((c) => c.key)).toEqual([
+      ...CANONICAL_COLUMN_KEYS,
+    ]);
+  });
+
+  /** Position and rank are one ordering read two ways; if they drift, a card
+   *  is "left of" something and "right of" it at once. */
+  it("orders columns the way the forward-only guard ranks them", async () => {
+    for (const column of await board.columns()) {
+      expect(column.position).toBe(
+        LANE_RANK[column.key as keyof typeof LANE_RANK],
+      );
+    }
+  });
+
+  it("starts work on the To Do lane", async () => {
+    expect(await board.startsWorkOn("todo")).toBe(true);
+  });
+
+  it("starts work nowhere else, including a column it does not have", async () => {
+    for (const key of CANONICAL_COLUMN_KEYS.filter((k) => k !== "todo")) {
+      expect(await board.startsWorkOn(key)).toBe(false);
+    }
+    expect(await board.startsWorkOn("code_review")).toBe(false);
+    expect(await board.startsWorkOn("")).toBe(false);
+  });
+});

--- a/apps/api/src/tools/task-board/board-handler.ts
+++ b/apps/api/src/tools/task-board/board-handler.ts
@@ -1,0 +1,65 @@
+import type { BoardColumn } from "@decocms/shared/task-board";
+import { CANONICAL_COLUMN_KEYS } from "@decocms/shared/task-board";
+
+/**
+ * A board's behaviour, as the questions its callers actually have.
+ *
+ * Deliberately not a lookup like "give me the column for role R". That would
+ * leave `"todo"` and `"in_review"` written at every call site, which is the
+ * thing being removed — the caller would still be reasoning in Studio's
+ * vocabulary, just through one more hop.
+ *
+ * So each method is a decision. Studio's own board decides with an `if` over
+ * the lanes it ships. A board mirrored from a customer's tracker decides by
+ * reading what someone configured for that column, and answers null wherever
+ * nothing is — which is most columns, and must stay uneventful rather than
+ * fall back to a guess.
+ */
+export interface BoardHandler {
+  /** The columns to render, left to right. */
+  columns(): Promise<BoardColumn[]>;
+
+  /**
+   * Does a card landing in `columnKey` start work?
+   *
+   * Boolean while every board that exists runs the Super Agent's built-in
+   * prompt. The prompt becomes part of this answer with the implementation
+   * that can actually carry one, rather than being modelled now and returned
+   * null by everybody.
+   */
+  startsWorkOn(columnKey: string): Promise<boolean>;
+}
+
+/** `title` is the key: the canonical columns are translated by the client,
+ *  which is the only place that knows the reader's language. A mirrored column
+ *  carries the name its tracker gave it, which is not ours to translate. */
+const CANONICAL: BoardColumn[] = CANONICAL_COLUMN_KEYS.map((key, position) => ({
+  key,
+  title: key,
+  position,
+  role: key,
+}));
+
+/** The board Studio ships with: a fixed set, and one lane that starts work. */
+class StaticBoardHandler implements BoardHandler {
+  columns(): Promise<BoardColumn[]> {
+    return Promise.resolve(CANONICAL);
+  }
+
+  startsWorkOn(columnKey: string): Promise<boolean> {
+    return Promise.resolve(columnKey === "todo");
+  }
+}
+
+const STATIC = new StaticBoardHandler();
+
+/**
+ * This org's board.
+ *
+ * One implementation today. It takes the org so every call site is already
+ * written the way it needs to be once a board can be tracker-owned instead,
+ * and choosing between the two is a change here rather than at each caller.
+ */
+export function boardHandler(_organizationId: string): BoardHandler {
+  return STATIC;
+}

--- a/apps/api/src/tools/task-board/lanes.ts
+++ b/apps/api/src/tools/task-board/lanes.ts
@@ -11,20 +11,21 @@
  * too, and those importing `run-reactions` for a constant would be a cycle.
  */
 
-import { DELIVERY_LANES } from "@decocms/shared/task-board";
+import {
+  CANONICAL_COLUMN_KEYS,
+  type CanonicalColumnKey,
+  DELIVERY_LANES,
+} from "@decocms/shared/task-board";
 import type { TaskBoardItemStatus } from "@/storage/types";
 
-export const LANE_RANK: Record<TaskBoardItemStatus, number> = {
-  triage: 0,
-  todo: 1,
-  in_progress: 2,
-  in_review: 3,
-  approved: 4,
-  merged: 5,
-  post_deploy_validation: 6,
-  done: 7,
-  archived: 8,
-};
+const RANK_BY_KEY = Object.fromEntries(
+  CANONICAL_COLUMN_KEYS.map((key, index) => [key, index]),
+) as Record<CanonicalColumnKey, number>;
+
+/** Annotated, not cast: a status added to the union with no place in
+ *  `CANONICAL_COLUMN_KEYS` fails to satisfy this `Record` and is a compile
+ *  error here, which is the whole reason the table is exhaustive. */
+export const LANE_RANK: Record<TaskBoardItemStatus, number> = RANK_BY_KEY;
 
 /** The delivery lanes, as board statuses — the assertion that the shared
  *  literal union stays a subset of this side's lane vocabulary. */

--- a/apps/api/src/tools/task-board/list.ts
+++ b/apps/api/src/tools/task-board/list.ts
@@ -1,9 +1,18 @@
+import { boardHandler } from "./board-handler";
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { requireAuth } from "@/core/studio-context";
 import { listRepoScopeLabels } from "@decocms/shared/github-repo-scope";
 import { SprintSchema, TaskBoardItemSchema } from "./schema";
 import { recoverStalledTasks } from "./stall-recovery";
+
+/** A board column as the client renders it — mirrors `BoardColumn` in shared. */
+const BoardColumnSchema = z.object({
+  key: z.string(),
+  title: z.string(),
+  position: z.number(),
+  role: z.string().nullable(),
+});
 
 export const TASK_BOARD_ITEM_LIST = defineTool({
   name: "TASK_BOARD_ITEM_LIST",
@@ -25,6 +34,8 @@ export const TASK_BOARD_ITEM_LIST = defineTool({
     repos: z.array(z.string()),
     // The sprint filter's option set, in reading order (running → next → past).
     sprints: z.array(SprintSchema),
+    // The board's columns, left to right — its whole vocabulary.
+    columns: z.array(BoardColumnSchema),
   }),
   handler: async (_input, ctx) => {
     requireAuth(ctx);
@@ -37,11 +48,13 @@ export const TASK_BOARD_ITEM_LIST = defineTool({
       );
     }
 
-    const [items, { items: githubConnections }, sprints] = await Promise.all([
-      ctx.storage.taskBoard.list(organizationId),
-      ctx.storage.connections.list(organizationId, { slug: "mcp-github" }),
-      ctx.storage.sprints.listByOrg(organizationId),
-    ]);
+    const [items, { items: githubConnections }, sprints, columns] =
+      await Promise.all([
+        ctx.storage.taskBoard.list(organizationId),
+        ctx.storage.connections.list(organizationId, { slug: "mcp-github" }),
+        ctx.storage.sprints.listByOrg(organizationId),
+        boardHandler(organizationId).columns(),
+      ]);
     const repos = listRepoScopeLabels(githubConnections);
 
     // Opening the board is the stall-recovery trigger: re-run the thread-finish
@@ -51,6 +64,6 @@ export const TASK_BOARD_ITEM_LIST = defineTool({
     // moves broadcast over SSE, which is how the board already learns them).
     void recoverStalledTasks(ctx, items);
 
-    return { items, repos, sprints };
+    return { items, repos, sprints, columns };
   },
 });

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -187,6 +187,41 @@ export function enabledReviewerKinds(
  * status stays in the union, keeping `LANE_RANK`/`STATUS_CONFIG` exhaustive.
  * The flag gates REACHABILITY: which lanes a board offers, where a ship lands.
  */
+/**
+ * The board Studio ships with, in board order.
+ *
+ * One ordering, read by both the rank guard (`LANE_RANK`) and the static
+ * column set, so "left of" cannot come to mean two different things.
+ */
+export const CANONICAL_COLUMN_KEYS = [
+  "triage",
+  "todo",
+  "in_progress",
+  "in_review",
+  "approved",
+  "merged",
+  "post_deploy_validation",
+  "done",
+  "archived",
+] as const;
+
+export type CanonicalColumnKey = (typeof CANONICAL_COLUMN_KEYS)[number];
+
+/**
+ * A board column as every surface reads it.
+ *
+ * `key` is the value a card's `status` holds. `role` is what automation keys
+ * on, and is nullable because a board mirrored from someone else's tracker
+ * will have columns nobody assigned a meaning to — null has to mean "nothing
+ * automatic happens here", not a guess.
+ */
+export interface BoardColumn {
+  key: string;
+  title: string;
+  position: number;
+  role: string | null;
+}
+
 export type DeliveryLane = "approved" | "merged" | "post_deploy_validation";
 
 export const DELIVERY_LANES: DeliveryLane[] = [

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -482,6 +482,12 @@ export interface StudioToolIO {
         startsAt: string | null;
         endsAt: string | null;
       }[];
+      columns: {
+        key: string;
+        title: string;
+        position: number;
+        role: string | null;
+      }[];
     };
   };
   TASK_BOARD_ITEM_UPDATE: {


### PR DESCRIPTION
## What is this contribution about?

Step one of moving the board off a hardcoded lane set: **introduce the seam, with the only board that exists today behind it.** No behaviour changes.

```ts
export interface BoardHandler {
  /** The columns to render, left to right. */
  columns(): Promise<BoardColumn[]>;
  /** Does a card landing in `columnKey` start work? */
  startsWorkOn(columnKey: string): Promise<boolean>;
}
```

Studio's own board decides with an `if` over the lanes it ships. A board mirrored from a customer's tracker will decide by reading what someone configured for that column, and answer no wherever nothing is — which will be most columns, and has to stay uneventful rather than fall back to a guess.

### It is a set of decisions, not a lookup

An earlier draft of this PR offered `forRole("todo")`. @viktormarinho called it strange and was right: that is the wrong altitude. It leaves the literal at the call site wearing a different hat, so every caller still reasons in Studio's vocabulary — just through one more hop. Nothing is actually removed.

Each method now answers the question its caller has, and the vocabulary lives inside the implementation. The one converted caller shows it. Auto-delegate used to read:

```ts
if (item.status !== "todo" || item.assigneeId) return item;
```

and now asks the board whether that column starts work. It is also exactly the call site that becomes per-column configuration next, so it is converted first rather than last.

### `startsWorkOn` is boolean on purpose

The configured prompt belongs in this answer — that is the point of the whole direction. But modelling it now means a field the only implementation always returns `null` for. Threading a custom prompt is real work in the Super Agent's prompt builder (`SuperAgentPromptOpts`), not a one-liner, and it is the next step's. The answer widens when there is an implementation that can carry one.

### No table, no seed — reversing my first attempt

I originally shipped this as a `task_board_columns` table seeded for every org. @viktormarinho pushed back and was right, so this is a rewrite.

The canonical columns are **constants, because that is what they are.** Rows would have been every org's worth of byte-identical data that says nothing, and worse, data that can drift out of agreement with the code defining it — a static board is only reliably static if it is a constant. Rows arrive with the second implementation, seeded when a board converts to tracker-owned, which is the only moment a seed means anything.

That correction also fixes an argument I had wrong. I claimed a handler interface would produce two identical implementations — but they were only identical *because* I had collapsed the static case into the same storage. One decides with an `if`, the other by reading configuration. The difference is real and the interface earns its keep.

Two things this avoids shipping dormant: an empty table with no writer, and a board-mode flag nothing branches on. Both belong to the step that introduces the second implementation.

### One source for the order

`CANONICAL_COLUMN_KEYS` now feeds both the column set and `LANE_RANK`, the latter assigned through an **annotation rather than a cast** — so a status added to the union with no place in the list is a compile error, which is what that table was always for.

Verified rather than assumed. Removing `post_deploy_validation`:

```
lanes.ts(28,14): error TS2741: Property 'post_deploy_validation' is missing in type
'Record<"approved" | "archived" | …, number>' but required in type 'Record<TaskBoardItemStatus, number>'.
```

Restoring it returns to zero.

## How did you verify your code works?

Four unit cases on the seam — pure, no DB, since the static board is a constant. They pin the contract the *second* implementation must honour, not just today's answers: every canonical column rendered left to right; **positions agree with `LANE_RANK`**, so the two readings of "left of" cannot drift; work starts on To Do; and work starts **nowhere else**, including a column this board does not have (`code_review`, `""`) — the uneventful case that matters most for a mirrored board.

Both interface methods have a real caller — `columns()` on the board read, `startsWorkOn()` in auto-delegate — so neither is dead.

638 pass / 0 fail across `apps/api/src/jira/` and `tools/task-board/`. `bun run check` 0 type errors, `bun run lint` 19 warnings identical to baseline, `knip` clean, `fmt:check` clean. Tool contracts regenerated for the new `columns` field.

**Not verified, flagging honestly:**

- **No e2e, and no client change.** The board read returns `columns` and nothing consumes it — the web still renders from its hardcoded config. Intentional here, but the new wire field's only proof is the unit tier.
- **The auto-delegate conversion has no test of its own.** Behaviour is unchanged and covered by the existing Jira suite, but nothing asserts "a board that starts work nowhere delegates nothing" against the real call path — that case is unreachable until a second implementation exists.
- `title` on a canonical column is the key (`in_progress`, not "In Progress"), because the client owns translation and duplicating i18n server-side would be worse. A mirrored column will carry the tracker's own name, which is not ours to translate.

## Screenshots/Demonstration

Not applicable — no user-visible change.

## How to Test

1. Open a board. Identical to before.
2. Confirm Jira auto-delegate still fires on a card landing in To Do, and still does not fire for an already-assigned card.
3. Call `TASK_BOARD_ITEM_LIST` and confirm the response carries `columns` alongside `sprints`.

## Migration Notes

None — no schema change, no data change. `TASK_BOARD_ITEM_LIST` gains a `columns` field; the generated `tool-io.ts` diff is committed.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes
