### PR TITLE
fix(database): don't treat a ?/$N inside a quoted identifier as a placeholder

### DIFF
--- a/apps/api/src/tools/database/index.test.ts
+++ b/apps/api/src/tools/database/index.test.ts
@@ -50,4 +50,28 @@ describe("interpolateParams", () => {
     );
     expect(result).toBe("SELECT * FROM t WHERE msg = 'it''s a ?' AND id = 5");
   });
+
+  test("does not treat a ? inside a quoted identifier as a placeholder", () => {
+    const result = interpolateParams(
+      'SELECT * FROM t WHERE "col?" = ? AND id = ?',
+      [1, 2],
+    );
+    expect(result).toBe('SELECT * FROM t WHERE "col?" = 1 AND id = 2');
+  });
+
+  test("does not treat a $1 inside a quoted identifier as a placeholder", () => {
+    const result = interpolateParams(
+      'SELECT "col$1" FROM t WHERE id = $1',
+      [5],
+    );
+    expect(result).toBe('SELECT "col$1" FROM t WHERE id = 5');
+  });
+
+  test('keeps a doubled "" escaped quote inside the identifier open', () => {
+    const result = interpolateParams(
+      'SELECT * FROM t WHERE "col""?" = ? AND id = ?',
+      [1, 2],
+    );
+    expect(result).toBe('SELECT * FROM t WHERE "col""?" = 1 AND id = 2');
+  });
 });

--- a/apps/api/src/tools/database/index.ts
+++ b/apps/api/src/tools/database/index.ts
@@ -51,25 +51,31 @@ function escapeSqlValue(value: unknown): string {
  * or `$1` (e.g. a string param holding "a?b") was then picked up as a REAL
  * placeholder by a later pass and substituted again, corrupting the query.
  *
- * Also tracks single-quoted string state: a literal `?` or `$1` typed inside
- * the SQL text's own string literal (e.g. `WHERE msg = 'what?'`) is not a
- * placeholder — treating it as one both mangles that literal and steals a
- * positional slot from the real placeholder later in the query. A doubled `''`
- * (the SQL-standard escaped quote) toggles the state twice in a row, which
- * keeps the string open, matching how Postgres itself reads it.
+ * Also tracks single- and double-quoted state: a literal `?` or `$1` typed
+ * inside the SQL text's own string literal (`'what?'`) or a quoted identifier
+ * (`"col?"`) is not a placeholder — treating it as one both mangles that
+ * literal/identifier and steals a positional slot from the real placeholder
+ * later in the query. A doubled `''`/`""` keeps the string/identifier open,
+ * matching how Postgres itself reads an escaped quote.
  */
 export function interpolateParams(sql: string, params: unknown[]): string {
   let result = "";
   let questionMarkIndex = 0;
   let inString = false;
+  let inIdentifier = false;
   for (let i = 0; i < sql.length; i++) {
     const char = sql[i];
-    if (char === "'") {
+    if (!inIdentifier && char === "'") {
       inString = !inString;
       result += char;
       continue;
     }
-    if (!inString && char === "$") {
+    if (!inString && char === '"') {
+      inIdentifier = !inIdentifier;
+      result += char;
+      continue;
+    }
+    if (!inString && !inIdentifier && char === "$") {
       const match = /^\$(\d+)/.exec(sql.slice(i));
       const paramIndex = match ? Number(match[1]) - 1 : -1;
       if (match && paramIndex >= 0 && paramIndex < params.length) {
@@ -77,7 +83,12 @@ export function interpolateParams(sql: string, params: unknown[]): string {
         i += match[0].length - 1;
         continue;
       }
-    } else if (!inString && char === "?" && questionMarkIndex < params.length) {
+    } else if (
+      !inString &&
+      !inIdentifier &&
+      char === "?" &&
+      questionMarkIndex < params.length
+    ) {
       result += escapeSqlValue(params[questionMarkIndex]);
       questionMarkIndex++;
       continue;


### PR DESCRIPTION
Follows #6735/#6712, which fixed `interpolateParams` treating a `?`/`$N` inside a single-quoted SQL *string literal* as a real placeholder. The same function still had the sibling bug for a double-quoted SQL *identifier* — it only tracked single-quote state, so a literal `?` or `$N` typed inside a quoted column/table name (e.g. `WHERE "col?" = 1`) is mangled and steals a positional slot from the real placeholder later in the query.

**Failure scenario:** `DATABASES_RUN_SQL` on `SELECT * FROM t WHERE "col?" = ? AND id = ?` with params `[1, 2]` currently produces `WHERE "col'1'" = 1 AND id = ...` — the identifier is corrupted and the params shift, because `interpolateParams` doesn't know it's inside a quoted identifier when it sees the `?`.

**Fix:** track double-quoted identifier state the same way the existing code tracks single-quoted string state (including the doubled `""` escape), and skip `$`/`?` interpretation while inside either.

**Verify:** `bun test apps/api/src/tools/database/index.test.ts` — added 3 tests mirroring the existing string-literal tests, for a quoted identifier containing `?`, `$1`, and a doubled `""` escape.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above (10/10 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `interpolateParams` so a `?` or `$N` inside a double-quoted SQL identifier is no longer parsed as a placeholder. Previously, literal `?`/`$N` in identifiers like `"col?"` corrupted the identifier and shifted positional params.

**Bug Fixes**

- Tracks double-quoted identifier state, including the `""` escape, matching how single-quoted strings are already handled.
- Adds three tests covering `?`, `$1`, and a doubled `""` quote inside identifiers.

<sup>Written for commit c9f3966ae19577c83572e8596c9fb81db525d61c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

