### PR TITLE
refactor(task-status): drop the unused verb field from StatusConfig

### DIFF
--- a/apps/web/src/lib/task-status.ts
+++ b/apps/web/src/lib/task-status.ts
@@ -2,7 +2,6 @@
  * Task status utilities.
  *
  * Status is a small colored icon inline with the title.
- * Each status has a "verb" — what this means for you as a manager.
  */
 
 import {
@@ -23,46 +22,39 @@ export type StatusKey =
 
 export interface StatusConfig {
   label: string;
-  /** What this status means for you — shown as metadata */
-  verb: string;
   icon: typeof Loading01;
   iconClassName: string;
-  /** Color for the verb/label text */
+  /** Color for the label text */
   labelColor: string;
 }
 
 export const STATUS_CONFIG: Record<StatusKey, StatusConfig> = {
   requires_action: {
     label: "Needs review",
-    verb: "Waiting for your review",
     icon: AlertCircle,
     iconClassName: "text-warning",
     labelColor: "text-warning",
   },
   failed: {
     label: "Failed",
-    verb: "Something went wrong",
     icon: XCircle,
     iconClassName: "text-destructive",
     labelColor: "text-destructive",
   },
   expired: {
     label: "Timed out",
-    verb: "Stopped responding",
     icon: Hourglass03,
     iconClassName: "text-warning",
     labelColor: "text-warning",
   },
   in_progress: {
     label: "Running",
-    verb: "Agent is working",
     icon: Loading01,
     iconClassName: "text-primary",
     labelColor: "text-primary",
   },
   completed: {
     label: "Done",
-    verb: "Completed",
     icon: CheckCircle,
     iconClassName: "text-muted-foreground/50",
     labelColor: "text-muted-foreground",
@@ -71,7 +63,6 @@ export const STATUS_CONFIG: Record<StatusKey, StatusConfig> = {
 
 const UNKNOWN: StatusConfig = {
   label: "Unknown",
-  verb: "Unknown status",
   icon: Circle,
   iconClassName: "text-muted-foreground",
   labelColor: "text-muted-foreground",


### PR DESCRIPTION
Dead-code reduction (C1) found while auditing the task-board area's recently-changed files.

`StatusConfig.verb` (and every status entry's `verb` string, plus the `UNKNOWN` fallback's) is set in `apps/web/src/lib/task-status.ts` but never read anywhere in the codebase — confirmed with `grep -rn "\.verb\b" apps/web/src apps/api/src packages` (only the definitions themselves and an unrelated `verb: string` parameter in `decofile-api.ts` match). All 5 real callers of this module (`task-group.tsx`, `tasks-panel/task-row.tsx`, `thread-sheet-body.tsx`, `routes/orgs/monitoring/threads.tsx`, `automation-runs.tsx`) only ever read `.label`, `.icon`, `.iconClassName`, `.labelColor`.

Net: -8 / +0 (five `verb: "..."` entries, the interface field, its doc comment, and the stale top-of-file comment describing the "verb" concept).

Behavior-preserving: nothing reads the removed field, so no rendered output changes. Verified with `bunx tsc --noEmit` in `apps/web` (the one pre-existing prosemirror-version error is unrelated and present on main too) and `bunx oxlint apps/web/src/lib/task-status.ts` (0 warnings/errors). No test file exists for this module to run.

Reviewer check: `grep -rn '\.verb\b' apps/web/src` should show nothing outside this diff's context.

Full CI (`bun run check`/`bun run lint`) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the unused `verb` field from `StatusConfig` in `apps/web/src/lib/task-status.ts`. No code reads the field, so this is a behavior-preserving dead-code removal.

<sup>Written for commit 5282b902d386b4764e24a0a35b267c5f2d33c263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

