### PR TITLE
refactor(decopilot): give VirtualClient.callTool its real return type

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/sandbox.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/sandbox.ts
@@ -1,5 +1,7 @@
 import type {
   CallToolRequest,
+  CallToolResult,
+  CompatibilityCallToolResult,
   GetPromptRequest,
   GetPromptResult,
   ListPromptsResult,
@@ -11,8 +13,9 @@ import type {
 
 export interface VirtualClient {
   listTools(): Promise<ListToolsResult>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  callTool(params: CallToolRequest["params"]): Promise<any>;
+  callTool(
+    params: CallToolRequest["params"],
+  ): Promise<CallToolResult | CompatibilityCallToolResult>;
   listResources(): Promise<ListResourcesResult>;
   readResource(
     params: ReadResourceRequest["params"],


### PR DESCRIPTION
**Source:** C-DEBT — `no-explicit-any` cleanup in `apps/api/src/harnesses/lib/decopilot/built-in-tools/sandbox.ts`, a recently-touched area (decopilot built-in tools).

**Why:** `VirtualClient.callTool` was typed `Promise<any>` while every other method on the same interface (`listTools`, `listResources`, `readResource`, `listPrompts`, `getPrompt`) is precisely typed from the MCP SDK. The concrete implementation this interface models — `GatewayClient.callTool` in `packages/mcp-utils/src/aggregate/gateway-client.ts:623-627`, which `PassthroughClient` extends — already returns `Promise<CallToolResult | CompatibilityCallToolResult>`. The `any` just threw away type safety the real implementation already provides; a caller reading the result today gets no compile-time check at all.

**Fix:** replaced `Promise<any>` with `Promise<CallToolResult | CompatibilityCallToolResult>` (both already exported from `@modelcontextprotocol/sdk/types.js`) and dropped the now-unneeded eslint-disable comment.

**Behavior:** unchanged — this is a type-only edit, no runtime code touched.

**Verify:** `cd apps/api && bunx tsc --noEmit` (green — no call site needed a cast, since none was calling `.callTool` through this exact interface in a way that assumed a wider shape than `CallToolResult`).

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/harnesses/lib/decopilot/built-in-tools/sandbox.ts` (0 warnings/errors). No test file exists for this pure interface-signature change; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives `VirtualClient.callTool` its actual return type from the MCP SDK, so callers get compile-time checking instead of `Promise<any>`. Runtime behavior is unchanged.

<sup>Written for commit b862378e34caa4a4846edb4ed3102836d1288781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

