### PR TITLE
fix(database): don't treat a ?/$N inside a SQL string literal as a placeholder

### DIFF
--- a/apps/api/src/tools/database/index.test.ts
+++ b/apps/api/src/tools/database/index.test.ts
@@ -26,4 +26,28 @@ describe("interpolateParams", () => {
     const result = interpolateParams("a = $1 AND b = $2", ["x"]);
     expect(result).toBe("a = 'x' AND b = $2");
   });
+
+  test("does not treat a ? inside a string literal as a placeholder", () => {
+    const result = interpolateParams(
+      "SELECT * FROM t WHERE msg = 'what?' AND id = ?",
+      [5],
+    );
+    expect(result).toBe("SELECT * FROM t WHERE msg = 'what?' AND id = 5");
+  });
+
+  test("does not treat a $1 inside a string literal as a placeholder", () => {
+    const result = interpolateParams(
+      "SELECT * FROM t WHERE msg = 'cost is $1' AND id = $1",
+      [5],
+    );
+    expect(result).toBe("SELECT * FROM t WHERE msg = 'cost is $1' AND id = 5");
+  });
+
+  test("keeps a doubled '' escaped quote inside the string open", () => {
+    const result = interpolateParams(
+      "SELECT * FROM t WHERE msg = 'it''s a ?' AND id = ?",
+      [5],
+    );
+    expect(result).toBe("SELECT * FROM t WHERE msg = 'it''s a ?' AND id = 5");
+  });
 });

--- a/apps/api/src/tools/database/index.ts
+++ b/apps/api/src/tools/database/index.ts
@@ -50,13 +50,26 @@ function escapeSqlValue(value: unknown): string {
  * string that grew with each pass; an escaped param containing a literal `?`
  * or `$1` (e.g. a string param holding "a?b") was then picked up as a REAL
  * placeholder by a later pass and substituted again, corrupting the query.
+ *
+ * Also tracks single-quoted string state: a literal `?` or `$1` typed inside
+ * the SQL text's own string literal (e.g. `WHERE msg = 'what?'`) is not a
+ * placeholder — treating it as one both mangles that literal and steals a
+ * positional slot from the real placeholder later in the query. A doubled `''`
+ * (the SQL-standard escaped quote) toggles the state twice in a row, which
+ * keeps the string open, matching how Postgres itself reads it.
  */
 export function interpolateParams(sql: string, params: unknown[]): string {
   let result = "";
   let questionMarkIndex = 0;
+  let inString = false;
   for (let i = 0; i < sql.length; i++) {
     const char = sql[i];
-    if (char === "$") {
+    if (char === "'") {
+      inString = !inString;
+      result += char;
+      continue;
+    }
+    if (!inString && char === "$") {
       const match = /^\$(\d+)/.exec(sql.slice(i));
       const paramIndex = match ? Number(match[1]) - 1 : -1;
       if (match && paramIndex >= 0 && paramIndex < params.length) {
@@ -64,7 +77,7 @@ export function interpolateParams(sql: string, params: unknown[]): string {
         i += match[0].length - 1;
         continue;
       }
-    } else if (char === "?" && questionMarkIndex < params.length) {
+    } else if (!inString && char === "?" && questionMarkIndex < params.length) {
       result += escapeSqlValue(params[questionMarkIndex]);
       questionMarkIndex++;
       continue;


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/tools/database/index.ts` (`DATABASES_RUN_SQL`'s param interpolation), which had two prior hardening passes (#6711, #6712) but not this one.

**Why a maintainer wants it:** `interpolateParams` walks the raw SQL text and swaps every `?`/`$N` it sees for an escaped param, with no awareness of SQL string-literal boundaries. A query like `WHERE msg = 'what?' AND id = ?` has its literal `?` inside `'what?'` consumed as if it were the real placeholder — corrupting that string literal *and* leaving the actual trailing `?` unreplaced, which then reaches Postgres as invalid SQL (or, worse, silently shifts every later positional param by one). Any DDL/DML the tool runs that has a `?` or `$1`-shaped substring inside a string literal breaks today.

**The fix:** track single-quote string state while scanning; a `?`/`$N` seen while inside an open `'...'` literal is copied through untouched instead of substituted. A doubled `''` (the SQL-standard escaped quote) toggles the state twice in a row, so it correctly keeps the string open rather than closing it early.

**Regression tests added** (`apps/api/src/tools/database/index.test.ts`):
- a literal `?` inside a string literal is left alone, and the real trailing `?` placeholder is substituted correctly
- same for a literal `$1` inside a string literal
- a doubled `''` escaped quote inside a literal containing `?` doesn't close the string early

**Verify:** `cd apps/api && bun test src/tools/database/index.test.ts`

**Checked locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, green), the targeted test file above (7/7 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `interpolateParams` so it no longer treats `?` or `$N` inside SQL string literals as placeholders. Previously, a query like `WHERE msg = 'what?' AND id = ?` would corrupt the literal and leave the real placeholder unresolved, or shift all later positional params. The function now tracks single-quote string state (including doubled `''` escaped quotes) and only substitutes placeholders outside string literals. Adds regression tests for literal `?`, `$1`, and escaped quotes.

<sup>Written for commit 504eb844d34b867ff72f7f491da69937d61edc50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

