### PR TITLE
refactor(monitoring): remove any casts from findNDJSONFiles

### DIFF
--- a/apps/api/src/monitoring/test-utils.ts
+++ b/apps/api/src/monitoring/test-utils.ts
@@ -199,7 +199,7 @@ export async function findNDJSONFiles(dir: string): Promise<string[]> {
     if (
       err instanceof Error &&
       "code" in err &&
-      (err as any).code === "ENOENT"
+      (err as NodeJS.ErrnoException).code === "ENOENT"
     ) {
       return [];
     }
@@ -207,8 +207,7 @@ export async function findNDJSONFiles(dir: string): Promise<string[]> {
   }
   for (const entry of entries) {
     if (entry.isFile() && entry.name.endsWith(".ndjson")) {
-      const parentPath = entry.parentPath ?? (entry as any).path;
-      results.push(join(parentPath, entry.name));
+      results.push(join(entry.parentPath, entry.name));
     }
   }
   return results;


### PR DESCRIPTION
C-DEBT: removes the two `any` casts in `apps/api/src/monitoring/test-utils.ts`'s `findNDJSONFiles` (a `no-explicit-any` warn-rule hit that CI doesn't block on, so it just sits there).

1. `(err as any).code === "ENOENT"` -> `(err as NodeJS.ErrnoException).code`, the actual Node type for the error code, already gated by the preceding `err instanceof Error && "code" in err` narrow.
2. `entry.parentPath ?? (entry as any).path` -> just `entry.parentPath`. `@types/node`'s `Dirent.parentPath` is a required (non-optional) `string`, and this repo's `package.json` pins `"engines": { "node": ">=24.0.0" }` — `parentPath` landed in Node 20.12/18.20, so on every supported runtime it's always populated and the `.path` fallback is dead code.

Both are type-only changes; no behavior differs on any Node version this repo supports.

Reviewer check: `cd apps/api && bunx tsc --noEmit` (clean) and `bun test apps/api/src/monitoring/ndjson-exporter.test.ts` (the real filesystem test exercising `findNDJSONFiles`, 5 pass).

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/monitoring/ndjson-exporter.test.ts`, `bunx oxlint apps/api/src/monitoring/test-utils.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the two `any` casts in `findNDJSONFiles` so the function no longer hits the `no-explicit-any` warning. This is a type-only refactor with no behavior change on any supported Node version.

- Casts the error to `NodeJS.ErrnoException` for the `ENOENT` check, which matches the existing `err instanceof Error` and `"code" in err` narrowing.
- Drops the `entry.parentPath ?? (entry as any).path` fallback because `Dirent.parentPath` is a required string and the repo requires Node >=24, so the fallback is dead code.

<sup>Written for commit bf97c6ed10bdaad423a757d40cc286889c07b7c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

