### PR TITLE
fix(threads): make getStatusConfig actually treat a null status as unknown

### DIFF
--- a/apps/web/src/components/thread/thread-sheet-body.tsx
+++ b/apps/web/src/components/thread/thread-sheet-body.tsx
@@ -200,7 +200,7 @@ function ThreadMetaRow({
     second: "2-digit",
   });
 
-  const statusCfg = getStatusConfig(thread.status ?? undefined);
+  const statusCfg = getStatusConfig(thread.status);
   const StatusIcon = statusCfg.icon;
 
   return (

--- a/apps/web/src/lib/task-status.test.ts
+++ b/apps/web/src/lib/task-status.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { getStatusConfig } from "./task-status";
+
+describe("getStatusConfig", () => {
+  it("treats a known status key as itself", () => {
+    expect(getStatusConfig("failed").labelKey).toBe("common.taskStatus.failed");
+  });
+
+  it("treats an unrecognized status string as unknown", () => {
+    expect(getStatusConfig("some_future_status").labelKey).toBe(
+      "common.taskStatus.unknown",
+    );
+  });
+
+  it("treats a null status as unknown, not completed", () => {
+    expect(getStatusConfig(null).labelKey).toBe("common.taskStatus.unknown");
+  });
+
+  it("treats an undefined status as completed", () => {
+    expect(getStatusConfig(undefined).labelKey).toBe(
+      "common.taskStatus.completed",
+    );
+  });
+});

--- a/apps/web/src/lib/task-status.ts
+++ b/apps/web/src/lib/task-status.ts
@@ -75,7 +75,11 @@ function isStatusKey(status: string): status is StatusKey {
   return status in STATUS_CONFIG;
 }
 
-export function getStatusConfig(status: string | undefined): StatusConfig {
+export function getStatusConfig(
+  status: string | null | undefined,
+): StatusConfig {
+  // Explicit null (unlike undefined) means a genuinely unknown status, not "no status field yet".
+  if (status === null) return UNKNOWN;
   const key = status ?? "completed";
   return isStatusKey(key) ? STATUS_CONFIG[key] : UNKNOWN;
 }

--- a/apps/web/src/routes/orgs/monitoring/threads.tsx
+++ b/apps/web/src/routes/orgs/monitoring/threads.tsx
@@ -98,7 +98,7 @@ function ThreadRow({
     minute: "2-digit",
   });
 
-  const statusCfg = getStatusConfig(thread.status ?? undefined);
+  const statusCfg = getStatusConfig(thread.status);
   const StatusIcon = statusCfg.icon;
 
   return (

--- a/apps/web/src/views/automations/automation-runs.tsx
+++ b/apps/web/src/views/automations/automation-runs.tsx
@@ -157,7 +157,7 @@ function RunRow({
     minute: "2-digit",
   });
 
-  const statusCfg = getStatusConfig(run.status ?? undefined);
+  const statusCfg = getStatusConfig(run.status);
   const StatusIcon = statusCfg.icon;
 
   return (


### PR DESCRIPTION
Follows #6756, which was supposed to stop a `null` thread status from rendering as "Completed" by routing 3 call sites through the shared `getStatusConfig()` helper. It didn't close the gap: those 3 sites call `getStatusConfig(thread.status ?? undefined)`, coercing `null` to `undefined` before the helper ever sees it — and `getStatusConfig` defaults `undefined` to `"completed"` (by design, for callers like `task-row.tsx` where a truly absent status means a new, not-yet-classified task). So a thread whose `status` is literally `null` (per `ThreadEntity`'s own `status: string | null` type) still renders a green checkmark labeled "Completed" — the exact scenario #6756's own PR body described as the bug, still reproducible after that PR merged.

**Why a maintainer wants it:** the previous fix's description and test claims don't match what the shipped code does — this closes that gap for real, distinguishing "no status field" (undefined → completed, unchanged) from "status is explicitly null" (→ unknown, the fix).

**Failure scenario:** open Monitoring → Threads, an automation's Runs tab, or a task's linked runs for an entity whose `status` is `null` — it shows "Completed" instead of "Unknown".

**Fix:** `getStatusConfig` now special-cases `status === null` to return the neutral `UNKNOWN` config before applying the `undefined → "completed"` default; the 3 call sites now pass `thread.status`/`run.status` straight through instead of coercing `null` to `undefined` first.

**Regression test:** added `apps/web/src/lib/task-status.test.ts` — asserts `getStatusConfig(null)` returns the unknown label while `getStatusConfig(undefined)` still returns completed (unchanged behavior) and a real status key still resolves to itself.

**Reviewer check:** `bun test apps/web/src/lib/task-status.test.ts`, or open a thread/run sheet for an entity with a null status.

**Locally verified:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean on touched files; one pre-existing unrelated prosemirror version-mismatch error elsewhere in the workspace), `bun test apps/web/src/lib/task-status.test.ts` (4 pass), `bunx oxlint` on all 5 changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the thread status display so an explicitly `null` status now renders as "Unknown" instead of the green "Completed" checkmark. The previous fix missed this because call sites coerced `null` to `undefined`, and `getStatusConfig` intentionally treats `undefined` as `completed` for new, unclassified tasks; `null` now returns the unknown config while `undefined` behavior stays unchanged.

<sup>Written for commit 33744d5583e38ff26173b0fdfd6173c41a5b8c30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

