### PR TITLE
fix(database): stop re-scanning substituted SQL for placeholders

### DIFF
--- a/apps/api/src/tools/database/index.test.ts
+++ b/apps/api/src/tools/database/index.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { interpolateParams } from "./index";
+
+describe("interpolateParams", () => {
+  test("does not splice a ? found inside an already-substituted $-style value", () => {
+    const result = interpolateParams("SELECT * FROM t WHERE a = $1 AND b = ?", [
+      "a question: ?",
+      "value2",
+    ]);
+    expect(result).toBe(
+      "SELECT * FROM t WHERE a = 'a question: ?' AND b = 'a question: ?'",
+    );
+  });
+
+  test("keeps a literal $1 inside an escaped $-style value intact", () => {
+    const result = interpolateParams("SELECT $1, $2", ["cost is $1", "ok"]);
+    expect(result).toBe("SELECT 'cost is $1', 'ok'");
+  });
+
+  test("substitutes repeated ? placeholders positionally", () => {
+    const result = interpolateParams("a = ? AND b = ?", [1, "two"]);
+    expect(result).toBe("a = 1 AND b = 'two'");
+  });
+
+  test("leaves an out-of-range $N placeholder untouched", () => {
+    const result = interpolateParams("a = $1 AND b = $2", ["x"]);
+    expect(result).toBe("a = 'x' AND b = $2");
+  });
+});

--- a/apps/api/src/tools/database/index.ts
+++ b/apps/api/src/tools/database/index.ts
@@ -42,41 +42,35 @@ function escapeSqlValue(value: unknown): string {
 }
 
 /**
- * Replace ALL placeholders (?, $1, $2, etc.) with escaped values
+ * Replace ALL placeholders (?, $1, $2, etc.) with escaped values.
  *
- * IMPORTANT: We find all placeholder positions FIRST, then replace from end to start.
- * This prevents ? characters inside interpolated values from being treated as placeholders.
+ * Walks the ORIGINAL sql string once, left to right, and only ever appends
+ * escaped values to the output — it never re-scans text it already produced.
+ * A prior version substituted placeholders in separate passes over a `result`
+ * string that grew with each pass; an escaped param containing a literal `?`
+ * or `$1` (e.g. a string param holding "a?b") was then picked up as a REAL
+ * placeholder by a later pass and substituted again, corrupting the query.
  */
-function interpolateParams(sql: string, params: unknown[]): string {
-  // First, handle $1, $2, etc. style placeholders (unambiguous)
-  let result = sql;
-  for (let i = params.length; i >= 1; i--) {
-    const placeholder = `$${i}`;
-    if (result.includes(placeholder)) {
-      result = result.replaceAll(placeholder, escapeSqlValue(params[i - 1]));
+export function interpolateParams(sql: string, params: unknown[]): string {
+  let result = "";
+  let questionMarkIndex = 0;
+  for (let i = 0; i < sql.length; i++) {
+    const char = sql[i];
+    if (char === "$") {
+      const match = /^\$(\d+)/.exec(sql.slice(i));
+      const paramIndex = match ? Number(match[1]) - 1 : -1;
+      if (match && paramIndex >= 0 && paramIndex < params.length) {
+        result += escapeSqlValue(params[paramIndex]);
+        i += match[0].length - 1;
+        continue;
+      }
+    } else if (char === "?" && questionMarkIndex < params.length) {
+      result += escapeSqlValue(params[questionMarkIndex]);
+      questionMarkIndex++;
+      continue;
     }
+    result += char;
   }
-
-  // For ? placeholders, find all positions FIRST, then replace from end to start
-  // This prevents ? inside interpolated values from being matched
-  const questionMarkPositions: number[] = [];
-  for (let i = 0; i < result.length; i++) {
-    if (result[i] === "?") {
-      questionMarkPositions.push(i);
-    }
-  }
-
-  // Replace from end to start so positions don't shift
-  for (
-    let i = Math.min(questionMarkPositions.length, params.length) - 1;
-    i >= 0;
-    i--
-  ) {
-    const pos = questionMarkPositions[i];
-    const escaped = escapeSqlValue(params[i]);
-    result = result.slice(0, pos!) + escaped + result.slice(pos! + 1);
-  }
-
   return result;
 }
 


### PR DESCRIPTION
Bug found while reading `apps/api/src/tools/database/index.ts` (touched by #6711, a pure any→unknown/Database type refactor of this same file).

`interpolateParams`, used by the `DATABASES_RUN_SQL` tool, substituted `$1`/`$2`/... placeholders across the whole query string first, then did a SECOND pass rescanning that already-substituted `result` string for `?` placeholders. If a `$N` param's value contained a literal `?`, that character was picked up as a real placeholder in the second pass and another param got spliced into the middle of the already-quoted, already-escaped literal — producing malformed SQL where a string literal is broken out of early by an unescaped-looking quote, instead of one safely-escaped value.

Failure scenario: `interpolateParams("SELECT * FROM t WHERE a = $1 AND b = ?", ["a question: ?", "value2"])` used to return
`SELECT * FROM t WHERE a = 'a question: 'a question: ?'' AND b = 'value2'` — a broken string literal — instead of a well-formed query with each param escaped once.

Fix: rewrote `interpolateParams` to walk the ORIGINAL sql string once, left to right, appending only escaped values to a fresh output string. It never rescans text it already produced, so an escaped param can never be picked up as a placeholder by a later pass.

Regression tests added in `apps/api/src/tools/database/index.test.ts` (exported `interpolateParams` for the test, previously module-private) — the first reproduces the exact corruption above and fails on the old code; the others cover repeated `?` placeholders and an out-of-range `$N`.

Reviewer check: `bun test apps/api/src/tools/database/index.test.ts`.

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `interpolateParams` in the `DATABASES_RUN_SQL` tool so a `?` or `$N` inside an already-escaped param value is no longer treated as a real placeholder, which previously produced malformed SQL by splicing another param into the middle of a string literal. The function now walks the original SQL string once, left to right, and appends only escaped values, so it never rescans output text.

- Exports `interpolateParams` and adds regression tests covering the corruption case, repeated `?` placeholders, and out-of-range `$N`.

<sup>Written for commit 89a1baabf6fb2af15d02457309a4bd80e85687ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

