### PR TITLE
feat(task-board): split auto-resolve-conflicts from auto-merge, run it on Sonnet

### DIFF
--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -10,6 +10,6 @@
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
   "notifications/dbos-digest.ts": "673bc164593266704d2918a0bcaaf838a2480dfb46d1d19c02bdb38c73ecc370",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",
-  "tools/task-board/dbos-github-read.ts": "8757159d594f776d021ed28887e5ba51f7a6e007607a2dc6962efd53152b4d60",
+  "tools/task-board/dbos-github-read.ts": "02f8d9e13cdca01a7e7a6ad00767229b7bf83443a4d773e836fad6aca95020f5",
   "tools/task-board/dbos-tag-merged-sweep.ts": "afc48f5309fd1da3196167855b52ec0074a5f24b8a96b8ef9be2e07a8abb7a0a"
 }

--- a/apps/api/src/dbos/workflow-version.ts
+++ b/apps/api/src/dbos/workflow-version.ts
@@ -80,5 +80,11 @@
  * removed and reordered, so a v8 digest instance replayed against v9 diverges.
  * Cheap to strand: the workflow was a five-minute tick that finishes in
  * milliseconds and holds nothing a user is waiting on.
+ *
+ * Version 10 adds `conflict` to `SweptPrState`, the recorded output of
+ * `taskBoardGithubReadWorkflow`'s `readPrState` step. Same step sequence and
+ * same GitHub call — only the recorded output contract widened, which is still
+ * a v9 instance replaying against a shape it never wrote. Cheap to strand: one
+ * throttled PR read the sweep re-issues on its next pass.
  */
-export const DBOS_WORKFLOW_VERSION = "9";
+export const DBOS_WORKFLOW_VERSION = "10";

--- a/apps/api/src/harnesses/claude-code-env.test.ts
+++ b/apps/api/src/harnesses/claude-code-env.test.ts
@@ -213,11 +213,35 @@ describe("claudeCodeEnvFromCredential", () => {
     ).toBe("anthropic/claude-opus-5");
   });
 
