### PR TITLE
fix(threads): don't render a null/unknown thread status as Completed

### DIFF
--- a/apps/web/src/components/thread/thread-sheet-body.tsx
+++ b/apps/web/src/components/thread/thread-sheet-body.tsx
@@ -37,7 +37,7 @@ import { IntegrationIcon } from "@/components/integration-icon.tsx";
 import { useInfiniteScroll } from "@/hooks/use-infinite-scroll.ts";
 import type { useMembers } from "@/hooks/use-members";
 import { KEYS } from "@/lib/query-keys";
-import { STATUS_CONFIG } from "@/lib/task-status";
+import { getStatusConfig } from "@/lib/task-status";
 import {
   getOrgMembers,
   getThreadAgentId,
@@ -200,9 +200,7 @@ function ThreadMetaRow({
     second: "2-digit",
   });
 
-  const statusCfg =
-    STATUS_CONFIG[thread.status as keyof typeof STATUS_CONFIG] ??
-    STATUS_CONFIG.completed;
+  const statusCfg = getStatusConfig(thread.status ?? undefined);
   const StatusIcon = statusCfg.icon;
 
   return (

--- a/apps/web/src/routes/orgs/monitoring/threads.tsx
+++ b/apps/web/src/routes/orgs/monitoring/threads.tsx
@@ -28,7 +28,7 @@ import {
   ThreadSheetBody,
   type ThreadEntity,
 } from "@/components/thread/thread-sheet-body.tsx";
-import { STATUS_CONFIG } from "@/lib/task-status";
+import { getStatusConfig } from "@/lib/task-status";
 import {
   formatCompactNumber,
   formatUsd,
@@ -98,9 +98,7 @@ function ThreadRow({
     minute: "2-digit",
   });
 
-  const statusCfg =
-    STATUS_CONFIG[thread.status as keyof typeof STATUS_CONFIG] ??
-    STATUS_CONFIG.completed;
+  const statusCfg = getStatusConfig(thread.status ?? undefined);
   const StatusIcon = statusCfg.icon;
 
   return (

--- a/apps/web/src/views/automations/automation-runs.tsx
+++ b/apps/web/src/views/automations/automation-runs.tsx
@@ -36,7 +36,7 @@ import { EmptyState } from "@/components/empty-state.tsx";
 import { useInfiniteScroll } from "@/hooks/use-infinite-scroll.ts";
 import { useMembers } from "@/hooks/use-members";
 import { KEYS } from "@/lib/query-keys";
-import { STATUS_CONFIG } from "@/lib/task-status";
+import { getStatusConfig } from "@/lib/task-status";
 import { useAutomationRunStats } from "@/hooks/use-automations";
 import { useStudioTools } from "@/lib/studio-tools";
 import { useT } from "@/i18n/use-t.ts";
@@ -157,9 +157,7 @@ function RunRow({
     minute: "2-digit",
   });
 
-  const statusCfg =
-    STATUS_CONFIG[run.status as keyof typeof STATUS_CONFIG] ??
-    STATUS_CONFIG.completed;
+  const statusCfg = getStatusConfig(run.status ?? undefined);
   const StatusIcon = statusCfg.icon;
 
   return (


### PR DESCRIPTION
**Source:** a bug found reading `apps/web/src/lib/task-status.ts` and its 3 direct-index call sites (found during a general debt/reduction hunt, not tied to a specific issue).

**Why a maintainer wants it:** `task-status.ts` exports `getStatusConfig()` specifically to handle a status that isn't one of the 5 known keys — it falls back to a neutral `UNKNOWN` config (gray circle, "Unknown" label). Three view files bypass it with `STATUS_CONFIG[x] ?? STATUS_CONFIG.completed`, so any thread whose status doesn't match a key (in practice: `null`, e.g. a task-board linked run entity that never started, per `ThreadSheetThread`'s own doc comment) renders a green checkmark labeled "Completed" — actively misleading about a run that hasn't happened.

**Failure scenario:** open the thread sheet (Monitoring → Threads, an automation's Runs tab, or a task's linked runs) for a run whose `status` is `null`. All three call sites (`thread-sheet-body.tsx`, `automation-runs.tsx`, `routes/orgs/monitoring/threads.tsx`) show it as "Completed" instead of "Unknown".

**Fix:** replace the manual `STATUS_CONFIG[...] ?? STATUS_CONFIG.completed` pattern at all 3 sites with the existing `getStatusConfig()` helper, which already has the correct fallback. No behavior change for any of the 5 real statuses — only the previously-mishandled null/unrecognized case changes (from "Completed" to "Unknown").

**Reviewer check:** `cd apps/web && bunx tsc --noEmit` (clean on the 3 touched files; one pre-existing, unrelated prosemirror-version type error elsewhere in the workspace) and open a thread sheet for a run with a null status.

**Locally verified:** `bun run fmt`, targeted `bunx tsc --noEmit` (no new errors), `bunx oxlint` on the 3 changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes thread status display so null or unrecognized statuses show as "Unknown" instead of a green "Completed" checkmark.

- Switches three call sites (thread sheet, automation runs, monitoring threads) from direct `STATUS_CONFIG` lookup with `completed` fallback to the shared `getStatusConfig()` helper.
- The helper already falls back to a neutral unknown state, so only the previously mishandled null/unrecognized case changes; valid statuses render exactly as before.

<sup>Written for commit ac5331e81f24844e146ceeb588586ecd9d397f5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

