### PR TITLE
fix(import-deco): slugify the site name before building its preview host

### DIFF
--- a/apps/web/src/components/import-from-deco-dialog.tsx
+++ b/apps/web/src/components/import-from-deco-dialog.tsx
@@ -12,8 +12,8 @@ import { useAutoInstallGitHub } from "@/hooks/use-auto-install-github";
 import { useNavigateToAgent } from "@/hooks/use-navigate-to-agent";
 import { resolveDecoSiteGithubRepo } from "@decocms/shared/deco-sites-github";
 import {
+  defaultPreviewServerUrl,
   pickProductionDomain,
-  productionUrlFromDomain,
 } from "@decocms/shared/deco-site-production-url";
 import { getOrgGithubConnections } from "@decocms/shared/github-repo-scope";
 import {
@@ -271,10 +271,8 @@ export function ImportFromDecoDialog({
         const projectIcon = connBody.icon ?? null;
         const slug = generateSlug(siteName);
         const siteSlug = siteName.toLowerCase();
-        // Default the preview server to the site's `{slug}.deco.site` host (legacy `productionUrl` dual-written for rollback).
-        const previewServerUrl = productionUrlFromDomain(
-          `${siteSlug}.deco.site`,
-        );
+        // Default to the `{slug}.deco.site` host (legacy `productionUrl` dual-written for rollback).
+        const previewServerUrl = defaultPreviewServerUrl(siteName);
 
         // 2. Create a space (virtual MCP) wired to both admin-mcp and GitHub.
         const result = (await client.callTool({

--- a/packages/shared/src/deco-site-production-url.test.ts
+++ b/packages/shared/src/deco-site-production-url.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  defaultPreviewServerUrl,
   pickProductionDomain,
   productionUrlFromDomain,
   resolvePreviewServerUrl,
@@ -79,6 +80,25 @@ describe("productionUrlFromDomain", () => {
     expect(productionUrlFromDomain("   ")).toBeNull();
     expect(productionUrlFromDomain(null)).toBeNull();
     expect(productionUrlFromDomain(undefined)).toBeNull();
+  });
+});
+
+describe("defaultPreviewServerUrl", () => {
+  it("slugifies a bare site name into the deco.site host", () => {
+    expect(defaultPreviewServerUrl("acme")).toBe("https://acme.deco.site/");
+  });
+
+  it("slugifies a display name with spaces and symbols", () => {
+    expect(defaultPreviewServerUrl("My Cool Site!")).toBe(
+      "https://my-cool-site.deco.site/",
+    );
+  });
+
+  it("returns null for empty / whitespace-only / nullish, instead of throwing", () => {
+    expect(defaultPreviewServerUrl("")).toBeNull();
+    expect(defaultPreviewServerUrl("   ")).toBeNull();
+    expect(defaultPreviewServerUrl(null)).toBeNull();
+    expect(defaultPreviewServerUrl(undefined)).toBeNull();
   });
 });
 

--- a/packages/shared/src/deco-site-production-url.ts
+++ b/packages/shared/src/deco-site-production-url.ts
@@ -1,3 +1,5 @@
+import { slugify } from "./utils/slugify";
+
 /**
  * Site-URL helpers for linked deco.cx sites.
  *
@@ -6,9 +8,9 @@
  * by imports before the rename and still read as a fallback). It is usually
  * the live production site, but any deco-runtime deployment works (staging, a
  * local `https://localhost:3100`, ...), which is why the canonical name is
- * "preview server". We deliberately do NOT derive it from `siteSlug` (the
- * `{slug}.deco.site` guess) — a site's real URL can be a custom domain, so we
- * persist what deco.cx actually reports at import time.
+ * "preview server". Imports default it to the site's `{slug}.deco.site` guess
+ * (see `defaultPreviewServerUrl`) rather than a reported custom domain, so the
+ * preview always targets the deco-runtime host.
  */
 
 /** Validate/normalize a stored site URL. Returns the canonical href or `null`. */
@@ -66,4 +68,19 @@ export function productionUrlFromDomain(
   if (!raw) return null;
   const withProtocol = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
   return sanitizeSiteUrl(withProtocol);
+}
+
+/**
+ * Guess a site's deco.site preview host from its display name. `siteName` is
+ * a free-text title (shown as-is in the import picker), not a hostname, so it
+ * is slugified first — an unslugified name with a space or symbol makes
+ * `new URL()` throw, and `productionUrlFromDomain` swallows that into `null`,
+ * silently leaving the imported site with no preview server at all.
+ */
+export function defaultPreviewServerUrl(
+  siteName: string | null | undefined,
+): string | null {
+  const slug = slugify(siteName ?? "");
+  if (!slug) return null;
+  return productionUrlFromDomain(`${slug}.deco.site`);
 }


### PR DESCRIPTION
Follows #6699, which switched the deco.cx import flow to default `previewServerUrl` to a `{slug}.deco.site` guess instead of the site's reported domain.

**The gap:** the guess was built from `siteName.toLowerCase()` (`site.name` is a free-text display title shown as-is in the import picker, not a hostname). Any site name containing a space or symbol — e.g. `"My Cool Site"` — produces `"my cool site.deco.site"`, which makes `new URL()` throw; `productionUrlFromDomain`'s `try/catch` swallows that into `null`. The import silently completes with no `previewServerUrl` (and no `productionUrl`, since it's dual-written from the same value), so the CMS preview has nothing to render against — no error, no toast.

**Fix:** extracted the host guess into `defaultPreviewServerUrl(siteName)` (`packages/shared/src/deco-site-production-url.ts`), which slugifies the name (reusing the existing `slugify` helper) before handing it to `productionUrlFromDomain`. The component now calls this instead of building the string inline. Also updated the module's header comment, which still described the pre-#6699 domain-preference behavior.

**Regression test:** `packages/shared/src/deco-site-production-url.test.ts` — `defaultPreviewServerUrl("My Cool Site!")` now resolves to `https://my-cool-site.deco.site/` instead of `null` (fails on current `main` before this fix... actually current main doesn't have the helper at all; the test asserts the fixed behavior directly and would fail against the pre-fix inline `${siteName.toLowerCase()}.deco.site` construction).

Reviewer command: `bun test packages/shared/src/deco-site-production-url.test.ts`

Locally verified: `bun run fmt`, `tsc --noEmit` in `packages/shared` and `apps/web` (clean for the touched files — apps/web has one pre-existing, unrelated prosemirror-version type error), `bunx oxlint` on the three touched files (0 warnings/errors), and the targeted test file above (17/17 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the deco.cx import flow so preview hosts built from site names are slugified, preventing silent failures when names contain spaces or symbols.

- The old inline `${siteName.toLowerCase()}.deco.site` construction could throw and be swallowed, leaving imported sites without a preview server. Now `defaultPreviewServerUrl` reuses the existing `slugify` helper and returns `null` for empty or nullish names instead of throwing.
- Adds tests covering slugified names and null handling.

<sup>Written for commit fbefb73cc99698f50a1e052b549d0e6a69651ce8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

