### PR TITLE
refactor(mcp-clients): type AuthTransport's tools map, not any

### DIFF
--- a/apps/api/src/mcp-clients/outbound/transports/auth.ts
+++ b/apps/api/src/mcp-clients/outbound/transports/auth.ts
@@ -20,6 +20,7 @@ import type {
   JSONRPCMessage,
   JSONRPCRequest,
   CallToolRequest,
+  Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import { WrapperTransport } from "@decocms/mcp-utils";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
@@ -92,7 +93,7 @@ export class AuthTransport extends WrapperTransport {
     return this.toolsListPromise;
   }
 
-  private async ensureToolsMap(): Promise<Map<string, any>> {
+  private async ensureToolsMap(): Promise<Map<string, Tool>> {
     const cache = this.options.cache ?? getMcpListCache();
 
     const tools = await fetchWithCache(
@@ -114,7 +115,7 @@ export class AuthTransport extends WrapperTransport {
       return new Map();
     }
 
-    return new Map((tools as Array<{ name: string }>).map((t) => [t.name, t]));
+    return new Map((tools as Tool[]).map((t) => [t.name, t]));
   }
 
   protected override async handleOutgoingMessage(


### PR DESCRIPTION
**Source:** C-DEBT (un-CI-enforced `no-explicit-any` debt) in `AuthTransport` (`apps/api/src/mcp-clients/outbound/transports/auth.ts`), the transport that authorizes every proxied `tools/call`.

**Why:** `ensureToolsMap()` returned `Map<string, any>` and separately cast the cached `tools/list` payload to `Array<{ name: string }>` to build it. The MCP SDK already exports the real `Tool` type (`@modelcontextprotocol/sdk/types.js`) — using it means a future shape change to the tool schema (e.g. a renamed/removed field this code reads) becomes a compile error here instead of silently passing through as `any`.

**Change:** `Map<string, any>` → `Map<string, Tool>`, and the cast on the cached list narrows to `Tool[]` instead of an ad-hoc inline shape. Pure type-level change, no behavior difference — the runtime values were already `Tool`-shaped (they come straight off `tools/list`).

**Verify:** `cd apps/api && bunx tsc --noEmit` (clean) and `bun test apps/api/src/mcp-clients/outbound/transports/auth.test.ts` (1 pass).

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace), `bunx oxlint apps/api/src/mcp-clients/outbound/transports/auth.ts` (0 warnings/errors), targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Types `AuthTransport`'s tools map as `Map<string, Tool>` instead of `Map<string, any>`. This makes future changes to the MCP SDK's tool schema surface as compile errors instead of silently passing through as `any`. Purely type-level; no runtime behavior changes.

<sup>Written for commit 4846b146cac3899bf6a63b98dedda83c988ebf58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

