### PR TITLE
feat(task-board): let a card's column be one Studio did not name

### DIFF
--- a/apps/api/migrations/193-task-board-status-column-fk.ts
+++ b/apps/api/migrations/193-task-board-status-column-fk.ts
@@ -1,0 +1,62 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Make a card's `status` a reference — but only on a board that has columns to
+ * reference.
+ *
+ * `status` is free text holding either one of Studio's lanes or a key from
+ * `task_board_columns`, and nothing has been stopping it from holding neither.
+ * A card whose status names no column renders nowhere: invisible, not broken,
+ * which is the worst way for a bug to arrive.
+ *
+ * The foreign key is optional by construction. Under MATCH SIMPLE a composite
+ * key with any NULL part is not checked, so `board_column_org` NULL means "this
+ * status is one of Studio's lanes" and the constraint sleeps. Set, it equals
+ * `organization_id` and the constraint holds. That is what lets a board built
+ * from constants coexist with one built from rows, without seeding rows for
+ * every org just to satisfy a constraint.
+ *
+ * ON DELETE RESTRICT on purpose. A column removed upstream must not take the
+ * customer's cards with it (CASCADE) and cannot blank a NOT NULL status (SET
+ * NULL), so the only honest action is to refuse — which forces the sync to
+ * rescue those cards before dropping the column, instead of orphaning them
+ * quietly. The rescue is application policy; the constraint only makes
+ * skipping it impossible.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_items")
+    .addColumn("board_column_org", "text")
+    .execute();
+
+  // Belt to the FK's braces: without it the two org ids could disagree and the
+  // key would be validating a column of some other tenant's board.
+  await sql`
+    ALTER TABLE task_board_items
+      ADD CONSTRAINT chk_task_board_items_column_org
+      CHECK (board_column_org IS NULL OR board_column_org = organization_id)
+  `.execute(db);
+
+  await sql`
+    ALTER TABLE task_board_items
+      ADD CONSTRAINT task_board_items_board_column_fkey
+      FOREIGN KEY (board_column_org, status)
+      REFERENCES task_board_columns (organization_id, key)
+      ON DELETE RESTRICT
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE task_board_items
+      DROP CONSTRAINT IF EXISTS task_board_items_board_column_fkey
+  `.execute(db);
+  await sql`
+    ALTER TABLE task_board_items
+      DROP CONSTRAINT IF EXISTS chk_task_board_items_column_org
+  `.execute(db);
+  await db.schema
+    .alterTable("task_board_items")
+    .dropColumn("board_column_org")
+    .execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -191,6 +191,7 @@ import * as migration189taskboardcolumnautomations from "./189-task-board-column
 import * as migration190taskboardreviewcyclestartedat from "./190-task-board-review-cycle-started-at.ts";
 import * as migration191taskboardcolumns from "./191-task-board-columns.ts";
 import * as migration192taskboardverdictnudgeactivity from "./192-task-board-verdict-nudge-activity.ts";
+import * as migration193taskboardstatuscolumnfk from "./193-task-board-status-column-fk.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -415,6 +416,7 @@ const migrations: Record<string, Migration> = {
   "191-task-board-columns": migration191taskboardcolumns,
   "192-task-board-verdict-nudge-activity":
     migration192taskboardverdictnudgeactivity,
