### PR TITLE
refactor(decofile): remove dead getTreeRecursive method

### DIFF
--- a/apps/api/src/decofile/github-git-data.ts
+++ b/apps/api/src/decofile/github-git-data.ts
@@ -198,10 +198,9 @@ export interface GitDataClient {
    */
   getTarballStream(ref: string): Promise<ReadableStream<Uint8Array>>;
   getCommitTreeSha(commitSha: string): Promise<string>;
-  getTreeRecursive(treeSha: string): Promise<TreeEntry[]>;
   /**
    * Block-dir view of a commit's tree WITHOUT a whole-repo recursive read.
-   * `getTreeRecursive` on the root tree of a large repo trips GitHub's
+   * A whole-repo recursive read on the root tree of a large repo trips GitHub's
    * 100k-entry / 7MB recursive cap (`truncated: true` → hard 502), which broke
    * every decofile read/write on big storefronts. Instead this walks
    * `<packagePath>/.deco/` non-recursively and returns only the block sources
@@ -527,24 +526,6 @@ export function createGitDataClient(params: {
         `${repoBase}/git/commits/${commitSha}`,
       );
       return json.tree.sha;
-    },
-
-    async getTreeRecursive(treeSha) {
-      const { json } = await call<{ tree: TreeEntry[]; truncated: boolean }>(
-        "GET",
-        `${repoBase}/git/trees/${treeSha}?recursive=1`,
-      );
-      if (json.truncated) {
-        // 100k-entry / 7MB response cap. A repo this size needs pagination by
-        // subtree; fail loudly rather than serving a silently partial decofile.
-        throw new GitHubApiError(
-          502,
-          "GET",
-          `${repoBase}/git/trees/${treeSha}`,
-          "tree listing truncated by GitHub; repo too large for recursive read",
-        );
-      }
-      return json.tree;
     },
 
     async getDecofileTree(commitTreeSha, packagePath) {


### PR DESCRIPTION
**Source**: C1 (dead code) — found while auditing `apps/api/src/decofile/github-git-data.ts`, a recently-churned file (two PRs merged this week, #6691/#6694, replaced whole-repo recursive tree reads with scoped ones).

**Payoff**: `getTreeRecursive` on the `GitDataClient` interface had zero remaining callers anywhere in the repo — confirmed with `rg -n "getTreeRecursive"` across `.ts` files, which only matched the interface declaration and its own implementation before this change. It's a leftover from before `getDecofileTree`/`getBlobsAtPaths` replaced whole-repo recursive reads (the very 502-on-large-repo bug those two recent PRs fixed) — the docstring on `getDecofileTree` even explains why `getTreeRecursive` was superseded. Keeping an unused GitHub-API method around invites a future caller to reach for the slow/broken path again.

**Change**: removed the `getTreeRecursive` interface member and its implementation (the fetch call + truncation-error handling). No other code path changed — `GitHubApiError` and every other method are untouched and still used elsewhere in the file. -20/+1 lines.

**Verify**: `rg -n "getTreeRecursive"` returns nothing repo-wide (proves no orphaned callers) + `cd apps/api && bunx tsc --noEmit` (green — the interface is used at every call site via the one `createGitDataClient` implementation, so a stale member there would fail to typecheck).

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/decofile/github-git-data.ts` (0 warnings/errors). No test exercised this dead code, so there was nothing to invert; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `getTreeRecursive` method from the `GitDataClient` interface and its implementation, a leftover from before `getDecofileTree` replaced whole-repo recursive reads. The `getDecofileTree` docstring now describes the large-repo cap problem without referencing the removed method; no other code changes.

<sup>Written for commit 7dd2df750acabe9cd338af95861678fc6a803e22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

