### PR TITLE
fix(task-board): open the review cycle when the PR link loses the race

### DIFF
--- a/apps/api/migrations/189-task-board-review-cycle-started-at.ts
+++ b/apps/api/migrations/189-task-board-review-cycle-started-at.ts
@@ -1,0 +1,71 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Decouple the review cycle from the board lane.
+ *
+ * The "current review cycle" — the boundary that decides which reviewer
+ * verdicts still count — used to be derived from the newest
+ * `status_changed → in_review` activity, i.e. from the LANE the card sits in.
+ * That made the lane load-bearing: a card could not be anywhere but In Review
+ * while its reviewer ran, because moving it would have reset the cycle and
+ * invalidated every verdict recorded before the move.
+ *
+ * `review_cycle_started_at` is that boundary as its own column. With it, the
+ * lane is free to say what a human actually wants to read — In Progress while
+ * an agent reviewer is still working, In Review once it is a person's turn —
+ * and the reviewer machinery keys on the column instead.
+ *
+ * Backfilled from the timeline so in-flight cycles survive the deploy:
+ * `reviewCycleStart` still falls back to the activity scan for a card that has
+ * neither (see `packages/shared/src/task-board.ts`), so a missed row degrades
+ * to the old behaviour rather than to a lost cycle.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_items")
+    .addColumn("review_cycle_started_at", "timestamptz")
+    .execute();
+
+  // Every card whose current lane means "a review cycle is open", anchored on
+  // the transition that opened it.
+  await sql`
+    UPDATE task_board_items i
+       SET review_cycle_started_at = (
+             SELECT max(a.occurred_at)
+               FROM task_board_activity a
+              WHERE a.task_board_item_id = i.id
+                AND a.action = 'status_changed'
+                AND a.data ->> 'to' = 'in_review'
+           )
+     WHERE i.status = 'in_review'
+  `.execute(db);
+
+  // Replaces idx_task_board_items_pending_review: the sweeper's work list is no
+  // longer "cards in the In Review lane" but "cards with an open review cycle",
+  // which spans In Progress and In Review.
+  await sql`
+    CREATE INDEX idx_task_board_items_review_cycle
+      ON task_board_items (updated_at, id)
+      WHERE (review_cycle_started_at IS NOT NULL OR status = 'in_review')
+        AND assignee_id = 'super-agent'
+        AND dismissed_at IS NULL
+  `.execute(db);
+  await sql`DROP INDEX IF EXISTS idx_task_board_items_pending_review`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE INDEX idx_task_board_items_pending_review
+      ON task_board_items (updated_at, id)
+      WHERE status = 'in_review'
+        AND assignee_id = 'super-agent'
+        AND dismissed_at IS NULL
+  `.execute(db);
+  await sql`DROP INDEX IF EXISTS idx_task_board_items_review_cycle`.execute(db);
+  await db.schema
+    .alterTable("task_board_items")
+    .dropColumn("review_cycle_started_at")
+    .execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -187,6 +187,7 @@ import * as migration185jirarescanexistingcards from "./185-jira-rescan-existing
 import * as migration186jirarescanpendingflag from "./186-jira-rescan-pending-flag.ts";
 import * as migration187taskboardcommentthread from "./187-task-board-comment-thread.ts";
 import * as migration188invitationautoaccept from "./188-invitation-auto-accept.ts";
+import * as migration189taskboardreviewcyclestartedat from "./189-task-board-review-cycle-started-at.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -405,6 +406,8 @@ const migrations: Record<string, Migration> = {
   "186-jira-rescan-pending-flag": migration186jirarescanpendingflag,
   "187-task-board-comment-thread": migration187taskboardcommentthread,
   "188-invitation-auto-accept": migration188invitationautoaccept,
+  "189-task-board-review-cycle-started-at":
+    migration189taskboardreviewcyclestartedat,
 };
 
 export default migrations;

--- a/apps/api/src/api/routes/decopilot/cluster-mcp-tool-hooks.ts
+++ b/apps/api/src/api/routes/decopilot/cluster-mcp-tool-hooks.ts
@@ -21,7 +21,7 @@ import type {
 } from "@/harnesses/lib/decopilot/mcp-tools";
 import { resolveArgsStorageRefs } from "./file-materializer";
 import {
-  advanceTaskBoardForRun,
+  openReviewCycleForRun,
   capturePrForRun,
   isPrCreateMcpTool,
 } from "@/tools/task-board/run-reactions";
@@ -51,10 +51,13 @@ export function buildClusterMcpToolHooks(
   return {
     resolveArgs: (input) => resolveArgsStorageRefs(input, ctx),
     onToolCalled: (event) => {
-      // A Super Agent task run just opened a PR via the GitHub MCP tool —
-      // move its card to In Review. Fire-and-forget (no-ops off a task run).
+      // A Super Agent task run just opened a PR via the GitHub MCP tool — open
+      // its card's review cycle so a reviewer picks it up. The card STAYS In
+      // Progress: an agent is still working on it, and In Review is what the
+      // board says once it is a person's turn. Fire-and-forget (no-ops off a
+      // task run).
       if (!event.isError && isPrCreateMcpTool(event.toolName)) {
-        void advanceTaskBoardForRun(ctx, "in_review", threadId);
+        void openReviewCycleForRun(ctx, threadId);
       }
       const orgId = ctx.organization?.id;
       const userId = ctx.auth?.user?.id;

--- a/apps/api/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/api/src/harnesses/decopilot/run-agent-loop.ts
@@ -44,7 +44,7 @@ import { assembleAgentTools } from "./assemble-agent-tools";
 import type { BuiltinToolParams } from "./built-in-tools";
 import { buildClusterMcpToolHooks } from "@/api/routes/decopilot/cluster-mcp-tool-hooks";
 import {
-  advanceTaskBoardForRun,
+  openReviewCycleForRun,
   capturePrForRun,
   isPrCreateBashCommand,
 } from "@/tools/task-board/run-reactions";
@@ -225,9 +225,9 @@ export async function runAgentLoop(
     : createLanguageModel(opts.provider, opts.models.thinking);
 
   // Watch each step's bash calls for `gh pr create` (or a REST fallback) and
-  // move a linked task card to In Review. The scan itself is a cheap per-step
+  // open a linked task card's review cycle. The scan itself is a cheap per-step
   // array walk, so it's unconditional — a normal run never has a `bash` call
-  // matching the PR regexes, and `advanceTaskBoardForRun` hits the DB only when
+  // matching the PR regexes, and `openReviewCycleForRun` hits the DB only when
   // one does: a link SELECT to resolve the target, then a write only if that
   // run is actually task-linked (a non-task match reads nothing to update).
   // (The GitHub MCP tool path is caught separately via
@@ -243,11 +243,7 @@ export async function runAgentLoop(
         command &&
         isPrCreateBashCommand(command)
       ) {
-        void advanceTaskBoardForRun(
-          opts.ctx,
-          "in_review",
-          opts.currentThreadId,
-        );
+        void openReviewCycleForRun(opts.ctx, opts.currentThreadId);
         // Link the PR too — its URL is in the bash call's stdout (`gh pr create`
         // prints it; a `curl … /pulls` POST returns it in the response body).
         // Only parse the matched call's own output, never every bash stdout.

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -548,21 +548,24 @@ export class SandboxDispatchClient {
       resume: { reason: string } | null,
     ): AsyncIterable<UIMessageChunk> =>
       (async function* () {
-        // The longest silence in the run: pod boot, clone, and (interactive)
-        // install. The chat has no per-thread stream here, so this rides
-        // the org `/watch`.
-        await publishRunStatusStage({
-          streamBuffer,
-          harnessId: SANDBOX_HOSTED_HARNESS,
-          taskId: runId,
-          stage: "starting-sandbox",
-        });
         const sandbox = await ensureSandbox(
           {
             virtualMcpId,
             branch,
             // Headless loop, no preview — unless someone is watching it.
             purpose: interactive ? "interactive" : "harness-run",
+            // The longest silence in the run: pod boot, clone, and
+            // (interactive) install. The chat has no per-thread stream here, so
+            // this rides the org `/watch`. Only on a cold start — an
+            // interactive agent keeps its pod between turns, and announcing a
+            // boot on every message made a warm resume look like a re-boot.
+            onColdStart: () =>
+              publishRunStatusStage({
+                streamBuffer,
+                harnessId: SANDBOX_HOSTED_HARNESS,
+                taskId: runId,
+                stage: "starting-sandbox",
+              }),
           },
           ctx,
         );

--- a/apps/api/src/storage/task-board-advance-review.integration.test.ts
+++ b/apps/api/src/storage/task-board-advance-review.integration.test.ts
@@ -173,8 +173,11 @@ describe("advanceToReviewIfInProgress (real Postgres)", () => {
     expect(results.filter((r) => r !== null)).toHaveLength(1);
   });
 
-  // A repo-backed task can't dead-end In Review with no PR — on finish it stays In Progress until a PR is linked, then the finish backstop advances it.
-  it("holds a repo-backed task on finish until a PR is linked", async () => {
+  // A repo-backed task can't dead-end with no PR — on finish it stays In
+  // Progress with no review cycle until a PR is linked, and then the finish
+  // backstop OPENS the cycle. It does not move the card: a reviewer is about to
+  // work on it, and In Review is what the board says once it is a person's turn.
+  it("opens the review cycle on finish only once a PR is linked", async () => {
     const task = await taskBoard.create({
       organizationId: ORG,
       title: "repo, no PR yet",
@@ -206,11 +209,13 @@ describe("advanceToReviewIfInProgress (real Postgres)", () => {
       })
       .execute();
 
-    // No PR → stays In Progress.
+    // No PR → stays In Progress with nothing to review.
     await taskBoard.advanceLinkedTasksToReviewOnThreadFinish(thread.id, ORG);
-    expect((await taskBoard.getById(task.id, ORG))?.status).toBe("in_progress");
+    const before = await taskBoard.getById(task.id, ORG);
+    expect(before?.status).toBe("in_progress");
+    expect(before?.reviewCycleStartedAt).toBeNull();
 
-    // Link a PR → the finish backstop now advances it.
+    // Link a PR → the finish backstop opens the cycle, and the lane holds.
     await taskBoard.linkPr({
       taskBoardItemId: task.id,
       organizationId: ORG,
@@ -220,7 +225,93 @@ describe("advanceToReviewIfInProgress (real Postgres)", () => {
       repoName: "site",
     });
     await taskBoard.advanceLinkedTasksToReviewOnThreadFinish(thread.id, ORG);
-    expect((await taskBoard.getById(task.id, ORG))?.status).toBe("in_review");
+    const after = await taskBoard.getById(task.id, ORG);
+    expect(after?.status).toBe("in_progress");
+    expect(after?.reviewCycleStartedAt).not.toBeNull();
+  });
+
+  /**
+   * The duplicate-stamp bug, re-encoded against the column that replaced the
+   * activity row. Re-stamping an OPEN cycle moves its boundary forward and
+   * invalidates every verdict already recorded against it — which is exactly
+   * how 13 prod cards ended up holding an approval that could never merge.
+   * `review_cycle_started_at IS NULL` in the WHERE is the whole guard, and only
+   * a real database proves a SQL predicate.
+   */
+  it("opens a review cycle exactly once, however many callers try", async () => {
+    const { task } = await cardWithFinishedRun("one cycle only");
+
+    const winners = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        taskBoard.openReviewCycleIfInProgress(task.id, ORG),
+      ),
+    );
+
+    expect(winners.filter((w) => w !== null)).toHaveLength(1);
+  });
+
+  it("re-opens a cycle only after it is closed", async () => {
+    const { task } = await cardWithFinishedRun("second round");
+    const first = await taskBoard.openReviewCycleIfInProgress(task.id, ORG);
+    expect(first).not.toBeNull();
+    const firstAt = first?.reviewCycleStartedAt;
+
+    // Still open — the boundary must not move under a standing verdict.
+    expect(
+      await taskBoard.openReviewCycleIfInProgress(task.id, ORG),
+    ).toBeNull();
+    expect((await taskBoard.getById(task.id, ORG))?.reviewCycleStartedAt).toBe(
+      firstAt as string,
+    );
+
+    await taskBoard.closeReviewCycle(task.id, ORG);
+    const second = await taskBoard.openReviewCycleIfInProgress(task.id, ORG);
+    expect(second).not.toBeNull();
+    expect(second?.reviewCycleStartedAt).not.toBe(firstAt as string);
+  });
+
+  it("never opens a cycle on a card that is not In Progress", async () => {
+    const { task } = await cardWithFinishedRun("wrong lane");
+    await taskBoard.advanceToReviewIfInProgress(task.id, ORG, USER);
+
+    expect(
+      await taskBoard.openReviewCycleIfInProgress(task.id, ORG),
+    ).toBeNull();
+  });
+
+  it("is org-scoped — another org cannot open the cycle", async () => {
+    const { task } = await cardWithFinishedRun("cross-org cycle");
+
+    expect(
+      await taskBoard.openReviewCycleIfInProgress(task.id, "org_other"),
+    ).toBeNull();
+    expect(
+      (await taskBoard.getById(task.id, ORG))?.reviewCycleStartedAt,
+    ).toBeNull();
+  });
+
+  // The sweeper's work list is the open cycle, not the lane — a card whose
+  // reviewer is working reads In Progress and still has to be swept.
+  it("lists an In Progress card with an open cycle as pending review", async () => {
+    const { task } = await cardWithFinishedRun("pending while in progress");
+    await taskBoard.openReviewCycleIfInProgress(task.id, ORG);
+
+    const pending = await taskBoard.listItemsPendingReview(100);
+
+    expect(pending.map((p) => p.id)).toContain(task.id);
+  });
+
+  it("drops a card out of the work list once it ships", async () => {
+    const { task } = await cardWithFinishedRun("shipped, stop sweeping");
+    await taskBoard.openReviewCycleIfInProgress(task.id, ORG);
+    await taskBoard.update(task.id, ORG, { status: "done" }, USER);
+
+    expect(
+      (await taskBoard.listItemsPendingReview(100)).map((p) => p.id),
+    ).not.toContain(task.id);
+    expect(
+      (await taskBoard.getById(task.id, ORG))?.reviewCycleStartedAt,
+    ).toBeNull();
   });
 });
 

--- a/apps/api/src/storage/task-board-advance-review.integration.test.ts
+++ b/apps/api/src/storage/task-board-advance-review.integration.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../database/test-db-pg";
 import { TaskBoardStorage } from "./task-board";
 import { SqlThreadStorage } from "./threads";
+import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 
 const ORG = "org_advance_review";
 const USER = "user_advance_review";
@@ -270,9 +271,69 @@ describe("advanceToReviewIfInProgress (real Postgres)", () => {
     expect(second?.reviewCycleStartedAt).not.toBe(firstAt as string);
   });
 
-  it("never opens a cycle on a card that is not In Progress", async () => {
-    const { task } = await cardWithFinishedRun("wrong lane");
+  /**
+   * The PR link can LOSE THE RACE to the thread-finish backstop: the backstop
+   * reads `listPrs` to decide repo-backed vs repo-less, and a run that links
+   * its PR moments after its thread goes terminal is read as repo-less and
+   * parked In Review. Observed at 52 seconds between the two on a real board.
+   *
+   * The old rule matched only In Progress, so the late link was a no-op, the
+   * cycle never opened, and the card sat In Review for the whole reviewer run
+   * with its verdicts falling back to the legacy activity scan. Inverted.
+   */
+  it("rescues a card the backstop parked In Review before the PR landed", async () => {
+    const { task } = await cardWithFinishedRun("late pr link");
+    await taskBoard.update(
+      task.id,
+      ORG,
+      { assigneeId: SUPER_AGENT_ASSIGNEE_ID },
+      USER,
+    );
     await taskBoard.advanceToReviewIfInProgress(task.id, ORG, USER);
+    expect((await taskBoard.getById(task.id, ORG))?.status).toBe("in_review");
+
+    const opened = await taskBoard.openReviewCycleIfInProgress(task.id, ORG);
+
+    expect(opened?.status).toBe("in_progress");
+    expect(opened?.reviewCycleStartedAt).not.toBeNull();
+  });
+
+  // Only while the cycle is null. Once one is open the card is mid-review, and
+  // `parkReviewedCardForHuman` put it In Review on a verdict — dragging it back
+  // would undo that and re-stamp a boundary verdicts already stand on.
+  it("leaves an In Review card with a cycle already open alone", async () => {
+    const { task } = await cardWithFinishedRun("mid review");
+    await taskBoard.openReviewCycleIfInProgress(task.id, ORG);
+    await taskBoard.update(task.id, ORG, { status: "in_review" }, USER);
+
+    expect(
+      await taskBoard.openReviewCycleIfInProgress(task.id, ORG),
+    ).toBeNull();
+    expect((await taskBoard.getById(task.id, ORG))?.status).toBe("in_review");
+  });
+
+  // A person took the card over (`handTaskToHuman` clears the assignee); the
+  // automation does not get to pull it back into the agents' lane.
+  it("never rescues a card a human owns", async () => {
+    const { task } = await cardWithFinishedRun("human owns it");
+    await taskBoard.update(
+      task.id,
+      ORG,
+      { assigneeId: SUPER_AGENT_ASSIGNEE_ID },
+      USER,
+    );
+    await taskBoard.advanceToReviewIfInProgress(task.id, ORG, USER);
+    await taskBoard.unassignSuperAgent(task.id, ORG, USER);
+
+    expect(
+      await taskBoard.openReviewCycleIfInProgress(task.id, ORG),
+    ).toBeNull();
+    expect((await taskBoard.getById(task.id, ORG))?.status).toBe("in_review");
+  });
+
+  it("never opens a cycle on a card past the review phase", async () => {
+    const { task } = await cardWithFinishedRun("wrong lane");
+    await taskBoard.update(task.id, ORG, { status: "done" }, USER);
 
     expect(
       await taskBoard.openReviewCycleIfInProgress(task.id, ORG),

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -107,6 +107,14 @@ function extractPartText(payload: unknown): string | null {
   return null;
 }
 
+/** The lanes a review cycle may span: an agent reviewer runs while the card
+ *  reads In Progress, and the card sits In Review once it is a person's turn.
+ *  Moving to any OTHER lane ends the cycle — see `update()`. */
+const REVIEW_PHASE_LANES = new Set<TaskBoardItemStatus>([
+  "in_progress",
+  "in_review",
+]);
+
 /** Thread run statuses that mean the run is over (not running / not paused on a
  *  user_ask). `requires_action` and `in_progress` are deliberately excluded. */
 export const TERMINAL_THREAD_STATUSES = new Set([
@@ -386,6 +394,14 @@ export class TaskBoardStorage {
         ...(data.dueDate !== undefined ? { due_date: data.dueDate } : {}),
         ...(data.sprintId !== undefined ? { sprint_id: data.sprintId } : {}),
         ...(data.sortOrder !== undefined ? { sort_order: data.sortOrder } : {}),
+        // Any move OUT of the two lanes a review can span closes the cycle.
+        // Done here rather than at the call sites so it covers every one of
+        // them — the ship paths, a human dragging a card back to To Do, the
+        // archive — present and future. Leaving a cycle open on a shipped card
+        // would keep it in the sweeper's work list forever.
+        ...(data.status !== undefined && !REVIEW_PHASE_LANES.has(data.status)
+          ? { review_cycle_started_at: null }
+          : {}),
         updated_by: by,
         updated_at: new Date().toISOString(),
       })
@@ -639,8 +655,14 @@ export class TaskBoardStorage {
    * without bounding what the sweep can ever reach.
    */
   /**
-   * The review sweeper's work list: cards parked In Review that are DUE a
-   * sweep, i.e. never swept or last swept before `dueBefore`.
+   * The review sweeper's work list: cards with an OPEN REVIEW CYCLE that are
+   * DUE a sweep, i.e. never swept or last swept before `dueBefore`.
+   *
+   * An open cycle, not the In Review lane: a card whose reviewer is still
+   * working reads In Progress on the board, and the sweeper is what dispatches
+   * and re-dispatches that reviewer, so keying it on the lane would leave the
+   * card with nothing watching it. `review_cycle_started_at` is the durable
+   * "a reviewer owns this" fact; see migration 189.
    *
    * That predicate is what bounds the sweeper's GitHub cost. Without it the same
    * cards came back on every tick of every replica — a card whose checks never
@@ -660,7 +682,18 @@ export class TaskBoardStorage {
     let query = this.db
       .selectFrom("task_board_items")
       .select(["id", "organization_id as organizationId", "updated_at"])
-      .where("status", "=", "in_review")
+      // Mirrors `inReviewPhase`: an OPEN CYCLE (a reviewer is working, and the
+      // card still reads In Progress) OR the In Review lane (parked for a
+      // person — its approvals stand and it stays merge-eligible). Either one
+      // alone leaves a real case unswept: cycle-only drops a card a conflict
+      // bounce put back In Review with no cycle, and lane-only drops every card
+      // currently under review, which is the whole point of migration 189.
+      .where((eb) =>
+        eb.or([
+          eb("review_cycle_started_at", "is not", null),
+          eb("status", "=", "in_review"),
+        ]),
+      )
       .where("dismissed_at", "is", null);
     if (dueBefore) {
       // A never-swept card (NULL) is always due — `<` alone would exclude it.
@@ -1297,9 +1330,17 @@ export class TaskBoardStorage {
   }
 
   /**
-   * A linked thread reached a terminal run status — advance any of its tasks
-   * that qualify (see `shouldAdvanceToReview`) to In Review. Returns the items
-   * that actually moved so the caller can broadcast them over SSE.
+   * A linked thread reached a terminal run status — settle any of its tasks
+   * that qualify (see `shouldAdvanceToReview`). Returns the items that actually
+   * moved so the caller can broadcast them over SSE.
+   *
+   * Two landings, because two different things are waiting:
+   *  - a REPO-BACKED task with a PR opens a review cycle and STAYS In Progress.
+   *    An agent reviewer is about to work on it, and In Review is what the
+   *    board says when it is a person's turn — see migration 189.
+   *  - a repo-less task goes to In Review. Its answer IS its deliverable, no
+   *    reviewer is ever dispatched (that needs a PR), so the only thing left is
+   *    a human reading it.
    */
   async advanceLinkedTasksToReviewOnThreadFinish(
     threadId: string,
@@ -1314,23 +1355,34 @@ export class TaskBoardStorage {
         item.repo != null &&
         (await this.listPrs(taskId, organizationId)).length > 0;
       if (!shouldAdvanceToReview(item, hasPr)) continue;
-      // The status flip is a CONDITIONAL update guarded on the status we just
-      // read, so exactly one concurrent caller can win it.
+
+      // Both writes below are CONDITIONAL updates guarded on what we just
+      // read, so exactly one concurrent caller can win either.
       //
-      // It used to be an unconditional `update()`, and the read-then-write above
-      // is not atomic: `recoverStalledTasks` runs fire-and-forget on EVERY
+      // The flip used to be an unconditional `update()`, and the read-then-write
+      // above is not atomic: `recoverStalledTasks` runs fire-and-forget on EVERY
       // `TASK_BOARD_ITEM_LIST` over the list that read already loaded, so N
       // overlapping board reads (multiple tabs, a refocus burst, the Super
       // Agent calling the tool itself) each saw `in_progress` and each wrote.
       // One prod item collected 42 of these; another took 27 inside 112 ms.
       //
-      // The duplicate ROW was not the real damage — the duplicate ACTIVITY was.
-      // `reviewCycleStart` reads the newest `status_changed→in_review` as the
-      // start of the current review cycle, so every redundant stamp invalidated
-      // every approval recorded before it: the verified-approval gate stopped
-      // seeing a complete set, auto-merge never fired, and the card sat In
-      // Review forever. In prod all 13 items holding an approval had been
-      // stranded this way, one of them 15 seconds after approving.
+      // The duplicate ROW was not the real damage — the duplicate CYCLE STAMP
+      // was. Every redundant stamp invalidated every approval recorded before
+      // it: the verified-approval gate stopped seeing a complete set, auto-merge
+      // never fired, and the card sat waiting forever. In prod all 13 items
+      // holding an approval had been stranded this way, one of them 15 seconds
+      // after approving. `openReviewCycleIfInProgress` carries that guarantee
+      // now — it only stamps a card that has NO cycle open.
+      if (hasPr) {
+        const opened = await this.openReviewCycleIfInProgress(
+          taskId,
+          organizationId,
+        );
+        if (!opened) continue;
+        moved.push(opened);
+        continue;
+      }
+
       const advanced = await this.advanceToReviewIfInProgress(
         taskId,
         organizationId,
@@ -1338,13 +1390,8 @@ export class TaskBoardStorage {
       );
       if (!advanced) continue;
       moved.push(advanced);
-      // Record the transition — the reviewer flow keys its "current review
-      // cycle" off the newest `status_changed→in_review` activity, and a
-      // re-review (Super Agent pushed a fix to the same PR, no new PR opened)
-      // re-enters In Review only through THIS path. Without the activity row
-      // the cycle boundary would stay stale and reviewers would never re-run.
       // Machine-driven, hence a null actor. Best-effort. Reached only by the
-      // caller that won the flip above, so it writes exactly once per cycle.
+      // caller that won the flip above, so it writes exactly once.
       await this.recordActivity({
         taskBoardItemId: taskId,
         action: "status_changed",
@@ -1355,6 +1402,64 @@ export class TaskBoardStorage {
       );
     }
     return moved;
+  }
+
+  /**
+   * Open a review cycle on a task that is still `in_progress` and has none
+   * open, returning the updated item or null when there was nothing to do.
+   *
+   * The `review_cycle_started_at IS NULL` predicate is what makes it safe to
+   * call from every trigger that notices reviewable work (the PR-open hook, the
+   * MCP tool hook, the thread-finish backstop): re-stamping an OPEN cycle would
+   * move its boundary forward and silently invalidate verdicts already recorded
+   * against it. Closing the cycle is the only way to start a new one, and that
+   * is `closeReviewCycle`, which every bounce-back-to-work path calls.
+   *
+   * `dismissed_at IS NULL` matters for the same reason as `listItemsDueForRetry`:
+   * a reports-pushed task's `delete()` only stamps `dismissed_at` and leaves
+   * `status` at `in_progress`, so a dismissed card whose linked thread finishes
+   * afterward would otherwise get resurrected into the reviewer's work list.
+   */
+  async openReviewCycleIfInProgress(
+    id: string,
+    organizationId: string,
+  ): Promise<TaskBoardItem | null> {
+    const row = await this.db
+      .updateTable("task_board_items")
+      .set({ review_cycle_started_at: new Date() })
+      .where("id", "=", id)
+      .where("organization_id", "=", organizationId)
+      .where("status", "=", "in_progress")
+      .where("review_cycle_started_at", "is", null)
+      .where("dismissed_at", "is", null)
+      .returningAll()
+      .executeTakeFirst();
+    if (!row) return null;
+    const item = this.itemFromDbRow(row);
+    await this.attachRefs([item], organizationId);
+    return item;
+  }
+
+  /**
+   * Close a task's review cycle — no reviewer owns it any more.
+   *
+   * Called by every path that sends a card back to work (a rerun, a
+   * conflict-resolution claim, a human re-engaging the thread) and by every
+   * path that ends the review (the verdict, a merge). It is what allows the
+   * NEXT `openReviewCycleIfInProgress` to stamp a fresh boundary, so forgetting
+   * it does not corrupt anything — it strands the card in the old cycle, where
+   * the previous verdict still stands.
+   *
+   * Not conditional on status: the callers each have their own fence, and a
+   * clear is idempotent.
+   */
+  async closeReviewCycle(id: string, organizationId: string): Promise<void> {
+    await this.db
+      .updateTable("task_board_items")
+      .set({ review_cycle_started_at: null })
+      .where("id", "=", id)
+      .where("organization_id", "=", organizationId)
+      .execute();
   }
 
   /**
@@ -1398,6 +1503,10 @@ export class TaskBoardStorage {
   /**
    * A new run is starting on a thread — pull any linked task sitting in In
    * Review back to In Progress (the user re-engaged it). Returns moved items.
+   *
+   * Closes the review cycle too: whatever a reviewer decided was about the code
+   * as it stood, and a fresh run is about to change it. Leaving the cycle open
+   * would carry that verdict onto work it never saw.
    */
   async reopenLinkedTasksOnThreadRun(
     threadId: string,
@@ -1407,6 +1516,7 @@ export class TaskBoardStorage {
     for (const taskId of await this.linkedTaskIds(threadId, organizationId)) {
       const item = await this.getById(taskId, organizationId);
       if (!item || item.status !== "in_review") continue;
+      await this.closeReviewCycle(taskId, organizationId);
       moved.push(
         await this.update(
           taskId,
@@ -1462,6 +1572,12 @@ export class TaskBoardStorage {
       .updateTable("task_board_items")
       .set({
         status: "in_progress",
+        // The claim exists to put the card back in the Super Agent's hands to
+        // fix something, so the review that just ended is over. Cleared in the
+        // SAME statement as the flip: a separate write could lose the race with
+        // the PR push that opens the next cycle, and an open cycle from the
+        // previous round would then swallow that push's fresh boundary.
+        review_cycle_started_at: null,
         updated_by: by,
         updated_at: new Date().toISOString(),
       })
@@ -1800,8 +1916,10 @@ export class TaskBoardStorage {
 
     for (const item of items) {
       const activity = byItem.get(item.id) ?? [];
-      const verdicts = reviewCycleVerdicts(activity);
+      const cycleStartedAt = item.reviewCycleStartedAt;
+      const verdicts = reviewCycleVerdicts(activity, { cycleStartedAt });
       const verifiedApprovals = reviewCycleVerdicts(activity, {
+        cycleStartedAt,
         verifiedOnly: true,
       });
       item.reviewVerdicts = REVIEWER_KINDS.flatMap((reviewer) => {
@@ -2193,6 +2311,7 @@ export class TaskBoardStorage {
     sort_order: number;
     key_seq: number;
     retry_attempts?: number;
+    review_cycle_started_at?: string | Date | null;
     created_by: string;
     created_at: string | Date;
     updated_by: string;
@@ -2217,6 +2336,10 @@ export class TaskBoardStorage {
       sortOrder: row.sort_order,
       keySeq: row.key_seq,
       retryAttempts: row.retry_attempts ?? 0,
+      reviewCycleStartedAt:
+        row.review_cycle_started_at instanceof Date
+          ? row.review_cycle_started_at.toISOString()
+          : (row.review_cycle_started_at ?? null),
       // Populated by attachRefs for reads; null/empty for a fresh create.
       jiraIssueKey: null,
       threads: [],

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1405,8 +1405,9 @@ export class TaskBoardStorage {
   }
 
   /**
-   * Open a review cycle on a task that is still `in_progress` and has none
-   * open, returning the updated item or null when there was nothing to do.
+   * Open a review cycle on a task that has none open, leaving it In Progress —
+   * where a card whose reviewer is working belongs — and returning the updated
+   * item, or null when there was nothing to do.
    *
    * The `review_cycle_started_at IS NULL` predicate is what makes it safe to
    * call from every trigger that notices reviewable work (the PR-open hook, the
@@ -1426,10 +1427,35 @@ export class TaskBoardStorage {
   ): Promise<TaskBoardItem | null> {
     const row = await this.db
       .updateTable("task_board_items")
-      .set({ review_cycle_started_at: new Date() })
+      .set({ review_cycle_started_at: new Date(), status: "in_progress" })
       .where("id", "=", id)
       .where("organization_id", "=", organizationId)
-      .where("status", "=", "in_progress")
+      // In Review is in here because the PR link can LOSE THE RACE to the
+      // thread-finish backstop. `advanceLinkedTasksToReviewOnThreadFinish`
+      // reads `listPrs` to decide repo-backed vs repo-less, and a run that
+      // links its PR moments after its thread goes terminal is read as
+      // repo-less and parked In Review. The link then lands on a card that is
+      // no longer In Progress, this update matched nothing, and the cycle
+      // never opened at all: the card sat In Review for the whole reviewer run
+      // — the exact thing migration 189 exists to prevent — with every verdict
+      // falling back to the legacy activity scan. Observed at 52 seconds
+      // between the two on a real board.
+      //
+      // Taking the card BACK to In Progress is safe precisely because the
+      // cycle is still null: a card whose cycle never opened has had no
+      // reviewer and no verdict, so there is nothing behind it to invalidate,
+      // and the Super Agent guard keeps it off a card a person has taken over
+      // (`handTaskToHuman` clears the assignee). Both columns move in ONE
+      // statement — a separate flip could interleave with the sweeper's read.
+      .where((eb) =>
+        eb.or([
+          eb("status", "=", "in_progress"),
+          eb.and([
+            eb("status", "=", "in_review"),
+            eb("assignee_id", "=", SUPER_AGENT_ASSIGNEE_ID),
+          ]),
+        ]),
+      )
       .where("review_cycle_started_at", "is", null)
       .where("dismissed_at", "is", null)
       .returningAll()

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1686,6 +1686,20 @@ export interface TaskBoardItemTable {
     Date | string | null | undefined,
     Date | string | null
   >;
+  /** When this card's CURRENT review cycle opened — the boundary that decides
+   *  which reviewer verdicts still count (`reviewCycleStart`). Null = no cycle
+   *  open, i.e. nothing is waiting on a reviewer.
+   *
+   *  It is a column rather than a derivation off the newest
+   *  `status_changed → in_review` precisely so the cycle does NOT ride on the
+   *  lane: an agent reviewer runs while the card reads In Progress, which it
+   *  could not do while moving the card meant resetting the cycle. See
+   *  `migrations/189-task-board-review-cycle-started-at.ts`. */
+  review_cycle_started_at: ColumnType<
+    Date | null,
+    Date | string | null | undefined,
+    Date | string | null
+  >;
   /** When this card is next due for an automatic re-dispatch after its run
    *  failed on infrastructure. Null = not waiting on a retry. Lives on the row
    *  so the schedule survives a pod restart — see
@@ -1913,6 +1927,11 @@ export interface TaskBoardItem {
   /** Infrastructure retries already spent on this card's runs — the budget
    *  `reactToFailedTaskRun` spends against `MAX_RUN_RETRIES`. */
   retryAttempts: number;
+  /** When this card's current review cycle opened; null when none is open.
+   *  The anchor every cycle-scoped reducer takes (`reviewCycleStart`), and the
+   *  one thing that says "a reviewer owns this card" independently of its
+   *  lane — see `reviewCycleOpen`. */
+  reviewCycleStartedAt: string | null;
   /** Agent threads linked to this task (most-recent first). */
   threads: TaskBoardItemThreadRef[];
   /** Org tags attached to this task, name ascending. */

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -239,6 +239,13 @@ export async function ensureSandbox(
      * agent-run SandboxTemplate + warm pool. Defaults to `interactive`.
      */
     purpose?: SandboxPurpose;
+    /**
+     * Fired only when this call actually has to provision a pod — i.e. the
+     * resume fast path below did NOT hit. Callers that show a "booting the
+     * sandbox" status use this so a warm resume doesn't announce a boot that
+     * isn't happening. Best-effort: a throw here must not fail the ensure.
+     */
+    onColdStart?: () => Promise<void>;
   },
   ctx: StudioContext,
 ): Promise<SandboxRecord> {
@@ -301,6 +308,8 @@ export async function ensureSandbox(
   const threadRepo = await getThreadGithubRepo(ctx, provisioningThreadId);
   const githubRepo =
     threadRepo ?? (metadata as GithubRepoMeta).githubRepo ?? null;
+  // Past the resume fast path: this call is a real boot, so tell the caller.
+  await input.onColdStart?.().catch(() => {});
   const { entry } = await provisionSandbox({
     ctx,
     userId,

--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -35,13 +35,17 @@ describe("buildClaudeCodeTaskPrompt", () => {
     expect(prompt).not.toContain("Description:");
   });
 
-  test("asks for a pull request and for the board move, with the task id", () => {
+  // Inverted with migration 189: the run used to be told to move its own card
+  // to In Review after opening the PR. Linking the PR is what starts the
+  // review now, and the card stays In Progress until the REVIEWER decides — so
+  // asking the model for that move would put the card in the wrong lane for
+  // the whole time an agent is still working on it.
+  test("asks for a pull request and for the PR link, not a board move", () => {
     const prompt = buildClaudeCodeTaskPrompt(task, repo);
     expect(prompt).toContain("open a pull request");
-    // The board move is the whole reason the run needs the Studio MCP.
-    expect(prompt).toContain("mcp__studio__TASK_BOARD_ITEM_UPDATE");
-    expect(prompt).toContain('id "tbi_1"');
-    expect(prompt).toContain('"in_review"');
+    expect(prompt).toContain("mcp__studio__TASK_BOARD_ITEM_PR_LINK");
+    expect(prompt).toContain("(task id: tbi_1)");
+    expect(prompt).not.toContain('status "in_review"');
   });
 
   test("says it runs autonomously", () => {
@@ -68,11 +72,11 @@ describe("buildClaudeCodeTaskPrompt", () => {
   // for a task that HAS a PR, so a no-PR task parked there had nobody to pick
   // it up — in prod every single In Review card was one of these, with zero
   // PRs and zero reviewer claims between them.
-  test("a task needing no code change goes to done, not in_review", () => {
+  test("a task needing no code change goes to done, not to a reviewer", () => {
     const prompt = buildClaudeCodeTaskPrompt(task, repo);
     expect(prompt).toContain("no code change");
-    expect(prompt).toContain('move it to "done" instead of "in_review"');
-    expect(prompt).not.toContain("move it to review anyway");
+    expect(prompt).toContain('move it to "done"');
+    expect(prompt).not.toContain("leave it for a reviewer anyway");
     // And it has to leave the reason where a human will read it.
     expect(prompt).toContain("mcp__studio__TASK_BOARD_COMMENT_CREATE");
   });
@@ -224,8 +228,8 @@ describe("buildClaudeCodeTaskPrompt with no repo (several in the org)", () => {
 
   test("still says how to finish", () => {
     const prompt = buildClaudeCodeTaskPrompt(task, null);
-    expect(prompt).toContain("TASK_BOARD_ITEM_UPDATE");
-    expect(prompt).toContain("in_review");
+    expect(prompt).toContain("TASK_BOARD_ITEM_PR_LINK");
+    expect(prompt).toContain('move it to "done"');
   });
 });
 

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -275,14 +275,16 @@ export function buildClaudeCodeTaskPrompt(
     // the pod, so no Studio-side hook sees it (see pr-link.ts). Reviewers are
     // dispatched from the linked PR, so skipping this strands the card.
     `- As soon as \`gh pr create\` prints the URL, call \`mcp__studio__TASK_BOARD_ITEM_PR_LINK\` with that url. Do this even if you also mention the PR in a comment — the reviewers are dispatched from the linked PR, not from your message.`,
