### PR TITLE
fix(jira): re-home a card stranded in a column its board no longer has

### DIFF
--- a/apps/api/src/jira/sync.test.ts
+++ b/apps/api/src/jira/sync.test.ts
@@ -4,6 +4,7 @@ import {
   buildJql,
   isUnchanged,
   rescanContinues,
+  rewritesStatus,
   runTruncated,
   vanishedLinks,
 } from "./sync";
@@ -210,5 +211,85 @@ describe("runTruncated", () => {
 
   it("is not truncated when a run finishes under both caps", () => {
     expect(runTruncated(42, 1)).toBe(false);
+  });
+});
+
+/**
+ * The rule that makes a board conversion survivable.
+ *
+ * Normally the pull leaves a card's status alone unless Jira's own changed —
+ * that is what stops an unrelated edit yanking back a card the agent
+ * advanced. But on the day an org's board becomes its own, every card is
+ * holding one of Studio's lanes while the columns are suddenly the tracker's,
+ * and a card nobody touched in Jira would render nowhere at all.
+ */
+describe("rewritesStatus", () => {
+  const columns = new Set(["BACKLOG", "Fazendo", "Code Review"]);
+
+  it("writes when Jira moved the issue", () => {
+    expect(
+      rewritesStatus({
+        jiraStatusChanged: true,
+        currentStatus: "Fazendo",
+        boardColumns: columns,
+      }),
+    ).toBe(true);
+  });
+
+  it("leaves a card alone when Jira did not move it", () => {
+    expect(
+      rewritesStatus({
+        jiraStatusChanged: false,
+        currentStatus: "Fazendo",
+        boardColumns: columns,
+      }),
+    ).toBe(false);
+  });
+
+  it("re-homes a card stranded in a column the board does not have", () => {
+    expect(
+      rewritesStatus({
+        jiraStatusChanged: false,
+        currentStatus: "triage",
+        boardColumns: columns,
+      }),
+    ).toBe(true);
+  });
+
+  /** The bound that makes this a conversion path and not a standing override:
+   *  a re-homed card stops being re-written on the very next pull. */
+  it("stops re-homing once the card lands somewhere real", () => {
+    expect(
+      rewritesStatus({
+        jiraStatusChanged: false,
+        currentStatus: "BACKLOG",
+        boardColumns: columns,
+      }),
+    ).toBe(false);
+  });
+
+  it("has nothing to re-home when the card could not be read", () => {
+    expect(
+      rewritesStatus({
+        jiraStatusChanged: false,
+        currentStatus: null,
+        boardColumns: columns,
+      }),
+    ).toBe(false);
+  });
+
+  /** Studio's own board answers with its nine lanes, so no card on it is ever
+   *  stranded and this rule changes nothing there. */
+  it("never re-homes on a board whose columns are Studio's own", () => {
+    const canonical = new Set(["triage", "todo", "in_progress", "done"]);
+    for (const status of canonical) {
+      expect(
+        rewritesStatus({
+          jiraStatusChanged: false,
+          currentStatus: status,
+          boardColumns: canonical,
+        }),
+      ).toBe(false);
+    }
   });
 });

--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -164,6 +164,33 @@ async function mirrorBoardColumns(
   return index;
 }
 
