### PR TITLE
refactor(database): replace any with unknown/Database in DATABASES_RUN_SQL

### DIFF
--- a/apps/api/src/tools/database/index.ts
+++ b/apps/api/src/tools/database/index.ts
@@ -3,6 +3,7 @@ import type { Kysely } from "kysely";
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth } from "../../core/studio-context";
+import type { Database } from "../../storage/types";
 
 const QueryResult = z.object({
   results: z.array(z.unknown()).optional(),
@@ -13,7 +14,7 @@ const QueryResult = z.object({
  * Safely escape and quote SQL values
  * This is still not as safe as parameterized queries, but better than raw replacement
  */
-function escapeSqlValue(value: any): string {
+function escapeSqlValue(value: unknown): string {
   if (value === null || value === undefined) {
     return "NULL";
   }
@@ -46,7 +47,7 @@ function escapeSqlValue(value: any): string {
  * IMPORTANT: We find all placeholder positions FIRST, then replace from end to start.
  * This prevents ? characters inside interpolated values from being treated as placeholders.
  */
-function interpolateParams(sql: string, params: any[]): string {
+function interpolateParams(sql: string, params: unknown[]): string {
   // First, handle $1, $2, etc. style placeholders (unambiguous)
   let result = sql;
   for (let i = params.length; i >= 1; i--) {
@@ -84,7 +85,7 @@ export type QueryResult = z.infer<typeof QueryResult>;
 const DatatabasesRunSqlInputSchema = z.object({
   sql: z.string().describe("The SQL query to run"),
   params: z
-    .array(z.any())
+    .array(z.unknown())
     .describe("The parameters to pass to the SQL query")
     .optional(),
 });
@@ -127,7 +128,7 @@ function isRoleOrSchemaNotFoundError(error: unknown): boolean {
  * - Revokes access to public schema for this role
  */
 async function createSchemaAndRole(
-  db: Kysely<any>,
+  db: Kysely<Database>,
   schemaName: string,
   roleName: string,
 ): Promise<void> {
@@ -178,11 +179,11 @@ async function createSchemaAndRole(
  * settings are automatically reset, preventing cross-request leakage.
  */
 async function executeWithIsolation(
-  db: Kysely<any>,
+  db: Kysely<Database>,
   schemaName: string,
   roleName: string,
   sqlQuery: string,
-): Promise<any> {
+): Promise<unknown> {
   try {
     // Use a transaction with SET LOCAL for concurrency-safe isolation
     // SET LOCAL only affects the current transaction - no leakage to other requests


### PR DESCRIPTION
C-DEBT: `apps/api/src/tools/database/index.ts` (the `DATABASES_RUN_SQL` tool) hand-typed `escapeSqlValue`/`interpolateParams` params as `any`, and `createSchemaAndRole`/`executeWithIsolation` took `db: Kysely<any>` — all on a path that starts from a user-supplied tool input (`params: z.array(z.any())` in the input schema too).

Why it's worth it: this is exactly the reinvented-type-safety debt category CI doesn't catch (`no-explicit-any` is warn-level) — an `any` here means a future refactor of the params shape or of `ctx.db`'s schema silently compiles even if it breaks this tool, since nothing here is checked against the real types.

What changed, no behavior change:
- `escapeSqlValue(value: any)` -> `escapeSqlValue(value: unknown)` — every branch already narrows with `typeof`/`instanceof` before using the value, so `unknown` type-checks as-is.
- `interpolateParams(sql, params: any[])` -> `params: unknown[]`, and the Zod input schema's `z.array(z.any())` -> `z.array(z.unknown())` to match.
- `createSchemaAndRole`/`executeWithIsolation`'s `db: Kysely<any>` -> `db: Kysely<Database>` (the same type `ctx.db` already has at the call site in `studio-context.ts`), and `executeWithIsolation`'s `Promise<any>` return -> `Promise<unknown>` (the caller already casts the result with `as { rows: unknown[] }`).

How I confirmed behavior is unchanged: every `any` was already used narrowly (typeof checks, or passed straight into Kysely's `sql`/`sql.id`/`sql.raw` helpers, which don't care about the schema type param). `bunx tsc --noEmit` in `apps/api` is clean with no other errors introduced.

Command a reviewer runs to confirm: `cd apps/api && bunx tsc --noEmit`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/tools/database/index.ts` (0 warnings/errors). No existing test file for this module (pure type change, no logic touched), so full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces `any` with `unknown`/`Database` in the `DATABASES_RUN_SQL` tool to close a type‑safety gap on a user‑facing path, without changing behavior. The SQL value helpers now accept `unknown` (they already narrow via `typeof`/`instanceof`), and `createSchemaAndRole`/`executeWithIsolation` now take `Kysely<Database>` to match the existing caller type. The parameter input schema also moves from `z.array(z.any())` to `z.array(z.unknown())`. Verified with `bunx tsc --noEmit` in `apps/api`.

<sup>Written for commit a59bae38f9d928ea8f8c01b89e0a23321d1d5075. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