-    `- Then move this task to review on the board: call \`mcp__studio__TASK_BOARD_ITEM_UPDATE\` with id "${task.id}" and status "in_review". Pass ONLY the fields you are changing.`,
-    // NOT "move it to review anyway": In Review is the reviewers' lane, and
-    // reviewers are only enqueued for a task that has a PR
-    // (`enqueueReviewersOnThreadFinish`). A no-PR task parked there had no
-    // reviewer to pick it up and no signal that a human should — every such
-    // card sat In Review untouched. Done is the terminal lane, and the comment
+    // Deliberately NOT "then move it to In Review". Linking the PR is what
+    // starts the review (`openReviewCycleIfInProgress`), and the card stays In
+    // Progress until the reviewer decides — an agent is still working on it.
+    // `parkReviewedCardForHuman` makes that move, on a verdict, not the model.
+    // NOT "leave it for a reviewer anyway": reviewers are only enqueued for a
+    // task that has a PR (`enqueueReviewersOnThreadFinish`). A no-PR task left
+    // waiting had no reviewer to pick it up and no signal that a human should —
+    // every such card sat untouched. Done is the terminal lane, and the comment
     // is what a human reads to disagree and reopen it.
-    `- If the task turns out to need no code change, do NOT open a PR: explain why in a comment on the task (\`mcp__studio__TASK_BOARD_COMMENT_CREATE\`) and move it to "done" instead of "in_review". There is nothing for a reviewer to review, so In Review would strand it.`,
+    `- If the task turns out to need no code change, do NOT open a PR: explain why in a comment on the task (\`mcp__studio__TASK_BOARD_COMMENT_CREATE\`) and move it to "done". There is nothing for a reviewer to review, so leaving it for one would strand it.`,
     // The board is where a human reads this task, so anything a reviewer needs
     // to know belongs there too — a final message they never open is not a
     // report. Optional: a comment per run, not per step.

