### PR TITLE
fix(task-board): guard a card the auto-archive sweep retires into an org column

### DIFF
--- a/apps/api/src/tools/task-board/archive-merged.integration.test.ts
+++ b/apps/api/src/tools/task-board/archive-merged.integration.test.ts
@@ -177,6 +177,71 @@ describe("auto-archive sweep", () => {
     expect(second.archived).toBe(0);
   });
 
+  /**
+   * The org-owned board's `archiveColumn()` names a row the foreign key can
+   * hold a card to (#6710/#6723). The sweep must guard the card the same way
+   * `update.ts` does, or it retires the card into that row without the
+   * discriminator the key needs to notice.
+   */
+  it("guards a card the sweep retires into an org-owned archive column", async () => {
+    const orgOwned = "org_archive_owned";
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: orgOwned,
+        name: orgOwned,
+        slug: "org-archive-owned",
+        createdAt: now,
+      })
+      .execute();
+    await new OrganizationSettingsStorage(database.db).upsert(orgOwned, {
+      flags: { org_board_columns: true },
+    });
+    await ctx.storage.boardColumns.replaceAll(orgOwned, [
+      { key: "Retired", title: "Retired" },
+    ]);
+    await ctx.storage.boardColumns.setRole(orgOwned, "Retired", "archived");
+
+    const settled = new Date(Date.now() - 3 * DAY_MS);
+    const item = await taskBoard.create({
+      organizationId: orgOwned,
+      title: "owned-board-archive",
+      status: "done",
+      by: USER,
+    });
+    await database.db
+      .updateTable("task_board_items")
+      .set({ updated_at: settled })
+      .where("id", "=", item.id)
+      .execute();
+    await taskBoard.linkPr({
+      taskBoardItemId: item.id,
+      organizationId: orgOwned,
+      url: `https://github.com/acme/repo/pull/${item.id}`,
+      prNumber: 1,
+      repoOwner: "acme",
+      repoName: "repo",
+    });
+
+    expect(
+      (
+        await archiveMergedForOrg(ctx, orgOwned, [item.id], async () => ({
+          state: "closed" as const,
+          merged: true,
+        }))
+      ).archived,
+    ).toBe(1);
+
+    const row = await database.db
+      .selectFrom("task_board_items")
+      .select(["status", "board_column_org"])
+      .where("id", "=", item.id)
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("Retired");
+    expect(row.board_column_org).toBe(orgOwned);
+  });
+
   it("archives past an abandoned PR, and waits on a second repo", async () => {
     const settled = new Date(Date.now() - 3 * DAY_MS);
     const link = (id: string, prNumber: number, repoName: string) =>

--- a/apps/api/src/tools/task-board/archive-merged.ts
+++ b/apps/api/src/tools/task-board/archive-merged.ts
@@ -114,13 +114,15 @@ async function archiveIfMerged(
   // The board says where a finished card retires to. A board with nowhere to
   // retire one leaves it in Done rather than filing it under a column it does
   // not have, which would make the card invisible instead of archived.
-  const archived = await (await boardFor(ctx, organizationId)).archiveColumn();
+  const board = await boardFor(ctx, organizationId);
+  const archived = await board.archiveColumn();
   if (!archived) return false;
 
   const updated = await ctx.storage.taskBoard.update(
     itemId,
     organizationId,
-    { status: archived },
+    // Guarded like a manual move: this can file the card under an org's own column too.
+    { status: archived, boardColumnOrg: board.columnOwner() },
     item.updatedBy,
   );
   await recordTaskActivity(ctx, {


### PR DESCRIPTION
Follows #6723 ("guard a card from the moment it is written"), which taught `create.ts`/`update.ts` to write `board_column_org` alongside `status` so the optional FK from #6710 actually holds a card to the org-owned column it names. It missed one writer: the hourly auto-archive sweep (`archiveIfMerged` in `archive-merged.ts`) also moves a card's `status` to a value from `board.archiveColumn()` — which, on an org-owned board, is a real row in `task_board_columns` — but only passed `{ status: archived }` to `taskBoard.update`, leaving `board_column_org` at its prior value (typically `null`, since the card was resting in the Studio-constant `done` lane). That leaves the retired card's FK asleep: if that archive column is later deleted, the RESTRICT this FK exists for won't fire, and the card silently becomes an invisible orphan — the exact failure #6710/#6723 were written to prevent, just reached through a different door.

Fix: resolve the board once, and pass `board.columnOwner()` alongside `status` in the sweep's update, same as the manual paths.

Added a real-Postgres regression test (`archive-merged.integration.test.ts`): seeds an org with `org_board_columns` on and a column mirrored with role `archived`, runs the sweep, and asserts `board_column_org` is set to the org id (fails on current code, which leaves it `null`).

To confirm: `bun test apps/api/src/tools/task-board/archive-merged.integration.test.ts` (needs the real-Postgres test harness CI runs; not runnable on this laptop, which has no Docker/Postgres).

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors). Full suite (including the new integration test) runs in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the auto-archive sweep so a card retired into an org-owned archive column is properly guarded by `board_column_org`, preventing it from becoming an invisible orphan if that column is later deleted. Previously the sweep only passed `status`, leaving the foreign key unset. It now passes `board.columnOwner()` alongside `status`, matching the manual update path. Adds a regression test that seeds an org-owned board with an archived column and asserts the card's `board_column_org` is set.

<sup>Written for commit 9e74c0613d2a104ffdc1222f779e60b8306b5419. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

