### PR TITLE
feat(web): default deco.cx imports to {slug}.deco.site preview with chat closed

### DIFF
--- a/apps/web/src/components/import-from-deco-dialog.tsx
+++ b/apps/web/src/components/import-from-deco-dialog.tsx
@@ -271,13 +271,9 @@ export function ImportFromDecoDialog({
         const projectIcon = connBody.icon ?? null;
         const slug = generateSlug(siteName);
         const siteSlug = siteName.toLowerCase();
-        // Persist the site's real deployed URL (custom domain when present,
-        // else the deco.site host) as the preview server so the CMS preview
-        // can render against it. `null` when the site has no domains. The
-        // legacy `productionUrl` key is dual-written so an older app version
-        // rolling back still finds the value.
+        // Default the preview server to the site's `{slug}.deco.site` host (legacy `productionUrl` dual-written for rollback).
         const previewServerUrl = productionUrlFromDomain(
-          pickProductionDomain(site.domains),
+          `${siteSlug}.deco.site`,
         );
 
         // 2. Create a space (virtual MCP) wired to both admin-mcp and GitHub.
@@ -320,7 +316,7 @@ export function ImportFromDecoDialog({
                   ],
                   layout: {
                     defaultMainView: { type: "preview" },
-                    chatDefaultOpen: true,
+                    chatDefaultOpen: false,
                   },
                 },
               },


### PR DESCRIPTION
## Summary
Two changes to the **Import from deco.cx** flow (`apps/web/src/components/import-from-deco-dialog.tsx`):

- **Preview server** now defaults to `https://<sitename>.deco.site` (built from the site slug) instead of picking the site's real production/custom domain from `site.domains`. `productionUrl` is still dual-written to the same value for rollback compatibility.
- **Show chat** now defaults to closed on import — `chatDefaultOpen: false` in the created space's `metadata.ui.layout` (was `true`).

## Notes
- `pickProductionDomain` remains imported; it's still used elsewhere in the dialog for display.
- Behavior change: sites running on a custom domain will now default their preview server to `<slug>.deco.site` rather than the custom domain. Users can edit the Preview server field afterward.

## Testing
- `bun run fmt` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes Import from deco.cx so the preview server defaults to `https://<slug>.deco.site` instead of the site's real production or custom domain, and new spaces start with the chat panel closed. `productionUrl` is still dual-written to the same value so a rollback to an older app version keeps working.

Sites on a custom domain will now see the deco.site host as the preview server by default; the field can still be edited after import.

<sup>Written for commit 3d4dc2e573359e1d26df10fec496aeca8039a424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

