### PR TITLE
fix(database): don't treat a $1 inside a dollar-quoted function body as a placeholder

### DIFF
--- a/apps/api/src/tools/database/index.test.ts
+++ b/apps/api/src/tools/database/index.test.ts
@@ -74,4 +74,24 @@ describe("interpolateParams", () => {
     );
     expect(result).toBe('SELECT * FROM t WHERE "col""?" = 1 AND id = 2');
   });
+
+  test("does not treat a $1 inside a dollar-quoted function body as a placeholder", () => {
+    const result = interpolateParams(
+      "DO $$ BEGIN PERFORM some_func($1); END $$; SELECT ? ",
+      ["x"],
+    );
+    expect(result).toBe(
+      "DO $$ BEGIN PERFORM some_func($1); END $$; SELECT 'x' ",
+    );
+  });
+
+  test("does not treat a $1 inside a tagged dollar-quoted body as a placeholder", () => {
+    const result = interpolateParams(
+      "CREATE FUNCTION f() RETURNS int AS $body$ SELECT $1 $body$ LANGUAGE sql; SELECT ?",
+      ["x"],
+    );
+    expect(result).toBe(
+      "CREATE FUNCTION f() RETURNS int AS $body$ SELECT $1 $body$ LANGUAGE sql; SELECT 'x'",
+    );
+  });
 });

--- a/apps/api/src/tools/database/index.ts
+++ b/apps/api/src/tools/database/index.ts
@@ -63,8 +63,21 @@ export function interpolateParams(sql: string, params: unknown[]): string {
   let questionMarkIndex = 0;
   let inString = false;
   let inIdentifier = false;
+  // A DO/CREATE FUNCTION body's own $1 (its arg, not our param) lives here.
+  let dollarQuoteTag: string | null = null;
   for (let i = 0; i < sql.length; i++) {
     const char = sql[i];
+    if (dollarQuoteTag !== null) {
+      const closeDelim = `$${dollarQuoteTag}$`;
+      if (sql.startsWith(closeDelim, i)) {
+        result += closeDelim;
+        i += closeDelim.length - 1;
+        dollarQuoteTag = null;
+      } else {
+        result += char;
+      }
+      continue;
+    }
     if (!inIdentifier && char === "'") {
       inString = !inString;
       result += char;
@@ -81,6 +94,14 @@ export function interpolateParams(sql: string, params: unknown[]): string {
       if (match && paramIndex >= 0 && paramIndex < params.length) {
         result += escapeSqlValue(params[paramIndex]);
         i += match[0].length - 1;
+        continue;
+      }
+      // A tag can't start with a digit, so this never fights the $1 case above.
+      const quoteStart = /^\$([A-Za-z_][A-Za-z0-9_]*)?\$/.exec(sql.slice(i));
+      if (quoteStart) {
+        dollarQuoteTag = quoteStart[1] ?? "";
+        result += quoteStart[0];
+        i += quoteStart[0].length - 1;
         continue;
       }
     } else if (


### PR DESCRIPTION
Continues the same hardening pass as #6712/#6735/#6740 on `interpolateParams` (`apps/api/src/tools/database/index.ts`), the placeholder-substitution used by `DATABASES_RUN_SQL`.

`interpolateParams` already tracks single-quote (`'...'`) and double-quote (`"..."`) state so a literal `$1`/`?` inside a string or identifier isn't mistaken for a real positional param. It had no equivalent tracking for Postgres's dollar-quoted strings (`$$...$$` / `$tag$...$tag$`), the syntax every `DO` block and `CREATE FUNCTION ... AS $$ ... $$` body uses.

**Failure scenario:** a caller runs a DDL statement like `DO $$ BEGIN PERFORM some_func($1); END $$;` (or a `CREATE FUNCTION` body) alongside a non-empty `params` array (e.g. a preceding statement's own placeholder, or just a param the caller happens to pass). The `$1` inside the dollar-quoted body is PL/pgSQL's reference to *that function's own* first argument — not this tool's param — but nothing in `interpolateParams` recognized it as being inside a quoted region, so it got silently substituted with the caller's param value, corrupting the function body.

Fix: added dollar-quote state tracking mirroring the existing single/double-quote handling — on encountering `$` outside a string/identifier, if it's not a valid in-range positional param, check whether it opens a dollar-quote (`$tag$`, tag optional) and if so, pass everything through unmodified until the matching `$tag$` close delimiter. A tag can't start with a digit, so this can never misfire against a real `$1`/`$2` placeholder.

Regression tests added (`apps/api/src/tools/database/index.test.ts`): a `DO $$ ... $1 ... $$` body and a tagged `$body$ ... $1 ... $body$` function body both keep their literal `$1` intact while a trailing real `?`/`$N` placeholder outside the dollar-quote still substitutes normally.

Reviewer check: `bun test apps/api/src/tools/database/index.test.ts` (12 pass).

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `interpolateParams` so a `$1` inside a Postgres dollar-quoted string (`$$...$$` or `$tag$...$tag$`) is no longer mistaken for a positional placeholder, preventing corruption of `DO` blocks and `CREATE FUNCTION` bodies.

- Adds dollar-quote state tracking in `apps/api/src/tools/database/index.ts` that mirrors existing single/double-quote handling.
- Adds regression tests for both untagged and tagged dollar-quoted bodies, verifying a trailing real placeholder still substitutes.

<sup>Written for commit 80d11a39d682e44cc67829f340e1d4efc9a2c346. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

