### PR TITLE
refactor(task-board): extract ConnectGitHubDialog into its own file

### DIFF
--- a/apps/web/src/layouts/task-board/connect-github-dialog.tsx
+++ b/apps/web/src/layouts/task-board/connect-github-dialog.tsx
@@ -1,0 +1,67 @@
+import { Loading01 } from "@untitledui/icons";
+import { Button } from "@decocms/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@decocms/ui/components/dialog.tsx";
+import { useT } from "@/i18n/use-t.ts";
+import { GitHubIcon } from "@/components/icons/github-icon";
+import { useConnectApp } from "@/hooks/use-connect-app";
+
+export function ConnectGitHubDialog({
+  open,
+  onOpenChange,
+  onConnected,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called after the connect attempt settles, success or failure — the
+   *  caller (the repo picker) has its own auto-install fallback either way. */
+  onConnected: () => void;
+}) {
+  const t = useT();
+  const { connect, isConnecting } = useConnectApp("deco/mcp-github");
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-md">
+        <div className="flex h-28 items-center justify-center bg-gradient-to-br from-muted via-muted to-accent">
+          <div className="flex size-14 items-center justify-center rounded-2xl bg-foreground text-background shadow-sm">
+            <GitHubIcon className="size-7" />
+          </div>
+        </div>
+        <div className="flex flex-col gap-4 p-6">
+          <DialogHeader>
+            <DialogTitle>
+              {t("taskBoard.taskBoard.connectGithubTitle")}
+            </DialogTitle>
+            <DialogDescription>
+              {t("taskBoard.taskBoard.connectGithubDescription")}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              onClick={async () => {
+                await connect();
+                onOpenChange(false);
+                onConnected();
+              }}
+              disabled={isConnecting}
+              className="gap-2"
+            >
+              {isConnecting ? (
+                <Loading01 size={16} className="animate-spin" />
+              ) : (
+                <GitHubIcon className="size-4" />
+              )}
+              {t("taskBoard.taskBoard.connectGithubButton")}
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -73,15 +73,6 @@ import {
 import { SuperAgentIcon } from "@/components/super-agent-icon";
 import { LoaderCircle } from "lucide-react";
 import { ReviewerIcon } from "@/components/reviewer-icon";
-import { GitHubIcon } from "@/components/icons/github-icon";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@decocms/ui/components/dialog.tsx";
 import {
   getWellKnownDecopilotVirtualMCP,
   useConnections,
@@ -92,7 +83,6 @@ import {
   listRepoScopeLabels,
 } from "@decocms/shared/github-repo-scope";
 import { GitHubRepoPicker } from "@/components/github-repo-picker";
-import { useConnectApp } from "@/hooks/use-connect-app";
 import { useMembers } from "@/hooks/use-members";
 import {
   useTaskBoardItemActions,
@@ -140,6 +130,7 @@ import {
   toEndOfDayIso,
 } from "./task-dialog";
 import { AssigneePickerContent } from "./assignee-picker";
+import { ConnectGitHubDialog } from "./connect-github-dialog";
 import { SubscriptionPaywallDialog } from "./subscription-paywall-dialog";
 import { RerunDialog } from "./rerun-dialog";
 import { subscriptionErrorKind } from "@/components/task-board/is-subscription-error";
@@ -1531,60 +1522,6 @@ export function TaskBoardPage() {
  * The Super Agent needs GitHub to open a PR, so we connect first. Once the
  * connection lands the card's Auto-fix button works on the next click.
  */
-function ConnectGitHubDialog({
-  open,
-  onOpenChange,
-  onConnected,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  /** Called after the connect attempt settles, success or failure — the
-   *  caller (the repo picker) has its own auto-install fallback either way. */
-  onConnected: () => void;
-}) {
-  const t = useT();
-  const { connect, isConnecting } = useConnectApp("deco/mcp-github");
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-md">
-        <div className="flex h-28 items-center justify-center bg-gradient-to-br from-muted via-muted to-accent">
-          <div className="flex size-14 items-center justify-center rounded-2xl bg-foreground text-background shadow-sm">
-            <GitHubIcon className="size-7" />
-          </div>
-        </div>
-        <div className="flex flex-col gap-4 p-6">
-          <DialogHeader>
-            <DialogTitle>
-              {t("taskBoard.taskBoard.connectGithubTitle")}
-            </DialogTitle>
-            <DialogDescription>
-              {t("taskBoard.taskBoard.connectGithubDescription")}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              onClick={async () => {
-                await connect();
-                onOpenChange(false);
-                onConnected();
-              }}
-              disabled={isConnecting}
-              className="gap-2"
-            >
-              {isConnecting ? (
-                <Loading01 size={16} className="animate-spin" />
-              ) : (
-                <GitHubIcon className="size-4" />
-              )}
-              {t("taskBoard.taskBoard.connectGithubButton")}
-            </Button>
-          </DialogFooter>
-        </div>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
 /**
  * Floating pill toolbar that appears once at least one card is selected —
  * count, a bulk "Actions" menu (move / tag / priority / delete), a quick


### PR DESCRIPTION
Source: C5 God-component extraction, per the bot's own accumulated memory that `apps/web/src/layouts/task-board/index.tsx` (2705 lines) was the last untried lead in this recently-changed pool at the current HEAD.

`ConnectGitHubDialog` is a fully self-contained dialog component — it only reads its own props (`open`, `onOpenChange`, `onConnected`) and its own hooks (`useT`, `useConnectApp`), with no closures over `index.tsx`'s outer state. Moving it to `connect-github-dialog.tsx` is a byte-identical relocation: same JSX, same behavior, plus the new import, and it lets `GitHubIcon`/`useConnectApp`/the `Dialog*` imports (which were only used by this component) drop out of `index.tsx` since they're no longer referenced there.

Net diff: -64/+1 in `index.tsx`, +68 in the new file — a real (if small) trim off a 2705-line file, not a rewrite.

How to confirm: `cd apps/web && bunx tsc --noEmit` (clean for both files; the one pre-existing unrelated error in `mention-suggestion.tsx` from a duplicate prosemirror-model version is present on main too, confirmed via `git stash`). `bunx oxlint apps/web/src/layouts/task-board/index.tsx apps/web/src/layouts/task-board/connect-github-dialog.tsx` — 0 warnings, 0 errors.

Checks run locally: `bun run fmt`, per-file `tsc --noEmit`, per-file `oxlint`. Full CI validates the rest (no behavior change to test — this is a pure move).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts the self-contained `ConnectGitHubDialog` out of the 2705-line `apps/web/src/layouts/task-board/index.tsx` into its own file. This is a pure move — same JSX, same behavior, no functionality changes.

The move trims `index.tsx` by 64 lines and lets the dialog-only imports (`GitHubIcon`, `useConnectApp`, `Dialog*` components) drop out of `index.tsx`, since nothing else there references them.

<sup>Written for commit a5acbd9c4673558bc9237cb26b717f7bd759e693. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

