### PR TITLE
refactor(web): remove dead setTaskId/openSidePanel/setMobileSurface from useWorkspaceLayoutState

### DIFF
--- a/apps/web/src/hooks/use-layout-state.ts
+++ b/apps/web/src/hooks/use-layout-state.ts
@@ -57,11 +57,8 @@ export interface WorkspaceLayoutState {
 }
 
 export interface WorkspaceLayoutActions {
-  setTaskId: (id: string, virtualMcpId?: string) => void;
   toggleMain: () => void;
   toggleSidePanel: () => void;
-  setMobileSurface: (surface: MobileWorkspaceSurface) => void;
-  openSidePanel: () => void;
   createNewTask: () => void;
 }
 
@@ -314,20 +311,6 @@ export function useWorkspaceLayoutState(
     });
   };
 
-  const setTaskId = (id: string, targetVirtualMcpId?: string) => {
-    navigateThread(
-      id,
-      () => {
-        const next: Record<string, unknown> = {};
-        if (targetVirtualMcpId) next.virtualmcpid = targetVirtualMcpId;
-        else Object.assign(next, preserveVirtualMcp);
-        return next;
-      },
-      /** The target thread's agent moves the `{-$project}` segment with it. */
-      { virtualMcpId: targetVirtualMcpId },
-    );
-  };
-
   const toggleMain = () => {
     const update = resolveWorkspacePanelAction(
       { type: "toggleMain" },
@@ -339,18 +322,6 @@ export function useWorkspaceLayoutState(
   const toggleSidePanel = () => {
     const update = resolveWorkspacePanelAction(
       { type: "toggleSidePanel" },
-      visibility,
-    );
-    if (update) navigateSearch(update, { replace: true });
-  };
-
-  const setMobileSurface = (surface: MobileWorkspaceSurface) => {
-    navigateSearch(mobileSurfaceSearch(surface), { replace: true });
-  };
-
-  const openSidePanel = () => {
-    const update = resolveWorkspacePanelAction(
-      { type: "openSidePanel" },
       visibility,
     );
     if (update) navigateSearch(update, { replace: true });
@@ -384,11 +355,8 @@ export function useWorkspaceLayoutState(
     sidePanelOpen,
     mainOpen,
     sidePanelParamPresent: search.sidepanel !== undefined,
-    setTaskId,
     toggleMain,
     toggleSidePanel,
-    setMobileSurface,
-    openSidePanel,
     createNewTask,
   };
 }


### PR DESCRIPTION
**Source:** dead-code reduction found while auditing `apps/web/src/hooks/use-layout-state.ts` and its sole consumer (`apps/web/src/layouts/agent-shell-layout/index.tsx`).

`useWorkspaceLayoutState` is called from exactly one place, and the `layout` object it returns is passed whole into `DesktopTaskWorkspace`/`MobileTaskWorkspace`, which only destructure `threadId`, `providerKey`, `sidePanelOpen`, `mainOpen`, `sidePanelParamPresent`, `toggleSidePanel`, `toggleMain`, and `createNewTask`. The `setTaskId`, `openSidePanel`, and `setMobileSurface` closures the hook also builds and returns are never read anywhere — confirmed with `rg -n "\.setTaskId\b|\.openSidePanel\b|\.setMobileSurface\b" apps/web/src` (only hits are the unrelated, actively-used `usePanelActions` in `shell-layout.tsx`, which is a separate implementation with the same names). Thread switching and side-panel opening in this app actually go through `usePanelActions` from `shell-layout.tsx`, not this hook.

Removing the three dead fields removes their unreachable computation (building `preserveVirtualMcp`-based search params via `navigateThread`, and duplicate `resolveWorkspacePanelAction`/`mobileSurfaceSearch` wiring) and narrows `WorkspaceLayoutActions` to what's actually consumed. Pure deletion, no behavior change — nothing called these closures, so nothing can observe their absence.

**Net delta:** -32 / +0.

**How I confirmed it's safe:**
- `rg` shows the only call site of `useWorkspaceLayoutState` is `agent-shell-layout/index.tsx`, and the whole `layout` object it produces is only ever destructured for the 8 fields kept.
- `rg` for `.setTaskId(`, `.openSidePanel(`, `.setMobileSurface(` across `apps/web/src` finds zero call sites on this hook's result.
- The still-exported pure helpers this hook uses (`resolveWorkspacePanelAction`, `resolveMobileSurface`, `mobileSurfaceSearch`) are untouched and keep their own direct test coverage in `use-layout-state.test.ts` (none of those tests exercised the removed hook closures — they call the pure functions directly).

**To confirm:** `bunx tsc --noEmit` in `apps/web` (pre-existing, unrelated prosemirror duplicate-version error only — confirmed present on `main` via `git stash`), `bun test apps/web/src/hooks/use-layout-state.test.ts` (35 pass), `bunx oxlint apps/web/src/hooks/use-layout-state.ts` (0 warnings/errors).

**Locally ran:** `bun run fmt`, targeted `tsc --noEmit`, the one test file above, and per-file oxlint. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `setTaskId`, `openSidePanel`, and `setMobileSurface` closures from `useWorkspaceLayoutState`. No behavior change—nothing calls these functions, and the only consumer destructures only the remaining fields.

<sup>Written for commit 45dfbc6bb2b6ee443aefd60ea59dec027c7eccff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

