### PR TITLE
fix(sandbox): never commit a repo's generated build artifacts

### DIFF
--- a/packages/sandbox/daemon-go/internal/gitx/buildartifacts_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/buildartifacts_test.go
@@ -1,0 +1,125 @@
+package gitx
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The real regression: `deno task dev` rewrote a tracked, compiled
+// static/tailwind.css in minified form, an agent's own `git add -A && git
+// commit` swallowed it, and every descendant thread branch inherited the 30k
+// line reformat. Asserted on the COMMITTED TREE, not the index: the tree is
+// what a pull request shows.
+func TestPreCommitHookKeepsBuildArtifactsOutOfTheAgentsCommit(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature/x")
+	if err := os.MkdirAll(filepath.Join(repo, "static"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(t, repo, "static/tailwind.css", "/* expanded release build */\n")
+	write(t, repo, "src/app.tsx", "export const A = 1\n")
+	gitIn(t, repo, "add", "-A")
+	gitIn(t, repo, "commit", "-q", "-m", "baseline")
+
+	if err := InstallSandboxHooks(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	// A dev server minifies the CSS while the agent edits a component.
+	write(t, repo, "static/tailwind.css", "*{margin:0}")
+	write(t, repo, "src/app.tsx", "export const A = 2\n")
+	gitIn(t, repo, "add", "-A")
+	gitIn(t, repo, "commit", "-q", "-m", "feat: bump A")
+
+	changed := gitIn(t, repo, "show", "--stat", "--name-only", "--format=", "HEAD")
+	if strings.Contains(changed, "static/tailwind.css") {
+		t.Fatalf("the artifact reached the commit — every descendant branch inherits it:\n%s", changed)
+	}
+	if !strings.Contains(changed, "src/app.tsx") {
+		t.Fatalf("the agent's actual change was dropped:\n%s", changed)
+	}
+	// Unstaged, not reverted: the file on disk is still the dev build, so the
+	// running dev server is not yanked out from under itself.
+	if got := read(t, repo, "static/tailwind.css"); got != "*{margin:0}" {
+		t.Fatalf("hook modified the working tree: %q", got)
+	}
+}
+
+func TestPreCommitHookLeavesDecofileBlocksAlone(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature/x")
+	if err := InstallSandboxHooks(repo); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, ".deco", "blocks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(t, repo, ".deco/blocks/site.json", `{"hreflang":true}`)
+	gitIn(t, repo, "add", "-A")
+	gitIn(t, repo, "commit", "-q", "-m", "feat: site config")
+
+	changed := gitIn(t, repo, "show", "--name-only", "--format=", "HEAD")
+	if !strings.Contains(changed, ".deco/blocks/site.json") {
+		t.Fatalf("decofile content is the point of many changes, not an artifact:\n%s", changed)
+	}
+}
+
+// Publish pushes with --no-verify, so the hook alone is not enough.
+func TestPublishDropsBuildArtifacts(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature/x")
+	if err := os.MkdirAll(filepath.Join(repo, "static"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(t, repo, "static/tailwind.css", "*{margin:0}")
+	write(t, repo, "src/app.tsx", "export const A = 1\n")
+
+	// The push fails (no origin in a temp repo) — irrelevant here, the commit is
+	// built first and the commit is what a pull request shows. A refusal to
+	// commit at all would be a different error, so guard against that one.
+	if err := Publish(PublishDeps{RepoDir: repo}, "autosave"); err != nil {
+		var blocked *PublishBlockedError
+		if errors.As(err, &blocked) {
+			t.Fatalf("feature branch refused as protected: %v", err)
+		}
+	}
+	changed := gitIn(t, repo, "show", "--name-only", "--format=", "HEAD")
+	if strings.Contains(changed, "static/tailwind.css") {
+		t.Fatalf("publish committed the artifact:\n%s", changed)
+	}
+	if !strings.Contains(changed, "src/app.tsx") {
+		t.Fatalf("publish dropped the real change:\n%s", changed)
+	}
+}
+
+func TestInstallSandboxHooksWritesTheArtifactList(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature/x")
+	if err := InstallSandboxHooks(repo); err != nil {
+		t.Fatal(err)
+	}
+	hook := filepath.Join(repo, ".git", "hooks", "pre-commit")
+	st, err := os.Stat(hook)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Mode().Perm()&0o111 == 0 {
+		t.Fatal("pre-commit hook is not executable")
+	}
+	// Without the data file the hook exits 0 and silently guards nothing.
+	list, err := os.ReadFile(filepath.Join(repo, ".git", "hooks", "build-artifacts"))
+	if err != nil {
+		t.Fatal("hook has no artifact list to read — it would guard nothing")
+	}
+	if string(list) != strings.Join(BuildArtifacts, "\n")+"\n" {
+		t.Fatalf("artifact list: got %q", list)
+	}
+}
+
+func read(t *testing.T, repo, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(repo, rel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/packages/sandbox/daemon-go/internal/gitx/checkout.go
+++ b/packages/sandbox/daemon-go/internal/gitx/checkout.go
@@ -130,7 +130,37 @@ func ProtectedBranches(repoDir string) []string {
 	return out
 }
 
-func InstallProtectedBranchHook(repoDir string) error {
+// Same shape as the pre-push hook above: the path list is a data file, never
+// interpolated into the script.
+//
+// This exists because the agent commits through Bash (`git add -A && git
+// commit`), which no daemon-side publish filter can see. One deco site's
+// `deno task dev` rewrote its tracked, compiled `static/tailwind.css` in
+// minified form; an agent's `git add -A` swallowed it; and because every
+// thread's synthetic branch descends from the last one, EVERY later pull
+// request on that repo carried the same 30k-line reformat — and later runs
+// spent turns proving it wasn't theirs before reverting it.
+//
+// Unstaging (rather than failing the commit) is deliberate: the artifact is
+// never what the agent meant to commit, so there is nothing for it to fix, and
+// a hard failure would just cost a turn. If the artifact was the ONLY staged
+// change, git then reports "no changes added to commit", which is the correct
+// answer to that commit.
+const buildArtifactHook = `#!/bin/sh
+artifacts="$(dirname "$0")/build-artifacts"
+[ -f "$artifacts" ] || exit 0
+while IFS= read -r p; do
+  [ -n "$p" ] || continue
+  git restore --staged -- "$p" 2>/dev/null || true
+done < "$artifacts"
+exit 0
+`
+
+// InstallSandboxHooks writes the local-only git hooks a sandbox checkout needs:
+// pre-push branch protection and pre-commit build-artifact unstaging. Called
+// again after any install step, whose scripts (lefthook, husky postinstall)
+// overwrite `.git/hooks`.
+func InstallSandboxHooks(repoDir string) error {
 	hooksDir := filepath.Join(repoDir, ".git", "hooks")
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
 		return err
@@ -139,7 +169,14 @@ func InstallProtectedBranchHook(repoDir string) error {
 		return err
 	}
 	list := strings.Join(ProtectedBranches(repoDir), "\n") + "\n"
-	return os.WriteFile(filepath.Join(hooksDir, "protected-branches"), []byte(list), 0o644)
+	if err := os.WriteFile(filepath.Join(hooksDir, "protected-branches"), []byte(list), 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(hooksDir, "pre-commit"), []byte(buildArtifactHook), 0o755); err != nil {
+		return err
+	}
+	artifacts := strings.Join(BuildArtifacts, "\n") + "\n"
+	return os.WriteFile(filepath.Join(hooksDir, "build-artifacts"), []byte(artifacts), 0o644)
 }
 
 func ConfigureGitIdentity(repoDir, userName, userEmail string) error {

--- a/packages/sandbox/daemon-go/internal/gitx/publish.go
+++ b/packages/sandbox/daemon-go/internal/gitx/publish.go
@@ -107,6 +107,23 @@ func changedPaths(status WorkingTreeStatus) []string {
 // run's MCP bearer token, which a push would leak into the repo's history.
 var NeverCommit = []string{".deco/tools/"}
 
+// BuildArtifacts are generated files some repos track anyway. A sandbox must
+// never commit one: it holds a DEV build (a `deno task dev` writes minified
+// Tailwind where the repo tracks the expanded release build), so committing it
+// is a large, meaningless reformat that every descendant branch then inherits.
+//
+// A repo tracking its own build output is the underlying bug, and gitignoring
+// it there is the real fix — this is the sandbox-side belt so no run makes it
+// worse in the meantime. Named paths, not patterns: a pattern would eventually
+// swallow something a user meant to commit.
+//
+// Note `.deco/metadata/` (a generated manifest), NOT `.deco/blocks/` — those
+// are decofile content and the whole point of many changes.
+var BuildArtifacts = []string{
+	"static/tailwind.css",
+	".deco/metadata/",
+}
+
 // dotenvName reports whether a file name is a `.env` variant — `.env` itself or
 // `.env.<anything>` (`.env.local`, `.env.production`). NOT `.envrc`, which repos
 // commit on purpose.
@@ -134,6 +151,14 @@ func dropNeverCommit(paths []string) []string {
 		for _, deny := range NeverCommit {
 			if rel == strings.TrimSuffix(deny, "/") || strings.HasPrefix(rel, deny) {
 				reason = "daemon-managed path"
+				break
+			}
+		}
+		// The pre-commit hook covers the agent's own `git add -A`; publish
+		// pushes with --no-verify, so it needs the same list in code.
+		for _, deny := range BuildArtifacts {
+			if rel == strings.TrimSuffix(deny, "/") || strings.HasPrefix(rel, deny) {
+				reason = "generated build artifact"
 				break
 			}
 		}

--- a/packages/sandbox/daemon-go/internal/gitx/publish_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/publish_test.go
@@ -53,9 +53,9 @@ func TestPublishRefusesProtectedBranch(t *testing.T) {
 	}
 }
 
-func TestInstallProtectedBranchHookWritesTheBranchList(t *testing.T) {
+func TestInstallSandboxHooksWritesTheBranchList(t *testing.T) {
 	repo := initRepoOnBranch(t, "feature/x")
-	if err := InstallProtectedBranchHook(repo); err != nil {
+	if err := InstallSandboxHooks(repo); err != nil {
 		t.Fatal(err)
 	}
 	hook := filepath.Join(repo, ".git", "hooks", "pre-push")

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -637,10 +637,11 @@ func (o *Orchestrator) stepInstallInner() bool {
 	o.mu.Unlock()
 
 	// Install scripts (postinstall/prepare — lefthook, husky) can overwrite
-	// .git/hooks/pre-push; reinstall so branch protection survives.
+	// .git/hooks; reinstall so branch protection and build-artifact unstaging
+	// survive.
 	if o.deps.RepoDir != "" {
-		if err := gitx.InstallProtectedBranchHook(o.deps.RepoDir); err != nil {
-			o.chunk(fmt.Sprintf("\r\n[orchestrator] warning: could not reinstall protected-branch hook: %s\r\n", err.Error()))
+		if err := gitx.InstallSandboxHooks(o.deps.RepoDir); err != nil {
+			o.chunk(fmt.Sprintf("\r\n[orchestrator] warning: could not reinstall sandbox git hooks: %s\r\n", err.Error()))
 		}
 	}
 
@@ -681,11 +682,11 @@ func (o *Orchestrator) relinkAfterGolden(cfg *config.Enriched, tier RestoreSourc
 		return
 	}
 	// The relink can run install scripts (postinstall/prepare — lefthook,
-	// husky), which overwrite .git/hooks/pre-push; reinstall so branch
-	// protection survives, same as the full-install path.
+	// husky), which overwrite .git/hooks; reinstall them, same as the
+	// full-install path.
 	if o.deps.RepoDir != "" {
-		if err := gitx.InstallProtectedBranchHook(o.deps.RepoDir); err != nil {
-			o.chunk(fmt.Sprintf("\r\n[orchestrator] warning: could not reinstall protected-branch hook: %s\r\n", err.Error()))
+		if err := gitx.InstallSandboxHooks(o.deps.RepoDir); err != nil {
+			o.chunk(fmt.Sprintf("\r\n[orchestrator] warning: could not reinstall sandbox git hooks: %s\r\n", err.Error()))
 		}
 	}
 }
@@ -857,8 +858,8 @@ func (o *Orchestrator) gitSetup(cfg *config.Enriched) {
 			o.chunk(fmt.Sprintf("\r\n[orchestrator] warning: git identity setup failed: %s\r\n", err.Error()))
 		}
 	}
-	if err := gitx.InstallProtectedBranchHook(o.deps.RepoDir); err != nil {
-		o.chunk(fmt.Sprintf("\r\n[orchestrator] warning: could not install protected-branch hook: %s\r\n", err.Error()))
+	if err := gitx.InstallSandboxHooks(o.deps.RepoDir); err != nil {
+		o.chunk(fmt.Sprintf("\r\n[orchestrator] warning: could not install sandbox git hooks: %s\r\n", err.Error()))
 	}
 	branch := cfg.Branch()
 	if branch != "" && !config.IsSyntheticBranch(branch) {


### PR DESCRIPTION
## Problem

Some repos track their own compiled output. A deco site tracks the **expanded** release build of `static/tailwind.css`; `deno task dev` rewrites it **minified**. An agent's own `git add -A && git commit` swallowed that, and because every thread's synthetic branch descends from the last one, every later PR on the repo inherited the same reformat:

```
$ git diff origin/main...HEAD --stat -- static/tailwind.css
 static/tailwind.css | 30443 +------------------------------------
 1 file changed, 1 insertion(+), 30442 deletions(-)

$ git log --oneline origin/main..HEAD -- static/tailwind.css
306bad69 fix(seo): let the page-level SEO V2 block override the site-wide tags
```

`origin/main`: 625,700 bytes / 30,442 lines. `HEAD`: 463,215 bytes / **1 line**.

On one production board, **18 of 23** agent-worked cards spent turns on this — and **13 of them never started a dev server at all**. They inherited it. One card spent 10 commands forensically proving the minification came from a previous run rather than its own change. Another eventually invented the workaround inline:

```bash
git add -A -- $(git status --short | awk '{print $2}' | grep -v tailwind.css)
```

## Fix

Two halves, because there are two committers:

1. **A `pre-commit` hook** covers the agent, which commits through Bash where no daemon-side publish filter can see it. Mirrors the existing `pre-push` protected-branch hook exactly, including keeping the path list as a data file rather than interpolating it into the script.
2. **The same list in `dropNeverCommit`**, since publish pushes `--no-verify` and skips hooks — the same reason `ProtectedBranches` is already shared between the hook and an in-code guard.

Two deliberate choices:

- **Unstages rather than fails.** The artifact is never what the agent meant to commit, so there's nothing for it to fix and a hard failure would just cost a turn. If it was the only staged change, git reports "no changes added to commit", which is the correct answer to that commit.
- **Leaves the working tree alone**, so a running dev server isn't yanked out from under itself.

**Named paths, not patterns** — a pattern would eventually swallow something a user meant to commit. `.deco/metadata/` (generated manifest) is in; `.deco/blocks/` (decofile content, and the point of many changes) is deliberately not, and there's a test pinning that.

`InstallProtectedBranchHook` → `InstallSandboxHooks`: it installs two hooks now, and all three call sites already wanted both (including the reinstall-after-install-scripts paths, since lefthook/husky postinstall overwrite `.git/hooks`).

## Scope — this is a belt, not the real fix

A repo tracking its own build output is the underlying bug, and gitignoring it in the site repo is the actual fix. This stops any sandbox making it worse in the meantime, for every repo, without needing per-repo hygiene. **It does not clean up the artifact already on those branches** — that's a separate one-time commit in `deco-sites/osklenbr` and `deco-sites/osklenus`.

## Testing

`go test ./...` in `packages/sandbox/daemon-go` — all pass. Four new tests in `internal/gitx/buildartifacts_test.go`, asserting on the **committed tree** rather than the index (the tree is what a PR shows):

- the artifact stays out of the agent's `git add -A` commit, while the real change goes in, and the working tree is untouched
- `.deco/blocks/site.json` still commits normally
- publish drops it too (the `--no-verify` path)
- the hook is executable and its data file is actually written — without it the hook exits 0 and silently guards nothing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents sandbox commits from including a repo's generated build artifacts, which were silently reformatting tracked files like `static/tailwind.css` and polluting every descendant branch with the resulting diff.

- Adds a `pre-commit` hook that unstages `static/tailwind.css` and `.deco/metadata/` from the agent's `git add -A` commit, leaving the working tree untouched.
- Mirrors that list in publish's path filter because publish pushes with `--no-verify` and skips hooks.
- Uses named paths, not patterns, so `.deco/blocks/` decofile content stays committable.
- Renames `InstallProtectedBranchHook` to `InstallSandboxHooks` and re-runs it after install scripts overwrite `.git/hooks`.
- Adds tests asserting on the committed tree, not just the index.
- Does not clean up artifacts already committed on branches; gitignoring tracked build output in the site repo is the real fix.

<sup>Written for commit 6e5750893c97dc8cacbfaa808515b4a7b620aab1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

