### PR TITLE
perf(decofile): make in-commit blocks.gen.json regen cache-aware

### DIFF
--- a/apps/api/src/decofile/commit-coalescer.ts
+++ b/apps/api/src/decofile/commit-coalescer.ts
@@ -8,9 +8,13 @@ import type { GitDataClient, TreeWriteEntry } from "./github-git-data";
 import { GitHubApiError } from "./github-git-data";
 import {
   aliasPathsForKey,
+  BLOB_FETCH_CONCURRENCY,
   blockEntriesInTree,
   blocksDirPath,
+  getBlockText,
+  mapBounded,
   primeBlobCache,
+  primeMergedSnapshot,
   resolveOrCreateHead,
 } from "./read-decofile";
 
@@ -171,14 +175,19 @@ async function commitBatch(batch: Batch): Promise<string> {
     const genPath = packagePath
       ? `${packagePath}/.deco/blocks.gen.json`
       : ".deco/blocks.gen.json";
+    // Non-null after an in-commit regen, so it can prime the read cache below.
+    let genContent: string | null = null;
     if (tree.some((e) => e.type === "blob" && e.path === genPath)) {
-      const files = await Promise.all(
-        [...nextBlocks.values()].map(async (b) => ({
+      // Disk-cache-first + bounded (see getBlockText), mirroring the read path.
+      const files = await mapBounded(
+        [...nextBlocks.values()],
+        BLOB_FETCH_CONCURRENCY,
+        async (b) => ({
           stem: b.stem,
-          content: b.content ?? (await client.getBlobText(b.sha as string)),
-        })),
+          content: b.content ?? (await getBlockText(client, b.sha as string)),
+        }),
       );
-      const { decofile: genContent, skipped } = mergeBlocks(files);
+      const { decofile, skipped } = mergeBlocks(files);
       if (skipped.length > 0) {
         console.warn("decofile gen: dropped blocks that were not valid JSON", {
           repo: `${client.owner}/${client.repo}`,
@@ -187,13 +196,14 @@ async function commitBatch(batch: Batch): Promise<string> {
           blocks: skipped.map((s) => s.key),
         });
       }
-      const genBlobSha = await client.createBlob(genContent);
+      const genBlobSha = await client.createBlob(decofile);
       writes.push({
         path: genPath,
         mode: "100644",
         type: "blob",
         sha: genBlobSha,
       });
+      genContent = decofile;
     }
 
     const newTreeSha = await client.createTree(baseTreeSha, writes);
@@ -204,6 +214,16 @@ async function commitBatch(batch: Batch): Promise<string> {
     });
     try {
       await client.updateRef(branch, commitSha);
+      // The read after this save then hits the merged doc on disk (fail-open).
+      if (genContent !== null) {
+        await primeMergedSnapshot(
+          client.owner,
+          client.repo,
+          commitSha,
+          packagePath,
+          genContent,
+        );
+      }
       return commitSha;
     } catch (err) {
       // Non-fast-forward: someone else advanced the branch between our head

--- a/apps/api/src/decofile/read-decofile.ts
+++ b/apps/api/src/decofile/read-decofile.ts
@@ -59,7 +59,7 @@ export async function resolveOrCreateHead(
  * stampedes the connection pool, flakes into timeouts, and can trip GitHub's
  * secondary (abuse) rate limit. Cold reads are rare — the blob cache makes
  * every subsequent read fetch only what changed. */
-const BLOB_FETCH_CONCURRENCY = 12;
+export const BLOB_FETCH_CONCURRENCY = 12;
 
 /** Above this many cache-missing blobs, a single tarball download beats
  * per-blob API calls (rate-limit- and latency-wise). */
@@ -188,6 +188,23 @@ export function primeBlobCache(
   return putBlob(owner, repo, blobSha, content);
 }
 
+/**
+ * A block blob's text, disk-cache-first (mirrors `resolveSnapshot`'s tail
+ * fetch). Writers share this so the in-commit `blocks.gen.json` regeneration
+ * reads the warm blobs the editor's read just primed, instead of re-fetching
+ * every block from GitHub uncached. A miss fetches once and writes through.
+ */
+export async function getBlockText(
+  client: GitDataClient,
+  sha: string,
+): Promise<string> {
+  const hit = await getBlob(client.owner, client.repo, sha);
+  if (hit !== null) return hit;
+  const content = await client.getBlobText(sha);
+  await putBlob(client.owner, client.repo, sha, content);
+  return content;
+}
+
 export interface DecofileSnapshot {
   /** Branch head commit sha — the version everywhere (ETag, __draft, response). */
   sha: string;
@@ -209,6 +226,25 @@ function mergedDocSha(sha: string, packagePath: string | null): string {
   return createHash("sha1")
     .update(`${MERGED_DOC_FORMAT}:${sha}:${packagePath ?? ""}`)
     .digest("hex");
+}
+
+/**
+ * Prime the merged-doc disk cache for `(sha, packagePath)` with a document the
+ * writer already computed in-commit, so the preview read right after a save is
+ * a disk hit instead of a tree read + full re-merge. Keyed identically to
+ * `resolveSnapshot`'s own writes (same `mergedDocSha`/format), and the writer's
+ * `mergeBlocks` output is byte-for-byte what `resolveSnapshot` would produce at
+ * that sha, so a later read is served correct. Fail-open (`putMerged` never
+ * throws): a cache miss just recomputes.
+ */
+export function primeMergedSnapshot(
+  owner: string,
+  repo: string,
+  sha: string,
+  packagePath: string | null,
+  decofile: string,
+): Promise<void> {
+  return putMerged(owner, repo, mergedDocSha(sha, packagePath), decofile);
 }
 
 /** Concurrent snapshot reads of the same content share ONE resolution — this

--- a/packages/e2e/tests/decofile-api.spec.ts
+++ b/packages/e2e/tests/decofile-api.spec.ts
@@ -561,6 +561,58 @@ test.describe("decofile API", () => {
     }
   });
 
+  test("PATCH regenerates a committed blocks.gen.json from the full block set", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    try {
+      const user = await signUpViaApi(ctx);
+      const org = user.orgSlug;
+      const owner = uniqueOwner();
+      const repo = "site";
+
+      const oldHero = { __resolveType: "site/sections/Hero.tsx", title: "old" };
+      const footer = { __resolveType: "site/sections/Footer.tsx", year: 2024 };
+      await seedStubRepo(ctx, {
+        owner,
+        repo,
+        defaultBranch: "main",
+        branches: {
+          main: {
+            files: {
+              ".deco/blocks/Hero.json": blockFileContent(oldHero),
+              ".deco/blocks/Footer.json": blockFileContent(footer),
+              // Deliberately stale (no Footer, pre-edit Hero): a pass proves a full re-merge.
+              ".deco/blocks.gen.json": `${JSON.stringify({ Hero: oldHero })}\n`,
+            },
+          },
+          draft: null,
+        },
+      });
+      const project = await createFastPreviewProject(ctx, org, { owner, repo });
+      const url = decofileUrl(project, "draft");
+
+      const newHero = { __resolveType: "site/sections/Hero.tsx", title: "new" };
+      const patchRes = await ctx.patch(url, {
+        data: { set: { Hero: newHero } },
+      });
+      expect(patchRes.status()).toBe(200);
+
+      const inspected = await inspectStubRepo(ctx, owner, repo);
+      const genRaw =
+        inspected.branches["draft"]?.files[".deco/blocks.gen.json"];
+      expect(genRaw).toBeDefined();
+      const gen = JSON.parse(genRaw as string) as Record<string, unknown>;
+      // Edited Hero + untouched Footer: the stale seed was replaced, not key-patched.
+      expect(gen["Hero"]).toEqual(newHero);
+      expect(gen["Footer"]).toEqual(footer);
+      // Keys sorted by filename (Footer.json < Hero.json), matching the daemon.
+      expect(Object.keys(gen)).toEqual(["Footer", "Hero"]);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
   test("large repo whose recursive tree read truncates still reads and writes blocks", async ({
     playwright,
   }) => {


### PR DESCRIPTION
## Summary

The decofile commit path (`commit-coalescer.ts`) regenerates a committed `.deco/blocks.gen.json` **inside every save commit**. Today it re-fetches every unchanged block via `client.getBlobText` (bypassing the disk cache) in an **unbounded `Promise.all`**. On a large repo (e.g. Granado, ~325 blocks) that's hundreds of uncached GitHub round-trips per save — several seconds of latency **before the preview can even load**, since the preview reads by commit sha.

This is the general-case (option "a") counterpart to per-repo untracking of the artifact: it helps every repo that keeps `blocks.gen.json` committed.

## Change

Align the in-commit regen with the read path (`resolveSnapshot`):

1. **Read unchanged blocks disk-cache-first + bounded.** New shared `getBlockText(client, sha)` tries the disk cache before GitHub and writes through on a miss; the loop uses `mapBounded(..., BLOB_FETCH_CONCURRENCY)`. The editor's read right before a save already primed those blobs, so a same-replica save is mostly cache hits; a cold replica fetches at most `N` at a time instead of stampeding GitHub's abuse limiter (the exact reason the read path is already bounded).
2. **Prime the merged-doc cache after commit.** `primeMergedSnapshot(...)` stores the just-computed document under the new sha's merged-doc key — byte-identical to what `resolveSnapshot` produces at that sha (same `mergeBlocks`, same sort) — so the preview read immediately after a save is a **disk hit** instead of a fresh tree read + re-merge.

## Scope / tradeoff

- **Only** repos that commit `blocks.gen.json` enter the regen branch; gitignored repos (the common case) are untouched.
- Known tradeoff (option "a"): the big win is on the **warm** path (same replica, not yet LRU-evicted). A cold replica still fetches all blocks — but now bounded instead of an unbounded stampede, so it's never worse than before. The deterministic-but-riskier alternative (incremental patch of the prev gen) would break byte-identity with the daemon's canonical merge, so it was not taken here.

## Testing

- New e2e (`decofile-api.spec.ts`): seeds a repo with a **stale** committed `blocks.gen.json` (missing a block, pre-edit value), PATCHes a block, and asserts the artifact was **fully re-merged** (edited + untouched blocks, keys sorted by filename). This branch had **zero** e2e coverage before. Passing locally against the real server + GitHub stub (`1 passed (15.4s)`).
- `bun run check` (apps/api + packages/e2e) and existing decofile unit tests pass; `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up saves in repos that commit `.deco/blocks.gen.json` by making the in-commit regeneration disk-cache-first and bounded, instead of re-fetching every unchanged block from GitHub in an unbounded `Promise.all`.

- Reads unchanged blocks through the shared `getBlockText` path with `BLOB_FETCH_CONCURRENCY` concurrency, mirroring the read path.
- Primes the merged-doc cache for the new commit sha so the preview read right after a save hits disk instead of re-reading the tree and re-merging.
- Only affects repos that commit the artifact; gitignored repos are untouched.
- Adds an e2e test covering the regeneration branch, which previously had no coverage.

<sup>Written for commit f92ea9605d7e029573de4b6b07114af8894f9de2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

