### PR TITLE
fix(home): open the clicked task's own card, not just the board

### DIFF
--- a/apps/web/src/components/home/home-tasks.tsx
+++ b/apps/web/src/components/home/home-tasks.tsx
@@ -7,6 +7,7 @@
  * board (the metric tiles).
  */
 import { type ReactNode, useState } from "react";
+import { useNavigate, useParams } from "@tanstack/react-router";
 import { formatTimeAgo } from "@/lib/format-time";
 import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import { cn } from "@decocms/ui/lib/utils.ts";
@@ -25,6 +26,7 @@ import {
   laneVisual,
   type TaskBoardItem,
 } from "@/layouts/task-board/config";
+import { taskRouteSegment } from "@/layouts/task-board/task-route";
 import { TaskBoardItemDialog } from "@/layouts/task-board/task-dialog";
 
 interface OrgMember {
@@ -155,6 +157,8 @@ function buildSummary(
 export function HomeTasks({ afterSummary }: { afterSummary?: ReactNode }) {
   const t = useT();
   const { openPanel } = usePanelNavigate();
+  const navigate = useNavigate();
+  const orgSlug = useParams({ strict: false }).org ?? "";
   const { items, error } = useTaskBoardItems();
   const actions = useTaskBoardItemActions();
   const { data: membersData } = useMembers();
@@ -177,6 +181,12 @@ export function HomeTasks({ afterSummary }: { afterSummary?: ReactNode }) {
 
   // The board is a destination of its own (same as the sidebar's Tasks).
   const openBoard = () => openPanel("board", { replace: false });
+  // Same card address the sidebar inbox links to.
+  const openTask = (task: TaskBoardItem) =>
+    navigate({
+      to: "/$org/tasks/{-$taskKey}",
+      params: { org: orgSlug, taskKey: taskRouteSegment(orgSlug, task) },
+    });
 
   return (
     <div className="flex flex-col gap-10">
@@ -250,7 +260,7 @@ export function HomeTasks({ afterSummary }: { afterSummary?: ReactNode }) {
                     ? memberByUserId.get(task.assigneeId)
                     : undefined
                 }
-                onOpen={openBoard}
+                onOpen={() => openTask(task)}
               />
             ))}
             <button


### PR DESCRIPTION
Every row in the Home overview's task strip (`HomeTasks`/`TaskRow`) called `onOpen={openBoard}` unconditionally, so clicking ANY task — regardless of which one — just opened the board's default view instead of that task's own card. The sidebar inbox already solved this exact problem (`InboxTaskItem` navigates to `/$org/tasks/{-$taskKey}`), so Home was the one remaining place a task row didn't deep-link to itself.

Fix: each row now navigates to `/$org/tasks/{-$taskKey}` using the existing `taskRouteSegment()` helper (the same one the board and the sidebar inbox already build their links with), which falls back to the raw task id for a pre-key-backfill row.

A reviewer can confirm by opening the Home overview, clicking a task in the strip, and checking it opens that task's own dialog (not just the board) — and clicking two different tasks lands on two different cards.

Verified locally: `bunx tsc --noEmit` in `apps/web` (no new errors — the only errors on this workspace are a pre-existing, unrelated prosemirror version-skew warning) and `bunx oxlint` on the touched file (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Home overview task strip so clicking a task opens that task's own card instead of the board's default view. It uses the same route helper as the board and sidebar inbox, so links work even for task rows that haven't been key-backfilled.

<sup>Written for commit cda9a356b7a9a863da61ada0c31ed1aa1001c6d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

