### PR TITLE
fix(jira): bound the statusMapping lane/status/name sizes on upsert

### DIFF
--- a/apps/api/src/tools/jira/index.test.ts
+++ b/apps/api/src/tools/jira/index.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { JIRA_INTEGRATION_UPSERT } from "./index";
+
+/**
+ * Regression: statusMapping had no bound on lane count, statuses per lane,
+ * or status-name length — an unbounded jsonb column any org member could
+ * grow, re-read by every ~10-minute sync tick.
+ */
+describe("JIRA_INTEGRATION_UPSERT statusMapping bounds", () => {
+  const base = { apiToken: "t", email: "e@example.com", siteUrl: "s" };
+
+  it("rejects more lanes than the cap", () => {
+    const statusMapping = Object.fromEntries(
+      Array.from({ length: 101 }, (_, i) => [`lane${i}`, ["Done"]]),
+    );
+    const result = JIRA_INTEGRATION_UPSERT.inputSchema.safeParse({
+      ...base,
+      statusMapping,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects more statuses per lane than the cap", () => {
+    const result = JIRA_INTEGRATION_UPSERT.inputSchema.safeParse({
+      ...base,
+      statusMapping: { Done: Array.from({ length: 101 }, (_, i) => `s${i}`) },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an oversized status name", () => {
+    const result = JIRA_INTEGRATION_UPSERT.inputSchema.safeParse({
+      ...base,
+      statusMapping: { Done: ["x".repeat(201)] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a mapping at the caps", () => {
+    const statusMapping = Object.fromEntries(
+      Array.from({ length: 100 }, (_, i) => [
+        `lane${i}`,
+        Array.from({ length: 100 }, (_, j) => `s${i}-${j}`),
+      ]),
+    );
+    const result = JIRA_INTEGRATION_UPSERT.inputSchema.safeParse({
+      ...base,
+      statusMapping,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/api/src/tools/jira/index.ts
+++ b/apps/api/src/tools/jira/index.ts
@@ -23,13 +23,27 @@ import { JiraClient, normalizeSiteUrl } from "@/jira/client";
 import { syncJiraIntegrationSafe } from "@/jira/sync";
 import type { OrgJiraIntegration } from "@/storage/types";
 
+// Caps the jsonb blob every sync tick re-reads; no real board has more.
+const MAX_STATUS_MAPPING_LANES = 100;
+const MAX_STATUSES_PER_LANE = 100;
+const MAX_STATUS_NAME_LENGTH = 200;
+
 // `partialRecord`, not `record`: a `z.record` over an enum demands EVERY lane
 // be present, so an org mapping three of its columns would fail validation.
 // A plain record now that a board column is any key: `partialRecord` over a
 // closed enum was what forced every lane to be listed, and there is no closed
 // set of lanes to enumerate on a board the org owns.
 const statusMappingSchema = z
-  .record(z.string().min(1), z.array(z.string()))
+  .record(
+    z.string().min(1).max(MAX_STATUS_NAME_LENGTH),
+    z
+      .array(z.string().min(1).max(MAX_STATUS_NAME_LENGTH))
+      .max(MAX_STATUSES_PER_LANE),
+  )
+  .refine(
+    (mapping) => Object.keys(mapping).length <= MAX_STATUS_MAPPING_LANES,
+    `Cannot map more than ${MAX_STATUS_MAPPING_LANES} lanes`,
+  )
   .describe(
     "Board status → its Jira status names, in board order. Several Jira " +
       "statuses may share a lane; the first is where a card entering that lane " +


### PR DESCRIPTION
Resource/DoS bound — no linked issue, found while auditing recently-touched Jira sync code.

`statusMappingSchema` in `apps/api/src/tools/jira/index.ts` was a fully unbounded `z.record(string, string[])`: any org member calling `JIRA_INTEGRATION_UPSERT` could write arbitrarily many lanes, arbitrarily many Jira statuses per lane, and arbitrarily long status-name strings into the integration's jsonb column. That blob is re-read and rebuilt into a `Map` (`laneIndex` in `packages/shared/src/jira-status-mapping.ts`) on every ~10-minute sync tick (`dbos-jira-sync.ts`) and on every `JIRA_INTEGRATION_GET`/upsert round-trip — an unbounded input keeps growing the row and the per-tick rebuild cost with no server-side ceiling.

This mirrors the same bound this codebase already applies elsewhere in the same package (`MAX_ISSUES_PER_RUN`, `MAX_SPRINT_FIELDS`, `MAX_TABLE_ROWS`, `MAX_UPLOADS` in `apps/api/src/jira/*.ts`) and in task-board tools (`MAX_TASK_DESCRIPTION_LENGTH`, the comment-body cap) — this specific field was the one left uncapped.

Caps added: 100 lanes, 100 statuses per lane, 200 chars per status name (a real Jira status name is a handful of words; a board has at most a few dozen lanes).

Failure scenario without the fix: a malicious or buggy client calls `JIRA_INTEGRATION_UPSERT` with thousands of lane keys or megabyte-scale status-name strings; it's accepted, persisted, and re-parsed by every sync cycle indefinitely.

Regression test: `apps/api/src/tools/jira/index.test.ts` (schema-level `safeParse`, no DB needed) — asserts the input is rejected over each cap and accepted right at the caps.

Reviewer check: `bun test apps/api/src/tools/jira/index.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (4/4 pass), and `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the Jira `statusMapping` input on `JIRA_INTEGRATION_UPSERT` so members can no longer write an unbounded blob into the integration's jsonb column. The blob was previously accepted as any record of string arrays, then re-read and rebuilt into a `Map` on every sync tick, so oversized or malicious inputs grew the row and rebuild cost indefinitely.

- Rejects more than 100 lanes, 100 statuses per lane, or 200 chars per status name, matching bounds already applied elsewhere in the Jira and task-board code.
- Adds a schema-level regression test that asserts rejection at each cap and acceptance right at the caps.

<sup>Written for commit a0dce8873a306844eb65c9b4786efb05c99731f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

