### PR TITLE
fix(harness): drop an orphan reasoning-end instead of letting it kill the run

### DIFF
--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -456,6 +456,62 @@ function retryingProviderChunk(): Record<string, unknown> {
 }
 
 /**
+ * Drops a `text-end` / `reasoning-end` whose part the consumer does not have
+ * open, and mirrors the AI SDK reducer's own part lifecycle to decide that.
+ *
+ * The reducer throws on an orphan end — `Received reasoning-end for missing
+ * reasoning part with ID "stream-2"` — and that throw kills the stream
+ * mid-run. Observed live: an agent that had cloned its repo and was still
+ * working in its pod had its Studio-side run torn down after two tool calls,
+ * while the pod kept going for minutes, oblivious.
+ *
+ * Two things upstream can separate an end from its start, and neither is a
+ * bug this can be fixed at:
+ *
+ *  - **A restart drops the start.** `pending` buffers everything until the
+ *    turn's message id is known, and an abandoned attempt clears it wholesale
+ *    (`pending.length = 0`) along with the coalescer — but `UiChunkTranslator`
+ *    keeps its `openStreamBlocks`, so the next `message_start` closes a block
+ *    whose start went in the bin.
+ *  - **A `finish-step` lands between them.** The reducer CLEARS its open parts
+ *    on that boundary, so every end after it is an orphan by definition. The
+ *    step-boundary call sites close open blocks first for exactly this reason;
+ *    this is the backstop for the next call site that forgets.
+ *
+ * Rather than chase each path, this sits at the one place every chunk reaches
+ * the consumer and enforces the reducer's rule directly: a start opens an id,
+ * an end closes it, and `finish-step` clears them all. An end with no open id
+ * is dropped — the part it referred to is already closed or was never opened,
+ * so dropping it costs nothing and keeps the run alive.
+ */
+export function createOrphanEndGuard(): (chunks: unknown[]) => unknown[] {
+  const open = new Set<string>();
+  return (chunks) =>
+    chunks.filter((chunk) => {
+      if (typeof chunk !== "object" || chunk === null) return true;
+      const { type, id } = chunk as { type?: unknown; id?: unknown };
+      if (type === "finish-step") {
+        open.clear();
+        return true;
+      }
+      if (typeof type !== "string" || typeof id !== "string") return true;
+      // Keyed on KIND and id, like the coalescer's merge check: ids are minted
+      // distinctly today, so a `reasoning-end` landing on a `text` part's id
+      // means something upstream is confused, and closing that part on its
+      // behalf would corrupt it rather than just misorder it.
+      if (type === "text-start" || type === "reasoning-start") {
+        open.add(`${type.slice(0, -"-start".length)}:${id}`);
+        return true;
+      }
+      // `delete` returns whether it was open — exactly the keep/drop answer.
+      if (type === "text-end" || type === "reasoning-end") {
+        return open.delete(`${type.slice(0, -"-end".length)}:${id}`);
+      }
+      return true;
+    });
+}
+
+/**
  * Coalesces adjacent text/reasoning deltas so token-level streaming does not
  * become token-level *framing*.
  *
@@ -561,10 +617,11 @@ export async function runClaudeCode(
   // produces before the first assistant message waits here, never longer.
   const pending: unknown[] = [];
   let started = false;
+  const guard = createOrphanEndGuard();
   const startTurn = (id: string) => {
     if (started) return;
     started = true;
-    emit({ chunks: [...turnStartChunks(id), ...pending.splice(0)] });
+    emit({ chunks: guard([...turnStartChunks(id), ...pending.splice(0)]) });
   };
   /**
    * Whether a failed attempt can be restarted without duplicating work.
@@ -579,8 +636,14 @@ export async function runClaudeCode(
   const coalescer = createDeltaCoalescer();
   const send = (chunks: unknown[]) => {
     if (chunks.length === 0) return;
-    if (started) emit({ chunks });
-    else pending.push(...chunks);
+    // Buffered chunks are guarded when `startTurn` flushes them, not here: an
+    // end whose start is still sitting in `pending` is not an orphan, and
+    // `pending` is dropped WHOLESALE on a restart, so what survives is only
+    // decidable at the emit that actually sends it.
+    if (started) {
+      const guarded = guard(chunks);
+      if (guarded.length > 0) emit({ chunks: guarded });
+    } else pending.push(...chunks);
   };
   const push = (chunks: unknown[]) => {
     if (chunks.length === 0) return;

--- a/packages/harness-runner/orphan-end-guard.test.ts
+++ b/packages/harness-runner/orphan-end-guard.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The orphan end that killed a live run: an agent had cloned its repo and was
+ * still working in its pod when the reducer threw `Received reasoning-end for
+ * missing reasoning part with ID "stream-2"` and tore the Studio-side run down.
+ */
+import { expect, test } from "bun:test";
+import { createOrphanEndGuard } from "./claude-code";
+
+const start = (id: string) => ({ type: "reasoning-start", id });
+const end = (id: string) => ({ type: "reasoning-end", id });
+const delta = (id: string) => ({ type: "reasoning-delta", id, delta: "x" });
+
+test("a matched start/end pair passes through untouched", () => {
+  const guard = createOrphanEndGuard();
+  const chunks = [start("a"), delta("a"), end("a")];
+  expect(guard(chunks)).toEqual(chunks);
+});
+
+test("an end whose start was never emitted is dropped", () => {
+  const guard = createOrphanEndGuard();
+  expect(guard([end("stream-2")])).toEqual([]);
+});
+
+test("finish-step closes every open part, as the reducer does", () => {
+  const guard = createOrphanEndGuard();
+  guard([start("stream-2")]);
+  // The reducer cleared its open parts here; an end after it is an orphan.
+  expect(guard([{ type: "finish-step" }, end("stream-2")])).toEqual([
+    { type: "finish-step" },
+  ]);
+});
+
+test("a second end for the same part is dropped", () => {
+  const guard = createOrphanEndGuard();
+  guard([start("a")]);
+  expect(guard([end("a")])).toEqual([end("a")]);
+  expect(guard([end("a")])).toEqual([]);
+});
+
+test("text parts are tracked independently of reasoning parts", () => {
+  const guard = createOrphanEndGuard();
+  guard([{ type: "text-start", id: "a" }]);
+  // Same id, different kind: the reasoning part was never opened.
+  expect(guard([end("a")])).toEqual([]);
+  expect(guard([{ type: "text-end", id: "a" }])).toEqual([
+    { type: "text-end", id: "a" },
+  ]);
+});
+
+test("everything that is not a part lifecycle chunk passes through", () => {
+  const guard = createOrphanEndGuard();
+  const others = [
+    { type: "start-step" },
+    { type: "tool-input-start", id: "t1" },
+    { type: "finish", finishReason: "stop" },
+    null,
+    "not an object",
+  ];
+  expect(guard(others)).toEqual(others);
+});


