### PR TITLE
fix(chat): cap the bash-sleep-start sessionStorage tracking to an LRU of 200

### DIFF
--- a/apps/web/src/components/chat/message/parts/tool-call-part/bash-wait.test.ts
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/bash-wait.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { upsertCallStartEntries } from "./bash-wait";
+
+describe("upsertCallStartEntries", () => {
+  test("adds a new entry", () => {
+    expect(upsertCallStartEntries([], "call-1", 100)).toEqual([
+      ["call-1", 100],
+    ]);
+  });
+
+  test("moves an existing entry to the most-recent slot without duplicating it", () => {
+    const entries: [string, number][] = [
+      ["call-1", 100],
+      ["call-2", 200],
+    ];
+    expect(upsertCallStartEntries(entries, "call-1", 999)).toEqual([
+      ["call-2", 200],
+      ["call-1", 999],
+    ]);
+  });
+
+  test("evicts the oldest entry once past the cap", () => {
+    const entries: [string, number][] = [
+      ["call-1", 100],
+      ["call-2", 200],
+    ];
+    expect(upsertCallStartEntries(entries, "call-3", 300, 2)).toEqual([
+      ["call-2", 200],
+      ["call-3", 300],
+    ]);
+  });
+});

--- a/apps/web/src/components/chat/message/parts/tool-call-part/bash-wait.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/bash-wait.tsx
@@ -2,7 +2,46 @@ import { useState } from "react";
 import { useT } from "@/i18n/use-t.ts";
 import { useClockTick } from "@/lib/use-clock-tick.ts";
 
-const STORAGE_PREFIX = "bash-sleep-start:";
+const STORAGE_KEY = "studio:bash-sleep-start:v1";
+
+/** LRU cap. A long session runs many `bash` calls; bounds sessionStorage growth. */
+const MAX_ENTRIES = 200;
+
+type StoredEntry = [toolCallId: string, startedAtMs: number];
+
+/**
+ * LRU upsert of `toolCallId`, evicting the oldest entries past `cap`. Pure —
+ * takes and returns the entry list, same shape as `thread-layout-memory`'s.
+ */
+export function upsertCallStartEntries(
+  entries: StoredEntry[],
+  toolCallId: string,
+  startedAtMs: number,
+  cap: number = MAX_ENTRIES,
+): StoredEntry[] {
+  const next = entries.filter(([id]) => id !== toolCallId);
+  next.push([toolCallId, startedAtMs]);
+  while (next.length > cap) next.shift();
+  return next;
+}
+
+function readEntries(): StoredEntry[] {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is StoredEntry =>
+        Array.isArray(e) &&
+        e.length === 2 &&
+        typeof e[0] === "string" &&
+        Number.isFinite(e[1]),
+    );
+  } catch {
+    return [];
+  }
+}
 
 /**
  * First-observed fire time (epoch ms) for a bash `sleep`, keyed by toolCallId
@@ -14,15 +53,15 @@ const STORAGE_PREFIX = "bash-sleep-start:";
  * `Date.now()` (and records it) the first time a given call is seen.
  */
 function firstSeenStart(toolCallId: string): number {
-  const key = STORAGE_PREFIX + toolCallId;
   try {
-    const stored = sessionStorage.getItem(key);
-    if (stored !== null) {
-      const parsed = Number.parseInt(stored, 10);
-      if (Number.isFinite(parsed)) return parsed;
-    }
+    const entries = readEntries();
+    const existing = entries.find(([id]) => id === toolCallId);
+    if (existing) return existing[1];
     const now = Date.now();
-    sessionStorage.setItem(key, String(now));
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(upsertCallStartEntries(entries, toolCallId, now)),
+    );
     return now;
   } catch {
     // sessionStorage unavailable (SSR / privacy mode): best-effort, non-sticky.


### PR DESCRIPTION
**Source:** un-CI-enforced resource-bound debt (C-DEBT/C3), spotted while auditing `bash-wait.tsx` (recently churned alongside the claude-code token-streaming work).

**Why a maintainer wants this:** `firstSeenStart` in `bash-wait.tsx` wrote one permanent `sessionStorage` key per bash `sleep` tool call the client ever rendered (`bash-sleep-start:<toolCallId>`), with no eviction — unlike its sibling `thread-layout-memory.ts`, which already caps its own sessionStorage entries at an LRU of 50 for exactly this reason (see its module docblock: "Bounds growth within a session"). A long chat session with many `sleep` calls (loops, retries, polling scripts) accumulates keys forever for the life of the tab.

**Fix:** collapsed the per-key storage into a single JSON-backed LRU list (cap 200), mirroring `thread-layout-memory`'s `upsertThreadLayoutEntries` shape/pattern almost exactly (`upsertCallStartEntries`). Behavior is unchanged for the common case — the anchor timestamp for a given `toolCallId` is still recovered across reload the same way — only growth is now bounded.

**Regression test:** `bash-wait.test.ts` covers the pure `upsertCallStartEntries` helper: adds a new entry, moves an existing entry to the most-recent slot without duplicating it, and evicts the oldest entry once past the cap.

**Reviewer command:** `bun test apps/web/src/components/chat/message/parts/tool-call-part/bash-wait.test.ts`

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` in `apps/web` (pre-existing, unrelated prosemirror version-mismatch error only — none in the touched files), the targeted test above, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `sessionStorage` growth in `bash-wait.tsx` so long chat sessions no longer accumulate an unbounded number of keys. Previously every bash `sleep` call wrote a permanent `bash-sleep-start:<toolCallId>` key; now all timestamps live in a single JSON-backed LRU list (cap 200) with the same behavior for recovering anchor times across reloads. Adds a unit test for the eviction logic.

<sup>Written for commit 3c9687cd92ab7bcda7901ab2142e15c4ff62e666. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

