### PR TITLE
fix(decofile): preserve a discarded file's git mode, not a hardcoded 100644

### DIFF
--- a/apps/api/src/decofile/git-compat.test.ts
+++ b/apps/api/src/decofile/git-compat.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import {
+  buildDiscardTreeEntries,
   buildMergeTreeEntries,
   buildPublishStatus,
   normalizeCompareStatus,
 } from "./git-compat";
+import type { TreeEntry } from "./github-git-data";
 
 describe("buildMergeTreeEntries", () => {
   it("writes a rename as create-destination + delete-source", () => {
@@ -78,6 +80,46 @@ describe("buildMergeTreeEntries", () => {
     expect(entries).toEqual([
       { path: "Old.json", mode: "100644", type: "blob", sha: null },
     ]);
+  });
+});
+
+describe("buildDiscardTreeEntries", () => {
+  const blob = (sha: string, mode: string): TreeEntry => ({
+    path: "irrelevant", // overwritten by the map key at lookup time
+    mode,
+    type: "blob",
+    sha,
+  });
+
+  it("restores the base blob's mode, not a hardcoded 100644", () => {
+    const entries = buildDiscardTreeEntries(
+      ["run.sh"],
+      new Map([["run.sh", blob("base-sha", "100755")]]),
+      new Map([["run.sh", blob("head-sha", "100755")]]),
+    );
+    expect(entries).toEqual([
+      { path: "run.sh", mode: "100755", type: "blob", sha: "base-sha" },
+    ]);
+  });
+
+  it("deletes a path the base doesn't have", () => {
+    const entries = buildDiscardTreeEntries(
+      ["New.json"],
+      new Map(),
+      new Map([["New.json", blob("head-sha", "100644")]]),
+    );
+    expect(entries).toEqual([
+      { path: "New.json", mode: "100644", type: "blob", sha: null },
+    ]);
+  });
+
+  it("is a no-op when base and head already match, or both are absent", () => {
+    const entries = buildDiscardTreeEntries(
+      ["Same.json", "Never.json"],
+      new Map([["Same.json", blob("s", "100644")]]),
+      new Map([["Same.json", blob("s", "100644")]]),
+    );
+    expect(entries).toEqual([]);
   });
 });
 

--- a/apps/api/src/decofile/git-compat.ts
+++ b/apps/api/src/decofile/git-compat.ts
@@ -15,6 +15,7 @@
 import {
   GitHubApiError,
   type GitDataClient,
+  type TreeEntry,
   type TreeWriteEntry,
 } from "./github-git-data";
 import { mapBounded, resolveOrCreateHead } from "./read-decofile";
@@ -359,6 +360,35 @@ export function buildMergeTreeEntries(
 }
 
 /**
+ * Tree write entries for a discard: reset each path to its blob (and MODE — a
+ * script's executable bit is real content, not metadata a discard should
+ * silently drop) at the merge base, or delete it when the base doesn't have
+ * it either. Pure, so it's unit-tested without a `GitDataClient`.
+ */
+export function buildDiscardTreeEntries(
+  filepaths: string[],
+  baseBlobByPath: Map<string, TreeEntry>,
+  headBlobByPath: Map<string, TreeEntry>,
+): TreeWriteEntry[] {
+  const entries: TreeWriteEntry[] = [];
+  for (const path of filepaths) {
+    const baseBlob = baseBlobByPath.get(path);
+    const headBlob = headBlobByPath.get(path);
+    // Already at the base content (or absent on both sides): nothing to do.
+    if (baseBlob?.sha === headBlob?.sha) continue;
+    // Deleting a path the head tree doesn't have is a 422, not a no-op.
+    if (!baseBlob && !headBlob) continue;
+    entries.push({
+      path,
+      mode: baseBlob?.mode ?? "100644",
+      type: "blob",
+      sha: baseBlob?.sha ?? null,
+    });
+  }
+  return entries;
+}
+
+/**
  * Discard the branch's changes to `filepaths`: a new commit on the branch that
  * resets each path to its content at the merge base with the default branch
  * (or deletes it when it did not exist there). The sandbox-less equivalent of
@@ -388,21 +418,11 @@ export async function githubGitDiscard(
       ),
     ]);
 
-    const entries: TreeWriteEntry[] = [];
-    for (const path of filepaths) {
-      const baseBlob = baseBlobByPath.get(path);
-      const headBlob = headBlobByPath.get(path);
-      // Already at the base content (or absent on both sides): nothing to do.
-      if (baseBlob?.sha === headBlob?.sha) continue;
-      // Deleting a path the head tree doesn't have is a 422, not a no-op.
-      if (!baseBlob && !headBlob) continue;
-      entries.push({
-        path,
-        mode: "100644",
-        type: "blob",
-        sha: baseBlob?.sha ?? null,
-      });
-    }
+    const entries = buildDiscardTreeEntries(
+      filepaths,
+      baseBlobByPath,
+      headBlobByPath,
+    );
     if (entries.length === 0) return;
 
     const treeSha = await client.createTree(


### PR DESCRIPTION
Bug found while auditing `apps/api/src/decofile/git-compat.ts` (already-hardened area, but this one path was missed).

`githubGitDiscard` (the sandbox-less "discard" for Fast Preview's CMS runtime, wired at `POST /:virtualMcpId/:branch/git/discard` in `sandbox-proxy.ts`) resets a changed path back to its content at the merge base by writing a new tree entry — but it hardcoded `mode: "100644"` on every entry instead of using the base blob's actual mode. `filepaths` here is arbitrary, caller-supplied paths (not scoped to `.deco/blocks/*.json`), so discarding a change to an executable file (e.g. a repo script) silently strips its executable bit even though the content is correctly restored.

The sibling function in the same file, `buildMergeTreeEntries` (used by the rebase/merge path), already does this correctly — it reads `blob?.mode ?? "100644"` — so this was a one-off oversight in the discard path, not a systemic gap.

Fix: extracted the tree-entry-building logic into a new pure `buildDiscardTreeEntries` helper (mirroring the existing `buildMergeTreeEntries` pattern) that carries `baseBlob?.mode ?? "100644"` through, and pointed `githubGitDiscard` at it. Behavior is otherwise unchanged — same no-op/delete/reset logic, just correct mode.

Failure scenario: a repo has an executable script tracked in git (mode 100755); a user edits it in Fast Preview's CMS mode, then discards the change. Before this fix, the discard commit resets the content but writes mode 100644, so the file loses its executable bit on GitHub even though nothing about permissions was touched.

Regression test: `apps/api/src/decofile/git-compat.test.ts` — new `buildDiscardTreeEntries` describe block asserts the base blob's mode (100755) is preserved on discard, plus the existing delete/no-op cases.

Reviewer check: `bun test apps/api/src/decofile/git-compat.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above (12 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the discard operation in Fast Preview's CMS runtime so restoring a file to its merge-base content also restores its git file mode (e.g., executable bit). Previously the discard commit always wrote mode `100644`, stripping permissions from scripts and other executable files even though content was restored correctly. The fix extracts the tree-entry building into a pure `buildDiscardTreeEntries` helper that carries `baseBlob?.mode ?? "100644"` and adds tests for mode preservation, deletion, and no-op cases.

<sup>Written for commit f0269a8d7fdef91f84390396942e27e53160e80b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

