### PR TITLE
feat(task-board): draw the columns the board says it has

### DIFF
--- a/apps/web/src/components/home/home-tasks.tsx
+++ b/apps/web/src/components/home/home-tasks.tsx
@@ -24,7 +24,6 @@ import {
   PRIORITY_CONFIG,
   laneVisual,
   type TaskBoardItem,
-  type TaskBoardItemStatus,
 } from "@/layouts/task-board/config";
 import { TaskBoardItemDialog } from "@/layouts/task-board/task-dialog";
 
@@ -33,9 +32,10 @@ interface OrgMember {
   user?: { name?: string; email?: string; image?: string | null };
 }
 
-type TaskTab =
-  | "all"
-  | Extract<TaskBoardItemStatus, "in_progress" | "in_review" | "done">;
+/** Named outright rather than `Extract`ed from a card's status: that is now any
+ *  column key, and extracting from an open `string` collapses to `never`. These
+ *  three are Studio's own lanes, which is exactly what this strip is about. */
+type TaskTab = "all" | "in_progress" | "in_review" | "done";
 
 const TASK_TABS: { id: TaskTab; labelKey: string }[] = [
   { id: "all", labelKey: "home.homeTasks.tabAll" },

--- a/apps/web/src/hooks/use-task-board-items.ts
+++ b/apps/web/src/hooks/use-task-board-items.ts
@@ -25,6 +25,9 @@ type TaskBoardItem = ToolOutput<"TASK_BOARD_ITEM_LIST">["items"][number];
 type TaskBoardData = {
   items: TaskBoardItem[];
   sprints: ToolOutput<"TASK_BOARD_ITEM_LIST">["sprints"];
+  /** The board's own columns. Studio's lanes for most orgs; an org that owns
+   *  its board sends its own, which is why the client cannot assume the set. */
+  columns: ToolOutput<"TASK_BOARD_ITEM_LIST">["columns"];
 };
 
 /**
@@ -42,8 +45,11 @@ export function useBoardSprintIndex(): Map<string, Sprint> {
   const { data } = useQuery({
     queryKey: KEYS.taskBoardItems(locator),
     queryFn: async (): Promise<TaskBoardData> => {
-      const { items, sprints } = await studio.call("TASK_BOARD_ITEM_LIST", {});
-      return { items, sprints };
+      const { items, sprints, columns } = await studio.call(
+        "TASK_BOARD_ITEM_LIST",
+        {},
+      );
+      return { items, sprints, columns };
     },
   });
   return new Map((data?.sprints ?? []).map((sprint) => [sprint.id, sprint]));
@@ -58,8 +64,11 @@ export function useTaskBoardItems() {
   const query = useQuery({
     queryKey,
     queryFn: async (): Promise<TaskBoardData> => {
-      const { items, sprints } = await studio.call("TASK_BOARD_ITEM_LIST", {});
-      return { items, sprints };
+      const { items, sprints, columns } = await studio.call(
+        "TASK_BOARD_ITEM_LIST",
+        {},
+      );
+      return { items, sprints, columns };
     },
     // Backstop for a stream that died without an error; paused when unfocused.
     refetchInterval: 60_000,
@@ -143,6 +152,7 @@ export function useTaskBoardItems() {
   return {
     items: query.data?.items ?? [],
     sprints: query.data?.sprints ?? [],
+    columns: query.data?.columns ?? [],
     isLoading: query.isLoading,
     error: query.error,
   };

--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -46,6 +46,9 @@ function item(id: string, sortOrder: number): TaskBoardItem {
   } as TaskBoardItem;
 }
 
+/** The board Studio ships with, in the shape the server sends it. */
+const CANONICAL = STATUSES.map((key) => ({ key }));
+
 describe("insertSortOrder", () => {
   const lane = [item("a", 0), item("b", 10), item("c", 20)];
 
@@ -303,8 +306,38 @@ describe("moveTargets", () => {
 describe("laneVisibility", () => {
   const shown: string[] = [];
 
+  /**
+   * The board Studio ships with is one answer, not the only one. A board whose
+   * columns are the org's own has to draw THOSE — falling back to our lanes
+   * would file its cards under names nobody there chose, and the delivery-lane
+   * rules simply do not apply to a set we did not define.
+   */
+  test("draws the org's own columns, in the order the server sent them", () => {
+    const { lanes, hidden, hideable } = laneVisibility({
+      columns: [{ key: "BACKLOG" }, { key: "Fazendo" }, { key: "Code Review" }],
+      deliveryEnabled: false,
+      shownLanes: shown,
+      occupied: [],
+    });
+    expect(lanes).toEqual(["BACKLOG", "Fazendo", "Code Review"]);
+    expect(hidden).toEqual([]);
+    expect(hideable).toEqual([]);
+  });
+
+  test("draws nothing for a board with no columns yet", () => {
+    expect(
+      laneVisibility({
+        columns: [],
+        deliveryEnabled: false,
+        shownLanes: shown,
+        occupied: [],
+      }),
+    ).toEqual({ lanes: [], hidden: [], hideable: [] });
+  });
+
   test("draws the delivery lanes as columns when they're on", () => {
     const { lanes, hidden } = laneVisibility({
+      columns: CANONICAL,
       deliveryEnabled: true,
       shownLanes: shown,
       occupied: [],
@@ -325,6 +358,7 @@ describe("laneVisibility", () => {
 
   test("an empty delivery lane is absent, not hidden, when they're off", () => {
     const { lanes, hidden } = laneVisibility({
+      columns: CANONICAL,
       deliveryEnabled: false,
       shownLanes: shown,
       occupied: [],
@@ -342,6 +376,7 @@ describe("laneVisibility", () => {
   // Lanes off with work still in one: the card must stay reachable.
   test("a card left in a delivery lane keeps the lane in the drawer", () => {
     const { lanes, hidden, hideable } = laneVisibility({
+      columns: CANONICAL,
       deliveryEnabled: false,
       shownLanes: shown,
       occupied: ["merged"],
@@ -353,6 +388,7 @@ describe("laneVisibility", () => {
 
   test("and showing it puts the column back", () => {
     const { lanes, hidden } = laneVisibility({
+      columns: CANONICAL,
       deliveryEnabled: false,
       shownLanes: ["merged"],
       occupied: ["merged"],
@@ -363,6 +399,7 @@ describe("laneVisibility", () => {
 
   test("a lane removed from the product can linger in the preference", () => {
     const { lanes } = laneVisibility({
+      columns: CANONICAL,
       deliveryEnabled: false,
       shownLanes: ["a_lane_that_no_longer_exists"],
       occupied: [],

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -230,7 +230,7 @@ export const STATUSES: TaskBoardItemStatus[] = [
  * "Hidden columns" until shown. They stay in `STATUSES`, so "Move to", drag
  * targets and status validation still know about them.
  */
-export const HIDDEN_STATUSES: TaskBoardItemStatus[] = ["archived"];
+export const HIDDEN_STATUSES: string[] = ["archived"];
 
 /** Keyed by Studio's OWN lanes, not by a card's status. Exhaustive on purpose:
  *  adding a lane is a compile error here. A card's status is any column key,
@@ -383,7 +383,7 @@ export const TASK_TYPE_CONFIG: Record<
 };
 
 /** True for one of the post-merge delivery lanes. */
-export function isDeliveryLane(status: TaskBoardItemStatus): boolean {
+export function isDeliveryLane(status: string): boolean {
   return (DELIVERY_LANES as string[]).includes(status);
 }
 
@@ -407,22 +407,30 @@ export function moveTargets(deliveryEnabled: boolean): TaskBoardItemStatus[] {
  * absent while empty, but reappears in the drawer the moment a card sits in it.
  */
 export function laneVisibility({
+  columns,
   deliveryEnabled,
   shownLanes,
   occupied,
 }: {
+  /** The board's own columns, left to right, as the server sent them. Empty
+   *  only while the read is in flight — an org that owns its board and has no
+   *  columns yet genuinely has an empty board, and rendering Studio's lanes
+   *  instead would file its cards under lanes nobody chose. */
+  columns: readonly { key: string }[];
   deliveryEnabled: boolean;
   /** `string[]`: it comes out of localStorage, which can hold a dead lane. */
   shownLanes: readonly string[];
-  occupied: readonly TaskBoardItemStatus[];
+  occupied: readonly string[];
 }): {
-  lanes: TaskBoardItemStatus[];
-  hidden: TaskBoardItemStatus[];
-  hideable: TaskBoardItemStatus[];
+  lanes: string[];
+  hidden: string[];
+  hideable: string[];
 } {
-  const known = STATUSES.filter(
-    (s) => deliveryEnabled || !isDeliveryLane(s) || occupied.includes(s),
-  );
+  const known = columns
+    .map((column) => column.key)
+    .filter(
+      (s) => deliveryEnabled || !isDeliveryLane(s) || occupied.includes(s),
+    );
   const hideable = known.filter(
     (s) =>
       HIDDEN_STATUSES.includes(s) || (!deliveryEnabled && isDeliveryLane(s)),

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -124,7 +124,6 @@ import {
   TASK_TYPES,
   type TaskBoardItem,
   type TaskBoardItemPriority,
-  type TaskBoardItemStatus,
   type TaskBoardItemTag,
   type Member,
 } from "./config";
@@ -831,7 +830,7 @@ function AssigneeDisplay({
 
 export function TaskBoardPage() {
   const t = useT();
-  const { items, sprints, isLoading } = useTaskBoardItems();
+  const { items, sprints, columns, isLoading } = useTaskBoardItems();
   const { data: orgTags = [] } = useTags();
   const actions = useTaskBoardItemActions();
   // Handing a task to the Super Agent makes it open a PR — so it needs at
@@ -940,7 +939,7 @@ export function TaskBoardPage() {
       else next.add(id);
       return next;
     });
-  const selectAllInLane = (status: TaskBoardItemStatus) =>
+  const selectAllInLane = (status: string) =>
     setSelectedIds((prev) => {
       const next = new Set(prev);
       for (const item of visibleItems)
@@ -957,9 +956,7 @@ export function TaskBoardPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   // Status a newly-created task should start in (set by a lane's "+"); null for
   // the generic "New task" button.
-  const [createStatus, setCreateStatus] = useState<TaskBoardItemStatus | null>(
-    null,
-  );
+  const [createStatus, setCreateStatus] = useState<string | null>(null);
   const { setTaskId } = usePanelActions();
   const { create } = useThreadActions();
   const studio = useStudioTools();
@@ -1071,7 +1068,7 @@ export function TaskBoardPage() {
     setDialogOpen(true);
   };
 
-  const openCreateInLane = (status: TaskBoardItemStatus) => {
+  const openCreateInLane = (status: string) => {
     setCreateStatus(status);
     setDialogOpen(true);
   };
@@ -1224,6 +1221,7 @@ export function TaskBoardPage() {
       ) : layout === "board" ? (
         <Lanes
           visible={!openItem}
+          columns={columns}
           items={visibleItems}
           members={members}
           memberByUserId={memberByUserId}
@@ -1607,7 +1605,7 @@ function SelectionBar({
 }: {
   count: number;
   members: Member[];
-  onMoveTo: (status: TaskBoardItemStatus) => void;
+  onMoveTo: (status: string) => void;
   onSetPriority: (priority: TaskBoardItemPriority) => void;
   onAddTag: (tagId: string) => void;
   onAssign: (userId: string | null) => void;
@@ -1798,7 +1796,7 @@ const LANE_DROPPABLE_PREFIX = "lane:";
 /** Where a card sits locally: while a drag is in flight, and then until the
  *  server's optimistic patch catches up. */
 interface Placement {
-  status: TaskBoardItemStatus;
+  status: string;
   sortOrder: number;
 }
 
@@ -1814,6 +1812,7 @@ function bySortOrder(a: TaskBoardItem, b: TaskBoardItem) {
 }
 
 function Lanes({
+  columns,
   items,
   members,
   memberByUserId,
@@ -1831,19 +1830,17 @@ function Lanes({
   onDueDateChange,
   visible,
 }: {
+  /** The board's own columns, as the server sent them. */
+  columns: readonly { key: string }[];
   items: TaskBoardItem[];
   members: Member[];
   memberByUserId: Map<string, Member>;
   selectedIds: Set<string>;
   onToggleSelect: (id: string) => void;
-  onSelectAllInLane: (status: TaskBoardItemStatus) => void;
+  onSelectAllInLane: (status: string) => void;
   onOpen: (item: TaskBoardItem) => void;
-  onCreate: (status: TaskBoardItemStatus) => void;
-  onMove: (
-    ids: string[],
-    status: TaskBoardItemStatus,
-    sortOrder: number,
-  ) => void;
+  onCreate: (status: string) => void;
+  onMove: (ids: string[], status: string, sortOrder: number) => void;
   onAutoFix?: (item: TaskBoardItem) => void;
   onRerun?: (item: TaskBoardItem) => void;
   onAssign?: (id: string, userId: string | null) => void;
@@ -1940,7 +1937,7 @@ function Lanes({
     visible,
   );
 
-  const laneItems = (status: TaskBoardItemStatus) =>
+  const laneItems = (status: string) =>
     placed.filter((item) => item.status === status).sort(bySortOrder);
 
   /** Shown-again lanes persist per person, so pulling one onto the board
@@ -1950,11 +1947,12 @@ function Lanes({
     hidden: hiddenLanes,
     hideable: hideableLanes,
   } = laneVisibility({
+    columns,
     deliveryEnabled,
     shownLanes: preferences.shownTaskBoardLanes,
     occupied: placed.map((item) => item.status),
   });
-  const setLaneShown = (status: TaskBoardItemStatus, shown: boolean) =>
+  const setLaneShown = (status: string, shown: boolean) =>
     setPreferences((prev) => ({
       ...prev,
       shownTaskBoardLanes: shown
@@ -1982,7 +1980,7 @@ function Lanes({
       ? [id, ...Array.from(selectedIds).filter((other) => other !== id)]
       : [id];
 
-  const place = (ids: string[], status: TaskBoardItemStatus, slot: number) => {
+  const place = (ids: string[], status: string, slot: number) => {
     const orders = runSortOrders(slot, ids.length);
     setOverrides((prev) => {
       const next = new Map(prev);
@@ -2195,9 +2193,9 @@ function HiddenLanes({
   countOf,
   onShow,
 }: {
-  statuses: TaskBoardItemStatus[];
-  countOf: (status: TaskBoardItemStatus) => number;
-  onShow: (status: TaskBoardItemStatus) => void;
+  statuses: string[];
+  countOf: (status: string) => number;
+  onShow: (status: string) => void;
 }) {
   const t = useT();
   return (
@@ -2276,7 +2274,7 @@ function Lane({
   onDueDateChange,
   onHide,
 }: {
-  status: TaskBoardItemStatus;
+  status: string;
   items: TaskBoardItem[];
   members: Member[];
   memberByUserId: Map<string, Member>;
@@ -2287,9 +2285,9 @@ function Lane({
   /** Cards that just landed from a drop — they play the settle animation. */
   landedIds: string[];
   onToggleSelect: (id: string) => void;
-  onSelectAllInLane: (status: TaskBoardItemStatus) => void;
+  onSelectAllInLane: (status: string) => void;
   onOpen: (item: TaskBoardItem) => void;
-  onCreate: (status: TaskBoardItemStatus) => void;
+  onCreate: (status: string) => void;
   onAutoFix?: (item: TaskBoardItem) => void;
   onRerun?: (item: TaskBoardItem) => void;
   onAssign?: (id: string, userId: string | null) => void;

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -121,6 +121,7 @@ export interface StudioToolIO {
         | {
             demo_mode?: boolean | undefined;
             reports_only?: boolean | undefined;
+            org_board_columns?: boolean | undefined;
             reviewer_enabled?: boolean | undefined;
             qa_agent_enabled?: boolean | undefined;
             code_reviewer_enabled?: boolean | undefined;
@@ -193,6 +194,7 @@ export interface StudioToolIO {
         | {
             demo_mode?: boolean | undefined;
             reports_only?: boolean | undefined;
+            org_board_columns?: boolean | undefined;
             reviewer_enabled?: boolean | undefined;
             qa_agent_enabled?: boolean | undefined;
             code_reviewer_enabled?: boolean | undefined;
@@ -265,6 +267,7 @@ export interface StudioToolIO {
         | {
             demo_mode?: boolean | undefined;
             reports_only?: boolean | undefined;
+            org_board_columns?: boolean | undefined;
             reviewer_enabled?: boolean | undefined;
             qa_agent_enabled?: boolean | undefined;
             code_reviewer_enabled?: boolean | undefined;
@@ -323,17 +326,7 @@ export interface StudioToolIO {
     input: {
       title: string;
       description?: string | null | undefined;
-      status?:
-        | "done"
-        | "triage"
-        | "todo"
-        | "in_progress"
-        | "in_review"
-        | "approved"
-        | "merged"
-        | "post_deploy_validation"
-        | "archived"
-        | undefined;
+      status?: string | undefined;
       priority?: "none" | "low" | "medium" | "high" | "urgent" | undefined;
       type?: "bug" | "feature" | "chore" | "spike" | "security" | undefined;
       assigneeId?: string | null | undefined;
@@ -348,16 +341,7 @@ export interface StudioToolIO {
         organizationId: string;
         title: string;
         description: string | null;
-        status:
-          | "done"
-          | "triage"
-          | "todo"
-          | "in_progress"
-          | "in_review"
-          | "approved"
-          | "merged"
-          | "post_deploy_validation"
-          | "archived";
+        status: string;
         priority: "none" | "low" | "medium" | "high" | "urgent";
         type: "bug" | "feature" | "chore" | "spike" | "security";
         assigneeId: string | null;
@@ -417,16 +401,7 @@ export interface StudioToolIO {
         organizationId: string;
         title: string;
         description: string | null;
-        status:
-          | "done"
-          | "triage"
-          | "todo"
-          | "in_progress"
-          | "in_review"
-          | "approved"
-          | "merged"
-          | "post_deploy_validation"
-          | "archived";
+        status: string;
         priority: "none" | "low" | "medium" | "high" | "urgent";
         type: "bug" | "feature" | "chore" | "spike" | "security";
         assigneeId: string | null;
@@ -497,17 +472,7 @@ export interface StudioToolIO {
       id: string;
       title?: string | undefined;
       description?: string | null | undefined;
-      status?:
-        | "done"
-        | "triage"
-        | "todo"
-        | "in_progress"
-        | "in_review"
-        | "approved"
-        | "merged"
-        | "post_deploy_validation"
-        | "archived"
-        | undefined;
+      status?: string | undefined;
       priority?: "none" | "low" | "medium" | "high" | "urgent" | undefined;
       type?: "bug" | "feature" | "chore" | "spike" | "security" | undefined;
       assigneeId?: string | null | undefined;
@@ -524,16 +489,7 @@ export interface StudioToolIO {
         organizationId: string;
         title: string;
         description: string | null;
-        status:
-          | "done"
-          | "triage"
-          | "todo"
-          | "in_progress"
-          | "in_review"
-          | "approved"
-          | "merged"
-          | "post_deploy_validation"
-          | "archived";
+        status: string;
         priority: "none" | "low" | "medium" | "high" | "urgent";
         type: "bug" | "feature" | "chore" | "spike" | "security";
         assigneeId: string | null;
@@ -648,35 +604,11 @@ export interface StudioToolIO {
       notes: string;
       reviewToken?: string | undefined;
     };
-    output: {
-      status:
-        | "done"
-        | "triage"
-        | "todo"
-        | "in_progress"
-        | "in_review"
-        | "approved"
-        | "merged"
-        | "post_deploy_validation"
-        | "archived";
-      merged: boolean;
-    };
+    output: { status: string; merged: boolean };
   };
   TASK_BOARD_PROMOTE_TO_PRODUCTION: {
     input: { taskBoardItemId: string };
-    output: {
-      status:
-        | "done"
-        | "triage"
-        | "todo"
-        | "in_progress"
-        | "in_review"
-        | "approved"
-        | "merged"
-        | "post_deploy_validation"
-        | "archived";
-      merged: boolean;
-    };
+    output: { status: string; merged: boolean };
   };
   TASK_BOARD_ACTIVITY_LIST: {
     input: { taskBoardItemId: string };
@@ -691,13 +623,13 @@ export interface StudioToolIO {
           | "review_requested"
           | "review_approved"
           | "review_changes_requested"
-          | "review_verdict_requested"
           | "merge_failed"
           | "priority_changed"
           | "due_date_changed"
           | "title_changed"
           | "description_changed"
           | "tags_changed"
+          | "review_verdict_requested"
           | "merge_conflict_resolution"
           | "type_changed";
         actorId: string | null;
@@ -4943,21 +4875,7 @@ export interface StudioToolIO {
         email: string;
         boardId: string | null;
         boardName: string | null;
-        statusMapping: Partial<
-          Record<
-            | "done"
-            | "triage"
-            | "todo"
-            | "in_progress"
-            | "in_review"
-            | "approved"
-            | "merged"
-            | "post_deploy_validation"
-            | "archived",
-            string[]
-          >
-        >;
-        autoDelegate: boolean;
+        statusMapping: Record<string, string[]>;
         webhookSecret: string;
         enabled: boolean;
         lastSyncedAt: string | null;
@@ -4973,23 +4891,7 @@ export interface StudioToolIO {
       apiToken?: string | undefined;
       boardId?: string | null | undefined;
       boardName?: string | null | undefined;
-      statusMapping?:
-        | Partial<
-            Record<
-              | "done"
-              | "triage"
-              | "todo"
-              | "in_progress"
-              | "in_review"
-              | "approved"
-              | "merged"
-              | "post_deploy_validation"
-              | "archived",
-              string[]
-            >
-          >
-        | undefined;
-      autoDelegate?: boolean | undefined;
+      statusMapping?: Record<string, string[]> | undefined;
       enabled?: boolean | undefined;
     };
     output: {
@@ -4999,21 +4901,7 @@ export interface StudioToolIO {
         email: string;
         boardId: string | null;
         boardName: string | null;
-        statusMapping: Partial<
-          Record<
-            | "done"
-            | "triage"
-            | "todo"
-            | "in_progress"
-            | "in_review"
-            | "approved"
-            | "merged"
-            | "post_deploy_validation"
-            | "archived",
-            string[]
-          >
-        >;
-        autoDelegate: boolean;
+        statusMapping: Record<string, string[]>;
         webhookSecret: string;
         enabled: boolean;
         lastSyncedAt: string | null;


### PR DESCRIPTION
## What is this contribution about?

#6710 taught the client to *tolerate* a column key it does not know. This teaches it to stop assuming it knows the **set**.

`laneVisibility` now takes the columns the board read returned, instead of starting from the hardcoded `STATUSES`:

```ts
const known = columns.map((c) => c.key).filter(…)
```

So an org that owns its board gets its own columns, in its own order, under its own names. `useTaskBoardItems` carries them through from `TASK_BOARD_ITEM_LIST`, and the board threads them into the lane renderer.

**A board with no columns draws none.** Falling back to Studio's lanes would file an org's cards under names nobody there chose — the exact failure this whole direction exists to remove — so the empty case is asserted first.

The delivery-lane and hidden-lane rules survive and still apply only to lanes Studio defined: `isDeliveryLane` is false for a key we did not invent, so those rules fall away on an org board with no special case for it.

### A stale artifact this uncovered

`packages/shared/src/tools/tool-io.ts` was **out of date on main**. It still carried the closed status union that #6710 removed, and was missing the `org_board_columns` flag added in #6698.

Typecheck passed anyway, which is the interesting part: the API compiles against Zod, and a stale *narrower* union is a subset, so nothing on the server noticed. The client was the only thing being lied to — and the client is exactly where the contract matters. Regenerated here.

That also explains a bug it was hiding: `TaskTab` in `home-tasks` was `Extract<TaskBoardItemStatus, "in_progress" | "in_review" | "done">`. With `status` open, `Extract` from a bare `string` collapses to `never` and the strip silently reduced to a single "All" tab. Named outright now — those three are Studio's own lanes, which is what that strip is about.

## How did you verify your code works?

Two new cases in `config.test.ts`, both about the thing that is new rather than the thing that already worked:

- **the org's own columns are drawn, in the server's order**, using names that are not ours (`BACKLOG`, `Fazendo`, `Code Review`) — and with `deliveryEnabled: false`, asserting `hidden` and `hideable` are empty, i.e. Studio's lane rules do not leak onto a set it did not define;
- **a board with no columns draws none** — `{ lanes: [], hidden: [], hideable: [] }`, not the nine lanes.

The existing `laneVisibility` cases keep passing with an explicit `CANONICAL` column set, which is the honest way to say "these describe the board Studio ships".

`apps/web/src` + `apps/api/src/tools/task-board`: **3545 pass / 114 fail**, against a baseline of **3543 / 114** measured by stashing and re-running — same failures, two more tests. `bun run check` 0 errors, `bun run lint` at baseline, `knip` clean, `fmt:check` clean.

**Not verified, flagging honestly:**

- **No live browser check.** The lane renderer, the drag targets and the "Hidden columns" drawer all now read a server-provided list, and I have asserted the list-building function, not the rendering. With the flag off the list is byte-identical to before, which is what makes that acceptable — but I would look at a real board before enabling it anywhere.
- **`title` is still not used.** Columns carry the tracker's own name and the client still renders `laneLabel(key, t)`, which translates a canonical key and otherwise shows the raw key. For a Jira board that means "Code Review" renders as `Code Review` (the key happens to be the name) but a renamed column would show the old key. Wiring `title` through is small and belongs with the sync that first produces titles worth showing.
- **Archived cards on an org board have nowhere to go.** `archived` is a Studio lane; an org board has no such column, so a card archived there would sit in no column. The FK does not catch it (`board_column_org` is null for those) and nothing renders it. Real, and it needs an answer before any org turns the flag on.

## Screenshots/Demonstration

Not captured. With `org_board_columns` off — every org today — the board is unchanged.

## How to Test

1. With the flag off, the board is exactly as before: nine lanes, delivery lanes gated, Archived hidden behind the drawer.
2. Set `org_board_columns: true` on a test org with no columns — the board should draw **nothing**, not Studio's lanes.
3. Insert a few columns for that org and confirm they appear in `position` order, with their own names.

## Migration Notes

None. No schema change. `tool-io.ts` is regenerated; the diff widens `status` to `string` and adds `org_board_columns` to the flags, both of which the server already accepted.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the task board render the columns the board read returns instead of starting from the hardcoded Studio `STATUSES`. An org that owns its board now sees its own columns, in the server's order, and a board with no columns draws none rather than falling back to Studio's nine lanes.

**New Features**
- Delivery-lane and hidden-lane rules still apply, but only to lanes Studio defined; `isDeliveryLane` is false for a key the client did not invent.
- Org boards need the `org_board_columns` flag enabled; with it off, the board is unchanged.

**Bug Fixes**
- `tool-io.ts` was stale on main — regenerated; `status` is now `string` and the missing `org_board_columns` flag is added, both of which the server already accepted.
- `TaskTab` in `home-tasks` collapsed to `never` when `Extract`ed from the open `string` status, silently leaving a single "All" tab; the three Studio lanes are now named outright.

Not verified: no live browser check, and column `title` is not yet rendered — a renamed column would show its raw key. A card moved to `archived` on an org board has nowhere to go, since that lane is Studio's.

<sup>Written for commit a892fb9b0097f51b71975091c9e808857252fbf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

