### PR TITLE
feat(task-board): wake the column foreign key

### DIFF
--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -638,6 +638,11 @@ async function runSync(
         description: await cardDescription(integration.siteUrl, issue, users),
         priority: mapPriority(issue),
         sprintId: await sprints.localIdFor(pickIssueSprint(issue.sprints)),
+        // Written alongside the status it describes, so a card enters the
+        // foreign key's protection the moment the sync first places it in a
+        // column of the org's own — no separate backfill, and a card the sync
+        // has not reached yet simply stays unguarded rather than wrong.
+        boardColumnOrg: orgOwnedColumns ? orgId : null,
       };
 
       if (link) {

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -277,6 +277,10 @@ export class TaskBoardStorage {
     title: string;
     description?: string | null;
     status?: string;
+    /** Set to the org id when the card's status names a row in
+     *  `task_board_columns`, which is what wakes the optional foreign key.
+     *  Null while the status is one of Studio's own lanes. */
+    boardColumnOrg?: string | null;
     priority?: TaskBoardItemPriority;
     type?: TaskBoardItemType;
     assigneeId?: string | null;
@@ -310,6 +314,7 @@ export class TaskBoardStorage {
           title: params.title,
           description: params.description ?? null,
           status,
+          board_column_org: params.boardColumnOrg ?? null,
           priority: params.priority ?? "medium",
           type: params.type ?? DEFAULT_TASK_TYPE,
           assignee_id: params.assigneeId ?? null,
@@ -357,6 +362,10 @@ export class TaskBoardStorage {
       title?: string;
       description?: string | null;
       status?: string;
+      /** Set to the org id when the card's status names a row in
+       *  `task_board_columns`, which is what wakes the optional foreign key.
+       *  Null while the status is one of Studio's own lanes. */
+      boardColumnOrg?: string | null;
       priority?: TaskBoardItemPriority;
       type?: TaskBoardItemType;
       assigneeId?: string | null;
@@ -387,6 +396,9 @@ export class TaskBoardStorage {
         ...(data.repo !== undefined ? { repo: data.repo } : {}),
         ...(data.dueDate !== undefined ? { due_date: data.dueDate } : {}),
         ...(data.sprintId !== undefined ? { sprint_id: data.sprintId } : {}),
+        ...(data.boardColumnOrg !== undefined
+          ? { board_column_org: data.boardColumnOrg }
+          : {}),
         ...(data.sortOrder !== undefined ? { sort_order: data.sortOrder } : {}),
         // Any move OUT of the two lanes a review can span closes the cycle.
         // Done here rather than at the call sites so it covers every one of

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1629,6 +1629,14 @@ export interface TaskBoardItemTable {
   /** The key of the column the card sits in — free text, because on a board
    *  whose columns are the org's own the key comes from their tracker. */
   status: ColumnType<string, string | undefined, string>;
+  /** The org id when `status` names a row in `task_board_columns`, null when it
+   *  names one of Studio's lanes. Half of the optional foreign key (migration
+   *  193): NULL is what lets the key sleep on a board built from constants. */
+  board_column_org: ColumnType<
+    string | null,
+    string | null | undefined,
+    string | null
+  >;
   priority: ColumnType<
     TaskBoardItemPriority,
     TaskBoardItemPriority | undefined,

--- a/apps/api/src/tools/task-board/board-handler.integration.test.ts
+++ b/apps/api/src/tools/task-board/board-handler.integration.test.ts
@@ -226,6 +226,36 @@ describe("boardHandler — a board whose columns are the org's own", () => {
     expect((await board().columns()).map((c) => c.key)).toEqual(["BACKLOG"]);
   });
 
+  /**
+   * The foreign key was paid for in #6710 and slept until something wrote the
+   * discriminator. These pin that it is now awake for a card the sync placed,
+   * and still asleep for one it has not — which is what makes adopting it
+   * incremental instead of a flag day.
+   */
+  it("refuses a card in a column the board does not have, once guarded", async () => {
+    await boardColumns.replaceAll(ORG_M, [
+      { key: "BACKLOG", title: "Backlog" },
+    ]);
+    const guarded = taskBoard.create({
+      organizationId: ORG_M,
+      title: "guarded",
+      status: "not_a_column",
+      boardColumnOrg: ORG_M,
+      by: USER_M,
+    });
+    await expect(guarded).rejects.toThrow(/foreign key|violates/i);
+  });
+
+  it("accepts the same card while it is still unguarded", async () => {
+    const card = await taskBoard.create({
+      organizationId: ORG_M,
+      title: "unguarded",
+      status: "not_a_column",
+      by: USER_M,
+    });
+    expect(card.status).toBe("not_a_column");
+  });
+
   it("runs a rule hung on a column the tracker named", async () => {
     await automations.upsert(ORG_M, "Code Review", "Review it.");
     expect((await board().automationFor("Code Review"))?.prompt).toBe(


### PR DESCRIPTION
The optional foreign key has been in the schema since #6710 and **asleep the whole time**, because nothing wrote the half that switches it on. The sync writes it now, alongside the status it describes.

### It is a property of the board, not of the card

`board_column_org` is the org id when a card's status names a row in `task_board_columns`, and null when it names one of Studio's lanes. That depends only on which board the org has — so there is no per-card decision to get wrong, and **no backfill**:

- a card enters the key's protection the moment the sync first places it in a column of the org's own;
- a card the sync has not reached yet stays *unguarded*, not wrong.

Adoption is incremental instead of a flag day.

### Why it follows the mirror rather than the flag

Setting the discriminator when `org_board_columns` is toggled would fail for every card still holding a canonical status — the columns do not exist until the first mirror runs, and the mirror only runs once the flag is on. Writing it with the status sidesteps that ordering problem entirely: the guard follows the data.

### A gap this uncovered

`types.ts` did not have `board_column_org` at all. Migration 193 added the column to Postgres and nothing to the typed schema, so the storage could not have written it even deliberately. Added here.

## How did you verify your code works?

Two real-Postgres cases, and they are a pair on purpose — either alone would pass an implementation that is wrong in the other direction:

- **a guarded card in a column the board does not have is refused** (`boardColumnOrg` set, status `not_a_column`) — the key is genuinely enforcing;
- **the same card is accepted while unguarded** — the key is genuinely optional, which is what makes incremental adoption work rather than breaking every card the sync has not touched.

Every `*.integration.test.ts` under `apps/api/src` run individually in `find | sort` order, the way CI runs them. Two fail — `org-fs` and `s3-service` — and both fail identically on baseline, measured by stashing and re-running; they are external-storage tests unrelated to this. `bun run check` 0 errors, `lint` at baseline, `knip` clean.

**Not verified, flagging honestly:**

- **No org board has cards yet**, so nothing has exercised the guarded path outside tests. The first real sync on an org-owned board is the first time this runs for real.
- **Existing cards are never retro-guarded** unless a sync touches them. An org that converts and then never edits an old card leaves it unguarded forever. That is the safe direction, but it means the key's coverage is "whatever the sync has seen", not "everything" — a full re-scan closes it, and `JIRA_RESYNC_REQUEST` is how you ask for one.
- **Nothing writes the discriminator outside the sync.** A card created in Studio on an org-owned board gets null, so it is unguarded. That is a real hole in the guarantee and the create/update tools are where it should be closed.

## Screenshots/Demonstration

Not applicable — no visible change.

## How to Test

1. With `org_board_columns` off: unchanged, and every card keeps a null discriminator.
2. On an org board after a sync, check `board_column_org` equals the org id on the cards the sync touched.
3. Try to move one of those cards to a status that is not a column, straight through SQL — Postgres should refuse it.
4. Do the same to a card the sync has not touched — it should be allowed, which is the intended asymmetry.

## Migration Notes

None — migration 193 already added the column. This is the first writer.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wakes the optional foreign key on `task_board_columns` by having the Jira sync write `board_column_org` alongside status. The key has been in the schema since #6710 but nothing wrote the discriminator, so it never enforced anything.

- `board_column_org` is the org id when a card's status names an org column, and null when it names a Studio lane.
- Writing it with the status avoids a backfill: a card is guarded from its first sync placement, and cards the sync hasn't reached stay unguarded.
- The typed schema in `types.ts` was missing the column, so storage could not have written it before.
- Integration tests pin both directions: a guarded card is refused for a column the board doesn't have, while the same card is accepted unguarded.

<sup>Written for commit b0bf07f4c351657873ca8f40c65d068ea7bd9e3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

