### PR TITLE
fix(task-board): tell the sandboxed reviewer its uploaded-image paths are real

### DIFF
--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -24,7 +24,10 @@ import { isOrgSharedConnection } from "@decocms/shared/github-repo-scope";
 import { SHALLOW_CHECKOUT_NOTE } from "@decocms/shared/task-board";
 import { agentSandboxEnabled } from "@/settings";
 import type { SuperAgentPromptOpts } from "./enqueue-super-agent";
-import { uploadsAsSandboxPaths } from "./description-uploads";
+import {
+  sandboxUploadHint,
+  uploadsAsSandboxPaths,
+} from "./description-uploads";
 
 /** The repo a claude-code task run works in. */
 export interface TaskRepo {
@@ -205,13 +208,9 @@ export function buildClaudeCodeTaskPrompt(
   if (task.description) {
     const description = uploadsAsSandboxPaths(task.description);
     lines.push("", "Description:", description);
-    // Only when the description actually carries one: an unconditional note
-    // about attachments that aren't there is noise the model has to rule out.
-    if (description !== task.description) {
-      lines.push(
-        "",
-        "The image and file links in that description are real paths in this sandbox, not URLs — `Read` them. A screenshot the task points at is usually the clearest statement of what it wants.",
-      );
+    const hint = sandboxUploadHint(task.description, description);
+    if (hint) {
+      lines.push("", hint);
     }
   }
   lines.push(

--- a/apps/api/src/tools/task-board/description-uploads.test.ts
+++ b/apps/api/src/tools/task-board/description-uploads.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { uploadsAsSandboxPaths } from "./description-uploads";
+import {
+  sandboxUploadHint,
+  uploadsAsSandboxPaths,
+} from "./description-uploads";
 
 describe("uploadsAsSandboxPaths", () => {
   it("points an editor image at its sandbox mount", () => {
@@ -46,5 +49,19 @@ describe("uploadsAsSandboxPaths", () => {
     const md =
       "See ![x](https://example.com/a.png) and /api/o/fs/uploads/read (no path)";
     expect(uploadsAsSandboxPaths(md)).toBe(md);
+  });
+});
+
+describe("sandboxUploadHint", () => {
+  it("is null when the rewrite changed nothing", () => {
+    const md = "Just plain text, no uploads.";
+    expect(sandboxUploadHint(md, uploadsAsSandboxPaths(md))).toBeNull();
+  });
+
+  it("fires when the rewrite pointed a link at the sandbox mount", () => {
+    const md = "![x](/api/o/fs/uploads/read?path=a.png)";
+    expect(sandboxUploadHint(md, uploadsAsSandboxPaths(md))).toContain(
+      "real paths in this sandbox",
+    );
   });
 });

--- a/apps/api/src/tools/task-board/description-uploads.ts
+++ b/apps/api/src/tools/task-board/description-uploads.ts
@@ -38,3 +38,20 @@ export function uploadsAsSandboxPaths(description: string): string {
     },
   );
 }
+
+/**
+ * The note to append after a rewritten description, so the run knows the
+ * `org/.uploads/…` paths `uploadsAsSandboxPaths` just wrote are real files to
+ * `Read`, not more prose. Only when the rewrite actually changed something —
+ * an unconditional note about attachments that aren't there is noise the
+ * model has to rule out. Shared by every sandboxed prompt that shows a task
+ * description (the task run itself and its reviewers).
+ */
+export function sandboxUploadHint(
+  original: string,
+  rewritten: string,
+): string | null {
+  return rewritten === original
+    ? null
+    : "The image and file links in that description are real paths in this sandbox, not URLs — `Read` them. A screenshot the task points at is usually the clearest statement of what it wants.";
+}

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -22,7 +22,10 @@ import {
 } from "./claude-code-task-run";
 import { isThreadRunStale } from "@/tools/thread/helpers";
 import { mintReviewToken } from "./review-token";
-import { uploadsAsSandboxPaths } from "./description-uploads";
+import {
+  sandboxUploadHint,
+  uploadsAsSandboxPaths,
+} from "./description-uploads";
 import { nudgeThreadTurn } from "./nudge-thread";
 import { orgFlagEnabled } from "@decocms/shared/organization/schema";
 import type { ClaudeCodeModelClass } from "@/harnesses/claude-code-env";
@@ -731,14 +734,21 @@ async function enqueueReviewerForTask(
       "other ref is not.",
   ].join("\n");
 
+  // Sandboxed only — `uploadsAsSandboxPaths` points at an org-fs mount the hosted harness lacks.
+  const reviewerDescription =
+    task.description && sandboxed
+      ? uploadsAsSandboxPaths(task.description)
+      : task.description;
+  const reviewerUploadHint =
+    task.description && reviewerDescription
+      ? sandboxUploadHint(task.description, reviewerDescription)
+      : null;
+
   const prompt = [
     ...(sandboxed ? [] : [instructions, ""]),
     `Task title: ${task.title}`,
-    // Sandboxed only: `uploadsAsSandboxPaths` points at an org-fs mount the
-    // hosted harness does not have.
-    task.description
-      ? `\nTask description:\n${sandboxed ? uploadsAsSandboxPaths(task.description) : task.description}\n`
-      : "",
+    reviewerDescription ? `\nTask description:\n${reviewerDescription}\n` : "",
+    ...(reviewerUploadHint ? [reviewerUploadHint, ""] : []),
     "How to work:",
     `- Call \`${prsGetTool}\` with the task id below to find the pull request under review.`,
     repo


### PR DESCRIPTION
Follows #6714. That PR rewrote a task description's upload links into sandbox-local paths (`org/.uploads/...`) and added a note in the task-run prompt telling the model those are real files to `Read`, not URLs — but `enqueue-reviewer.ts` already called the same `uploadsAsSandboxPaths` rewrite for the sandboxed reviewer prompt without ever getting that note. A sandboxed reviewer sees the same rewritten path with no hint it's a file to open, and is left to guess.

Extracted the note into a shared `sandboxUploadHint()` helper in `description-uploads.ts` (used by both the implementer and reviewer prompts) so the fix doesn't drift out of sync between the two call sites again, and wired it into `enqueue-reviewer.ts`'s sandboxed path.

Regression test: `description-uploads.test.ts` now covers `sandboxUploadHint` — null when the rewrite is a no-op, fires when a link was actually rewritten.

Reviewer: run `bun test apps/api/src/tools/task-board/description-uploads.test.ts apps/api/src/tools/task-board/claude-code-task-run.test.ts`.

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the two targeted test files above (31 pass), and `bunx oxlint` on all 4 changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tells the sandboxed reviewer that rewritten image and file links in a task description are real sandbox paths to `Read`, matching the implementer prompt. Previously the reviewer saw the rewritten paths without the hint, so it had to guess whether to open them. The hint now lives in a shared helper so both prompts stay in sync.

- Extracts the hint text into `sandboxUploadHint()` in `description-uploads.ts`.
- Wires the hint into the sandboxed reviewer prompt and keeps the implementer prompt behavior unchanged.
- Adds regression tests for `sandboxUploadHint` (returns `null` when no rewrite, contains the hint when it does).

<sup>Written for commit 4c4759e651a6427ea4e1db0324cad3c24bfe8097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

