### PR TITLE
fix(virtual-mcp): prune homeTile/homeTiles when their connection is removed

### DIFF
--- a/apps/api/src/storage/prune-orphaned-ui-refs.test.ts
+++ b/apps/api/src/storage/prune-orphaned-ui-refs.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { pruneOrphanedUiRefs } from "./prune-orphaned-ui-refs";
+
+test("drops a pinned view for the removed connection", () => {
+  const { ui, changed } = pruneOrphanedUiRefs(
+    {
+      pinnedViews: [
+        { connectionId: "conn_a", toolName: "foo" },
+        { connectionId: "conn_b", toolName: "bar" },
+      ],
+    },
+    "conn_a",
+  );
+  expect(changed).toBe(true);
+  expect(ui.pinnedViews).toEqual([{ connectionId: "conn_b", toolName: "bar" }]);
+});
+
+test("nulls pinnedViews once every entry is dropped", () => {
+  const { ui, changed } = pruneOrphanedUiRefs(
+    { pinnedViews: [{ connectionId: "conn_a", toolName: "foo" }] },
+    "conn_a",
+  );
+  expect(changed).toBe(true);
+  expect(ui.pinnedViews).toBeNull();
+});
+
+test("nulls the legacy single homeTile when it points at the removed connection", () => {
+  const { ui, changed } = pruneOrphanedUiRefs(
+    { homeTile: { connectionId: "conn_a", resourceUri: "ui://x" } },
+    "conn_a",
+  );
+  expect(changed).toBe(true);
+  expect(ui.homeTile).toBeNull();
+});
+
+test("drops a homeTiles entry for the removed connection", () => {
+  const { ui, changed } = pruneOrphanedUiRefs(
+    {
+      homeTiles: [
+        { connectionId: "conn_a", resourceUri: "ui://a" },
+        { connectionId: "conn_b", resourceUri: "ui://b" },
+      ],
+    },
+    "conn_a",
+  );
+  expect(changed).toBe(true);
+  expect(ui.homeTiles).toEqual([
+    { connectionId: "conn_b", resourceUri: "ui://b" },
+  ]);
+});
+
+test("is a no-op when nothing references the removed connection", () => {
+  const original = {
+    pinnedViews: [{ connectionId: "conn_b", toolName: "bar" }],
+    homeTile: { connectionId: "conn_b", resourceUri: "ui://b" },
+  };
+  const { ui, changed } = pruneOrphanedUiRefs(original, "conn_a");
+  expect(changed).toBe(false);
+  expect(ui).toEqual(original);
+});
+
+test("leaves a homeTile with no connectionId untouched", () => {
+  const { ui, changed } = pruneOrphanedUiRefs(
+    { homeTile: { resourceUri: "ui://x" } },
+    "conn_a",
+  );
+  expect(changed).toBe(false);
+  expect(ui.homeTile).toEqual({ resourceUri: "ui://x" });
+});

--- a/apps/api/src/storage/prune-orphaned-ui-refs.ts
+++ b/apps/api/src/storage/prune-orphaned-ui-refs.ts
@@ -1,0 +1,49 @@
+/**
+ * Drop `metadata.ui` references to a removed connection.
+ *
+ * `pinnedViews` used to be the only field pruned when a connection left an
+ * agent's aggregation (see `keepAttachedPinnedViews` on the web side, which
+ * fixed the same orphan class for the tab bar). `homeTile` / `homeTiles` carry
+ * the identical `connectionId` shape and are just as capable of stranding a
+ * home-board tile that points at a connection which no longer exists — left
+ * out of the original fix as a known gap, closed here.
+ *
+ * Pure so the prune logic is unit-tested without a database.
+ */
+export function pruneOrphanedUiRefs(
+  ui: Record<string, unknown>,
+  removedConnectionId: string,
+): { ui: Record<string, unknown>; changed: boolean } {
+  let changed = false;
+  const next: Record<string, unknown> = { ...ui };
+
+  const pinnedViews = ui.pinnedViews;
+  if (Array.isArray(pinnedViews)) {
+    const filtered = pinnedViews.filter(
+      (pv: { connectionId: string }) => pv.connectionId !== removedConnectionId,
+    );
+    if (filtered.length !== pinnedViews.length) {
+      changed = true;
+      next.pinnedViews = filtered.length > 0 ? filtered : null;
+    }
+  }
+
+  const homeTile = ui.homeTile as { connectionId?: string } | null | undefined;
+  if (homeTile && homeTile.connectionId === removedConnectionId) {
+    changed = true;
+    next.homeTile = null;
+  }
+
+  const homeTiles = ui.homeTiles;
+  if (Array.isArray(homeTiles)) {
+    const filtered = homeTiles.filter(
+      (t: { connectionId?: string }) => t.connectionId !== removedConnectionId,
+    );
+    if (filtered.length !== homeTiles.length) {
+      changed = true;
+      next.homeTiles = filtered.length > 0 ? filtered : null;
+    }
+  }
+
+  return { ui: next, changed };
+}

