### PR TITLE
fix(decopilot): refuse redirects fetching a reference image, closing an SSRF bypass

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
@@ -91,6 +91,23 @@ describe("fetchImageBytes", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("refuses a redirect response, so a compromised host can't bounce the fetch to a private address", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://169.254.169.254/latest/meta-data/" },
+      })) as unknown as typeof fetch;
+
+    try {
+      await expect(
+        fetchImageBytes("https://93.184.216.34/reference.png", {}),
+      ).rejects.toThrow(/redirect/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe("generateImageCore", () => {

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
@@ -234,7 +234,8 @@ export async function fetchImageBytes(
     : timeoutSignal;
   let res: Response;
   try {
-    res = await fetch(url, { signal });
+    // Refuses redirects — otherwise bypasses the SSRF checks above.
+    res = await fetch(url, { signal, redirect: "manual" });
   } catch (err) {
     if (err instanceof Error && err.name === "TimeoutError") {
       throw new Error(
@@ -242,6 +243,9 @@ export async function fetchImageBytes(
       );
     }
     throw err;
+  }
+  if (res.status >= 300 && res.status < 400) {
+    throw new Error(`Refusing to follow a redirect fetching image from ${url}`);
   }
   if (!res.ok) {
     throw new Error(`Failed to fetch image from ${url}: ${res.status}`);


### PR DESCRIPTION
**Source:** SSRF/trust-boundary hardening found while reading `portable-media-tools.ts` (recently touched by #6731). Not tied to an issue or open PR.

**Why it matters:** `fetchImageBytes` (used by the `generateImage` tool for image-to-image reference images) validates the literal hostname (`validateExternalUrl`) and does a DNS-rebinding check (`assertUrlDoesNotResolvePrivate`) before fetching a user-supplied URL — but the `fetch()` call itself still followed redirects by default. A malicious or compromised image host can pass both checks on the initial URL, then 3xx-redirect the request to a private/cloud-metadata address (e.g. `http://169.254.169.254/...`), completely bypassing the SSRF guards. This exact bug class was already fixed the same way in `tools/registry/discover-tools.ts` (`createNoRedirectFetch`) and `api/routes/oauth-proxy.ts` — this file had the same gap.

**Fix:** pass `redirect: "manual"` to the `fetch` call and reject any 3xx response, matching the existing pattern in this codebase.

**Regression test:** added `refuses a redirect response, so a compromised host can't bounce the fetch to a private address` in `portable-media-tools.test.ts` — stubs `fetch` to return a 302 to a metadata IP and asserts `fetchImageBytes` rejects instead of following it.

**To verify:** `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts`

**Checked locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file (11/11 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `fetchImageBytes` from following redirects, closing an SSRF bypass where a compromised image host could redirect to a private or metadata address.

- Sets `redirect: "manual"` and rejects any 3xx response, matching existing patterns in the codebase.
- Adds a regression test that stubs a 302 redirect to a metadata IP and verifies the fetch is rejected.

<sup>Written for commit 063923e7f2dd21c0890ec467b107259acde68a8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

