### PR TITLE
fix(task-status): translate the shared task/thread status labels

### DIFF
--- a/apps/web/src/components/sidebar/task-groups/task-group.tsx
+++ b/apps/web/src/components/sidebar/task-groups/task-group.tsx
@@ -5,6 +5,7 @@ import type { StatusGroupData } from "./group-threads";
 import { useGroupExpanded } from "./use-group-expanded";
 import type { Task } from "@/components/chat/task/types";
 import { STATUS_CONFIG } from "@/lib/task-status";
+import { useT } from "@/i18n/use-t.ts";
 import { ShowMoreButton } from "./show-more-button";
 import type { SidebarFilters } from "./next-page-offset";
 import { useGroupShowMore } from "./use-group-show-more";
@@ -90,6 +91,7 @@ export function StatusGroup({
   canArchive: boolean;
   filters: SidebarFilters;
 }) {
+  const t = useT();
   const config = STATUS_CONFIG[status];
   const StatusIcon = config.icon;
   const [expanded, setExpanded] = useGroupExpanded(`status-${status}`, false);
@@ -122,7 +124,7 @@ export function StatusGroup({
             {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
           </span>
         </div>
-        <span className="flex-1 truncate">{config.label}</span>
+        <span className="flex-1 truncate">{t(config.labelKey)}</span>
         <div className="size-5 shrink-0 flex items-center justify-center">
           <span className="text-xs text-muted-foreground tabular-nums">
             {threads.length}

--- a/apps/web/src/components/thread/thread-sheet-body.tsx
+++ b/apps/web/src/components/thread/thread-sheet-body.tsx
@@ -214,7 +214,7 @@ function ThreadMetaRow({
         <div className="flex items-center gap-1.5">
           <StatusIcon size={13} className={statusCfg.iconClassName} />
           <span className={cn("text-sm", statusCfg.labelColor)}>
-            {statusCfg.label}
+            {t(statusCfg.labelKey)}
           </span>
         </div>
       </div>

--- a/apps/web/src/i18n/en/common.ts
+++ b/apps/web/src/i18n/en/common.ts
@@ -297,4 +297,10 @@ export const common = {
   "common.taskBoard.listView": "List",
   "common.taskBoard.boardView": "Board",
   "common.openExternalFailed": "Could not open this link in your browser.",
+  "common.taskStatus.requiresAction": "Needs review",
+  "common.taskStatus.failed": "Failed",
+  "common.taskStatus.expired": "Timed out",
+  "common.taskStatus.inProgress": "Running",
+  "common.taskStatus.completed": "Done",
+  "common.taskStatus.unknown": "Unknown",
 } as const;

--- a/apps/web/src/i18n/pt-br/common.ts
+++ b/apps/web/src/i18n/pt-br/common.ts
@@ -307,4 +307,10 @@ export const common = {
   "common.taskBoard.listView": "Lista",
   "common.taskBoard.boardView": "Quadro",
   "common.openExternalFailed": "Não foi possível abrir este link no navegador.",
+  "common.taskStatus.requiresAction": "Requer revisão",
+  "common.taskStatus.failed": "Falhou",
+  "common.taskStatus.expired": "Expirou",
+  "common.taskStatus.inProgress": "Em execução",
+  "common.taskStatus.completed": "Concluído",
+  "common.taskStatus.unknown": "Desconhecido",
 } satisfies Record<keyof typeof commonEn, string>;

--- a/apps/web/src/layouts/tasks-panel/task-row.tsx
+++ b/apps/web/src/layouts/tasks-panel/task-row.tsx
@@ -143,7 +143,7 @@ export function TaskRow({
               onArchive && "group-hover/row:opacity-0",
             )}
             aria-label={t("tasksPanel.taskRow.statusLabel", {
-              status: config.label,
+              status: t(config.labelKey),
             })}
           >
             <StatusIcon

--- a/apps/web/src/lib/task-status.ts
+++ b/apps/web/src/lib/task-status.ts
@@ -12,6 +12,7 @@ import {
   Loading01,
   XCircle,
 } from "@untitledui/icons";
+import type { TranslationKey } from "@/i18n/en/index.ts";
 
 export type StatusKey =
   | "requires_action"
@@ -21,7 +22,9 @@ export type StatusKey =
   | "completed";
 
 export interface StatusConfig {
-  label: string;
+  /** Translation key for the label — resolve with `t()`, this is not
+   *  display-ready on its own. */
+  labelKey: TranslationKey;
   icon: typeof Loading01;
   iconClassName: string;
   /** Color for the label text */
@@ -30,31 +33,31 @@ export interface StatusConfig {
 
 export const STATUS_CONFIG: Record<StatusKey, StatusConfig> = {
   requires_action: {
-    label: "Needs review",
+    labelKey: "common.taskStatus.requiresAction",
     icon: AlertCircle,
     iconClassName: "text-warning",
     labelColor: "text-warning",
   },
   failed: {
-    label: "Failed",
+    labelKey: "common.taskStatus.failed",
     icon: XCircle,
     iconClassName: "text-destructive",
     labelColor: "text-destructive",
   },
   expired: {
-    label: "Timed out",
+    labelKey: "common.taskStatus.expired",
     icon: Hourglass03,
     iconClassName: "text-warning",
     labelColor: "text-warning",
   },
   in_progress: {
-    label: "Running",
+    labelKey: "common.taskStatus.inProgress",
     icon: Loading01,
     iconClassName: "text-primary",
     labelColor: "text-primary",
   },
   completed: {
-    label: "Done",
+    labelKey: "common.taskStatus.completed",
     icon: CheckCircle,
     iconClassName: "text-muted-foreground/50",
     labelColor: "text-muted-foreground",
@@ -62,7 +65,7 @@ export const STATUS_CONFIG: Record<StatusKey, StatusConfig> = {
 };
 
 const UNKNOWN: StatusConfig = {
-  label: "Unknown",
+  labelKey: "common.taskStatus.unknown",
   icon: Circle,
   iconClassName: "text-muted-foreground",
   labelColor: "text-muted-foreground",

--- a/apps/web/src/routes/orgs/monitoring/threads.tsx
+++ b/apps/web/src/routes/orgs/monitoring/threads.tsx
@@ -69,6 +69,7 @@ function ThreadRow({
   onClick: () => void;
   lastRowRef?: (node: HTMLTableRowElement | null) => void;
 }) {
+  const t = useT();
   const agentId = getThreadAgentId(thread);
   const agentName = resolveAgentName(
     agentId,
@@ -141,7 +142,7 @@ function ThreadRow({
         <div className="flex items-center gap-1.5">
           <StatusIcon size={14} className={statusCfg.iconClassName} />
           <span className={cn("text-sm", statusCfg.labelColor)}>
-            {statusCfg.label}
+            {t(statusCfg.labelKey)}
           </span>
         </div>
       </TableCell>

--- a/apps/web/src/views/automations/automation-runs.tsx
+++ b/apps/web/src/views/automations/automation-runs.tsx
@@ -146,6 +146,7 @@ function RunRow({
   onClick: () => void;
   lastRowRef?: (node: HTMLTableRowElement | null) => void;
 }) {
+  const t = useT();
   const date = new Date(run.created_at);
   const dateStr = date.toLocaleDateString("en-US", {
     month: "short",
@@ -174,7 +175,7 @@ function RunRow({
         <div className="flex items-center gap-1.5">
           <StatusIcon size={14} className={statusCfg.iconClassName} />
           <span className={cn("text-sm", statusCfg.labelColor)}>
-            {statusCfg.label}
+            {t(statusCfg.labelKey)}
           </span>
         </div>
       </TableCell>


### PR DESCRIPTION
**Source:** i18n coverage gap in `apps/web/src/lib/task-status.ts` — the shared `STATUS_CONFIG`/`getStatusConfig` used by 5 different views hardcoded English labels ("Needs review", "Failed", "Timed out", "Running", "Done", "Unknown") with no pt-br translation, unlike the rest of the codebase (every other user-facing string goes through `t()` per repo convention).

**Payoff:** a pt-BR user sees these exact English words in the tasks-panel sidebar, the thread sheet, the automation runs table, and the org monitoring threads table — the one remaining untranslated status surface in that group of views.

**Change:** `StatusConfig.label: string` → `labelKey: TranslationKey`, pointing at new `common.taskStatus.*` keys (en + pt-br). Each of the 5 call sites now resolves the label with `t(config.labelKey)` instead of rendering the literal string; two of those components didn't have `useT()` in scope yet, so it was added. No behavior change beyond the rendered string — same icons, same colors, same status→config mapping.

**Verify:** `cd apps/web && bunx tsc --noEmit` (zero new errors — confirmed identical error count against a clean `main` checkout, the one remaining error is a pre-existing, unrelated prosemirror version-skew type error). `bunx oxlint` on all 8 touched files: 0 warnings/errors. `bun run fmt` clean.

**Local checks run:** targeted typecheck + per-file oxlint + fmt, per the notes above. No existing test covers `lib/task-status.ts` (confirmed via grep — none exists to break). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translates the shared task/thread status labels so pt-BR users see localized text instead of hardcoded English ("Needs review", "Failed", "Timed out", "Running", "Done", "Unknown") across the tasks panel sidebar, thread sheet, automation runs table, and org monitoring threads table.

`StatusConfig.label` is now `labelKey`, pointing at new `common.taskStatus.*` keys (en + pt-br). All 5 call sites resolve the label with `t()` instead of rendering the literal string. No behavior change beyond the rendered string — same icons, colors, and status mapping.

<sup>Written for commit 1cd8dbd3f1ce476fe350f87c5e8024efb638afc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

