### PR TITLE
fix(decopilot): cap a single stashed tool output at 2MB

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { MAX_TOOL_OUTPUTS, createToolOutputMap } from "./read-tool-output";
+import {
+  MAX_TOOL_OUTPUT_CHARS,
+  MAX_TOOL_OUTPUTS,
+  createToolOutputMap,
+} from "./read-tool-output";
 
 describe("createToolOutputMap", () => {
   it("stays under the cap by evicting the oldest entry", () => {
@@ -20,5 +24,12 @@ describe("createToolOutputMap", () => {
     map.set("call_0", "updated");
     expect(map.size).toBe(MAX_TOOL_OUTPUTS);
     expect(map.get("call_0")).toBe("updated");
+  });
+
+  it("trims a single oversized value instead of storing it whole", () => {
+    const map = createToolOutputMap();
+    const huge = "x".repeat(MAX_TOOL_OUTPUT_CHARS + 1000);
+    map.set("call_0", huge);
+    expect(map.get("call_0")?.length).toBe(MAX_TOOL_OUTPUT_CHARS);
   });
 });

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.ts
@@ -13,6 +13,13 @@ export interface ReadToolOutputParams {
  *  output is a fair trade for a bounded memory footprint. */
 export const MAX_TOOL_OUTPUTS = 200;
 
+/** The entry-count cap above only bounds the number of stashed outputs, not
+ *  their size — a single oversized one (a bash dump, or an untrusted MCP
+ *  server's response) is stored whole before this cap ever kicks in. Trim each
+ *  value at insertion so MAX_TOOL_OUTPUTS entries stay a bounded footprint
+ *  rather than up to MAX_TOOL_OUTPUTS copies of an unbounded string. */
+export const MAX_TOOL_OUTPUT_CHARS = 2_000_000;
+
 export function createToolOutputMap(): Map<string, string> {
   const map = new Map<string, string>();
   const set = map.set.bind(map);
@@ -21,7 +28,12 @@ export function createToolOutputMap(): Map<string, string> {
       const oldest = map.keys().next().value;
       if (oldest !== undefined) map.delete(oldest);
     }
-    return set(key, value);
+    return set(
+      key,
+      value.length > MAX_TOOL_OUTPUT_CHARS
+        ? value.slice(0, MAX_TOOL_OUTPUT_CHARS)
+        : value,
+    );
   };
   return map;
 }


### PR DESCRIPTION
**Source:** a bounded-memory gap in `read-tool-output.ts`'s `createToolOutputMap`, in the same family as the repo's existing "cap a run-scoped output map" fixes (#6591, #6601, #6630 et al.), but at a different layer of the same map.

**Why a maintainer wants this:** `createToolOutputMap`'s entry-count cap (`MAX_TOOL_OUTPUTS = 200`) only bounds *how many* oversized tool outputs stay stashed for the run — it does nothing about the *size* of any one entry. Every call site (`vm-tools/common.ts`'s `maybeTruncate`, the MCP-passthrough path in `mcp-tools.ts`, and `web-search.ts`) stores the full serialized string before the eviction logic ever runs. An untrusted downstream MCP server (or a `bash`/`grep` call that dumps a huge file) can hand back an arbitrarily large string, which then sits in memory for the life of the run — the entry-count cap does not stop this, so the map's actual memory footprint was still unbounded per entry, not just per count.

**Fix:** trim each value to `MAX_TOOL_OUTPUT_CHARS` (2MB) inside the same `map.set` wrapper that already handles LRU-style eviction — one choke point, no changes needed at any of the three call sites.

**Regression test:** `read-tool-output.test.ts` — "trims a single oversized value instead of storing it whole", asserting a value larger than the cap is truncated to exactly `MAX_TOOL_OUTPUT_CHARS`.

**To confirm:** `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps a single stashed tool output at 2MB so one oversized response no longer keeps an unbounded string in memory for the run's lifetime. Previously the output map only bounded how many entries were kept (200), not how large each entry could be.

- Trims values at insertion in the same choke point that already handles eviction, so none of the call sites need changes.
- Adds a regression test asserting values above the cap are truncated to exactly `MAX_TOOL_OUTPUT_CHARS`.

<sup>Written for commit 10b5fdd51f54ddea73b1262908ef60d595138cf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