### PR DESCRIPTION
An agent cloned its repo, made two tool calls, and its card went to In Review reading "Completed — I'll start by cloning the repo." **The agent was still running in its pod**, and kept running for minutes after Studio had torn its stream down and moved on.

```
[Decopilot] stream pump error for thread thrd_OXa6vEC0kfR3O_-jsB9NA:
  Received reasoning-end for missing reasoning part with ID "stream-2".
  Ensure a "reasoning-start" chunk is sent before any "reasoning-end" chunks.
```

The AI SDK reducer throws on an end for a part it does not have open, and that throw kills the stream.

## Two ways a start goes missing

- **A restart drops it.** `pending` buffers every chunk until the turn's message id is known, and an abandoned attempt clears it wholesale (`pending.length = 0`) along with the coalescer — but `UiChunkTranslator` keeps its `openStreamBlocks`, so the next `message_start` closes a block whose start went in the bin.
- **A `finish-step` lands between them.** The reducer CLEARS its open parts on that boundary, so every end after it is an orphan by definition. The step-boundary call sites already close open blocks first for exactly this reason — this is the backstop for the next call site that forgets.

## The fix

Rather than chase each path, the guard sits at the one place every chunk reaches the consumer and enforces the reducer's own rule directly: a start opens an id, an end closes it, `finish-step` clears them all. An end with no open id is dropped — the part it referred to is already closed or was never opened, so dropping it costs nothing and keeps the run alive.

Keyed on **kind and id**, like the coalescer's merge check: ids are minted distinctly, so a `reasoning-end` landing on a `text` part's id means something upstream is confused, and closing that part on its behalf would corrupt it rather than just misorder it.

Buffered chunks are guarded at the `startTurn` flush, not on the way into `pending` — an end whose start is still buffered is not an orphan, and `pending` is dropped wholesale on a restart, so what survives is only decidable at the emit that actually sends it.

## Testing

`packages/harness-runner/orphan-end-guard.test.ts` — 6 cases: the matched pair passes untouched, the bare end is dropped, `finish-step` orphans a still-open part, a double end is dropped, kinds are tracked independently, and non-lifecycle chunks (including `null` and a bare string) pass through.

`bun test packages/harness-runner/` → 78 pass / 0 fail. `bun run --cwd=apps/api check`, `bun run lint` (0 errors), `bun run fmt` clean.

## Known, not fixed here

The pump rethrows correctly, but the run still landed as **`completed`** rather than `failed`, which is what let the card advance to In Review while the agent was mid-work. That mislabel is a separate defect — worth its own change, and it only bites when a crash happens, which this PR is meant to stop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an orphan-end guard in `packages/harness-runner` so a `reasoning-end` or `text-end` for a part the AI SDK doesn't have open is dropped instead of throwing and killing the stream. Previously such a chunk tore down the run mid-work; now the run continues and the chunk is ignored.

- Tracks open parts by kind and id, matching the coalescer's merge check, and clears them on `finish-step`.
- Guards buffered chunks at flush time, so an end whose start is still buffered isn't treated as orphaned.
- Adds tests for matched pairs, orphaned ends, double ends, `finish-step`, kind separation, and pass-through chunks.
- Does not fix the separate issue where a crashed run is labeled `completed` instead of `failed`.

<sup>Written for commit 169429930b2568cf221c880b5c28ae1e1ee0c12a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

