### PR TITLE
fix(task-board): TASK_ADD_REPO returned success on an empty checkout

### DIFF
--- a/apps/api/src/tools/task-board/add-repo.test.ts
+++ b/apps/api/src/tools/task-board/add-repo.test.ts
@@ -5,24 +5,34 @@ import {
   secondaryRepoCapExceeded,
 } from "./add-repo";
 
-// The probe is what decides "you can start reading files now". A HEAD ref lands
-// before the checkout does on a lagging FS, so the marker alone must NOT count
-// as ready — that false positive returns success on an empty directory.
-test("the HEAD marker alone is not a checkout", () => {
-  expect(parseRepoProbe("__CLONED__\n")).toEqual({
+// The probe is what decides "you can start reading files now", and the marker is
+// the only part of it that can. The checkout directory is never empty: the pod
+// stages `.deco` and mounts `org` into it before any clone starts.
+test("the pod's own scaffolding is not a checkout", () => {
+  // The exact probe output that shipped a 20-second "completed" task: no
+  // marker, but two entries the old rule counted as a working tree.
+  expect(parseRepoProbe(".deco\norg\n")).toEqual({
     cloned: false,
-    listing: "",
+    listing: ".deco\norg",
   });
-  expect(parseRepoProbe("__CLONED__\n.git\n")).toEqual({
+  expect(parseRepoProbe(".deco\n.git\norg\n")).toEqual({
     cloned: false,
-    listing: "",
+    listing: ".deco\norg",
   });
 });
 
-test("working-tree entries are, and .git is not one of them", () => {
+test("the marker is the checkout, whatever else is in the directory", () => {
   expect(parseRepoProbe("__CLONED__\n.git\npackage.json\nsrc\n")).toEqual({
     cloned: true,
     listing: "package.json\nsrc",
+  });
+  // Scaffolding stays in the listing the model reads — it just no longer
+  // decides anything.
+  expect(
+    parseRepoProbe("__CLONED__\n.deco\n.git\norg\npackage.json\n"),
+  ).toEqual({
+    cloned: true,
+    listing: ".deco\norg\npackage.json",
   });
 });
 

--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -181,19 +181,37 @@ async function podBash(
 }
 
 /**
- * Interpret the clone probe (`__CLONED__` marker + `ls -A`). A HEAD ref can
- * appear before the checkout does, so entries — not the marker — are what make
- * it ready. Pure, so the readiness rule is unit-tested.
+ * Interpret the clone probe (`__CLONED__` marker + `ls -A`).
+ *
+ * The marker is the answer, and the directory listing is NOT. Readiness used to
+ * be "`ls -A` has an entry that isn't `.git`", on the reasoning that a HEAD ref
+ * lands before the checkout does. But the checkout directory is never empty to
+ * begin with: the pod stages `.deco` (the MCP tool stubs) and mounts `org` (the
+ * org filesystem) into it before any clone starts. Both survive the `.git`
+ * filter, both are there on the first probe, and neither changes — so the
+ * "stabilized across two probes" guard agreed with them, and the tool returned
+ * `cloned: true, files: ".deco\\norg"` about a second and a half in, having
+ * waited for nothing.
+ *
+ * The run that produced this then did exactly what it was told: read the
+ * directory, found no repository in it, and finished. It opened no PR, so its
+ * card took the repo-less path to In Review and sat there waiting for a person
+ * — a task "completed" in twenty seconds without a line of code read.
+ *
+ * `git ls-files` is what the marker is built from now (see the probe in
+ * `addRepoToThread`): a non-empty index means the checkout has actually written
+ * the tree, which no amount of pre-staged scaffolding can fake. The listing is
+ * still returned, because it is what the model reads — it just no longer gets a
+ * vote on whether the clone happened.
  */
 export function parseRepoProbe(stdout: string): {
   cloned: boolean;
   listing: string;
 } {
-  const entries = stdout
-    .split("\n")
-    .map((l) => l.trim())
-    .filter((l) => l && l !== ".git" && l !== "__CLONED__");
-  return { cloned: entries.length > 0, listing: entries.join("\n") };
+  const lines = stdout.split("\n").map((l) => l.trim());
+  const cloned = lines.includes("__CLONED__");
+  const entries = lines.filter((l) => l && l !== ".git" && l !== "__CLONED__");
+  return { cloned, listing: entries.join("\n") };
 }
 
 /**
@@ -534,7 +552,12 @@ export const TASK_ADD_REPO = defineTool({
         provider,
         record.sandboxHandle,
         threadId,
-        `cd ${checkoutDir} 2>/dev/null || exit 1; if git rev-parse HEAD >/dev/null 2>&1; then echo __CLONED__; fi; ls -A 2>/dev/null`,
+        // `git ls-files`, not `git rev-parse HEAD`: the ref can be written
+        // before the tree is, and the directory is never empty anyway (the pod
+        // stages `.deco` and mounts `org` into it before the clone starts), so
+        // neither HEAD nor the listing can tell a checkout from scaffolding. A
+        // non-empty index can only come from one. See `parseRepoProbe`.
+        `cd ${checkoutDir} 2>/dev/null || exit 1; if [ -n "$(git ls-files 2>/dev/null | head -1)" ]; then echo __CLONED__; fi; ls -A 2>/dev/null`,
       ).catch(() => null);
       if (!probe) {
         if (++failures >= CLONE_MAX_CONSECUTIVE_FAILURES) break;


### PR DESCRIPTION
## Summary

A Super Agent run "completed" in twenty seconds without reading a line of code.
Its transcript:

```
assistant  I'll start by cloning the repo.
tool       TASK_ADD_REPO { connectionId: … }
           → { "cloned": true, "files": ".deco\norg",
               "message": "… is checked out at your working directory
                           on branch sandbox/thread-…. Start working." }
tool       Bash  ls -a && find . -maxdepth 3 …
           → .  ..  .deco  .git  org
assistant  finish
```

The tool said the repository was there. It was not. The run did exactly what it
was told, found nothing to work on, and stopped.

## The probe asked the wrong question

Readiness was **"`ls -A` has an entry that isn't `.git`"**, on the reasoning
that a HEAD ref can land before the checkout does — so entries, not the marker,
were trusted.

But the checkout directory is never empty to begin with. The pod stages `.deco`
(the MCP tool stubs) and mounts `org` (the org filesystem) into it **before any
clone starts**. Both survive the `.git` filter, both are present on the very
first probe, and neither ever changes — so the "stabilized across two probes"
guard agreed with them too. `TASK_ADD_REPO` returned `cloned: true` about a
second and a half in, having waited for nothing.

The 45s `CLONE_TIMEOUT_MS` and the stabilize guard were never reached, because
the condition they gate on was already true before the work began.

## The fix

The marker is built from **`git ls-files`** and is now the sole readiness
signal. A non-empty index can only come from a checkout that actually wrote the
tree — no amount of pre-staged scaffolding can fake one, and unlike HEAD it
cannot be written ahead of the files.

```diff
-if git rev-parse HEAD >/dev/null 2>&1; then echo __CLONED__; fi; ls -A
+if [ -n "$(git ls-files 2>/dev/null | head -1)" ]; then echo __CLONED__; fi; ls -A
```

The listing is still returned — it is what the model reads to orient itself. It
just no longer gets a vote on whether the clone happened.

The stabilize guard keeps its meaning and gets a better one: it now measures
the listing settling *after* the checkout has begun, which is what it was
always trying to do.

## Downstream

This is also why the card reached **In Review with no reviewer**. No PR was
opened, so the card took the repo-less path (`advanceLinkedTasksToReviewOnThreadFinish`),
which parks a task whose answer *is* its deliverable for a human. That path
behaved correctly — it was handed a run that had genuinely produced nothing.

## Testing

- The two tests that encoded the old rule are **inverted**, not appended. The
  first now asserts on the exact probe output that shipped the twenty-second
  task (`.deco\norg` → **not** cloned).
- `bun test apps/api/src/tools/task-board apps/api/src/tools/sandbox` → 8
  pre-existing failures on `origin/main`, 8 on this branch, **zero regressions**.
- `bun run --cwd=apps/api check`, `bun run lint` (0 errors), `bun run fmt` — clean.

Found on a live cluster, not in review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `TASK_ADD_REPO` reporting a successful clone when the working directory was empty, which let Super Agent runs "complete" in seconds without reading any code. The probe now uses a `git ls-files` index marker as the sole readiness signal instead of trusting directory entries, since the pod pre-stages `.deco` and mounts `org` before any clone starts.

**Bug Fixes**
- Pre-staged scaffolding no longer counts as evidence of a checkout; readiness requires a non-empty git index.
- The directory listing is still returned to the model but no longer influences the `cloned` decision.
- Inverted the two tests that encoded the old rule so the exact probe output that shipped the empty-checkout run now asserts as not cloned.

<sup>Written for commit f9fcc7ef49c091e2278a557153f217efcfb096f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

