### PR TITLE
fix(web): open the chat panel for a thread that already has messages

### DIFF
--- a/apps/web/src/hooks/use-layout-state.test.ts
+++ b/apps/web/src/hooks/use-layout-state.test.ts
@@ -57,6 +57,49 @@ describe("resolveDefaultPanelState", () => {
     ).toEqual({ sidePanelOpen: false, mainOpen: true });
   });
 
+  test("a thread that already has messages opens the chat despite chatDefaultOpen:false", () => {
+    // Returning to a chat you've talked in reopens it even when the agent opts out of the chat panel.
+    expect(
+      resolveDefaultPanelState({
+        entityMetadata: {
+          defaultMainView: { type: "content" },
+          chatDefaultOpen: false,
+        },
+        ...absentSearch,
+        threadHasMessages: true,
+      }),
+    ).toEqual({ sidePanelOpen: true, mainOpen: true });
+  });
+
+  test("an empty thread keeps a chatDefaultOpen:false agent chat closed", () => {
+    expect(
+      resolveDefaultPanelState({
+        entityMetadata: {
+          defaultMainView: { type: "content" },
+          chatDefaultOpen: false,
+        },
+        ...absentSearch,
+        threadHasMessages: false,
+      }),
+    ).toEqual({ sidePanelOpen: false, mainOpen: true });
+  });
+
+  test("an explicit sidepanel=false still hides the chat even with messages", () => {
+    // The user's URL param beats the messages-present default.
+    expect(
+      resolveDefaultPanelState({
+        entityMetadata: {
+          defaultMainView: { type: "content" },
+          chatDefaultOpen: false,
+        },
+        panelNamed: false,
+        sidePanelParamPresent: true,
+        sidePanelParamValue: false,
+        threadHasMessages: true,
+      }),
+    ).toEqual({ sidePanelOpen: false, mainOpen: true });
+  });
+
   test("chatDefaultOpen maps to the Chat side panel", () => {
     expect(
       resolveDefaultPanelState({

--- a/apps/web/src/hooks/use-layout-state.ts
+++ b/apps/web/src/hooks/use-layout-state.ts
@@ -28,6 +28,7 @@ import { useRouteThreadId, useThreadNavigate } from "@/layouts/thread-route";
 import { useActivePanelTabId } from "@/layouts/main-panel-tabs/use-panel-navigate";
 import { useRouteDefaultMain } from "@/hooks/use-route-default-main";
 import { useThreadActions, useThreads } from "@/components/chat/store/hooks";
+import { threadHasMessages } from "@/lib/thread-has-messages";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -141,6 +142,11 @@ export function resolveDefaultPanelState(ctx: {
   /** The destination route's default view (e.g. `board` on `/$org/tasks`).
    *  Wins over the agent's `defaultMainView`, loses to the path segment. */
   routeDefaultMain?: string | null;
+  /** The current thread already holds a conversation. Forces the chat panel
+   *  open even when the agent opts out of it (`chatDefaultOpen: false`), so
+   *  returning to a chat you've been talking in never drops you on a closed
+   *  panel. An empty composer (no thread / empty thread) leaves this false. */
+  threadHasMessages?: boolean;
 }): WorkspaceVisibility {
   const defaultView = ctx.entityMetadata?.defaultMainView ?? null;
   const defaultIsChat = defaultView == null || defaultView.type === "chat";
@@ -157,7 +163,9 @@ export function resolveDefaultPanelState(ctx: {
    */
   const defaultSidePanelOpen = ctx.routeDefaultMain
     ? false
-    : defaultIsChat || ctx.entityMetadata?.chatDefaultOpen === true;
+    : defaultIsChat ||
+      ctx.entityMetadata?.chatDefaultOpen === true ||
+      ctx.threadHasMessages === true;
   const sidePanelOpen = ctx.sidePanelParamPresent
     ? ctx.sidePanelParamValue === true
     : defaultSidePanelOpen;
@@ -260,16 +268,6 @@ export function useWorkspaceLayoutState(
   const routeDefaultMain = useRouteDefaultMain();
   const panelTabId = useActivePanelTabId();
 
-  const { sidePanelOpen, mainOpen } = resolveDefaultPanelState({
-    entityMetadata,
-    mainPanelParam: search.mainpanel,
-    panelNamed: panelTabId !== undefined,
-    sidePanelParamPresent: search.sidepanel !== undefined,
-    sidePanelParamValue: search.sidepanel,
-    routeDefaultMain,
-  });
-  const visibility = { sidePanelOpen, mainOpen };
-
   const routeThreadId = useRouteThreadId();
   const fallbackRef = useRef(crypto.randomUUID());
   const { threadId, providerKey } = resolveWorkspaceThread({
@@ -277,6 +275,21 @@ export function useWorkspaceLayoutState(
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
     fallbackKey: fallbackRef.current,
   });
+
+  // Reopen the chat for a thread that already holds a conversation (threadHasMessages).
+  const currentThread =
+    threadId != null ? threads.find((t) => t.id === threadId) : undefined;
+
+  const { sidePanelOpen, mainOpen } = resolveDefaultPanelState({
+    entityMetadata,
+    mainPanelParam: search.mainpanel,
+    panelNamed: panelTabId !== undefined,
+    sidePanelParamPresent: search.sidepanel !== undefined,
+    sidePanelParamValue: search.sidepanel,
+    routeDefaultMain,
+    threadHasMessages: currentThread ? threadHasMessages(currentThread) : false,
+  });
+  const visibility = { sidePanelOpen, mainOpen };
 
   /** The legacy `/$org/$taskId` is the only route that records its agent in
    *  search; every destination drops the key (`resolveDestinationThreadSearch`)

--- a/apps/web/src/lib/thread-has-messages.test.ts
+++ b/apps/web/src/lib/thread-has-messages.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import type { Task } from "@/components/chat/task/types";
+import { threadHasMessages } from "./thread-has-messages";
+
+function makeThread(overrides: Partial<Task>): Task {
+  return {
+    id: "t1",
+    title: "New chat",
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("threadHasMessages", () => {
+  test("an empty New chat with no harness has no messages", () => {
+    expect(threadHasMessages(makeThread({ title: "New chat" }))).toBe(false);
+  });
+
+  test("a thread with a pinned harness_id has messages", () => {
+    // harness_id is pinned on the first message, even one that failed or is in flight.
+    expect(
+      threadHasMessages(
+        makeThread({ title: "New chat", harness_id: "claude-code" }),
+      ),
+    ).toBe(true);
+  });
+
+  test("a titled thread (completed a turn) has messages even without harness_id", () => {
+    expect(threadHasMessages(makeThread({ title: "Fix the bug" }))).toBe(true);
+  });
+
+  test("an untitled empty thread has no messages", () => {
+    expect(threadHasMessages(makeThread({ title: "" }))).toBe(false);
+  });
+});

--- a/apps/web/src/lib/thread-has-messages.ts
+++ b/apps/web/src/lib/thread-has-messages.ts
@@ -1,0 +1,22 @@
+import type { Task } from "@/components/chat/task/types";
+
+/**
+ * Whether a thread row represents a conversation that has already had at least
+ * one message — i.e. it is NOT an empty "New chat". This is the inverse of the
+ * emptiness test in `findReusableNewChat`.
+ *
+ * `harness_id` is pinned on the first message (even one that failed or is still
+ * in flight), so its presence is the primary signal. `title !== "New chat"`
+ * covers legacy threads that completed a turn before `harness_id` was recorded —
+ * a thread stays titled "New chat" until it finishes a successful turn.
+ *
+ * Used to force the chat panel open when returning to an agent whose layout opts
+ * out of the chat panel (`chatDefaultOpen: false`): an empty composer stays
+ * closed, but a real conversation reopens.
+ */
+export function threadHasMessages(thread: Task): boolean {
+  return (
+    Boolean(thread.harness_id) ||
+    (!!thread.title && thread.title !== "New chat")
+  );
+}


### PR DESCRIPTION
## Summary

An agent whose layout opts out of the chat panel (`chatDefaultOpen: false`) always landed you on a **closed** chat panel — even when returning to a thread you'd already been talking in. `resolveDefaultPanelState` opened the side panel only for a chat default or an explicit `chatDefaultOpen`, ignoring whether the current thread already held a conversation.

This makes the chat reopen whenever the current thread already has messages, while a fresh/empty composer still respects the agent's opt-out.

## Changes

- **`apps/web/src/lib/thread-has-messages.ts`** (new) — pure predicate `threadHasMessages(thread)`: a thread has messages when `harness_id` is pinned (set on the first message, even failed/in-flight) or its title is set and isn't `"New chat"` (legacy threads that completed a turn). It's the inverse of the emptiness test in `findReusableNewChat`.
- **`apps/web/src/hooks/use-layout-state.ts`** — added a `threadHasMessages?: boolean` input to `resolveDefaultPanelState`, OR'd into the side-panel default. The hook resolves `threadId` first, looks up the current thread row from the reactive `useThreads()` store, and passes the predicate through.

## Behavior preserved

- Empty composer on a Show-chat-off agent → chat stays closed.
- Explicit `?sidepanel=false` in the URL still hides the chat (user intent wins).
- Destination routes with their own `defaultMain` (e.g. Tasks board) are unaffected.

## Testing

- New `apps/web/src/lib/thread-has-messages.test.ts` + three cases in `use-layout-state.test.ts` (messages force open; empty thread stays closed; explicit `?sidepanel=false` beats the messages default).
- `bun test` (39 pass), `bun run --cwd=apps/web check` (exit 0), `bun run lint` (no issues in changed files), `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reopens the chat panel for threads that already have messages, even when the agent's layout opts out of the chat panel (`chatDefaultOpen: false`). Previously, agents with that opt-out always landed on a closed panel; now a fresh or empty composer still stays closed, and an explicit `?sidepanel=false` in the URL still wins over the messages default.

**Behavior**
- A thread counts as having messages when `harness_id` is set (pinned on the first message) or its title is set and isn't `"New chat"` (covers legacy threads).
- `resolveDefaultPanelState` now takes a `threadHasMessages` flag that forces the side panel open.
- Routes with their own `defaultMain` (e.g. the Tasks board) are unaffected.

<sup>Written for commit 5473d4d1eb9a0c6f047085b0dbdfad011b7c4f4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

