### PR TITLE
Potential fix for code scanning alert no. 1: Inefficient regular expression

### DIFF
--- a/apps/web/src/views/registry/registry-item-dialog.tsx
+++ b/apps/web/src/views/registry/registry-item-dialog.tsx
@@ -64,7 +64,7 @@ interface RegistryItemDialogProps {
 }
 
 const REMOTE_TYPES = new Set(["http", "sse", "stdio"]);
-const ID_PATTERN = /^[a-z0-9]+(?:[/-][a-z0-9._-]+)*$/;
+const ID_PATTERN = /^[a-z0-9]+(?:[/-][a-z0-9._]+)*$/;
 const DEFAULT_TAGS = [
   "internal",
   "automation",


### PR DESCRIPTION
Potential fix for [https://github.com/decocms/studio/security/code-scanning/1](https://github.com/decocms/studio/security/code-scanning/1)

To fix this safely, make the repeated segment unambiguous by ensuring the separator (`/` or `-`) is consumed only by `[/-]` and not also by the following character class.  
Concretely, in `apps/web/src/views/registry/registry-item-dialog.tsx` line 67 region, change:

- from: `^[a-z0-9]+(?:[/-][a-z0-9._-]+)*$`
- to: `^[a-z0-9]+(?:[/-][a-z0-9._]+)*$`

This preserves existing functionality for typical IDs (alphanumerics, dots, underscores, with `/` or `-` as segment separators) while removing the ambiguous double-consumption of `-` that causes pathological backtracking. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the inefficient `ID_PATTERN` regex in `apps/web/src/views/registry/registry-item-dialog.tsx` that triggered a code scanning alert. The pattern now consumes `-` only as a segment separator instead of also inside segments, removing ambiguous backtracking while preserving validation for typical IDs.

<sup>Written for commit 57e3020111d784090322cc19da12d18ed0bf151f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

