### PR TITLE
feat(task-board): guard a card from the moment it is written

### DIFF
--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -541,6 +541,7 @@ async function runSync(
   // board the org owns it is DERIVED from the board's own configuration —
   // Jira already knows which statuses each of its columns groups, so asking
   // anyone to restate that by hand was the mapping screen's whole mistake.
+  const board = await boardFor(ctx, integration.organizationId);
   const laneOf = orgOwnedColumns
     ? await mirrorBoardColumns(ctx, integration, boardId)
     : laneIndex(integration.statusMapping);
@@ -638,11 +639,11 @@ async function runSync(
         description: await cardDescription(integration.siteUrl, issue, users),
         priority: mapPriority(issue),
         sprintId: await sprints.localIdFor(pickIssueSprint(issue.sprints)),
-        // Written alongside the status it describes, so a card enters the
-        // foreign key's protection the moment the sync first places it in a
-        // column of the org's own — no separate backfill, and a card the sync
-        // has not reached yet simply stays unguarded rather than wrong.
-        boardColumnOrg: orgOwnedColumns ? orgId : null,
+        // Asked of the board, not recomputed from the flag: one answer for
+        // every writer, so a card cannot be guarded by one path and not by
+        // another. A card the sync has not reached yet stays unguarded rather
+        // than wrong, which is what makes adopting the key incremental.
+        boardColumnOrg: board.columnOwner(),
       };
 
       if (link) {

--- a/apps/api/src/tools/task-board/board-handler.integration.test.ts
+++ b/apps/api/src/tools/task-board/board-handler.integration.test.ts
@@ -77,6 +77,10 @@ describe("boardHandler — the board Studio ships with", () => {
     }
   });
 
+  it("leaves a card unguarded, because its lanes are constants", () => {
+    expect(board().columnOwner()).toBe(null);
+  });
+
   it("retires a finished card to its Archived lane", async () => {
     expect(await board().archiveColumn()).toBe("archived");
   });
@@ -254,6 +258,12 @@ describe("boardHandler — a board whose columns are the org's own", () => {
       by: USER_M,
     });
     expect(card.status).toBe("not_a_column");
+  });
+
+  /** The value every writer asks for instead of recomputing. Getting it from
+   *  the board is what stops one path guarding a card and another not. */
+  it("names itself as the owner a guarded card is held to", () => {
+    expect(board().columnOwner()).toBe(ORG_M);
   });
 
   it("runs a rule hung on a column the tracker named", async () => {

--- a/apps/api/src/tools/task-board/board-handler.ts
+++ b/apps/api/src/tools/task-board/board-handler.ts
@@ -42,6 +42,16 @@ export interface BoardHandler {
    * that does not exist — invisible, which is worse than not archiving.
    */
   archiveColumn(): Promise<string | null>;
+
+  /**
+   * What to write into a card's `board_column_org` — the org id when this
+   * board's columns are rows the foreign key can hold it to, null when they
+   * are Studio's constants and the key must stay asleep.
+   *
+   * Asked of the board rather than recomputed from the flag at each writer, so
+   * one answer cannot drift from another and leave a card unguarded.
+   */
+  columnOwner(): string | null;
 }
 
 /** `title` is the key: the canonical columns are translated by the client,
@@ -72,6 +82,10 @@ class StudioBoardHandler implements BoardHandler {
 
   archiveColumn(): Promise<string | null> {
     return Promise.resolve("archived");
+  }
+
+  columnOwner(): string | null {
+    return null;
   }
 }
 
@@ -108,6 +122,10 @@ class OrgBoardHandler implements BoardHandler {
   async archiveColumn(): Promise<string | null> {
     const columns = await this.boardColumns.listByOrg(this.organizationId);
     return columns.find((column) => column.role === "archived")?.key ?? null;
+  }
+
+  columnOwner(): string | null {
+    return this.organizationId;
   }
 }
 

--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -76,11 +76,11 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
       );
     }
 
+    // Resolved once and reused below: the same board answers whether the status
+    // is real and whether the card is one the foreign key can hold.
+    const board = await boardFor(ctx, organizationId);
     if (input.status !== undefined) {
-      await assertBoardHasColumn(
-        await boardFor(ctx, organizationId),
-        input.status,
-      );
+      await assertBoardHasColumn(board, input.status);
       const settings =
         await ctx.storage.organizationSettings.get(organizationId);
       if (
@@ -119,6 +119,8 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
       description: input.description ?? null,
       // A task handed to the Super Agent is queued to run — land it in To Do.
       status: delegatedToSuperAgent ? "todo" : input.status,
+      // Guarded from birth, not from whenever a sync first touches it.
+      boardColumnOrg: board.columnOwner(),
       priority: input.priority,
       type: input.type,
       assigneeId: input.assigneeId ?? null,

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -291,11 +291,9 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
       throw new Error(`Task board item not found: ${input.id}`);
     }
 
+    const board = await boardFor(ctx, organizationId);
     if (input.status !== undefined) {
-      await assertBoardHasColumn(
-        await boardFor(ctx, organizationId),
-        input.status,
-      );
+      await assertBoardHasColumn(board, input.status);
     }
 
     if (input.status !== undefined && isDeliveryLane(input.status)) {
@@ -389,6 +387,11 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
           title: input.title,
           description: input.description,
           status: becameSuperAgent ? "todo" : input.status,
+          // Written with the status it describes, so a card cannot end up in a
+          // column of the org's own while still unguarded.
+          ...(input.status !== undefined || becameSuperAgent
+            ? { boardColumnOrg: board.columnOwner() }
+            : {}),
           priority: input.priority,
           type: input.type,
           assigneeId: input.assigneeId,


### PR DESCRIPTION
#6721 woke the foreign key for cards the **sync** places. A card written in Studio still got a null discriminator — so on a board whose columns are the org's own it sat outside the protection we had just paid for. A hole from the first card anyone created on the screen.

I flagged this in #6721's own description; this closes it.

### One answer, asked of the board

```ts
/** What to write into a card's `board_column_org` — the org id when this
 *  board's columns are rows the key can hold it to, null when they are
 *  Studio's constants and the key must stay asleep. */
columnOwner(): string | null;
```

Both write tools set it, from the same board instance that just said the status was real. The sync now asks the same question instead of reading the flag itself, so there is **one** answer rather than three.

That matters more than it looks. Two writers deriving the same value independently is how one of them ends up wrong, and the failure here is silent: an unguarded card is indistinguishable from a guarded one right up until the day it is filed under a column that does not exist.

`update` writes it only alongside a status change — the discriminator describes the status, and nothing else about a card can invalidate it.

## How did you verify your code works?

A case per board, asserting the two answers that must not be the same value:

- Studio's board reports `null` — *because its lanes are constants*, so the key has nothing to hold a card to and must stay asleep;
- an org board reports its org id — the value a guarded card is held to.

These sit alongside the pair from #6721 (a guarded card in a nonexistent column is refused; the same card unguarded is accepted), which together now cover the whole state machine: who is guarded, by what, and what happens when they are not.

`apps/api/src`: **4055 pass / 49 fail** against a baseline of **4053 / 49**, measured by checking out `origin/main`'s tree, re-running, and restoring. Same failures, two more tests. The 49 are `org-fs` and `s3-service` (external storage, unrelated) plus the known order-dependent set.

Every `*.integration.test.ts` under `apps/api/src` also run individually in `find | sort` order, the way CI runs them — only those same two files fail, identically on baseline. `bun run check` 0 errors, `lint` at baseline, `knip` clean.

**Not verified, flagging honestly:**

- **Still no org board with cards anywhere**, so the guarded path has only ever run in tests. That stays true until someone enables the flag.
- **Import and other bulk writers are untouched.** `task-board-import` and anything else writing a card through storage directly still leaves the discriminator null. Same shape of hole as this one, smaller surface; I did not audit every storage caller and would not claim the guarantee is now total.
- **Cards written before this** keep null until a sync or an edit touches them. A full re-scan closes it for Jira-linked cards; a Studio-native card on an org board needs an edit.

## Screenshots/Demonstration

Not applicable — no visible change.

## How to Test

1. With `org_board_columns` off, create and move cards: the discriminator stays null everywhere, exactly as before.
2. On an org board, create a card through the UI and check `board_column_org` equals the org id.
3. Move it to a column that does not exist via direct SQL — Postgres should now refuse.
4. Confirm a card created before this change is still allowed that move, until you edit its status through the tool.

## Migration Notes

None. No schema change; this is the second writer of a column that already exists.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards cards written in Studio with the `board_column_org` foreign key, closing the hole where an org-board card created through the UI sat unguarded until a sync or edit touched it.

- Adds `columnOwner()` to the board handler and has `create`, `update`, and the sync ask the board for the value, so all three writers can't drift apart.
- `update` writes the discriminator only alongside a status change; other card edits leave it untouched.
- Existing cards keep null until a sync or an edit reaches them; bulk writers like `task-board-import` are not covered.

<sup>Written for commit 542db960cd35e55f365b67b19fa9604546b46c90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

