### PR TITLE
fix(task-board): guard a card the reconcile ships into an org column

### DIFF
--- a/apps/api/src/tools/task-board/reconcile-merged.test.ts
+++ b/apps/api/src/tools/task-board/reconcile-merged.test.ts
@@ -37,15 +37,22 @@ const item = (over: Partial<TaskBoardItem> = {}): TaskBoardItem =>
   }) as TaskBoardItem;
 
 function fakeCtx(
-  over: { humanRejectedDone?: boolean; deliveryLanes?: boolean } = {},
+  over: {
+    humanRejectedDone?: boolean;
+    deliveryLanes?: boolean;
+    orgOwnedColumns?: boolean;
+  } = {},
 ) {
-  const updates: { status: string }[] = [];
+  const updates: { status: string; boardColumnOrg: string | null }[] = [];
   const activity: Record<string, unknown>[] = [];
   const ctx = {
     storage: {
       organizationSettings: {
         get: async () => ({
-          flags: { delivery_lanes_enabled: over.deliveryLanes ?? false },
+          flags: {
+            delivery_lanes_enabled: over.deliveryLanes ?? false,
+            org_board_columns: over.orgOwnedColumns ?? false,
+          },
         }),
       },
       taskBoard: {
@@ -53,7 +60,7 @@ function fakeCtx(
         update: async (
           _id: string,
           _org: string,
-          patch: { status: string },
+          patch: { status: string; boardColumnOrg: string | null },
         ) => {
           updates.push(patch);
           return item({ status: "done" });
@@ -71,7 +78,7 @@ describe("advanceToDoneIfMerged", () => {
   it("moves a card whose PR landed outside Studio to Done, and says why", async () => {
     const { ctx, updates, activity } = fakeCtx();
     expect(await advanceToDoneIfMerged(ctx, item(), [merged])).toBe(true);
-    expect(updates).toEqual([{ status: "done" }]);
+    expect(updates).toEqual([{ status: "done", boardColumnOrg: null }]);
     expect(activity).toEqual([
       {
         taskBoardItemId: "item-1",
@@ -86,10 +93,17 @@ describe("advanceToDoneIfMerged", () => {
   it("lands on Merged when the org runs the delivery lanes", async () => {
     const { ctx, updates, activity } = fakeCtx({ deliveryLanes: true });
     expect(await advanceToDoneIfMerged(ctx, item(), [merged])).toBe(true);
-    expect(updates).toEqual([{ status: "merged" }]);
+    expect(updates).toEqual([{ status: "merged", boardColumnOrg: null }]);
     expect(activity[0]).toMatchObject({
       data: { from: "in_review", to: "merged", reason: "pr_merged" },
     });
+  });
+
+  // The org-owned board needs the same discriminator a manual move sets (#6725).
+  it("guards a card it ships into an org-owned board", async () => {
+    const { ctx, updates } = fakeCtx({ orgOwnedColumns: true });
+    expect(await advanceToDoneIfMerged(ctx, item(), [merged])).toBe(true);
+    expect(updates).toEqual([{ status: "done", boardColumnOrg: "org-1" }]);
   });
 
   it("leaves an unmerged card alone", async () => {
@@ -118,7 +132,7 @@ describe("advanceToDoneIfMerged", () => {
     expect(await advanceToDoneIfMerged(ctx, item(), [abandoned, merged])).toBe(
       true,
     );
-    expect(updates).toEqual([{ status: "done" }]);
+    expect(updates).toEqual([{ status: "done", boardColumnOrg: null }]);
   });
 
   it("does nothing for a card with no linked PR", async () => {
@@ -150,7 +164,7 @@ describe("advanceToDoneIfMerged", () => {
         [merged],
       ),
     ).toBe(true);
-    expect(updates).toEqual([{ status: "done" }]);
+    expect(updates).toEqual([{ status: "done", boardColumnOrg: null }]);
   });
 
   // A person who pulled the card back out of Done outranks a merged PR.

--- a/apps/api/src/tools/task-board/reconcile-merged.ts
+++ b/apps/api/src/tools/task-board/reconcile-merged.ts
@@ -24,6 +24,7 @@ import type { TaskBoardItem } from "@/storage/types";
 import { shippedLane } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
 import { cardWorkLanded, type PrLanding } from "./archive-merged";
+import { boardFor } from "./board-handler";
 import { inReviewPhase } from "./lanes";
 import { emitTaskBoardUpdated } from "./run-reactions";
 
@@ -63,10 +64,12 @@ export async function advanceToDoneIfMerged(
   // Read only once the card is actually shipping.
   const settings = await ctx.storage.organizationSettings.get(orgId);
   const shipped = shippedLane(settings?.flags);
+  const board = await boardFor(ctx, orgId);
   const done = await ctx.storage.taskBoard.update(
     item.id,
     orgId,
-    { status: shipped },
+    // Guarded like a manual move: this can file the card under an org's own column too.
+    { status: shipped, boardColumnOrg: board.columnOwner() },
     item.updatedBy,
   );
   await recordTaskActivity(ctx, {


### PR DESCRIPTION
Follows #6725's fix in `archive-merged.ts` — the same gap in its sibling, `reconcile-merged.ts`'s `advanceToDoneIfMerged`, the sweep that moves an In Review card to Merged/Done when its linked PR landed outside Studio (merged by a person, or by GitHub's own auto-merge).

**Bug:** `delivery_lanes_enabled` and `org_board_columns` are independent org flags — both can be on at once. `advanceToDoneIfMerged` writes `shippedLane(settings.flags)` (`"merged"` or `"done"`, Studio's own vocabulary) straight into `status`, with no `boardColumnOrg` discriminator. On an org running both flags, that files the card under a column key the foreign key can't tell apart from the org's own board — the exact bug #6725 fixed for the archive sweep, just in the reconcile that ships a card out of review.

**Fix:** ask `boardFor(ctx, orgId)` for `columnOwner()` and write it alongside `status`, mirroring `archive-merged.ts` and `update.ts`'s existing guard.

**Regression test:** added `"guards a card it ships into an org-owned board"` to `reconcile-merged.test.ts`, asserting `boardColumnOrg` is the org id when `org_board_columns` is on (and stays `null` otherwise — updated the other assertions in the same file to match the new field).

Reviewer command: `bun test apps/api/src/tools/task-board/reconcile-merged.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test file (11 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `advanceToDoneIfMerged` so cards shipped to Merged/Done carry the `boardColumnOrg` discriminator, preventing them from landing in a wrongly-keyed org-owned column when both `delivery_lanes_enabled` and `org_board_columns` are on.

- Writes `board.columnOwner()` alongside `status`, matching the guard already in `archive-merged.ts` and `update.ts`.
- Adds a regression test asserting `boardColumnOrg` is the org id when `org_board_columns` is enabled, and `null` otherwise.

<sup>Written for commit 160092e624e63fce8c59d0a7ed4b5ac23d1e39bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

