### PR TITLE
fix(task-board): stop the run viewer lying about a live run, and the retry chatter

### DIFF
--- a/apps/web/src/components/thread/thread-sheet-body.tsx
+++ b/apps/web/src/components/thread/thread-sheet-body.tsx
@@ -386,7 +386,19 @@ function ThreadConversationPanel({
                 <MessagePair
                   pair={pair}
                   isLastPair={idx === messagePairs.length - 1}
-                  status="ready"
+                  // The sheet is a read-only viewer with no chat stream behind
+                  // it, so `useOptionalChatStream()` is null inside and an
+                  // assistant message with no parts yet reads as settled —
+                  // rendering "No response was generated" over a run that is
+                  // still generating. The thread's own status is the signal
+                  // the sheet does have; only the last pair can be the live
+                  // one, and marking an earlier one would shimmer history.
+                  status={
+                    idx === messagePairs.length - 1 &&
+                    thread.status === "in_progress"
+                      ? "streaming"
+                      : "ready"
+                  }
                 />
               </div>
             ))}

--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -6,6 +6,8 @@ import {
   dueDateUrgency,
   formatSprintDates,
   insertSortOrder,
+  isFeedWorthyActivity,
+  isLiveAttempt,
   isTaskHandedToHuman,
   laneVisibility,
   moveTargets,
@@ -365,5 +367,54 @@ describe("laneVisibility", () => {
       occupied: [],
     });
     expect(lanes).not.toContain("a_lane_that_no_longer_exists");
+  });
+});
+
+describe("isFeedWorthyActivity", () => {
+  test("drops the per-retry line — it says nothing a person acts on", () => {
+    expect(
+      isFeedWorthyActivity({
+        action: "status_changed",
+        data: { from: "in_progress", to: "in_progress", retry: 1, of: 1 },
+      }),
+    ).toBe(false);
+  });
+
+  test("keeps the terminal line that counts the retries", () => {
+    expect(
+      isFeedWorthyActivity({
+        action: "status_changed",
+        data: { from: "in_progress", to: "todo", retriesSpent: 1 },
+      }),
+    ).toBe(true);
+  });
+
+  test("keeps ordinary moves, and anything that is not a status change", () => {
+    expect(
+      isFeedWorthyActivity({
+        action: "status_changed",
+        data: { from: "todo", to: "in_progress" },
+      }),
+    ).toBe(true);
+    expect(isFeedWorthyActivity({ action: "created", data: null })).toBe(true);
+    // `retry` is only a retry when it is a count — a stray string is not one.
+    expect(
+      isFeedWorthyActivity({ action: "status_changed", data: { retry: "1" } }),
+    ).toBe(true);
+  });
+});
+
+describe("isLiveAttempt", () => {
+  test("drops a superseded attempt — a newer run replaced it", () => {
+    expect(isLiveAttempt({ failureKind: "superseded" })).toBe(false);
+  });
+
+  test("keeps the attempt that actually ended the card", () => {
+    // The last attempt is never superseded (nothing replaced it), so a card
+    // whose every run failed still shows one card, and one transcript.
+    expect(isLiveAttempt({ failureKind: "error" })).toBe(true);
+    expect(isLiveAttempt({ failureKind: "ended_after_delivery" })).toBe(true);
+    expect(isLiveAttempt({ failureKind: null })).toBe(true);
+    expect(isLiveAttempt({})).toBe(true);
   });
 });

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -41,6 +41,36 @@ export type TaskBoardItemTag = TaskBoardItem["tags"][number];
 export type TaskBoardItemPr =
   ToolOutput<"TASK_BOARD_ITEM_PRS_GET">["prs"][number];
 
