### PR TITLE
fix(task-board): super agent verifies locally, not on the deploy preview

### DIFF
--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -52,19 +52,25 @@ describe("buildClaudeCodeTaskPrompt", () => {
     expect(buildClaudeCodeTaskPrompt(task, repo)).toContain("AUTONOMOUSLY");
   });
 
-  test("requires reachability and a preview check before handing over", () => {
+  // Inverted: this used to require fetching the PR's `previewUrl` and
+  // verifying on the deploy preview. That is the reviewer's job — the Super
+  // Agent implements and verifies locally, and must not sit waiting for a
+  // deploy.
+  test("requires reachability and a LOCAL check before handing over", () => {
     const prompt = buildClaudeCodeTaskPrompt(task, repo);
     expect(prompt).toContain("must be REACHABLE");
-    expect(prompt).toContain("mcp__studio__TASK_BOARD_ITEM_PRS_GET");
+    expect(prompt).toContain("VERIFY the task's outcome LOCALLY");
     expect(prompt).toContain("A green test suite is not the bar");
+    expect(prompt).not.toContain("mcp__studio__TASK_BOARD_ITEM_PRS_GET");
   });
 
-  test("a reviewer bounce says to reproduce the check on the preview", () => {
+  test("a reviewer bounce says to reproduce the check locally", () => {
     const prompt = buildClaudeCodeTaskPrompt(task, repo, {
       feedback: "view_item never fires",
       pr: { number: 340, url: "https://github.com/acme/web/pull/340" },
     });
-    expect(prompt).toContain("judged the DEPLOYED PREVIEW");
+    expect(prompt).toContain("Reproduce their check LOCALLY");
+    expect(prompt).not.toContain("DEPLOYED PREVIEW");
   });
 
   // Inverted: this used to say "move it to review anyway so a human can close

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -247,7 +247,7 @@ export function buildClaudeCodeTaskPrompt(
       opts.pr
         ? `Check that branch out (\`gh pr checkout ${opts.pr.number}\`) before editing, address the feedback, then push to update the SAME pull request — do NOT open a new one.`
         : "Address this feedback.",
-      "The reviewer judged the DEPLOYED PREVIEW, not your diff. Reproduce their check there before you push again — a fix that only looks right in the code comes straight back.",
+      "The reviewer judged the running app, not your diff. Reproduce their check LOCALLY before you push again — a fix that only looks right in the code comes straight back.",
       "",
     );
   } else if (opts?.pr) {
@@ -270,7 +270,10 @@ export function buildClaudeCodeTaskPrompt(
     "- Change only what the task needs. Don't refactor around it.",
     // The two defects behind every card that burned its bounce budget.
     "- The change must be REACHABLE from the surface the task names: edit the component that route actually renders, not one that merely looks like the right place. A change nothing imports is dead code, and it is the most common reason a task comes back rejected.",
-    `- Before handing over, VERIFY the task's outcome the way the reviewer will: get the PR's \`previewUrl\` from \`mcp__studio__TASK_BOARD_ITEM_PRS_GET\` (give the deploy a minute), open the affected route there, and confirm the behaviour actually happens. A green test suite is not the bar — the reviewer approves what it can see on the preview.`,
+    // Deliberately LOCAL-only. Verifying on the deploy preview means waiting
+    // for a deploy that may not exist yet, and that is the reviewer's job
+    // (`enqueue-reviewer.ts`) — this run implements and hands over.
+    `- Before handing over, VERIFY the task's outcome LOCALLY, in the sandbox: exercise the affected code path (the dev server hot-reloads, so hit the route it renders) and confirm the behaviour actually happens. A green test suite is not the bar. Do NOT wait for, or verify against, the PR's deploy preview — a reviewer checks that after you hand over.`,
     // The ONLY reliable way the board learns the PR: Claude Code opens it inside
     // the pod, so no Studio-side hook sees it (see pr-link.ts). Reviewers are
     // dispatched from the linked PR, so skipping this strands the card.


### PR DESCRIPTION
## What

The sandbox Super Agent prompt (`buildClaudeCodeTaskPrompt`) told the run to fetch the PR's `previewUrl`, "give the deploy a minute", and confirm the behaviour on the deploy preview before handing over — and a reviewer bounce told it the reviewer "judged the DEPLOYED PREVIEW" and to reproduce the check there.

That's the Reviewer's job (`enqueue-reviewer.ts` already waits for the preview to catch up with the PR head). The Super Agent should implement and verify **locally** in the sandbox, then hand over.

- Hand-over step now says: exercise the affected code path in the sandbox (dev server hot-reloads), and explicitly **do not** wait for or verify against the deploy preview.
- Reviewer-bounce lead now says reproduce the reviewer's check locally.

## Testing

`bun test apps/api/src/tools/task-board/claude-code-task-run.test.ts` — 25 pass. The two tests that encoded the old behavior are inverted (they now assert the prompt does *not* mention `TASK_BOARD_ITEM_PRS_GET` / `DEPLOYED PREVIEW`).

Prompt-only change; the reviewer path is untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the sandbox Super Agent from verifying work against the PR's deploy preview before handing over. It now verifies the task's outcome locally in the sandbox, and both the hand-over step and reviewer-bounce lead tell it to reproduce the check locally and not wait for or verify against the deploy preview; the reviewer path is untouched.

**Testing**
- The two tests that encoded the old behavior now assert the prompt omits `TASK_BOARD_ITEM_PRS_GET` and `DEPLOYED PREVIEW`; all 25 tests pass.

<sup>Written for commit 7d286d8f315b9d779dd415c81810c5062760c4b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

