### PR TITLE
fix(decopilot): cap generateImage's referenceImages array at 10

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
@@ -2,9 +2,32 @@ import { describe, expect, it } from "bun:test";
 import {
   assertUrlDoesNotResolvePrivate,
   fetchImageBytes,
+  GenerateImageInputSchema,
   generateImageCore,
   validateExternalUrl,
 } from "./portable-media-tools";
+
+describe("GenerateImageInputSchema", () => {
+  it("rejects more reference images than one call may fetch", () => {
+    const referenceImages = Array.from({ length: 11 }, (_, i) => ({
+      uri: `studio-storage://generated-images/${i}.png`,
+    }));
+    expect(
+      GenerateImageInputSchema.safeParse({ prompt: "x", referenceImages })
+        .success,
+    ).toBe(false);
+  });
+
+  it("allows up to the reference-image cap", () => {
+    const referenceImages = Array.from({ length: 10 }, (_, i) => ({
+      uri: `studio-storage://generated-images/${i}.png`,
+    }));
+    expect(
+      GenerateImageInputSchema.safeParse({ prompt: "x", referenceImages })
+        .success,
+    ).toBe(true);
+  });
+});
 
 describe("validateExternalUrl", () => {
   it("rejects loopback", () => {

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
@@ -61,6 +61,8 @@ export const GenerateImageInputSchema = z.object({
           ),
       }),
     )
+    // Each entry fans out into its own outbound fetch in generateImageCore.
+    .max(10)
     .optional()
     .describe(
       "Reference images to use as input for image-to-image generation. " +


### PR DESCRIPTION
Bounded a resource-exhaustion gap found while auditing `apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts` (touched by recent decopilot commits, no open PR covers it).

`GenerateImageInputSchema.referenceImages` was an unbounded array, but `generateImageCore` fans each entry out into its own outbound fetch (`fetchImageBytes`) that runs SSRF/DNS-rebinding checks and can download up to 20MB — all in one `Promise.all`. A single tool call with a large `referenceImages` array (LLM-generated, so attacker-influenceable via prompt injection) could trigger an unbounded burst of concurrent outbound requests and downloads. This matches the same 'cap an attacker-controlled array on a tool input' pattern already fixed repeatedly elsewhere in this codebase (task-board `tagIds`/`externalKeys`, etc.).

Fix: `.max(10)` on the `referenceImages` array in the Zod schema — well above any real use case (image models typically accept only a few reference images anyway).

Failure scenario without the fix: a run passes hundreds of reference-image URIs, causing hundreds of concurrent fetches/DNS lookups/downloads from a single tool call.

Regression test: `apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts` — new `GenerateImageInputSchema` describe block asserts 11 reference images are rejected and 10 are accepted.

Reviewer check: `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test file (10 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap `GenerateImageInputSchema.referenceImages` at 10 entries to prevent a single tool call from triggering an unbounded number of concurrent outbound requests (each reference image is fetched with SSRF checks and a 20MB download). Added schema validation tests that confirm 11 entries are rejected and 10 are accepted.

<sup>Written for commit 052b6562091ee51a5e4079edd24ec7a8aeae4888. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

