### PR TITLE
fix(task-board): cap a column automation's prompt length

### DIFF
--- a/apps/api/src/tools/task-board/automations.test.ts
+++ b/apps/api/src/tools/task-board/automations.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { TASK_BOARD_AUTOMATION_UPSERT } from "./automations";
+
+/**
+ * Regression: `prompt` had no length cap — an unbounded `text` column,
+ * writable directly by any org member's tool call. Same gap as the task
+ * description cap (#6574's sibling), just on the automation's instruction.
+ */
+describe("TASK_BOARD_AUTOMATION_UPSERT prompt length", () => {
+  it("rejects a prompt over the cap", () => {
+    const result = TASK_BOARD_AUTOMATION_UPSERT.inputSchema.safeParse({
+      columnKey: "todo",
+      prompt: "x".repeat(50_001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a prompt at the cap", () => {
+    const result = TASK_BOARD_AUTOMATION_UPSERT.inputSchema.safeParse({
+      columnKey: "todo",
+      prompt: "x".repeat(50_000),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a null prompt (the default instruction)", () => {
+    const result = TASK_BOARD_AUTOMATION_UPSERT.inputSchema.safeParse({
+      columnKey: "todo",
+      prompt: null,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/api/src/tools/task-board/automations.ts
+++ b/apps/api/src/tools/task-board/automations.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { requireAuth } from "@/core/studio-context";
 import { boardHandler } from "./board-handler";
+import { MAX_AUTOMATION_PROMPT_LENGTH } from "./schema";
 
 const AutomationSchema = z.object({
   columnKey: z.string(),
@@ -46,6 +47,7 @@ export const TASK_BOARD_AUTOMATION_UPSERT = defineTool({
       .describe("A column of this board — see TASK_BOARD_ITEM_LIST."),
     prompt: z
       .string()
+      .max(MAX_AUTOMATION_PROMPT_LENGTH)
       .nullable()
       .optional()
       .describe("What to do with a card landing here; null for the default."),

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -16,6 +16,10 @@ export const MAX_TASK_TITLE_LENGTH = 500;
  *  so nothing legitimate approaches this; same reasoning as the caps above. */
 export const MAX_TASK_REPO_LENGTH = 200;
 
+/** A column automation's prompt is an instruction, not the message body —
+ *  same reasoning as MAX_TASK_DESCRIPTION_LENGTH. */
+export const MAX_AUTOMATION_PROMPT_LENGTH = 50_000;
+
 export const TaskBoardItemStatusSchema = z.enum([
   "triage",
   "todo",


### PR DESCRIPTION
`TASK_BOARD_AUTOMATION_UPSERT` (landed same-day in #6690, `apps/api/src/tools/task-board/automations.ts`) took `prompt` as an unbounded `z.string().nullable().optional()`, writable directly by any org member's tool call into an unbounded `text` column — the same gap this codebase has repeatedly capped on sibling fields (task `description`/`title`, comment `body`, repo string), per the resource-bound hardening lane in the project history.

Why it matters: an org member (or a buggy caller) can write an arbitrarily large prompt into `task_board_column_automations`, which then gets fed into the Super Agent's instruction on every card landing in that column — unbounded row growth and an unbounded string re-sent on every automated run.

Fix: added `MAX_AUTOMATION_PROMPT_LENGTH = 50_000` next to the existing `MAX_TASK_DESCRIPTION_LENGTH`/`MAX_TASK_TITLE_LENGTH`/`MAX_TASK_REPO_LENGTH` caps in `schema.ts` (same 50k bound as description/comment body), and applied it to the `prompt` field in `TASK_BOARD_AUTOMATION_UPSERT`'s input schema.

Regression test: `apps/api/src/tools/task-board/automations.test.ts`, mirroring the existing `description-length.test.ts` pattern — asserts the schema rejects a prompt one character over the cap, accepts one at the cap, and still accepts `null` (the default-instruction sentinel).

To verify: `bun test apps/api/src/tools/task-board/automations.test.ts`.

Checked locally: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on the three touched files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the `prompt` field in `TASK_BOARD_AUTOMATION_UPSERT` at 50,000 characters, matching the existing cap on task descriptions, so an org member's tool call can no longer store an arbitrarily large instruction that gets re-sent on every card landing.

- Adds a regression test covering the cap and the `null` default-instruction sentinel.
- No migration needed; existing prompts are unaffected.

<sup>Written for commit 080132c934394b60858b1de702c3fcca336a45b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

