### PR TITLE
refactor(task-status): narrow getStatusConfig with a type guard instead of an as-cast

### DIFF
--- a/apps/web/src/lib/task-status.ts
+++ b/apps/web/src/lib/task-status.ts
@@ -77,6 +77,11 @@ const UNKNOWN: StatusConfig = {
   labelColor: "text-muted-foreground",
 };
 
+function isStatusKey(status: string): status is StatusKey {
+  return status in STATUS_CONFIG;
+}
+
 export function getStatusConfig(status: string | undefined): StatusConfig {
-  return STATUS_CONFIG[(status ?? "completed") as StatusKey] ?? UNKNOWN;
+  const key = status ?? "completed";
+  return isStatusKey(key) ? STATUS_CONFIG[key] : UNKNOWN;
 }


### PR DESCRIPTION
Source: C-DEBT (compile-time-safety cleanup), found while auditing `apps/web/src/lib/task-status.ts`.

`getStatusConfig` indexed `STATUS_CONFIG` with `(status ?? "completed") as StatusKey` — an unchecked cast that makes an arbitrary `status: string` (e.g. any other task/thread status the app doesn't render an icon for) type-check as a `StatusKey` even when it isn't one. The `?? UNKNOWN` after it happened to catch the runtime miss, but a future edit narrowing `STATUS_CONFIG`'s type or removing the fallback would silently regress with no compile error — the exact 'a rename is a compile error, not a runtime regression' failure mode the repo's own style guide calls out.

Replaced the cast with an `isStatusKey` type guard (`status in STATUS_CONFIG`) so TypeScript actually narrows the key, and the miss case is explicit rather than relying on `??` to paper over an invalid index. Behavior is byte-identical: same key resolution, same `UNKNOWN` fallback for anything not in `STATUS_CONFIG`.

Only caller is `apps/web/src/layouts/tasks-panel/task-row.tsx` (confirmed via grep — no other usage of `getStatusConfig`), so this is a fully contained, single-function change.

To confirm: `cd apps/web && bunx tsc --noEmit` (no new errors — the only pre-existing failure is an unrelated prosemirror-model version-duplication error in mention-suggestion.tsx) and `bunx oxlint apps/web/src/lib/task-status.ts` (0 warnings/errors).

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in apps/web, and `oxlint` on the changed file. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the unchecked `as StatusKey` cast in `getStatusConfig` with an `isStatusKey` type guard, so invalid statuses now fail type-checking instead of silently resolving to `UNKNOWN`. Runtime behavior is unchanged — same key resolution and same fallback.

**Refactors**
- `isStatusKey` checks `status in STATUS_CONFIG`, making the miss case explicit rather than relying on `??` to mask an invalid index.
- The only caller is `task-row.tsx`, so the change is fully contained to this one function.

<sup>Written for commit 2905b3768cbbec6fe99947992741e1f8efdf14d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

