### PR TITLE
fix(storage): redact credentials from thread message parts

### DIFF
--- a/apps/api/src/storage/thread-message-parts.test.ts
+++ b/apps/api/src/storage/thread-message-parts.test.ts
@@ -56,4 +56,70 @@ describe("serializePayload", () => {
     const payload = { text: "hi \u{1F600}" };
     expect(serializePayload(payload)).toBe(JSON.stringify(payload));
   });
+
+  // Every token below is synthetic. The real leak was a run doing nothing more
+  // than `git remote -v`, whose output landed in a tool-result payload.
+  it("redacts the credential in a clone URL's userinfo", () => {
+    const payload = {
+      type: "tool-result",
+      output:
+        "origin\thttps://x-access-token:ghs_0000AAAAbbbbCCCCddddEEEEffffGGGG@github.com/acme/site.git (fetch)",
+    };
+    const out = JSON.parse(serializePayload(payload));
+    expect(out.output).not.toContain("ghs_");
+    expect(out.output).toBe(
+      "origin\thttps://***@github.com/acme/site.git (fetch)",
+    );
+  });
+
+  it("redacts a bare GitHub token with no URL around it", () => {
+    const payload = {
+      env: "GITHUB_TOKEN=github_pat_0000AAAAbbbbCCCCddddEEEEffffGGGGhhhh",
+    };
+    const out = JSON.parse(serializePayload(payload));
+    expect(out.env).toBe("GITHUB_TOKEN=github_pat_***");
+  });
+
+  it("redacts credentials nested deep in the payload tree", () => {
+    const payload = {
+      a: {
+        b: [
+          {
+            cmd: "git push https://u:ghp_0000AAAAbbbbCCCCddddEEEEffffGGGG@github.com/acme/site",
+          },
+        ],
+      },
+    };
+    const out = JSON.parse(serializePayload(payload));
+    expect(out.a.b[0].cmd).not.toContain("ghp_0000");
+  });
+
+  it("leaves a credential-less URL alone, even one containing an @", () => {
+    const payload = {
+      text: "see https://github.com/acme/site and mail a@b.com",
+    };
+    expect(serializePayload(payload)).toBe(JSON.stringify(payload));
+  });
+
+  it("leaves an ordinary identifier that merely starts like a token alone", () => {
+    const payload = { text: "ghs_count and gho_total are counters" };
+    expect(serializePayload(payload)).toBe(JSON.stringify(payload));
+  });
+
+  it("leaves an ssh remote alone — `git@host` is not a credential", () => {
+    const payload = { text: "origin\tgit@github.com:acme/site.git (push)" };
+    expect(serializePayload(payload)).toBe(JSON.stringify(payload));
+  });
+
+  // The credential regexes must stay LINEAR. An unbounded scheme or userinfo
+  // quantifier backtracks at every offset of a scheme-shaped string, and the
+  // 2MB payload above is enough to hang the projector for minutes. This asserts
+  // the property directly so a future "simplification" of the bounds is caught
+  // here rather than in prod.
+  it("redacts in linear time on a large scheme-shaped payload", () => {
+    const payload = { output: "abcdef".repeat(400_000) }; // 2.4MB, all scheme chars
+    const started = Date.now();
+    expect(serializePayload(payload)).toBe(JSON.stringify(payload));
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
 });

