### PR TITLE
fix(mcp-clients): don't trust a downstream tool's own name for the public-tool bypass

### DIFF
--- a/apps/api/src/core/access-control.test.ts
+++ b/apps/api/src/core/access-control.test.ts
@@ -131,6 +131,28 @@ describe("AccessControl", () => {
       expect(mockBoundAuth.hasPermission).not.toHaveBeenCalled();
     });
 
+    it("grants a STUDIO_PUBLIC_ tool by name alone, with no auth at all", async () => {
+      const ac = new AccessControl(undefined, "STUDIO_PUBLIC_TOOL");
+      await ac.check();
+      expect(ac.granted()).toBe(true);
+    });
+
+    it("does NOT trust the STUDIO_PUBLIC_ prefix when the tool name is untrusted", async () => {
+      // A downstream connection could name its own tool this to spoof the prefix.
+      const ac = new AccessControl(
+        "user_1",
+        "STUDIO_PUBLIC_TOOL",
+        createMockBoundAuth({}), // no permissions
+        "user",
+        "self",
+        undefined,
+        undefined,
+        false, // trustPublicPrefix
+      );
+      await expect(ac.check()).rejects.toThrow(ForbiddenError);
+      expect(ac.granted()).toBe(false);
+    });
+
     it("should bypass checks for admin role", async () => {
       const ac = new AccessControl(
         "user_1",

--- a/apps/api/src/core/access-control.ts
+++ b/apps/api/src/core/access-control.ts
@@ -69,6 +69,8 @@ export class AccessControl {
     private connectionId: string = "self", // For connection-specific checks (matches permission resource key)
     private getToolMeta?: GetToolMetaFn, // Optional callback for public tool check
     private organizationId?: string, // Path-resolved org (overrides session active org)
+    // False when toolName is untrusted (e.g. a downstream connection's own tool name).
+    private trustPublicPrefix: boolean = true,
   ) {}
 
   setToolName(toolName: string): void {
@@ -133,8 +135,9 @@ export class AccessControl {
     }
     // tool is public with zero IO operations, so we can grant access immediately
     if (
-      this.toolName?.startsWith("STUDIO_PUBLIC_") ||
-      this.toolName?.startsWith("MESH_PUBLIC_")
+      this.trustPublicPrefix &&
+      (this.toolName?.startsWith("STUDIO_PUBLIC_") ||
+        this.toolName?.startsWith("MESH_PUBLIC_"))
     ) {
       this.grant();
       return;
@@ -248,8 +251,9 @@ export class AccessControl {
    */
   private async isToolPublic(): Promise<boolean> {
     if (
-      this.toolName?.startsWith("STUDIO_PUBLIC_") ||
-      this.toolName?.startsWith("MESH_PUBLIC_")
+      this.trustPublicPrefix &&
+      (this.toolName?.startsWith("STUDIO_PUBLIC_") ||
+        this.toolName?.startsWith("MESH_PUBLIC_"))
     ) {
       return true;
     }

--- a/apps/api/src/mcp-clients/outbound/transports/auth.ts
+++ b/apps/api/src/mcp-clients/outbound/transports/auth.ts
@@ -181,19 +181,14 @@ export class AuthTransport extends WrapperTransport {
       connection.id, // Connection ID for permission check
       getToolMeta, // Callback for public tool check
       ctx.organization?.id, // Path-resolved org for permission checks
+      false, // toolName is the downstream connection's own name — don't trust its prefix
     );
 
     await connectionAccessControl.check(toolName);
   }
 
+  // toolName is the downstream server's own name for it — never trust its prefix, only its _meta.
   private async isPublicTool(toolName: string): Promise<boolean> {
-    if (
-      toolName.startsWith("STUDIO_PUBLIC_") ||
-      toolName.startsWith("MESH_PUBLIC_")
-    ) {
-      return true;
-    }
-
     const toolsMap = await this.ensureToolsMap();
     const tool = toolsMap.get(toolName);
     if (!tool?._meta) {


### PR DESCRIPTION
**Bug**: `AuthTransport` (`apps/api/src/mcp-clients/outbound/transports/auth.ts`) wraps every outbound MCP connection — including arbitrary user-added HTTP/Websocket/STDIO servers, not just Studio's own tools. Both its own `isPublicTool()` and the `AccessControl` it constructs treated any tool whose name starts with `STUDIO_PUBLIC_`/`MESH_PUBLIC_` as automatically public, skipping authentication and per-connection permission checks entirely. That prefix convention is meant for Studio's own `defineTool` registry, but `toolName` here is `params.name` from the *downstream connection's own* `tools/call`/`tools/list` — fully controlled by whoever operates that MCP server. Any connection could expose a tool literally named e.g. `STUDIO_PUBLIC_admin_action` and have Studio's gateway grant unauthenticated, unauthorized access to it, including to users outside the connection's org.

**Why a maintainer wants this**: it's a real cross-tenant auth-bypass at a trust boundary (untrusted downstream tool name → security decision) — the exact class of bug this repo's hottest lane ("Auth org-scoping / multi-role correctness") targets.

**Fix**: added an explicit `trustPublicPrefix` flag (default `true`, preserving behavior for the two existing call sites that pass Studio's own trusted tool name) to `AccessControl`, and set it `false` at the one call site where `toolName` is untrusted downstream input (`auth.ts`). Also dropped the equivalent naive prefix check from `AuthTransport.isPublicTool()`, which already had a correct `_meta.public_tool` fallback — that's now the only path.

**Regression test**: `apps/api/src/core/access-control.test.ts` — new test asserts a spoofed `STUDIO_PUBLIC_` tool name is denied (403) when `trustPublicPrefix: false`, alongside a regression test confirming the existing trusted-prefix bypass still works unchanged.

**To verify**: `bun test apps/api/src/core/access-control.test.ts apps/api/src/mcp-clients/outbound/transports/auth.test.ts`

**Checked locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the two targeted test files above (29/29 pass), `bunx oxlint` on all 3 touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a security bypass where a downstream MCP server could name its own tool with a reserved prefix (like `STUDIO_PUBLIC_`) and get unauthenticated access to it. Now the prefix bypass only works for Studio's own trusted tools, and downstream tools rely solely on their `_meta.public_tool` flag.

- Adds a `trustPublicPrefix` flag to `AccessControl`, disabled for the untrusted downstream tool name in `AuthTransport`.
- Adds regression tests verifying the spoofed prefix is denied and the trusted path still works.

<sup>Written for commit a25ae1294799532ffbbd437bda8ce772c09f2406. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

