### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete multi-character sanitization

### DIFF
--- a/apps/web/src/components/sections-editor/array-item-display.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.ts
@@ -94,7 +94,13 @@ export function renderMustacheTemplate(
 
 /** Strip HTML tags to extract the text content (e.g. `<h1>Title</h1>` → `Title`). */
 function stripHtmlTags(html: string): string {
-  return html.replace(/<[^>]*>/g, "").trim();
+  let previous: string;
+  let current = html;
+  do {
+    previous = current;
+    current = current.replace(/<[^>]*>/g, "");
+  } while (current !== previous);
+  return current.trim();
 }
 
 /** Drop Mustache tokens from a title, leaving only its static text


### PR DESCRIPTION
Potential fix for [https://github.com/decocms/studio/security/code-scanning/11](https://github.com/decocms/studio/security/code-scanning/11)

Use an iterative replacement strategy so tag-like patterns are removed repeatedly until the string stabilizes. This addresses the incomplete multi-character sanitization class without changing the function’s intent (extract text from HTML-ish input).

Best targeted fix in `apps/web/src/components/sections-editor/array-item-display.ts`:
- Update `stripHtmlTags` (lines around 95–98) to loop `replace(/<[^>]*>/g, "")` until no further changes occur.
- Keep the existing trimming behavior.
- No new imports or dependencies are required.

This preserves current functionality (strip tags, normalize by trim) while preventing one-pass bypasses where unsafe fragments reappear after a single replacement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the code scanning alert for incomplete multi-character sanitization in `stripHtmlTags` so tag-like patterns that reappear after a single replacement are fully removed.

- Runs the tag-stripping regex repeatedly until the string stabilizes.
- Keeps the existing trim behavior and requires no new dependencies.

<sup>Written for commit 6494383a4607a0e8ec50612ab86f506530a9bb72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

