### PR TITLE
feat(jira): mirror the board's own columns instead of asking for a mapping

### DIFF
--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -24,6 +24,7 @@
  * its issue is next updated in Jira.
  */
 
+import { orgFlagEnabled } from "@decocms/shared/organization/schema";
 import { boardFor } from "@/tools/task-board/board-handler";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import type { StudioContext } from "@/core/studio-context";
@@ -31,7 +32,6 @@ import type {
   OrgJiraIntegration,
   TaskBoardItem,
   TaskBoardItemPriority,
-  TaskBoardItemStatus,
 } from "@/storage/types";
 import { reactToSuperAgentDelegation } from "@/tools/task-board/enqueue-super-agent";
 import { emitTaskBoardUpdated } from "@/tools/task-board/run-reactions";
@@ -129,6 +129,41 @@ export async function syncJiraIntegrationSafe(
  * Jira's clock, so it can sit ahead of ours, and a negative window emits
  * `updated >= --25m` — a JQL 400 on every tick until the clocks converge.
  */
+/**
+ * Make the org's board look like its Jira board, and hand back the reverse
+ * index the pull needs: Jira status name → the column that groups it.
+ *
+ * Both come from the same call. Jira's board configuration already says which
+ * statuses live in which column, so the mapping is read rather than
+ * configured — and the columns Studio renders are the ones the team sees in
+ * Jira, under the names they gave them.
+ */
+async function mirrorBoardColumns(
+  ctx: StudioContext,
+  integration: OrgJiraIntegration,
+  boardId: string,
+): Promise<Map<string, string>> {
+  const client = new JiraClient(
+    integration.siteUrl,
+    integration.email,
+    integration.apiToken,
+  );
+  const columns = await client.getBoardColumns(boardId);
+  await ctx.storage.boardColumns.replaceAll(
+    integration.organizationId,
+    columns.map((column) => ({ key: column.name, title: column.name })),
+  );
+  const index = new Map<string, string>();
+  for (const column of columns) {
+    // First column wins, as it does for the hand-written mapping: a Jira status
+    // in two columns would otherwise make a card's lane depend on iteration.
+    for (const status of column.statuses) {
+      if (!index.has(status)) index.set(status, column.name);
+    }
+  }
+  return index;
+}
+
 export function buildJql(
   integration: OrgJiraIntegration,
   scopeJql: string,
@@ -497,10 +532,24 @@ async function runSync(
   if (!boardId) {
     throw new Error("No Jira board selected");
   }
-  // One reverse index for the whole sync rather than a scan per issue.
-  const laneOf = laneIndex(integration.statusMapping);
+  const settings = await ctx.storage.organizationSettings.get(
+    integration.organizationId,
+  );
+  const orgOwnedColumns = orgFlagEnabled(settings?.flags, "org_board_columns");
+
+  // One reverse index for the whole sync rather than a scan per issue. On a
+  // board the org owns it is DERIVED from the board's own configuration —
+  // Jira already knows which statuses each of its columns groups, so asking
+  // anyone to restate that by hand was the mapping screen's whole mistake.
+  const laneOf = orgOwnedColumns
+    ? await mirrorBoardColumns(ctx, integration, boardId)
+    : laneIndex(integration.statusMapping);
   if (laneOf.size === 0) {
-    throw new Error("No status mapping configured");
+    throw new Error(
+      orgOwnedColumns
+        ? "This Jira board has no columns to mirror"
+        : "No status mapping configured",
+    );
   }
 
   // First connect / scope change (migration 184) or an unfinished rescan (migration 186).
@@ -566,9 +615,7 @@ async function runSync(
         throw new Error(`Unparseable updated on ${issue.key}`);
       }
 
-      const status = laneOf.get(issue.fields.status.name) as
-        | TaskBoardItemStatus
-        | undefined;
+      const status = laneOf.get(issue.fields.status.name);
       if (!status || !isCardIssue(issue)) {
         if (!status && isCardIssue(issue)) {
           unmapped.add(issue.fields.status.name);

--- a/apps/api/src/storage/task-board-columns.ts
+++ b/apps/api/src/storage/task-board-columns.ts
@@ -43,19 +43,53 @@ export class BoardColumnStorage {
     return await this.db.transaction().execute(async (tx) => {
       const existing = await tx
         .selectFrom("task_board_columns")
-        .select(["key", "role"])
+        .select(["key", "title", "role"])
         .where("organization_id", "=", organizationId)
         .execute();
       const roleOf = new Map(existing.map((r) => [r.key, r.role]));
 
-      await tx
-        .deleteFrom("task_board_columns")
-        .where("organization_id", "=", organizationId)
-        .execute();
+      // A column the tracker dropped that still holds cards is kept, appended
+      // after the mirrored set. Deleting it is refused by the foreign key, and
+      // rightly: moving someone's cards somewhere we picked is a worse answer
+      // than showing a column their tracker no longer has. It disappears on the
+      // first sync after the last card leaves it.
+      const mirrored = new Set(columns.map((column) => column.key));
+      const orphaned = existing.filter((row) => !mirrored.has(row.key));
+      const occupied = orphaned.length
+        ? await tx
+            .selectFrom("task_board_items")
+            .select("status")
+            .distinct()
+            .where("organization_id", "=", organizationId)
+            .where(
+              "status",
+              "in",
+              orphaned.map((row) => row.key),
+            )
+            .execute()
+        : [];
+      const keep = new Set(occupied.map((row) => row.status));
 
-      if (columns.length === 0) return [];
+      const drop = orphaned
+        .filter((row) => !keep.has(row.key))
+        .map((row) => row.key);
+      if (drop.length > 0) {
+        await tx
+          .deleteFrom("task_board_columns")
+          .where("organization_id", "=", organizationId)
+          .where("key", "in", drop)
+          .execute();
+      }
 
-      const rows = columns.map((column, position) => ({
+      const all = [
+        ...columns,
+        ...orphaned
+          .filter((row) => keep.has(row.key))
+          .map((row) => ({ key: row.key, title: row.title })),
+      ];
+      if (all.length === 0) return [];
+
+      const rows = all.map((column, position) => ({
         id: `tbc_${organizationId}_${column.key}`,
         organization_id: organizationId,
         key: column.key,
@@ -63,7 +97,17 @@ export class BoardColumnStorage {
         position,
         role: roleOf.get(column.key) ?? null,
       }));
-      await tx.insertInto("task_board_columns").values(rows).execute();
+      await tx
+        .insertInto("task_board_columns")
+        .values(rows)
+        .onConflict((oc) =>
+          oc.columns(["organization_id", "key"]).doUpdateSet((eb) => ({
+            title: eb.ref("excluded.title"),
+            position: eb.ref("excluded.position"),
+            updated_at: new Date(),
+          })),
+        )
+        .execute();
       return rows.map(({ key, title, position, role }) => ({
         key,
         title,

--- a/apps/api/src/tools/task-board/board-handler.integration.test.ts
+++ b/apps/api/src/tools/task-board/board-handler.integration.test.ts
@@ -7,6 +7,8 @@
  * runs an agent on every card that moves.
  */
 
+import { sql } from "kysely";
+import { TaskBoardStorage } from "@/storage/task-board";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { CANONICAL_COLUMN_KEYS } from "@decocms/shared/task-board";
 import type { StudioDatabase } from "@/database";
@@ -23,10 +25,12 @@ import { LANE_RANK } from "./lanes";
 const ORG = "org_bh_1";
 const OTHER = "org_bh_2";
 const ORG_M = "org_bh_m";
+const USER_M = "user_bh_m";
 
 let database: StudioDatabase;
 let automations: ColumnAutomationStorage;
 let boardColumns: BoardColumnStorage;
+let taskBoard: TaskBoardStorage;
 
 /** One pool for the file. `connectTestPgDatabase` hands back a shared instance,
  *  so a per-describe lifecycle would close it out from under the next one. */
@@ -40,8 +44,13 @@ beforeAll(async () => {
       .values({ id, name: id, slug: id.replace(/_/g, "-"), createdAt: now })
       .execute();
   }
+  await sql`
+    INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+    VALUES (${USER_M}, ${"bhm@test.test"}, false, ${USER_M}, ${now}, ${now})
+  `.execute(database.db);
   automations = new ColumnAutomationStorage(database.db);
   boardColumns = new BoardColumnStorage(database.db);
+  taskBoard = new TaskBoardStorage(database.db);
 });
 
 afterAll(async () => {
@@ -182,6 +191,39 @@ describe("boardHandler — a board whose columns are the org's own", () => {
     expect(await board().archiveColumn()).toBe("BACKLOG");
     await boardColumns.setRole(ORG_M, "BACKLOG", null);
     expect(await board().archiveColumn()).toBe(null);
+  });
+
+  /**
+   * The obligation the foreign key creates. A column the tracker dropped that
+   * still holds cards cannot be deleted — RESTRICT refuses — and moving those
+   * cards somewhere Studio picked is a worse answer than showing a column the
+   * tracker no longer has. It goes to the end and leaves on its own once empty.
+   */
+  it("keeps a dropped column that still holds cards, and drops it once empty", async () => {
+    await boardColumns.replaceAll(ORG_M, [
+      { key: "BACKLOG", title: "Backlog" },
+      { key: "Retired", title: "Retired" },
+    ]);
+    const card = await taskBoard.create({
+      organizationId: ORG_M,
+      title: "left behind",
+      status: "Retired",
+      by: USER_M,
+    });
+
+    await boardColumns.replaceAll(ORG_M, [
+      { key: "BACKLOG", title: "Backlog" },
+    ]);
+    expect((await board().columns()).map((c) => c.key)).toEqual([
+      "BACKLOG",
+      "Retired",
+    ]);
+
+    await taskBoard.update(card.id, ORG_M, { status: "BACKLOG" }, USER_M);
+    await boardColumns.replaceAll(ORG_M, [
+      { key: "BACKLOG", title: "Backlog" },
+    ]);
+    expect((await board().columns()).map((c) => c.key)).toEqual(["BACKLOG"]);
   });
 
   it("runs a rule hung on a column the tracker named", async () => {


### PR DESCRIPTION
The last piece. An org whose board is its own now gets its columns **from Jira**, under the names its team gave them, with each card in the column Jira puts it in.

Both halves come from one call:

```ts
const columns = await client.getBoardColumns(boardId);   // { name, statuses[] }[]
await ctx.storage.boardColumns.replaceAll(org, columns.map(c => ({ key: c.name, title: c.name })));
// and the reverse index the pull needs: Jira status -> the column that groups it
```

**Jira already knows the mapping.** That the mapping screen ever existed is the mistake this removes: it asked a team to restate, by hand and per lane, something their tracker already knew — and it is what made Studio's vocabulary leak into everything downstream, including the agent.

Studio's own board is untouched. It still reads the hand-written mapping, because its lanes are ours and Jira has no idea what they mean.

### Honouring the foreign key, not working around it

`replaceAll` now **keeps a column the tracker dropped when it still holds cards**, appended after the mirrored set.

That is the obligation `ON DELETE RESTRICT` created, and I said in #6710 that writing this sync without it would break production the first time someone tidied their Jira board. The alternatives are worse: RESTRICT refuses the delete outright, and relocating someone's cards to a column *Studio* picked is a worse answer than showing a column their tracker no longer has. It leaves on its own on the first sync after the last card is out.

One implementation detail worth a reviewer's eye: I first made the delete a `not in [...kept, sentinel]` to keep the list non-empty, using a NUL byte as the sentinel. Postgres rejects NUL in text, which the tests caught. It builds an explicit drop list now and skips the statement when it is empty — a sentinel there was a bad idea regardless of the encoding.

## How did you verify your code works?

The case the whole design turns on, against real Postgres: **a dropped column that still holds cards survives, and disappears once emptied.** Both halves in one test, because either alone passes a broken implementation — keeping forever, or dropping immediately.

`apps/api/src`: **4051 pass / 49 fail** against a baseline of **4050 / 49**, measured by checking out `origin/main`'s tree, re-running, and restoring. Same failures, one more test. (My first attempt at that measurement was worthless — I had already committed, so the stash was empty and I compared the change to itself. Worth saying because the number looked fine either way.)

Every `*.integration.test.ts` under `tools/task-board`, `storage` and `jira` also run individually in `find | sort` order, the way CI runs them: all green. `bun run check` 0 errors, `lint` at baseline, `knip` clean.

**Not verified, flagging honestly:**

- **Nothing exercises this against a real Jira.** The mirror is one `getBoardColumns` call and a `replaceAll`; the storage half is covered, the client call is not, and the suite has no fake Jira. The first real sync on an org board is genuinely the first run.
- **A renamed Jira column reads as delete + create.** The column's identity here is its *name*, and the Agile board API gives no stable id for a column. So renaming "Code Review" leaves the old column (holding its cards, by the rule above) and adds an empty new one. Not destructive, but confusing, and someone will hit it. Matching by status-set to detect a rename is the fix and it is not here.
- **`board_column_org` is still never written**, so the foreign key still sleeps even for these cards. That is the next thing, and until it lands the FK is protection we have paid for and are not using.
- **`in_review` roles are still inert** — settable since #6718, read by nothing.

## Screenshots/Demonstration

Not captured. With `org_board_columns` off — every org today — the sync behaves exactly as before.

## How to Test

1. On an org with Jira and the flag **off**: unchanged, the hand-written mapping still drives everything.
2. Turn `org_board_columns` on, run a sync, and confirm the board shows that Jira board's columns, in its order, with its names.
3. Confirm each card sits in the column Jira has its status in.
4. Delete a column in Jira that still has cards, sync, and confirm the column stays at the end with its cards — and that the sync does **not** error.
5. Move those cards out, sync again, and confirm the column disappears.

## Migration Notes

None. No schema change. `status_mapping` is still read for Studio's own board and is untouched; it becomes dead only once every Jira org is on its own board.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Org-owned boards now get their columns read from Jira instead of asking teams to hand-maintain a status mapping, placing each card in the column Jira's board config assigns its status. With the `org_board_columns` flag off, the hand-written mapping still drives everything, and Studio's own board is untouched.

**New Features**
- The sync reads the board's columns and their status groups from Jira in one call and replaces the stored board columns, preserving existing roles.
- A tracker-dropped column that still holds cards is kept at the end of the list and removed on the first sync after the last card leaves, honoring the `ON DELETE RESTRICT` foreign key.
- Caveat: a renamed Jira column comes through as delete + create, since the column's name is its identity and the Agile API exposes no stable column id; the old column lingers with its cards and an empty new one appears.

<sup>Written for commit f9002bb7e3571a85233276940ab292da8178c803. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

