### PR TITLE
fix(web): Page JSON panel follows current page on switch

### DIFF
--- a/apps/web/src/components/sandbox/blocks/blocks-panel.tsx
+++ b/apps/web/src/components/sandbox/blocks/blocks-panel.tsx
@@ -46,7 +46,7 @@ export function BlocksPanel({
    * Open the page's raw JSON in a side panel (Preview owns the slot). When
    * omitted the editor falls back to its local modal.
    */
-  onViewJsonFile?: (pageKey: string) => void;
+  onViewJsonFile?: () => void;
 }) {
   const { org } = useProjectContext();
   const { currentBranch, taskId } = useChatTask();

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -360,20 +360,17 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   } | null>(null);
   const previewIframeRef = useRef<HTMLIFrameElement>(null);
   const blocksPanelRef = useRef<PanelImperativeHandle>(null);
-  // Page key whose raw JSON is open in the side panel next to Blocks (null = closed).
-  const [jsonPageKey, setJsonPageKey] = useState<string | null>(null);
+  // Raw Page JSON side panel open state; the page it shows follows currentPageKey.
+  const [jsonPanelOpen, setJsonPanelOpen] = useState(false);
   const jsonPanelHandleRef = useRef<PageJsonPanelHandle>(null);
   const closeJsonPanel = () => {
     jsonPanelHandleRef.current?.flush();
-    setJsonPageKey(null);
+    setJsonPanelOpen(false);
   };
-  const toggleJsonPanel = (pageKey: string) =>
-    setJsonPageKey((current) => {
-      if (current === pageKey) {
-        jsonPanelHandleRef.current?.flush();
-        return null;
-      }
-      return pageKey;
+  const toggleJsonPanel = () =>
+    setJsonPanelOpen((open) => {
+      if (open) jsonPanelHandleRef.current?.flush();
+      return !open;
     });
   // Live canvas size, used to scale the fixed-width frame to fit.
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
@@ -1977,12 +1974,12 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
               externalSelection={cmsSelectedSection}
               onViewJsonFile={toggleJsonPanel}
             />
-            {jsonPageKey && (
+            {jsonPanelOpen && currentPageKey && (
               <div className="absolute inset-0 z-10">
                 <PageJsonPanel
                   ref={jsonPanelHandleRef}
                   virtualMcpId={virtualMcpId}
-                  pageKey={jsonPageKey}
+                  pageKey={currentPageKey}
                   onClose={closeJsonPanel}
                 />
               </div>
@@ -2022,9 +2019,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             >
               <ResizablePanelGroup
                 orientation="horizontal"
-                disabled={!jsonPageKey}
+                disabled={!(jsonPanelOpen && currentPageKey)}
               >
-                {jsonPageKey && (
+                {jsonPanelOpen && currentPageKey && (
                   <>
                     <ResizablePanel
                       id="preview-json-editor"
@@ -2035,7 +2032,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                       <PageJsonPanel
                         ref={jsonPanelHandleRef}
                         virtualMcpId={virtualMcpId}
-                        pageKey={jsonPageKey}
+                        pageKey={currentPageKey}
                         onClose={closeJsonPanel}
                       />
                     </ResizablePanel>

--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -167,7 +167,7 @@ export function SectionsEditor({
    * view (passing the decofile block key) instead of the built-in JSON modal.
    * Hosts without a file surface (Content tab) omit this and get the modal.
    */
-  onViewJsonFile?: (pageKey: string) => void;
+  onViewJsonFile?: () => void;
   /**
    * Called when the selected section variant changes so the host can force the
    * preview iframe to render that variant via `x-deco-matchers-override`.
@@ -2656,7 +2656,7 @@ export function SectionsEditor({
                   className="size-7 shrink-0"
                   onClick={() =>
                     onViewJsonFile && activePageKey
-                      ? onViewJsonFile(activePageKey)
+                      ? onViewJsonFile()
                       : setJsonOpen(true)
                   }
                 >


### PR DESCRIPTION
## Summary

The raw **Page JSON** side panel in the preview kept showing the page it was opened on even after switching pages via the URL-bar dropdown.

The panel's target page was stored in a frozen `useState` (`jsonPageKey`), captured at the moment "View JSON" was clicked. Changing pages updates the *current* page (`currentPageKey`) but never touched `jsonPageKey`, so the panel rendered stale JSON (e.g. `Home` / `"/"` while the dropdown had moved to `Ajuda e Contato /hc/pt-br`).

## Changes (`apps/web`)

- `preview.tsx`: replaced `jsonPageKey: string | null` with an `jsonPanelOpen: boolean`. Both `PageJsonPanel` render sites now pass `pageKey={currentPageKey}` and gate on `jsonPanelOpen && currentPageKey`, so the panel follows the active page (Monaco already remounts when `pageKey` changes). When a global section or loader is active (`currentPageKey === null`), the panel hides instead of showing a stale page.
- Dropped the now-unused `pageKey` argument from the `onViewJsonFile` prop in `blocks-panel.tsx` and `sections-editor.tsx`.

The `PageJsonPanel` component itself needed no change. The separate Content-tab JSON dialog (`content-browser.tsx`) is a different per-page modal and was intentionally left as-is.

## Testing

- `bun run fmt` + `apps/web` typecheck pass.
- Manual: not yet clicked through the running app — recommend verifying that switching pages with the panel open updates the JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Page JSON side panel in the preview no longer shows stale JSON when you switch pages via the URL-bar dropdown. It now follows the current page and hides when a global section or loader is active (no current page).

<sup>Written for commit 3d9e6b2c6b48e187928b05b39a867dc9a602eed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

