### PR TITLE
fix(task-board): make a task description's images readable by the agent

### DIFF
--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -24,6 +24,7 @@ import { isOrgSharedConnection } from "@decocms/shared/github-repo-scope";
 import { SHALLOW_CHECKOUT_NOTE } from "@decocms/shared/task-board";
 import { agentSandboxEnabled } from "@/settings";
 import type { SuperAgentPromptOpts } from "./enqueue-super-agent";
+import { uploadsAsSandboxPaths } from "./description-uploads";
 
 /** The repo a claude-code task run works in. */
 export interface TaskRepo {
@@ -201,7 +202,18 @@ export function buildClaudeCodeTaskPrompt(
     "",
     `Title: ${task.title}`,
   ];
-  if (task.description) lines.push("", "Description:", task.description);
+  if (task.description) {
+    const description = uploadsAsSandboxPaths(task.description);
+    lines.push("", "Description:", description);
+    // Only when the description actually carries one: an unconditional note
+    // about attachments that aren't there is noise the model has to rule out.
+    if (description !== task.description) {
+      lines.push(
+        "",
+        "The image and file links in that description are real paths in this sandbox, not URLs — `Read` them. A screenshot the task points at is usually the clearest statement of what it wants.",
+      );
+    }
+  }
   lines.push(
     "",
     repo

--- a/apps/api/src/tools/task-board/description-uploads.test.ts
+++ b/apps/api/src/tools/task-board/description-uploads.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { uploadsAsSandboxPaths } from "./description-uploads";
+
+describe("uploadsAsSandboxPaths", () => {
+  it("points an editor image at its sandbox mount", () => {
+    // Verbatim shape the markdown editor writes (DANI-19's description).
+    expect(
+      uploadsAsSandboxPaths(
+        "![image.png](/api/daniela-tombini/fs/uploads/read?path=editor-images%2Fc0aa15c2.png)",
+      ),
+    ).toBe("![image.png](org/.uploads/editor-images/c0aa15c2.png)");
+  });
+
+  it("rewrites every upload in the description, not just the first", () => {
+    const out = uploadsAsSandboxPaths(
+      "![a](/api/o/fs/uploads/read?path=editor-images%2Fa.png)\n\n" +
+        "[spec.pdf](/api/o/fs/uploads/read?path=editor-files%2Fspec.pdf)",
+    );
+    expect(out).toBe(
+      "![a](org/.uploads/editor-images/a.png)\n\n" +
+        "[spec.pdf](org/.uploads/editor-files/spec.pdf)",
+    );
+  });
+
+  it("maps each volume to its own mount point", () => {
+    expect(uploadsAsSandboxPaths("(/api/o/fs/home/read?path=notes.md)")).toBe(
+      "(org/home/notes.md)",
+    );
+    expect(
+      uploadsAsSandboxPaths("(/api/o/fs/outputs/read?path=t1/x.png)"),
+    ).toBe("(org/.outputs/t1/x.png)");
+  });
+
+  it("leaves a path that could climb out of the mount alone", () => {
+    for (const path of [
+      "..%2F..%2Fetc%2Fpasswd",
+      "%2Fetc%2Fpasswd",
+      "%E0%A4",
+    ]) {
+      const url = `![x](/api/o/fs/uploads/read?path=${path})`;
+      expect(uploadsAsSandboxPaths(url)).toBe(url);
+    }
+  });
+
+  it("leaves everything that isn't an org-fs read URL alone", () => {
+    const md =
+      "See ![x](https://example.com/a.png) and /api/o/fs/uploads/read (no path)";
+    expect(uploadsAsSandboxPaths(md)).toBe(md);
+  });
+});

--- a/apps/api/src/tools/task-board/description-uploads.ts
+++ b/apps/api/src/tools/task-board/description-uploads.ts
@@ -1,0 +1,40 @@
+import { orgFsSandboxPath } from "@/file-storage/mount/provisioning";
+
+/**
+ * Point a task description's uploaded files at the sandbox, not at Studio.
+ *
+ * The markdown editor stores an upload as a link to the org filesystem's HTTP
+ * read endpoint (`/api/:org/fs/:volume/read?path=…`, see
+ * `apps/web/src/components/markdown-editor/uploads.ts`). That URL is relative
+ * and cookie-authenticated, so it means nothing inside a sandbox: an agent
+ * handed the raw description sees `![image.png](/api/…)` and has no way to
+ * fetch it. It reads as text and gets treated as one — the DANI-19 run
+ * described an image it had never seen.
+ *
+ * The same bytes are already mounted in the pod (`org/.uploads/…`), so the fix
+ * is to rewrite the URL to that path. `Read` renders a PNG visually, so the
+ * model actually looks at the screenshot the task is about.
+ *
+ * Sandboxed runs ONLY — a hosted harness has no org-fs mount, and there the
+ * original URL is at least a link a human can click.
+ */
+export function uploadsAsSandboxPaths(description: string): string {
+  return description.replace(
+    // The editor writes `?path=` as the whole query, so everything up to the
+    // closing paren (or whitespace) is the encoded path.
+    /\/api\/[^/\s)]+\/fs\/([^/\s)]+)\/read\?path=([^)\s]+)/g,
+    (url, volume: string, encodedPath: string) => {
+      let path: string;
+      try {
+        path = decodeURIComponent(encodedPath);
+      } catch {
+        return url;
+      }
+      // A description is user-written, and this path becomes a filesystem read
+      // inside the pod. Anything that could climb out of the mount keeps its
+      // original URL rather than resolving somewhere it shouldn't.
+      if (path.startsWith("/") || path.split("/").includes("..")) return url;
+      return orgFsSandboxPath(decodeURIComponent(volume), path);
+    },
+  );
+}

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -22,6 +22,7 @@ import {
 } from "./claude-code-task-run";
 import { isThreadRunStale } from "@/tools/thread/helpers";
 import { mintReviewToken } from "./review-token";