--- a/apps/api/src/storage/virtual.ts
+++ b/apps/api/src/storage/virtual.ts
@@ -26,6 +26,7 @@ import type {
   VirtualMCPUpdateData,
 } from "./ports";
 import type { Database, DependencyMode } from "./types";
+import { pruneOrphanedUiRefs } from "./prune-orphaned-ui-refs";
 
 /** Raw database row type for connections (VIRTUAL type) */
 type RawConnectionRow = {
@@ -497,7 +498,8 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
   }
 
   /**
-   * Remove pinned views that reference a specific connection from the given virtual MCPs.
+   * Remove pinned views and home tiles that reference a specific connection
+   * from the given virtual MCPs.
    */
   private async cleanOrphanedPinnedViews(
     virtualMcpIds: string[],
@@ -521,25 +523,16 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
       } catch {
         continue;
       }
-      const pinnedViews = (metadata?.ui as Record<string, unknown>)
-        ?.pinnedViews;
-      if (!Array.isArray(pinnedViews)) continue;
+      const ui = (metadata.ui as Record<string, unknown>) ?? null;
+      if (!ui) continue;
 
-      const filtered = pinnedViews.filter(
-        (pv: { connectionId: string }) =>
-          pv.connectionId !== removedConnectionId,
+      const { ui: prunedUi, changed } = pruneOrphanedUiRefs(
+        ui,
+        removedConnectionId,
       );
+      if (!changed) continue;
 
-      if (filtered.length === pinnedViews.length) continue;
-
-      const ui = (metadata.ui as Record<string, unknown>) ?? {};
-      const updatedMetadata = {
-        ...metadata,
-        ui: {
-          ...ui,
-          pinnedViews: filtered.length > 0 ? filtered : null,
-        },
-      };
+      const updatedMetadata = { ...metadata, ui: prunedUi };
 
       await this.db
         .updateTable("connections")


### PR DESCRIPTION
## Source

Follow-up to #6674 (merged, fixes #6673's orphaned pinned-view tab). That PR's own body flagged this exact gap under "Not in scope":

> `metadata.ui.homeTiles` / `homeTile` have the same orphan class and are not pruned by `cleanOrphanedPinnedViews` in `apps/api/src/storage/virtual.ts` either. No reported breakage, left for a follow-up.

## Why a maintainer wants this

`cleanOrphanedPinnedViews` (called both when an agent's connection list is updated and when a connection is deleted) only stripped `metadata.ui.pinnedViews` referencing the removed connection. `homeTile`/`homeTiles` carry the identical `connectionId` field and are just as reachable from `removeConnectionReferences` — a deleted or detached connection can leave a stranded home-board tile the same way it left the stranded pinned-view tab in #6673, with no UI path to remove it (the home-tile editor also only lists live/attached connections).

## What changed

Extracted the pinned-view filtering into a pure `pruneOrphanedUiRefs(ui, removedConnectionId)` (`apps/api/src/storage/prune-orphaned-ui-refs.ts`) that now prunes `pinnedViews`, the legacy single `homeTile`, and the `homeTiles` array together. `cleanOrphanedPinnedViews` calls it instead of hand-rolling the pinnedViews-only filter. Net: -17/+10 in `virtual.ts`, +2 new files (helper + test).

Behavior-preserving for the existing pinnedViews path — same filter predicate, same null-vs-empty-array handling, same field wiring in the callers (`updateVirtualMCP`, `removeConnectionReferences`).

## Regression test

`apps/api/src/storage/prune-orphaned-ui-refs.test.ts` — 6 cases: drops a pinned view for the removed connection, nulls `pinnedViews` once empty, nulls a matching legacy `homeTile`, drops a matching `homeTiles` entry, no-op when nothing references the connection, and a `homeTile` with no `connectionId` is left untouched (was previously untestable — `cleanOrphanedPinnedViews` was a private DB-coupled method with zero existing coverage).

## To verify

`bun test apps/api/src/storage/prune-orphaned-ui-refs.test.ts`

## Checks run locally

- `bun run fmt`
- `cd apps/api && bunx tsc --noEmit` — clean
- `bun test apps/api/src/storage/prune-orphaned-ui-refs.test.ts` — 6/6 pass
- `bunx oxlint` on all three touched files — 0 warnings/errors

Full CI (integration/e2e) validates the DB-coupled `cleanOrphanedPinnedViews` wiring, which needs Postgres and isn't exercised here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes `homeTile`/`homeTiles` from agent UI metadata when their connection is removed. Previously only `pinnedViews` were cleaned up, leaving home-board tiles stranded with no UI path to remove them.

- Extracts the pruning into a pure `pruneOrphanedUiRefs` helper with unit tests for `pinnedViews`, `homeTile`, and `homeTiles`.
- Existing `pinnedViews` behavior is unchanged; empty arrays still collapse to `null`.

<sup>Written for commit b38f883ca3e56788a4ec047eccaa41c17be15e16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

