### PR TITLE
refactor(monitoring): drop unused catch bindings in types.tsx

### DIFF
--- a/apps/web/src/components/monitoring/types.tsx
+++ b/apps/web/src/components/monitoring/types.tsx
@@ -435,7 +435,7 @@ export function ExpandedLogContent({ log }: ExpandedLogContentProps) {
         setCopiedOutput(true);
         setTimeout(() => setCopiedOutput(false), 2000);
       }
-    } catch (error) {
+    } catch {
       toast.error(t("monitoring.types.failedToCopy"));
     }
   };
@@ -483,7 +483,7 @@ export function ExpandedLogContent({ log }: ExpandedLogContentProps) {
       await navigator.clipboard.writeText(log.requestId);
       setCopiedRequestId(true);
       setTimeout(() => setCopiedRequestId(false), 2000);
-    } catch (error) {
+    } catch {
       toast.error(t("monitoring.types.failedToCopy"));
     }
   };
@@ -626,7 +626,7 @@ export function ExpandedLogContent({ log }: ExpandedLogContentProps) {
                               `${key}=${value}`,
                             );
                             toast.success(t("monitoring.types.copiedFilter"));
-                          } catch (error) {
+                          } catch {
                             toast.error(t("monitoring.types.failedToCopy"));
                           }
                         }}
@@ -642,7 +642,7 @@ export function ExpandedLogContent({ log }: ExpandedLogContentProps) {
                           try {
                             await navigator.clipboard.writeText(key);
                             toast.success(t("monitoring.types.copiedKey"));
-                          } catch (error) {
+                          } catch {
                             toast.error(t("monitoring.types.failedToCopy"));
                           }
                         }}
@@ -658,7 +658,7 @@ export function ExpandedLogContent({ log }: ExpandedLogContentProps) {
                           try {
                             await navigator.clipboard.writeText(value);
                             toast.success(t("monitoring.types.copiedValue"));
-                          } catch (error) {
+                          } catch {
                             toast.error(t("monitoring.types.failedToCopy"));
                           }
                         }}


### PR DESCRIPTION
Un-CI-enforced debt cleanup (C-DEBT lane, `eslint(no-unused-vars)` is `warn`-level in `.oxlintrc.json` so CI never blocks it).

Five clipboard-copy handlers in `apps/web/src/components/monitoring/types.tsx` (`handleCopy`, `handleCopyRequestId`, and three inline popover copy actions) had `catch (error) { toast.error(...) }` where `error` was never read. Switched each to a bare `catch { ... }` — same control flow, same error toast, one fewer unused binding oxlint has to warn about every run.

Behavior-preserving: no logic changed, only the catch parameter was dropped. Confirmed with `bunx oxlint --config .oxlintrc.json apps/web/src/components/monitoring/types.tsx` — 5 warnings → 0. `bunx tsc --noEmit` in `apps/web` shows the same single pre-existing, unrelated error (a prosemirror-model version-mismatch in `mention-suggestion.tsx`) before and after this change, confirmed via `git stash`.

Reviewer check: `bunx oxlint --config .oxlintrc.json apps/web/src/components/monitoring/types.tsx` should report 0 warnings.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web), and the targeted oxlint pass above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `error` parameter from five clipboard-copy handlers in `apps/web/src/components/monitoring/types.tsx`. The error toasts still fire exactly as before, but oxlint stops warning about the unused catch binding — this was never CI-enforced, so it's just debt cleanup.

**Verification**
- `bunx oxlint --config .oxlintrc.json apps/web/src/components/monitoring/types.tsx` now reports 0 warnings (was 5).
- `tsc --noEmit` in `apps/web` is unchanged: the same single pre-existing, unrelated error remains.

<sup>Written for commit 4daf6fbf319db023eac81555cd6cb1ecbd5ab602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

