### PR TITLE
fix(automations): track the open run sheet by id, not array index

### DIFF
--- a/apps/web/src/views/automations/automation-runs.tsx
+++ b/apps/web/src/views/automations/automation-runs.tsx
@@ -215,7 +215,8 @@ export function AutomationRunsView({
   const allVirtualMcps = useVirtualMCPs();
   const { data: membersData } = useMembers();
 
-  const [selectedRunIndex, setSelectedRunIndex] = useState<number | null>(null);
+  // By id, not index: a refetch can reorder `runs` while the sheet is open.
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
 
   const hasTriggers = triggerIds.length > 0;
 
@@ -288,13 +289,18 @@ export function AutomationRunsView({
     isFetchingNextPage,
   );
 
-  const selectedRun =
-    selectedRunIndex !== null ? (runs[selectedRunIndex] ?? null) : null;
+  const selectedRunIndex =
+    selectedRunId !== null ? runs.findIndex((r) => r.id === selectedRunId) : -1;
+  const selectedRun = selectedRunIndex !== -1 ? runs[selectedRunIndex] : null;
 
-  const handlePrev = () =>
-    setSelectedRunIndex((i) => (i !== null && i > 0 ? i - 1 : i));
-  const handleNext = () =>
-    setSelectedRunIndex((i) => (i !== null && i < runs.length - 1 ? i + 1 : i));
+  const handlePrev = () => {
+    const prev = runs[selectedRunIndex - 1];
+    if (selectedRunIndex > 0 && prev) setSelectedRunId(prev.id);
+  };
+  const handleNext = () => {
+    const next = runs[selectedRunIndex + 1];
+    if (selectedRunIndex !== -1 && next) setSelectedRunId(next.id);
+  };
 
   return (
     <div className="flex flex-col gap-5">
@@ -345,7 +351,7 @@ export function AutomationRunsView({
                 key={run.id}
                 run={run}
                 usage={usageMap.get(run.id)}
-                onClick={() => setSelectedRunIndex(idx)}
+                onClick={() => setSelectedRunId(run.id)}
                 lastRowRef={
                   idx === runs.length - 1
                     ? (lastRowRef as (node: HTMLTableRowElement | null) => void)
@@ -364,13 +370,13 @@ export function AutomationRunsView({
       )}
 
       <Sheet
-        open={selectedRunIndex !== null}
+        open={selectedRunId !== null}
         onOpenChange={(open) => {
-          if (!open) setSelectedRunIndex(null);
+          if (!open) setSelectedRunId(null);
         }}
       >
         <SheetContent className="sm:max-w-2xl flex flex-col p-0 gap-0">
-          {selectedRun && selectedRunIndex !== null && (
+          {selectedRun && (
             <ThreadSheetBody
               thread={selectedRun}
               client={client}


### PR DESCRIPTION
Same bug class as the currently-open PR #6760 (threads.tsx), found independently in `automation-runs.tsx`.

`AutomationRunsView` stored the open transcript sheet's target as `selectedRunIndex` into `runs`, the flattened pages of `COLLECTION_THREADS_LIST`. That query has no `refetchInterval` but keeps react-query's default `refetchOnWindowFocus`, so a window refocus while the sheet is open re-runs page 1; if a new run landed since, it prepends and shifts every existing run down one slot. The stored index then resolves to a different run, silently swapping the open sheet's content without the user clicking anything.

Fix: store `selectedRunId` instead, derive `selectedRunIndex` by `findIndex` each render, and step prev/next by looking up the neighboring id. Behavior-preserving otherwise — same Sheet open/close semantics, same nav shape passed to `ThreadSheetBody`.

How to confirm: open Monitoring → an automation's Runs tab, click a run to open its transcript sheet, then (with a way to trigger a new run, or by editing the query data in devtools) cause the runs list to refetch with a new item prepended — the sheet should stay on the same run instead of jumping.

Verified locally: `bun run fmt`; `bunx tsc --noEmit` in `apps/web` (clean aside from a pre-existing unrelated prosemirror-model version-skew error, untouched by this change); `bunx oxlint` on the changed file (0 warnings/errors). Full CI validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the automation runs transcript sheet so it stays on the run you opened instead of silently switching to another run when the list refetches and reorders (e.g. on window focus). `AutomationRunsView` tracked the open sheet by array index; it now tracks by run id and derives the index per render, with prev/next navigation stepping by id. No other behavior changes.

<sup>Written for commit 41b8c78415bc00624f1fb576c7cbfc6ba79faaae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

