### PR TITLE
fix(web): cap the per-user org localStorage cache

### DIFF
--- a/apps/web/src/lib/query-persist.test.ts
+++ b/apps/web/src/lib/query-persist.test.ts
@@ -106,6 +106,41 @@ describe("readCachedOrg/writeCachedOrg", () => {
     localStorageStub.setItem("studio:org-cache:user-5", "{not json");
     expect(readCachedOrg("user-5", "acme")).toBeNull();
   });
+
+  test("caps the per-user map at 20 orgs, evicting the least-recently-updated", () => {
+    const key = "studio:org-cache:user-7";
+    const stale: Record<string, { data: unknown; updatedAt: number }> = {};
+    for (let i = 0; i < 20; i++) {
+      stale[`org-${i}`] = { data: { n: i }, updatedAt: Date.now() - (20 - i) };
+    }
+    localStorageStub.setItem(key, JSON.stringify(stale));
+
+    writeCachedOrg("user-7", "org-new", { n: 20 });
+
+    const raw = localStorageStub.getItem(key);
+    expect(Object.keys(JSON.parse(raw ?? "{}"))).toHaveLength(20);
+    expect(readCachedOrg("user-7", "org-0")).toBeNull();
+    expect(readCachedOrg("user-7", "org-19")?.data).toEqual({ n: 19 });
+    expect(readCachedOrg("user-7", "org-new")?.data).toEqual({ n: 20 });
+  });
+
+  test("prunes expired entries out of the map on write, not just on read", () => {
+    const key = "studio:org-cache:user-8";
+    localStorageStub.setItem(
+      key,
+      JSON.stringify({
+        stale: {
+          data: { name: "Stale" },
+          updatedAt: Date.now() - 25 * 60 * 60 * 1000,
+        },
+      }),
+    );
+
+    writeCachedOrg("user-8", "fresh", { name: "Fresh" });
+
+    const raw = localStorageStub.getItem(key);
+    expect(Object.keys(JSON.parse(raw ?? "{}"))).toEqual(["fresh"]);
+  });
 });
 
 describe("clearPersistedQueryCache", () => {

--- a/apps/web/src/lib/query-persist.ts
+++ b/apps/web/src/lib/query-persist.ts
@@ -148,7 +148,27 @@ export function persistQueryClient(queryClient: QueryClient): () => void {
 
 const ORG_KEY_PREFIX = "studio:org-cache:";
 
+/** Cap on distinct orgs cached per user. Bounds unbounded localStorage growth
+ * for an account that has visited many orgs over time. */
+const MAX_CACHED_ORGS = 20;
+
 type CachedOrgMap = Record<string, { data: unknown; updatedAt: number }>;
+
+/**
+ * Drop expired entries, then keep only the `MAX_CACHED_ORGS` most-recently
+ * updated ones. `readCachedOrg` already ignores expired entries, but without
+ * this the map itself never shrinks — every org a user ever visits, active or
+ * not, stays in localStorage forever.
+ */
+function pruneOrgMap(map: CachedOrgMap): CachedOrgMap {
+  const now = Date.now();
+  const fresh = Object.entries(map).filter(
+    ([, entry]) => now - entry.updatedAt <= MAX_AGE_MS,
+  );
+  fresh.sort(([, a], [, b]) => a.updatedAt - b.updatedAt);
+  while (fresh.length > MAX_CACHED_ORGS) fresh.shift();
+  return Object.fromEntries(fresh);
+}
 
 function orgCacheKey(userId: string): string {
   return `${ORG_KEY_PREFIX}${userId}`;
@@ -184,7 +204,7 @@ export function writeCachedOrg(
     const raw = window.localStorage.getItem(key);
     const map: CachedOrgMap = raw ? JSON.parse(raw) : {};
     map[slug] = { data, updatedAt: Date.now() };
-    window.localStorage.setItem(key, JSON.stringify(map));
+    window.localStorage.setItem(key, JSON.stringify(pruneOrgMap(map)));
   } catch {
     // Quota / serialization failure is non-fatal.
   }


### PR DESCRIPTION
**Source:** a bounded-growth reduction — same class of bug the bot has already fixed twice this in the sessionStorage layer (`bash-wait.tsx` #6684, `thread-layout-memory.ts`), found by auditing the other `localStorage`/`sessionStorage` writers in `apps/web/src/lib` for the same shape.

**The bug:** `query-persist.ts`'s `writeCachedOrg` stores a per-user map of `{ [orgSlug]: { data, updatedAt } }` under one `localStorage` key (`studio:org-cache:<userId>`), and `readCachedOrg` already treats an entry as expired once `Date.now() - updatedAt > MAX_AGE_MS` (24h) — but expiry only gates the *read*. The map itself is never pruned on write, so every org an account has ever opened, active or long stale, accumulates in that key forever. Unlike the sessionStorage caches this pattern was already fixed in, this one is `localStorage`, so it persists indefinitely across the account's lifetime, not just the tab session.

**The fix:** `pruneOrgMap` runs on every `writeCachedOrg`, dropping entries older than `MAX_AGE_MS` and capping the map at the 20 most-recently-updated orgs (oldest evicted first, consistent with the array-based LRU eviction already used in `bash-wait.tsx`/`thread-layout-memory.ts`).

**Regression test:** `query-persist.test.ts` — one test seeds 20 stale-but-fresh entries then writes a 21st, asserting the map stays at 20 and the oldest (`org-0`) is evicted while the rest survive; another seeds one expired entry and asserts a fresh write prunes it out of the persisted map (not just at read time).

**To confirm:** `bun test apps/web/src/lib/query-persist.test.ts`

**Checks run locally:** `bun run fmt`, the targeted test file above (8/8 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full `apps/web` `tsc --noEmit` has one pre-existing, unrelated failure in `mention-suggestion.tsx` from a duplicate `prosemirror-model` version in the lockfile — not touched by this change. CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the per-user org cache in `localStorage` so it no longer grows without bound.

- Prunes expired entries and caps the map at the 20 most-recently-updated orgs on every write.
- Previously, `readCachedOrg` only ignored expired entries at read time; the map itself stayed in `localStorage` forever.
- Adds regression tests covering eviction of the oldest org and pruning of expired entries.

<sup>Written for commit 290f142fe7f00803009b1f42736320a3aee58784. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

