### PR TITLE
fix(connections): reject a connection id that collides with another's isolated DB schema

### DIFF
--- a/apps/api/src/storage/connection.integration.test.ts
+++ b/apps/api/src/storage/connection.integration.test.ts
@@ -169,6 +169,42 @@ describe("ConnectionStorage", () => {
     });
   });
 
+  describe("findBySanitizedId", () => {
+    it("should find a connection whose id folds to the same schema/role name", async () => {
+      await storage.create({
+        id: "conn-acme-prod",
+        organization_id: "org_123",
+        created_by: "user_123",
+        title: "Acme Prod",
+        connection_type: "HTTP",
+        connection_url: "https://acme-prod.invalid/mcp",
+      });
+
+      const collision = await storage.findBySanitizedId("conn_acme_prod");
+      expect(collision?.id).toBe("conn-acme-prod");
+    });
+
+    it("should not report a connection as colliding with itself", async () => {
+      const created = await storage.create({
+        organization_id: "org_123",
+        created_by: "user_123",
+        title: "No Self Collision",
+        connection_type: "HTTP",
+        connection_url: "https://no-self-collision.invalid/mcp",
+      });
+
+      const collision = await storage.findBySanitizedId(created.id);
+      expect(collision).toBeNull();
+    });
+
+    it("should return null when no id sanitizes to the same value", async () => {
+      const collision = await storage.findBySanitizedId(
+        "conn_completely_unused_id",
+      );
+      expect(collision).toBeNull();
+    });
+  });
+
   describe("list", () => {
     it("should list all connections for an organization", async () => {
       await storage.create({

--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -315,6 +315,26 @@ export class ConnectionStorage implements ConnectionStoragePort {
     return row ? this.deserializeConnection(row as RawConnectionRow) : null;
   }
 
+  /**
+   * A connection whose id collides with `id` once `DATABASES_RUN_SQL` folds
+   * hyphens to underscores to build its Postgres schema/role name — excluding
+   * `id` itself. That fold is not injective ("acme-prod" and "acme_prod" both
+   * become "acme_prod"), so two DIFFERENT connections, in different orgs, can
+   * end up sharing the exact same isolated schema and role. Used to refuse
+   * creating the second one rather than silently handing it the first one's
+   * data (see `create.ts`).
+   */
+  async findBySanitizedId(id: string): Promise<ConnectionEntity | null> {
+    const sanitized = id.replace(/-/g, "_");
+    const row = await this.db
+      .selectFrom("connections")
+      .selectAll()
+      .where(sql<string>`replace(id, '-', '_')`, "=", sanitized)
+      .where("id", "!=", id)
+      .executeTakeFirst();
+    return row ? this.deserializeConnection(row as RawConnectionRow) : null;
+  }
+
   async list(
     organizationId: string,
     options?: {

--- a/apps/api/src/storage/ports.ts
+++ b/apps/api/src/storage/ports.ts
@@ -306,6 +306,8 @@ export interface ConnectionStoragePort {
   create(data: Partial<ConnectionEntity>): Promise<ConnectionEntity>;
   createNew(data: Partial<ConnectionEntity>): Promise<ConnectionEntity>;
   findById(id: string): Promise<ConnectionEntity | null>;
+  /** See `ConnectionStorage.findBySanitizedId`. */
+  findBySanitizedId(id: string): Promise<ConnectionEntity | null>;
   list(
     organizationId: string,
     options?: {

--- a/apps/api/src/tools/connection/create.ts
+++ b/apps/api/src/tools/connection/create.ts
@@ -84,6 +84,15 @@ export const COLLECTION_CONNECTIONS_CREATE = defineTool({
       if (existing?.organization_id === organization.id) {
         throw new Error("Connection already exists in organization");
       }
+      // Would collide with another connection's DATABASES_RUN_SQL schema/role — see findBySanitizedId.
+      const collision = await ctx.storage.connections.findBySanitizedId(
+        connectionData.id,
+      );
+      if (collision) {
+        throw new Error(
+          "Connection id conflicts with an existing connection's isolated database schema",
+        );
+      }
     }
 
     // Validate VIRTUAL connections - ensure the referenced Virtual MCP exists


### PR DESCRIPTION
A bug found while reading `apps/api/src/tools/database/index.ts` (DATABASES_RUN_SQL) alongside `COLLECTION_CONNECTIONS_CREATE`, not tied to an issue or a merged PR.

**The gap:** `COLLECTION_CONNECTIONS_CREATE` lets a caller supply an arbitrary connection `id` (`apps/api/src/tools/connection/create.ts` only rejects it if the exact same id already exists *in the same org*). `DATABASES_RUN_SQL` derives that connection's isolated Postgres schema/role names by folding every `-` in the id to `_` (`sanitizeIdentifier` in `database/index.ts`). That fold is not injective: `"acme-prod"` and `"acme_prod"` both become `"acme_prod"`. So an org can create a connection with id `acme_prod`, and its `DATABASES_RUN_SQL` calls run with `SET ROLE app_role_acme_prod` / `search_path = app_acme_prod` — the exact same schema and role already created for an unrelated `acme-prod` connection in a *different* org, since a globally-unique id column doesn't stop two distinct strings from sanitizing to the same value. That connection now has full read/write access to another org's supposedly isolated database schema.

**Fix:** at creation time, in addition to the existing same-org id check, reject an id whose hyphen→underscore fold matches any other existing connection's fold (`ConnectionStorage.findBySanitizedId`, a `replace(id, '-', '_') = $1` query excluding the row's own id). This only gates *new* connections going forward — it doesn't touch already-created schemas/roles, so no migration and no risk to existing connections.

**Regression test:** `apps/api/src/storage/connection.integration.test.ts` — `findBySanitizedId` finds a colliding id, doesn't flag a connection against itself, and returns null when nothing collides.

**To confirm:** `cd apps/api && bunx tsc --noEmit`, then (needs Postgres) `bun test apps/api/src/storage/connection.integration.test.ts`.

**Checked locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace), `bunx oxlint` on the four touched files — all clean. The integration test needs a real Postgres (this laptop has none), so full CI validates it; I traced the SQL and existing `findById`/`create` patterns closely to keep it consistent with the storage layer's style.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects connection IDs that would collide with another connection's isolated Postgres schema/role, preventing cross-org database access.

`DATABASES_RUN_SQL` derives schema/role names by replacing `-` with `_`, so `acme-prod` and `acme_prod` sanitize to the same value. Previously, creation only rejected an exact same-org ID, so a different org could create the colliding ID and get read/write access to the first connection's schema. Creation now also checks the sanitized ID against all existing connections and fails on a match. Existing connections are unaffected; no migration is needed.

<sup>Written for commit 18758af58d9d15615ac289580132bc447ec5b5c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

