### PR TITLE
feat(settings): say what each column means, instead of mapping them

### DIFF
--- a/apps/web/src/hooks/use-jira-integration.ts
+++ b/apps/web/src/hooks/use-jira-integration.ts
@@ -100,3 +100,27 @@ export function useRequestJiraResync() {
       queryClient.invalidateQueries({ queryKey: KEYS.jiraIntegration(org.id) }),
   });
 }
+
+/**
+ * Say what one of the board's columns means to Studio.
+ *
+ * Invalidates the board read, not the integration: the roles live on the
+ * columns that read carries, and the settings screen and the board itself are
+ * looking at the same cached list.
+ */
+export function useSetColumnRole() {
+  const { locator } = useProjectContext();
+  const studio = useStudioTools();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { columnKey: string; role: string | null }) =>
+      await studio.call("TASK_BOARD_COLUMN_ROLE_SET", {
+        columnKey: input.columnKey,
+        role: input.role as "in_review" | "archived" | null,
+      }),
+    onSettled: () =>
+      queryClient.invalidateQueries({
+        queryKey: KEYS.taskBoardItems(locator),
+      }),
+  });
+}

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -44,6 +44,14 @@ export const settings = {
   "settings.jira.boardSearchPlaceholder": "Search boards…",
   "settings.jira.noBoardsMatch": "No board matches that search",
   "settings.jira.loadingBoards": "Loading boards…",
+  "settings.jira.rolesLabel": "What each column means",
+  "settings.jira.rolesDescription":
+    "Your board's columns come from Jira. Tell Studio which of them is where review happens, and which retires a card — most columns mean nothing to it, and that is fine.",
+  "settings.jira.roleNone": "Nothing special",
+  "settings.jira.roleInReview": "Under review",
+  "settings.jira.roleArchived": "Archive",
+  "settings.jira.noColumnsYet":
+    "No columns yet — they arrive with the next sync.",
   "settings.jira.mappingLabel": "Column mapping",
   "settings.jira.mappingDescription":
     "Map the board's columns onto this board's lanes. Columns marked “Don't sync” never appear here.",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -46,6 +46,14 @@ export const settings = {
   "settings.jira.boardSearchPlaceholder": "Buscar boards…",
   "settings.jira.noBoardsMatch": "Nenhum board corresponde à busca",
   "settings.jira.loadingBoards": "Carregando boards…",
+  "settings.jira.rolesLabel": "O que cada coluna significa",
+  "settings.jira.rolesDescription":
+    "As colunas do seu board vêm do Jira. Diga ao Studio qual delas é onde a revisão acontece, e qual arquiva um card — a maioria não significa nada pra ele, e tudo bem.",
+  "settings.jira.roleNone": "Nada em especial",
+  "settings.jira.roleInReview": "Em revisão",
+  "settings.jira.roleArchived": "Arquivo",
+  "settings.jira.noColumnsYet":
+    "Nenhuma coluna ainda — elas chegam na próxima sincronização.",
   "settings.jira.mappingLabel": "Mapeamento de colunas",
   "settings.jira.mappingDescription":
     "Mapeie as colunas do board pras lanes deste quadro. Colunas marcadas como “Não sincronizar” nunca aparecem aqui.",

--- a/apps/web/src/views/settings/jira.tsx
+++ b/apps/web/src/views/settings/jira.tsx
@@ -6,6 +6,7 @@
  * account.
  */
 
+import { useTaskBoardItems } from "@/hooks/use-task-board-items";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@decocms/ui/components/button.tsx";
@@ -56,6 +57,7 @@ import {
 import { useT } from "@/i18n/use-t.ts";
 import type { TranslationKey } from "@/i18n/en";
 import {
+  useSetColumnRole,
   type JiraIntegration,
   useDeleteJiraIntegration,
   useJiraBoardColumns,
@@ -245,6 +247,78 @@ function SyncStatusLine({ integration }: { integration: JiraIntegration }) {
           })
         : t("settings.jira.waitingFirstSync")}
     </p>
+  );
+}
+
+/** No role — the honest default for a column nobody has told us about. */
+const NO_ROLE = "__none__";
+
+/**
+ * What each of the board's own columns means to Studio.
+ *
+ * Replaces the status mapping for an org whose board is its own. The mapping
+ * asked a team to restate, lane by lane, something their tracker already knew;
+ * this asks the one thing it could not know — which of THEIR columns is where
+ * review happens, and which retires a card. Most columns mean nothing to us,
+ * and leaving them that way is the safe answer rather than a gap to fill.
+ */
+function ColumnRoleRows() {
+  const t = useT();
+  const { columns, isLoading } = useTaskBoardItems();
+  const setRole = useSetColumnRole();
+
+  if (isLoading) return <Skeleton className="h-24 w-full mt-3" />;
+  if (columns.length === 0) {
+    return (
+      <p className="mt-3 text-xs text-muted-foreground">
+        {t("settings.jira.noColumnsYet")}
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col mt-3">
+      {columns.map((column) => (
+        <div
+          key={column.key}
+          className="flex items-center justify-between gap-4 py-2.5 border-b border-border/60 last:border-b-0"
+        >
+          <span className="min-w-0 truncate text-sm">{column.title}</span>
+          <Select
+            value={column.role ?? NO_ROLE}
+            onValueChange={(value) =>
+              setRole.mutate(
+                {
+                  columnKey: column.key,
+                  role: value === NO_ROLE ? null : value,
+                },
+                {
+                  onError: (err) =>
+                    toast.error(
+                      errorMessage(err, t("settings.jira.saveFailed")),
+                    ),
+                },
+              )
+            }
+          >
+            <SelectTrigger className="w-44 shrink-0">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NO_ROLE}>
+                {t("settings.jira.roleNone")}
+              </SelectItem>
+              <SelectItem value="in_review">
+                {t("settings.jira.roleInReview")}
+              </SelectItem>
+              <SelectItem value="archived">
+                {t("settings.jira.roleArchived")}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -505,12 +579,25 @@ function BoardRow({ integration }: { integration: JiraIntegration }) {
 
 function MappingRow({ integration }: { integration: JiraIntegration }) {
   const t = useT();
+  const orgOwnedColumns = useOrgFlag("org_board_columns");
   return (
     <SettingsCardItem
-      title={t("settings.jira.mappingLabel")}
-      description={t("settings.jira.mappingDescription")}
+      title={
+        orgOwnedColumns
+          ? t("settings.jira.rolesLabel")
+          : t("settings.jira.mappingLabel")
+      }
+      description={
+        orgOwnedColumns
+          ? t("settings.jira.rolesDescription")
+          : t("settings.jira.mappingDescription")
+      }
     >
-      <ColumnMappingRows integration={integration} />
+      {orgOwnedColumns ? (
+        <ColumnRoleRows />
+      ) : (
+        <ColumnMappingRows integration={integration} />
+      )}
     </SettingsCardItem>
   );
 }


### PR DESCRIPTION
The screen this whole direction set out to remove — **replaced, not deleted**.

An org whose board is its own now sees its Jira columns in Settings → Tasks → Jira, with one question each: *what does this mean to Studio?* Options are "Nothing special" (the default), "Under review", and "Archive".

**Most columns mean nothing, and leaving them that way is the answer** — not a gap to fill. That is the whole difference from the mapping it replaces. The mapping asked a team to restate, lane by lane, something their tracker already knew, and every unmapped column was a silent hole. This asks the one thing Jira cannot tell us: which of *their* columns is where review happens, and which retires a card.

Same place in settings. The mapping is untouched for an org on Studio's board — its lanes are ours and Jira has no idea what they mean, so there is nothing to ask there.

This is the third of three UIs this work has owed. **Automations (#6690) and the board mode (#6698) are still tool-only**, and I would not call the debt cleared.

## How did you verify your code works?

`bun run check` 0 errors — which also proves the pt-BR dictionary mirrors en, since the `satisfies` contract makes a missing key a compile error, and six new keys landed on both sides. `bun run lint` at baseline, `knip` clean, `fmt:check` clean.

`apps/web/src/views` + the board layout: **184 pass / 4 fail**, identical to baseline measured by stashing and re-running. Those four (`PublishPolicyField` and neighbours) are the known order-dependent set at that scope.

**Not verified, and this is the weak part of this PR:**

- **No test at all for the new component**, and **no live browser check**. Nothing here asserts that the rows render, that the select shows the current role, or that choosing one calls the mutation. A component test needs `QueryClientProvider` and `ProjectContextProvider`, which by this repo's own rule makes it e2e rather than unit — and there is no e2e for settings. So the honest position is: the types line up and the pieces it composes are each covered elsewhere, but this specific screen has been reasoned about, not exercised. It wants a look before anyone relies on it.
- **It reads the whole board** via `useTaskBoardItems` to get the columns, because that read is the only source of a column's `role`. On a settings page that is heavier than it needs to be; it is cached and shared with the board itself, so the cost is usually zero, but a dedicated read would be cleaner.
- **No optimistic update.** The mapping UI keeps a local copy to survive a slow round-trip; this one waits for the invalidation, so a slow save shows the old value briefly.
- **Only two roles are offered** because only two exist. `in_review` is settable and still read by nothing (flagged in #6718) — so choosing it today records an intent that nothing acts on yet.

## Screenshots/Demonstration

Not captured — see above. The visible change is the mapping table swapped for a column-and-role table, only for an org with `org_board_columns` on, of which there are none.

## How to Test

1. On any org today (flag off): Settings → Tasks → Jira shows the status mapping, unchanged.
2. Turn `org_board_columns` on and sync so the columns exist. The same card should now read "What each column means" and list the Jira columns.
3. Set one to "Archive" and confirm the archive sweep starts retiring cards there.
4. Set it back to "Nothing special" and confirm it stops.
5. Before the first sync, confirm the empty state reads "No columns yet".

## Migration Notes

None. Client-only; the tool it calls shipped in #6718.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the Jira column mapping screen in Settings → Tasks → Jira with a per-column role picker, only for orgs whose board is their own. Most columns mean nothing to Studio, and "Nothing special" is now the honest default instead of a silent unmapped gap.

- Each Jira column gets a select: Nothing special (default), Under review, or Archive.
- The old mapping stays untouched for orgs on Studio's board.
- Adds `useSetColumnRole`, which calls `TASK_BOARD_COLUMN_ROLE_SET` and invalidates the shared board read.
- New labels landed in en and pt-br, covered by the existing `satisfies` contract.
- No migration needed — client-only.
- The new component has no test and got no live browser check; the pieces it composes are covered elsewhere, but this screen is reasoned about, not exercised.
- No optimistic update — a slow save shows the old value briefly.
- `in_review` is settable but nothing reads it yet, so choosing it records intent nothing acts on.

<sup>Written for commit 20706873fc618ce51436b38c766fbf7aa4299302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

