### PR TITLE
feat(task-board): written Auto-fix button instead of flash glyph

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -443,7 +443,7 @@ function FooterDueDate({
   );
 }
 
-/** The card's one run action, as a footer glyph. Its slot is always reserved, so revealing it on hover shifts nothing and covers nothing. */
+/** The card's one run action, as a written footer button. Revealed on hover; its collapsed width keeps the resting footer uncluttered. */
 function CardActionGlyph({
   action,
 }: {
@@ -452,17 +452,17 @@ function CardActionGlyph({
   return (
     <Button
       variant="ghost"
-      size="icon-sm"
-      title={action.label}
+      size="sm"
       aria-label={action.label}
       onClick={(e) => {
         e.stopPropagation();
         action.onClick();
       }}
       onPointerDown={(e) => e.stopPropagation()}
-      className="-m-1.5 pointer-events-none opacity-0 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
+      className="-my-1.5 h-7 gap-1.5 px-2 text-xs font-medium pointer-events-none opacity-0 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
     >
       <action.icon className={PROPERTY_GLYPH_CLASS} />
+      {action.label}
     </Button>
   );
 }


### PR DESCRIPTION
## Summary

On the task board card footer, the one run action (Auto-fix / Rerun) was an **icon-only** button — the lightning glyph — with its label available only through the tooltip. This makes it a **written button** (icon + label), so the action reads at a glance without hovering.

- `CardActionGlyph` now renders `action.icon` + `action.label` as a compact `size="sm"` ghost button.
- Label still comes from the existing translated `action.label` (`taskBoard.taskBoard.autoFix` / `.rerun`), so pt-br stays "Auto-correção".
- Kept the hover/focus reveal and `stopPropagation` (so clicking the button doesn't open the card).

## Before / after
- Before: 🗲 (tooltip "Auto-correção")
- After: 🗲 Auto-correção

## Testing
- `bun run fmt` ✅
- Not run in-app yet — the button is now wider than the glyph and shares the footer row with priority/checks/avatar; happy to spin up dev to eyeball the layout if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the task board card footer run action from an icon-only lightning glyph to a written icon + label button so the action reads without hovering for the tooltip.

The label stays sourced from existing translations (pt-br remains "Auto-correção"), and the hover/focus reveal and `stopPropagation` behavior are unchanged. The button is now wider and shares the footer row with priority, checks, and avatar; the new layout hasn't been verified in-app yet.

<sup>Written for commit f8935ab51710701920ba25081950e5e64fd20d4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