+import { uploadsAsSandboxPaths } from "./description-uploads";
 import { nudgeThreadTurn } from "./nudge-thread";
 import { orgFlagEnabled } from "@decocms/shared/organization/schema";
 import type { ClaudeCodeModelClass } from "@/harnesses/claude-code-env";
@@ -733,7 +734,11 @@ async function enqueueReviewerForTask(
   const prompt = [
     ...(sandboxed ? [] : [instructions, ""]),
     `Task title: ${task.title}`,
-    task.description ? `\nTask description:\n${task.description}\n` : "",
+    // Sandboxed only: `uploadsAsSandboxPaths` points at an org-fs mount the
+    // hosted harness does not have.
+    task.description
+      ? `\nTask description:\n${sandboxed ? uploadsAsSandboxPaths(task.description) : task.description}\n`
+      : "",
     "How to work:",
     `- Call \`${prsGetTool}\` with the task id below to find the pull request under review.`,
     repo


### PR DESCRIPTION
## Summary

The markdown editor stores an upload as a link to the org filesystem's HTTP read endpoint — `/api/:org/fs/uploads/read?path=editor-images%2F….png` (`apps/web/src/components/markdown-editor/uploads.ts`). That URL is relative and cookie-authenticated, so it means nothing inside a sandbox. The agent is handed the raw markdown, sees `![image.png](/api/…)` as plain text, and has no way to fetch it.

On `daniela-tombini/DANI-19` the description was one sentence plus two screenshots. The run's first reasoning step was *"The image shows a card with a banner-style layout featuring a CONFERIR button"* — it had never seen the image. Everything after that was inference from the filename and the repo.

The same bytes are already mounted in the pod: `provisioning.ts` mounts the `uploads` volume at `org/.uploads`, and `orgFsSandboxPath()` exists precisely to tell an agent where an org-fs file lands. So rewrite the description's org-fs URLs to that path before it goes into the prompt. Claude Code's `Read` renders a PNG visually, so the model looks at the screenshot instead of guessing.

- `description-uploads.ts` — one regex over the description; every org-fs read URL becomes its sandbox path (`uploads` → `org/.uploads/…`, `home` → `org/home/…`, `outputs` → `org/.outputs/…`).
- Applied in the super agent prompt (`claude-code-task-run.ts`, always sandboxed) and the reviewer prompt (`enqueue-reviewer.ts`, gated on `sandboxed` — a hosted harness has no mount, and there the original URL is at least clickable by a human).
- When a rewrite happened, one line tells the agent those links are files to `Read`. Only then — an unconditional note about attachments that aren't there is noise.

A description is user-written and this path becomes a filesystem read inside the pod, so an absolute path, a `..` segment, or an undecodable escape keeps its original URL rather than resolving somewhere it shouldn't.

## Testing

- New `description-uploads.test.ts` — 5 cases: the verbatim DANI-19 shape, multiple uploads in one description, per-volume mount mapping, the traversal/undecodable guards, and non-org-fs URLs left alone.
- `bun test apps/api/src/tools/task-board/{description-uploads,claude-code-task-run,enqueue-reviewer}.test.ts apps/api/src/api/routes/admin-prompt-region.test.ts` — 80 pass.
- `bun run --cwd=apps/api check`, `bun run fmt`, `bun run lint` clean.
- The 12 failures in the full `src/tools/task-board/` run are the `*.integration.test.ts` files wanting a local Postgres on 5432; unrelated and pre-existing on this machine.

## Not in this PR

The images also never reach the **hosted** (non-sandbox) harness, which would need them attached as real multimodal content parts rather than a path — a different fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites task description image and file links to sandbox filesystem paths so the agent can actually see screenshots instead of guessing from filenames.

- Replaces org-fs HTTP read URLs (`/api/:org/fs/:volume/read?path=…`) with their already-mounted sandbox paths (`org/.uploads/…`, `org/home/…`, `org/.outputs/…`).
- Applies the rewrite to the super agent prompt (always sandboxed) and the reviewer prompt (sandboxed runs only), since hosted harnesses have no mount.
- When a rewrite happens, tells the agent those links are real paths to `Read`.
- Leaves URLs alone if the path is absolute, contains `..`, is undecodable, or isn't an org-fs read URL.
- Does not fix image delivery to the hosted (non-sandbox) harness, which needs a separate multimodal attachment approach.

<sup>Written for commit e8d73d439460e66f489bf1ef38829e963e078c4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

