### PR TITLE
refactor(mcp-utils): drop an unneeded any-cast reading sessionId off Transport

### DIFF
--- a/packages/mcp-utils/src/compose-transport.ts
+++ b/packages/mcp-utils/src/compose-transport.ts
@@ -25,7 +25,7 @@ export abstract class WrapperTransport implements Transport {
   constructor(protected innerTransport: Transport) {}
 
   get sessionId(): string | undefined {
-    return (this.innerTransport as any).sessionId;
+    return this.innerTransport.sessionId;
   }
 
   async start(): Promise<void> {


### PR DESCRIPTION
**Source:** C-DEBT — a `no-explicit-any`-warn violation found while sweeping for real (not test-coverage) frontend/backend debt.

**Why a maintainer wants it:** `WrapperTransport.sessionId` cast `this.innerTransport` to `any` to read `.sessionId`, but the MCP SDK's own `Transport` interface (`@modelcontextprotocol/sdk/shared/transport.d.ts`) already declares `sessionId?: string` as a real optional property. The cast was silently defeating type-checking on every subclass of `WrapperTransport` (auth/monitoring/etc. transport middlewares in the compose pipeline) for no reason — a future rename or type change to `sessionId` on `Transport` would not be caught here.

**Change:** drop the `as any` and read `this.innerTransport.sessionId` directly, now that TypeScript can verify the property exists. Purely a type-safety cleanup — the runtime value returned is identical.

**Net delta:** 1 line changed, no line-count change (just replaces the cast).

**How a reviewer verifies:** `cd packages/mcp-utils && bunx tsc --noEmit` (green) and `bun test packages/mcp-utils/src/compose-transport.test.ts` (all 14 existing tests still pass unchanged).

**Locally ran:** `bun run fmt`, `cd packages/mcp-utils && bunx tsc --noEmit`, `bun test packages/mcp-utils/src/compose-transport.test.ts` (14 pass), `bunx oxlint packages/mcp-utils/src/compose-transport.ts` (0 warnings/errors). Full CI validates the rest of the monorepo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes an unnecessary `as any` cast when reading `sessionId` off `WrapperTransport`. The MCP SDK's `Transport` interface already declares `sessionId?: string`, so the cast was defeating type-checking without changing runtime behavior.

- No longer masks future type changes to `Transport.sessionId`.
- Runtime value returned is identical.

<sup>Written for commit dda7df355d3ef026bb6a7816202c1f578febc486. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

