### PR TITLE
fix(task-board): guard org-owned column when a card ships via the PR-poll reconcile

### DIFF
--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -14,6 +14,7 @@ import { retry, RetryError } from "@decocms/shared/std";
 import { InMemoryMcpReadCache } from "@/mcp-clients/mcp-read-cache";
 import { TaskBoardItemPrSchema } from "./schema";
 import { cardWorkLanded } from "./archive-merged";
+import { boardFor, shippedPatch } from "./board-handler";
 import { recordTaskActivity } from "./activity";
 import { inReviewPhase, movesForward } from "./lanes";
 import { emitTaskBoardUpdated } from "./run-reactions";
@@ -1266,10 +1267,11 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
             organizationId,
           ))
         ) {
+          const board = await boardFor(ctx, organizationId);
           const updated = await ctx.storage.taskBoard.update(
             taskBoardItemId,
             organizationId,
-            { status: shipped },
+            shippedPatch(board, shipped),
             item.updatedBy,
           );
           // Every other path that moves a card to Done (the review-decision


### PR DESCRIPTION
Follows #6742.

#6742 introduced the `shippedPatch` helper and used it to fix the same bug — a ship-to-Done write that dropped the `boardColumnOrg` discriminator — at five sibling call sites (archive-merged, merge-pr, promote-to-production, reconcile-merged, review-decision). `prs-get.ts` has a sixth ship site: the merged-PR reconcile that runs whenever `TASK_BOARD_ITEM_PRS_GET` observes a merged PR. It still built the raw `{ status: shipped }` patch, so on an org-owned board (`org_board_columns` flag) this path lands the card without `boardColumnOrg` set — the exact bug #6725/#6739/#6742 fixed everywhere else, just missed here since this tool wasn't touched in that PR.

Fix: import `boardFor`/`shippedPatch` from `board-handler.ts` and use them here too, matching the five already-fixed sites.

Reviewer check: `grep -rn 'status: shipped' apps/api/src/tools/task-board/*.ts` now shows zero raw call sites — every ship-to-Done write goes through `shippedPatch`.

Verified locally: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/tools/task-board/prs-get.ts` (0 warnings/errors). `shippedPatch`'s guard behavior itself is already covered by `board-handler.test.ts` (added in #6742); no new test needed since the fix is calling that pre-tested helper instead of hand-rolling the patch. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the PR-poll reconcile in `prs-get.ts` so shipping a merged PR on an org-owned board keeps the `boardColumnOrg` discriminator.

The card now uses the same `shippedPatch` helper as the other five ship-to-Done paths, so every ship write preserves org-owned board columns.

<sup>Written for commit d4bac844dcd5b7146622a7ace3c20888de09681c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

