### PR TITLE
fix(database): skip SQL comments when interpolating placeholders

### DIFF
--- a/apps/api/src/tools/database/index.test.ts
+++ b/apps/api/src/tools/database/index.test.ts
@@ -94,4 +94,24 @@ describe("interpolateParams", () => {
       "CREATE FUNCTION f() RETURNS int AS $body$ SELECT $1 $body$ LANGUAGE sql; SELECT 'x'",
     );
   });
+
+  test("does not let a ? inside a line comment shift later positional params", () => {
+    const result = interpolateParams(
+      "SELECT * FROM t WHERE a = ? -- filter by a, right?\nAND b = ?",
+      [1, 2],
+    );
+    expect(result).toBe(
+      "SELECT * FROM t WHERE a = 1 -- filter by a, right?\nAND b = 2",
+    );
+  });
+
+  test("does not let a ? inside a block comment shift later positional params", () => {
+    const result = interpolateParams(
+      "SELECT * FROM t WHERE a = ? /* is this right? */ AND b = ?",
+      [1, 2],
+    );
+    expect(result).toBe(
+      "SELECT * FROM t WHERE a = 1 /* is this right? */ AND b = 2",
+    );
+  });
 });

--- a/apps/api/src/tools/database/index.ts
+++ b/apps/api/src/tools/database/index.ts
@@ -67,6 +67,23 @@ export function interpolateParams(sql: string, params: unknown[]): string {
   let dollarQuoteTag: string | null = null;
   for (let i = 0; i < sql.length; i++) {
     const char = sql[i];
+    if (!inString && !inIdentifier && dollarQuoteTag === null) {
+      // A `?` inside a comment would otherwise shift every later positional index.
+      if (sql.startsWith("--", i)) {
+        const end = sql.indexOf("\n", i);
+        const comment = end === -1 ? sql.slice(i) : sql.slice(i, end);
+        result += comment;
+        i += comment.length - 1;
+        continue;
+      }
+      if (sql.startsWith("/*", i)) {
+        const end = sql.indexOf("*/", i + 2);
+        const comment = end === -1 ? sql.slice(i) : sql.slice(i, end + 2);
+        result += comment;
+        i += comment.length - 1;
+        continue;
+      }
+    }
     if (dollarQuoteTag !== null) {
       const closeDelim = `$${dollarQuoteTag}$`;
       if (sql.startsWith(closeDelim, i)) {


### PR DESCRIPTION
Follows #6712/#6735/#6740/#6744, which hardened `interpolateParams` (DATABASES_RUN_SQL) against `?`/`$N` false-positives inside substituted values, string literals, quoted identifiers, and dollar-quoted function bodies. This PR closes the remaining gap: SQL line comments (`-- ...`) and block comments (`/* ... */`).

**Failure scenario:** `interpolateParams("SELECT * FROM t WHERE a = ? -- filter by a, right?\nAND b = ?", [1, 2])`. Today the `?` inside the comment is counted as a positional placeholder, so it consumes `params[0]` there and every real `?` after it shifts by one — `b`'s `?` silently gets the wrong param value. The same shift risk applies to a `?` inside a `/* ... */` block comment. (A `$N` inside a comment doesn't shift indices since `$N` is looked up positionally rather than sequentially, but it's still wrong to substitute inside dead text — this fix skips both comment kinds uniformly, matching how string literals and quoted identifiers are already skipped.)

Regression tests added: `does not let a ? inside a line comment shift later positional params` and `...block comment...` in `apps/api/src/tools/database/index.test.ts`.

To confirm: `bun test apps/api/src/tools/database/index.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `interpolateParams` so placeholders inside SQL comments are skipped, preventing later positional parameters from shifting.

**Bug Fixes**
- `?` inside `--` line comments and `/* */` block comments no longer consumes a parameter.
- Comments are now skipped uniformly for both `?` and `$N`, matching handling of strings and identifiers.
- Adds two regression tests for line and block comments.

<sup>Written for commit c2ffcc29f40e51a96377b8d8ada236ffc545be93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

