### PR TITLE
feat(branch-picker): pick or create a branch from a chat with messages

### DIFF
--- a/apps/web/src/components/chat/pills/branch-pill.tsx
+++ b/apps/web/src/components/chat/pills/branch-pill.tsx
@@ -1,12 +1,4 @@
 import type { SandboxMap } from "@/sdk";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@decocms/ui/components/tooltip.tsx";
-import { cn } from "@decocms/ui/lib/utils.ts";
-import { GitBranch01 } from "@untitledui/icons";
-import { useT } from "@/i18n/use-t.ts";
 import { BranchPicker } from "../../thread/github/branch-picker";
 
 interface Props {
@@ -26,52 +18,15 @@ interface Props {
   placement?: "chat" | "header";
 }
 
-/**
- * Thin wrapper over `BranchPicker` that maps the chat-level `locked`
- * flag onto the picker's `disabled` prop. The picker still renders its
- * Button + Tooltip when disabled — the user just can't open the
- * popover.
- *
- * When `locked` is true (chat has messages or is a thread-locked thread)
- * we replace the picker with a non-clickable lock chip so the user can
- * see the active branch without being able to change it.
- */
+/** Thin wrapper over `BranchPicker`: a `locked` chat has a fixed branch, so any
+ *  pick/create opens a new chat on it instead of switching (`spawnsNewChat`). */
 export function BranchPill({ locked, placement, value, ...props }: Props) {
-  const t = useT();
-  const isHeader = placement === "header";
-
-  if (locked) {
-    const branchLabel = value ?? t("chat.branchPill.noBranch");
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            data-testid="branch-picker-locked"
-            aria-disabled="true"
-            className={cn(
-              "inline-flex items-center gap-1.5 rounded-md font-mono text-xs",
-              "text-muted-foreground cursor-default min-w-0 max-w-[200px]",
-              isHeader
-                ? "h-8 border border-input bg-background px-2.5"
-                : "h-9 px-2",
-            )}
-          >
-            <GitBranch01 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-            {/* Show the branch (truncated); below 768px of panel header collapse
-                to an icon-only chip — the name stays available via the tooltip.
-                Container query on `@container/panel-header`, matching the rest
-                of the strip (see header-actions). */}
-            <span className="min-w-0 truncate @max-3xl/panel-header:hidden">
-              {branchLabel}
-            </span>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>
-          {t("chat.branchPill.lockedTooltip", { branch: branchLabel })}
-        </TooltipContent>
-      </Tooltip>
-    );
-  }
-
-  return <BranchPicker {...props} value={value} placement={placement} />;
+  return (
+    <BranchPicker
+      {...props}
+      value={value}
+      placement={placement}
+      spawnsNewChat={locked}
+    />
+  );
 }

--- a/apps/web/src/components/chat/pills/chat-mode-row.test.tsx
+++ b/apps/web/src/components/chat/pills/chat-mode-row.test.tsx
@@ -10,7 +10,14 @@ import type { ReactNode } from "react";
 // network/hook dependencies. The mock just renders a plain <button>
 // so tests can assert the unlocked path forwards to BranchPicker.
 mock.module("../../thread/github/branch-picker", () => ({
-  BranchPicker: () => <button type="button">branch-picker</button>,
+  BranchPicker: ({ spawnsNewChat }: { spawnsNewChat?: boolean }) => (
+    <button
+      type="button"
+      data-spawns-new-chat={spawnsNewChat ? "true" : "false"}
+    >
+      branch-picker
+    </button>
+  ),
 }));
 
 import { ChatModeRowPure } from "./chat-mode-row";
