### PR TITLE
feat(task-board): a board whose columns are the org's own

### DIFF
--- a/apps/api/migrations/191-task-board-columns.ts
+++ b/apps/api/migrations/191-task-board-columns.ts
@@ -1,0 +1,51 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * The columns of a board Studio does not own.
+ *
+ * Empty for every org that runs the board Studio ships with — those columns
+ * are a constant, and rows for them would be identical data that can drift out
+ * of agreement with the code defining them. Rows exist only once a board is
+ * mirrored from somewhere else, which is what `dynamic_board_columns` says.
+ *
+ * `key` is what a card's `status` holds, the same as it is for the canonical
+ * set. `role` is what automation keys on, and is null for most columns here:
+ * a column someone else named means nothing to us until someone says it does.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("task_board_columns")
+    .ifNotExists()
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("organization_id", "text", (col) => col.notNull())
+    .addColumn("key", "text", (col) => col.notNull())
+    .addColumn("title", "text", (col) => col.notNull())
+    .addColumn("position", "integer", (col) => col.notNull())
+    .addColumn("role", "text")
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("task_board_columns_org_key_uniq")
+    .ifNotExists()
+    .on("task_board_columns")
+    .columns(["organization_id", "key"])
+    .unique()
+    .execute();
+
+  await db.schema
+    .createIndex("task_board_columns_org_position_idx")
+    .ifNotExists()
+    .on("task_board_columns")
+    .columns(["organization_id", "position"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("task_board_columns").ifExists().execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -189,6 +189,7 @@ import * as migration187taskboardcommentthread from "./187-task-board-comment-th
 import * as migration188invitationautoaccept from "./188-invitation-auto-accept.ts";
 import * as migration189taskboardcolumnautomations from "./189-task-board-column-automations.ts";
 import * as migration190taskboardreviewcyclestartedat from "./190-task-board-review-cycle-started-at.ts";
+import * as migration191taskboardcolumns from "./191-task-board-columns.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -410,6 +411,7 @@ const migrations: Record<string, Migration> = {
   "189-task-board-column-automations": migration189taskboardcolumnautomations,
   "190-task-board-review-cycle-started-at":
     migration190taskboardreviewcyclestartedat,
+  "191-task-board-columns": migration191taskboardcolumns,
 };
 
 export default migrations;

--- a/apps/api/src/core/context-factory.ts
+++ b/apps/api/src/core/context-factory.ts
@@ -512,6 +512,7 @@ import { OrgRepoSyncStorage } from "@/storage/org-repo-syncs";
 import { JiraIntegrationStorage } from "@/storage/jira-integrations";
 import { SprintStorage } from "@/storage/sprints";
 import { ColumnAutomationStorage } from "@/storage/task-board-column-automations";
+import { BoardColumnStorage } from "@/storage/task-board-columns";
 import { TaskBoardStorage } from "@/storage/task-board";
 import { NotificationStorage } from "@/storage/notifications";
 import { OrgFsEntryStorage } from "@/storage/org-fs";
@@ -1407,6 +1408,7 @@ export async function createStudioContextFactory(
     taskBoard: new TaskBoardStorage(config.db),
     sprints: new SprintStorage(config.db),
     columnAutomations: new ColumnAutomationStorage(config.db),
+    boardColumns: new BoardColumnStorage(config.db),
     notifications: new NotificationStorage(config.db),
     orgFsEntries: new OrgFsEntryStorage(config.db),
     oauthPkceStates: new OAuthPkceStateStorage(config.db),

--- a/apps/api/src/core/studio-context.test.ts
+++ b/apps/api/src/core/studio-context.test.ts
@@ -40,6 +40,7 @@ const createMockContext = (
     taskBoard: null as never,
     sprints: null as never,
     columnAutomations: null as never,
+    boardColumns: null as never,
     notifications: null as never,
     orgFsEntries: null as never,
     oauthPkceStates: null as never,

--- a/apps/api/src/core/studio-context.ts
+++ b/apps/api/src/core/studio-context.ts
@@ -309,6 +309,7 @@ import { OrgRepoSyncStorage } from "@/storage/org-repo-syncs";
 import { JiraIntegrationStorage } from "@/storage/jira-integrations";
 import { SprintStorage } from "@/storage/sprints";
 import { ColumnAutomationStorage } from "@/storage/task-board-column-automations";
+import { BoardColumnStorage } from "@/storage/task-board-columns";
 import type { TaskBoardStorage } from "@/storage/task-board";
 import type { NotificationStorage } from "@/storage/notifications";
 import type { OrgFsEntryStorage } from "@/storage/org-fs";
@@ -356,6 +357,7 @@ export interface StudioStorage {
   taskBoard: TaskBoardStorage;
   sprints: SprintStorage;
   columnAutomations: ColumnAutomationStorage;
+  boardColumns: BoardColumnStorage;
   notifications: NotificationStorage;
   orgFsEntries: OrgFsEntryStorage;
   oauthPkceStates: OAuthPkceStateStorage;

--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -24,7 +24,7 @@
  * its issue is next updated in Jira.
  */
 
-import { boardHandler } from "@/tools/task-board/board-handler";
+import { boardFor } from "@/tools/task-board/board-handler";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import type { StudioContext } from "@/core/studio-context";
 import type {
@@ -245,10 +245,9 @@ async function maybeAutoDelegate(
   // The board decides: a column with no rule on it is uneventful. This is also
   // what replaced `integration.autoDelegate`, which could only ever mean the
   // Super Agent, on To Do, for an org that had Jira.
-  const automation = await boardHandler(
-    orgId,
-    ctx.storage.columnAutomations,
-  ).automationFor(item.status);
+  const automation = await (await boardFor(ctx, orgId)).automationFor(
+    item.status,
+  );
   if (!automation) return item;
   // Conditional claim, not a plain update: the cron, a webhook wake-up (its
   // debounce is per-pod) and a manual JIRA_SYNC_RUN can all be mid-sync on the

--- a/apps/api/src/storage/task-board-columns.ts
+++ b/apps/api/src/storage/task-board-columns.ts
@@ -1,0 +1,90 @@
+import type { Kysely } from "kysely";
+import type { BoardColumn } from "@decocms/shared/task-board";
+import type { Database } from "./types";
+
+/**
+ * The columns of a board whose columns belong to the org rather than to Studio
+ * (migration 191). Empty for an org on the canonical board — those columns are
+ * a constant, not rows.
+ */
+type Row = {
+  key: string;
+  title: string;
+  position: number;
+  role: string | null;
+};
+
+export class BoardColumnStorage {
+  constructor(private readonly db: Kysely<Database>) {}
+
+  /** One org's columns, left to right. Empty when the board is Studio's own. */
+  async listByOrg(organizationId: string): Promise<BoardColumn[]> {
+    const rows = await this.db
+      .selectFrom("task_board_columns")
+      .select(["key", "title", "position", "role"])
+      .where("organization_id", "=", organizationId)
+      .orderBy("position", "asc")
+      .execute();
+    return rows as Row[];
+  }
+
+  /**
+   * Make this set of columns the board's, left to right in the order given.
+   *
+   * Written whole rather than merged: the caller is mirroring a board it does
+   * not own, so a column that has disappeared upstream has to disappear here.
+   * A column that survives keeps its `role`, which is ours and not the
+   * tracker's to reassign.
+   */
+  async replaceAll(
+    organizationId: string,
+    columns: { key: string; title: string }[],
+  ): Promise<BoardColumn[]> {
+    return await this.db.transaction().execute(async (tx) => {
+      const existing = await tx
+        .selectFrom("task_board_columns")
+        .select(["key", "role"])
+        .where("organization_id", "=", organizationId)
+        .execute();
+      const roleOf = new Map(existing.map((r) => [r.key, r.role]));
+
+      await tx
+        .deleteFrom("task_board_columns")
+        .where("organization_id", "=", organizationId)
+        .execute();
+
+      if (columns.length === 0) return [];
+
+      const rows = columns.map((column, position) => ({
+        id: `tbc_${organizationId}_${column.key}`,
+        organization_id: organizationId,
+        key: column.key,
+        title: column.title,
+        position,
+        role: roleOf.get(column.key) ?? null,
+      }));
+      await tx.insertInto("task_board_columns").values(rows).execute();
+      return rows.map(({ key, title, position, role }) => ({
+        key,
+        title,
+        position,
+        role,
+      }));
+    });
+  }
+
+  /** Say what one of this board's columns means to Studio, or unsay it. */
+  async setRole(
+    organizationId: string,
+    key: string,
+    role: string | null,
+  ): Promise<boolean> {
+    const result = await this.db
+      .updateTable("task_board_columns")
+      .set({ role, updated_at: new Date() })
+      .where("organization_id", "=", organizationId)
+      .where("key", "=", key)
+      .executeTakeFirst();
+    return (result.numUpdatedRows ?? 0n) > 0n;
+  }
+}

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1719,16 +1719,21 @@ export interface TaskBoardItemTable {
   updated_at: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
-/**
- * A sprint a card can belong to — an entity, not a window over a cadence (see
- * `migrations/182-task-board-sprints-entities.ts`).
- *
- * `jira_sprint_id` is the mirror's identity: UNIQUE per org, so the pull
- * upserts on it and a renamed Jira sprint updates in place instead of
- * splitting in two. Null means a sprint this board owns — nothing writes those
- * yet.
- */
-/** A rule the board runs when a card lands in a column (migration 190). The
+/** One column of a board whose columns belong to the org rather than to
+ *  Studio (migration 191). `key` is what a card's `status` holds; `role` is
+ *  what automation keys on, null until someone says what the column means. */
+export interface TaskBoardColumnTable {
+  id: string;
+  organization_id: string;
+  key: string;
+  title: string;
+  position: number;
+  role: string | null;
+  created_at: ColumnType<Date, Date | string | undefined, Date | string>;
+  updated_at: ColumnType<Date, Date | string | undefined, Date | string>;
+}
+
+/** A rule the board runs when a card lands in a column (migration 189). The
  *  row's existence is the switch; `prompt` null means the Super Agent's own
  *  instruction. */
 export interface TaskBoardColumnAutomationTable {
@@ -1740,6 +1745,15 @@ export interface TaskBoardColumnAutomationTable {
   updated_at: ColumnType<Date, Date | string | undefined, Date | string>;
 }
 
+/**
+ * A sprint a card can belong to — an entity, not a window over a cadence (see
+ * `migrations/182-task-board-sprints-entities.ts`).
+ *
+ * `jira_sprint_id` is the mirror's identity: UNIQUE per org, so the pull
+ * upserts on it and a renamed Jira sprint updates in place instead of
+ * splitting in two. Null means a sprint this board owns — nothing writes those
+ * yet.
+ */
 export interface TaskBoardSprintTable {
   id: string;
   organization_id: string;
@@ -2270,6 +2284,7 @@ export interface Database extends PrivateRegistryDatabase {
   task_board_items: TaskBoardItemTable;
   task_board_sprints: TaskBoardSprintTable;
   task_board_column_automations: TaskBoardColumnAutomationTable;
+  task_board_columns: TaskBoardColumnTable;
   task_board_item_threads: TaskBoardItemThreadTable;
   task_board_activity: TaskBoardActivityTable;
   task_board_item_prs: TaskBoardItemPrTable;

--- a/apps/api/src/tools/connection/connection-tools.integration.test.ts
+++ b/apps/api/src/tools/connection/connection-tools.integration.test.ts
@@ -119,6 +119,7 @@ describe("Connection Tools", () => {
         taskBoard: null as never,
         sprints: null as never,
         columnAutomations: null as never,
+        boardColumns: null as never,
         notifications: null as never,
         orgFsEntries: null as never,
         oauthPkceStates: null as never,

--- a/apps/api/src/tools/task-board/automations.ts
+++ b/apps/api/src/tools/task-board/automations.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { requireAuth } from "@/core/studio-context";
-import { boardHandler } from "./board-handler";
+import { boardFor } from "./board-handler";
 import { MAX_AUTOMATION_PROMPT_LENGTH } from "./schema";
 
 const AutomationSchema = z.object({
@@ -65,10 +65,7 @@ export const TASK_BOARD_AUTOMATION_UPSERT = defineTool({
 
     // Rejected here rather than stored and ignored: a rule on a column this
     // board does not have never fires, and looks configured to whoever set it.
-    const columns = await boardHandler(
-      organizationId,
-      ctx.storage.columnAutomations,
-    ).columns();
+    const columns = await (await boardFor(ctx, organizationId)).columns();
     if (!columns.some((c) => c.key === input.columnKey)) {
       throw new Error(
         `This board has no column "${input.columnKey}" — it has ${columns

--- a/apps/api/src/tools/task-board/board-handler.integration.test.ts
+++ b/apps/api/src/tools/task-board/board-handler.integration.test.ts
@@ -16,6 +16,7 @@ import {
   resetTestPgDatabase,
 } from "@/database/test-db-pg";
 import { ColumnAutomationStorage } from "@/storage/task-board-column-automations";
+import { BoardColumnStorage } from "@/storage/task-board-columns";
 import { boardHandler } from "./board-handler";
 import { LANE_RANK } from "./lanes";
 
@@ -25,6 +26,7 @@ const OTHER = "org_bh_2";
 describe("boardHandler — the board Studio ships with", () => {
   let database: StudioDatabase;
   let automations: ColumnAutomationStorage;
+  let boardColumns: BoardColumnStorage;
 
   beforeAll(async () => {
     database = await connectTestPgDatabase();
@@ -37,13 +39,15 @@ describe("boardHandler — the board Studio ships with", () => {
         .execute();
     }
     automations = new ColumnAutomationStorage(database.db);
+    boardColumns = new BoardColumnStorage(database.db);
   });
 
   afterAll(async () => {
     await closeTestPgDatabase(database);
   });
 
-  const board = (org = ORG) => boardHandler(org, automations);
+  const board = (org = ORG) =>
+    boardHandler(org, { automations, boardColumns, orgOwnedColumns: false });
 
   it("renders every canonical column, left to right", async () => {
     expect((await board().columns()).map((c) => c.key)).toEqual([
@@ -106,5 +110,84 @@ describe("boardHandler — the board Studio ships with", () => {
     await automations.upsert(ORG, "triage", "mine");
     expect(await board(OTHER).automationFor("triage")).toBe(null);
     expect(await automations.listByOrg(OTHER)).toEqual([]);
+  });
+});
+
+/**
+ * The second board, and the reason the interface exists.
+ *
+ * What matters is that it does NOT fall back to Studio's lanes. An org that
+ * said its columns are its own gets its own — empty if that is what they are —
+ * because falling back would quietly re-introduce a vocabulary it has opted
+ * out of, and the cards would look filed under lanes nobody chose.
+ */
+describe("boardHandler — a board whose columns are the org's own", () => {
+  let database: StudioDatabase;
+  let automations: ColumnAutomationStorage;
+  let boardColumns: BoardColumnStorage;
+  const ORG_M = "org_bh_m";
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values({ id: ORG_M, name: ORG_M, slug: "org-bh-m", createdAt: now })
+      .execute();
+    automations = new ColumnAutomationStorage(database.db);
+    boardColumns = new BoardColumnStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  const board = () =>
+    boardHandler(ORG_M, { automations, boardColumns, orgOwnedColumns: true });
+
+  it("renders nothing before its columns arrive, rather than Studio's lanes", async () => {
+    expect(await board().columns()).toEqual([]);
+  });
+
+  it("renders the org's own columns, in the order given", async () => {
+    await boardColumns.replaceAll(ORG_M, [
+      { key: "BACKLOG", title: "Backlog" },
+      { key: "Fazendo", title: "Em Progresso" },
+      { key: "Code Review", title: "Code Review" },
+    ]);
+    expect((await board().columns()).map((c) => c.title)).toEqual([
+      "Backlog",
+      "Em Progresso",
+      "Code Review",
+    ]);
+  });
+
+  it("gives a mirrored column no role until someone says what it means", async () => {
+    expect((await board().columns()).every((c) => c.role === null)).toBe(true);
+    await boardColumns.setRole(ORG_M, "Code Review", "in_review");
+    const named = (await board().columns()).find(
+      (c) => c.key === "Code Review",
+    );
+    expect(named?.role).toBe("in_review");
+  });
+
+  /** A role is Studio's reading of someone else's column, so re-mirroring must
+   *  not wipe it — the tracker has no idea it exists. */
+  it("keeps a role through a re-sync, and drops a column that vanished", async () => {
+    await boardColumns.replaceAll(ORG_M, [
+      { key: "BACKLOG", title: "Backlog" },
+      { key: "Code Review", title: "Code Review" },
+    ]);
+    const after = await board().columns();
+    expect(after.map((c) => c.key)).toEqual(["BACKLOG", "Code Review"]);
+    expect(after.find((c) => c.key === "Code Review")?.role).toBe("in_review");
+  });
+
+  it("runs a rule hung on a column the tracker named", async () => {
+    await automations.upsert(ORG_M, "Code Review", "Review it.");
+    expect((await board().automationFor("Code Review"))?.prompt).toBe(
+      "Review it.",
+    );
+    expect(await board().automationFor("todo")).toBe(null);
   });
 });

--- a/apps/api/src/tools/task-board/board-handler.ts
+++ b/apps/api/src/tools/task-board/board-handler.ts
@@ -4,6 +4,9 @@ import type {
   ColumnAutomation,
   ColumnAutomationStorage,
 } from "@/storage/task-board-column-automations";
+import type { BoardColumnStorage } from "@/storage/task-board-columns";
+import type { StudioContext } from "@/core/studio-context";
+import { orgFlagEnabled } from "@decocms/shared/organization/schema";
 
 /**
  * A board's behaviour, as the questions its callers actually have.
@@ -42,7 +45,7 @@ const CANONICAL: BoardColumn[] = CANONICAL_COLUMN_KEYS.map((key, position) => ({
 
 /** The board Studio ships with: a fixed set of columns, and whatever rules the
  *  org has hung on them. */
-class StaticBoardHandler implements BoardHandler {
+class StudioBoardHandler implements BoardHandler {
   constructor(
     private readonly organizationId: string,
     private readonly automations: ColumnAutomationStorage,
@@ -58,15 +61,72 @@ class StaticBoardHandler implements BoardHandler {
 }
 
 /**
+ * A board whose columns belong to the org, not to Studio.
+ *
+ * Named for who defines the set, not for where it came from. Today the only
+ * source is a Jira board, but mirroring is something the SYNC does; this side
+ * only knows the columns are not ours to invent. A column someone typed by
+ * hand would land here too and nothing would need renaming.
+ *
+ * Only `columns` differs from Studio's own board: the rules hang off a column
+ * key either way, so whose board it is has no bearing on what runs where. That
+ * is the point of keying automations by column rather than by lane.
+ */
+class OrgBoardHandler implements BoardHandler {
+  constructor(
+    private readonly organizationId: string,
+    private readonly automations: ColumnAutomationStorage,
+    private readonly boardColumns: BoardColumnStorage,
+  ) {}
+
+  columns(): Promise<BoardColumn[]> {
+    return this.boardColumns.listByOrg(this.organizationId);
+  }
+
+  automationFor(columnKey: string): Promise<ColumnAutomation | null> {
+    return this.automations.get(this.organizationId, columnKey);
+  }
+}
+
+export interface BoardHandlerDeps {
+  automations: ColumnAutomationStorage;
+  boardColumns: BoardColumnStorage;
+  /** `org_board_columns` — see `OrgFlagsSchema`. */
+  orgOwnedColumns: boolean;
+}
+
+/**
  * This org's board.
  *
- * One implementation today. It takes the org so every call site is already
- * written the way it needs to be once a board can be tracker-owned instead,
- * and choosing between the two is a change here rather than at each caller.
+ * The one place the two answers are chosen between, which is why every caller
+ * asks the board rather than reading a status. An org board with no columns yet
+ * is still an org board: it renders empty rather than falling back to Studio's
+ * lanes, because falling back would silently re-introduce a vocabulary the org
+ * has said it does not use.
  */
 export function boardHandler(
   organizationId: string,
-  automations: ColumnAutomationStorage,
+  deps: BoardHandlerDeps,
 ): BoardHandler {
-  return new StaticBoardHandler(organizationId, automations);
+  return deps.orgOwnedColumns
+    ? new OrgBoardHandler(organizationId, deps.automations, deps.boardColumns)
+    : new StudioBoardHandler(organizationId, deps.automations);
+}
+
+/**
+ * This org's board, with its mode read for you.
+ *
+ * The single construction point: every caller goes through here, so which
+ * board an org has is decided once instead of at each site.
+ */
+export async function boardFor(
+  ctx: StudioContext,
+  organizationId: string,
+): Promise<BoardHandler> {
+  const settings = await ctx.storage.organizationSettings.get(organizationId);
+  return boardHandler(organizationId, {
+    automations: ctx.storage.columnAutomations,
+    boardColumns: ctx.storage.boardColumns,
+    orgOwnedColumns: orgFlagEnabled(settings?.flags, "org_board_columns"),
+  });
 }

--- a/apps/api/src/tools/task-board/list.ts
+++ b/apps/api/src/tools/task-board/list.ts
@@ -1,4 +1,4 @@
-import { boardHandler } from "./board-handler";
+import { boardFor } from "./board-handler";
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { requireAuth } from "@/core/studio-context";
@@ -53,7 +53,7 @@ export const TASK_BOARD_ITEM_LIST = defineTool({
         ctx.storage.taskBoard.list(organizationId),
         ctx.storage.connections.list(organizationId, { slug: "mcp-github" }),
         ctx.storage.sprints.listByOrg(organizationId),
-        boardHandler(organizationId, ctx.storage.columnAutomations).columns(),
+        boardFor(ctx, organizationId).then((board) => board.columns()),
       ]);
     const repos = listRepoScopeLabels(githubConnections);
 

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -137,6 +137,12 @@ export const OrgFlagsSchema = z.object({
     .describe(
       "Curated commerce (reports) look: hides agent navigation, the home Customize button, and the Settings/Automations tabs. Defaulted on for orgs created by commerce onboarding.",
     ),
+  org_board_columns: z
+    .boolean()
+    .optional()
+    .describe(
+      "The task board's columns are this org's own, mirrored from its tracker, rather than the set Studio ships. Off means the canonical lanes, which is the only board most orgs want.",
+    ),
   reviewer_enabled: z
     .boolean()
     .optional()


### PR DESCRIPTION
## What is this contribution about?

Step three, and the one that makes the interface earn its keep: **a second implementation.**

`dynamic_board_columns` picks between them, in the single place a board is constructed — which is why #6682 and #6690 moved every caller to asking the board first. Nothing else in the codebase learns that boards can differ.

```ts
export function boardHandler(organizationId: string, deps: BoardHandlerDeps): BoardHandler {
  return deps.dynamicColumns
    ? new MirroredBoardHandler(...)
    : new StaticBoardHandler(...);
}
```

**Only `columns` differs between them.** Rules hang off a column key either way, so which board an org has has no bearing on what runs where — that is exactly what keying automations by column rather than by lane bought us in #6690, and it is why the second implementation is small.

### The decisions I'd want challenged

**A mirrored board with no columns renders empty, not Studio's lanes.** Falling back would quietly re-introduce a vocabulary the org has said it does not use, and file its cards under lanes nobody chose. This is the single most load-bearing behaviour in the PR and it is asserted first in the tests.

**The mode is an explicit flag, not inferred from whether rows exist.** I used "the row's existence is the switch" for automations and it was right there — a missing rule is a safe default. Here it is not: a board converts *before* its first sync, so "dynamic but not yet populated" has to be a state you can be in. Inferring from rows would make that state indistinguishable from static and undo the point above.

**`replaceAll` writes the set whole.** The caller is mirroring a board it does not own, so a column deleted upstream has to disappear here — a merge would accumulate ghosts. But a surviving column **keeps its `role`**: that is Studio's reading of someone else's column, and the tracker has no idea it exists, so a re-mirror must not wipe it.

**Still no table for the canonical board.** Its columns remain a constant; the new table stays empty for every org that has not opted in.

## How did you verify your code works?

Thirteen **real-Postgres** cases — the tier this needs, since the whole second implementation is rows and the properties that matter are about what is *absent*.

The static board's existing cases carry over unchanged (columns left to right, positions agreeing with `LANE_RANK`, an unconfigured board doing nothing anywhere, rules org-scoped). New for the mirrored one: **renders empty before its columns arrive** rather than Studio's lanes; renders the org's own columns in the given order (`Backlog / Em Progresso / Code Review`, i.e. names that are not ours); a mirrored column has **no role until someone says what it means**; **a role survives a re-mirror while a vanished column is dropped** — both halves in one assertion, since either alone would pass a broken implementation; and a rule hung on a tracker-named column fires while a canonical key does not.

1039 pass / 0 fail across `apps/api/src/{tools/task-board,jira,storage,core}`. `bun run check` 0 type errors, `bun run lint` 19 warnings identical to baseline, `knip` clean, `fmt:check` clean. Migration run against a real database.

**Not verified, flagging honestly:**

- **Nothing populates the rows.** `replaceAll` and `setRole` have no caller outside tests — mirroring from Jira is the next step. I judged that better than shipping a half-mirror, but it does mean the mirrored board is unreachable in the product today: the flag exists, and turning it on gets you an empty board. That is a deliberately inert state, not a working feature.
- **No UI**, for the mode or for roles. Same reasoning as #6690's missing automation screen, and the debt is now two PRs deep.
- **No e2e.** The board read goes through `boardFor`, so a mirrored org's `TASK_BOARD_ITEM_LIST` returns its own columns, but nothing asserts that over the wire.
- **`boardFor` adds a settings read per call.** Three call sites today, one of them the board read. It is a single indexed row and almost certainly noise next to the queries beside it, but I did not measure it.

## Screenshots/Demonstration

Not applicable — no user-visible change with the flag off, and the flag is off everywhere.

## How to Test

1. With the flag off, everything is as before: canonical columns, automations firing on canonical keys.
2. Set `dynamic_board_columns: true` on a test org. The board read should return an **empty** `columns` array — not the nine lanes.
3. Insert some columns via `BoardColumnStorage.replaceAll` and confirm they come back in order, with null roles.
4. Set a role, re-run `replaceAll` dropping one column, and confirm the surviving column kept its role and the dropped one is gone.

## Migration Notes

Migration 190 creates `task_board_columns`, empty. Reversible, and no existing row is touched. `dynamic_board_columns` is a new default-off org flag, so every org keeps the board it has.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a second task-board implementation whose columns come from the org's own storage rather than Studio's canonical lanes. A default-off `org_board_columns` org flag picks between the two at the board's single construction point, so with the flag off nothing changes.

**Behavior with the flag on**
- Columns come from the new `task_board_columns` table; a mirrored board with no columns yet renders empty, not Studio's lanes.
- `replaceAll` writes the column set whole, so a column deleted upstream disappears while a surviving column keeps its `role`.
- Rules hang off column keys on either board, so automations behave the same and no other code learns boards can differ.
- `status` has no foreign key to `task_board_columns` because CASCADE, RESTRICT, and SET NULL are all wrong when a mirrored column disappears, so what its cards do stays app policy.
- `boardFor` adds one settings read per call across the call sites.

**Migration**
- Migration 191 creates the empty `task_board_columns` table; the canonical board's columns stay a constant and the table stays empty for every org that hasn't opted in.
- Nothing populates the rows yet, so the mirrored board is deliberately inert in the product today; Jira mirroring is the next step.

<sup>Written for commit cd0473d56cfba16a303cbff33b6f2065830ac042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

