### PR TITLE
fix(mcp-clients): cap MonitoringTransport's inflight-request map

### DIFF
--- a/apps/api/src/mcp-clients/outbound/transports/monitoring.test.ts
+++ b/apps/api/src/mcp-clients/outbound/transports/monitoring.test.ts
@@ -232,6 +232,31 @@ describe("MonitoringTransport emitMonitoringLog", () => {
     expect(emitCalledBeforeEnd).toBe(true);
   });
 
+  it("should not leak inflight entries past MAX_INFLIGHT_REQUESTS when responses never arrive", async () => {
+    const { transport, mockSpan } = createMockTransportAndCtx();
+    const { MAX_INFLIGHT_REQUESTS } = await import("./monitoring");
+
+    transport.onmessage = vi.fn();
+    await transport.start();
+
+    // None of these ever get a response, simulating a connection that drops replies.
+    for (let i = 0; i < MAX_INFLIGHT_REQUESTS + 1; i++) {
+      await transport.send({
+        jsonrpc: "2.0",
+        id: i,
+        method: "tools/call",
+        params: { name: "TOOL", arguments: {} },
+      } as any);
+    }
+
+    expect(
+      (transport as unknown as { inflightRequests: Map<unknown, unknown> })
+        .inflightRequests.size,
+    ).toBe(MAX_INFLIGHT_REQUESTS);
+    // The evicted (oldest) request's span must have been ended, not just dropped.
+    expect(mockSpan.isEnded()).toBe(true);
+  });
+
   it("should not call emitMonitoringLog for non-tool-call methods", async () => {
     const { transport, simulateResponse } = createMockTransportAndCtx();
 

--- a/apps/api/src/mcp-clients/outbound/transports/monitoring.ts
+++ b/apps/api/src/mcp-clients/outbound/transports/monitoring.ts
@@ -39,6 +39,13 @@ interface InflightRequest {
   span?: Span;
 }
 
+/** A pooled connection's transport lives for the pool's whole lifetime, not one
+ *  request — so a response that never arrives (a dropped connection, a
+ *  malformed frame missing the request id) would otherwise leak its entry,
+ *  and the span it holds, forever. Cap the count, ending and evicting the
+ *  oldest (Map preserves insertion order) once a new entry would exceed it. */
+export const MAX_INFLIGHT_REQUESTS = 500;
+
 export class MonitoringTransport extends WrapperTransport {
   private inflightRequests = new Map<string | number, InflightRequest>();
   private requestContext: Context;
@@ -107,6 +114,17 @@ export class MonitoringTransport extends WrapperTransport {
 
     // Only track if request has an ID
     if (request.id !== null && request.id !== undefined) {
+      if (
+        !this.inflightRequests.has(request.id) &&
+        this.inflightRequests.size >= MAX_INFLIGHT_REQUESTS
+      ) {
+        const oldestId = this.inflightRequests.keys().next().value;
+        if (oldestId !== undefined) {
+          this.inflightRequests.get(oldestId)?.span?.end();
+          this.inflightRequests.delete(oldestId);
+        }
+      }
+
       // Store request info with span
       this.inflightRequests.set(request.id, {
         startTime: Date.now(),


### PR DESCRIPTION
**Source:** C-DEBT-style resource-bound gap found while auditing `apps/api/src/mcp-clients/outbound/transports/` (a file the studio-bot memory ledger marked untried).

**Why a maintainer wants this:** `MonitoringTransport` is composed onto the transport for pooled MCP client connections (`createOutboundClient` / `ctx.getOrCreateClient` / `stdioPool`), so one instance — and its `inflightRequests` Map — lives for the whole lifetime of a long-lived pooled connection, not one request. If a response never arrives for some request id (a dropped connection, a malformed frame missing the id, a downstream server that hangs mid-call), that entry — and the OTel `Span` it holds — is never removed. Over the life of a busy, long-lived connection this grows without bound: a real memory/span leak, the same class of bug the repo already fixed once for `read-tool-output.ts`'s tool-output stash (`MAX_TOOL_OUTPUTS`, capped Map with oldest-eviction).

**The fix:** cap `inflightRequests` at `MAX_INFLIGHT_REQUESTS = 500`. When a new request would push it over the cap, evict the oldest entry (Map preserves insertion order) and call `span.end()` on it first so it isn't just silently dropped from the tracer's perspective.

**Regression test:** `monitoring.test.ts` sends `MAX_INFLIGHT_REQUESTS + 1` `tools/call` requests that never get a response, and asserts the map stays at the cap and the evicted request's span was ended (not just dropped).

**To verify:** `bun test apps/api/src/mcp-clients/outbound/transports/monitoring.test.ts`

**Locally run:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above (6/6 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `MonitoringTransport`'s inflight-request map from growing without bound on long-lived pooled connections when responses never arrive, leaking memory and OTel spans.

- Caps `inflightRequests` at 500 entries; once a new request would exceed the cap, the oldest entry (Map insertion order) is evicted.
- Ends the evicted request's span before removal so tracing sees it closed rather than silently dropped.
- Adds a regression test that sends 501 never-responded requests and verifies the map stays at 500 and the evicted span is ended.

<sup>Written for commit 0b01122409e3f89cda3f2f4fc7993ff6c502ced9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