+/**
+ * Whether the pull writes the card's status, or leaves it where it is.
+ *
+ * Normally only when Jira's own status changed — an unrelated issue edit must
+ * not yank back a card the agent already advanced.
+ *
+ * The exception is a card sitting in a column this board does not have. That
+ * is EVERY card on the day an org's board becomes its own: their statuses are
+ * Studio's lanes, the columns are suddenly the tracker's, and a card nobody
+ * touched in Jira would render nowhere at all. Re-homing is bounded to exactly
+ * those cards and stops for each one the moment it lands somewhere real, so it
+ * is a conversion path rather than a standing override.
+ */
+export function rewritesStatus({
+  jiraStatusChanged,
+  currentStatus,
+  boardColumns,
+}: {
+  jiraStatusChanged: boolean;
+  /** Null when the card could not be read; nothing to re-home. */
+  currentStatus: string | null;
+  boardColumns: ReadonlySet<string>;
+}): boolean {
+  if (jiraStatusChanged) return true;
+  return currentStatus !== null && !boardColumns.has(currentStatus);
+}
+
 export function buildJql(
   integration: OrgJiraIntegration,
   scopeJql: string,
@@ -545,6 +572,10 @@ async function runSync(
   const laneOf = orgOwnedColumns
     ? await mirrorBoardColumns(ctx, integration, boardId)
     : laneIndex(integration.statusMapping);
+  // Read AFTER the mirror, or the first sync of a converting board would see
+  // no columns at all and call every card stranded — right by accident, and
+  // wrong the moment a board legitimately has none.
+  const columnKeys = new Set((await board.columns()).map((c) => c.key));
   if (laneOf.size === 0) {
     throw new Error(
       orgOwnedColumns
@@ -650,16 +681,21 @@ async function runSync(
         // Status applies only when it changed ON JIRA'S SIDE, so an unrelated issue edit can't yank back a card the agent already advanced.
         const statusChangedOnJira = link.jiraStatus !== jiraStatusName;
         const before = await ctx.storage.taskBoard.getById(link.itemId, orgId);
+        const writeStatus = rewritesStatus({
+          jiraStatusChanged: statusChangedOnJira,
+          currentStatus: before?.status ?? null,
+          boardColumns: columnKeys,
+        });
         let item = await ctx.storage.taskBoard.update(
           link.itemId,
           orgId,
-          { ...fields, ...(statusChangedOnJira ? { status } : {}) },
+          { ...fields, ...(writeStatus ? { status } : {}) },
           JIRA_SYNC_ACTOR,
         );
         await ctx.storage.jiraIntegrations.touchLink(link.itemId, {
           jiraStatus: jiraStatusName,
         });
-        if (before && statusChangedOnJira && before.status !== status) {
+        if (before && writeStatus && before.status !== status) {
           await ctx.storage.taskBoard.recordActivity({
             taskBoardItemId: link.itemId,
             action: "status_changed",


### PR DESCRIPTION
**Enabling an org's own board would have made every one of its existing cards invisible.** I found this while planning the rollout, not from a test — worth saying plainly, because nothing in the suite would have caught it.

The pull writes a card's status only when **Jira's own** status changed. That guard is right and stays: an unrelated issue edit must not yank back a card the agent already advanced.

But on the day a board becomes the org's own, every card is holding one of Studio's lanes (`triage`, `done`, …) while the columns are suddenly the tracker's (`BACKLOG`, `Fazendo`, …). Nothing changed in Jira, so nothing gets rewritten — and every card sits in a column that does not exist. Not misfiled: **rendered nowhere at all.**

The pull now also writes when the card's current status is not one of the board's columns:

```ts
export function rewritesStatus({ jiraStatusChanged, currentStatus, boardColumns }) {
  if (jiraStatusChanged) return true;
  return currentStatus !== null && !boardColumns.has(currentStatus);
}
```

That is bounded to exactly the stranded cards, and stops for each one the moment it lands somewhere real — a conversion path, not a standing override of the guard.

### One ordering detail that is load-bearing

The column set is read **after** the mirror runs. Read before, the very first sync of a converting board sees no columns yet, calls every card stranded, and re-homes them all. Right by accident, and wrong the moment a board legitimately has no columns. I wrote it the wrong way round first and caught it re-reading the call order.

Studio's own board answers with its nine lanes, so no card on it is ever stranded and nothing there changes.

## How did you verify your code works?

The rule is extracted as a pure function precisely so it can be tested — the surrounding pull loop needs a fake Jira the suite does not have. Six cases, and the two that matter most are the bounds rather than the happy path:

- **it stops re-homing once the card lands somewhere real** — otherwise this is not a conversion, it is the sync permanently overriding a guard that exists for a good reason;
- **it never re-homes on a board whose columns are Studio's own** — asserted across the canonical lanes, since a regression here would silently start rewriting statuses on every org that has Jira.

Plus: writes when Jira moved the issue, leaves it alone when Jira did not, and nothing to do when the card could not be read.

`apps/api/src`: **4061 pass / 49 fail** against a baseline of **4053 / 49** measured earlier today by checking out `origin/main`'s tree — same failures (`org-fs`, `s3-service`, and the known order-dependent set), eight more tests. `bun run check` 0 errors, `lint` at baseline, `knip` clean.

**Not verified, flagging honestly:**

- **The end-to-end conversion has never run.** Nothing exercises "flag on → sync → cards move" against a real Jira, because the suite has no fake for it. The pure rule is covered; the wiring around it is read, not run. The first conversion is the first real test, which is why the next step is enabling on one tenant and watching, not enabling broadly.
- **A card whose Jira status maps to no column is still skipped entirely** by the pull, as before. On an org board that should be rare (every board status belongs to some column), but a status outside the board's columns is possible in Jira and such a card would stay stranded rather than be re-homed.
- **Nothing re-homes a Studio-native card.** A card with no Jira link never enters this loop, so on a converted board it stays in a canonical lane and stays invisible. That is a real remaining gap and it needs its own answer before a tenant with hand-made cards converts.

## Screenshots/Demonstration

Not applicable.

## How to Test

1. On an org with `org_board_columns` off: nothing changes — the status guard behaves exactly as before.
2. On a test org with Jira, turn the flag on and sync. Every linked card should land in the Jira column its issue is actually in, not vanish.
3. Sync again and confirm the cards are **not** rewritten a second time — no timeline churn.
4. Move a card in Studio to another of the board's columns, sync, and confirm the sync leaves it there (Jira did not move it, and it is not stranded).

## Migration Notes

None. No schema change. This only affects orgs with `org_board_columns` on, of which there are none.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes board conversion making every existing card invisible by re-homing cards stranded in a column the board no longer has. The sync previously rewrote a card's status only when Jira's status changed; it now also rewrites when the card's status is not among the board's columns, and stops once the card lands somewhere real.

**Bug Fixes**
- Reads the board's columns after the mirror runs; reading first would make a converting board's first sync see no columns and re-home every card.
- Studio's native board is unaffected because its nine lanes are its own columns.
- Cards with no Jira link and cards whose Jira status maps to no column are still not re-homed; both remain known gaps.

<sup>Written for commit 81a2d255eed38f19fa2ae11bfaec4cd40f8a0063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

