### PR TITLE
fix(task-board): make a column role unique when reassigned

### DIFF
--- a/apps/api/src/storage/task-board-columns.ts
+++ b/apps/api/src/storage/task-board-columns.ts
@@ -117,18 +117,37 @@ export class BoardColumnStorage {
     });
   }
 
-  /** Say what one of this board's columns means to Studio, or unsay it. */
+  /**
+   * Say what one of this board's columns means to Studio, or unsay it.
+   *
+   * A role means one column, not a set of them — `archiveColumn` and
+   * `automationFor` both read it that way, picking whichever row happens to
+   * match first. So giving a role to a column strips it from whichever column
+   * held it before, in the same transaction, rather than leaving two columns
+   * quietly claiming the same meaning.
+   */
   async setRole(
     organizationId: string,
     key: string,
     role: string | null,
   ): Promise<boolean> {
-    const result = await this.db
-      .updateTable("task_board_columns")
-      .set({ role, updated_at: new Date() })
-      .where("organization_id", "=", organizationId)
-      .where("key", "=", key)
-      .executeTakeFirst();
-    return (result.numUpdatedRows ?? 0n) > 0n;
+    return await this.db.transaction().execute(async (tx) => {
+      if (role !== null) {
+        await tx
+          .updateTable("task_board_columns")
+          .set({ role: null, updated_at: new Date() })
+          .where("organization_id", "=", organizationId)
+          .where("role", "=", role)
+          .where("key", "!=", key)
+          .execute();
+      }
+      const result = await tx
+        .updateTable("task_board_columns")
+        .set({ role, updated_at: new Date() })
+        .where("organization_id", "=", organizationId)
+        .where("key", "=", key)
+        .executeTakeFirst();
+      return (result.numUpdatedRows ?? 0n) > 0n;
+    });
   }
 }

--- a/apps/api/src/tools/task-board/board-handler.integration.test.ts
+++ b/apps/api/src/tools/task-board/board-handler.integration.test.ts
@@ -193,6 +193,17 @@ describe("boardHandler — a board whose columns are the org's own", () => {
     expect(await board().archiveColumn()).toBe(null);
   });
 
+  /** A role names one column. Re-pointing it must strip it from wherever it
+   *  used to be, or `archiveColumn` picks between two columns that both
+   *  quietly claim "archived" — whichever the query happens to return first. */
+  it("moves a role rather than duplicating it onto a second column", async () => {
+    await boardColumns.setRole(ORG_M, "BACKLOG", "archived");
+    await boardColumns.setRole(ORG_M, "Code Review", "archived");
+    const columns = await board().columns();
+    expect(columns.filter((c) => c.role === "archived")).toHaveLength(1);
+    expect(await board().archiveColumn()).toBe("Code Review");
+  });
+
   /**
    * The obligation the foreign key creates. A column the tracker dropped that
    * still holds cards cannot be deleted — RESTRICT refuses — and moving those


### PR DESCRIPTION
Follows #6718.

`TASK_BOARD_COLUMN_ROLE_SET` (and the underlying `BoardColumnStorage.setRole`) writes a role onto the target column but never clears it from wherever it used to be. Re-pointing the org's "archived" (or "in_review") role from column A to column B leaves both A and B carrying the role — `archiveColumn()`/`automationFor()` pick a match with `.find()`, so which column actually fires the archive sweep or the review automation becomes arbitrary based on column position, and the previous column silently keeps acting as the archive/review lane even though the org believes it moved.

Failure scenario: an org sets `archived` on column `BACKLOG`, later reassigns it to `Code Review` (e.g. renaming their tracker's done-lane). Before this fix, `BACKLOG` still has `role: "archived"` in storage, so a card auto-archived could land back in `BACKLOG` depending on column ordering, not the org's intended column.

Fix: `setRole()` now clears the role from any other column in the org that holds it, in the same DB transaction, before writing it to the target column — a role names one column.

Regression test added in `board-handler.integration.test.ts` ("moves a role rather than duplicating it onto a second column"), following the file's existing real-Postgres integration-test pattern.

To confirm: `DATABASE_URL=... bun test apps/api/src/tools/task-board/board-handler.integration.test.ts` (needs the `storage-integration` Postgres service, per the file's own header — I could not run it locally since this laptop's embedded Postgres belongs to an unrelated project with a divergent migration history; CI's `storage-integration` job will exercise it).

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean on touched files), `bunx oxlint` on both changed files (0 warnings/errors). Full CI (including `storage-integration`) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `setRole()` so a column role moves instead of duplicating when reassigned. Re-pointing `archived` or `in_review` from one column to another used to leave the role on both columns, so `archiveColumn()` and `automationFor()` picked arbitrarily by column position and the old column silently kept acting as the archive or review lane. Now the role is cleared from any other column in the org in the same transaction before being written to the target.

**Regression test**
- Verifies a role moves rather than duplicating onto a second column in `board-handler.integration.test.ts`.

<sup>Written for commit eb896acc49951d5a94338b27766cc3f2e1f8591c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