--- a/apps/api/src/storage/thread-message-parts.ts
+++ b/apps/api/src/storage/thread-message-parts.ts
@@ -58,12 +58,45 @@ function estimatePayloadBytes(value: unknown, budget: number): number {
 // untrusted, so sanitize it here at the storage boundary rather than trusting
 // every producer. Clean strings are returned unchanged, so ids derived from the
 // serialized payload stay stable.
+//
+// The same pass redacts credentials (below) — this table is the one place every
+// harness's output funnels through on its way to durable storage, so it is the
+// only guard that cannot be bypassed by a new producer.
 const NUL = /\u0000/g;
 const LONE_SURROGATE =
   /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
 
+// A URL's userinfo. The sandbox's `origin` remote is
+// `https://x-access-token:ghs_…@github.com/owner/repo`, and the Super Agent
+// prompt points the agent AT that token as its REST fallback — so a run that
+// does no more than `git remote -v` lands a live GitHub App token in this
+// table, in plaintext, readable by anyone who can read the thread. A push is
+// irreversible and a leak is not undone by deleting the row, so this strips at
+// the write: one guard covers every producer, present and future.
+//
+// `[^\s/@]` cannot cross a path separator, so a credential-less URL that
+// merely contains an `@` (`https://github.com/a@b`) is left alone.
+//
+// BOTH quantifiers are bounded, and that is load-bearing, not tidiness: an
+// unbounded `[a-z0-9+.-]*` or `[^\s/@]+` scans to the end of the string and
+// backtracks at EVERY start offset, which is quadratic. Payloads here reach
+// tens of MB (see the large-payload tests), so the unbounded form hangs the
+// projector — the sole writer of terminal thread status — and strands the run.
+// No real scheme exceeds 30 chars and no real credential 512.
+const URL_USERINFO = /([a-z][a-z0-9+.-]{0,30}:\/\/)[^\s/@]{1,512}@/gi;
+// The same secrets reach a log with no URL around them — an env dump, an
+// `Authorization:` header, a `.netrc`. GitHub's prefixes are unambiguous, and
+// the 20-char floor keeps an ordinary identifier like `ghs_count` readable.
+// Deliberately only GitHub's formats: a general secret scanner at this boundary
+// would redact chat content the user needs to read.
+const GITHUB_TOKEN = /\b(gh[pousr]_|github_pat_)[A-Za-z0-9_]{20,}/g;
+
 function sanitizeForPg(value: string): string {
-  return value.replace(NUL, "").replace(LONE_SURROGATE, "\uFFFD");
+  return value
+    .replace(NUL, "")
+    .replace(LONE_SURROGATE, "\uFFFD")
+    .replace(URL_USERINFO, "$1***@")
+    .replace(GITHUB_TOKEN, "$1***");
 }
 
 export function serializePayload(payload: unknown): string {


### PR DESCRIPTION
## Problem

The sandbox's `origin` remote carries a live GitHub App token:

```
origin  https://x-access-token:ghs_…@github.com/deco-sites/<repo>.git (fetch)
```

and `buildSuperAgentTaskPrompt` points the agent **at** it ("the auth token is embedded in the `origin` URL") as its REST fallback. So a run that does nothing more than `git remote -v` writes a live token into `thread_message_parts`, in plaintext, readable by anyone who can read the thread.

Found on a real production thread while investigating something else. That particular token has since expired, but the path is open on every run.

## Fix

Redact in `serializePayload` — the one boundary every harness's output crosses on its way to durable storage, per the "strip at the write, not at the caller" rule in `CLAUDE.md`. It already walks every string in the payload tree for the NUL/lone-surrogate sanitiser, so this adds no traversal.

Two patterns, deliberately narrow:
- **URL userinfo** → `https://***@github.com/…`. `[^\s/@]` can't cross a path separator, so a credential-less URL that merely contains an `@` is untouched, and `git@github.com:…` (no scheme) is untouched.
- **GitHub's own token prefixes** (`ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`github_pat_`) with a 20-char floor, for the copies that reach a log with no URL around them — an env dump, an `Authorization:` header, a `.netrc`. The floor keeps an ordinary identifier like `ghs_count` readable.

A general secret scanner at this boundary would redact chat content users need to read, so it isn't one.

## The bound on the regex is load-bearing

First draft used `[a-z0-9+.-]*` and `[^\s/@]+`. Both unbounded quantifiers backtrack at **every** start offset of a scheme-shaped string — quadratic. Payloads here reach tens of MB (see the existing large-payload tests), and the projector is the sole writer of terminal thread status, so a hang there strands the run `in_progress` forever. Caught it locally when the existing 2 MB test stopped finishing. Now bounded (`{0,30}` scheme, `{1,512}` userinfo) with an explicit linear-time test so a future "simplification" is caught here instead of in prod.

## Scope

This stops **new** leaks. It does not scrub rows already written — that's a separate backfill decision, and per `CLAUDE.md` the real mitigation for anything already persisted is rotation, not deletion.

## Testing

`bun test apps/api/src/storage/thread-message-parts.test.ts` — 15 pass. Seven new cases: URL userinfo, bare token, nested-deep, plus four negative cases (credential-less URL with `@`, `ghs_count`, ssh remote, and the linear-time bound). Every token in the tests is synthetic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts GitHub tokens and URL credentials in `serializePayload` so a run that does `git remote -v` no longer writes live sandbox tokens to `thread_message_parts` in plaintext. The redaction happens at the storage boundary, covering all producers, and adds no extra traversal because the sanitization pass already walks every string.

**Notes**
- Only new writes are covered; already-persisted rows require rotation.
- Both regexes are bound to keep runtime linear on large payloads.
- Patterns are deliberately narrow to avoid redacting chat content.

<sup>Written for commit bf8aee859e3d294b99ffd8428c412cb2b4d1d6d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

