### PR TITLE
fix(helm): publish NATS startup probe recovery

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,6 +2,8 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
+# 0.16.1: let a single-node NATS recover a poisoned JetStream stream by using
+# js-server-only for its startup probe; the API can then connect and repair it.
 # 0.16.0: hosted execution is now enabled explicitly with
 # STUDIO_AGENT_SANDBOX_ENABLED; the provider and runner selectors are gone.
 # 0.15.0: the single-writer migration Job now runs outside preview too
@@ -78,7 +80,7 @@ type: application
 # when disabled, so existing releases are unaffected.
 # 0.12.4: chart-managed API/worker dispatch roles now use
 # STUDIO_DISPATCH_ROLE; legacy overrides are rejected.
-version: 0.16.0
+version: 0.16.1
 appVersion: "latest"
 
 dependencies:


### PR DESCRIPTION
## Summary

- bump chart-deco-studio from 0.16.0 to 0.16.1
- publish the NATS startup-probe recovery added in #6679
- allow staging NATS to enter the Service so the API can repair the poisoned DECOPILOT_STREAMS metadata

Without this bump, the Helm publish workflow is not triggered and staging remains on chart 0.16.0 with the old /healthz startup probe.

## Testing

- bun run fmt
- helm lint deploy/helm/studio --set secret.secretName=verification-only
- helm template confirms both NATS readiness and startup probes use /healthz?js-server-only=true
- git diff --check

## Deployment

The chart publish workflow dispatches studio-chart-bump to deco-apps-cd, which updates staging and production. No separate CD repository PR is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `chart-deco-studio` from 0.16.0 to 0.16.1 so the NATS startup probe recovery ships to staging and production. The old chart left the startup probe at `/healthz`, which can block a single-node NATS from recovering a poisoned JetStream stream; the new chart uses `/healthz?js-server-only=true` so the API can connect and repair the stream. Without this bump, the Helm publish workflow is never triggered.

**Deployment**
- The chart publish workflow dispatches `studio-chart-bump` to `deco-apps-cd`, which updates staging and production. No separate CD PR is required.

<sup>Written for commit 2502612fb6f86ddc1e4ff02523c047368176470d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

