### PR TITLE
fix(task-board): validate the decoded volume, not just the path, in uploadsAsSandboxPaths

### DIFF
--- a/apps/api/src/tools/task-board/description-uploads.test.ts
+++ b/apps/api/src/tools/task-board/description-uploads.test.ts
@@ -45,6 +45,12 @@ describe("uploadsAsSandboxPaths", () => {
     }
   });
 
+  it("leaves an encoded-slash volume that could climb out of the mount alone", () => {
+    // `..%2F..%2Fetc` decodes to `../../etc` though the raw capture has no slash.
+    const url = "(/api/o/fs/..%2F..%2Fetc/read?path=passwd)";
+    expect(uploadsAsSandboxPaths(url)).toBe(url);
+  });
+
   it("leaves everything that isn't an org-fs read URL alone", () => {
     const md =
       "See ![x](https://example.com/a.png) and /api/o/fs/uploads/read (no path)";

--- a/apps/api/src/tools/task-board/description-uploads.ts
+++ b/apps/api/src/tools/task-board/description-uploads.ts
@@ -23,18 +23,20 @@ export function uploadsAsSandboxPaths(description: string): string {
     // The editor writes `?path=` as the whole query, so everything up to the
     // closing paren (or whitespace) is the encoded path.
     /\/api\/[^/\s)]+\/fs\/([^/\s)]+)\/read\?path=([^)\s]+)/g,
-    (url, volume: string, encodedPath: string) => {
+    (url, encodedVolume: string, encodedPath: string) => {
+      let volume: string;
       let path: string;
       try {
+        volume = decodeURIComponent(encodedVolume);
         path = decodeURIComponent(encodedPath);
       } catch {
         return url;
       }
-      // A description is user-written, and this path becomes a filesystem read
-      // inside the pod. Anything that could climb out of the mount keeps its
-      // original URL rather than resolving somewhere it shouldn't.
-      if (path.startsWith("/") || path.split("/").includes("..")) return url;
-      return orgFsSandboxPath(decodeURIComponent(volume), path);
+      // Checked on the DECODED value: `%2F` hides a climb-out slash from the capture.
+      const climbsOut = (part: string) =>
+        part.startsWith("/") || part.split("/").includes("..");
+      if (climbsOut(volume) || climbsOut(path)) return url;
+      return orgFsSandboxPath(volume, path);
     },
   );
 }


### PR DESCRIPTION
Bug found while auditing `uploadsAsSandboxPaths` (`apps/api/src/tools/task-board/description-uploads.ts`), which rewrites org-fs read links in a task description into the sandbox pod's real mount path before a claude-code run reads them.

The regex captures the volume segment with `[^/\s)]+`, which forbids a literal slash — but the code only ran `decodeURIComponent` on the *path* group before its traversal check (`startsWith("/")` / includes `".."`), and decoded the *volume* separately, unchecked, right before handing it to `orgFsSandboxPath`. A volume written as `..%2F..%2Fetc` has no slash in its raw capture, so it sails past the character class, then decodes to `../../etc` and gets concatenated as `org/../../etc/<path>` in `orgFsSandboxPath` — resolving outside the org-fs mount.

**Why it matters**: a task description is user-written text that becomes a filesystem read inside a sandboxed agent's pod once rewritten — exactly the trust boundary the existing path check was already defending, just missing on the volume side.

**Fix**: decode both `volume` and `path` up front, and run the same traversal check (`startsWith("/")` or a `..` path segment) against both decoded values before calling `orgFsSandboxPath`.

**Regression test**: added a case in `description-uploads.test.ts` with an encoded-slash volume (`..%2F..%2Fetc`) confirming the URL is now left untouched instead of rewritten to a path that climbs out of the mount.

**To verify**: `bun test apps/api/src/tools/task-board/description-uploads.test.ts`

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above (8/8 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a traversal hole in `uploadsAsSandboxPaths` so an encoded-slash volume like `..%2F..%2Fetc` can no longer escape the org-fs mount inside a sandboxed pod. The volume is now decoded and checked before rewriting, and such URLs are left untouched.

**Bug Fixes**
- Adds a regression test confirming an encoded-slash volume is left alone.

<sup>Written for commit e1a5b46318ffe7f617daa93ff4a35fb65278b73e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