+  "193-task-board-status-column-fk": migration193taskboardstatuscolumnfk,
 };
 
 export default migrations;

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -110,10 +110,7 @@ function extractPartText(payload: unknown): string | null {
 /** The lanes a review cycle may span: an agent reviewer runs while the card
  *  reads In Progress, and the card sits In Review once it is a person's turn.
  *  Moving to any OTHER lane ends the cycle — see `update()`. */
-const REVIEW_PHASE_LANES = new Set<TaskBoardItemStatus>([
-  "in_progress",
-  "in_review",
-]);
+const REVIEW_PHASE_LANES = new Set<string>(["in_progress", "in_review"]);
 
 /** Thread run statuses that mean the run is over (not running / not paused on a
  *  user_ask). `requires_action` and `in_progress` are deliberately excluded. */
@@ -142,7 +139,7 @@ export const TERMINAL_THREAD_STATUSES = new Set([
  */
 export function shouldAdvanceToReview(
   item: {
-    status: TaskBoardItemStatus;
+    status: string;
     repo?: string | null;
     threads: { status: string | null; hasMessages: boolean }[];
   },
@@ -223,10 +220,7 @@ function newestIso(
 /** Lanes a merged PR can leave a card on, and therefore where the merged-tag
  *  sweep has to look. `archived` is deliberately absent: a card that far along
  *  is history, and tagging it moves nothing. */
-const TAGGABLE_MERGED_STATUSES: TaskBoardItemStatus[] = [
-  ...DELIVERY_LANES,
-  "done",
-];
+const TAGGABLE_MERGED_STATUSES: string[] = [...DELIVERY_LANES, "done"];
 
 export class TaskBoardStorage {
   constructor(private db: Kysely<Database>) {}
@@ -282,7 +276,7 @@ export class TaskBoardStorage {
     organizationId: string;
     title: string;
     description?: string | null;
-    status?: TaskBoardItemStatus;
+    status?: string;
     priority?: TaskBoardItemPriority;
     type?: TaskBoardItemType;
     assigneeId?: string | null;
@@ -362,7 +356,7 @@ export class TaskBoardStorage {
     data: {
       title?: string;
       description?: string | null;
-      status?: TaskBoardItemStatus;
+      status?: string;
       priority?: TaskBoardItemPriority;
       type?: TaskBoardItemType;
       assigneeId?: string | null;

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1626,11 +1626,9 @@ export interface TaskBoardItemTable {
   organization_id: string;
   title: string;
   description: string | null;
-  status: ColumnType<
-    TaskBoardItemStatus,
-    TaskBoardItemStatus | undefined,
-    string
-  >;
+  /** The key of the column the card sits in — free text, because on a board
+   *  whose columns are the org's own the key comes from their tracker. */
+  status: ColumnType<string, string | undefined, string>;
   priority: ColumnType<
     TaskBoardItemPriority,
     TaskBoardItemPriority | undefined,
@@ -1931,7 +1929,11 @@ export interface TaskBoardItem {
   organizationId: string;
   title: string;
   description: string | null;
-  status: TaskBoardItemStatus;
+  /** The key of the column this card sits in. A string, not the lane union:
+   *  on a board whose columns are the org's own the key comes from their
+   *  tracker. `TaskBoardItemStatus` still names Studio's OWN lanes, which is
+   *  what canonical logic reasons about. */
+  status: string;
   priority: TaskBoardItemPriority;
   /** What kind of work this is. Required; defaults to `chore`. */
   type: TaskBoardItemType;

--- a/apps/api/src/tools/jira/index.ts
+++ b/apps/api/src/tools/jira/index.ts
@@ -22,12 +22,14 @@ import {
 import { JiraClient, normalizeSiteUrl } from "@/jira/client";
 import { syncJiraIntegrationSafe } from "@/jira/sync";
 import type { OrgJiraIntegration } from "@/storage/types";
-import { TaskBoardItemStatusSchema } from "../task-board/schema";
 
 // `partialRecord`, not `record`: a `z.record` over an enum demands EVERY lane
 // be present, so an org mapping three of its columns would fail validation.
+// A plain record now that a board column is any key: `partialRecord` over a
+// closed enum was what forced every lane to be listed, and there is no closed
+// set of lanes to enumerate on a board the org owns.
 const statusMappingSchema = z
-  .partialRecord(TaskBoardItemStatusSchema, z.array(z.string()))
+  .record(z.string().min(1), z.array(z.string()))
   .describe(
     "Board status → its Jira status names, in board order. Several Jira " +
       "statuses may share a lane; the first is where a card entering that lane " +

--- a/apps/api/src/tools/task-board/board-handler.integration.test.ts
+++ b/apps/api/src/tools/task-board/board-handler.integration.test.ts
@@ -22,30 +22,33 @@ import { LANE_RANK } from "./lanes";
 
 const ORG = "org_bh_1";
 const OTHER = "org_bh_2";
+const ORG_M = "org_bh_m";
+
+let database: StudioDatabase;
+let automations: ColumnAutomationStorage;
+let boardColumns: BoardColumnStorage;
+
+/** One pool for the file. `connectTestPgDatabase` hands back a shared instance,
+ *  so a per-describe lifecycle would close it out from under the next one. */
+beforeAll(async () => {
+  database = await connectTestPgDatabase();
+  await resetTestPgDatabase(database);
+  const now = new Date().toISOString();
+  for (const id of [ORG, OTHER, ORG_M]) {
+    await database.db
+      .insertInto("organization")
+      .values({ id, name: id, slug: id.replace(/_/g, "-"), createdAt: now })
+      .execute();
+  }
+  automations = new ColumnAutomationStorage(database.db);
+  boardColumns = new BoardColumnStorage(database.db);
+});
+
+afterAll(async () => {
+  await closeTestPgDatabase(database);
+});
 
 describe("boardHandler — the board Studio ships with", () => {
-  let database: StudioDatabase;
-  let automations: ColumnAutomationStorage;
-  let boardColumns: BoardColumnStorage;
-
-  beforeAll(async () => {
-    database = await connectTestPgDatabase();
-    await resetTestPgDatabase(database);
-    const now = new Date().toISOString();
-    for (const id of [ORG, OTHER]) {
-      await database.db
-        .insertInto("organization")
-        .values({ id, name: id, slug: id.replace(/_/g, "-"), createdAt: now })
-        .execute();
-    }
-    automations = new ColumnAutomationStorage(database.db);
-    boardColumns = new BoardColumnStorage(database.db);
-  });
-
-  afterAll(async () => {
-    await closeTestPgDatabase(database);
-  });
-
   const board = (org = ORG) =>
     boardHandler(org, { automations, boardColumns, orgOwnedColumns: false });
 
@@ -122,26 +125,6 @@ describe("boardHandler — the board Studio ships with", () => {
  * out of, and the cards would look filed under lanes nobody chose.
  */
 describe("boardHandler — a board whose columns are the org's own", () => {
-  let database: StudioDatabase;
-  let automations: ColumnAutomationStorage;
-  let boardColumns: BoardColumnStorage;
-  const ORG_M = "org_bh_m";
-
-  beforeAll(async () => {
-    database = await connectTestPgDatabase();
-    const now = new Date().toISOString();
-    await database.db
-      .insertInto("organization")
-      .values({ id: ORG_M, name: ORG_M, slug: "org-bh-m", createdAt: now })
-      .execute();
-    automations = new ColumnAutomationStorage(database.db);
-    boardColumns = new BoardColumnStorage(database.db);
-  });
-
-  afterAll(async () => {
-    await closeTestPgDatabase(database);
-  });
-
   const board = () =>
     boardHandler(ORG_M, { automations, boardColumns, orgOwnedColumns: true });
 

--- a/apps/api/src/tools/task-board/board-handler.ts
+++ b/apps/api/src/tools/task-board/board-handler.ts
@@ -130,3 +130,24 @@ export async function boardFor(
     orgOwnedColumns: orgFlagEnabled(settings?.flags, "org_board_columns"),
   });
 }
+
+/**
+ * Refuse a status this board has no column for.
+ *
+ * What the closed enum used to do, moved to where the answer actually lives:
+ * only the board knows which keys are real for this org. Silence here means a
+ * card filed under a column that does not exist — it renders nowhere, which is
+ * the worst way for a bug to arrive.
+ */
+export async function assertBoardHasColumn(
+  board: BoardHandler,
+  status: string,
+): Promise<void> {
+  const columns = await board.columns();
+  if (columns.some((column) => column.key === status)) return;
+  throw new Error(
+    `This board has no column "${status}" — it has ${
+      columns.map((c) => c.key).join(", ") || "none yet"
+    }`,
+  );
+}

--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -1,3 +1,4 @@
+import { assertBoardHasColumn, boardFor } from "./board-handler";
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { getUserId, requireAuth } from "@/core/studio-context";
@@ -76,6 +77,10 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
     }
 
     if (input.status !== undefined) {
+      await assertBoardHasColumn(
+        await boardFor(ctx, organizationId),
+        input.status,
+      );
       const settings =
         await ctx.storage.organizationSettings.get(organizationId);
       if (

--- a/apps/api/src/tools/task-board/lanes.test.ts
+++ b/apps/api/src/tools/task-board/lanes.test.ts
@@ -11,10 +11,11 @@ import { DELIVERY_LANES, shippedLane } from "@decocms/shared/task-board";
 import type { TaskBoardItemStatus } from "@/storage/types";
 import {
   DELIVERY_LANE_STATUSES,
-  inReviewPhase,
   LANE_RANK,
-  movesForward,
   SHIP_ELIGIBLE_LANES,
+  inReviewPhase,
+  laneRank,
+  movesForward,
 } from "./lanes";
 
 const BOARD_ORDER: TaskBoardItemStatus[] = [
@@ -38,8 +39,8 @@ describe("LANE_RANK", () => {
 
   it("puts every delivery lane between In Review and Done", () => {
     for (const lane of DELIVERY_LANE_STATUSES) {
-      expect(LANE_RANK[lane]).toBeGreaterThan(LANE_RANK.in_review);
-      expect(LANE_RANK[lane]).toBeLessThan(LANE_RANK.done);
+      expect(laneRank(lane)).toBeGreaterThan(LANE_RANK.in_review);
+      expect(laneRank(lane)).toBeLessThan(LANE_RANK.done);
     }
   });
 

--- a/apps/api/src/tools/task-board/lanes.ts
+++ b/apps/api/src/tools/task-board/lanes.ts
@@ -27,15 +27,33 @@ const RANK_BY_KEY = Object.fromEntries(
  *  error here, which is the whole reason the table is exhaustive. */
 export const LANE_RANK: Record<TaskBoardItemStatus, number> = RANK_BY_KEY;
 
+/** Widened read of the same table. A card's status is any column key, and
+ *  indexing the closed Record would let the compiler believe every status has
+ *  a rank. */
+const RANK_LOOKUP: Record<string, number> = LANE_RANK;
+
+/**
+ * Where a status sits in Studio's own order, or null for a column Studio did
+ * not define.
+ *
+ * An org board's order is its columns' positions, not this table, so null is
+ * the honest answer rather than a guessed rank — and callers decide what an
+ * unrankable status means for them, instead of silently comparing against a
+ * number that was invented.
+ */
+export function laneRank(status: string): number | null {
+  return RANK_LOOKUP[status] ?? null;
+}
+
 /** The delivery lanes, as board statuses — the assertion that the shared
  *  literal union stays a subset of this side's lane vocabulary. */
-export const DELIVERY_LANE_STATUSES: TaskBoardItemStatus[] = DELIVERY_LANES;
+export const DELIVERY_LANE_STATUSES: string[] = DELIVERY_LANES;
 
 /** True for one of the post-merge delivery lanes (Approved, Merged, Post-deploy
  *  Validation) — the statuses that only exist for an org running
  *  `delivery_lanes_enabled`. Mirrors the web-side `isDeliveryLane` in
  *  `layouts/task-board/config.tsx`. */
-export function isDeliveryLane(status: TaskBoardItemStatus): boolean {
+export function isDeliveryLane(status: string): boolean {
   return DELIVERY_LANE_STATUSES.includes(status);
 }
 
@@ -47,11 +65,14 @@ export function isDeliveryLane(status: TaskBoardItemStatus): boolean {
  * enumeration is correct only for the lanes that existed when it was written,
  * so adding one silently turns it into a path that drags cards BACKWARD.
  */
-export function movesForward(
-  from: TaskBoardItemStatus,
-  to: TaskBoardItemStatus,
-): boolean {
-  return LANE_RANK[to] > LANE_RANK[from];
+export function movesForward(from: string, to: string): boolean {
+  const before = laneRank(from);
+  const after = laneRank(to);
+  // Either side unrankable means one of them is a column Studio did not
+  // define. There is no order to be forward in, so the guard abstains rather
+  // than inventing one.
+  if (before === null || after === null) return true;
+  return after > before;
 }
 
 /**
@@ -60,7 +81,7 @@ export function movesForward(
  * Without Approved, moving a card into it would lock the ship button out — the
  * lane would be a dead end.
  */
-export const SHIP_ELIGIBLE_LANES: ReadonlySet<TaskBoardItemStatus> = new Set([
+export const SHIP_ELIGIBLE_LANES: ReadonlySet<string> = new Set([
   "in_review",
   "approved",
 ]);
@@ -71,7 +92,7 @@ export const SHIP_ELIGIBLE_LANES: ReadonlySet<TaskBoardItemStatus> = new Set([
  * candidate query and the re-read inside the org's context have to agree, or
  * the sweep picks cards it then refuses.
  */
-export function isTaggableMergedStatus(status: TaskBoardItemStatus): boolean {
+export function isTaggableMergedStatus(status: string): boolean {
   return status === "done" || DELIVERY_LANE_STATUSES.includes(status);
 }
 
@@ -90,10 +111,13 @@ export function isTaggableMergedStatus(status: TaskBoardItemStatus): boolean {
  * can never drag a merged card back into the sweeper's work.
  */
 export function inReviewPhase(item: {
-  status: TaskBoardItemStatus;
+  status: string;
   reviewCycleStartedAt: string | null;
 }): boolean {
-  if (LANE_RANK[item.status] > LANE_RANK.in_review) return false;
+  const rank = laneRank(item.status);
+  // A column Studio did not define has no place in this order, so the rank
+  // bound simply does not apply to it.
+  if (rank !== null && rank > LANE_RANK.in_review) return false;
   // Truthiness, not `!== null`: an absent stamp must read as "no cycle", and
   // a partial item (a fixture, a projection) carries `undefined`, not `null`.
   return item.status === "in_review" || Boolean(item.reviewCycleStartedAt);

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -19,14 +19,14 @@ import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import type { StudioContext } from "@/core/studio-context";
 import { resolveTier } from "@/core/resolve-tier";
 import type { TaskBoardStorage } from "@/storage/task-board";
-import type { TaskBoardItem, TaskBoardItemStatus } from "@/storage/types";
+import type { TaskBoardItem } from "@/storage/types";
 import { extractPrFromValue, type ExtractedPr } from "./pr-extract";
 import { resolveRunTaskTargets, emitTaskBoardUpdated } from "./run-reactions";
 
 /** Statuses from which a PR-open may put a card into the review phase. Terminal
  *  lanes (and in_review itself) are left alone so a re-opened PR never regresses
  *  a finished card. */
-const ADVANCEABLE: ReadonlySet<TaskBoardItemStatus> = new Set([
+const ADVANCEABLE: ReadonlySet<string> = new Set([
   "triage",
   "todo",
   "in_progress",

--- a/apps/api/src/tools/task-board/reports-task-guards.integration.test.ts
+++ b/apps/api/src/tools/task-board/reports-task-guards.integration.test.ts
@@ -6,6 +6,9 @@
  * explicit config, since the tool reads frozen global settings.
  */
 
+import { OrganizationSettingsStorage } from "@/storage/organization-settings";
+import { ColumnAutomationStorage } from "@/storage/task-board-column-automations";
+import { BoardColumnStorage } from "@/storage/task-board-columns";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { sql } from "kysely";
 import type { StudioContext } from "../../core/studio-context";
@@ -60,6 +63,11 @@ describe("reports-task guards", () => {
       storage: {
         taskBoard,
         organizationBilling: new OrganizationBillingStorage(database.db),
+        // A write now asks the board which columns it has, and the board asks
+        // the org which one it is.
+        organizationSettings: new OrganizationSettingsStorage(database.db),
+        columnAutomations: new ColumnAutomationStorage(database.db),
+        boardColumns: new BoardColumnStorage(database.db),
       },
       access: {
         granted: () => true,

--- a/apps/api/src/tools/task-board/rerun.ts
+++ b/apps/api/src/tools/task-board/rerun.ts
@@ -43,7 +43,6 @@ import {
   SUPER_AGENT_ASSIGNEE_ID,
 } from "@decocms/shared/task-board";
 import { TERMINAL_THREAD_STATUSES } from "@/storage/task-board";
-import type { TaskBoardItemStatus } from "@/storage/types";
 import { inReviewPhase } from "./lanes";
 import { broadcastRunCancel } from "@/api/routes/decopilot/cancel-registry";
 import { cancelHostedHarness } from "@/dispatch-queue";
@@ -254,7 +253,7 @@ export async function refuseIfMergePending(
   ctx: StudioContext,
   item: {
     id: string;
-    status: TaskBoardItemStatus;
+    status: string;
     organizationId: string;
     reviewCycleStartedAt: string | null;
   },

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -42,9 +42,9 @@ import {
   TASK_BOARD_ITEM_UPDATED_EVENT,
 } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
-import { inReviewPhase, LANE_RANK } from "./lanes";
+import { LANE_RANK, inReviewPhase, laneRank } from "./lanes";
 import type { TaskBoardStorage } from "@/storage/task-board";
-import type { TaskBoardItem, TaskBoardItemStatus } from "@/storage/types";
+import type { TaskBoardItem } from "@/storage/types";
 
 /** Run-lifecycle funnel events (auto-fix leg of the PLG funnel). System
  *  actions with no acting user — org identity, person processing off.
@@ -146,7 +146,7 @@ export async function resolveRunTaskTargets(
  */
 export async function advanceTaskBoardForRun(
   ctx: StudioContext,
-  status: TaskBoardItemStatus,
+  status: string,
   threadId?: string,
 ): Promise<void> {
   const orgId = ctx.organization?.id;
@@ -157,9 +157,12 @@ export async function advanceTaskBoardForRun(
       // ponytail: read-then-write rank guard. A single run's transitions are
       // sequential, so the race window is negligible; it buys idempotency (a
       // repeated PR tool call, or in_progress re-fired on a DBOS retry, won't
-      // regress a card that's already further along). Upgrade to a conditional
-      // UPDATE ... WHERE status-rank < new-rank only if concurrency ever bites.
-      if (!current || LANE_RANK[status] <= LANE_RANK[current.status]) continue;
+      // regress a card that's already further along). A status with no rank is
+      // a column Studio did not define, and inventing an order for someone
+      // else's columns would be worse than not guarding.
+      const to = laneRank(status);
+      const from = laneRank(current?.status ?? "");
+      if (!current || (to !== null && from !== null && to <= from)) continue;
       const item = await ctx.storage.taskBoard.update(
         itemId,
         orgId,
@@ -316,11 +319,11 @@ export async function advanceTasksToReviewOnThreadFinish(
  * lost stream as a plain failure.
  */
 function cardDelivered(item: {
-  status: TaskBoardItemStatus;
+  status: string;
   reviewCycleStartedAt: string | null;
 }): boolean {
   return (
-    LANE_RANK[item.status] >= LANE_RANK.in_review ||
+    (laneRank(item.status) ?? -1) >= LANE_RANK.in_review ||
     Boolean(item.reviewCycleStartedAt)
   );
 }

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -20,17 +20,16 @@ export const MAX_TASK_REPO_LENGTH = 200;
  *  same reasoning as MAX_TASK_DESCRIPTION_LENGTH. */
 export const MAX_AUTOMATION_PROMPT_LENGTH = 50_000;
 
-export const TaskBoardItemStatusSchema = z.enum([
-  "triage",
-  "todo",
-  "in_progress",
-  "in_review",
-  "approved",
-  "merged",
-  "post_deploy_validation",
-  "done",
-  "archived",
-]);
+/**
+ * A card's column, by key.
+ *
+ * Not an enum: on a board whose columns are the org's own the keys come from
+ * their tracker, and a closed union would reject the only values that board
+ * has. What an enum used to guarantee is now the board's job — see
+ * `assertBoardHasColumn` — because only the board knows which keys are real
+ * for the org making the call.
+ */
+export const TaskBoardItemStatusSchema = z.string().min(1);
 
 /**
  * A sprint cards can belong to — mirrored from the tracker the board syncs

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -1,12 +1,9 @@
+import { assertBoardHasColumn, boardFor } from "./board-handler";
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { getUserId, requireAuth } from "@/core/studio-context";
 import { orgFlagEnabled } from "@decocms/shared/organization/schema";
-import type {
-  TaskBoardActivityAction,
-  TaskBoardItem,
-  TaskBoardItemStatus,
-} from "@/storage/types";
+import type { TaskBoardActivityAction, TaskBoardItem } from "@/storage/types";
 import {
   MAX_TASK_DESCRIPTION_LENGTH,
   MAX_TASK_REPO_LENGTH,
@@ -145,7 +142,7 @@ export function delegatesToSuperAgent(
  *  review just as effectively as completing it does. The delivery lanes count
  *  too: they sit past In Review, so a run setting `merged` would escape this
  *  guard and drop the card out of `listItemsPendingReview`. */
-const REVIEW_CLOSING_STATUSES = new Set<TaskBoardItemStatus>([
+const REVIEW_CLOSING_STATUSES = new Set<string>([
   "approved",
   "merged",
   "post_deploy_validation",
@@ -156,10 +153,8 @@ const REVIEW_CLOSING_STATUSES = new Set<TaskBoardItemStatus>([
 /** `task-run-context` withholds REVIEW_DECISION and PROMOTE_TO_PRODUCTION for this
  *  invariant; this tool sets `status` freely, so it needs the same guard. */
 export function closesOwnReview(
-  inputStatus: TaskBoardItemStatus | undefined,
-  previous:
-    | { status: TaskBoardItemStatus; reviewCycleStartedAt: string | null }
-    | undefined,
+  inputStatus: string | undefined,
+  previous: { status: string; reviewCycleStartedAt: string | null } | undefined,
   isTaskRun: boolean,
 ): boolean {
   const completesTask =
@@ -183,7 +178,7 @@ export function closesOwnReview(
  * gate the UI's own drag/dropdown, not the tool underneath them.
  */
 export function rejectsUngatedDeliveryLane(
-  inputStatus: TaskBoardItemStatus | undefined,
+  inputStatus: string | undefined,
   deliveryLanesEnabled: boolean,
 ): boolean {
   return (
@@ -294,6 +289,13 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     // longer org-scoped itself (the join table has no organization_id).
     if (hasFieldUpdate && !previous) {
       throw new Error(`Task board item not found: ${input.id}`);
+    }
+
+    if (input.status !== undefined) {
+      await assertBoardHasColumn(
+        await boardFor(ctx, organizationId),
+        input.status,
+      );
     }
 
     if (input.status !== undefined && isDeliveryLane(input.status)) {

--- a/apps/web/src/components/home/home-tasks.tsx
+++ b/apps/web/src/components/home/home-tasks.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/hooks/use-task-board-items";
 import {
   PRIORITY_CONFIG,
-  STATUS_CONFIG,
+  laneVisual,
   type TaskBoardItem,
   type TaskBoardItemStatus,
 } from "@/layouts/task-board/config";
@@ -56,7 +56,7 @@ function TaskRow({
   assignee?: OrgMember;
   onOpen: () => void;
 }) {
-  const statusConfig = STATUS_CONFIG[task.status];
+  const statusConfig = laneVisual(task.status);
   const StatusIcon = statusConfig.icon;
   const priority = PRIORITY_CONFIG[task.priority];
   const assigneeName =

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -1,3 +1,4 @@
+import type { CanonicalColumnKey } from "@decocms/shared/task-board";
 import {
   AlertCircle,
   AlertOctagon,
@@ -143,7 +144,7 @@ export function cardNeedsAttention(item: TaskBoardItem): boolean {
 export function statusIconClassName(item: TaskBoardItem): string {
   return item.status === "in_progress" && isTaskBlocked(item)
     ? "text-warning animate-pulse"
-    : STATUS_CONFIG[item.status].iconClassName;
+    : laneVisual(item.status).iconClassName;
 }
 
 /**
@@ -231,8 +232,11 @@ export const STATUSES: TaskBoardItemStatus[] = [
  */
 export const HIDDEN_STATUSES: TaskBoardItemStatus[] = ["archived"];
 
+/** Keyed by Studio's OWN lanes, not by a card's status. Exhaustive on purpose:
+ *  adding a lane is a compile error here. A card's status is any column key,
+ *  which is what `laneVisual` and `laneLabel` are for. */
 export const STATUS_CONFIG: Record<
-  TaskBoardItemStatus,
+  CanonicalColumnKey,
   { labelKey: TranslationKey; icon: typeof Circle; iconClassName: string }
 > = {
   triage: {
@@ -281,6 +285,46 @@ export const STATUS_CONFIG: Record<
     iconClassName: "text-muted-foreground",
   },
 };
+
+/** What a lane looks like, for a status we may not recognise. */
+export type LaneVisual = {
+  icon: typeof Circle;
+  iconClassName: string;
+};
+
+/** Neutral stand-in for a column Studio did not name. An org board's columns
+ *  come from its tracker, so there is no icon of ours and no translation. */
+const UNKNOWN_LANE: LaneVisual = {
+  icon: Circle,
+  iconClassName: "text-muted-foreground",
+};
+
+/** Widened on purpose. `STATUS_CONFIG` is exhaustive over Studio's own lanes —
+ *  that is what makes adding one a compile error — but a card's status is any
+ *  column key, and indexing the closed Record would let the compiler believe
+ *  every lookup hits. */
+const LANE_VISUALS: Record<string, LaneVisual> = STATUS_CONFIG;
+
+export function laneVisual(status: string): LaneVisual {
+  return LANE_VISUALS[status] ?? UNKNOWN_LANE;
+}
+
+/**
+ * What to call a lane.
+ *
+ * Studio's own lanes are translated; a column mirrored from a tracker is
+ * called whatever that tracker calls it, which is not ours to translate. Pass
+ * `title` when the board read gave you one — callers without it get the raw
+ * key, which is still the name the team uses.
+ */
+export function laneLabel(
+  status: string,
+  t: (key: TranslationKey) => string,
+  title?: string,
+): string {
+  const known = STATUS_CONFIG[status as keyof typeof STATUS_CONFIG];
+  return known ? t(known.labelKey) : (title ?? status);
+}
 
 export const TASK_TYPES: TaskBoardItemType[] = [
   "bug",

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -116,7 +116,8 @@ import {
   PRIORITY_CONFIG,
   runSortOrders,
   statusIconClassName,
-  STATUS_CONFIG,
+  laneLabel,
+  laneVisual,
   STATUSES,
   SUPER_AGENT_ASSIGNEE_ID,
   tagDotColor,
@@ -1650,7 +1651,7 @@ function SelectionBar({
                     key={status}
                     onClick={() => onMoveTo(status)}
                   >
-                    {t(STATUS_CONFIG[status].labelKey)}
+                    {laneLabel(status, t)}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuSubContent>
@@ -2210,7 +2211,7 @@ function HiddenLanes({
       </summary>
       <div className="flex flex-col gap-2 px-1 pt-1">
         {statuses.map((status) => {
-          const config = STATUS_CONFIG[status];
+          const config = laneVisual(status);
           const LaneIcon = config.icon;
           return (
             <div
@@ -2223,7 +2224,7 @@ function HiddenLanes({
                 className={cn("shrink-0", config.iconClassName)}
               />
               <span className="text-sm font-medium text-foreground">
-                {t(config.labelKey)}
+                {laneLabel(status, t)}
               </span>
               <span className="ml-auto text-[11px] font-medium text-muted-foreground">
                 {countOf(status)}
@@ -2233,7 +2234,7 @@ function HiddenLanes({
                   <button
                     type="button"
                     aria-label={t("taskBoard.taskBoard.laneMenuAriaLabel", {
-                      lane: t(config.labelKey),
+                      lane: laneLabel(status, t),
                     })}
                     className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                   >
@@ -2299,7 +2300,7 @@ function Lane({
   onHide?: () => void;
 }) {
   const t = useT();
-  const config = STATUS_CONFIG[status];
+  const config = laneVisual(status);
   const LaneIcon = config.icon;
   // The lane's own droppable covers the empty space below the last card, so an
   // empty lane (and the area past the end of a short one) still takes a drop.
@@ -2339,7 +2340,7 @@ function Lane({
           )}
         />
         <span className="text-sm font-medium text-foreground">
-          {t(config.labelKey)}
+          {laneLabel(status, t)}
         </span>
         <span className="rounded-md bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
           {items.length}
@@ -2349,7 +2350,7 @@ function Lane({
             <button
               type="button"
               aria-label={t("taskBoard.taskBoard.laneMenuAriaLabel", {
-                lane: t(config.labelKey),
+                lane: laneLabel(status, t),
               })}
               className="ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
@@ -2370,10 +2371,10 @@ function Lane({
         <button
           type="button"
           aria-label={t("taskBoard.taskBoard.newTaskInLaneAriaLabel", {
-            lane: t(config.labelKey),
+            lane: laneLabel(status, t),
           })}
           title={t("taskBoard.taskBoard.newTaskInLaneTitle", {
-            lane: t(config.labelKey),
+            lane: laneLabel(status, t),
           })}
           onClick={() => onCreate(status)}
           className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
@@ -2651,7 +2652,7 @@ function ListRow({
   assignedBy?: Member;
   onOpen: () => void;
 }) {
-  const StatusIcon = STATUS_CONFIG[item.status].icon;
+  const StatusIcon = laneVisual(item.status).icon;
   const sprint = useCardSprint(item);
   return (
     <button

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -88,6 +88,8 @@ import {
   TASK_TYPES,
   type TaskBoardItemType,
   DEFAULT_TASK_TYPE,
+  laneLabel,
+  laneVisual,
   STATUS_CONFIG,
   moveTargets,
   statusIconClassName,
@@ -613,7 +615,7 @@ function TaskBoardItemEditor({
   const assignedBy = item?.assignedBy
     ? members.find((m) => m.userId === item.assignedBy)
     : undefined;
-  const StatusIcon = STATUS_CONFIG[status].icon;
+  const StatusIcon = laneVisual(status).icon;
   // Reports-generated tasks: content (title/description/priority) is owned by
   // the reports sync, which refreshes it on open items — TASK_BOARD_ITEM_UPDATE
   // rejects a write that touches any of those fields. Board interactions
@@ -963,15 +965,15 @@ function TaskBoardItemEditor({
                       className={cn(
                         item
                           ? statusIconClassName({ ...item, status })
-                          : STATUS_CONFIG[status].iconClassName,
+                          : laneVisual(status).iconClassName,
                       )}
                     />
-                    {t(STATUS_CONFIG[status].labelKey)}
+                    {laneLabel(status, t)}
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" className="w-44">
                   {moveTargets(deliveryEnabled).map((s) => {
-                    const Icon = STATUS_CONFIG[s].icon;
+                    const Icon = laneVisual(s).icon;
                     return (
                       <DropdownMenuItem
                         key={s}
@@ -980,9 +982,9 @@ function TaskBoardItemEditor({
                       >
                         <Icon
                           size={16}
-                          className={STATUS_CONFIG[s].iconClassName}
+                          className={laneVisual(s).iconClassName}
                         />
-                        {t(STATUS_CONFIG[s].labelKey)}
+                        {laneLabel(s, t)}
                       </DropdownMenuItem>
                     );
                   })}


### PR DESCRIPTION
## What is this contribution about?

Four pieces that only work together, which is why they are one PR:

1. `status` stops being a closed enum on the wire
2. the **board** says which keys are real
3. an **optional foreign key** holds that on the boards that have rows
4. the client stops assuming it knows every column

**The enum was the validation.** Dropping it without a replacement is a hole; keeping it makes an org-owned board impossible, since its keys come from the org's tracker and the union rejects exactly those. So the check moves to where the answer lives — only the board knows which keys are real for the org making the call.

### The foreign key, which I got wrong twice

I argued a FK was impossible, then that every `ON DELETE` action was wrong. @viktormarinho pushed back both times and was right. Under `MATCH SIMPLE` a composite key with a NULL part is not checked, so the constraint can be optional:

```sql
board_column_org text NULL,
FOREIGN KEY (board_column_org, status)
  REFERENCES task_board_columns (organization_id, key) ON DELETE RESTRICT,
CHECK (board_column_org IS NULL OR board_column_org = organization_id)
```

Null means "this status is one of Studio's lanes" and the key sleeps. Set, it equals `organization_id` and the key holds. That is what lets a board built from constants coexist with one built from rows **without seeding rows for every org**.

And `RESTRICT` is the right action, not a bad one: it refuses to drop a column that still has cards, which makes the orphan **impossible** instead of improbable and forces the sync to rescue those cards rather than stranding them.

### What stayed closed

`TaskBoardItemStatus` still names Studio's **own** lanes. `LANE_RANK` and `STATUS_CONFIG` stay keyed by it, so both stay exhaustive and adding a lane is still a compile error — the guarantee added in #6682 survives. What widened is the *card's* `status`, which is any column key.

Widening it is what made the compiler find **all 32 sites** that assumed otherwise. Each needed a decision, not a cast:

- **`laneRank(status)` returns null** for a column Studio did not define, and every caller says what that means for it.
- **`movesForward` abstains** when either side is unrankable. An org board's order is its columns' positions, not Studio's table, and inventing one for someone else's columns would be worse than not guarding.
- **`inReviewPhase`'s rank bound** simply does not apply to a column outside the order.
- Web: `laneVisual` / `laneLabel` resolve with a fallback, so an unknown key renders neutral instead of throwing on `STATUS_CONFIG[...].icon`.

## How did you verify your code works?

**The foreign key, against real Postgres** — six properties, because this is the piece I had reasoned about wrongly twice and would not trust an argument for:

```
static board (discriminator NULL), canonical status  → OK       key sleeps
org board, column does not exist                     → REJECTED
org board, column exists                             → OK
discriminator naming another org                     → REJECTED (CHECK)
delete a column with a card in it                    → REJECTED (RESTRICT)
delete an empty column                               → OK
```

**The suites**: 4177 pass / 72 fail across `apps/api/src` and the board's web tests — **identical with and without this change**, measured by stashing and re-running. Those 72 are pre-existing order-dependent failures at that scope. `bun run check` 0 errors, `bun run lint` 19 warnings at baseline, `knip` clean, `fmt:check` clean.

One test needed fixing rather than working around: `reports-task-guards.integration.test.ts` built a context without `organizationSettings`, and a write now asks the board which columns it has. I gave the test the storage instead of moving the check later to dodge it.

**Not verified, flagging honestly:**

- **Nothing writes `board_column_org`.** No org board has cards until the sync mirrors its columns, so the constraint ships ready and asleep. The proof it works is the probe above, not production traffic.
- **The client still renders Studio's lanes.** It now *tolerates* an unknown key, but it does not yet render the column set the board read returns. Turning the flag on still shows canonical lanes. That is the next piece, and it is the one that makes any of this visible.
- **No test covers `assertBoardHasColumn` rejecting.** It runs on every create and update, so the happy path is exercised everywhere; the rejection is not, because with the flag off every canonical key is valid. It becomes testable when an org board can hold cards.
- **The `RESTRICT`-forces-rescue obligation is unimplemented.** When the sync starts mirroring, removing a column upstream will fail the delete until the cards in it are moved. If I write that sync without the rescue, it breaks in production the first time someone tidies their Jira board. Writing it down here so it is not a surprise.

## Screenshots/Demonstration

Not applicable — no visible change. `org_board_columns` is off everywhere.

## How to Test

1. Everything behaves as before: create and move cards across the canonical lanes.
2. `TASK_BOARD_ITEM_UPDATE { status: "not_a_column" }` should be refused, naming the columns the board does have — previously the enum refused it, now the board does.
3. Confirm the board renders and the lane menus read correctly (they go through `laneLabel` now).

## Migration Notes

Migration 192 adds a nullable `board_column_org`, a CHECK, and the composite FK. Nothing is backfilled and no existing row changes, so it is safe in both directions on a rolling deploy.

`TaskBoardItemStatusSchema` is now `z.string().min(1)`; the generated `tool-io.ts` widens `status` from a union to `string`. Callers that switched exhaustively on it will need a default — none in this repo do.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets a task card's status be any column key instead of Studio's closed lane enum, so a board whose columns come from the org's tracker can hold cards. Validation moves from the schema enum to the board: creates and updates now reject keys the board has no column for, and an optional composite foreign key (NULL `board_column_org` skips the check under `MATCH SIMPLE`) keeps board-owned rows honest. Widening the card's `status` to a string also let the compiler find all the sites that assumed a known lane; `laneRank` returns null for unknown keys, and the web UI renders a neutral fallback instead of throwing. The board-handler integration test now shares one database pool across both describes, fixing the CI failure where closing it in the first describe destroyed it for the second.

**Migration**
- Migration 193 adds a nullable `board_column_org`, a CHECK tying it to `organization_id`, and a composite FK with `ON DELETE RESTRICT`; nothing is backfilled and both directions are safe on a rolling deploy.
- `TaskBoardItemStatusSchema` is now `z.string().min(1)`; callers that switch exhaustively on it need a default (none in this repo do).

**Known gaps**
- Nothing writes `board_column_org` yet, since no org board has cards until the sync mirrors its columns.
- The web client tolerates an unknown lane but still renders Studio's canonical lanes.
- `ON DELETE RESTRICT` will force the future sync to rescue a column's cards before dropping it upstream; that rescue is not implemented yet.

<sup>Written for commit 511c66b651172c65dacd002909acba692b35a48f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