@@ -58,17 +65,20 @@ const BRANCH_PILL_PROPS = {
 } as const;
 
 describe("BranchPill", () => {
-  it("renders the lock chip when locked=true", () => {
-    const { getByTestId } = renderWithQueryClient(
+  it("opens picks/creates in a new chat when locked=true", () => {
+    const { getByRole } = renderWithQueryClient(
       <BranchPill {...BRANCH_PILL_PROPS} locked={true} />,
     );
-    expect(getByTestId("branch-picker-locked")).toBeInTheDocument();
+    expect(getByRole("button")).toHaveAttribute("data-spawns-new-chat", "true");
   });
 
-  it("renders BranchPicker (a button) when locked=false", () => {
+  it("switches in place when locked=false", () => {
     const { getByRole } = renderWithQueryClient(
       <BranchPill {...BRANCH_PILL_PROPS} locked={false} />,
     );
-    expect(getByRole("button")).toBeInTheDocument();
+    expect(getByRole("button")).toHaveAttribute(
+      "data-spawns-new-chat",
+      "false",
+    );
   });
 });

--- a/apps/web/src/components/chat/pills/chat-mode-row.tsx
+++ b/apps/web/src/components/chat/pills/chat-mode-row.tsx
@@ -83,10 +83,16 @@ export function ChatModeRow({ virtualMcp, currentBranch }: SmartProps) {
         sandboxMap={virtualMcp?.metadata?.sandboxMap}
         value={currentBranch}
         onChange={(next) => {
-          if (setCurrentTaskBranch) void setCurrentTaskBranch(next);
+          // Locked chat's branch is fixed: open a new chat on the picked branch.
+          if (locked && createTask) {
+            createTask({ branch: next });
+          } else if (setCurrentTaskBranch) {
+            void setCurrentTaskBranch(next);
+          }
         }}
         onCreateBranch={(next) => {
-          if (createBranchAsCms && createTask) {
+          // Locked or CMS→sandbox: branch off into a fresh thread, don't re-point.
+          if ((locked || createBranchAsCms) && createTask) {
             createTask({ branch: next });
           } else if (setCurrentTaskBranch) {
             void setCurrentTaskBranch(next);

--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -60,6 +60,10 @@ interface Props {
   /** When true, the trigger is disabled — the user can't open the
    *  picker. The tooltip still surfaces the current branch on hover. */
   disabled?: boolean;
+  /** When true, selecting or creating a branch opens a *new* chat on it rather
+   *  than switching in place — the current thread's branch is fixed (its chat
+   *  has messages). Surfaces a hint so the new-chat behavior isn't surprising. */
+  spawnsNewChat?: boolean;
   /** Chat input uses responsive label collapse; header always shows the name. */
   placement?: "chat" | "header";
 }
@@ -86,6 +90,7 @@ export function BranchPicker({
   onChange,
   onCreateBranch,
   disabled = false,
+  spawnsNewChat = false,
   placement = "chat",
 }: Props) {
   const t = useT();
@@ -268,6 +273,11 @@ export function BranchPicker({
               </Button>
             )}
           </div>
+          {spawnsNewChat && (
+            <p className="px-3 py-2 text-xs text-muted-foreground">
+              {t("thread.branchPicker.newChatHint")}
+            </p>
+          )}
           <Tabs
             className="px-2 pt-2 pb-1"
             value={tab}

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -35,9 +35,6 @@ export const chat = {
   "chat.assistant.resumedBackgroundTask": "Resumed — background task completed",
   "chat.assistant.resumingTask": "Resuming task...",
   "chat.assistant.toolCallPlural": "{count} tool call(s)",
-  "chat.branchPill.lockedTooltip":
-    "This chat is using branch {branch}. Start a new chat to use a different branch.",
-  "chat.branchPill.noBranch": "(no branch)",
   "chat.brandContext.brand": "Brand",
   "chat.brandContext.brandContextSet": "Brand context set",
   "chat.brandContext.brandSet": "Brand set: {name}",

--- a/apps/web/src/i18n/en/thread.ts
+++ b/apps/web/src/i18n/en/thread.ts
@@ -6,6 +6,8 @@ export const thread = {
   "thread.branchPicker.couldntLoadPullRequests":
     "Couldn't load pull requests from GitHub.",
   "thread.branchPicker.createBranch": 'Create "{name}"',
+  "thread.branchPicker.newChatHint":
+    "This chat's branch is fixed. Picking or creating a branch opens a new chat on it.",
   "thread.branchPicker.hiddenForkPrs":
     "{count} PR(s) from forks hidden — open on a branch in this repo",
   "thread.branchPicker.last7Days": "Last 7 days",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -39,9 +39,6 @@ export const chat = {
     "Retomado — tarefa em segundo plano concluída",
   "chat.assistant.resumingTask": "Retomando tarefa...",
   "chat.assistant.toolCallPlural": "{count} chamada(s) de ferramenta",
-  "chat.branchPill.lockedTooltip":
-    "Este chat está usando a branch {branch}. Inicie um novo chat para usar uma branch diferente.",
-  "chat.branchPill.noBranch": "(sem branch)",
   "chat.brandContext.brand": "Marca",
   "chat.brandContext.brandContextSet": "Contexto de marca definido",
   "chat.brandContext.brandSet": "Marca definida: {name}",

--- a/apps/web/src/i18n/pt-br/thread.ts
+++ b/apps/web/src/i18n/pt-br/thread.ts
@@ -8,6 +8,8 @@ export const thread = {
   "thread.branchPicker.couldntLoadPullRequests":
     "Não foi possível carregar pull requests do GitHub.",
   "thread.branchPicker.createBranch": 'Criar "{name}"',
+  "thread.branchPicker.newChatHint":
+    "A branch deste chat é fixa. Escolher ou criar uma branch abre um chat novo nela.",
   "thread.branchPicker.hiddenForkPrs":
     "{count} PR(s) de forks ocultado(s) — abra em uma branch deste repositório",
   "thread.branchPicker.last7Days": "Últimos 7 dias",


### PR DESCRIPTION
## Summary

Creating (or switching to) a branch used to require an **empty chat**. Once a chat had messages, the branch pill collapsed into a non-clickable lock chip, so the only way to start a new branch was to open a fresh empty chat first — the annoyance this fixes.

The lock exists for a real reason: a thread's runtime/branch is fixed once the conversation starts, so you can't re-point an in-flight thread's branch. But **starting a new chat on another branch** is always valid.

So now, in a chat that already has messages, the branch pill shows the **full picker** (branch list + PRs + create), and **any choice opens a new chat on the chosen branch** — picking an existing branch, opening a PR, or creating a new one. The current conversation is left untouched. A one-line hint in the popover makes the new-chat behavior explicit. Empty chats are unchanged (switch/create in place).

## Changes

- `branch-picker.tsx` — new `spawnsNewChat` prop: keeps the full picker but surfaces a hint that a selection opens a new chat.
- `branch-pill.tsx` — when `locked`, renders the picker with `spawnsNewChat` instead of the dead lock chip.
- `chat-mode-row.tsx` — when locked, both `onChange` (switch) and `onCreateBranch` (create) route through `createTask({ branch })` (new thread); empty chats still use `setCurrentTaskBranch` (in place).
- i18n — added `thread.branchPicker.newChatHint` (en + pt-br); removed the now-orphaned `chat.branchPill.lockedTooltip` / `noBranch` keys.
- `chat-mode-row.test.tsx` — inverted the old "renders lock chip when locked" assertion to the new `spawnsNewChat` behavior.

## Testing

- `bun test apps/web/src/components/chat/pills/chat-mode-row.test.tsx` — 4 pass
- `bun run --cwd=apps/web check` (tsc) — clean
- `bun run fmt` — no changes · `bun run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets a chat that already has messages pick or create a branch instead of showing a dead lock chip, which previously forced opening a fresh empty chat. Any selection now opens a new chat on the chosen branch; the current conversation is left untouched.

- Locked chats route branch picks and creates through `createTask` (new thread), while empty chats still switch in place.
- The picker shows a hint explaining the new-chat behavior; the old locked-tooltip and no-branch strings were removed.

<sup>Written for commit 230803c7c2ecc8e798d4c882ef045f3e52856f8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

