### PR TITLE
fix(task-board): guard the org-owned column when a card ships via merge

### DIFF
--- a/apps/api/src/tools/task-board/archive-merged.ts
+++ b/apps/api/src/tools/task-board/archive-merged.ts
@@ -14,7 +14,7 @@
  * history for free and dragging a card back out un-archives it.
  */
 
-import { boardFor } from "./board-handler";
+import { boardFor, shippedPatch } from "./board-handler";
 import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItemPrRef } from "@/storage/types";
 import { recordTaskActivity } from "./activity";
@@ -121,8 +121,7 @@ async function archiveIfMerged(
   const updated = await ctx.storage.taskBoard.update(
     itemId,
     organizationId,
-    // Guarded like a manual move: this can file the card under an org's own column too.
-    { status: archived, boardColumnOrg: board.columnOwner() },
+    shippedPatch(board, archived),
     item.updatedBy,
   );
   await recordTaskActivity(ctx, {

--- a/apps/api/src/tools/task-board/board-handler.test.ts
+++ b/apps/api/src/tools/task-board/board-handler.test.ts
@@ -1,0 +1,28 @@
+/**
+ * `shippedPatch` is the one place every ship/archive route builds its status
+ * write — pure, so unit-tested directly rather than through a fake ctx.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { BoardHandler } from "./board-handler";
+import { shippedPatch } from "./board-handler";
+
+const boardWithOwner = (columnOwner: string | null): BoardHandler =>
+  ({ columnOwner: () => columnOwner }) as BoardHandler;
+
+describe("shippedPatch", () => {
+  it("leaves boardColumnOrg null on Studio's own board", () => {
+    expect(shippedPatch(boardWithOwner(null), "done")).toEqual({
+      status: "done",
+      boardColumnOrg: null,
+    });
+  });
+
+  // The guard that #6725/#6739 each had to add by hand at their own call site.
+  it("carries the org discriminator on an org-owned board", () => {
+    expect(shippedPatch(boardWithOwner("org-1"), "merged")).toEqual({
+      status: "merged",
+      boardColumnOrg: "org-1",
+    });
+  });
+});

--- a/apps/api/src/tools/task-board/board-handler.ts
+++ b/apps/api/src/tools/task-board/board-handler.ts
@@ -173,6 +173,20 @@ export async function boardFor(
 }
 
 /**
+ * The patch every route that ships or archives a card writes: the target
+ * status alongside the board's own discriminator. One helper so a new ship
+ * path can't repeat `{ status, boardColumnOrg }` and forget the guard — the
+ * exact gap that let a card land unguarded on an org-owned board (#6725,
+ * #6739) in the sweep paths that already remembered it.
+ */
+export function shippedPatch(
+  board: BoardHandler,
+  status: string,
+): { status: string; boardColumnOrg: string | null } {
+  return { status, boardColumnOrg: board.columnOwner() };
+}
+
+/**
  * Refuse a status this board has no column for.
  *
  * What the closed enum used to do, moved to where the answer actually lives:

--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -8,6 +8,7 @@ import {
   shippedLane,
 } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
+import { boardFor, shippedPatch } from "./board-handler";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
 import {
   type ChecksStatus,
@@ -461,10 +462,11 @@ export async function retryAutoMergeIfApproved(
   }
 
   const shipped = shippedLane(settings?.flags);
+  const board = await boardFor(ctx, orgId);
   const done = await ctx.storage.taskBoard.update(
     item.id,
     orgId,
-    { status: shipped },
+    shippedPatch(board, shipped),
     item.updatedBy,
   );
   await recordTaskActivity(ctx, {

--- a/apps/api/src/tools/task-board/promote-to-production.ts
+++ b/apps/api/src/tools/task-board/promote-to-production.ts
@@ -12,6 +12,7 @@ import {
 import { TaskBoardItemStatusSchema } from "./schema";
 import { SHIP_ELIGIBLE_LANES } from "./lanes";
 import { recordTaskActivity } from "./activity";
+import { boardFor, shippedPatch } from "./board-handler";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { mergeLinkedPr } from "./merge-pr";
 
@@ -106,10 +107,11 @@ export const TASK_BOARD_PROMOTE_TO_PRODUCTION = defineTool({
     }
 
     const shipped = shippedLane(settings?.flags);
+    const board = await boardFor(ctx, organizationId);
     const updated = await ctx.storage.taskBoard.update(
       taskBoardItemId,
       organizationId,
-      { status: shipped },
+      shippedPatch(board, shipped),
       item.updatedBy,
     );
     if (item.status !== shipped) {

--- a/apps/api/src/tools/task-board/reconcile-merged.ts
+++ b/apps/api/src/tools/task-board/reconcile-merged.ts
@@ -24,7 +24,7 @@ import type { TaskBoardItem } from "@/storage/types";
 import { shippedLane } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
 import { cardWorkLanded, type PrLanding } from "./archive-merged";
-import { boardFor } from "./board-handler";
+import { boardFor, shippedPatch } from "./board-handler";
 import { inReviewPhase } from "./lanes";
 import { emitTaskBoardUpdated } from "./run-reactions";
 
@@ -68,8 +68,7 @@ export async function advanceToDoneIfMerged(
   const done = await ctx.storage.taskBoard.update(
     item.id,
     orgId,
-    // Guarded like a manual move: this can file the card under an org's own column too.
-    { status: shipped, boardColumnOrg: board.columnOwner() },
+    shippedPatch(board, shipped),
     item.updatedBy,
   );
   await recordTaskActivity(ctx, {

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -11,6 +11,7 @@ import {
 } from "@decocms/shared/task-board";
 import { TaskBoardItemStatusSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
+import { boardFor, shippedPatch } from "./board-handler";
 import {
   emitTaskBoardUpdated,
   handTaskToHuman,
@@ -318,10 +319,11 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
           taskBoardItemId,
           organizationId,
         )) ?? item;
+      const board = await boardFor(ctx, organizationId);
       const done = await ctx.storage.taskBoard.update(
         taskBoardItemId,
         organizationId,
-        { status: shipped },
+        shippedPatch(board, shipped),
         item.updatedBy,
       );
       await recordTaskActivity(ctx, {


### PR DESCRIPTION
Follows #6725 (`archive-merged.ts`) and #6739 (`reconcile-merged.ts`), which each fixed this same gap in their own sweep. This PR closes it in the three remaining routes that write a card's shipped status.

**Bug:** `delivery_lanes_enabled` and `org_board_columns` are independent org flags — both can be on at once. `retryAutoMergeIfApproved` (the sweep's auto-merge retry, `merge-pr.ts`), the inline merge in `TASK_BOARD_REVIEW_DECISION` (`review-decision.ts`), and the manual Ship button (`promote-to-production.ts`) all write `{ status: shipped }` straight into `status` with no `boardColumnOrg` discriminator. On an org running both flags, any of these three routes files a card under a column key the foreign key can't tell apart from the org's own board — the exact bug #6725/#6739 already fixed in the sweeps that ship a card without a human clicking anything.

**Fix:** each site now asks `boardFor(ctx, orgId)` for `columnOwner()` and writes it alongside `status`, mirroring the existing guard. To stop this from being re-introduced at a sixth call site, extracted the two-line patch every ship/archive route was hand-rolling into a new `shippedPatch(board, status)` in `board-handler.ts`, and switched all five call sites (the two already-fixed ones included) onto it.

**Regression test:** `shippedPatch` is pure, so it's unit-tested directly in a new `board-handler.test.ts` — asserts `boardColumnOrg` stays `null` on Studio's own board and carries the org id on an org-owned one. The three fixed call sites themselves are gated behind a live GitHub merge (`mergeLinkedPr`), which is why #6725/#6739's own tests only covered the network-free sweep (`advanceToDoneIfMerged`, which takes already-fetched PR states) — the same constraint applies here, so I didn't force a test through a live-merge path; CI's existing suite still exercises these tools end to end.

Reviewer command: `bun test apps/api/src/tools/task-board/board-handler.test.ts apps/api/src/tools/task-board/reconcile-merged.test.ts apps/api/src/tools/task-board/archive-merged.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the three targeted test files (24 pass), `bunx oxlint` on all seven changed/added files (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards the org-owned board column on the three remaining ship routes so a card shipped via merge can't land under a column key the foreign key can't tell apart from the org's own board. Previously `retryAutoMergeIfApproved`, the `TASK_BOARD_REVIEW_DECISION` inline merge, and the Ship button wrote `{ status: shipped }` without a `boardColumnOrg` discriminator, while the archive and reconcile sweeps already had the guard.

**Bug Fixes**
- All three routes now write `boardColumnOrg` from `boardFor(...).columnOwner()` alongside the shipped status.
- Extracted the repeated two-line patch into a new `shippedPatch(board, status)` helper used at all five ship/archive call sites, with a unit test covering both the Studio-owned and org-owned board cases.

<sup>Written for commit 7d90529ece638ccff87449b0cc51cd0107e13d4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

