### PR TITLE
refactor(auth): use the api-key plugin's own expired-key sweep

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -1870,13 +1870,10 @@ export async function createApp(options: CreateAppOptions = {}) {
       );
   }
 
-  // Expired API key cleanup (e.g. short-lived claude-code-session keys)
+  // Expired API key cleanup — the api-key plugin's own sweep, not a raw query.
   const cleanupExpiredApiKeys = () =>
-    database.db
-      .deleteFrom("apikey" as any)
-      .where("expiresAt" as any, "<", new Date())
-      .execute()
-      .then(() => {})
+    auth.api
+      .deleteAllExpiredApiKeys()
       .catch((err: unknown) =>
         console.error("[auth] Expired API key cleanup failed:", err),
       );


### PR DESCRIPTION
Reinvented-dependency cleanup (C1): `createApp`'s daily `cleanupExpiredApiKeys` job hand-rolled a raw Kysely `deleteFrom("apikey" as any).where("expiresAt" as any, "<", now)` query against Better Auth's api-key table — cast to `any` twice because that table isn't part of the app's own typed `Database` schema (it's managed by the Better Auth plugin, not our migrations).

Better Auth's `apiKey` plugin (already configured in `auth/index.ts`) ships this exact operation as a first-class server method: `auth.api.deleteAllExpiredApiKeys()` — it deletes rows where `expiresAt < now` (excluding null) through the plugin's own adapter, i.e. the same table/columns, just resolved by the plugin instead of a hardcoded string. It's also literally the same routine Better Auth runs opportunistically on every API-key-authenticated request, so this just reuses it for the scheduled sweep instead of re-deriving the query by hand.

Net effect: -6/+3 lines, two `as any` casts removed, no behavior change (same table, same condition, same daily interval + startup call, same error swallowing).

How to verify: `cd apps/api && bunx tsc --noEmit` (passes — the plugin method is fully typed, no `any` needed). No existing test covered this inline job; it's a straight library-API substitution for a raw query doing the identical delete, so no new test was added.

Locally ran: `bun run fmt` (clean), `bunx tsc --noEmit` in `apps/api` (clean), `bunx oxlint apps/api/src/api/app.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swaps the daily expired API key cleanup from a raw Kysely query against the `apikey` table to the `apiKey` plugin's own `deleteAllExpiredApiKeys()` method, dropping two `as any` casts. Behavior is unchanged: the plugin targets the same table and `expiresAt < now` condition through its own adapter, and the existing schedule and error handling stay the same.

<sup>Written for commit d5655fa8e20443e074c2e31496cd328d6aca6531. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

