### PR TITLE
fix(database): honor backslash escapes in E'...' strings in interpolateParams

### DIFF
--- a/apps/api/src/tools/database/index.test.ts
+++ b/apps/api/src/tools/database/index.test.ts
@@ -122,4 +122,9 @@ describe("interpolateParams", () => {
     );
     expect(result).toBe("SELECT 1 /* outer /* inner */ trailing ? */, 2");
   });
+
+  test("keeps a placeholder after a backslash-escaped quote in an E'...' string", () => {
+    const result = interpolateParams("SELECT E'it\\'s', ?", [1]);
+    expect(result).toBe("SELECT E'it\\'s', 1");
+  });
 });

--- a/apps/api/src/tools/database/index.ts
+++ b/apps/api/src/tools/database/index.ts
@@ -63,6 +63,8 @@ export function interpolateParams(sql: string, params: unknown[]): string {
   let questionMarkIndex = 0;
   let inString = false;
   let inIdentifier = false;
+  // Only an E'...' string treats \' as an escape, not a closing quote.
+  let inEscapedString = false;
   // A DO/CREATE FUNCTION body's own $1 (its arg, not our param) lives here.
   let dollarQuoteTag: string | null = null;
   for (let i = 0; i < sql.length; i++) {
@@ -108,7 +110,18 @@ export function interpolateParams(sql: string, params: unknown[]): string {
       }
       continue;
     }
+    if (inString && inEscapedString && char === "\\" && i + 1 < sql.length) {
+      result += char + sql[i + 1];
+      i += 1;
+      continue;
+    }
     if (!inIdentifier && char === "'") {
+      if (!inString) {
+        const prev = sql[i - 1];
+        const prevPrev = sql[i - 2] ?? "";
+        inEscapedString =
+          (prev === "e" || prev === "E") && !/[A-Za-z0-9_]/.test(prevPrev);
+      }
       inString = !inString;
       result += char;
       continue;


### PR DESCRIPTION
Follows #6751 (nested block-comment handling) and the prior string-literal fix — another gap in `interpolateParams`'s quote-tracking state machine.

The function toggles `inString` on every unescaped `'`, but a Postgres `E'...'` string treats a backslash as an escape character (`\'` doesn't close the string, unlike a plain `'...'` literal). The parser didn't know about this, so a backslash-escaped quote inside an E-string flipped `inString` early, leaving the tracker permanently "inside a string" for the rest of the query. Every `?`/`$N` placeholder after that point was then left as a literal, un-substituted placeholder instead of being interpolated — silently producing malformed SQL sent to Postgres.

Failure scenario: `interpolateParams("SELECT E'it\\'s', ?", [1])` left the trailing `?` untouched instead of substituting `1`.

Fix: track whether the currently-open string is an E-string (quote immediately preceded by a bare `e`/`E`), and while inside one, treat a backslash as consuming (and not toggling on) the following character — matching how Postgres itself parses `E'...'` literals. Plain `'...'` strings are unaffected (doubled `''` still works via the existing toggle).

Regression test added in `index.test.ts`: fails on current main (leaves the `?` unsubstituted), passes with the fix.

Reviewer check: `bun test apps/api/src/tools/database/index.test.ts`

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `interpolateParams` so placeholders after backslash-escaped quotes in Postgres `E'...'` strings are still substituted.

The parser previously toggled string state on every unescaped quote, so a `\'` inside an E-string flipped it out of string mode early. Every `?` or `$N` after that point stayed as a literal placeholder, producing malformed SQL. The fix tracks whether the open string is an E-string and consumes backslash escapes accordingly; plain `'...'` strings are unaffected. Adds a regression test that fails on the old behavior and passes with the fix.

<sup>Written for commit 593ac9a46203d34518cec31a2123e559ccd74374. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

