### PR TITLE
fix(task-board): drop the reviewer-bounce line from the super agent prompt

### DIFF
--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -64,15 +64,6 @@ describe("buildClaudeCodeTaskPrompt", () => {
     expect(prompt).not.toContain("mcp__studio__TASK_BOARD_ITEM_PRS_GET");
   });
 
-  test("a reviewer bounce says to reproduce the check locally", () => {
-    const prompt = buildClaudeCodeTaskPrompt(task, repo, {
-      feedback: "view_item never fires",
-      pr: { number: 340, url: "https://github.com/acme/web/pull/340" },
-    });
-    expect(prompt).toContain("Reproduce their check LOCALLY");
-    expect(prompt).not.toContain("DEPLOYED PREVIEW");
-  });
-
   // Inverted: this used to say "move it to review anyway so a human can close
   // it out". In Review is the reviewers' lane and reviewers are only enqueued
   // for a task that HAS a PR, so a no-PR task parked there had nobody to pick

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -239,6 +239,10 @@ export function buildClaudeCodeTaskPrompt(
       "",
     );
   } else if (opts?.feedback) {
+    // Review is SINGLE-PASS (`review-decision.ts`): a `request_changes` verdict
+    // hands the card to a human and is never bounced back here. This lead only
+    // reaches a run a HUMAN re-ran on such a card, carrying the verdict's notes
+    // so the re-run continues from them (`outstandingReviewFeedback`).
     lines.push(
       opts.pr
         ? `A reviewer requested changes on pull request #${opts.pr.number} (${opts.pr.url}):`
@@ -247,7 +251,6 @@ export function buildClaudeCodeTaskPrompt(
       opts.pr
         ? `Check that branch out (\`gh pr checkout ${opts.pr.number}\`) before editing, address the feedback, then push to update the SAME pull request — do NOT open a new one.`
         : "Address this feedback.",
-      "The reviewer judged the running app, not your diff. Reproduce their check LOCALLY before you push again — a fix that only looks right in the code comes straight back.",
       "",
     );
   } else if (opts?.pr) {

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -389,11 +389,12 @@ export function approvedButUnverified(
  * The notes of the task's most recent review verdict, when that verdict asked
  * for changes — i.e. the work still outstanding on its pull request.
  *
- * This is what makes a re-run a CONTINUATION rather than a restart. A reviewer
- * bounce already carries its own notes into the re-run prompt; a human pressing
- * Re-run (or re-assigning the card to the Super Agent) carried nothing, so the
- * agent re-derived the whole task from the title and re-litigated an approach
- * the reviewer had explicitly told it to keep. Two prod cards spent five rounds
+ * This is what makes a re-run a CONTINUATION rather than a restart. Review is
+ * single-pass, so a change request is never bounced back to the Super Agent —
+ * the only way one reaches a run is a human pressing Re-run (or re-assigning
+ * the card), and that path carried nothing, so the agent re-derived the whole
+ * task from the title and re-litigated an approach the reviewer had explicitly
+ * told it to keep. Two prod cards spent five rounds
  * that way, one with a reviewer writing "a correção em si está CERTA — não
  * refaça o approach" into a run that then redid it.
  *


### PR DESCRIPTION
Stacked on #6705 — merge that one first; this branch is that PR plus one commit.

## What

Review is **single-pass**: `TASK_BOARD_REVIEW_DECISION` with `request_changes` records the verdict and calls `handTaskToHuman` — it is never bounced back to the Super Agent (the reviewer applies its own findings on the PR branch). So the prompt line telling the Super Agent how the reviewer judged its work, and to re-check before pushing again, describes a loop that no longer exists.

- Removed that sentence from the feedback lead.
- Replaced it with a comment naming where the lead *can* still come from: the `feedback` branch is now only reachable when a **human** re-runs a card whose latest verdict was `request_changes`, with the notes carried in by `outstandingReviewFeedback`.
- Fixed the same stale claim in `outstandingReviewFeedback`'s doc comment ("a reviewer bounce already carries its own notes into the re-run prompt").

The feedback branch itself stays — a human re-run on a rejected card should still see the notes.

## Testing

`bun test apps/api/src/tools/task-board/claude-code-task-run.test.ts packages/shared/src/task-board.test.ts` — 44 pass. Dropped the test that asserted the removed sentence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the reviewer-bounce guidance from the Super Agent task-board prompt. Review is single-pass — a `request_changes` verdict hands the card to a human and never returns to the agent — so the line telling the agent to reproduce the reviewer's preview check before pushing again described a loop that no longer exists. The prompt now has the agent verify the task's outcome locally in the sandbox instead of against the deploy preview.

- The feedback lead stays, but it is now reachable only when a human re-runs a card whose latest verdict was `request_changes`, with notes carried in by `outstandingReviewFeedback`.
- Updated `outstandingReviewFeedback`'s doc comment, which still claimed a reviewer bounce carries its own notes.
- Dropped the test asserting the removed preview-check behavior; the rest of the suite passes.

<sup>Written for commit 090ae8ce515367e532c907cb420b3b7e674007d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

