### PR TITLE
fix(decofile): scope discard/merge tree reads to their known paths, not a whole-repo recursive read

### DIFF
--- a/apps/api/src/decofile/git-compat.ts
+++ b/apps/api/src/decofile/git-compat.ts
@@ -376,16 +376,17 @@ export async function githubGitDiscard(
   for (let attempt = 1; ; attempt++) {
     const branchHead = await client.getHeadSha(branch);
     const { mergeBaseSha } = await client.compareDetailed(base, branch);
-    const [baseTree, headTree] = await Promise.all([
-      client.getTreeRecursive(await client.getCommitTreeSha(mergeBaseSha)),
-      client.getTreeRecursive(await client.getCommitTreeSha(branchHead)),
+    // Scoped to `filepaths`, not a whole-repo recursive read.
+    const [baseBlobByPath, headBlobByPath] = await Promise.all([
+      client.getBlobsAtPaths(
+        await client.getCommitTreeSha(mergeBaseSha),
+        filepaths,
+      ),
+      client.getBlobsAtPaths(
+        await client.getCommitTreeSha(branchHead),
+        filepaths,
+      ),
     ]);
-    const baseBlobByPath = new Map(
-      baseTree.filter((e) => e.type === "blob").map((e) => [e.path, e]),
-    );
-    const headBlobByPath = new Map(
-      headTree.filter((e) => e.type === "blob").map((e) => [e.path, e]),
-    );
 
     const entries: TreeWriteEntry[] = [];
     for (const path of filepaths) {
@@ -454,12 +455,10 @@ async function buildBranchWinsTree(
     );
   }
 
-  // Blob shas AND modes come from the branch tree — compare carries no modes.
-  const branchTree = await client.getTreeRecursive(
+  // Blob shas AND modes, scoped to `files` rather than a whole-repo recursive read.
+  const branchBlobByPath = await client.getBlobsAtPaths(
     await client.getCommitTreeSha(branchHead),
-  );
-  const branchBlobByPath = new Map(
-    branchTree.filter((e) => e.type === "blob").map((e) => [e.path, e]),
+    files.map((f) => f.filename),
   );
 
   return client.createTree(

--- a/apps/api/src/decofile/github-git-data.test.ts
+++ b/apps/api/src/decofile/github-git-data.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import { resolveBlobsAtPaths, type TreeEntry } from "./github-git-data";
+
+/** An in-memory repo tree, keyed by directory path ("" for root). */
+function fakeOps(dirs: Record<string, TreeEntry[]>) {
+  return {
+    resolveSubtreeSha: (_root: string, segments: string[]) => {
+      const dir = segments.join("/");
+      return Promise.resolve(dir in dirs ? `tree:${dir}` : null);
+    },
+    treeShallow: (treeSha: string) => {
+      const dir = treeSha.slice("tree:".length);
+      return Promise.resolve(dirs[dir] ?? []);
+    },
+  };
+}
+
+const blob = (path: string, sha: string): TreeEntry => ({
+  path,
+  mode: "100644",
+  type: "blob",
+  sha,
+});
+
+describe("resolveBlobsAtPaths", () => {
+  it("resolves blobs at the root and in nested directories", async () => {
+    const ops = fakeOps({
+      "": [
+        blob("Header.json", "b1"),
+        { ...blob("blocks", "t1"), type: "tree" },
+      ],
+      blocks: [blob("Footer.json", "b2")],
+    });
+
+    const result = await resolveBlobsAtPaths(
+      "root",
+      ["Header.json", "blocks/Footer.json"],
+      ops,
+    );
+
+    expect(result.get("Header.json")?.sha).toBe("b1");
+    expect(result.get("blocks/Footer.json")?.sha).toBe("b2");
+  });
+
+  it("omits a path missing at this commit instead of throwing", async () => {
+    const ops = fakeOps({ "": [blob("Header.json", "b1")] });
+
+    const result = await resolveBlobsAtPaths(
+      "root",
+      ["Header.json", "Deleted.json"],
+      ops,
+    );
+
+    expect(result.has("Header.json")).toBe(true);
+    expect(result.has("Deleted.json")).toBe(false);
+  });
+
+  it("omits every path under a directory that does not exist", async () => {
+    const ops = fakeOps({ "": [] });
+
+    const result = await resolveBlobsAtPaths(
+      "root",
+      ["missing/dir/File.json"],
+      ops,
+    );
+
+    expect(result.size).toBe(0);
+  });
+
+  it("lists a shared directory once for paths in the same directory", async () => {
+    let listings = 0;
+    const dirs = { "": [blob("A.json", "a"), blob("B.json", "b")] };
+    const ops = {
+      resolveSubtreeSha: fakeOps(dirs).resolveSubtreeSha,
+      treeShallow: (treeSha: string) => {
+        listings++;
+        return fakeOps(dirs).treeShallow(treeSha);
+      },
+    };
+
+    await resolveBlobsAtPaths("root", ["A.json", "B.json"], ops);
+
+    expect(listings).toBe(1);
+  });
+});

--- a/apps/api/src/decofile/github-git-data.ts
+++ b/apps/api/src/decofile/github-git-data.ts
@@ -215,6 +215,19 @@ export interface GitDataClient {
     commitTreeSha: string,
     packagePath: string | null,
   ): Promise<TreeEntry[]>;
+  /**
+   * Blob entries for a bounded, caller-known set of paths — the same
+   * 502-on-large-repo cap `getDecofileTree` dodges for decofile reads, but for
+   * callers that already know exactly which paths they need (discard's
+   * `filepaths`, the branch-wins merge's changed-file list) instead of a
+   * whole subdirectory. Walks only the directories those paths live in, so
+   * cost scales with the path set, never with repo size. A path absent at
+   * this commit (deleted, or never existed) is omitted from the map.
+   */
+  getBlobsAtPaths(
+    commitTreeSha: string,
+    paths: string[],
+  ): Promise<Map<string, TreeEntry>>;
   getBlobText(blobSha: string): Promise<string>;
   /**
    * One file's text at a ref, addressed by PATH rather than blob sha — null when
@@ -286,6 +299,44 @@ export interface GitDataClient {
      */
     commitMessages: string[];
   }>;
+}
+
+/**
+ * `getBlobsAtPaths`'s directory-scoped walk, factored out for testing: given
+ * how to list a subtree's direct children, resolve each path to its blob
+ * entry by visiting only the directories the paths actually live in (cached
+ * per directory, so siblings share one listing call).
+ */
+export async function resolveBlobsAtPaths(
+  rootTreeSha: string,
+  paths: string[],
+  ops: {
+    resolveSubtreeSha: (
+      rootTreeSha: string,
+      segments: string[],
+    ) => Promise<string | null>;
+    treeShallow: (treeSha: string) => Promise<TreeEntry[]>;
+  },
+): Promise<Map<string, TreeEntry>> {
+  const result = new Map<string, TreeEntry>();
+  const dirListings = new Map<string, TreeEntry[] | null>();
+  for (const path of paths) {
+    const slash = path.lastIndexOf("/");
+    const dir = slash === -1 ? "" : path.slice(0, slash);
+    const base = slash === -1 ? path : path.slice(slash + 1);
+    let listing = dirListings.get(dir);
+    if (listing === undefined) {
+      const subtreeSha = await ops.resolveSubtreeSha(
+        rootTreeSha,
+        dir === "" ? [] : dir.split("/"),
+      );
+      listing = subtreeSha === null ? null : await ops.treeShallow(subtreeSha);
+      dirListings.set(dir, listing);
+    }
+    const entry = listing?.find((e) => e.type === "blob" && e.path === base);
+    if (entry) result.set(path, { ...entry, path });
+  }
+  return result;
 }
 
 export function createGitDataClient(params: {
@@ -521,6 +572,13 @@ export function createGitDataClient(params: {
         }
       }
       return out;
+    },
+
+    getBlobsAtPaths(commitTreeSha, paths) {
+      return resolveBlobsAtPaths(commitTreeSha, paths, {
+        resolveSubtreeSha,
+        treeShallow,
+      });
     },
 
     getBlobText(blobSha) {


### PR DESCRIPTION
Follows #6691, which scoped decofile READS off a whole-repo `getTreeRecursive` (GitHub's 100k-entry/7MB recursive-tree cap trips on large repos and hard-502s) to a `.deco/`-only walk. Two sibling paths in the same file still did the whole-repo recursive read: `githubGitDiscard` (Fast Preview's "undo my edits" flow) and `buildBranchWinsTree` (the branch-wins auto-merge). Both only ever need blob shas for a small, already-known set of paths (`filepaths` for discard, the compare's changed-file list for merge, capped at `MERGE_REPLAY_FILE_CAP`) — so both would still 502 on a big storefront exactly like the reads did before #6691, just on discard/merge instead of read.

Adds `GitDataClient.getBlobsAtPaths(commitTreeSha, paths)`, which walks only the directories those paths live in (caching each directory's listing so paths sharing a directory cost one call) instead of recursively walking the whole tree, and switches both call sites to it.

Failure scenario before this fix: a Fast Preview project backed by a large repo (over GitHub's recursive-tree cap) calls discard on a couple of files, or a branch trips the branch-wins auto-merge path — both throw a 502 from the whole-repo `getTreeRecursive` call, exactly the bug #6691 fixed for reads.

Regression test: `apps/api/src/decofile/github-git-data.test.ts` covers the new `resolveBlobsAtPaths` helper directly with a fake directory-listing implementation (root + nested paths, a path missing at the commit, a whole missing directory, and directory-listing reuse across sibling paths) — no network/GitHub API involved, since `GitDataClient` is a plain interface.

Reviewer check: `bun test apps/api/src/decofile/github-git-data.test.ts` and `bun test apps/api/src/decofile/git-compat.test.ts` (existing suite, unaffected).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bunx oxlint` on the three changed files, and both test files above — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes decofile discard and branch-wins merge tree reads to only the paths they need, so those flows no longer 502 on repos that exceed GitHub's recursive-tree cap.

- Adds `GitDataClient.getBlobsAtPaths`, which walks only the directories the requested paths live in and caches each directory's listing.
- Switches `githubGitDiscard` and `buildBranchWinsTree` to the new method; both keep the same behavior otherwise.
- Adds regression tests for root and nested paths, missing paths at a commit, missing directories, and directory-listing reuse across sibling paths.

<sup>Written for commit ddd49301548bbe42c595b13321dec1603388d3e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

