### PR TITLE
fix(task-board): name lanes after the board's columns, not Studio's

### DIFF
--- a/apps/web/src/hooks/use-task-board-items.ts
+++ b/apps/web/src/hooks/use-task-board-items.ts
@@ -55,6 +55,29 @@ export function useBoardSprintIndex(): Map<string, Sprint> {
   return new Map((data?.sprints ?? []).map((sprint) => [sprint.id, sprint]));
 }
 
+/**
+ * The board's columns, read from the same cached list the board loads.
+ *
+ * Exists for the reason `useBoardSprintIndex` does: `useTaskBoardItems` also
+ * opens the board's SSE subscriptions, and a dialog that only needs to know
+ * which lanes this board HAS should not pay for a stream per render.
+ */
+export function useBoardColumns(): TaskBoardData["columns"] {
+  const { locator } = useProjectContext();
+  const studio = useStudioTools();
+  const { data } = useQuery({
+    queryKey: KEYS.taskBoardItems(locator),
+    queryFn: async (): Promise<TaskBoardData> => {
+      const { items, sprints, columns } = await studio.call(
+        "TASK_BOARD_ITEM_LIST",
+        {},
+      );
+      return { items, sprints, columns };
+    },
+  });
+  return data?.columns ?? [];
+}
+
 export function useTaskBoardItems() {
   const { org, locator } = useProjectContext();
   const studio = useStudioTools();

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -47,6 +47,9 @@ export const taskBoard = {
   "taskBoard.taskBoard.selectAllInLane": "Select all",
   "taskBoard.taskBoard.hideColumn": "Hide",
   "taskBoard.taskBoard.hiddenColumns": "Hidden columns",
+  "taskBoard.taskBoard.offBoardLaneBadge": "off board",
+  "taskBoard.taskBoard.offBoardLaneTooltip":
+    "No column on this board is “{status}”. These cards are shown here so they aren\u2019t lost — move them to a column to file them.",
   "taskBoard.taskBoard.showColumn": "Show",
   "taskBoard.taskBoard.selectedCount": "{count} selected",
   "taskBoard.taskBoard.clearSelectionButton": "Clear",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -51,6 +51,9 @@ export const taskBoard = {
   "taskBoard.taskBoard.selectAllInLane": "Selecionar todos",
   "taskBoard.taskBoard.hideColumn": "Ocultar",
   "taskBoard.taskBoard.hiddenColumns": "Colunas ocultas",
+  "taskBoard.taskBoard.offBoardLaneBadge": "fora do board",
+  "taskBoard.taskBoard.offBoardLaneTooltip":
+    "Nenhuma coluna deste board \u00e9 \u201c{status}\u201d. Estes cards aparecem aqui para n\u00e3o se perderem \u2014 mova-os para uma coluna.",
   "taskBoard.taskBoard.showColumn": "Mostrar",
   "taskBoard.taskBoard.selectedCount": "{count} selecionado(s)",
   "taskBoard.taskBoard.clearSelectionButton": "Limpar",

--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -1,19 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
+import {
+  CANONICAL_COLUMN_KEYS,
+  SUPER_AGENT_ASSIGNEE_ID,
+} from "@decocms/shared/task-board";
 import {
   agentRunState,
   cardNeedsAttention,
+  dropLane,
   dueDateUrgency,
   formatSprintDates,
   insertSortOrder,
   isFeedWorthyActivity,
   isLiveAttempt,
   isTaskHandedToHuman,
+  laneHeader,
   laneVisibility,
+  laneVisual,
   moveTargets,
   runSortOrders,
   statusIconClassName,
-  STATUSES,
 } from "./config";
 import type { TaskBoardItem } from "./config";
 
@@ -47,7 +52,15 @@ function item(id: string, sortOrder: number): TaskBoardItem {
 }
 
 /** The board Studio ships with, in the shape the server sends it. */
-const CANONICAL = STATUSES.map((key) => ({ key }));
+const column = (key: string, position: number) => ({
+  key,
+  title: key,
+  position,
+  role: null,
+});
+const STATUSES: string[] = [...CANONICAL_COLUMN_KEYS];
+const CANONICAL_COLUMNS = STATUSES.map(column);
+const CANONICAL = CANONICAL_COLUMNS;
 
 describe("insertSortOrder", () => {
   const lane = [item("a", 0), item("b", 10), item("c", 20)];
@@ -288,7 +301,7 @@ describe("cardNeedsAttention", () => {
 
 describe("moveTargets", () => {
   test("offers no delivery lane to a board that doesn't run them", () => {
-    expect(moveTargets(false)).toEqual([
+    expect(moveTargets(CANONICAL_COLUMNS, false)).toEqual([
       "triage",
       "todo",
       "in_progress",
@@ -299,7 +312,89 @@ describe("moveTargets", () => {
   });
 
   test("offers every lane once they're on", () => {
-    expect(moveTargets(true)).toEqual(STATUSES);
+    expect(moveTargets(CANONICAL_COLUMNS, true)).toEqual(STATUSES);
+  });
+
+  /**
+   * The menu used to be Studio's lanes whoever's board it was, so on a
+   * mirrored board every entry named a column that does not exist and the
+   * server rejected the write — a list of ways to fail.
+   */
+  test("offers the org's own columns on a board Studio doesn't define", () => {
+    expect(
+      moveTargets(
+        [column("BACKLOG", 0), column("Fazendo", 1), column("Code Review", 2)],
+        false,
+      ),
+    ).toEqual(["BACKLOG", "Fazendo", "Code Review"]);
+  });
+});
+
+describe("dropLane", () => {
+  const columnKeys = new Set(["BACKLOG", "Fazendo"]);
+  const statusOf = (id: string) =>
+    ({ card_in_column: "Fazendo", card_off_board: "triage" })[id];
+  const over = (overId: string | undefined) =>
+    dropLane({ overId, columnKeys, statusOf });
+
+  /**
+   * The bug: this was matched against Studio's canonical statuses, which on a
+   * mirrored board match no column at all — so dragging a card into an empty
+   * Jira column resolved to null and the card sprang back.
+   */
+  test("lands a drag in an empty column of the org's own", () => {
+    expect(over("lane:Fazendo")).toBe("Fazendo");
+  });
+
+  test("lands a drag on a card, in that card's column", () => {
+    expect(over("card_in_column")).toBe("Fazendo");
+  });
+
+  /** Both ways of being over an off-board lane are the same illegal landing:
+   *  it is not a column, and the server rejects the write either way. */
+  test("refuses an off-board lane, hovered directly or through its card", () => {
+    expect(over("lane:triage")).toBeNull();
+    expect(over("card_off_board")).toBeNull();
+  });
+
+  test("refuses a card it has never heard of, and no target at all", () => {
+    expect(over("card_that_left")).toBeNull();
+    expect(over(undefined)).toBeNull();
+  });
+});
+
+describe("laneHeader", () => {
+  const t = ((key: string) => `t:${key}`) as never;
+
+  test("calls a mirrored column whatever its tracker calls it", () => {
+    expect(
+      laneHeader("Fazendo", t, [
+        { key: "Fazendo", title: "Em Progresso", position: 0, role: null },
+      ]).label,
+    ).toBe("Em Progresso");
+  });
+
+  /** Studio's own columns carry their key as the title, because the client is
+   *  the only side that knows the reader's language. */
+  test("translates a column of Studio's own", () => {
+    expect(laneHeader("in_progress", t, CANONICAL_COLUMNS).label).toBe(
+      "t:taskBoard.config.statusInProgress",
+    );
+  });
+
+  /**
+   * The bug this exists for: a `triage` card stranded on a mirrored board was
+   * labelled with OUR translation, so it rendered as a second "Backlog" beside
+   * the tracker's real one — a column nobody could act on, because it does not
+   * exist over there.
+   */
+  test("borrows neither our name nor our icon for a status off the board", () => {
+    const header = laneHeader("triage", t, [
+      { key: "BACKLOG", title: "BACKLOG", position: 0, role: null },
+    ]);
+    expect(header.offBoard).toBe(true);
+    expect(header.label).toBe("triage");
+    expect(header.visual).not.toBe(laneVisual("triage"));
   });
 });
 
@@ -314,7 +409,11 @@ describe("laneVisibility", () => {
    */
   test("draws the org's own columns, in the order the server sent them", () => {
     const { lanes, hidden, hideable } = laneVisibility({
-      columns: [{ key: "BACKLOG" }, { key: "Fazendo" }, { key: "Code Review" }],
+      columns: [
+        column("BACKLOG", 0),
+        column("Fazendo", 1),
+        column("Code Review", 2),
+      ],
       deliveryEnabled: false,
       shownLanes: shown,
       occupied: [],
@@ -332,8 +431,8 @@ describe("laneVisibility", () => {
    * hiding is the invisibility this exists to prevent.
    */
   test("gives a card the board cannot place a lane of its own", () => {
-    const { lanes, hidden, hideable } = laneVisibility({
-      columns: [{ key: "BACKLOG" }, { key: "Fazendo" }],
+    const { lanes, hidden, hideable, unplaced } = laneVisibility({
+      columns: [column("BACKLOG", 0), column("Fazendo", 1)],
       deliveryEnabled: false,
       shownLanes: shown,
       occupied: ["Fazendo", "triage", "done"],
@@ -341,12 +440,15 @@ describe("laneVisibility", () => {
     expect(lanes).toEqual(["BACKLOG", "Fazendo", "done", "triage"]);
     expect(hidden).toEqual([]);
     expect(hideable).toEqual([]);
+    // Reported apart from the columns: the board draws these as what they are
+    // and refuses drops into them, neither of which it could tell from `lanes`.
+    expect(unplaced).toEqual(["done", "triage"]);
   });
 
   test("the extra lane goes away once its last card leaves", () => {
     expect(
       laneVisibility({
-        columns: [{ key: "BACKLOG" }],
+        columns: [column("BACKLOG", 0)],
         deliveryEnabled: false,
         shownLanes: shown,
         occupied: [],
@@ -375,7 +477,7 @@ describe("laneVisibility", () => {
         shownLanes: shown,
         occupied: [],
       }),
-    ).toEqual({ lanes: [], hidden: [], hideable: [] });
+    ).toEqual({ lanes: [], hidden: [], hideable: [], unplaced: [] });
   });
 
   test("draws the delivery lanes as columns when they're on", () => {

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -1,4 +1,7 @@
-import type { CanonicalColumnKey } from "@decocms/shared/task-board";
+import type {
+  BoardColumn,
+  CanonicalColumnKey,
+} from "@decocms/shared/task-board";
 import {
   AlertCircle,
   AlertOctagon,
@@ -213,22 +216,10 @@ export type Member = {
   user?: { name?: string | null; image?: string | null };
 };
 
-export const STATUSES: TaskBoardItemStatus[] = [
-  "triage",
-  "todo",
-  "in_progress",
-  "in_review",
-  "approved",
-  "merged",
-  "post_deploy_validation",
-  "done",
-  "archived",
-];
-
 /**
  * Lanes that don't earn a board column by default — they sit collapsed under
- * "Hidden columns" until shown. They stay in `STATUSES`, so "Move to", drag
- * targets and status validation still know about them.
+ * "Hidden columns" until shown. They stay a column of the board, so "Move to",
+ * drag targets and status validation still know about them.
  */
 export const HIDDEN_STATUSES: string[] = ["archived"];
 
@@ -313,17 +304,47 @@ export function laneVisual(status: string): LaneVisual {
  * What to call a lane.
  *
  * Studio's own lanes are translated; a column mirrored from a tracker is
- * called whatever that tracker calls it, which is not ours to translate. Pass
- * `title` when the board read gave you one — callers without it get the raw
- * key, which is still the name the team uses.
+ * called whatever that tracker calls it, which is not ours to translate.
+ *
+ * Module-private on purpose: naming a lane requires knowing whether the board
+ * even HAS a column for it, and every caller that skipped that question got a
+ * canonical translation for a status the board could not place. Go through
+ * {@link laneHeader}.
  */
-export function laneLabel(
+function laneLabel(
   status: string,
   t: (key: TranslationKey) => string,
-  title?: string,
+  title: string,
 ): string {
   const known = STATUS_CONFIG[status as keyof typeof STATUS_CONFIG];
-  return known ? t(known.labelKey) : (title ?? status);
+  return known ? t(known.labelKey) : title;
+}
+
+/**
+ * How a lane reads on THIS board.
+ *
+ * A column the board owns is drawn with its own name and, when it is one of
+ * Studio's, our icon. A status no column accounts for gets neither: it is
+ * named by its raw key and drawn with the neutral visual, because borrowing
+ * ours is exactly what let an unplaceable card pass for a column somebody
+ * configured. A `triage` card stranded on a Jira board rendered as "Backlog" —
+ * a second one, next to the tracker's real Backlog, that nobody could act on
+ * because it does not exist over there.
+ */
+export function laneHeader(
+  status: string,
+  t: (key: TranslationKey) => string,
+  columns: readonly BoardColumn[],
+): { label: string; visual: LaneVisual; offBoard: boolean } {
+  const column = columns.find((c) => c.key === status);
+  if (!column) {
+    return { label: status, visual: UNKNOWN_LANE, offBoard: true };
+  }
+  return {
+    label: laneLabel(status, t, column.title),
+    visual: laneVisual(status),
+    offBoard: false,
+  };
 }
 
 export const TASK_TYPES: TaskBoardItemType[] = [
@@ -388,15 +409,21 @@ export function isDeliveryLane(status: string): boolean {
 }
 
 /**
- * Lanes a card may be MOVED to — "Move to", the status dropdown, drag targets.
- * With the delivery lanes off they aren't offered, so nobody can put a card
- * somewhere the org's state machine doesn't ship to. Rendering a lane's own
- * label is a separate question, always answered by `STATUS_CONFIG`.
+ * Lanes a card may be MOVED to — "Move to", the status dropdown.
+ *
+ * The board's own columns, not Studio's: on a board mirrored from a tracker
+ * every canonical lane is a column that does not exist, and the server rejects
+ * the write, so the menu was offering a list of ways to fail. With the delivery
+ * lanes off they aren't offered either, so nobody can put a card somewhere the
+ * org's state machine doesn't ship to.
  */
-export function moveTargets(deliveryEnabled: boolean): TaskBoardItemStatus[] {
-  return deliveryEnabled
-    ? STATUSES
-    : STATUSES.filter((s) => !isDeliveryLane(s));
+export function moveTargets(
+  columns: readonly BoardColumn[],
+  deliveryEnabled: boolean,
+): string[] {
+  return columns
+    .map((column) => column.key)
+    .filter((key) => deliveryEnabled || !isDeliveryLane(key));
 }
 
 /**
@@ -425,6 +452,10 @@ export function laneVisibility({
   lanes: string[];
   hidden: string[];
   hideable: string[];
+  /** Lanes that exist only because cards are stuck in them — see below. Kept
+   *  separate so the board can draw them as what they are, and refuse drops
+   *  into a lane that is not a column. */
+  unplaced: string[];
 } {
   const known = columns
     .map((column) => column.key)
@@ -450,7 +481,44 @@ export function laneVisibility({
     lanes: [...known.filter((s) => !hidden.includes(s)), ...unplaced],
     hidden,
     hideable,
+    unplaced,
   };
+}
+
+/** dnd-kit id prefix for a lane's own droppable — the empty space below the
+ *  last card. Anything else `over` reports is a card id. */
+export const LANE_DROPPABLE_PREFIX = "lane:";
+
+/**
+ * Where a drag currently sits, or null when it sits nowhere it may land.
+ *
+ * Two ways to be over a lane — its own droppable, or a card in it — and one
+ * rule over both: the landing has to be a column this board HAS.
+ *
+ * Both halves of that were wrong. The droppable was matched against Studio's
+ * canonical statuses, which on a board mirrored from a tracker match no column
+ * at all, so dragging into an empty column resolved to null and the card
+ * sprang back. And a card in an off-board lane resolved to that lane, which is
+ * not a column either — the server rejects the write, so the drop only looked
+ * like it worked until the list refetched.
+ */
+export function dropLane({
+  overId,
+  columnKeys,
+  statusOf,
+}: {
+  overId: string | number | undefined;
+  /** Keys of the board's own columns. */
+  columnKeys: ReadonlySet<string>;
+  /** A card's lane, by card id. */
+  statusOf: (cardId: string) => string | undefined;
+}): string | null {
+  if (overId === undefined) return null;
+  const id = String(overId);
+  const status = id.startsWith(LANE_DROPPABLE_PREFIX)
+    ? id.slice(LANE_DROPPABLE_PREFIX.length)
+    : statusOf(id);
+  return status !== undefined && columnKeys.has(status) ? status : null;
 }
 
 export const PRIORITIES: TaskBoardItemPriority[] = [

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -86,6 +86,7 @@ import { GitHubRepoPicker } from "@/components/github-repo-picker";
 import { useMembers } from "@/hooks/use-members";
 import {
   useTaskBoardItemActions,
+  useBoardColumns,
   useBoardSprintIndex,
   useTaskBoardItems,
 } from "@/hooks/use-task-board-items";
@@ -106,9 +107,10 @@ import {
   PRIORITY_CONFIG,
   runSortOrders,
   statusIconClassName,
-  laneLabel,
+  dropLane,
+  LANE_DROPPABLE_PREFIX,
+  laneHeader,
   laneVisual,
-  STATUSES,
   SUPER_AGENT_ASSIGNEE_ID,
   tagDotColor,
   TASK_TYPES,
@@ -122,6 +124,7 @@ import {
   useOrgFlag,
   useReviewerEnabled,
 } from "@/hooks/use-organization-settings";
+import type { BoardColumn } from "@decocms/shared/task-board";
 import type { Sprint } from "@decocms/shared/sprints";
 import { usePreferences } from "@/hooks/use-preferences";
 import {
@@ -1559,6 +1562,7 @@ function SelectionBar({
   const t = useT();
   const { data: orgTags = [] } = useTags();
   const deliveryEnabled = useOrgFlag("delivery_lanes_enabled");
+  const columns = useBoardColumns();
   return (
     <div className="pointer-events-none absolute inset-x-0 bottom-6 z-20 flex justify-center">
       <div className="pointer-events-auto flex items-center gap-2 rounded-full bg-background px-3 py-2 card-shadow">
@@ -1581,12 +1585,12 @@ function SelectionBar({
                 {t("taskBoard.taskBoard.moveToButton")}
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
-                {moveTargets(deliveryEnabled).map((status) => (
+                {moveTargets(columns, deliveryEnabled).map((status) => (
                   <DropdownMenuItem
                     key={status}
                     onClick={() => onMoveTo(status)}
                   >
-                    {laneLabel(status, t)}
+                    {laneHeader(status, t, columns).label}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuSubContent>
@@ -1727,9 +1731,6 @@ function LayoutToggle({
   );
 }
 
-/** Prefix for a lane's own droppable id, so it can't collide with a card id. */
-const LANE_DROPPABLE_PREFIX = "lane:";
-
 /** Where a card sits locally: while a drag is in flight, and then until the
  *  server's optimistic patch catches up. */
 interface Placement {
@@ -1768,7 +1769,7 @@ function Lanes({
   visible,
 }: {
   /** The board's own columns, as the server sent them. */
-  columns: readonly { key: string }[];
+  columns: readonly BoardColumn[];
   items: TaskBoardItem[];
   members: Member[];
   memberByUserId: Map<string, Member>;
@@ -1883,6 +1884,7 @@ function Lanes({
     lanes: boardLanes,
     hidden: hiddenLanes,
     hideable: hideableLanes,
+    unplaced: unplacedLanes,
   } = laneVisibility({
     columns,
     deliveryEnabled,
@@ -1897,18 +1899,18 @@ function Lanes({
         : prev.shownTaskBoardLanes.filter((s) => s !== status),
     }));
 
-  /** The lane a drop target belongs to: a lane's own droppable, or the lane of
-   *  the card being hovered. Resolved against `placed` rather than dnd-kit's
-   *  `over.data`, which is a ref and can't be read during render. */
-  const laneOf = (overId: string | number | undefined) => {
-    if (overId === undefined) return null;
-    const id = String(overId);
-    if (id.startsWith(LANE_DROPPABLE_PREFIX)) {
-      const status = id.slice(LANE_DROPPABLE_PREFIX.length);
-      return STATUSES.find((candidate) => candidate === status) ?? null;
-    }
-    return placed.find((item) => item.id === id)?.status ?? null;
-  };
+  /** The columns a drag may land in — the board's own, never an off-board
+   *  lane: a card can leave one, never be filed into one. */
+  const columnKeys = new Set(columns.map((column) => column.key));
+
+  /** Resolved against `placed` rather than dnd-kit's `over.data`, which is a
+   *  ref and can't be read during render. */
+  const laneOf = (overId: string | number | undefined) =>
+    dropLane({
+      overId,
+      columnKeys,
+      statusOf: (cardId) => placed.find((item) => item.id === cardId)?.status,
+    });
 
   // A card inside a multi-selection drags the whole selection, grabbed card
   // first so it leads the run and the others follow in order.
@@ -2041,6 +2043,8 @@ function Lanes({
             <Lane
               key={status}
               status={status}
+              columns={columns}
+              offBoard={unplacedLanes.includes(status)}
               items={laneItems(status)}
               members={members}
               memberByUserId={memberByUserId}
@@ -2072,6 +2076,7 @@ function Lanes({
           {hiddenLanes.length > 0 && (
             <HiddenLanes
               statuses={hiddenLanes}
+              columns={columns}
               countOf={(status) => laneItems(status).length}
               onShow={(status) => setLaneShown(status, true)}
             />
@@ -2127,10 +2132,12 @@ function Lanes({
  *  gives the collapse (closed by default) without any state of its own. */
 function HiddenLanes({
   statuses,
+  columns,
   countOf,
   onShow,
 }: {
   statuses: string[];
+  columns: readonly BoardColumn[];
   countOf: (status: string) => number;
   onShow: (status: string) => void;
 }) {
@@ -2146,8 +2153,8 @@ function HiddenLanes({
       </summary>
       <div className="flex flex-col gap-2 px-1 pt-1">
         {statuses.map((status) => {
-          const config = laneVisual(status);
-          const LaneIcon = config.icon;
+          const { label, visual } = laneHeader(status, t, columns);
+          const LaneIcon = visual.icon;
           return (
             <div
               key={status}
@@ -2156,10 +2163,10 @@ function HiddenLanes({
             >
               <LaneIcon
                 size={15}
-                className={cn("shrink-0", config.iconClassName)}
+                className={cn("shrink-0", visual.iconClassName)}
               />
               <span className="text-sm font-medium text-foreground">
-                {laneLabel(status, t)}
+                {label}
               </span>
               <span className="ml-auto text-[11px] font-medium text-muted-foreground">
                 {countOf(status)}
@@ -2169,7 +2176,7 @@ function HiddenLanes({
                   <button
                     type="button"
                     aria-label={t("taskBoard.taskBoard.laneMenuAriaLabel", {
-                      lane: laneLabel(status, t),
+                      lane: label,
                     })}
                     className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                   >
@@ -2192,6 +2199,8 @@ function HiddenLanes({
 
 function Lane({
   status,
+  columns,
+  offBoard,
   items,
   members,
   memberByUserId,
@@ -2212,6 +2221,11 @@ function Lane({
   onHide,
 }: {
   status: string;
+  /** The board's own columns — what gives this lane its name. */
+  columns: readonly BoardColumn[];
+  /** No column on this board accounts for this status; the lane exists only
+   *  because cards are sitting in it. */
+  offBoard: boolean;
   items: TaskBoardItem[];
   members: Member[];
   memberByUserId: Map<string, Member>;
@@ -2235,8 +2249,8 @@ function Lane({
   onHide?: () => void;
 }) {
   const t = useT();
-  const config = laneVisual(status);
-  const LaneIcon = config.icon;
+  const { label, visual } = laneHeader(status, t, columns);
+  const LaneIcon = visual.icon;
   // The lane's own droppable covers the empty space below the last card, so an
   // empty lane (and the area past the end of a short one) still takes a drop.
   const { setNodeRef } = useDroppable({
@@ -2271,21 +2285,27 @@ function Lane({
           size={15}
           className={cn(
             "shrink-0",
-            config.iconClassName.replace(/\banimate-\S+\b/g, "").trim(),
+            visual.iconClassName.replace(/\banimate-\S+\b/g, "").trim(),
           )}
         />
-        <span className="text-sm font-medium text-foreground">
-          {laneLabel(status, t)}
-        </span>
+        <span className="text-sm font-medium text-foreground">{label}</span>
         <span className="rounded-md bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
           {items.length}
         </span>
+        {offBoard && (
+          <span
+            className="rounded-md border border-border px-1.5 text-[11px] font-medium text-muted-foreground"
+            title={t("taskBoard.taskBoard.offBoardLaneTooltip", { status })}
+          >
+            {t("taskBoard.taskBoard.offBoardLaneBadge")}
+          </span>
+        )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button
               type="button"
               aria-label={t("taskBoard.taskBoard.laneMenuAriaLabel", {
-                lane: laneLabel(status, t),
+                lane: label,
               })}
               className="ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
@@ -2303,19 +2323,21 @@ function Lane({
             )}
           </DropdownMenuContent>
         </DropdownMenu>
-        <button
-          type="button"
-          aria-label={t("taskBoard.taskBoard.newTaskInLaneAriaLabel", {
-            lane: laneLabel(status, t),
-          })}
-          title={t("taskBoard.taskBoard.newTaskInLaneTitle", {
-            lane: laneLabel(status, t),
-          })}
-          onClick={() => onCreate(status)}
-          className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <Plus size={15} />
-        </button>
+        {/* No "new task here" off board: the lane is not a column, so a card
+            created in it would be stranded the moment it existed. */}
+        {!offBoard && (
+          <button
+            type="button"
+            aria-label={t("taskBoard.taskBoard.newTaskInLaneAriaLabel", {
+              lane: label,
+            })}
+            title={t("taskBoard.taskBoard.newTaskInLaneTitle", { lane: label })}
+            onClick={() => onCreate(status)}
+            className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <Plus size={15} />
+          </button>
+        )}
       </div>
       {/* px-1 so each card's shadow has room inside the scrollport — an
           overflow-y container clips the x-axis too, which would clip a FLIP-

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -88,7 +88,7 @@ import {
   TASK_TYPES,
   type TaskBoardItemType,
   DEFAULT_TASK_TYPE,
-  laneLabel,
+  laneHeader,
   laneVisual,
   STATUS_CONFIG,
   moveTargets,
@@ -108,7 +108,10 @@ import { summarizeTaskCost } from "./task-cost";
 import { prCardActions } from "./pr-card-actions";
 import { toast } from "sonner";
 import { useTaskBoardItemPrs } from "@/hooks/use-task-board-item-prs";
-import { useBoardSprintIndex } from "@/hooks/use-task-board-items";
+import {
+  useBoardColumns,
+  useBoardSprintIndex,
+} from "@/hooks/use-task-board-items";
 import {
   useTaskBoardActivity,
   type TaskBoardActivity,
@@ -421,6 +424,7 @@ function TaskBoardItemEditor({
   const { data } = useMembers();
   const members = (data?.data?.members ?? []) as Member[];
   const deliveryEnabled = useOrgFlag("delivery_lanes_enabled");
+  const columns = useBoardColumns();
   const { handleCopy, copied } = useCopy();
   const { handleCopy: copyLink, copied: linkCopied } = useCopy();
   const { handleCopy: copyId, copied: idCopied } = useCopy();
@@ -968,23 +972,21 @@ function TaskBoardItemEditor({
                           : laneVisual(status).iconClassName,
                       )}
                     />
-                    {laneLabel(status, t)}
+                    {laneHeader(status, t, columns).label}
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" className="w-44">
-                  {moveTargets(deliveryEnabled).map((s) => {
-                    const Icon = laneVisual(s).icon;
+                  {moveTargets(columns, deliveryEnabled).map((s) => {
+                    const { label, visual } = laneHeader(s, t, columns);
+                    const Icon = visual.icon;
                     return (
                       <DropdownMenuItem
                         key={s}
                         onSelect={() => patch({ status: s })}
                         className="gap-2"
                       >
-                        <Icon
-                          size={16}
-                          className={laneVisual(s).iconClassName}
-                        />
-                        {laneLabel(s, t)}
+                        <Icon size={16} className={visual.iconClassName} />
+                        {label}
                       </DropdownMenuItem>
                     );
                   })}


### PR DESCRIPTION
Follow-up to the mirrored-board series. On a board whose columns come from a
tracker, three surfaces were still speaking Studio's vocabulary. Each one
misled differently.

## A stranded card was masquerading as a column

The board draws a lane for any status no column accounts for (#6727), so a card
can't go invisible. But that lane was labelled with **our** translation — a
`triage` card on a mirrored board rendered as **"Backlog"**, sitting next to the
tracker's own Backlog column. Two identical-looking columns, one of which does
not exist over there and nobody can act on.

`laneHeader(status, t, columns)` now answers naming and appearance together,
because they're the same question: a column the board owns is drawn with its
own name and, if it's one of ours, our icon. A status off the board gets
neither — it's labelled by its raw key and carries an `off board` badge with a
tooltip saying why it's on screen. The "new task here" button is gone for it
too: a card created in a non-column would be stranded the moment it existed.

`laneLabel` is now module-private. Naming a lane requires knowing whether the
board even *has* a column for it, and every caller that skipped that question
is the bug above.

## You couldn't drag a card into an empty column

A lane's droppable was validated against Studio's `STATUSES`, which on a
mirrored board matches **no column at all** — so dropping onto an empty column
resolved to null and the card sprang back. Only dropping onto an existing card
worked, which made it look like an intermittent bug rather than a rule.

Extracted as `dropLane`, validated against the board's columns, with the two
ways of being over a lane (its droppable, or a card in it) gated by one rule.
That closes the mirror-image hole too: hovering a card in an off-board lane
used to resolve to that lane, so the drop appeared to work until the list
refetched and the server's rejection showed.

## "Move to" was a list of ways to fail

The bulk menu and the task's status dropdown offered the canonical lanes
whoever's board it was. On a mirrored board every entry named a column the
server rejects. `moveTargets` takes the board's columns now; `useBoardColumns`
reads them off the same cached list without opening the board's SSE streams.

`STATUSES` is deleted — it had become a second copy of `CANONICAL_COLUMN_KEYS`
with no reader but a test.

## Verification

Against a local board with five mirrored columns and one Studio-native card
stranded off it:

- Lanes render the tracker's names; the stranded card's lane reads its raw
  status with the `off board` badge and no new-task button.
- The status dropdown lists exactly the five columns — no canonical lanes.
- A card dragged into a **previously empty** mirrored column landed and
  persisted (verified in Postgres). That run predates the `dropLane`
  extraction; the extraction itself is covered by unit tests, and the wiring
  is four lines.

Unit tests cover `dropLane` (4), `laneHeader` (3), `moveTargets` on a mirrored
board, and `laneVisibility`'s new `unplaced`. `bun run check`, `lint`, `fmt`,
and `knip` are clean.

## Still open

- A renamed tracker column still reads as delete + create — the Agile API gives
  no stable column id, so the key is the name.
- Bulk/import writers still leave `board_column_org` null.
- `in_review` roles are settable but read by nothing yet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the task board so lanes, drag targets, and the move menu follow the board's own columns instead of Studio's canonical statuses. On boards mirrored from a tracker, canonical names matched no real column, so stranded cards looked like phantom columns, drops into empty columns failed, and "Move to" listed statuses the server rejects.

**Bug Fixes**
- A lane with no matching column now shows its raw status key with an "off board" badge and no "new task here" button.
- Drops are validated against the board's columns, so mirrored empty columns accept cards and off-board lanes refuse them.
- "Move to" and the status dropdown now list only the board's own columns.

**Refactors**
- `laneHeader` replaces the public `laneLabel`, which is now module-private; naming a lane requires knowing whether the board has a column for it.
- `dropLane` handles both ways of being over a lane — its droppable or a card in it — with one rule.
- `STATUSES` is deleted; `moveTargets` and `useBoardColumns` read columns from the same cached query as the board.

<sup>Written for commit 582599aff32795cc3b72bc28cdb0cc73604e1cad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