+/**
+ * An infrastructure retry is not news. Each one wrote its own
+ * `In Progress → In Progress` activity ("scheduled retry 1 of 1 — error"), so a
+ * card that burned its budget read as a wall of retry chatter with the actual
+ * story buried in it. The retry is still counted — the terminal
+ * `activityRetriesExhausted` line ("moved to To Do after N failed retries") is
+ * the part a person acts on, and it survives this filter.
+ */
+export function isFeedWorthyActivity(a: {
+  action: string;
+  data?: Record<string, unknown> | null;
+}): boolean {
+  return !(a.action === "status_changed" && typeof a.data?.retry === "number");
+}
+
+/**
+ * The same noise from the other side: every retry spawns a fresh thread, and
+ * each one rendered its own card, so three attempts meant three near-identical
+ * "Retried" cards stacked above the one that matters.
+ *
+ * `superseded` means a NEWER attempt replaced this one, so a superseded thread
+ * can never be the newest — the live (or last) run always survives this filter,
+ * and with it the link to a transcript.
+ */
+export function isLiveAttempt(thread: {
+  failureKind?: string | null;
+}): boolean {
+  return thread.failureKind !== "superseded";
+}
+
 /** Org tag, as returned by TAGS_LIST/TAGS_CREATE (same shape a task's `tags`
  *  snapshot is drawn from). */
 export type OrgTag = ToolOutput<"TAGS_LIST">["tags"][number];

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -92,6 +92,8 @@ import {
   moveTargets,
   statusIconClassName,
   SUPER_AGENT_ASSIGNEE_ID,
+  isFeedWorthyActivity,
+  isLiveAttempt,
   tagDotColor,
   type Member,
   type TaskBoardItem,
@@ -2112,14 +2114,14 @@ function ActivitySection({
     | { kind: "thread"; at: number; thread: TaskBoardItemThread }
     | { kind: "comment"; at: number; comment: TaskComment };
   const events: Ev[] = [
-    ...(activity ?? []).map(
+    ...(activity ?? []).filter(isFeedWorthyActivity).map(
       (a): Ev => ({
         kind: "activity",
         at: new Date(a.occurredAt).getTime(),
         activity: a,
       }),
     ),
-    ...item.threads.map(
+    ...item.threads.filter(isLiveAttempt).map(
       (thread): Ev => ({
         kind: "thread",
         at: new Date(thread.createdAt).getTime(),


### PR DESCRIPTION
## Summary

Two things a failing task run made unreadable.

### 1. The run sheet claimed nothing was generated while it was generating

`TaskThreadSheet` is a read-only viewer — it renders `ThreadSheetBody` with a
hardcoded `status="ready"` and no chat-stream provider above it. So inside,
`useOptionalChatStream()` is `null`, `isRunInProgress` falls back to `false`,
and an assistant message that has no parts *yet* is indistinguishable from one
that finished empty. The sheet printed **"No response was generated"** over a
run whose card, three inches to the left, said **Running**.

The thread's own `status` is the signal the sheet does have. Only the last pair
can be the live one — marking an earlier one would shimmer settled history — so
the status is scoped to it.

### 2. Every retry surfaced twice, as a line and as a card

An infrastructure retry wrote its own `In Progress → In Progress` activity
("scheduled retry 1 of 1 — error") **and** spawned its own thread, which
rendered its own "Retried" card. Three attempts meant three near-identical
cards stacked above the one that matters, with the actual story buried between
them.

Both are filtered out of the feed:

- `isFeedWorthyActivity` drops the per-retry `status_changed`. The terminal
  `activityRetriesExhausted` line — "moved to To Do after N failed retries" —
  survives. It counts them, and it is the part a person acts on.
- `isLiveAttempt` drops a `superseded` thread. `superseded` means a *newer*
  attempt replaced this one, so a superseded thread can never be the newest:
  the live (or last) run always keeps its card, and with it the link to a
  transcript. A card whose every attempt failed still shows exactly one.

Both predicates live in `config.tsx` next to the other board predicates rather
than inside the 2.6k-line dialog, so they are testable without mounting it.

## Testing

- `bun test apps/web/src` → **102 pre-existing failures on `origin/main`, 102 on
  this branch, zero regressions.**
- New unit cases for both predicates in `config.test.ts` (44 pass), including
  the ones that must NOT be filtered: an ordinary move, a non-`status_changed`
  action, the retries-exhausted line, and a `retry` that is a string rather
  than a count.
- `bun run --cwd=apps/web check`, `bun run lint` (0 errors), `bun run fmt`,
  `knip` — clean.

## Screenshots

None attached — both bugs are text in a feed, described inline above. There is
no new UI for the after: the sheet renders the existing thinking shimmer, and
the feed renders the same cards it always did, minus the duplicates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the run sheet claiming "No response was generated" on a live run, and stops every infrastructure retry from surfacing twice in the task activity feed.

- The sheet derives streaming state from the thread's own status, scoped to the last message pair so older pairs keep their settled look.
- Drops per-retry `status_changed` lines and superseded attempt cards; the terminal "moved to To Do after N failed retries" line and the current attempt's card remain.
- Both filters live in `config.tsx` as standalone predicates so they're unit-testable without mounting the task dialog.

<sup>Written for commit 325b44e455c50240f645942d4f27b22ceb73458e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

