### PR TITLE
fix(task-board): no card renders nowhere

### DIFF
--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -324,6 +324,49 @@ describe("laneVisibility", () => {
     expect(hideable).toEqual([]);
   });
 
+  /**
+   * The last way a card could vanish. A card the board cannot place — a
+   * Studio-native one on a converted board, or any status no column accounts
+   * for — gets its own lane at the end rather than being hidden or re-filed
+   * under a column we picked. Re-filing is a decision only the org can make;
+   * hiding is the invisibility this exists to prevent.
+   */
+  test("gives a card the board cannot place a lane of its own", () => {
+    const { lanes, hidden, hideable } = laneVisibility({
+      columns: [{ key: "BACKLOG" }, { key: "Fazendo" }],
+      deliveryEnabled: false,
+      shownLanes: shown,
+      occupied: ["Fazendo", "triage", "done"],
+    });
+    expect(lanes).toEqual(["BACKLOG", "Fazendo", "done", "triage"]);
+    expect(hidden).toEqual([]);
+    expect(hideable).toEqual([]);
+  });
+
+  test("the extra lane goes away once its last card leaves", () => {
+    expect(
+      laneVisibility({
+        columns: [{ key: "BACKLOG" }],
+        deliveryEnabled: false,
+        shownLanes: shown,
+        occupied: [],
+      }).lanes,
+    ).toEqual(["BACKLOG"]);
+  });
+
+  /** Studio's own board accounts for every canonical status, so nothing is
+   *  ever unplaced there and this cannot start inventing lanes. */
+  test("never invents a lane on the board Studio ships", () => {
+    expect(
+      laneVisibility({
+        columns: CANONICAL,
+        deliveryEnabled: true,
+        shownLanes: STATUSES,
+        occupied: ["triage", "done", "archived"],
+      }).lanes,
+    ).toEqual(STATUSES);
+  });
+
   test("draws nothing for a board with no columns yet", () => {
     expect(
       laneVisibility({

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -436,7 +436,21 @@ export function laneVisibility({
       HIDDEN_STATUSES.includes(s) || (!deliveryEnabled && isDeliveryLane(s)),
   );
   const hidden = hideable.filter((s) => !shownLanes.includes(s));
-  return { lanes: known.filter((s) => !hidden.includes(s)), hidden, hideable };
+
+  // A status no column accounts for, but cards are sitting in. Appended as its
+  // own lane rather than hidden or re-filed: a card the board cannot place is
+  // still the org's card, and rendering it under a column we picked would be
+  // us deciding something only they can. Deliberately not hideable — hiding it
+  // is the invisibility this exists to prevent. It goes away when the last card
+  // leaves, the same way a column the tracker dropped does.
+  const placed = new Set(known);
+  const unplaced = [...new Set(occupied)].filter((s) => !placed.has(s)).sort();
+
+  return {
+    lanes: [...known.filter((s) => !hidden.includes(s)), ...unplaced],
+    hidden,
+    hideable,
+  };
 }
 
 export const PRIORITIES: TaskBoardItemPriority[] = [


### PR DESCRIPTION
The last way a card could disappear.

A card the board cannot place — a Studio-native one on a converted board, or any status no column accounts for — was rendered by **nothing at all**. Not misfiled, not hidden: absent.

It gets its own lane at the end now. Not hidden, and **not re-filed under a column Studio picked**: re-filing is a decision only the org can make, and hiding is exactly the invisibility this exists to prevent. The lane goes away when its last card leaves, the same way a column the tracker dropped does.

That is the third time the same answer has been right in this series:

| situation | answer |
|---|---|
| a column the tracker deleted, still holding cards | keep the column (#6720) |
| a card in a column being deleted | refuse the delete (`ON DELETE RESTRICT`) |
| a status no column accounts for | draw it anyway (here) |

Whenever Studio would have to *guess* where someone's card belongs, showing it where it is beats moving it somewhere we chose.

Studio's own board accounts for every canonical status, so nothing is ever unplaced there and this cannot start inventing lanes.

## How did you verify your code works?

Three cases in `config.test.ts`, chosen as the bounds rather than the happy path:

- **a card the board cannot place gets a lane** — with a mixed set (`Fazendo` placed, `triage` and `done` not), asserting the unplaced ones land at the end and are **not** marked hideable, since hiding them is the failure mode;
- **the extra lane goes away once its last card leaves** — otherwise this accumulates dead lanes forever;
- **it never invents a lane on the board Studio ships** — asserted with every canonical status occupied, because a regression here would add phantom columns to every org that has no Jira at all.

`apps/web/src`: **3054 pass / 114 fail** against a baseline of **3051 / 114**, measured by checking out `origin/main`'s tree, re-running, and restoring. Same failures, three more tests. `bun run check` 0 errors, `lint` at baseline, `knip` clean.

**Not verified, flagging honestly:**

- **You can drag a card INTO an unplaced lane, and the server will refuse it.** `assertBoardHasColumn` rejects the write, so the card snaps back with an error toast. Dragging *out* — the thing you actually want — works. It is a rough edge I chose not to paper over by hiding the lane, since hiding is the bug; making those lanes drop-hostile in the DnD layer is the real fix and it is not here.
- **No live browser check.** The lane list is asserted; how an unplaced lane looks next to real ones is not. Its header will read the raw status key (or its canonical translation), with a neutral icon.
- Nothing exercises this on a real converted board, because there still is not one.

## Screenshots/Demonstration

Not captured. On every org today — all of them on Studio's board — the lane list is byte-identical to before.

## How to Test

1. Any org today: the board is unchanged, and no extra lane appears.
2. On an org board, leave a card holding a canonical status (a Studio-native card, or one the sync has not re-homed). It should appear in a lane of its own at the end rather than vanishing.
3. Drag it into a real column; the extra lane should disappear on the next render.
4. Confirm the extra lane is not offered in the "Hidden columns" drawer.

## Migration Notes

None. Client-only, no schema or API change.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the task board so cards with no matching column render in an unplaced lane at the end instead of disappearing.

- The unplaced lane is not offered in the "Hidden columns" drawer, because hiding it would recreate the invisibility this fixes.
- The lane disappears automatically when its last card leaves.
- Studio's default board accounts for all statuses, so no extra lane appears there.
- Added three tests covering the unplaced lane, its removal, and the default-board case.
- Known limitation: dragging a card into an unplaced lane is rejected by the server; dragging out works.

<sup>Written for commit 7056dc818e25d80304dc3441b796998ecd3e21df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

