### PR TITLE
fix(monitoring): close the detail sheet when the selected row drops out of the list

### DIFF
--- a/apps/web/src/hooks/use-id-selection.test.ts
+++ b/apps/web/src/hooks/use-id-selection.test.ts
@@ -1,0 +1,51 @@
+import { setupComponentTest } from "../../test/setup";
+setupComponentTest();
+import { describe, expect, it } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+import { useIdSelection } from "./use-id-selection";
+
+describe("useIdSelection", () => {
+  it("resolves the selected item by id and reports it open", () => {
+    const items = [{ id: "a" }, { id: "b" }];
+    const { result } = renderHook(() => useIdSelection(items));
+
+    act(() => result.current.select("b"));
+
+    expect(result.current.selected).toEqual({ id: "b" });
+    expect(result.current.index).toBe(1);
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("closes instead of staying open on a stale id when the item drops out of the list", () => {
+    const items = [{ id: "a" }, { id: "b" }];
+    const { result, rerender } = renderHook(
+      ({ items }) => useIdSelection(items),
+      { initialProps: { items } },
+    );
+
+    act(() => result.current.select("b"));
+    expect(result.current.isOpen).toBe(true);
+
+    // "b" is filtered out from underneath the open sheet.
+    rerender({ items: [items[0]!] });
+
+    expect(result.current.selected).toBeNull();
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("prev/next follow the current list order and clamp at the ends", () => {
+    const items = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const { result } = renderHook(() => useIdSelection(items));
+
+    act(() => result.current.select("a"));
+    act(() => result.current.prev());
+    expect(result.current.selected?.id).toBe("a"); // clamped, no item before the first
+
+    act(() => result.current.next());
+    expect(result.current.selected?.id).toBe("b");
+
+    act(() => result.current.select("c"));
+    act(() => result.current.next());
+    expect(result.current.selected?.id).toBe("c"); // clamped, no item after the last
+  });
+});

--- a/apps/web/src/hooks/use-id-selection.ts
+++ b/apps/web/src/hooks/use-id-selection.ts
@@ -1,0 +1,35 @@
+import { useState } from "react";
+
+/**
+ * Tracks a selected row by id rather than array index, so a refetch/sort/filter
+ * that reorders or shrinks `items` in place doesn't point the selection at the
+ * wrong row. `isOpen` reflects whether the id still resolves to an item in
+ * `items` — if the selected row drops out of the list (e.g. a filter change
+ * while its detail sheet is open), the sheet closes instead of staying open
+ * with nothing to show.
+ */
+export function useIdSelection<T extends { id: string }>(items: T[]) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const index =
+    selectedId !== null
+      ? items.findIndex((item) => item.id === selectedId)
+      : -1;
+  const selected = index !== -1 ? items[index] : null;
+
+  return {
+    selected,
+    index,
+    isOpen: selected !== null,
+    select: (id: string) => setSelectedId(id),
+    close: () => setSelectedId(null),
+    prev: () => {
+      const prevItem = items[index - 1];
+      if (index > 0 && prevItem) setSelectedId(prevItem.id);
+    },
+    next: () => {
+      const nextItem = items[index + 1];
+      if (index !== -1 && nextItem) setSelectedId(nextItem.id);
+    },
+  };
+}

--- a/apps/web/src/routes/orgs/monitoring/audit.tsx
+++ b/apps/web/src/routes/orgs/monitoring/audit.tsx
@@ -2,7 +2,6 @@
  * Audit Tab — log table with detail sheet.
  */
 
-import { useState } from "react";
 import type { useConnections, useVirtualMCPs } from "@/sdk";
 import { useMCPClient } from "@/sdk";
 import type { useProjectContext } from "@/sdk";
@@ -31,6 +30,7 @@ import {
   type MonitoringLogsResponse,
 } from "@/components/monitoring";
 import { IntegrationIcon } from "@/components/integration-icon.tsx";
+import { useIdSelection } from "@/hooks/use-id-selection.ts";
 import { useInfiniteScroll } from "@/hooks/use-infinite-scroll.ts";
 import type { useMembers } from "@/hooks/use-members";
 import { useT } from "@/i18n/use-t.ts";
@@ -73,9 +73,6 @@ function MonitoringLogsTableContent({
   const t = useT();
   const connections = connectionsData ?? [];
   const virtualMcps = virtualMcpsData ?? [];
-  // By id, not index: a streaming refetch can reorder filteredLogs while the sheet is open.
-  const [selectedLogId, setSelectedLogId] = useState<string | null>(null);
-
   const lastLogRef = useInfiniteScroll(onLoadMore, hasMore, isLoadingMore);
 
   const members = getOrgMembers(membersData);
@@ -125,12 +122,8 @@ function MonitoringLogsTableContent({
     );
   }
 
-  const selectedLogIndex =
-    selectedLogId !== null
-      ? filteredLogs.findIndex((log) => log.id === selectedLogId)
-      : -1;
-  const selectedLog =
-    selectedLogIndex !== -1 ? filteredLogs[selectedLogIndex] : null;
+  const selection = useIdSelection(filteredLogs);
+  const selectedLog = selection.selected;
 
   // Lazy-load full input/output when a log is selected (list query omits them)
   const detailQuery = useQuery({
@@ -218,7 +211,7 @@ function MonitoringLogsTableContent({
                   connection={connectionMap.get(log.connectionId)}
                   virtualMcpName={log.virtualMcpName ?? ""}
                   virtualMcpIcon={log.virtualMcpIcon}
-                  onClick={() => setSelectedLogId(log.id)}
+                  onClick={() => selection.select(log.id)}
                   lastLogRef={
                     index === filteredLogs.length - 1 ? lastLogRef : undefined
                   }
@@ -230,9 +223,9 @@ function MonitoringLogsTableContent({
       </div>
 
       <Sheet
-        open={selectedLogId !== null}
+        open={selection.isOpen}
         onOpenChange={(open) => {
-          if (!open) setSelectedLogId(null);
+          if (!open) selection.close();
         }}
       >
         <SheetContent className="sm:max-w-2xl flex flex-col p-0 gap-0">
@@ -267,13 +260,8 @@ function MonitoringLogsTableContent({
                     <Button
                       size="icon"
                       variant="ghost"
-                      onClick={() => {
-                        const prev = filteredLogs[selectedLogIndex - 1];
-                        if (selectedLogIndex > 0 && prev) {
-                          setSelectedLogId(prev.id);
-                        }
-                      }}
-                      disabled={selectedLogIndex === 0}
+                      onClick={selection.prev}
+                      disabled={selection.index === 0}
                       className="h-7 w-7 text-muted-foreground"
                       aria-label={t("orgs.audit.previousEntry")}
                     >
@@ -282,13 +270,8 @@ function MonitoringLogsTableContent({
                     <Button
                       size="icon"
                       variant="ghost"
-                      onClick={() => {
-                        const next = filteredLogs[selectedLogIndex + 1];
-                        if (selectedLogIndex !== -1 && next) {
-                          setSelectedLogId(next.id);
-                        }
-                      }}
-                      disabled={selectedLogIndex === filteredLogs.length - 1}
+                      onClick={selection.next}
+                      disabled={selection.index === filteredLogs.length - 1}
                       className="h-7 w-7 text-muted-foreground"
                       aria-label={t("orgs.audit.nextEntry")}
                     >

--- a/apps/web/src/routes/orgs/monitoring/threads.tsx
+++ b/apps/web/src/routes/orgs/monitoring/threads.tsx
@@ -21,6 +21,7 @@ import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import { ChevronUp, ChevronDown, Container } from "@untitledui/icons";
 import { EmptyState } from "@/components/empty-state.tsx";
 import { IntegrationIcon } from "@/components/integration-icon.tsx";
+import { useIdSelection } from "@/hooks/use-id-selection.ts";
 import { useInfiniteScroll } from "@/hooks/use-infinite-scroll.ts";
 import type { useMembers } from "@/hooks/use-members";
 import { KEYS } from "@/lib/query-keys";
@@ -233,9 +234,6 @@ export function ThreadsTabContent({
   filterStatus,
 }: ThreadsTabContentProps) {
   const t = useT();
-  // By id, not index: sort toggles reorder `displayThreads` in place.
-  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
-
   const startDate = dateRange.startDate.toISOString();
   const endDate = dateRange.endDate.toISOString();
 
@@ -353,12 +351,8 @@ export function ThreadsTabContent({
       })
     : visibleThreads;
 
-  const selectedThreadIndex =
-    selectedThreadId !== null
-      ? displayThreads.findIndex((t) => t.id === selectedThreadId)
-      : -1;
-  const selectedThread =
-    selectedThreadIndex !== -1 ? displayThreads[selectedThreadIndex] : null;
+  const selection = useIdSelection(displayThreads);
+  const selectedThread = selection.selected;
 
   const handleLoadMore = () => {
     if (hasNextPage && !isFetchingNextPage) fetchNextPage();
@@ -375,15 +369,6 @@ export function ThreadsTabContent({
     (filterAgentIds?.length ?? 0) > 0 ||
     (filterUserIds?.length ?? 0) > 0 ||
     !!(filterStatus && filterStatus !== "all");
-
-  const handlePrev = () => {
-    const prev = displayThreads[selectedThreadIndex - 1];
-    if (selectedThreadIndex > 0 && prev) setSelectedThreadId(prev.id);
-  };
-  const handleNext = () => {
-    const next = displayThreads[selectedThreadIndex + 1];
-    if (selectedThreadIndex !== -1 && next) setSelectedThreadId(next.id);
-  };
 
   return (
     <div className="flex-1 flex flex-col overflow-auto min-w-0">
@@ -459,7 +444,7 @@ export function ThreadsTabContent({
                           members={membersData}
                           connections={allConnections}
                           virtualMcps={allVirtualMcps}
-                          onClick={() => setSelectedThreadId(thread.id)}
+                          onClick={() => selection.select(thread.id)}
                           lastRowRef={
                             idx === displayThreads.length - 1
                               ? (lastRowRef as (
@@ -480,9 +465,9 @@ export function ThreadsTabContent({
       </div>
 
       <Sheet
-        open={selectedThreadId !== null}
+        open={selection.isOpen}
         onOpenChange={(open) => {
-          if (!open) setSelectedThreadId(null);
+          if (!open) selection.close();
         }}
       >
         <SheetContent className="sm:max-w-2xl flex flex-col p-0 gap-0">
@@ -495,10 +480,10 @@ export function ThreadsTabContent({
               virtualMcps={allVirtualMcps}
               members={membersData}
               nav={{
-                index: selectedThreadIndex,
+                index: selection.index,
                 total: displayThreads.length,
-                onPrev: handlePrev,
-                onNext: handleNext,
+                onPrev: selection.prev,
+                onNext: selection.next,
               }}
             />
           )}

--- a/apps/web/src/views/automations/automation-runs.tsx
+++ b/apps/web/src/views/automations/automation-runs.tsx
@@ -12,7 +12,6 @@
  * settings layout, which has no chat panel.
  */
 
-import { useState } from "react";
 import {
   useMCPClient,
   useConnections,
@@ -33,6 +32,7 @@ import {
   TableRow,
 } from "@decocms/ui/components/table.tsx";
 import { EmptyState } from "@/components/empty-state.tsx";
+import { useIdSelection } from "@/hooks/use-id-selection.ts";
 import { useInfiniteScroll } from "@/hooks/use-infinite-scroll.ts";
 import { useMembers } from "@/hooks/use-members";
 import { KEYS } from "@/lib/query-keys";
@@ -215,9 +215,6 @@ export function AutomationRunsView({
   const allVirtualMcps = useVirtualMCPs();
   const { data: membersData } = useMembers();
 
-  // By id, not index: a refetch can reorder `runs` while the sheet is open.
-  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
-
   const hasTriggers = triggerIds.length > 0;
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
@@ -289,18 +286,8 @@ export function AutomationRunsView({
     isFetchingNextPage,
   );
 
-  const selectedRunIndex =
-    selectedRunId !== null ? runs.findIndex((r) => r.id === selectedRunId) : -1;
-  const selectedRun = selectedRunIndex !== -1 ? runs[selectedRunIndex] : null;
-
-  const handlePrev = () => {
-    const prev = runs[selectedRunIndex - 1];
-    if (selectedRunIndex > 0 && prev) setSelectedRunId(prev.id);
-  };
-  const handleNext = () => {
-    const next = runs[selectedRunIndex + 1];
-    if (selectedRunIndex !== -1 && next) setSelectedRunId(next.id);
-  };
+  const selection = useIdSelection(runs);
+  const selectedRun = selection.selected;
 
   return (
     <div className="flex flex-col gap-5">
@@ -351,7 +338,7 @@ export function AutomationRunsView({
                 key={run.id}
                 run={run}
                 usage={usageMap.get(run.id)}
-                onClick={() => setSelectedRunId(run.id)}
+                onClick={() => selection.select(run.id)}
                 lastRowRef={
                   idx === runs.length - 1
                     ? (lastRowRef as (node: HTMLTableRowElement | null) => void)
@@ -370,9 +357,9 @@ export function AutomationRunsView({
       )}
 
       <Sheet
-        open={selectedRunId !== null}
+        open={selection.isOpen}
         onOpenChange={(open) => {
-          if (!open) setSelectedRunId(null);
+          if (!open) selection.close();
         }}
       >
         <SheetContent className="sm:max-w-2xl flex flex-col p-0 gap-0">
@@ -385,10 +372,10 @@ export function AutomationRunsView({
               virtualMcps={allVirtualMcps}
               members={membersData}
               nav={{
-                index: selectedRunIndex,
+                index: selection.index,
                 total: runs.length,
-                onPrev: handlePrev,
-                onNext: handleNext,
+                onPrev: selection.prev,
+                onNext: selection.next,
               }}
             />
           )}


### PR DESCRIPTION
Follows #6762, which fixed the audit log sheet's stale-index bug at one of three sites sharing this exact pattern (audit logs, automation runs, threads). All three derived `open` from `selectedId !== null` while the rendered content was gated on the row still resolving from the current list — so a filter/sort change (or a streaming refetch) that dropped the selected row left the sheet open with nothing to show inside it, until the user manually closed it.

**Failure scenario:** open a log's detail sheet in the audit tab, then change the connection/tool filter so that log no longer matches. The sheet stays open, blank, with no content and no obvious way to know why — the same class of bug #6762 fixed for the index case, just resurfacing through the `open` derivation instead.

**Fix:** extracted the duplicated select-by-id/prev/next logic (identical across all three files) into a shared `useIdSelection` hook, and derive `open` from whether the selected id still resolves to an item in the list, so the sheet auto-closes instead of going blank. Net diff on the three call sites is a reduction (-73/+28 there), plus the new hook + its test (+86).

**Regression test:** `apps/web/src/hooks/use-id-selection.test.ts` — "closes instead of staying open on a stale id when the item drops out of the list" fails on the old per-file logic pattern (which had no such derivation) and passes with the hook's `isOpen`.

**To verify:** `bun test apps/web/src/hooks/use-id-selection.test.ts`, and manually: open a log/run/thread detail sheet in monitoring, then apply a filter that excludes it — the sheet should close itself.

Locally ran: `bun run fmt` (no changes needed), `cd apps/web && bunx tsc --noEmit` (no new errors — one pre-existing, unrelated prosemirror version-mismatch error remains), `bun test apps/web/src/hooks/use-id-selection.test.ts` (3 pass), `bunx oxlint` on all changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the monitoring detail sheets (audit logs, automation runs, threads) to close when the selected row drops out of the list (e.g., after a filter change or refetch) instead of staying open with no content.

**Details**
- Extracts the duplicated select-by-id/prev/next logic into a shared `useIdSelection` hook.
- Derives `isOpen` from whether the selected id still resolves to an item in the list.
- Adds a regression test covering the stale-selection close behavior.

<sup>Written for commit 71c47d3939c85ab2e7c85105a5f74e834117673f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

