### PR TITLE
fix(monitoring): track the open audit-log sheet by id, not array index

### DIFF
--- a/apps/web/src/routes/orgs/monitoring/audit.tsx
+++ b/apps/web/src/routes/orgs/monitoring/audit.tsx
@@ -73,7 +73,8 @@ function MonitoringLogsTableContent({
   const t = useT();
   const connections = connectionsData ?? [];
   const virtualMcps = virtualMcpsData ?? [];
-  const [selectedLogIndex, setSelectedLogIndex] = useState<number | null>(null);
+  // By id, not index: a streaming refetch can reorder filteredLogs while the sheet is open.
+  const [selectedLogId, setSelectedLogId] = useState<string | null>(null);
 
   const lastLogRef = useInfiniteScroll(onLoadMore, hasMore, isLoadingMore);
 
@@ -124,8 +125,12 @@ function MonitoringLogsTableContent({
     );
   }
 
+  const selectedLogIndex =
+    selectedLogId !== null
+      ? filteredLogs.findIndex((log) => log.id === selectedLogId)
+      : -1;
   const selectedLog =
-    selectedLogIndex !== null ? (filteredLogs[selectedLogIndex] ?? null) : null;
+    selectedLogIndex !== -1 ? filteredLogs[selectedLogIndex] : null;
 
   // Lazy-load full input/output when a log is selected (list query omits them)
   const detailQuery = useQuery({
@@ -213,7 +218,7 @@ function MonitoringLogsTableContent({
                   connection={connectionMap.get(log.connectionId)}
                   virtualMcpName={log.virtualMcpName ?? ""}
                   virtualMcpIcon={log.virtualMcpIcon}
-                  onClick={() => setSelectedLogIndex(index)}
+                  onClick={() => setSelectedLogId(log.id)}
                   lastLogRef={
                     index === filteredLogs.length - 1 ? lastLogRef : undefined
                   }
@@ -225,13 +230,13 @@ function MonitoringLogsTableContent({
       </div>
 
       <Sheet
-        open={selectedLogIndex !== null}
+        open={selectedLogId !== null}
         onOpenChange={(open) => {
-          if (!open) setSelectedLogIndex(null);
+          if (!open) setSelectedLogId(null);
         }}
       >
         <SheetContent className="sm:max-w-2xl flex flex-col p-0 gap-0">
-          {selectedLog && selectedLogIndex !== null && (
+          {selectedLog && (
             <>
               <SheetHeader className="px-5 md:px-6 pt-6 pb-5 border-b border-border shrink-0">
                 <div className="flex items-start justify-between gap-3 pr-8">
@@ -262,11 +267,12 @@ function MonitoringLogsTableContent({
                     <Button
                       size="icon"
                       variant="ghost"
-                      onClick={() =>
-                        setSelectedLogIndex((i) =>
-                          i !== null && i > 0 ? i - 1 : i,
-                        )
-                      }
+                      onClick={() => {
+                        const prev = filteredLogs[selectedLogIndex - 1];
+                        if (selectedLogIndex > 0 && prev) {
+                          setSelectedLogId(prev.id);
+                        }
+                      }}
                       disabled={selectedLogIndex === 0}
                       className="h-7 w-7 text-muted-foreground"
                       aria-label={t("orgs.audit.previousEntry")}
@@ -276,11 +282,12 @@ function MonitoringLogsTableContent({
                     <Button
                       size="icon"
                       variant="ghost"
-                      onClick={() =>
-                        setSelectedLogIndex((i) =>
-                          i !== null && i < filteredLogs.length - 1 ? i + 1 : i,
-                        )
-                      }
+                      onClick={() => {
+                        const next = filteredLogs[selectedLogIndex + 1];
+                        if (selectedLogIndex !== -1 && next) {
+                          setSelectedLogId(next.id);
+                        }
+                      }}
                       disabled={selectedLogIndex === filteredLogs.length - 1}
                       className="h-7 w-7 text-muted-foreground"
                       aria-label={t("orgs.audit.nextEntry")}


### PR DESCRIPTION
Follows #6760 and #6761 — same class of bug, third sibling site.

The audit log table (`apps/web/src/routes/orgs/monitoring/audit.tsx`) stores `selectedLogIndex` and reads `filteredLogs[selectedLogIndex]` to drive the detail sheet. `MonitoringLogsTableContent` is fed by `useSuspenseInfiniteQuery` with `refetchInterval: isStreaming ? streamingRefetchInterval : false` — while streaming, a periodic refetch can prepend newly logged calls, reordering `filteredLogs` while the sheet is open. The stored index then points at a different log's data, silently swapping the open sheet's content without the user clicking anything.

Fix: store `selectedLogId` instead, derive the index by `findIndex` each render, and step prev/next by id — the same fix already applied to `threads.tsx` (#6760) and `automation-runs.tsx` (#6761).

To confirm: open Monitoring → Audit while `isStreaming` is true, select a log, and let a background call arrive — the sheet should stay on the log you clicked instead of jumping.

Verified locally: `bun run fmt`; `bunx tsc --noEmit` in `apps/web` (no new errors); `bunx oxlint` on the changed file (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the audit log detail sheet so it stays on the log you clicked even when a streaming refresh reorders the list. The sheet now tracks the selected log by its id instead of its array index, and prev/next navigation uses ids, matching the fix already applied to threads and automation runs.

<sup>Written for commit 096158fc0c654bbbc18a1595d3f8cbb44cee33bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

