### PR TITLE
fix(task-board): close a rerun's inherited review cycle

### DIFF
--- a/apps/api/src/tools/task-board/rerun-closes-review-cycle.integration.test.ts
+++ b/apps/api/src/tools/task-board/rerun-closes-review-cycle.integration.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Real-Postgres coverage for a re-run closing the card's review cycle.
+ *
+ * `TASK_BOARD_ITEM_RERUN` moves a card back to In Progress, but until now it
+ * never called `closeReviewCycle` — the storage method whose own doc comment
+ * claims "every path that sends a card back to work (a rerun, a
+ * conflict-resolution claim, a human re-engaging the thread)" calls it. Left
+ * stamped, `openReviewCycleIfInProgress` (which only stamps a FRESH boundary
+ * when the column is null) never fires for the new attempt, so its own review
+ * dispatch inherits the superseded attempt's cycle boundary — and with it,
+ * verdicts recorded against work the new run never produced.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../../database/test-db-pg";
+import { TaskBoardStorage } from "../../storage/task-board";
+
+const ORG = "org_rerun_cycle_1";
+const USER = "user_rc1";
+
+describe("a re-run closes the review cycle it inherited", () => {
+  let database: StudioDatabase;
+  let taskBoard: TaskBoardStorage;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values({ id: ORG, name: ORG, slug: "org-rerun-cycle-1", createdAt: now })
+      .execute();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"rc1@rerun.test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    taskBoard = new TaskBoardStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("lets a fresh cycle open after the sequence rerun.ts now runs", async () => {
+    const item = await taskBoard.create({
+      organizationId: ORG,
+      title: "stuck mid-review",
+      by: USER,
+    });
+    // A reviewer already stamped an open cycle — the state a rerun targets.
+    const opened = await taskBoard.openReviewCycleIfInProgress(item.id, ORG);
+    expect(opened?.reviewCycleStartedAt).not.toBeNull();
+
+    // The exact sequence TASK_BOARD_ITEM_RERUN's handler now runs.
+    await taskBoard.closeReviewCycle(item.id, ORG);
+    await taskBoard.update(item.id, ORG, { status: "in_progress" }, USER);
+
+    // Without the fix this returns null: the column is still non-null.
+    const reopened = await taskBoard.openReviewCycleIfInProgress(item.id, ORG);
+    expect(reopened).not.toBeNull();
+    expect(reopened?.reviewCycleStartedAt).not.toBe(
+      opened?.reviewCycleStartedAt,
+    );
+  });
+});

--- a/apps/api/src/tools/task-board/rerun.ts
+++ b/apps/api/src/tools/task-board/rerun.ts
@@ -366,6 +366,9 @@ export const TASK_BOARD_ITEM_RERUN = defineTool({
       await stopSupersededRun(ctx, threadId, organizationId);
     }
 
+    // Whatever a reviewer decided was about the pre-rerun work — same reasoning as `reopenLinkedTasksOnThreadRun`.
+    await ctx.storage.taskBoard.closeReviewCycle(id, organizationId);
+
     // In Progress before dispatch, so the card reads as running the moment the
     // board refreshes rather than sitting in its old lane until the run's first
     // chunk lands. `enqueueSuperAgentForTask` claims quota itself (idempotent


### PR DESCRIPTION
Follows #6689 (migration 190's `review_cycle_started_at`).

`TASK_BOARD_ITEM_RERUN` moves a card back to In Progress but never called `closeReviewCycle` — the storage method whose own doc comment says every path that sends a card back to work ("a rerun, a conflict-resolution claim, a human re-engaging the thread") calls it. `reopenLinkedTasksOnThreadRun` does; the rerun tool didn't.

Failure scenario: a card's reviewer is running (In Progress with `review_cycle_started_at` stamped) or the card is parked In Review, and someone re-runs it. `openReviewCycleIfInProgress` only stamps a *fresh* boundary when that column is null — so with the stale stamp left in place, the new attempt's own review dispatch never opens its own cycle. Verdicts recorded against the superseded attempt keep counting (via `inReviewPhase`, the auto-merge gate, the review-token cycle check) as if they applied to the new run's work, which they never saw.

Fix: call `ctx.storage.taskBoard.closeReviewCycle(id, organizationId)` before moving the card to In Progress, mirroring the exact sequence `reopenLinkedTasksOnThreadRun` already uses for the same reason.

Regression test: `apps/api/src/tools/task-board/rerun-closes-review-cycle.integration.test.ts` (real Postgres) opens a cycle, runs the same close-then-update sequence rerun.ts now runs, and asserts `openReviewCycleIfInProgress` can stamp a fresh boundary afterward — it would return null (no-op) without the fix.

Reviewer: `bun test apps/api/src/tools/task-board/rerun-closes-review-cycle.integration.test.ts` (needs Postgres — CI runs it; not runnable in this sandbox).

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors). Full integration/e2e suite left to CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a task-board rerun carrying over its old card's review cycle, so verdicts recorded against the superseded attempt no longer count toward the new run. `TASK_BOARD_ITEM_RERUN` now calls `closeReviewCycle` before moving the card back to In Progress, matching what `reopenLinkedTasksOnThreadRun` already does; previously the stale `review_cycle_started_at` stamp blocked a fresh cycle from opening and let the auto-merge gate and review checks treat old verdicts as valid for the new run.

- Adds a real-Postgres regression test that reproduces the close-then-update sequence and asserts a fresh cycle opens afterward.

<sup>Written for commit faf4980e16707faff4cf0e2ee92b0f9f6fafffea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

