### PR TITLE
fix(task-board): tell the super agent qa-screenshot exists

### DIFF
--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -277,6 +277,12 @@ export function buildClaudeCodeTaskPrompt(
     // for a deploy that may not exist yet, and that is the reviewer's job
     // (`enqueue-reviewer.ts`) — this run implements and hands over.
     `- Before handing over, VERIFY the task's outcome LOCALLY, in the sandbox: exercise the affected code path (the dev server hot-reloads, so hit the route it renders) and confirm the behaviour actually happens. A green test suite is not the bar. Do NOT wait for, or verify against, the PR's deploy preview — a reviewer checks that after you hand over.`,
+    // The sandbox image bakes in chromium + a global playwright-core and wraps
+    // them as `qa-screenshot` (packages/sandbox/image/Dockerfile). Nothing told
+    // this run about it, so a UI task would `ls node_modules/.bin | grep
+    // playwright`, find nothing in the USER's repo, conclude no browser exists,
+    // and either hand-roll a CDP client or give up on looking at the change.
+    "- For a VISUAL change that means LOOKING at it: `qa-screenshot <url> <path>.png [--mobile] [--full] [--selector=<css>]` renders the page in headless Chromium — it reaches your own dev server on localhost, and unlike `curl` it runs the page's JS, so lazily-rendered sections are actually there. Then `Read` the file: a screenshot you never opened is not verification. It is already installed; do NOT look for playwright in the repo's `node_modules` or start a browser yourself.",
     // The ONLY reliable way the board learns the PR: Claude Code opens it inside
     // the pod, so no Studio-side hook sees it (see pr-link.ts). Reviewers are
     // dispatched from the linked PR, so skipping this strands the card.


### PR DESCRIPTION
## Summary

The sandbox image installs chromium + a global `playwright-core` and ships `qa-screenshot` on PATH (`packages/sandbox/image/Dockerfile:112-149`), but it is advertised in exactly one prompt — the QA reviewer's (`enqueue-reviewer.ts:583`). The super agent is never told.

So a super agent on a visual task runs `ls node_modules/.bin | grep -i playwright` against the *user's* repo, gets nothing, and concludes there is no browser. Observed on `daniela-tombini/DANI-19` ("Ajuste do botão conferir"): the run then spent ~30 turns curling the dev server (which returns the pre-hydration HTML, so the lazily-rendered section it needed to see was simply absent), trying a Googlebot UA, and finally hand-rolling a CDP client over Bun WebSockets to drive `/usr/bin/chromium` directly.

Adds the `qa-screenshot` bullet to the super agent's "How to finish" block, next to the existing verify-locally instruction, with the two facts that run needed: it runs the page's JS (unlike `curl`), and it is already installed — stop looking for playwright in the repo.

## Testing

- `bun test apps/api/src/tools/task-board/claude-code-task-run.test.ts apps/api/src/api/routes/admin-prompt-region.test.ts` — 34 pass
- `bun run fmt` clean
- Prompt-only change; the edit is inside the existing `prompt-region` markers so the admin prompt editor still resolves it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tells the task-board super agent that the sandbox's pre-installed `qa-screenshot` tool exists, so visual tasks stop trying to find playwright in the user's repo and hand-rolling a CDP client.

- Adds `qa-screenshot` usage to the super agent's "How to finish" block, next to the verify-locally instruction.
- Notes it runs the page's JavaScript (unlike `curl`) so lazily-rendered sections are visible.
- Prompt-only change inside the existing `prompt-region` markers; the admin prompt editor still resolves it.

<sup>Written for commit 4e9f73bdbe915a556286f24cb98b4b48778de718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

