### PR TITLE
fix(decofile): scope tree reads to .deco/blocks to avoid 502 on large repos

### DIFF
--- a/apps/api/src/decofile/commit-coalescer.ts
+++ b/apps/api/src/decofile/commit-coalescer.ts
@@ -124,7 +124,7 @@ async function commitBatch(batch: Batch): Promise<string> {
     // materialize it here (a save can race ahead of the editor's first read).
     const headSha = await resolveOrCreateHead(client, branch);
     const baseTreeSha = await client.getCommitTreeSha(headSha);
-    const tree = await client.getTreeRecursive(baseTreeSha);
+    const tree = await client.getDecofileTree(baseTreeSha, packagePath);
     const entries = blockEntriesInTree(tree, packagePath);
 
     const writes: TreeWriteEntry[] = [];

--- a/apps/api/src/decofile/github-git-data.ts
+++ b/apps/api/src/decofile/github-git-data.ts
@@ -199,6 +199,22 @@ export interface GitDataClient {
   getTarballStream(ref: string): Promise<ReadableStream<Uint8Array>>;
   getCommitTreeSha(commitSha: string): Promise<string>;
   getTreeRecursive(treeSha: string): Promise<TreeEntry[]>;
+  /**
+   * Block-dir view of a commit's tree WITHOUT a whole-repo recursive read.
+   * `getTreeRecursive` on the root tree of a large repo trips GitHub's
+   * 100k-entry / 7MB recursive cap (`truncated: true` → hard 502), which broke
+   * every decofile read/write on big storefronts. Instead this walks
+   * `<packagePath>/.deco/` non-recursively and returns only the block sources
+   * (`<dir>/.deco/blocks/*.json`) plus the merged artifact
+   * (`<dir>/.deco/blocks.gen.json`) when the repo commits it — the whole set the
+   * decofile read/merge and the commit coalescer consume. Paths are full and
+   * repo-relative, so `blockEntriesInTree` and the gen-file check operate on the
+   * result unchanged. Empty when the project has no `.deco/` yet.
+   */
+  getDecofileTree(
+    commitTreeSha: string,
+    packagePath: string | null,
+  ): Promise<TreeEntry[]>;
   getBlobText(blobSha: string): Promise<string>;
   /**
    * One file's text at a ref, addressed by PATH rather than blob sha — null when
@@ -358,6 +374,43 @@ export function createGitDataClient(params: {
     return Buffer.from(json.content, "base64").toString("utf-8");
   }
 
+  /** One tree's DIRECT children (non-recursive). GitHub returns subdirectories
+   * as `type: "tree"` entries carrying their own sha; the entry `path` is the
+   * bare child name, not a repo-relative path. */
+  async function treeShallow(treeSha: string): Promise<TreeEntry[]> {
+    const { json } = await call<{ tree: TreeEntry[]; truncated: boolean }>(
+      "GET",
+      `${repoBase}/git/trees/${treeSha}`,
+    );
+    if (json.truncated) {
+      // One directory over the cap: unreachable once scoped, but fail loud.
+      throw new GitHubApiError(
+        502,
+        "GET",
+        `${repoBase}/git/trees/${treeSha}`,
+        "tree listing truncated by GitHub; directory too large",
+      );
+    }
+    return json.tree;
+  }
+
+  /** Walk `segments` from `rootTreeSha`, returning the final subtree's sha, or
+   * null when any segment is missing or is not a directory. */
+  async function resolveSubtreeSha(
+    rootTreeSha: string,
+    segments: string[],
+  ): Promise<string | null> {
+    let sha = rootTreeSha;
+    for (const segment of segments) {
+      const child = (await treeShallow(sha)).find(
+        (e) => e.type === "tree" && e.path === segment,
+      );
+      if (!child) return null;
+      sha = child.sha;
+    }
+    return sha;
+  }
+
   return {
     owner,
     repo,
@@ -441,6 +494,33 @@ export function createGitDataClient(params: {
         );
       }
       return json.tree;
+    },
+
+    async getDecofileTree(commitTreeSha, packagePath) {
+      const decoSegments = [
+        ...(packagePath ? packagePath.split("/") : []),
+        ".deco",
+      ];
+      const decoTreeSha = await resolveSubtreeSha(commitTreeSha, decoSegments);
+      if (decoTreeSha === null) return []; // no `.deco/` in this project yet
+      const decoDir = packagePath ? `${packagePath}/.deco` : ".deco";
+      const decoChildren = await treeShallow(decoTreeSha);
+      const out: TreeEntry[] = [];
+      // The merged artifact, only when this repo commits it (usually gitignored).
+      const gen = decoChildren.find(
+        (e) => e.type === "blob" && e.path === "blocks.gen.json",
+      );
+      if (gen) out.push({ ...gen, path: `${decoDir}/blocks.gen.json` });
+      const blocksDir = decoChildren.find(
+        (e) => e.type === "tree" && e.path === "blocks",
+      );
+      if (blocksDir) {
+        for (const child of await treeShallow(blocksDir.sha)) {
+          if (child.type !== "blob") continue;
+          out.push({ ...child, path: `${decoDir}/blocks/${child.path}` });
+        }
+      }
+      return out;
     },
 
     getBlobText(blobSha) {

--- a/apps/api/src/decofile/read-decofile.ts
+++ b/apps/api/src/decofile/read-decofile.ts
@@ -252,7 +252,7 @@ async function resolveSnapshot(
   if (cachedMerged !== null) return { sha, decofile: cachedMerged };
 
   const treeSha = await client.getCommitTreeSha(sha);
-  const tree = await client.getTreeRecursive(treeSha);
+  const tree = await client.getDecofileTree(treeSha, packagePath);
   const entries = blockEntriesInTree(tree, packagePath);
 
   // Per-blob disk hits first; only what's left goes to GitHub.

--- a/packages/e2e/fixtures/fast-preview.ts
+++ b/packages/e2e/fixtures/fast-preview.ts
@@ -34,6 +34,7 @@ export async function seedStubRepo(
       { files?: Record<string, string>; committedAt?: string } | null
     >;
     mergeMode?: "merge" | "conflict" | "blocked";
+    truncateRecursive?: boolean;
   },
 ): Promise<void> {
   const res = await ctx.post(`${GITHUB_STUB_ORIGIN}/__admin/repos`, {

--- a/packages/e2e/fixtures/github-stub.ts
+++ b/packages/e2e/fixtures/github-stub.ts
@@ -22,7 +22,7 @@
  *   GET   /repos/{o}/{r}                              -> { default_branch }
  *   GET   /repos/{o}/{r}/git/ref/heads/{branch}       -> { object: { sha } }
  *   GET   /repos/{o}/{r}/git/commits/{sha}            -> { tree: { sha }, parents }
- *   GET   /repos/{o}/{r}/git/trees/{sha}?recursive=1  -> { tree: [...], truncated }
+ *   GET   /repos/{o}/{r}/git/trees/{sha}[?recursive=1] -> { tree: [...], truncated } (non-recursive = direct children + subtree shas)
  *   GET   /repos/{o}/{r}/git/blobs/{sha}              -> { content, encoding }
  *   GET   /repos/{o}/{r}/contents/{path}?ref={sha}    -> { sha, content, encoding }
  *   POST  /repos/{o}/{r}/git/blobs                    -> { sha }
@@ -87,10 +87,16 @@ interface RepoState {
   commitLog: string[];
   /** treeSha -> (path -> blobSha) */
   trees: Map<string, Map<string, string>>;
+  /** Synthetic subtree sha -> the root tree + path prefix it lists (minted on
+   *  demand when a non-recursive listing descends into a subdirectory). */
+  subtrees: Map<string, { rootSha: string; prefix: string }>;
   /** blobSha -> utf-8 content */
   blobs: Map<string, string>;
   pulls: PullRecord[];
   nextPullNumber: number;
+  /** When set, recursive tree reads answer `truncated: true` (GitHub's
+   *  100k-entry / 7MB cap) — arms the large-repo path in tests. */
+  truncateRecursive: boolean;
 }
 
 interface SeedRepoBody {
@@ -108,6 +114,9 @@ interface SeedRepoBody {
     { files?: Record<string, string>; committedAt?: string } | null
   >;
   mergeMode?: MergeMode;
+  /** Make recursive tree reads return `truncated: true`, simulating a repo too
+   *  large for GitHub's recursive listing. */
+  truncateRecursive?: boolean;
 }
 
 const repos = new Map<string, RepoState>();
@@ -233,9 +242,11 @@ function seedRepo(body: SeedRepoBody): RepoState {
     commits: new Map(),
     commitLog: [],
     trees: new Map(),
+    subtrees: new Map(),
     blobs: new Map(),
     pulls: [],
     nextPullNumber: 1,
+    truncateRecursive: body.truncateRecursive ?? false,
   };
 
   const branches = body.branches ?? {};
@@ -471,30 +482,75 @@ async function handleRepos(
     return;
   }
 
-  // GET /repos/{o}/{r}/git/trees/{sha}
+  // GET /repos/{o}/{r}/git/trees/{sha}[?recursive=1]
   if (
     req.method === "GET" &&
     rest[0] === "git" &&
     rest[1] === "trees" &&
     rest.length === 3
   ) {
-    const tree = rest[2] ? repo.trees.get(rest[2]) : undefined;
-    if (!tree) {
+    const treeSha = rest[2];
+    // A tree sha is a real root tree, or a synthetic subtree sha (see below).
+    const sub = treeSha ? repo.subtrees.get(treeSha) : undefined;
+    const rootSha = sub ? sub.rootSha : treeSha;
+    const prefix = sub ? sub.prefix : "";
+    const flat = rootSha ? repo.trees.get(rootSha) : undefined;
+    if (!treeSha || !rootSha || !flat) {
       notFound(res);
       return;
     }
+    // GitHub returns blob byte size; the decofile cold read pre-validates on it.
+    const blobSize = (blobSha: string): number =>
+      Buffer.byteLength(repo.blobs.get(blobSha) ?? "", "utf8");
+    if (url.searchParams.get("recursive") === "1") {
+      // truncateRecursive arms GitHub's cap; recursive only hits a root tree.
+      if (repo.truncateRecursive) {
+        json(res, 200, { sha: treeSha, truncated: true, tree: [] });
+        return;
+      }
+      json(res, 200, {
+        sha: treeSha,
+        truncated: false,
+        tree: [...flat.entries()].map(([path, blobSha]) => ({
+          path,
+          mode: "100644",
+          type: "blob",
+          sha: blobSha,
+          size: blobSize(blobSha),
+        })),
+      });
+      return;
+    }
+    // Non-recursive: DIRECT children under `prefix`; a subdir becomes a `tree`.
+    const blobEntries: Array<Record<string, unknown>> = [];
+    const subdirs = new Set<string>();
+    for (const [path, blobSha] of flat) {
+      if (!path.startsWith(prefix)) continue;
+      const rel = path.slice(prefix.length);
+      const slash = rel.indexOf("/");
+      if (slash === -1) {
+        blobEntries.push({
+          path: rel,
+          mode: "100644",
+          type: "blob",
+          sha: blobSha,
+          size: blobSize(blobSha),
+        });
+      } else {
+        subdirs.add(rel.slice(0, slash));
+      }
+    }
+    // Register each subtree sha so a follow-up GET can list that directory.
+    const treeEntries = [...subdirs].map((name) => {
+      const childPrefix = `${prefix}${name}/`;
+      const childSha = sha1(`subtree:${rootSha}:${childPrefix}`);
+      repo.subtrees.set(childSha, { rootSha, prefix: childPrefix });
+      return { path: name, mode: "040000", type: "tree", sha: childSha };
+    });
     json(res, 200, {
-      sha: rest[2],
+      sha: treeSha,
       truncated: false,
-      tree: [...tree.entries()].map(([path, blobSha]) => ({
-        path,
-        mode: "100644",
-        type: "blob",
-        sha: blobSha,
-        // GitHub returns the blob byte size for blob entries; the decofile
-        // cold-read path pre-validates tarball downloads against it.
-        size: Buffer.byteLength(repo.blobs.get(blobSha) ?? "", "utf8"),
-      })),
+      tree: [...blobEntries, ...treeEntries],
     });
     return;
   }

--- a/packages/e2e/tests/decofile-api.spec.ts
+++ b/packages/e2e/tests/decofile-api.spec.ts
@@ -561,6 +561,64 @@ test.describe("decofile API", () => {
     }
   });
 
+  test("large repo whose recursive tree read truncates still reads and writes blocks", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    try {
+      const user = await signUpViaApi(ctx);
+      const org = user.orgSlug;
+      const owner = uniqueOwner();
+      const repo = "site";
+
+      const hero = { __resolveType: "site/sections/Hero.tsx", title: "old" };
+      await seedStubRepo(ctx, {
+        owner,
+        repo,
+        defaultBranch: "main",
+        // A recursive read of this root tree 502s (GitHub's truncation cap).
+        truncateRecursive: true,
+        branches: {
+          main: {
+            files: {
+              ".deco/blocks/Hero.json": blockFileContent(hero),
+              // Non-block files a recursive read would drag in.
+              "src/index.ts": "export const x = 1;\n",
+              "package.json": '{"name":"site"}\n',
+            },
+          },
+          draft: null,
+        },
+      });
+      const project = await createFastPreviewProject(ctx, org, { owner, repo });
+      const url = decofileUrl(project, "draft");
+
+      // Read resolves the block via the scoped subtree walk, not a recursive read.
+      const before = (await (await ctx.get(url)).json()) as DecofileGetBody;
+      expect(before.decofile["Hero"]).toEqual(hero);
+
+      // Write lands even though a recursive tree read would 502.
+      const nextHero = { ...hero, title: "Fresh" };
+      const patchRes = await ctx.patch(url, {
+        data: { set: { Hero: nextHero } },
+      });
+      expect(patchRes.status()).toBe(200);
+      const patchBody = (await patchRes.json()) as { version: string };
+      expect(patchBody.version).toMatch(/^[0-9a-f]{40}$/);
+
+      const inspected = await inspectStubRepo(ctx, owner, repo);
+      expect(inspected.branches["draft"]?.files[".deco/blocks/Hero.json"]).toBe(
+        blockFileContent(nextHero),
+      );
+
+      const after = (await (await ctx.get(url)).json()) as DecofileGetBody;
+      expect(after.version).toBe(patchBody.version);
+      expect(after.decofile["Hero"]).toEqual(nextHero);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
   test("PATCH batches set+delete into one commit and delete removes every alias file", async ({
     playwright,
   }) => {


### PR DESCRIPTION
## Summary

Fixes a **100%-reproducible 502** on decofile PATCH (block saves) for large storefronts — reproduced on **Granado**, while smaller repos were unaffected.

**Root cause:** both the decofile read (`resolveSnapshot`) and write (`commitBatch`) paths fetched the **entire repo tree recursively** (`getTreeRecursive` on the root commit tree) just to keep the handful of `.deco/blocks/*.json` entries. On a big repo that recursive listing exceeds GitHub's **100k-entry / 7MB** cap, returns `truncated: true`, and `getTreeRecursive` throws a hard **502**. Because it's keyed purely on repo size, it fired deterministically on Granado and never on smaller sites. Reads survive via the disk cache (warm), so the site loaded but **every save 502'd** — exactly the reported symptom.

## Fix

- New `getDecofileTree(commitTreeSha, packagePath)` walks `<packagePath>/.deco/` **non-recursively** (real-GitHub nested trees, per-directory shas) and returns only the block sources (`.deco/blocks/*.json`) plus the merged `.deco/blocks.gen.json` when the repo commits it. Paths are full & repo-relative, so `blockEntriesInTree` and the gen-file presence check work **unchanged**.
- Both consumers (`commit-coalescer.ts`, `read-decofile.ts`) now use it. This removes the whole-repo recursive read from the decofile hot path for **all** repos, not just Granado — a few tiny scoped calls instead of one multi-MB truncating one.
- `getTreeRecursive` stays for the `git-compat.ts` diff paths that genuinely need the full tree.

The scoped `.deco/blocks` subtree has ~40k-entry headroom before it could itself truncate — far above any real block count — vs. the Contents API's 1000-entry cap, so large repos stay correct.

## Testing

- `bun run --cwd=apps/api check` + `packages/e2e check`: clean.
- `bun test` decofile unit tests: pass.
- `bun run lint`: no new warnings.
- **Direct client-vs-stub sanity run** (real `createGitDataClient` against the real e2e stub, `truncateRecursive` on): confirmed scoped reads return the right blocks for root & nested `packagePath`, the gen file is included, empty `.deco/` returns `[]`, and `getTreeRecursive` **throws** (proving the old path 502s while the new one works).
- New e2e spec `large repo whose recursive tree read truncates still reads and writes blocks` seeds a repo whose recursive read truncates and asserts read + PATCH succeed. The e2e stub gained faithful non-recursive subtree listing + a `truncateRecursive` flag.

## Follow-up

`git-compat.ts` still does root-recursive reads for publish-status/diff and would 502 on the same large repos; out of scope here (different feature, may need the full tree) — worth a scoped-diff follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deterministic 502 on decofile saves and reads for large repos. Both the save coalescer and snapshot reader fetched the entire repo tree recursively; on repos over GitHub's 100k-entry / 7MB tree listing cap that call returns `truncated: true` and throws, so every save failed while small repos were unaffected.

**Bug Fixes**
- Added `getDecofileTree`, which walks `<packagePath>/.deco/` non-recursively via GitHub's nested tree shas and returns only block sources plus committed `blocks.gen.json`.
- Both decofile read and write paths now use it; `getTreeRecursive` remains for `git-compat.ts` diff paths, which can still 502 on the same large repos (follow-up).
- The e2e stub gained non-recursive subtree listing and a truncation flag; a new spec seeds a repo whose recursive read truncates and asserts read + PATCH succeed.

<sup>Written for commit ffa5e61a98a85bd0ce02bb50fc0e10a97da4c6c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