--- a/apps/api/src/tools/task-board/conflict-reaction.ts
+++ b/apps/api/src/tools/task-board/conflict-reaction.ts
@@ -84,7 +84,12 @@ export async function reactToApprovedPrConflict(
   // an approval standing behind it.
   const enabled = enabledReviewerKinds(flags);
   const activity = await ctx.storage.taskBoard.listActivity(item.id, orgId);
-  if (!allReviewersApproved(activity, enabled, { verifiedOnly: true })) {
+  if (
+    !allReviewersApproved(activity, enabled, {
+      cycleStartedAt: item.reviewCycleStartedAt,
+      verifiedOnly: true,
+    })
+  ) {
     return false;
   }
 

--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -49,9 +49,9 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
       .optional()
       .describe(
         "GitHub pull request URL to link to the new task, e.g. " +
-          "https://github.com/owner/repo/pull/123. Pass this with " +
-          '`status: "in_review"` right after you open a PR so the card lands ' +
-          "on the board with its PR already attached for review.",
+          "https://github.com/owner/repo/pull/123. Pass it right after you " +
+          "open a PR so the card lands on the board with its PR already " +
+          "attached for review.",
       ),
   }),
   outputSchema: z.object({ item: TaskBoardItemSchema }),

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -191,10 +191,10 @@ export async function enqueueEnabledReviewers(
     : "default";
 
   // A reviewer belongs to the current cycle if its thread is still live, or was
-  // created since the task last entered In Review — either way don't re-enqueue.
+  // created since the cycle opened — either way don't re-enqueue.
   // A stale thread from a PRIOR cycle (before a Super Agent re-run bounced the
   // task back and forward) does NOT count, so reviewers re-run on re-review.
-  const lastInReviewAt = await lastInReviewTime(ctx, task);
+  const lastInReviewAt = await reviewCycleStartTime(ctx, task);
   const cycleAt = new Date(lastInReviewAt);
 
   // One reviewer today, but the enqueue stays a fan-out over `enabled`: each
@@ -431,18 +431,23 @@ export function reviewerHandledThisCycle(
   return spent.length !== thisCycle.length;
 }
 
-/** When the task most recently entered In Review (ms), else 0. Drawn from the
- *  activity timeline (shared reducer) so it survives across the many-to-many
- *  thread links and stays in lockstep with the merge gate + ship button. */
-async function lastInReviewTime(
+/** When the task's current review cycle opened (ms), else 0. Reads the card's
+ *  own `reviewCycleStartedAt` through the shared reducer, so it stays in
+ *  lockstep with the merge gate and the ship button; the activity fallback
+ *  inside `reviewCycleStart` only serves cards stamped before migration 189,
+ *  which is why the timeline is still fetched. */
+async function reviewCycleStartTime(
   ctx: StudioContext,
   task: TaskBoardItem,
 ): Promise<number> {
+  if (task.reviewCycleStartedAt) {
+    return new Date(task.reviewCycleStartedAt).getTime();
+  }
   const activity = await ctx.storage.taskBoard.listActivity(
     task.id,
     task.organizationId,
   );
-  return reviewCycleStart(activity);
+  return reviewCycleStart(activity, null);
 }
 
 /**

--- a/apps/api/src/tools/task-board/lanes.test.ts
+++ b/apps/api/src/tools/task-board/lanes.test.ts
@@ -11,6 +11,7 @@ import { DELIVERY_LANES, shippedLane } from "@decocms/shared/task-board";
 import type { TaskBoardItemStatus } from "@/storage/types";
 import {
   DELIVERY_LANE_STATUSES,
+  inReviewPhase,
   LANE_RANK,
   movesForward,
   SHIP_ELIGIBLE_LANES,
@@ -105,5 +106,44 @@ describe("SHIP_ELIGIBLE_LANES", () => {
     for (const lane of ["merged", "post_deploy_validation", "done"] as const) {
       expect(SHIP_ELIGIBLE_LANES.has(lane)).toBe(false);
     }
+  });
+});
+
+describe("inReviewPhase", () => {
+  const card = (
+    status: TaskBoardItemStatus,
+    reviewCycleStartedAt: string | null = null,
+  ) => ({ status, reviewCycleStartedAt });
+  const CYCLE = "2026-01-01T10:00:00.000Z";
+
+  // The whole point of migration 189: a card whose reviewer is working reads
+  // In Progress, and only the open cycle says it is under review.
+  it("covers an In Progress card with an open cycle", () => {
+    expect(inReviewPhase(card("in_progress", CYCLE))).toBe(true);
+    expect(inReviewPhase(card("in_progress"))).toBe(false);
+  });
+
+  it("covers In Review with or without a cycle stamp", () => {
+    expect(inReviewPhase(card("in_review", CYCLE))).toBe(true);
+    // Pre-migration cards carry no stamp; the lane still answers for them.
+    expect(inReviewPhase(card("in_review"))).toBe(true);
+  });
+
+  // A stale stamp must never drag a shipped card back into the sweeper's work.
+  it("is false past In Review however stale the stamp", () => {
+    for (const lane of [
+      "approved",
+      "merged",
+      "post_deploy_validation",
+      "done",
+      "archived",
+    ] as const) {
+      expect(inReviewPhase(card(lane, CYCLE))).toBe(false);
+    }
+  });
+
+  it("is false for a card that has not been worked yet", () => {
+    expect(inReviewPhase(card("triage"))).toBe(false);
+    expect(inReviewPhase(card("todo"))).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/lanes.ts
+++ b/apps/api/src/tools/task-board/lanes.ts
@@ -73,3 +73,27 @@ export const SHIP_ELIGIBLE_LANES: ReadonlySet<TaskBoardItemStatus> = new Set([
 export function isTaggableMergedStatus(status: TaskBoardItemStatus): boolean {
   return status === "done" || DELIVERY_LANE_STATUSES.includes(status);
 }
+
+/**
+ * True while a card is in its REVIEW PHASE: a reviewer owns it, or it is parked
+ * In Review waiting on a person.
+ *
+ * This is the gate every automatic review path takes, and it is deliberately
+ * not `status === "in_review"`. Since migration 189 an agent reviewer runs
+ * while the card still reads In Progress — the lane says whose turn it is, and
+ * during a review it is nobody's — so the durable fact is the open cycle
+ * (`reviewCycleStartedAt`), not the lane.
+ *
+ * Still bounded by rank: a card that has shipped (Approved and beyond) is out
+ * of the phase whatever a stale cycle stamp says, so a missed `closeReviewCycle`
+ * can never drag a merged card back into the sweeper's work.
+ */
+export function inReviewPhase(item: {
+  status: TaskBoardItemStatus;
+  reviewCycleStartedAt: string | null;
+}): boolean {
+  if (LANE_RANK[item.status] > LANE_RANK.in_review) return false;
+  // Truthiness, not `!== null`: an absent stamp must read as "no cycle", and
+  // a partial item (a fixture, a projection) carries `undefined`, not `null`.
+  return item.status === "in_review" || Boolean(item.reviewCycleStartedAt);
+}

--- a/apps/api/src/tools/task-board/merge-pr.test.ts
+++ b/apps/api/src/tools/task-board/merge-pr.test.ts
@@ -183,20 +183,26 @@ describe("checksBlockMerge", () => {
 describe("approvedButUnverified", () => {
   it("is true when the approval is unverified — green checks that can never merge", () => {
     expect(
-      approvedButUnverified([approved("reviewer", false)], [...ENABLED]),
+      approvedButUnverified([approved("reviewer", false)], [...ENABLED], {
+        cycleStartedAt: null,
+      }),
     ).toBe(true);
   });
 
   // The happy path must not be handed to a human — it is about to merge.
   it("is false when the approval verified", () => {
     expect(
-      approvedButUnverified([approved("reviewer", true)], [...ENABLED]),
+      approvedButUnverified([approved("reviewer", true)], [...ENABLED], {
+        cycleStartedAt: null,
+      }),
     ).toBe(false);
   });
 
   // Not yet voted is not a dead end.
   it("is false while the reviewer has not voted yet", () => {
-    expect(approvedButUnverified([], [...ENABLED])).toBe(false);
+    expect(
+      approvedButUnverified([], [...ENABLED], { cycleStartedAt: null }),
+    ).toBe(false);
   });
 
   it("is false when the reviewer requested changes", () => {
@@ -207,7 +213,9 @@ describe("approvedButUnverified", () => {
         occurredAt: at,
       },
     ];
-    expect(approvedButUnverified(activity, [...ENABLED])).toBe(false);
+    expect(
+      approvedButUnverified(activity, [...ENABLED], { cycleStartedAt: null }),
+    ).toBe(false);
   });
 });
 

--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -18,6 +18,7 @@ import {
   pickActivePr,
   resolveGithubConnection,
 } from "./prs-get";
+import { inReviewPhase } from "./lanes";
 import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
 
 /** Cap the merge round-trip so a slow GitHub can't hang the caller. */
@@ -303,7 +304,11 @@ export async function allEnabledReviewersVerifiedApproved(
     taskBoardItemId,
     orgId,
   );
-  return allReviewersApproved(activity, enabled, { verifiedOnly: true });
+  const item = await ctx.storage.taskBoard.getById(taskBoardItemId, orgId);
+  return allReviewersApproved(activity, enabled, {
+    cycleStartedAt: item?.reviewCycleStartedAt ?? null,
+    verifiedOnly: true,
+  });
 }
 
 /**
@@ -330,7 +335,13 @@ async function handUnverifiedApprovalToHuman(
     item.id,
     item.organizationId,
   );
-  if (!approvedButUnverified(activity, enabled)) return;
+  if (
+    !approvedButUnverified(activity, enabled, {
+      cycleStartedAt: item.reviewCycleStartedAt,
+    })
+  ) {
+    return;
+  }
   await handTaskToHuman(
     ctx,
     item,
@@ -431,7 +442,7 @@ export async function retryAutoMergeIfApproved(
   item: TaskBoardItem,
 ): Promise<boolean> {
   const orgId = item.organizationId;
-  if (item.status !== "in_review") return false;
+  if (!inReviewPhase(item)) return false;
   const settings = await ctx.storage.organizationSettings.get(orgId);
   if (settings?.flags?.auto_merge !== true) return false;
   // Same human-override guard `review-decision.ts` and `prs-get` honor.

--- a/apps/api/src/tools/task-board/pr-link.ts
+++ b/apps/api/src/tools/task-board/pr-link.ts
@@ -84,6 +84,15 @@ export const TASK_BOARD_ITEM_PR_LINK = defineTool({
         repoOwner: pr.owner,
         repoName: pr.repo,
       });
+      // There is something to review now — open the cycle, which is what puts
+      // the card on the sweeper's work list. The card is NOT moved: an agent
+      // reviewer is about to work on it, and In Review is what the board says
+      // once it is a person's turn (migration 189). Idempotent: a re-call, or a
+      // second PR on the same card, cannot move a boundary verdicts stand on.
+      await ctx.storage.taskBoard.openReviewCycleIfInProgress(
+        taskBoardItemId,
+        organizationId,
+      );
       // The sweeper is what hands the card to the reviewers, and it may have
       // just claimed this card's 5-minute budget while it had no PR to look at.
       // Make it due again so the hand-off happens on the next tick (<=60s).

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts
@@ -89,7 +89,11 @@ describe("applyBoardDecision", () => {
     await closeTestPgDatabase(database);
   });
 
-  it("create: opens a new card in review with the PR and thread linked", async () => {
+  // Inverted with migration 189: a PR used to put the card In Review. It now
+  // opens the card's REVIEW CYCLE and leaves the lane at In Progress — an agent
+  // reviewer is about to work on it, and In Review is what the board says once
+  // it is a person's turn.
+  it("create: opens a new card under review with the PR and thread linked", async () => {
     const item = await apply(
       {
         action: "create",
@@ -100,7 +104,8 @@ describe("applyBoardDecision", () => {
       "thr_create",
     );
     expect(item).not.toBeNull();
-    expect(item!.status).toBe("in_review");
+    expect(item!.status).toBe("in_progress");
+    expect(item!.reviewCycleStartedAt).not.toBeNull();
     expect(item!.title).toBe("Ship the widget");
     // Owned by the Super Agent — otherwise the reviewers never pick the card up.
     expect(item!.assigneeId).toBe(SUPER_AGENT_ASSIGNEE_ID);
@@ -115,7 +120,7 @@ describe("applyBoardDecision", () => {
     expect(comments.map((c) => c.body)).toContain("left the CSS alone");
   });
 
-  it("update: moves an in-progress card to review and links the PR", async () => {
+  it("update: opens the review cycle on an in-progress card and links the PR", async () => {
     const card = await taskBoard.create({
       organizationId: ORG,
       title: "Existing work",
@@ -128,15 +133,16 @@ describe("applyBoardDecision", () => {
       "thr_update",
     );
     expect(item!.id).toBe(card.id);
-    expect(item!.status).toBe("in_review");
-    // Was unassigned, so advancing into review claims it for the Super Agent.
+    expect(item!.status).toBe("in_progress");
+    expect(item!.reviewCycleStartedAt).not.toBeNull();
+    // Was unassigned, so entering the review phase claims it for the Super Agent.
     expect(item!.assigneeId).toBe(SUPER_AGENT_ASSIGNEE_ID);
     const prs = await taskBoard.listPrs(card.id, ORG);
     expect(prs.map((p) => p.number)).toEqual([7]);
     expect(await taskBoard.linkedTaskIds("thr_update", ORG)).toContain(card.id);
   });
 
-  it("update leaves a human assignee in place when advancing to review", async () => {
+  it("update leaves a human assignee in place when entering review", async () => {
     const card = await taskBoard.create({
       organizationId: ORG,
       title: "human owned",
@@ -150,7 +156,8 @@ describe("applyBoardDecision", () => {
       "thr_human",
     );
     expect(item!.id).toBe(card.id);
-    expect(item!.status).toBe("in_review");
+    expect(item!.status).toBe("in_progress");
+    expect(item!.reviewCycleStartedAt).not.toBeNull();
     // A human owns it — the claim must not steal the card from them.
     expect(item!.assigneeId).toBe(USER);
   });
@@ -169,7 +176,8 @@ describe("applyBoardDecision", () => {
     );
     expect(item).not.toBeNull();
     expect(item!.id).not.toBe(card.id);
-    expect(item!.status).toBe("in_review");
+    expect(item!.status).toBe("in_progress");
+    expect(item!.reviewCycleStartedAt).not.toBeNull();
     expect(await taskBoard.linkedTaskIds("thr_fallback", ORG)).toContain(
       item!.id,
     );
@@ -189,8 +197,10 @@ describe("applyBoardDecision", () => {
     );
     expect(item!.id).toBe(card.id);
     expect(item!.status).toBe("done");
-    // A terminal card is not advanced, so it is not claimed either.
+    // A terminal card is not advanced, so it is not claimed either — and no
+    // reviewer is put on work that already shipped.
     expect(item!.assigneeId).toBeNull();
+    expect(item!.reviewCycleStartedAt).toBeNull();
     const prs = await taskBoard.listPrs(card.id, ORG);
     expect(prs.map((p) => p.number)).toEqual([7]);
   });

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -23,7 +23,7 @@ import type { TaskBoardItem, TaskBoardItemStatus } from "@/storage/types";
 import { extractPrFromValue, type ExtractedPr } from "./pr-extract";
 import { resolveRunTaskTargets, emitTaskBoardUpdated } from "./run-reactions";
 
-/** Statuses from which a PR-open advance may move a card into review. Terminal
+/** Statuses from which a PR-open may put a card into the review phase. Terminal
  *  lanes (and in_review itself) are left alone so a re-opened PR never regresses
  *  a finished card. */
 const ADVANCEABLE: ReadonlySet<TaskBoardItemStatus> = new Set([
@@ -155,7 +155,7 @@ export async function applyBoardDecision(
 
   let item: TaskBoardItem | null;
   if (target) {
-    // Advance into review only from an earlier lane; never regress a finished card.
+    // Enter the review phase only from an earlier lane; never regress a finished card.
     const advancing = ADVANCEABLE.has(target.status);
     // Claim an unowned card for the Super Agent (reviewer dispatch gates on it); never a human's.
     const claimSuperAgent = advancing && target.assigneeId == null;
@@ -163,23 +163,28 @@ export async function applyBoardDecision(
       target.id,
       orgId,
       {
-        status: advancing ? "in_review" : undefined,
+        // In Progress, not In Review: a reviewer is about to work on this PR,
+        // and In Review is what the board says once it is a person's turn.
+        // The open cycle below is what puts it on the reviewer's work list.
+        status: advancing ? "in_progress" : undefined,
         ...(claimSuperAgent
           ? { assigneeId: SUPER_AGENT_ASSIGNEE_ID, assignedBy: userId }
           : {}),
       },
       userId,
     );
+    if (advancing) await storage.openReviewCycleIfInProgress(target.id, orgId);
   } else {
     // Create (also the unknown-taskId fallback), owned by the Super Agent so reviewers pick it up.
     item = await storage.create({
       organizationId: orgId,
       title: decision.title?.trim() || `PR #${pr.number}`,
-      status: "in_review",
+      status: "in_progress",
       assigneeId: SUPER_AGENT_ASSIGNEE_ID,
       assignedBy: userId,
       by: userId,
     });
+    if (item) await storage.openReviewCycleIfInProgress(item.id, orgId);
   }
   if (!item) return null;
 

--- a/apps/api/src/tools/task-board/promote-to-production.test.ts
+++ b/apps/api/src/tools/task-board/promote-to-production.test.ts
@@ -20,37 +20,41 @@ function approved(reviewer: ReviewerKind): ReviewCycleActivity {
   };
 }
 
+/** The cycle every approval in this file was recorded inside. Passing it is
+ *  what makes those approvals current — see `reviewCycleStart`. */
+const CYCLE = "2026-01-01T00:00:00.000Z";
+
 describe("isReadyToShip", () => {
   it("rejects a task that never entered review, even with no reviewers enabled", () => {
-    expect(isReadyToShip("todo", [], [])).toBe(false);
-    expect(isReadyToShip("in_progress", [], [])).toBe(false);
+    expect(isReadyToShip("todo", [], [], CYCLE)).toBe(false);
+    expect(isReadyToShip("in_progress", [], [], CYCLE)).toBe(false);
   });
 
   it("allows an in_review task straight through when no reviewers are enabled", () => {
-    expect(isReadyToShip("in_review", [], [])).toBe(true);
+    expect(isReadyToShip("in_review", [], [], CYCLE)).toBe(true);
   });
 
   it("rejects an in_review task while the required reviewer hasn't approved", () => {
-    expect(isReadyToShip("in_review", [], ["reviewer"])).toBe(false);
+    expect(isReadyToShip("in_review", [], ["reviewer"], CYCLE)).toBe(false);
   });
 
   it("allows an in_review task once the enabled reviewer approved", () => {
     expect(
-      isReadyToShip("in_review", [approved("reviewer")], ["reviewer"]),
+      isReadyToShip("in_review", [approved("reviewer")], ["reviewer"], CYCLE),
     ).toBe(true);
   });
 
   // Refusing to ship from Approved would make the lane a dead end.
   it("allows shipping from Approved", () => {
-    expect(isReadyToShip("approved", [], [])).toBe(true);
+    expect(isReadyToShip("approved", [], [], CYCLE)).toBe(true);
     expect(
-      isReadyToShip("approved", [approved("reviewer")], ["reviewer"]),
+      isReadyToShip("approved", [approved("reviewer")], ["reviewer"], CYCLE),
     ).toBe(true);
   });
 
   it("rejects an already-shipped task", () => {
-    expect(isReadyToShip("merged", [], [])).toBe(false);
-    expect(isReadyToShip("post_deploy_validation", [], [])).toBe(false);
-    expect(isReadyToShip("done", [], [])).toBe(false);
+    expect(isReadyToShip("merged", [], [], CYCLE)).toBe(false);
+    expect(isReadyToShip("post_deploy_validation", [], [], CYCLE)).toBe(false);
+    expect(isReadyToShip("done", [], [], CYCLE)).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/promote-to-production.ts
+++ b/apps/api/src/tools/task-board/promote-to-production.ts
@@ -27,9 +27,13 @@ export function isReadyToShip(
   status: TaskBoardItem["status"],
   activity: ReviewCycleActivity[],
   enabled: ReviewerKind[],
+  cycleStartedAt: string | null,
 ): boolean {
   if (!SHIP_ELIGIBLE_LANES.has(status)) return false;
-  return enabled.length === 0 || allReviewersApproved(activity, enabled);
+  return (
+    enabled.length === 0 ||
+    allReviewersApproved(activity, enabled, { cycleStartedAt })
+  );
 }
 
 export const TASK_BOARD_PROMOTE_TO_PRODUCTION = defineTool({
@@ -77,7 +81,9 @@ export const TASK_BOARD_PROMOTE_TO_PRODUCTION = defineTool({
       taskBoardItemId,
       organizationId,
     );
-    if (!isReadyToShip(item.status, activity, enabled)) {
+    if (
+      !isReadyToShip(item.status, activity, enabled, item.reviewCycleStartedAt)
+    ) {
       throw new Error(
         "Task is not ready to ship: it must be In Review or Approved with every enabled reviewer approved",
       );

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -15,7 +15,7 @@ import { InMemoryMcpReadCache } from "@/mcp-clients/mcp-read-cache";
 import { TaskBoardItemPrSchema } from "./schema";
 import { cardWorkLanded } from "./archive-merged";
 import { recordTaskActivity } from "./activity";
-import { movesForward } from "./lanes";
+import { inReviewPhase, movesForward } from "./lanes";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
@@ -1208,7 +1208,7 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
     const openPr = prs.find((p) => p.state === "open" && !p.merged);
     if (
       item &&
-      item.status === "in_review" &&
+      inReviewPhase(item) &&
       item.assigneeId === SUPER_AGENT_ASSIGNEE_ID &&
       prReadyForReview(prs)
     ) {

--- a/apps/api/src/tools/task-board/reconcile-merged.test.ts
+++ b/apps/api/src/tools/task-board/reconcile-merged.test.ts
@@ -31,6 +31,7 @@ const item = (over: Partial<TaskBoardItem> = {}): TaskBoardItem =>
     id: "item-1",
     organizationId: "org-1",
     status: "in_review",
+    reviewCycleStartedAt: null,
     updatedBy: "user-1",
     ...over,
   }) as TaskBoardItem;
@@ -125,13 +126,31 @@ describe("advanceToDoneIfMerged", () => {
     expect(await advanceToDoneIfMerged(ctx, item(), [])).toBe(false);
   });
 
-  it("only ever moves a card that is still In Review", async () => {
+  it("only ever moves a card that is still in the review phase", async () => {
     const { ctx } = fakeCtx();
     expect(
       await advanceToDoneIfMerged(ctx, item({ status: "in_progress" }), [
         merged,
       ]),
     ).toBe(false);
+  });
+
+  // A card whose reviewer is still working reads In Progress since migration
+  // 189, and a PR merged out from under it must still catch the card up —
+  // gating on the lane alone would leave it behind forever.
+  it("moves an In Progress card whose review cycle is open", async () => {
+    const { ctx, updates } = fakeCtx();
+    expect(
+      await advanceToDoneIfMerged(
+        ctx,
+        item({
+          status: "in_progress",
+          reviewCycleStartedAt: "2026-01-01T00:00:00.000Z",
+        }),
+        [merged],
+      ),
+    ).toBe(true);
+    expect(updates).toEqual([{ status: "done" }]);
   });
 
   // A person who pulled the card back out of Done outranks a merged PR.

--- a/apps/api/src/tools/task-board/reconcile-merged.ts
+++ b/apps/api/src/tools/task-board/reconcile-merged.ts
@@ -24,6 +24,7 @@ import type { TaskBoardItem } from "@/storage/types";
 import { shippedLane } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
 import { cardWorkLanded, type PrLanding } from "./archive-merged";
+import { inReviewPhase } from "./lanes";
 import { emitTaskBoardUpdated } from "./run-reactions";
 
 /**
@@ -53,7 +54,7 @@ export async function advanceToDoneIfMerged(
   prs: PrLanding[],
 ): Promise<boolean> {
   const orgId = item.organizationId;
-  if (item.status !== "in_review") return false;
+  if (!inReviewPhase(item)) return false;
   if (!cardWorkLanded(prs)) return false;
   if (await ctx.storage.taskBoard.hasHumanRejectedDone(item.id, orgId)) {
     return false;

--- a/apps/api/src/tools/task-board/rerun-merge-pending.integration.test.ts
+++ b/apps/api/src/tools/task-board/rerun-merge-pending.integration.test.ts
@@ -49,7 +49,14 @@ describe("refuseIfMergePending", () => {
         data: { reviewer, verified },
       });
     }
-    return { id: item.id, status: "in_review", organizationId: ORG };
+    return {
+      id: item.id,
+      status: "in_review" as const,
+      organizationId: ORG,
+      // Null on purpose: these approvals are dated `now`, and the legacy
+      // activity fallback then puts the cycle start at 0 so they all count.
+      reviewCycleStartedAt: null,
+    };
   };
 
   beforeAll(async () => {
@@ -104,13 +111,30 @@ describe("refuseIfMergePending", () => {
     await expect(refuseIfMergePending(ctx, item)).resolves.toBeUndefined();
   });
 
-  it("allows a re-run of a card that is not In Review", async () => {
+  it("allows a re-run of a card that is out of the review phase", async () => {
     const item = await cardWithVerdicts([
       { reviewer: "reviewer", verified: true },
     ]);
     await expect(
       refuseIfMergePending(ctx, { ...item, status: "in_progress" }),
     ).resolves.toBeUndefined();
+  });
+
+  // The lane alone no longer answers "is this card under review": since
+  // migration 189 a card whose reviewer is working reads In Progress, and the
+  // open cycle is what says the merge is still coming. Gating on the lane here
+  // would hand the human a re-run that throws away a merge one tick out.
+  it("refuses an In Progress card whose review cycle is still open", async () => {
+    const item = await cardWithVerdicts([
+      { reviewer: "reviewer", verified: true },
+    ]);
+    await expect(
+      refuseIfMergePending(ctx, {
+        ...item,
+        status: "in_progress",
+        reviewCycleStartedAt: new Date(0).toISOString(),
+      }),
+    ).rejects.toThrow(/merge is retrying/);
   });
 
   it("allows a re-run when the org has auto-merge off", async () => {

--- a/apps/api/src/tools/task-board/rerun.test.ts
+++ b/apps/api/src/tools/task-board/rerun.test.ts
@@ -133,6 +133,7 @@ describe("mergeRetryExpired", () => {
       mergeRetryExpired(
         [inReview(ago(12 * MINUTE)), approved(ago(MINUTE))],
         NOW,
+        null,
       ),
     ).toBe(false);
   });
@@ -142,6 +143,7 @@ describe("mergeRetryExpired", () => {
       mergeRetryExpired(
         [inReview(ago(30 * MINUTE)), approved(ago(20 * MINUTE))],
         NOW,
+        null,
       ),
     ).toBe(true);
   });
@@ -152,6 +154,7 @@ describe("mergeRetryExpired", () => {
       mergeRetryExpired(
         [approved(ago(60 * MINUTE)), inReview(ago(MINUTE))],
         NOW,
+        null,
       ),
     ).toBe(true);
   });
@@ -159,6 +162,16 @@ describe("mergeRetryExpired", () => {
   // No approval to read at all (activity unreadable) — the human is here and
   // the machine has shown nothing, so the re-run wins.
   test("expires when there is no approval to read", () => {
-    expect(mergeRetryExpired([], NOW)).toBe(true);
+    expect(mergeRetryExpired([], NOW, null)).toBe(true);
+  });
+
+  // Since migration 189 the cycle boundary is the card's column, not a lane
+  // transition on the timeline — a card mid-review has no `→ in_review` entry
+  // to read at all, so the column is the only thing that can date its cycle.
+  test("takes the cycle boundary from the card's column when it has one", () => {
+    const activity = [approved(ago(60 * MINUTE)), approved(ago(MINUTE))];
+    expect(mergeRetryExpired(activity, NOW, ago(30 * MINUTE))).toBe(false);
+    // Same activity, a cycle that opened AFTER both approvals: neither counts.
+    expect(mergeRetryExpired(activity, NOW, ago(0))).toBe(true);
   });
 });

--- a/apps/api/src/tools/task-board/rerun.ts
+++ b/apps/api/src/tools/task-board/rerun.ts
@@ -43,6 +43,8 @@ import {
   SUPER_AGENT_ASSIGNEE_ID,
 } from "@decocms/shared/task-board";
 import { TERMINAL_THREAD_STATUSES } from "@/storage/task-board";
+import type { TaskBoardItemStatus } from "@/storage/types";
+import { inReviewPhase } from "./lanes";
 import { broadcastRunCancel } from "@/api/routes/decopilot/cancel-registry";
 import { cancelHostedHarness } from "@/dispatch-queue";
 import { cancelThreadGateHead } from "@/dispatch-queue/thread-gate-queue";
@@ -207,8 +209,9 @@ const MERGE_RETRY_GRACE_MS = 15 * 60 * 1000;
 export function mergeRetryExpired(
   activity: ReviewCycleActivity[],
   nowMs: number,
+  cycleStartedAt: string | null,
 ): boolean {
-  const cycleStart = reviewCycleStart(activity);
+  const cycleStart = reviewCycleStart(activity, cycleStartedAt);
   let latestApproval = 0;
   for (const a of activity) {
     if (a.action !== "review_approved") continue;
@@ -249,9 +252,14 @@ export function mergeRetryExpired(
  */
 export async function refuseIfMergePending(
   ctx: StudioContext,
-  item: { id: string; status: string; organizationId: string },
+  item: {
+    id: string;
+    status: TaskBoardItemStatus;
+    organizationId: string;
+    reviewCycleStartedAt: string | null;
+  },
 ): Promise<void> {
-  if (item.status !== "in_review") return;
+  if (!inReviewPhase(item)) return;
   const settings = await ctx.storage.organizationSettings.get(
     item.organizationId,
   );
@@ -265,7 +273,8 @@ export async function refuseIfMergePending(
   const activity = await ctx.storage.taskBoard
     .listActivity(item.id, item.organizationId)
     .catch(() => []);
-  if (mergeRetryExpired(activity, Date.now())) return;
+  if (mergeRetryExpired(activity, Date.now(), item.reviewCycleStartedAt))
+    return;
   if (await mergeIsDeadlocked(ctx, item, activity)) return;
   throw new Error(
     "Every reviewer approved this task and its merge is retrying — re-running " +

--- a/apps/api/src/tools/task-board/review-decision.test.ts
+++ b/apps/api/src/tools/task-board/review-decision.test.ts
@@ -71,7 +71,7 @@ describe("isDuplicateChangeRequest", () => {
       cycle("2026-08-13T02:39:20Z"),
       changes("reviewer", "2026-08-13T02:54:59Z"),
     ];
-    expect(isDuplicateChangeRequest(history, "reviewer")).toBe(true);
+    expect(isDuplicateChangeRequest(history, "reviewer", null)).toBe(true);
   });
 
   it("is false once the card came back for a fresh cycle", () => {
@@ -80,7 +80,19 @@ describe("isDuplicateChangeRequest", () => {
       changes("reviewer", "2026-08-13T02:54:59Z"),
       cycle("2026-08-13T02:55:21Z"),
     ];
-    expect(isDuplicateChangeRequest(history, "reviewer")).toBe(false);
+    expect(isDuplicateChangeRequest(history, "reviewer", null)).toBe(false);
+  });
+
+  // The column wins over the timeline: a card whose reviewer is mid-run has no
+  // `→ in_review` entry to derive a cycle from (migration 189).
+  it("dates the cycle from the card's column when it has one", () => {
+    const history = [changes("reviewer", "2026-08-13T02:54:59Z")];
+    expect(
+      isDuplicateChangeRequest(history, "reviewer", "2026-08-13T02:39:20Z"),
+    ).toBe(true);
+    expect(
+      isDuplicateChangeRequest(history, "reviewer", "2026-08-13T03:00:00Z"),
+    ).toBe(false);
   });
 
   it("is false when this cycle's only verdict was an approval", () => {
@@ -92,6 +104,6 @@ describe("isDuplicateChangeRequest", () => {
         occurredAt: "2026-08-13T02:44:00Z",
       } as ReviewCycleActivity,
     ];
-    expect(isDuplicateChangeRequest(history, "reviewer")).toBe(false);
+    expect(isDuplicateChangeRequest(history, "reviewer", null)).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -11,7 +11,11 @@ import {
 } from "@decocms/shared/task-board";
 import { TaskBoardItemStatusSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
-import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
+import {
+  emitTaskBoardUpdated,
+  handTaskToHuman,
+  parkReviewedCardForHuman,
+} from "./run-reactions";
 import {
   allEnabledReviewersVerifiedApproved,
   conflictSignal,
@@ -74,8 +78,12 @@ export function reviewTokenVerified(
 export function isDuplicateChangeRequest(
   history: ReviewCycleActivity[],
   reviewer: ReviewerKind,
+  cycleStartedAt: string | null,
 ): boolean {
-  return reviewCycleVerdicts(history).get(reviewer) === "changes_requested";
+  return (
+    reviewCycleVerdicts(history, { cycleStartedAt }).get(reviewer) ===
+    "changes_requested"
+  );
 }
 
 export const TASK_BOARD_REVIEW_DECISION = defineTool({
@@ -177,10 +185,13 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
     // drained — a day is ample.
     const currentCycleAt = reviewToken
       ? reviewCycleStart(
-          await ctx.storage.taskBoard.listActivity(
-            taskBoardItemId,
-            organizationId,
-          ),
+          item.reviewCycleStartedAt
+            ? []
+            : await ctx.storage.taskBoard.listActivity(
+                taskBoardItemId,
+                organizationId,
+              ),
+          item.reviewCycleStartedAt,
         )
       : 0;
     const verified =
@@ -227,7 +238,9 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
         taskBoardItemId,
         organizationId,
       );
-      if (isDuplicateChangeRequest(history, reviewer)) {
+      if (
+        isDuplicateChangeRequest(history, reviewer, item.reviewCycleStartedAt)
+      ) {
         return { status: item.status, merged: false };
       }
       await recordTaskActivity(ctx, {
@@ -256,6 +269,14 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
       actorId: null,
       data: { reviewer, notes, verified },
     });
+
+    // The reviewer is done with the card whatever happens next, so settle the
+    // lane before deciding about the merge: a verdict means it is a person's
+    // turn, and until this the card has been reading In Progress (migration
+    // 189). A merge moves it further along from here; a conflict bounce pulls
+    // it back — both are forward-only against In Review, so neither cares that
+    // it passed through.
+    await parkReviewedCardForHuman(ctx, item);
 
     // Only the LAST enabled reviewer to (verifiably) approve completes the
     // review. Until then the task waits In Review for the other reviewer.
@@ -289,6 +310,14 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
     // A merge ships the task → Merged with the delivery lanes on, else Done.
     if (merged) {
       const shipped = shippedLane(settings?.flags);
+      // Re-read: `parkReviewedCardForHuman` above may have moved the card since
+      // `item` was loaded, and the timeline's `from` has to be where it
+      // actually came from.
+      const before =
+        (await ctx.storage.taskBoard.getById(
+          taskBoardItemId,
+          organizationId,
+        )) ?? item;
       const done = await ctx.storage.taskBoard.update(
         taskBoardItemId,
         organizationId,
@@ -299,7 +328,7 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
         taskBoardItemId,
         action: "status_changed",
         actorId: null,
-        data: { from: item.status, to: shipped },
+        data: { from: before.status, to: shipped },
       });
       emitTaskBoardUpdated(organizationId, done);
       return { status: done.status, merged: true };

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -72,6 +72,7 @@ import {
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
 import { retryAutoMergeIfApproved } from "./merge-pr";
+import { inReviewPhase } from "./lanes";
 import { advanceToDoneIfMerged } from "./reconcile-merged";
 import {
   emitTaskBoardUpdated,
@@ -443,7 +444,14 @@ export class TaskBoardReviewSweeper {
       item.id,
       item.organizationId,
     );
-    if (!noPrHandoffDue(reviewCycleStart(activity), Date.now())) return;
+    if (
+      !noPrHandoffDue(
+        reviewCycleStart(activity, item.reviewCycleStartedAt),
+        Date.now(),
+      )
+    ) {
+      return;
+    }
     await handTaskToHuman(
       ctx,
       item,
@@ -468,7 +476,7 @@ export class TaskBoardReviewSweeper {
     // Re-check against the fresh row: `listItemsPendingReview` scanned a
     // possibly-stale snapshot, and a human can bounce the card between that scan
     // and this reconcile.
-    if (item.status !== "in_review") return false;
+    if (!inReviewPhase(item)) return false;
     // Everything below EXCEPT the merge retry needs the Super Agent to still own
     // the card — the same gate `TASK_BOARD_ITEM_PRS_GET` applies before its own
     // `enqueueEnabledReviewers` call. A handed-off card burns no agent runs, but

--- a/apps/api/src/tools/task-board/run-reactions.test.ts
+++ b/apps/api/src/tools/task-board/run-reactions.test.ts
@@ -213,6 +213,7 @@ function makeItem(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
     keySeq: 1,
     jiraIssueKey: null,
     retryAttempts: 0,
+    reviewCycleStartedAt: null,
     threads: [],
     tags: [],
     reviewVerdicts: [],

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -2,20 +2,27 @@
  * Super Agent run → task board status reactions.
  *
  * A task delegated to the Super Agent rides its run's lifecycle:
- *   enqueued            → todo         (create/update tool, synchronous)
- *   loop starts         → in_progress  (runHostedHarness)
- *   agent opens a PR    → in_review    (github MCP tool call OR bash `gh pr create`)
- *   thread finishes,    → in_review    (projector terminal → thread-finish hook)
+ *   enqueued            → todo          (create/update tool, synchronous)
+ *   loop starts         → in_progress    (runHostedHarness)
+ *   agent opens a PR    → review cycle   (github MCP tool call OR bash `gh pr create`)
+ *                         opens, lane
+ *                         stays in_progress
+ *   thread finishes,    → in_review      (projector terminal → thread-finish hook)
  *     no repo loaded
- *   user re-prompts a   → in_progress  (runHostedHarness, thread-run hook)
+ *   reviewer decides    → in_review      (`parkReviewedCardForHuman`)
+ *   user re-prompts a   → in_progress    (runHostedHarness, thread-run hook)
  *     reviewed task
  *
- * The last two are LINK-based (`task_board_item_threads`), not runMetadata-based,
- * so they hold for a re-prompted thread that carries no run metadata.
+ * A PR does NOT move the card. Since migration 189 the review cycle is a column
+ * (`review_cycle_started_at`), not a lane, so an agent reviewer can work on a
+ * card that still truthfully reads In Progress; In Review is reserved for "it
+ * is a person's turn". `inReviewPhase` is the predicate that spans both.
  *
- * The PR-open path resolves the item from `ctx.metadata.runMetadata.taskBoardItemId`
- * (set at enqueue) first, falling back to the same thread link when that's absent —
- * so a repo-backed task's SECOND PR, opened after a re-prompt, still lands In Review.
+ * The link-based transitions use `task_board_item_threads`, not runMetadata, so
+ * they hold for a re-prompted thread that carries no run metadata. The PR-open
+ * path resolves the item from `ctx.metadata.runMetadata.taskBoardItemId` (set at
+ * enqueue) first, falling back to the same thread link when that's absent — so a
+ * repo-backed task's SECOND PR, opened after a re-prompt, still opens a cycle.
  * Each transition also pushes the updated item over SSE for a real-time board.
  */
 
@@ -35,7 +42,7 @@ import {
   TASK_BOARD_ITEM_UPDATED_EVENT,
 } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
-import { LANE_RANK } from "./lanes";
+import { inReviewPhase, LANE_RANK } from "./lanes";
 import type { TaskBoardStorage } from "@/storage/task-board";
 import type { TaskBoardItem, TaskBoardItemStatus } from "@/storage/types";
 
@@ -172,18 +179,54 @@ export async function advanceTaskBoardForRun(
           console.error("[task-board] activity log write failed", err),
         );
       emitTaskBoardUpdated(orgId, item);
-      if (status === "in_progress" || status === "in_review") {
-        captureTaskRunEvent(
-          status === "in_progress" ? "task_run_started" : "task_run_completed",
-          orgId,
-          item,
-          // in_review lands here only from the PR-open hook (see module doc).
-          { from: current.status, via: "pr_open" },
-        );
+      // The PR-open hook no longer comes through here — it opens a review
+      // cycle instead (`openReviewCycleForRun`) and emits its own event — so
+      // the only advance left to report is the run starting.
+      if (status === "in_progress") {
+        captureTaskRunEvent("task_run_started", orgId, item, {
+          from: current.status,
+        });
       }
     }
   } catch (err) {
     console.error("[task-board] run transition failed", err);
+  }
+}
+
+/**
+ * A run opened a GitHub PR — open the review cycle on its linked task(s).
+ *
+ * This is the real-time trigger: the card gets a reviewer the moment the PR
+ * exists, mid-run, rather than waiting for the thread-finish backstop. It does
+ * NOT move the card — an agent is still the one working on it, so it stays In
+ * Progress until a verdict lands (`parkReviewedCardForHuman`).
+ *
+ * Idempotent by construction: `openReviewCycleIfInProgress` only stamps a card
+ * that has no cycle open, so a run that opens two PRs, or a tool hook that
+ * fires twice, cannot move a boundary that already has verdicts behind it.
+ * Best-effort — a failure here never disturbs the agent run.
+ */
+export async function openReviewCycleForRun(
+  ctx: StudioContext,
+  threadId?: string,
+): Promise<void> {
+  const orgId = ctx.organization?.id;
+  if (!orgId) return;
+  try {
+    for (const itemId of await resolveRunTaskTargets(ctx, orgId, threadId)) {
+      const opened = await ctx.storage.taskBoard.openReviewCycleIfInProgress(
+        itemId,
+        orgId,
+      );
+      if (!opened) continue;
+      emitTaskBoardUpdated(orgId, opened);
+      captureTaskRunEvent("task_run_completed", orgId, opened, {
+        from: "in_progress",
+        via: "pr_open",
+      });
+    }
+  } catch (err) {
+    console.error("[task-board] review-cycle open failed", err);
   }
 }
 
@@ -262,6 +305,26 @@ export async function advanceTasksToReviewOnThreadFinish(
   await refundUnproductiveTaskClaims(taskBoard, billing, threadId, orgId);
 }
 
+/**
+ * True when a card has demonstrably produced something a person can look at:
+ * it reached In Review or beyond, or it is still In Progress with a review
+ * cycle open — which since migration 189 is exactly where a card sits while an
+ * agent reviews its pull request.
+ *
+ * Rank alone used to answer this, and would now read a card mid-review as
+ * having delivered nothing: it would refund its own quota claim and relabel a
+ * lost stream as a plain failure.
+ */
+function cardDelivered(item: {
+  status: TaskBoardItemStatus;
+  reviewCycleStartedAt: string | null;
+}): boolean {
+  return (
+    LANE_RANK[item.status] >= LANE_RANK.in_review ||
+    Boolean(item.reviewCycleStartedAt)
+  );
+}
+
 /** The per-failure retry budget lives in `transient-failure.ts`
  *  (`retryBudgetFor`): the full budget for recognized infrastructure, one
  *  benefit-of-the-doubt attempt for anything unrecognized, none for a
@@ -312,13 +375,21 @@ export async function reactToFailedTaskRun(
       const item = await taskBoard.getById(itemId, orgId);
       if (!item) continue;
       // The run moved the card itself and only THEN lost its stream. By rank, so
-      // a card the merged-PR reconcile pushed further still counts as delivered.
-      if (LANE_RANK[item.status] >= LANE_RANK.in_review) {
+      // a card the merged-PR reconcile pushed further still counts as delivered
+      // — as does one still In Progress with a review cycle open, which since
+      // migration 189 is what a card with a PR under review looks like.
+      if (cardDelivered(item)) {
         await taskBoard
           .relabelDeliveredFailure(threadId, orgId, DELIVERED_FAILURE_REASON)
           .catch(() => {});
       }
       if (item.status !== "in_progress") continue;
+      // A REVIEWER's run failed, not the author's: the card is In Progress only
+      // because that is where a card under review sits now. Retrying it here
+      // would dispatch a fresh Super Agent run over a PR that is waiting for a
+      // verdict, or park a reviewed card back on To Do. The reviewer has its
+      // own budget (`spentAttemptsThisCycle`), and the sweeper spends it.
+      if (item.reviewCycleStartedAt) continue;
       // Another of this card's threads is still working — its outcome decides
       // the card, not this one's.
       if (
@@ -416,7 +487,7 @@ export async function refundUnproductiveTaskClaims(
     for (const taskId of await taskBoard.linkedTaskIds(threadId, orgId)) {
       const item = await taskBoard.getById(taskId, orgId);
       if (!item) continue;
-      if (LANE_RANK[item.status] >= LANE_RANK.in_review) continue;
+      if (cardDelivered(item)) continue;
       const stillRunning = item.threads.some(
         (t) =>
           t.hasMessages &&
@@ -430,6 +501,49 @@ export async function refundUnproductiveTaskClaims(
     }
   } catch (err) {
     console.error("[task-board] quota refund pass failed", err);
+  }
+}
+
+/**
+ * The agent side of a review is over — move the card into In Review, where a
+ * person picks it up.
+ *
+ * This is the OTHER half of migration 189. A card whose reviewer is still
+ * running reads In Progress, because that is the truthful thing to say while an
+ * agent is working; In Review means "it is your turn". Something has to make
+ * that second transition, and it is this: every terminal of the review —
+ * a verdict, an exhausted retry budget, a hand-off — comes through here.
+ *
+ * A no-op unless the card is actually mid-cycle In Progress, so it can neither
+ * drag a card backward out of a delivery lane nor re-park one a human already
+ * moved. The cycle stays OPEN (In Review is inside the review phase), which is
+ * what keeps the verdict that just landed valid.
+ *
+ * Best-effort: never fail a verdict over the lane it lands in.
+ */
+export async function parkReviewedCardForHuman(
+  ctx: StudioContext,
+  item: TaskBoardItem,
+): Promise<void> {
+  if (item.status !== "in_progress" || !inReviewPhase(item)) return;
+  try {
+    const parked = await ctx.storage.taskBoard.update(
+      item.id,
+      item.organizationId,
+      { status: "in_review" },
+      item.updatedBy,
+    );
+    await ctx.storage.taskBoard
+      .recordActivity({
+        taskBoardItemId: item.id,
+        action: "status_changed",
+        actorId: null,
+        data: { from: item.status, to: "in_review" },
+      })
+      .catch(() => {});
+    emitTaskBoardUpdated(item.organizationId, parked);
+  } catch (err) {
+    console.error(`[task-board] parking ${item.id} for review failed`, err);
   }
 }
 
@@ -449,7 +563,9 @@ export async function refundUnproductiveTaskClaims(
  * requires the Super Agent as assignee, so a handed-over card is visited once
  * and then left alone. Deliberately leaves the STATUS untouched — In Review is
  * where a human wants to pick a reviewed card up, and moving it would lose the
- * reviewers' notes' context. Returns true when this call did the handover.
+ * reviewers' notes' context — `parkReviewedCardForHuman` is what settles the
+ * lane, and it runs first here so a handed-off card never reads as still being
+ * worked on. Returns true when this call did the handover.
  */
 export async function handTaskToHuman(
   ctx: StudioContext,
@@ -459,6 +575,7 @@ export async function handTaskToHuman(
   const orgId = item.organizationId;
   if (item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID) return false;
   try {
+    await parkReviewedCardForHuman(ctx, item);
     // Re-checks the assignee against the DB, not this stale `item`.
     const handed = await ctx.storage.taskBoard.unassignSuperAgent(
       item.id,

--- a/apps/api/src/tools/task-board/schema.test.ts
+++ b/apps/api/src/tools/task-board/schema.test.ts
@@ -44,6 +44,7 @@ describe("TaskBoardItemSchema – proxy round-trip validation", () => {
     keySeq: 1,
     jiraIssueKey: null,
     retryAttempts: 0,
+    reviewCycleStartedAt: null,
     threads: [],
     tags: [],
     reviewVerdicts: [],

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -197,6 +197,13 @@ export const TaskBoardItemSchema = z.object({
   // reject every response with `-32602: Structured content does not match
   // the tool's output schema` the moment a row carried a non-zero value.
   retryAttempts: z.number(),
+  /** When this card's current review cycle opened; null when none is open — the
+   *  boundary that decides which reviewer verdicts still count, and the one
+   *  thing that says a reviewer owns the card while its lane still reads In
+   *  Progress. Present on every `TaskBoardItem`, so — like `retryAttempts`
+   *  above — it MUST be modeled here or Ajv-revalidating MCP clients reject
+   *  every response with `-32602`. */
+  reviewCycleStartedAt: z.string().datetime().nullable(),
   // Agent threads linked to this task (many-to-many), most-recent first.
   threads: z.array(TaskBoardItemThreadSchema),
   // Org tags attached to this task, name ascending.

--- a/apps/api/src/tools/task-board/update.test.ts
+++ b/apps/api/src/tools/task-board/update.test.ts
@@ -34,6 +34,7 @@ function item(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
     keySeq: 1,
     jiraIssueKey: null,
     retryAttempts: 0,
+    reviewCycleStartedAt: null,
     threads: [],
     tags: [],
     reviewVerdicts: [],
@@ -207,34 +208,62 @@ describe("delegatesToSuperAgent", () => {
 });
 
 describe("closesOwnReview", () => {
+  /** A card in the review phase, as the guard now reads it. `in_review` is the
+   *  lane a card takes AFTER its reviewer decided; while one is still working
+   *  the card reads In Progress with its cycle open (migration 189), and both
+   *  must be protected from the author's own run closing them out. */
+  const underReview = (
+    status: TaskBoardItem["status"] = "in_review",
+    reviewCycleStartedAt: string | null = null,
+  ) => ({ status, reviewCycleStartedAt });
+
   it("catches a run completing a task under review", () => {
-    expect(closesOwnReview("done", "in_review", true)).toBe(true);
+    expect(closesOwnReview("done", underReview(), true)).toBe(true);
   });
 
   it("catches a run archiving a task under review — archiving skips review just like completing", () => {
-    expect(closesOwnReview("archived", "in_review", true)).toBe(true);
+    expect(closesOwnReview("archived", underReview(), true)).toBe(true);
   });
 
   // Shipping yourself past review also drops the card out of the review sweep.
   it("catches a run shipping a task under review into a delivery lane", () => {
-    expect(closesOwnReview("approved", "in_review", true)).toBe(true);
-    expect(closesOwnReview("merged", "in_review", true)).toBe(true);
-    expect(closesOwnReview("post_deploy_validation", "in_review", true)).toBe(
+    expect(closesOwnReview("approved", underReview(), true)).toBe(true);
+    expect(closesOwnReview("merged", underReview(), true)).toBe(true);
+    expect(closesOwnReview("post_deploy_validation", underReview(), true)).toBe(
       true,
     );
   });
 
+  // The lane alone used to answer this, and In Progress read as "not under
+  // review" — which is now exactly where a card sits while its reviewer works.
+  // The open cycle is what protects it.
+  it("catches a run completing a task whose reviewer is still working", () => {
+    expect(
+      closesOwnReview(
+        "done",
+        underReview("in_progress", "2026-08-13T02:39:20Z"),
+        true,
+      ),
+    ).toBe(true);
+  });
+
   it("allows a run to complete a task that needed no code change", () => {
-    expect(closesOwnReview("done", "in_progress", true)).toBe(false);
+    expect(closesOwnReview("done", underReview("in_progress"), true)).toBe(
+      false,
+    );
   });
 
   it("allows a run to move a task under review BACKWARD, or not at all", () => {
-    expect(closesOwnReview("in_progress", "in_review", true)).toBe(false);
-    expect(closesOwnReview(undefined, "in_review", true)).toBe(false);
+    expect(closesOwnReview("in_progress", underReview(), true)).toBe(false);
+    expect(closesOwnReview(undefined, underReview(), true)).toBe(false);
   });
 
   it("never catches a person", () => {
-    expect(closesOwnReview("done", "in_review", false)).toBe(false);
+    expect(closesOwnReview("done", underReview(), false)).toBe(false);
+  });
+
+  it("has nothing to protect without a pre-update card", () => {
+    expect(closesOwnReview("done", undefined, true)).toBe(false);
   });
 });
 

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -17,7 +17,7 @@ import {
   TaskBoardItemSchema,
   TaskBoardItemStatusSchema,
 } from "./schema";
-import { isDeliveryLane } from "./lanes";
+import { inReviewPhase, isDeliveryLane } from "./lanes";
 import { assertValidAssignee } from "./validate-assignee";
 import { reactToSuperAgentDelegation } from "./enqueue-super-agent";
 import { recordTaskActivities } from "./activity";
@@ -157,12 +157,17 @@ const REVIEW_CLOSING_STATUSES = new Set<TaskBoardItemStatus>([
  *  invariant; this tool sets `status` freely, so it needs the same guard. */
 export function closesOwnReview(
   inputStatus: TaskBoardItemStatus | undefined,
-  previousStatus: TaskBoardItemStatus | undefined,
+  previous:
+    | { status: TaskBoardItemStatus; reviewCycleStartedAt: string | null }
+    | undefined,
   isTaskRun: boolean,
 ): boolean {
   const completesTask =
     inputStatus !== undefined && REVIEW_CLOSING_STATUSES.has(inputStatus);
-  const awaitingReview = previousStatus === "in_review";
+  // The PHASE, not the lane: a card whose reviewer is still working reads In
+  // Progress since migration 189, and gating on the lane alone would let the
+  // author's own run mark its work Done out from under that reviewer.
+  const awaitingReview = previous !== undefined && inReviewPhase(previous);
   return isTaskRun && completesTask && awaitingReview;
 }
 
@@ -225,8 +230,8 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
       .optional()
       .describe(
         "GitHub pull request URL to link to this task, e.g. " +
-          "https://github.com/owner/repo/pull/123. Pass this with " +
-          '`status: "in_review"` after opening a PR for an existing card.',
+          "https://github.com/owner/repo/pull/123. Pass it after opening a " +
+          "PR for an existing card; linking one is what starts its review.",
       ),
   }),
   outputSchema: z.object({ item: TaskBoardItemSchema }),
@@ -309,10 +314,10 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     }
 
     const isTaskRun = taskRunContextStore.getStore() !== undefined;
-    if (closesOwnReview(input.status, previous?.status, isTaskRun)) {
+    if (closesOwnReview(input.status, previous ?? undefined, isTaskRun)) {
       throw new Error(
-        "This task is In Review — a run can't move it to Done or Archived. " +
-          "Leave it in in_review for the reviewer; only a person, or " +
+        "This task is under review — a run can't move it to Done or Archived. " +
+          "Leave it for the reviewer; only a person, or " +
           "TASK_BOARD_REVIEW_DECISION on a reviewer's own run, closes out a " +
           "task under review.",
       );

--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -33,6 +33,7 @@ function item(id: string, sortOrder: number): TaskBoardItem {
     keySeq: 1,
     jiraIssueKey: null,
     retryAttempts: 0,
+    reviewCycleStartedAt: null,
     threads: [],
     tags: [],
     reviewVerdicts: [],

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -697,13 +697,22 @@ function AgentRunIndicator({ state }: { state: "running" | "failed" }) {
  * The card's checks indicator, or null when there is nothing to say: this org
  * runs no reviewers, or the task has not reached review yet (a To Do card with
  * `0/1` would be reporting a failure that hasn't had a chance to happen).
+ *
+ * "Reached review" is the open cycle, not the In Review lane. Since migration
+ * 189 a card whose reviewer is working reads In Progress, and that is exactly
+ * when the pending chip earns its place — the lane alone would hide the checks
+ * for the whole time they are actually being decided.
  */
 function useCardChecks(item: TaskBoardItem): {
   summary: ChecksSummary;
   enabled: ReviewerKind[];
 } | null {
   const enabled = enabledReviewers(useReviewerEnabled());
-  if (item.reviewVerdicts.length === 0 && item.status !== "in_review") {
+  if (
+    item.reviewVerdicts.length === 0 &&
+    item.status !== "in_review" &&
+    !item.reviewCycleStartedAt
+  ) {
     return null;
   }
   const summary = checksSummary(item.reviewVerdicts, enabled);

--- a/apps/web/src/layouts/task-board/review-status.test.ts
+++ b/apps/web/src/layouts/task-board/review-status.test.ts
@@ -54,11 +54,13 @@ describe("enabledReviewers", () => {
 
 describe("reviewsSatisfiedForPromotion", () => {
   it("is ready when no reviewers are enabled (nothing to wait on)", () => {
-    expect(reviewsSatisfiedForPromotion([IN_REVIEW], [])).toBe(true);
+    expect(reviewsSatisfiedForPromotion([IN_REVIEW], [], null)).toBe(true);
   });
 
   it("waits until the enabled reviewer approved this cycle", () => {
-    expect(reviewsSatisfiedForPromotion([IN_REVIEW], ENABLED)).toBe(false);
+    expect(reviewsSatisfiedForPromotion([IN_REVIEW], ENABLED, null)).toBe(
+      false,
+    );
     expect(
       reviewsSatisfiedForPromotion(
         [
@@ -70,6 +72,7 @@ describe("reviewsSatisfiedForPromotion", () => {
           ),
         ],
         ENABLED,
+        null,
       ),
     ).toBe(true);
   });
@@ -84,7 +87,7 @@ describe("reviewsSatisfiedForPromotion", () => {
         "2026-01-01T10:06:00Z",
       ),
     ];
-    expect(reviewsSatisfiedForPromotion(activity, ENABLED)).toBe(false);
+    expect(reviewsSatisfiedForPromotion(activity, ENABLED, null)).toBe(false);
   });
 
   it("ignores the two-reviewer era's approvals — they are not this reviewer's", () => {
@@ -97,7 +100,23 @@ describe("reviewsSatisfiedForPromotion", () => {
         "2026-01-01T10:06:00Z",
       ),
     ];
-    expect(reviewsSatisfiedForPromotion(activity, ENABLED)).toBe(false);
+    expect(reviewsSatisfiedForPromotion(activity, ENABLED, null)).toBe(false);
+  });
+
+  // The lane transition is only the legacy anchor. A card whose reviewer is
+  // still working never enters In Review at all (migration 189), so the
+  // column is the only thing that can date its cycle.
+  it("dates the cycle from the card's stamp when it has one", () => {
+    const activity = [
+      act("review_approved", { reviewer: "reviewer" }, "2026-01-01T10:05:00Z"),
+    ];
+    expect(
+      reviewsSatisfiedForPromotion(activity, ENABLED, "2026-01-01T10:00:00Z"),
+    ).toBe(true);
+    // A cycle that opened after the approval: it belongs to the round before.
+    expect(
+      reviewsSatisfiedForPromotion(activity, ENABLED, "2026-01-01T11:00:00Z"),
+    ).toBe(false);
   });
 
   it("ignores approvals from a prior review cycle (before the latest In Review)", () => {
@@ -108,7 +127,7 @@ describe("reviewsSatisfiedForPromotion", () => {
       // stale.
       IN_REVIEW,
     ];
-    expect(reviewsSatisfiedForPromotion(activity, ENABLED)).toBe(false);
+    expect(reviewsSatisfiedForPromotion(activity, ENABLED, null)).toBe(false);
   });
 });
 

--- a/apps/web/src/layouts/task-board/review-status.ts
+++ b/apps/web/src/layouts/task-board/review-status.ts
@@ -29,9 +29,13 @@ export function enabledReviewers(enabled: boolean): ReviewerKind[] {
 export function reviewsSatisfiedForPromotion(
   activity: TaskBoardActivity[],
   enabled: ReviewerKind[],
+  /** The card's `reviewCycleStartedAt` — the boundary the approvals have to sit
+   *  inside. Since migration 189 it is a column, not a lane transition, so the
+   *  activity timeline alone can no longer date the cycle. */
+  cycleStartedAt: string | null,
 ): boolean {
   if (enabled.length === 0) return true;
-  return allReviewersApproved(activity, enabled);
+  return allReviewersApproved(activity, enabled, { cycleStartedAt });
 }
 
 /** What a card's checks indicator shows: how many enabled reviewers have
@@ -45,6 +49,9 @@ export type ChecksSummary = {
 /**
  * The card's `0/1` checks indicator, or null when this org runs no reviewers
  * (nothing to count, so nothing to show).
+ *
+ * `verdicts` arrive already scoped to the current cycle by the server (see
+ * `attachRefs`), so this reducer needs no cycle argument of its own.
  *
  * The chip must never contradict its own number: if it says `1/1`, it is green.
  * An earlier cut held a full set of approvals at amber when they weren't

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -1973,7 +1973,11 @@ function LinksSection({
   // token verification). The per-card PrCard adds the PR-open + green-checks gate.
   const reviewsReady =
     laneCanShip(item.status) &&
-    reviewsSatisfiedForPromotion(activity ?? [], enabledReviewers(reviewerOn));
+    reviewsSatisfiedForPromotion(
+      activity ?? [],
+      enabledReviewers(reviewerOn),
+      item.reviewCycleStartedAt,
+    );
   const onShip = () =>
     promote.mutate(undefined, {
       onSuccess: (res) =>

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -178,6 +178,11 @@ export interface TaskBoardItem {
   /** Infrastructure retries already spent on this card's runs — the budget
    *  `reactToFailedTaskRun` spends against `MAX_RUN_RETRIES`. */
   retryAttempts: number;
+  /** When this card's current review cycle opened; null when none is open.
+   *  The boundary that decides which reviewer verdicts still count, and what
+   *  says a reviewer owns the card while its lane still reads In Progress.
+   *  Mirrors `task_board_items.review_cycle_started_at`. */
+  reviewCycleStartedAt: string | null;
   threads: TaskBoardItemThreadRef[];
   tags: TaskBoardItemTagRef[];
   /** Each reviewer's standing verdict in the current review cycle; reviewers

--- a/packages/shared/src/task-board.test.ts
+++ b/packages/shared/src/task-board.test.ts
@@ -78,51 +78,71 @@ describe("isReviewerThreadTitle", () => {
 });
 
 describe("reviewCycleStart", () => {
-  it("is the latest in_review transition (0 when none)", () => {
-    expect(reviewCycleStart([IN_REVIEW_1, IN_REVIEW_2])).toBe(
+  // The column is the boundary since migration 189 — the lane transition is
+  // only the fallback for cards stamped before it.
+  it("is the card's own cycle stamp when it has one", () => {
+    expect(
+      reviewCycleStart([IN_REVIEW_1, IN_REVIEW_2], "2026-02-02T09:00:00Z"),
+    ).toBe(new Date("2026-02-02T09:00:00Z").getTime());
+    expect(reviewCycleStart([], "2026-02-02T09:00:00Z")).toBe(
+      new Date("2026-02-02T09:00:00Z").getTime(),
+    );
+  });
+
+  it("falls back to the latest in_review transition (0 when none)", () => {
+    expect(reviewCycleStart([IN_REVIEW_1, IN_REVIEW_2], null)).toBe(
       new Date("2026-01-01T12:00:00Z").getTime(),
     );
-    expect(reviewCycleStart([])).toBe(0);
+    expect(reviewCycleStart([], null)).toBe(0);
   });
 });
 
 describe("reviewCycleVerdicts", () => {
   it("keeps the latest verdict within the current cycle", () => {
-    const v = reviewCycleVerdicts([
-      IN_REVIEW_1,
-      at("review_approved", { reviewer: "reviewer" }, "2026-01-01T10:05:00Z"),
-      at(
-        "review_changes_requested",
-        { reviewer: "reviewer" },
-        "2026-01-01T10:06:00Z",
-      ),
-    ]);
+    const v = reviewCycleVerdicts(
+      [
+        IN_REVIEW_1,
+        at("review_approved", { reviewer: "reviewer" }, "2026-01-01T10:05:00Z"),
+        at(
+          "review_changes_requested",
+          { reviewer: "reviewer" },
+          "2026-01-01T10:06:00Z",
+        ),
+      ],
+      { cycleStartedAt: null },
+    );
     expect(v.get("reviewer")).toBe("changes_requested");
   });
 
   it("ignores verdicts from a prior cycle (before the latest in_review)", () => {
-    const v = reviewCycleVerdicts([
-      IN_REVIEW_1,
-      at("review_approved", { reviewer: "reviewer" }, "2026-01-01T10:05:00Z"),
-      IN_REVIEW_2, // re-review — old approval is now stale
-    ]);
+    const v = reviewCycleVerdicts(
+      [
+        IN_REVIEW_1,
+        at("review_approved", { reviewer: "reviewer" }, "2026-01-01T10:05:00Z"),
+        IN_REVIEW_2, // re-review — old approval is now stale
+      ],
+      { cycleStartedAt: null },
+    );
     expect(v.get("reviewer")).toBeUndefined();
   });
 
   it("ignores the two-reviewer era's verdicts — half a review is not a review", () => {
-    const v = reviewCycleVerdicts([
-      IN_REVIEW_1,
-      at(
-        "review_approved",
-        { reviewer: "qa", verified: true },
-        "2026-01-01T10:05:00Z",
-      ),
-      at(
-        "review_approved",
-        { reviewer: "code_review", verified: true },
-        "2026-01-01T10:06:00Z",
-      ),
-    ]);
+    const v = reviewCycleVerdicts(
+      [
+        IN_REVIEW_1,
+        at(
+          "review_approved",
+          { reviewer: "qa", verified: true },
+          "2026-01-01T10:05:00Z",
+        ),
+        at(
+          "review_approved",
+          { reviewer: "code_review", verified: true },
+          "2026-01-01T10:06:00Z",
+        ),
+      ],
+      { cycleStartedAt: null },
+    );
     expect(v.size).toBe(0);
   });
 
@@ -144,12 +164,20 @@ describe("reviewCycleVerdicts", () => {
       ),
     ];
     expect(
-      reviewCycleVerdicts(verified, { verifiedOnly: true }).get("reviewer"),
+      reviewCycleVerdicts(verified, {
+        cycleStartedAt: null,
+        verifiedOnly: true,
+      }).get("reviewer"),
     ).toBe("approved");
     expect(
-      reviewCycleVerdicts(unverified, { verifiedOnly: true }).get("reviewer"),
+      reviewCycleVerdicts(unverified, {
+        cycleStartedAt: null,
+        verifiedOnly: true,
+      }).get("reviewer"),
     ).toBeUndefined();
-    expect(reviewCycleVerdicts(unverified).get("reviewer")).toBe("approved");
+    expect(
+      reviewCycleVerdicts(unverified, { cycleStartedAt: null }).get("reviewer"),
+    ).toBe("approved");
   });
 });
 
@@ -164,22 +192,37 @@ describe("allReviewersApproved", () => {
   ];
 
   it("is false until the enabled reviewer approved", () => {
-    expect(allReviewersApproved([IN_REVIEW_1], ["reviewer"])).toBe(false);
-    expect(allReviewersApproved(approved(true), ["reviewer"])).toBe(true);
+    expect(
+      allReviewersApproved([IN_REVIEW_1], ["reviewer"], {
+        cycleStartedAt: null,
+      }),
+    ).toBe(false);
+    expect(
+      allReviewersApproved(approved(true), ["reviewer"], {
+        cycleStartedAt: null,
+      }),
+    ).toBe(true);
   });
 
   it("empty enabled → false (nothing has signed off)", () => {
-    expect(allReviewersApproved(approved(true), [])).toBe(false);
+    expect(
+      allReviewersApproved(approved(true), [], { cycleStartedAt: null }),
+    ).toBe(false);
   });
 
   it("verifiedOnly gate: an unverified approval never completes the review (anti-forgery)", () => {
     expect(
       allReviewersApproved(approved(false), ["reviewer"], {
+        cycleStartedAt: null,
         verifiedOnly: true,
       }),
     ).toBe(false);
     // The human ship button (no verifiedOnly) still sees it as approved.
-    expect(allReviewersApproved(approved(false), ["reviewer"])).toBe(true);
+    expect(
+      allReviewersApproved(approved(false), ["reviewer"], {
+        cycleStartedAt: null,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -236,9 +236,27 @@ export type ReviewCycleActivity = {
   occurredAt: string;
 };
 
-/** When the task most recently entered In Review (ms since epoch), else 0 — the
- *  start of the current review cycle. Verdicts before this are stale. */
-export function reviewCycleStart(activity: ReviewCycleActivity[]): number {
+/**
+ * When the task's current review cycle opened (ms since epoch), else 0 —
+ * verdicts recorded before it are stale.
+ *
+ * The card's `reviewCycleStartedAt` IS the boundary: it is stamped when the
+ * work becomes reviewable and re-stamped on every re-review, independently of
+ * what lane the card sits in. That independence is the point — the cycle used
+ * to be derived from the newest `status_changed → in_review`, which made the
+ * lane load-bearing (a card could not leave In Review mid-review without
+ * invalidating its own reviewer's verdict), and so pinned every card to In
+ * Review while an agent was still working on it.
+ *
+ * The activity scan survives only as the fallback for a card stamped before
+ * migration 189. Pass `null` for a card that has no column value and the old
+ * derivation applies, so an in-flight cycle is never lost mid-deploy.
+ */
+export function reviewCycleStart(
+  activity: ReviewCycleActivity[],
+  cycleStartedAt: string | Date | null | undefined,
+): number {
+  if (cycleStartedAt) return new Date(cycleStartedAt).getTime();
   let latest = 0;
   for (const a of activity) {
     if (a.action !== "status_changed") continue;
@@ -250,6 +268,19 @@ export function reviewCycleStart(activity: ReviewCycleActivity[]): number {
   return latest;
 }
 
+/**
+ * What every cycle-scoped reducer below needs: the card's own
+ * `reviewCycleStartedAt` (see {@link reviewCycleStart}). It is a REQUIRED
+ * field, not an optional one — a caller that forgets it would silently fall
+ * back to the activity scan, which for a card written after migration 189 finds
+ * no boundary at all and so counts a previous cycle's verdicts as current.
+ */
+export type ReviewCycleOpts = {
+  cycleStartedAt: string | Date | null | undefined;
+  /** Count an approval only when it was token-verified (`data.verified`). */
+  verifiedOnly?: boolean;
+};
+
 /** Each reviewer's latest verdict within the current review cycle. Approvals /
  *  change-requests recorded before the cycle start are ignored. With
  *  `verifiedOnly`, an approval counts only when it was token-verified
@@ -257,9 +288,9 @@ export function reviewCycleStart(activity: ReviewCycleActivity[]): number {
  *  (unverifiable) approval can't ship; the manual ship button does not. */
 export function reviewCycleVerdicts(
   activity: ReviewCycleActivity[],
-  opts?: { verifiedOnly?: boolean },
+  opts: ReviewCycleOpts,
 ): Map<ReviewerKind, "approved" | "changes_requested"> {
-  const start = reviewCycleStart(activity);
+  const start = reviewCycleStart(activity, opts.cycleStartedAt);
   const latest = new Map<ReviewerKind, "approved" | "changes_requested">();
   for (const a of activity) {
     if (
@@ -291,7 +322,7 @@ export function reviewCycleVerdicts(
 export function allReviewersApproved(
   activity: ReviewCycleActivity[],
   enabled: ReviewerKind[],
-  opts?: { verifiedOnly?: boolean },
+  opts: ReviewCycleOpts,
 ): boolean {
   if (enabled.length === 0) return false;
   const verdicts = reviewCycleVerdicts(activity, opts);
@@ -311,10 +342,11 @@ export function allReviewersApproved(
 export function approvedButUnverified(
   activity: ReviewCycleActivity[],
   enabled: ReviewerKind[],
+  opts: ReviewCycleOpts,
 ): boolean {
   return (
-    allReviewersApproved(activity, enabled) &&
-    !allReviewersApproved(activity, enabled, { verifiedOnly: true })
+    allReviewersApproved(activity, enabled, opts) &&
+    !allReviewersApproved(activity, enabled, { ...opts, verifiedOnly: true })
   );
 }
 

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -366,6 +366,7 @@ export interface StudioToolIO {
         keySeq: number | null;
         jiraIssueKey: string | null;
         retryAttempts: number;
+        reviewCycleStartedAt: string | null;
         threads: {
           threadId: string;
           virtualMcpId: string | null;
@@ -434,6 +435,7 @@ export interface StudioToolIO {
         keySeq: number | null;
         jiraIssueKey: string | null;
         retryAttempts: number;
+        reviewCycleStartedAt: string | null;
         threads: {
           threadId: string;
           virtualMcpId: string | null;
@@ -534,6 +536,7 @@ export interface StudioToolIO {
         keySeq: number | null;
         jiraIssueKey: string | null;
         retryAttempts: number;
+        reviewCycleStartedAt: string | null;
         threads: {
           threadId: string;
           virtualMcpId: string | null;


### PR DESCRIPTION
Stacked on #6689 — merge into `feat/review-cycle-off-lane`, not `main`.

## The hole

Found by running #6689 on a live cluster. A card went to In Review and **stayed there for the whole reviewer run** — the exact thing the branch exists to prevent.

`advanceLinkedTasksToReviewOnThreadFinish` reads `listPrs` to decide repo-backed vs repo-less. A run that links its PR moments *after* its thread goes terminal is read as repo-less and parked In Review. The link then lands on a card that is no longer In Progress, so `openReviewCycleIfInProgress` matches nothing and the cycle never opens at all.

Observed at **52 seconds** between the two:

```
15:42:47  thread finished, listPrs empty  ->  card moved to In Review
15:43:39  PR #423 linked                  ->  update matched nothing, no cycle
15:49:37  sweeper dispatched the reviewer via the in_review lane branch
```

Two consequences, both silent:

- the card reads **In Review while an agent is reviewing it** — migration 189 undone for exactly the cards it was written for;
- `review_cycle_started_at` stays NULL, so every verdict on that card falls back to the pre-189 activity scan.

## The fix

The predicate now also matches a **Super-Agent-owned card sitting In Review with no cycle open**, and takes it back to In Progress in the same statement.

Safe precisely *because* the cycle is null: a card whose cycle never opened has had no reviewer and no verdict, so there is nothing behind it to invalidate. Once a cycle IS open, the card is mid-review and `parkReviewedCardForHuman` is what put it In Review — dragging it back would undo a verdict and re-stamp a boundary that verdicts stand on, so that case still returns null.

The Super Agent guard keeps it off a card a person has taken over (`handTaskToHuman` clears the assignee). One statement, so the two columns cannot interleave with the sweeper's read.

## Testing

Real Postgres (embedded), 27 pass / 0 fail in the file:

- the late-link rescue (In Review + no cycle -> In Progress + cycle stamped)
- an In Review card with a cycle **already open** is left alone
- a **human-owned** card is left alone
- a **shipped** card is left alone

The test that asserted the old narrow rule (`never opens a cycle on a card that is not In Progress`) is **inverted**, not appended.

`bun run --cwd=apps/api check`, `bun run lint` (0 errors), `bun run fmt` clean. 36 pre-existing failures on the base branch, 36 here, zero regressions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race that left a card In Review for the whole reviewer run, with `review_cycle_started_at` NULL, when the PR link landed after the thread finished—so every verdict on that card fell back to the legacy activity scan.

**Bug Fixes**
- `openReviewCycleIfInProgress` now also matches a Super-Agent-owned card sitting In Review with no cycle open, moving it back to In Progress and stamping the cycle in the same statement.
- The rescue is safe only while the cycle is null; an In Review card with an open cycle was parked on a verdict and is still left alone, and human-owned cards are excluded.

<sup>Written for commit bfa845c5127b6e4c61473d22a3a8fba88186529e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

