### PR TITLE
fix(threads): track the open thread sheet by id, not array index

### DIFF
--- a/apps/web/src/routes/orgs/monitoring/threads.tsx
+++ b/apps/web/src/routes/orgs/monitoring/threads.tsx
@@ -233,9 +233,8 @@ export function ThreadsTabContent({
   filterStatus,
 }: ThreadsTabContentProps) {
   const t = useT();
-  const [selectedThreadIndex, setSelectedThreadIndex] = useState<number | null>(
-    null,
-  );
+  // By id, not index: sort toggles reorder `displayThreads` in place.
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
 
   const startDate = dateRange.startDate.toISOString();
   const endDate = dateRange.endDate.toISOString();
@@ -354,10 +353,12 @@ export function ThreadsTabContent({
       })
     : visibleThreads;
 
+  const selectedThreadIndex =
+    selectedThreadId !== null
+      ? displayThreads.findIndex((t) => t.id === selectedThreadId)
+      : -1;
   const selectedThread =
-    selectedThreadIndex !== null
-      ? (displayThreads[selectedThreadIndex] ?? null)
-      : null;
+    selectedThreadIndex !== -1 ? displayThreads[selectedThreadIndex] : null;
 
   const handleLoadMore = () => {
     if (hasNextPage && !isFetchingNextPage) fetchNextPage();
@@ -375,12 +376,14 @@ export function ThreadsTabContent({
     (filterUserIds?.length ?? 0) > 0 ||
     !!(filterStatus && filterStatus !== "all");
 
-  const handlePrev = () =>
-    setSelectedThreadIndex((i) => (i !== null && i > 0 ? i - 1 : i));
-  const handleNext = () =>
-    setSelectedThreadIndex((i) =>
-      i !== null && i < displayThreads.length - 1 ? i + 1 : i,
-    );
+  const handlePrev = () => {
+    const prev = displayThreads[selectedThreadIndex - 1];
+    if (selectedThreadIndex > 0 && prev) setSelectedThreadId(prev.id);
+  };
+  const handleNext = () => {
+    const next = displayThreads[selectedThreadIndex + 1];
+    if (selectedThreadIndex !== -1 && next) setSelectedThreadId(next.id);
+  };
 
   return (
     <div className="flex-1 flex flex-col overflow-auto min-w-0">
@@ -456,7 +459,7 @@ export function ThreadsTabContent({
                           members={membersData}
                           connections={allConnections}
                           virtualMcps={allVirtualMcps}
-                          onClick={() => setSelectedThreadIndex(idx)}
+                          onClick={() => setSelectedThreadId(thread.id)}
                           lastRowRef={
                             idx === displayThreads.length - 1
                               ? (lastRowRef as (
@@ -477,13 +480,13 @@ export function ThreadsTabContent({
       </div>
 
       <Sheet
-        open={selectedThreadIndex !== null}
+        open={selectedThreadId !== null}
         onOpenChange={(open) => {
-          if (!open) setSelectedThreadIndex(null);
+          if (!open) setSelectedThreadId(null);
         }}
       >
         <SheetContent className="sm:max-w-2xl flex flex-col p-0 gap-0">
-          {selectedThread && selectedThreadIndex !== null && (
+          {selectedThread && (
             <ThreadSheetBody
               thread={selectedThread}
               client={client}


### PR DESCRIPTION
Bug found while auditing `apps/web/src/routes/orgs/monitoring/threads.tsx`.

`ThreadsTabContent` stored the open transcript sheet's selection as `selectedThreadIndex`, an index into `displayThreads`. But `displayThreads` is `visibleThreads` re-sorted client-side whenever the user toggles the Tokens or Cost column sort (`sortKey`/`sortDir`). If a user opened a thread's sheet and then clicked a sort header, `displayThreads` reordered in place while the stored index stayed put — the sheet silently swapped to showing a *different* thread's transcript, with no indication anything changed (nav's total/prev-next still looked consistent).

Fix: track the selection by thread id instead, and derive the index (for the existing prev/next nav) by looking the id up in the current `displayThreads` on each render. Sorting now leaves the open sheet pointed at the same thread; closing/reopening behavior is unchanged.

Failure scenario: click any row to open its transcript sheet, then click the "Tokens" or "Cost" column header to sort — the sheet now shows a thread you never clicked.

How to confirm: `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint src/routes/orgs/monitoring/threads.tsx` (0 warnings/errors). This is UI-state logic with no isolated pure function to cheaply unit test (the bug lives in the component's derived state), so I verified it by tracing the data flow rather than adding a test; a reviewer can confirm by reproducing the repro steps above in a running app.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web workspace), `bunx oxlint` on the changed file. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the monitoring threads tab so sorting by Tokens or Cost no longer silently swaps the open transcript sheet to a different thread.

- Tracks the selected thread by id; the index used for prev/next is derived from the current sorted list on each render.
- Opening, closing, and prev/next navigation behavior is unchanged.

<sup>Written for commit b722f112b87359c13f1111fe8e85db1bf2cde1dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