-  test("modelClassFromMetadata only trusts the exact reviewer value", () => {
+  test("modelClassFromMetadata only trusts the exact class values", () => {
     expect(modelClassFromMetadata("reviewer")).toBe("reviewer");
-    for (const value of [undefined, "", "default", "Reviewer", "qa", "cheap"]) {
+    expect(modelClassFromMetadata("conflict")).toBe("conflict");
+    for (const value of [
+      undefined,
+      "",
+      "default",
+      "Reviewer",
+      "Conflict",
+      "qa",
+      "cheap",
+    ]) {
       expect(modelClassFromMetadata(value)).toBe("default");
     }
+  });
+
+  test("a conflict re-run runs on the cheap tier, capped like a reviewer", () => {
+    const env = claudeCodeEnvFromCredential(
+      { providerId: "anthropic", apiKey: "sk-a" },
+      "conflict",
+    );
+    expect(env.CLAUDE_CODE_MODEL).toBe("claude-sonnet-5");
+    expect(env.CLAUDE_CODE_MAX_TURNS).toBe("60");
+    expect(
+      claudeCodeEnvFromCredential(
+        { providerId: "openrouter", apiKey: "sk-o" },
+        "conflict",
+      ).CLAUDE_CODE_MODEL,
+    ).toBe("anthropic/claude-sonnet-5");
   });
 
   test("the error never contains the key", () => {

--- a/apps/api/src/harnesses/claude-code-env.ts
+++ b/apps/api/src/harnesses/claude-code-env.ts
@@ -45,17 +45,28 @@ const OPENROUTER_ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
  * boards (1,247 vs 707) and took 57% of the spend — all of it at the builder's
  * model. On by default via the `cheap_reviewer_model` flag; an org opts back
  * into reviewing on the builder's model by setting it to exactly `false`.
+ *
+ * `conflict` is the same cheap tier for a merge-conflict re-run. The change is
+ * already written and already approved; the run replays the base branch over it
+ * and reconciles two known texts. That is not the work the builder's model is
+ * priced for, and it is a class of its own rather than `reviewer` so the run
+ * metadata says what the run actually was.
  */
-export type ClaudeCodeModelClass = "default" | "reviewer";
+export type ClaudeCodeModelClass = "default" | "reviewer" | "conflict";
 
 const CLAUDE_CODE_MODEL: Record<
   "anthropic" | "openrouter",
   Record<ClaudeCodeModelClass, string>
 > = {
-  anthropic: { default: "claude-opus-5", reviewer: "claude-sonnet-5" },
+  anthropic: {
+    default: "claude-opus-5",
+    reviewer: "claude-sonnet-5",
+    conflict: "claude-sonnet-5",
+  },
   openrouter: {
     default: "anthropic/claude-opus-5",
     reviewer: "anthropic/claude-sonnet-5",
+    conflict: "anthropic/claude-sonnet-5",
   },
 };
 
@@ -70,7 +81,9 @@ export const MODEL_CLASS_METADATA_KEY = "claudeCodeModelClass";
 export function modelClassFromMetadata(
   value: string | undefined,
 ): ClaudeCodeModelClass {
-  return value === "reviewer" ? "reviewer" : "default";
+  if (value === "reviewer") return "reviewer";
+  if (value === "conflict") return "conflict";
+  return "default";
 }
 
 /**
@@ -105,6 +118,7 @@ export const CLAUDE_CODE_MAX_OUTPUT_TOKENS = 32_000;
 const CLAUDE_CODE_MAX_TURNS: Record<ClaudeCodeModelClass, number | null> = {
   default: null,
   reviewer: 60,
+  conflict: 60,
 };
 
 /** The subset of a resolved model source this needs. */

--- a/apps/api/src/tools/task-board/conflict-reaction.ts
+++ b/apps/api/src/tools/task-board/conflict-reaction.ts
@@ -6,6 +6,7 @@ import {
   type ReviewCycleActivity,
   SUPER_AGENT_ASSIGNEE_ID,
 } from "@decocms/shared/task-board";
+import { autoResolveConflictsEnabled } from "@decocms/shared/organization/schema";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated, parkOnRunsExhausted } from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
@@ -76,7 +77,7 @@ export async function reactToApprovedPrConflict(
 
   const settings = await ctx.storage.organizationSettings.get(orgId);
   const flags = settings?.flags ?? {};
-  if (flags.auto_merge !== true) return false;
+  if (!autoResolveConflictsEnabled(flags)) return false;
 
   // Same gate as the auto-merge: EVERY enabled reviewer must have a
   // token-verified approval in the current cycle. With no reviewer enabled

--- a/apps/api/src/tools/task-board/dbos-github-read.ts
+++ b/apps/api/src/tools/task-board/dbos-github-read.ts
@@ -97,12 +97,18 @@ export type SweptPrState = {
   /** Head's checks, derived from the same `get` (`checksFromMergeableState`) —
    *  no extra GitHub call. Gates the QA dispatch (`previewMatchesHead`). */
   checksStatus: ChecksStatus;
+  /** Conflicts with the base branch, from the same `get` (`conflictFromPrGet`).
+   *  `null` is unknown and never acts. Lets the sweep hand a conflicting PR
+   *  back to the Super Agent without an auto-merge attempt to discover it — an
+   *  org can run `auto_resolve_conflicts` with `auto_merge` off. */
+  conflict: boolean | null;
 };
 
 const UNKNOWN: SweptPrState = {
   state: null,
   merged: null,
   checksStatus: null,
+  conflict: null,
 };
 
 async function readPrState(

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -15,6 +15,7 @@ import { captureOrgEvent } from "@/posthog";
 import { getSettings } from "@/settings";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
 import type { RunClass } from "@/dispatch-queue/run-priority";
+import type { ClaudeCodeModelClass } from "@/harnesses/claude-code-env";
 import { fetchPrHeadRef } from "./prs-get";
 import { readPrStateThrottled } from "./dbos-github-read";
 import {
@@ -312,6 +313,12 @@ export async function enqueueSuperAgentForTask(
     // no repos imported runs Decopilot exactly as before.
     const choice = await resolveTaskRepoChoice(ctx, task.organizationId);
 
+    // Set here, not per caller, so the automatic hand-back and the manual
+    // "Resolve conflict" button land on the same tier.
+    const modelClass: ClaudeCodeModelClass | undefined = opts?.resolveConflict
+      ? "conflict"
+      : undefined;
+
     if (choice) {
       harness = "claude-code";
       const repo = "repo" in choice ? choice.repo : null;
@@ -327,6 +334,7 @@ export async function enqueueSuperAgentForTask(
         }),
         temperature: 0.5,
         harnessId: "claude-code",
+        ...(modelClass ? { modelClass } : {}),
         ...(repo ? { repo } : {}),
       });
     } else {

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -1060,6 +1060,7 @@ export async function fetchPrCandidateState(
   state: "open" | "closed" | null;
   merged: boolean | null;
   checksStatus: ChecksStatus;
+  conflict: boolean | null;
 }> {
   const obj = await fetchPrGet(ctx, orgId, pr, "candidate");
   return {
@@ -1071,6 +1072,8 @@ export async function fetchPrCandidateState(
           : null,
     merged: typeof obj?.merged === "boolean" ? obj.merged : null,
     checksStatus: checksFromMergeableState(obj?.mergeable_state),
+    // Rides the same `get` — the sweep's conflict signal costs nothing extra.
+    conflict: conflictFromPrGet(obj),
   };
 }
 

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -85,6 +85,7 @@ import { ABANDONED_FAILURE_REASON } from "./stall-recovery";
 import { THREAD_EXPIRY_MS } from "@/tools/thread/helpers";
 import { previewMatchesHead, prReadyForReview } from "./prs-get";
 import { readPrStateThrottled } from "./dbos-github-read";
+import { reactToApprovedPrConflict } from "./conflict-reaction";
 
 /** How often to LOOK for due cards. A minute is well under the time a human
  *  would take to notice a stuck card, and the work list is one index scan when
@@ -542,6 +543,8 @@ export class TaskBoardReviewSweeper {
     // card that has no reviewer left to enqueue. Gated on verified approval +
     // auto-merge inside, so it can't ship anything the reviewers didn't.
     if (await retryAutoMergeIfApproved(ctx, item)) return true;
+    // With `auto_merge` off there is no refused merge to reveal a conflict.
+    if (await this.resolveConflictFromSweep(ctx, item, live)) return true;
     if (!owned) return false;
 
     if (!prReadyForReview(live)) return false;
@@ -550,6 +553,33 @@ export class TaskBoardReviewSweeper {
       previewMatchesHead: previewMatchesHead(live),
     });
     return true;
+  }
+
+  /**
+   * Hand a swept card's conflicting PR back to the Super Agent, using the
+   * conflict already read by `readPrStateThrottled` — no second GitHub call
+   * (the whole reason `SweptPrState` carries it). Best-effort: a dispatch
+   * failure must not abort the sweep pass for every other card.
+   */
+  private async resolveConflictFromSweep(
+    ctx: StudioContext,
+    item: TaskBoardItem,
+    live: readonly {
+      number: number;
+      url: string;
+      state: "open" | "closed" | null;
+      conflict: boolean | null;
+    }[],
+  ): Promise<boolean> {
+    const pr = live.find((p) => p.state !== "closed" && p.conflict === true);
+    if (!pr) return false;
+    return await reactToApprovedPrConflict(ctx, item.organizationId, item, {
+      pr: { number: pr.number, url: pr.url },
+      conflict: true,
+    }).catch((err) => {
+      console.error("[task-board-review-sweeper] conflict resolve failed", err);
+      return false;
+    });
   }
 
   dispose(): void {

--- a/apps/web/src/components/settings/review-settings.tsx
+++ b/apps/web/src/components/settings/review-settings.tsx
@@ -4,6 +4,7 @@ import {
   Coins01,
   Cube01,
   FileSearch02,
+  GitBranch01,
   GitMerge,
   Rocket01,
   Terminal,
@@ -14,7 +15,11 @@ import {
   SettingsCardItem,
   SettingsSection,
 } from "@/components/settings/settings-section";
-import { useOrgFlag, useSetOrgFlag } from "@/hooks/use-organization-settings";
+import {
+  useAutoResolveConflicts,
+  useOrgFlag,
+  useSetOrgFlag,
+} from "@/hooks/use-organization-settings";
 import type { OrgFlags } from "@decocms/shared/organization/schema";
 import { useT } from "@/i18n/use-t.ts";
 import type { TranslationKey } from "@/i18n/use-t.ts";
@@ -50,6 +55,7 @@ export function ReviewSettings() {
           titleKey="settings.review.autoMergeTitle"
           descriptionKey="settings.review.autoMergeDescription"
         />
+        <AutoResolveConflictsToggle />
         <FlagToggle
           flag="delivery_lanes_enabled"
           icon={<Rocket01 size={16} />}
@@ -111,20 +117,43 @@ export function CodeAgentsSettings() {
   );
 }
 
+/**
+ * Conflict resolution reads through `useAutoResolveConflicts`, not the raw
+ * flag: unset it follows `auto_merge`, so a switch bound to the raw value would
+ * read off while the server is resolving conflicts.
+ */
+function AutoResolveConflictsToggle() {
+  const enabled = useAutoResolveConflicts();
+  return (
+    <FlagToggle
+      flag="auto_resolve_conflicts"
+      icon={<GitBranch01 size={16} />}
+      titleKey="settings.review.autoResolveConflictsTitle"
+      descriptionKey="settings.review.autoResolveConflictsDescription"
+      enabled={enabled}
+    />
+  );
+}
+
 /** One org flag as a switch. Shared with the other org-settings sections. */
 function FlagToggle({
   flag,
   icon,
   titleKey,
   descriptionKey,
+  enabled: enabledOverride,
 }: {
   flag: keyof OrgFlags;
   icon: ReactNode;
   titleKey: TranslationKey;
   descriptionKey: TranslationKey;
+  /** Effective value when the flag's default is derived rather than a plain
+   *  `orgFlagEnabled` read. */
+  enabled?: boolean;
 }) {
   const t = useT();
-  const enabled = useOrgFlag(flag);
+  const flagValue = useOrgFlag(flag);
+  const enabled = enabledOverride ?? flagValue;
   const setFlag = useSetOrgFlag();
   return (
     <SettingsCardItem

--- a/apps/web/src/hooks/use-organization-settings.ts
+++ b/apps/web/src/hooks/use-organization-settings.ts
@@ -14,6 +14,7 @@ import type { StudioToolInput as ToolInput } from "@decocms/shared/tools/tool-io
 
 export type { SimpleModeTier } from "@decocms/shared/organization/schema";
 import {
+  autoResolveConflictsEnabled,
   DEFAULT_ON_FLAGS,
   orgFlagEnabled,
 } from "@decocms/shared/organization/schema";
@@ -256,6 +257,19 @@ export function useOrgFlag(flag: keyof OrgFlags): boolean {
     orgFlagEnabled(s.flags, flag),
   );
   return data ?? DEFAULT_ON_FLAGS.has(flag);
+}
+
+/**
+ * Whether an approved-but-conflicting PR is auto-handed back to the Super
+ * Agent. Not `useOrgFlag`: unset it inherits `auto_merge` (see
+ * `autoResolveConflictsEnabled`), so the switch must show what the server gate
+ * will actually do rather than a raw `undefined`.
+ */
+export function useAutoResolveConflicts(): boolean {
+  const { data } = useOrganizationSettings((s) =>
+    autoResolveConflictsEnabled(s.flags),
+  );
+  return data ?? false;
 }
 
 /**

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -465,7 +465,10 @@ export const settings = {
     "The Reviewer runs on a smaller model than the Super Agent that wrote the change. Cuts review cost; may cut review depth.",
   "settings.review.autoMergeTitle": "Enable Auto-merge",
   "settings.review.autoMergeDescription":
-    "When every enabled reviewer approves, merge the pull request automatically instead of waiting for a human. If a conflict blocks the merge, the Super Agent resolves it first.",
+    "When every enabled reviewer approves, merge the pull request automatically instead of waiting for a human.",
+  "settings.review.autoResolveConflictsTitle": "Auto-resolve merge conflicts",
+  "settings.review.autoResolveConflictsDescription":
+    "When an approved pull request conflicts with its base branch, hand it back to the Super Agent to check out the branch, merge the base and push. Follows Auto-merge unless you set it here.",
   "settings.review.deliveryLanesTitle": "Show delivery lanes",
   "settings.review.deliveryLanesDescription":
     "Add Approved, Merged and Post-deploy Validation between In Review and Done, and land a merged pull request on Merged instead of Done. For teams whose release process continues after the merge.",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -356,7 +356,7 @@ export const settings = {
   "settings.decoCreditsHero.disconnect": "Desconectar",
   "settings.decoCreditsHero.disconnectButton": "Desconectar",
   "settings.decoCreditsHero.disconnectDescription":
-    "Isso remover\u00e1 o Deco AI Gateway deste espa\u00e7o de trabalho. Seu saldo de cr\u00e9dito \u00e9 preservado e estar\u00e1 dispon\u00edvel se voc\u00ea se reconectar.",
+    "Isso remover\u00e1 o Deco AI Gateway deste espa\u00e7o de trabalho. Seu saldo de cr\u00e9dito \u00e9 preservado e estar\u00e1 dispon\u00edvel se você se reconectar.",
   "settings.decoCreditsHero.disconnectError": "Falha ao desconectar: {message}",
   "settings.decoCreditsHero.disconnectSuccess": "Deco AI Gateway desconectado",
   "settings.decoCreditsHero.disconnectTitle": "Desconectar Deco AI Gateway",
@@ -473,14 +473,18 @@ export const settings = {
     "O Reviewer autom\u00e1tico roda no pull request de uma tarefa assim que ela entra em Revis\u00e3o (checks passando ou inexistentes). Ele aparece como uma sess\u00e3o no card da tarefa.",
   "settings.review.reviewerTitle": "Ativar Reviewer",
   "settings.review.reviewerDescription":
-    "Revisa o c\u00f3digo com as skills de review do pr\u00f3prio reposit\u00f3rio, corrige o que encontra na branch do pull request e depois testa a mudan\u00e7a no preview do deploy \u2014 e passa a tarefa para voc\u00ea quando n\u00e3o consegue resolver algo.",
+    "Revisa o c\u00f3digo com as skills de review do pr\u00f3prio reposit\u00f3rio, corrige o que encontra na branch do pull request e depois testa a mudan\u00e7a no preview do deploy \u2014 e passa a tarefa para você quando n\u00e3o consegue resolver algo.",
   "settings.review.cheapReviewerModelTitle":
     "Rodar os revisores em um modelo mais barato",
   "settings.review.cheapReviewerModelDescription":
     "O Reviewer roda em um modelo menor que o Super Agent que escreveu a mudança. Reduz o custo da revisão; pode reduzir a profundidade.",
   "settings.review.autoMergeTitle": "Ativar Auto-merge",
   "settings.review.autoMergeDescription":
-    "Quando todos os revisores habilitados aprovam, mescla o pull request automaticamente em vez de esperar por uma pessoa. Se um conflito bloquear o merge, o Super Agent resolve antes.",
+    "Quando todos os revisores habilitados aprovam, mescla o pull request automaticamente em vez de esperar por uma pessoa.",
+  "settings.review.autoResolveConflictsTitle":
+    "Resolver conflitos de merge automaticamente",
+  "settings.review.autoResolveConflictsDescription":
+    "Quando um pull request aprovado conflita com a branch base, devolve para o Super Agent fazer checkout da branch, mesclar a base e dar push. Segue o Auto-merge, a menos que você ajuste aqui.",
   "settings.review.deliveryLanesTitle": "Mostrar as colunas de entrega",
   "settings.review.deliveryLanesDescription":
     "Adiciona Aprovado, Implantado e Valida\u00e7\u00e3o P\u00f3s Deploy entre Em Revis\u00e3o e Conclu\u00eddo, e faz um pull request mesclado cair em Implantado em vez de Conclu\u00eddo. Para times cujo processo de release continua depois do merge.",

--- a/packages/shared/src/organization/schema.test.ts
+++ b/packages/shared/src/organization/schema.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { DEFAULT_ON_FLAGS, orgFlagEnabled } from "./schema";
+import {
+  autoResolveConflictsEnabled,
+  DEFAULT_ON_FLAGS,
+  orgFlagEnabled,
+} from "./schema";
 
 describe("orgFlagEnabled", () => {
   it("default-on flags read as enabled unless stored exactly false", () => {
@@ -27,6 +31,33 @@ describe("orgFlagEnabled", () => {
     expect(orgFlagEnabled({ auto_merge: null }, "auto_merge")).toBe(false);
     expect(orgFlagEnabled({ auto_merge: false }, "auto_merge")).toBe(false);
     expect(orgFlagEnabled({ auto_merge: true }, "auto_merge")).toBe(true);
+  });
+
+  it("auto_resolve_conflicts inherits auto_merge until set explicitly", () => {
+    expect(autoResolveConflictsEnabled(null)).toBe(false);
+    expect(autoResolveConflictsEnabled({})).toBe(false);
+    expect(autoResolveConflictsEnabled({ auto_merge: true })).toBe(true);
+    expect(autoResolveConflictsEnabled({ auto_merge: false })).toBe(false);
+    // An explicit value wins in BOTH directions — that is the whole split.
+    expect(
+      autoResolveConflictsEnabled({
+        auto_merge: true,
+        auto_resolve_conflicts: false,
+      }),
+    ).toBe(false);
+    expect(
+      autoResolveConflictsEnabled({
+        auto_merge: false,
+        auto_resolve_conflicts: true,
+      }),
+    ).toBe(true);
+    // Raw jsonb bypasses zod: a non-boolean is not "explicit".
+    expect(
+      autoResolveConflictsEnabled({
+        auto_merge: true,
+        auto_resolve_conflicts: "false",
+      }),
+    ).toBe(true);
   });
 
   it("a non-boolean stored value follows the branch's strict comparison", () => {

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -166,7 +166,13 @@ export const OrgFlagsSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      "When the Reviewer approves a task's pull request, merge it automatically instead of leaving the merge to a human. If the merge is blocked by a conflict with the base branch, hand the PR back to the Super Agent to resolve the conflict (check out the branch, merge the base, push) so it can then merge.",
+      "When the Reviewer approves a task's pull request, merge it automatically instead of leaving the merge to a human.",
+    ),
+  auto_resolve_conflicts: z
+    .boolean()
+    .optional()
+    .describe(
+      "When an approved pull request can't be merged because it conflicts with its base branch, hand it back to the Super Agent to resolve the conflict (check out the branch, merge the base, push). Unset, it follows `auto_merge`; set it explicitly to run one without the other.",
     ),
   cheap_reviewer_model: z
     .boolean()
@@ -235,6 +241,20 @@ export function orgFlagEnabled(
 ): boolean {
   const value = flags?.[flag];
   return DEFAULT_ON_FLAGS.has(flag) ? value !== false : value === true;
+}
+
+/**
+ * Whether an approved-but-conflicting PR is handed back to the Super Agent.
+ * Not `orgFlagEnabled`: unset it INHERITS `auto_merge`, which is the behavior
+ * every org on auto-merge already has — splitting the two must not silently
+ * take conflict resolution away from them. An explicit value wins either way,
+ * so an org can resolve conflicts without auto-merging, or vice versa.
+ */
+export function autoResolveConflictsEnabled(
+  flags: Record<string, unknown> | null | undefined,
+): boolean {
+  const value = flags?.auto_resolve_conflicts;
+  return typeof value === "boolean" ? value : flags?.auto_merge === true;
 }
 
 /**

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -126,6 +126,7 @@ export interface StudioToolIO {
             qa_agent_enabled?: boolean | undefined;
             code_reviewer_enabled?: boolean | undefined;
             auto_merge?: boolean | undefined;
+            auto_resolve_conflicts?: boolean | undefined;
             cheap_reviewer_model?: boolean | undefined;
             coding_agent_org_mcps?: boolean | undefined;
             coding_agents_claude_code?: boolean | undefined;
@@ -199,6 +200,7 @@ export interface StudioToolIO {
             qa_agent_enabled?: boolean | undefined;
             code_reviewer_enabled?: boolean | undefined;
             auto_merge?: boolean | undefined;
+            auto_resolve_conflicts?: boolean | undefined;
             cheap_reviewer_model?: boolean | undefined;
             coding_agent_org_mcps?: boolean | undefined;
             coding_agents_claude_code?: boolean | undefined;
@@ -272,6 +274,7 @@ export interface StudioToolIO {
             qa_agent_enabled?: boolean | undefined;
             code_reviewer_enabled?: boolean | undefined;
             auto_merge?: boolean | undefined;
+            auto_resolve_conflicts?: boolean | undefined;
             cheap_reviewer_model?: boolean | undefined;
             coding_agent_org_mcps?: boolean | undefined;
             coding_agents_claude_code?: boolean | undefined;


### PR DESCRIPTION
## Summary

Conflict auto-resolution was gated on the `auto_merge` org flag, so an org could not run one without the other. `osklen` is the case that surfaced it: 9 of 17 In Review cards sit on `CONFLICTING` PRs, all already approved by the Reviewer, and none will ever self-resolve — the org has no `auto_merge`, and turning it on to get conflict resolution would also start shipping PRs automatically.

Splits the two, and fixes the model the conflict run dispatches on.

## The flag

New `auto_resolve_conflicts`. **Unset, it inherits `auto_merge`** (`autoResolveConflictsEnabled` in `packages/shared/src/organization/schema.ts`), so every org running auto-merge today keeps exactly the behavior it has. An explicit value wins in both directions — resolve without merging, or merge without auto-resolving.

The gate swap alone was not enough. With `auto_merge` off there is no merge attempt to be *refused*, so `retryAutoMergeIfApproved` returns early and the sweeper never discovers a conflict — the new flag would only have taken effect when a human happened to open the PR modal. So `SweptPrState` now carries `conflict`, read from the `get` the sweep already makes, and the sweeper hands a conflicting card back directly.

**No extra GitHub calls.** `mergeable` was already on the response `checksFromMergeableState` reads; it was just being dropped. That budget is not notional — a per-card multiplier here held the App's rate limit shut for 17 hours once.

The existing `resolveConflictAfterRefusedMerge` stays: it can infer a conflict from the 405 refusal text when GitHub answers `mergeable: null` (still computing — 3 of the osklen PRs did exactly that on first read), which the swept signal cannot. It runs first, so the better signal wins the claim fence.

## Model

Conflict re-runs dispatched on **`claude-opus-5` with no turn ceiling**: `enqueueSuperAgentForTask` never set a model class, so they fell through to `"default"`, and only `enqueue-reviewer.ts` ever set anything else.

A conflict re-run replays a base branch over a diff that is already written and already approved. New `"conflict"` model class → `claude-sonnet-5` (`anthropic/claude-sonnet-5` on OpenRouter), `maxTurns` 60. Its own class rather than reusing `"reviewer"` so the run metadata says what the run actually was. Set once at the dispatch, so the automatic hand-back and the manual "Resolve conflict" button land on the same tier.

## DBOS version bump

Adding `conflict` to `SweptPrState` widens the recorded output of `taskBoardGithubReadWorkflow`'s `readPrState` step, so `DBOS_WORKFLOW_VERSION` 9 → 10 and the source-guard snapshot is re-baselined. In-flight v9 instances strand by design — cheap here: one throttled PR read the sweep re-issues on its next pass.

## Not in this PR

Two things I found and deliberately left, happy to add either:

1. The conflict lead is **prepended** to the full Super Agent prompt rather than replacing it, so a run whose whole job is `gh pr checkout` + merge + push still reads "First decide whether this task requires changing code", the `load_repo` decision tree, and PR-opening instructions. Trimming it touches the prompt both branches share.
2. `conflict-reaction.ts` dispatches with no `runClass`, so an automatic conflict re-run queues as `new_task` while the manual button passes `"retry"`. One word, but it is a queue-priority policy call.

## Testing

- `bun run check` clean across all workspaces; `knip` clean; `bun run lint` 0 errors.
- Unit tests added for the inheritance semantics (`autoResolveConflictsEnabled` — both override directions, plus a non-boolean jsonb value not counting as explicit) and for the new model class / metadata narrowing.
- `bun test` over the touched trees (`packages/shared`, `apps/api/src/harnesses`, `apps/api/src/dbos`) plus `apps/api/src/tools/task-board`: pass, apart from the suites that need a Postgres on :5432, which my machine does not have (embedded PG runs on a dynamic port). Those are DB-dependent, not related to this change — CI is the real signal for them.
- Not exercised end to end against a real board; the flag path itself is integration-tier.
