### PR TITLE
fix(database): honor Postgres nested block comments in interpolateParams

### DIFF
--- a/apps/api/src/tools/database/index.test.ts
+++ b/apps/api/src/tools/database/index.test.ts
@@ -114,4 +114,12 @@ describe("interpolateParams", () => {
       "SELECT * FROM t WHERE a = 1 /* is this right? */ AND b = 2",
     );
   });
+
+  test("keeps a nested block comment closed until its outer terminator", () => {
+    const result = interpolateParams(
+      "SELECT ? /* outer /* inner */ trailing ? */, ?",
+      [1, 2, 3],
+    );
+    expect(result).toBe("SELECT 1 /* outer /* inner */ trailing ? */, 2");
+  });
 });

--- a/apps/api/src/tools/database/index.ts
+++ b/apps/api/src/tools/database/index.ts
@@ -77,8 +77,21 @@ export function interpolateParams(sql: string, params: unknown[]): string {
         continue;
       }
       if (sql.startsWith("/*", i)) {
-        const end = sql.indexOf("*/", i + 2);
-        const comment = end === -1 ? sql.slice(i) : sql.slice(i, end + 2);
+        // Postgres block comments nest, so a `/*` inside bumps depth back up.
+        let depth = 1;
+        let j = i + 2;
+        while (depth > 0 && j < sql.length) {
+          if (sql.startsWith("/*", j)) {
+            depth++;
+            j += 2;
+          } else if (sql.startsWith("*/", j)) {
+            depth--;
+            j += 2;
+          } else {
+            j++;
+          }
+        }
+        const comment = sql.slice(i, j);
         result += comment;
         i += comment.length - 1;
         continue;


### PR DESCRIPTION
Follows #6747, which taught `interpolateParams` to skip `--` and `/* */` comments so a literal `?`/`$N` inside a comment can't steal a positional param slot. Its block-comment handling closed at the first `*/`, but Postgres block comments nest (documented behavior) — a comment like `/* outer /* inner */ trailing text */` is one comment to Postgres, closed only by the outer `*/`.

Failure scenario: `interpolateParams("SELECT ? /* outer /* inner */ trailing ? */, ?", [1, 2, 3])`. The old code treats `/* outer /* inner */` as the whole comment, then reads ` trailing ? */, ?` as real SQL — so the `?` inside what Postgres considers still-commented text gets substituted as a real positional param, shifting every later placeholder and corrupting the query. Same root cause class as #6747 (a `?` inside "commented-out" text being read as a real placeholder), just for nested comments instead of the flat case.

Fix tracks comment nesting depth instead of scanning for the first `*/`. Added a regression test (`keeps a nested block comment closed until its outer terminator`) that fails on the old code (asserts `3` did NOT get substituted for the trailing `?` and the comment markers survive verbatim) and passes after the fix.

To confirm: `bun test apps/api/src/tools/database/index.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `interpolateParams` to honor Postgres nested block comments, so a `?` inside a nested `/* ... /* ... */ ... */` comment no longer gets substituted as a real placeholder and shifts subsequent parameters.

- Tracks comment nesting depth instead of closing at the first `*/`.
- Adds a regression test that fails on the old behavior.

<sup>Written for commit b5557e51273660bfd890ab1313dd09b7f27398a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

