### PR TITLE
fix(sandbox): run a repo's own pre-commit hook before the build-artifact guard

### DIFF
--- a/packages/sandbox/daemon-go/internal/gitx/buildartifacts_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/buildartifacts_test.go
@@ -3,6 +3,7 @@ package gitx
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -112,6 +113,32 @@ func TestInstallSandboxHooksWritesTheArtifactList(t *testing.T) {
 	}
 	if string(list) != strings.Join(BuildArtifacts, "\n")+"\n" {
 		t.Fatalf("artifact list: got %q", list)
+	}
+}
+
+// InstallSandboxHooks used to overwrite pre-commit unconditionally, which
+// silently dropped a repo's OWN pre-commit hook (lefthook, husky) on every
+// reinstall — the format/lint check a maintainer relies on then never ran
+// inside the sandbox at all.
+func TestPreCommitHookStillRunsARepoOwnHook(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature/x")
+	// Simulate lefthook/husky writing its own pre-commit hook (e.g. during a
+	// postinstall step) before we install ours.
+	localHook := "#!/bin/sh\necho blocked by local hook >&2\nexit 1\n"
+	write(t, repo, ".git/hooks/pre-commit", localHook)
+	if err := os.Chmod(filepath.Join(repo, ".git", "hooks", "pre-commit"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := InstallSandboxHooks(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	write(t, repo, "src/app.tsx", "export const A = 1\n")
+	gitIn(t, repo, "add", "-A")
+	cmd := exec.Command("git", "-C", repo, "commit", "-q", "-m", "feat: bump A")
+	if err := cmd.Run(); err == nil {
+		t.Fatal("commit should have been blocked by the repo's own pre-commit hook")
 	}
 }
 

--- a/packages/sandbox/daemon-go/internal/gitx/checkout.go
+++ b/packages/sandbox/daemon-go/internal/gitx/checkout.go
@@ -146,8 +146,20 @@ func ProtectedBranches(repoDir string) []string {
 // a hard failure would just cost a turn. If the artifact was the ONLY staged
 // change, git then reports "no changes added to commit", which is the correct
 // answer to that commit.
-const buildArtifactHook = `#!/bin/sh
-artifacts="$(dirname "$0")/build-artifacts"
+//
+// This wrapper runs a repo's OWN pre-commit hook first (saved as
+// `pre-commit.local` below), if the install step that ran just before us wrote
+// one — lefthook/husky format-and-lint-on-commit is exactly the kind of check
+// an agent's commit inside the sandbox should still be held to, and the naive
+// unconditional overwrite silently dropped it project-wide.
+const buildArtifactHookMarker = "# decocms-sandbox-build-artifact-hook"
+
+const buildArtifactHook = "#!/bin/sh\n" + buildArtifactHookMarker + `
+here="$(dirname "$0")"
+if [ -x "$here/pre-commit.local" ]; then
+  "$here/pre-commit.local" "$@" || exit $?
+fi
+artifacts="$here/build-artifacts"
 [ -f "$artifacts" ] || exit 0
 while IFS= read -r p; do
   [ -n "$p" ] || continue
@@ -172,7 +184,17 @@ func InstallSandboxHooks(repoDir string) error {
 	if err := os.WriteFile(filepath.Join(hooksDir, "protected-branches"), []byte(list), 0o644); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(hooksDir, "pre-commit"), []byte(buildArtifactHook), 0o755); err != nil {
+	// An install step (lefthook, husky) may have just written its OWN
+	// pre-commit hook; preserve it under a fixed name so our wrapper can still
+	// run it, instead of silently replacing it every time we reinstall.
+	preCommitPath := filepath.Join(hooksDir, "pre-commit")
+	if existing, err := os.ReadFile(preCommitPath); err == nil &&
+		!strings.Contains(string(existing), buildArtifactHookMarker) {
+		if err := os.WriteFile(filepath.Join(hooksDir, "pre-commit.local"), existing, 0o755); err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(preCommitPath, []byte(buildArtifactHook), 0o755); err != nil {
 		return err
 	}
 	artifacts := strings.Join(BuildArtifacts, "\n") + "\n"


### PR DESCRIPTION
Follows #6765.

#6765 added `InstallSandboxHooks`'s unconditional overwrite of `.git/hooks/pre-commit`, called again after every install step specifically because lefthook/husky postinstall scripts write their own hooks there. The comment on that call site says the reinstall exists so "branch protection and build-artifact unstaging survive" — but the side effect is that whatever the install step just wrote (a repo's own format/lint pre-commit hook) is silently discarded every single time, with no signal to anyone. This repo is itself an example: `CLAUDE.md` documents a lefthook pre-commit hook that runs `bun run fmt`, and it would never fire inside a sandbox once `InstallSandboxHooks` re-runs post-install.

Fix: when installing the build-artifact hook, if a pre-commit hook already exists and isn't ours (no marker), save it as `pre-commit.local`. The build-artifact hook now execs `pre-commit.local` first and propagates its exit code before doing its own unstaging, so a repo's own checks still run and can still block a bad commit.

Failure scenario: a repo with a lefthook/husky pre-commit format-or-lint hook, running inside a sandbox — before this fix, that hook silently never ran after the first `InstallSandboxHooks` reinstall; an agent's commit that fails the repo's own lint gate would go through uncaught.

Regression test: `TestPreCommitHookStillRunsARepoOwnHook` in `packages/sandbox/daemon-go/internal/gitx/buildartifacts_test.go` — writes a fake local pre-commit hook that always exits 1, installs the sandbox hooks over it, and asserts a commit is still blocked. Verified it fails on the pre-fix code and passes after.

To confirm: `cd packages/sandbox/daemon-go && go test ./internal/gitx/...`

Locally ran: `go test ./internal/gitx/...` (full package, green), `gofmt -l` + `go vet` on the changed files (clean). Full CI (daemon-e2e, etc.) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`InstallSandboxHooks` now preserves a repo's own pre-commit hook (e.g. lefthook, husky) instead of unconditionally overwriting it on reinstall, so format/lint checks still run inside sandboxes and can still block a commit.

**Details**
- The build-artifact hook saves the repo's existing pre-commit hook as `pre-commit.local` and runs it first, propagating its exit code.
- Adds a regression test with a fake repo-owned hook that always exits 1 to confirm the commit is blocked.

<sup>Written for commit 67c82cf03e6fb901efc60b12e06cfa948b95720c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

