### PR TITLE
fix(jira): make sprint two-way, the way status already is

### DIFF
--- a/apps/api/migrations/194-jira-link-sprint.ts
+++ b/apps/api/migrations/194-jira-link-sprint.ts
@@ -1,0 +1,33 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Records the sprint a linked issue was last SEEN OR SET in on the Jira side,
+ * so sprint can be two-way the way status already is.
+ *
+ * Until now the sync was the only writer of a card's sprint, so overwriting it
+ * on every pull lost nothing. The moment a person can move a card between the
+ * backlog and a sprint from Studio, that unguarded overwrite is data loss: the
+ * next tick reads Jira's unchanged sprint and undoes the move.
+ *
+ * Same shape and same job as `jira_status`. The pull applies sprint only when
+ * this changed, and the push records its target here so the echo is a no-op.
+ *
+ * Nullable with no backfill, and that is safe rather than lucky: null reads as
+ * "no sprint", so the first pull after this rewrites the sprint of every card
+ * whose issue IS in one and skips every card whose issue is not. Both land on
+ * what the unconditional pull had already written, because until now the sync
+ * was the only writer there was.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_item_jira_links")
+    .addColumn("jira_sprint_id", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_item_jira_links")
+    .dropColumn("jira_sprint_id")
+    .execute();
+}

--- a/apps/api/migrations/195-task-board-sprint-activity.ts
+++ b/apps/api/migrations/195-task-board-sprint-activity.ts
@@ -1,0 +1,54 @@
+import { type Kysely, sql } from "kysely";
+
+/** Migration 192's action list, plus `sprint_changed` — recorded when a card
+ *  moves between the backlog and a sprint, which is now something a person can
+ *  do rather than only something the tracker reports. Frozen snapshot: the
+ *  constraint is replaced wholesale because 192 may already be live, so
+ *  editing its list in place wouldn't reach a deployed database.
+ *  `activity-actions.test.ts` reads this one (the newest) to prove SQL and
+ *  TypeScript agree. */
+export const ACTIONS = [
+  "created",
+  "status_changed",
+  "assignee_changed",
+  "priority_changed",
+  "due_date_changed",
+  "title_changed",
+  "description_changed",
+  "tags_changed",
+  "review_requested",
+  "review_approved",
+  "review_changes_requested",
+  "review_verdict_requested",
+  "merge_conflict_resolution",
+  "merge_failed",
+  "type_changed",
+  "sprint_changed",
+] as const;
+
+const NEW_ACTIONS = new Set(["sprint_changed"]);
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await replaceActivityActionCheck(db, ACTIONS);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await replaceActivityActionCheck(
+    db,
+    ACTIONS.filter((a) => !NEW_ACTIONS.has(a)),
+  );
+}
+
+/** Swap `task_board_activity`'s action CHECK constraint for one allowing
+ *  exactly `actions`. */
+async function replaceActivityActionCheck(
+  db: Kysely<unknown>,
+  actions: readonly string[],
+): Promise<void> {
+  await sql`ALTER TABLE task_board_activity DROP CONSTRAINT chk_task_board_activity_action`.execute(
+    db,
+  );
+  await sql`ALTER TABLE task_board_activity ADD CONSTRAINT chk_task_board_activity_action CHECK (action IN (${sql.join(
+    actions.map((a) => sql.lit(a)),
+  )}))`.execute(db);
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -192,6 +192,8 @@ import * as migration190taskboardreviewcyclestartedat from "./190-task-board-rev
 import * as migration191taskboardcolumns from "./191-task-board-columns.ts";
 import * as migration192taskboardverdictnudgeactivity from "./192-task-board-verdict-nudge-activity.ts";
 import * as migration193taskboardstatuscolumnfk from "./193-task-board-status-column-fk.ts";
+import * as migration194jiralinksprint from "./194-jira-link-sprint.ts";
+import * as migration195taskboardsprintactivity from "./195-task-board-sprint-activity.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -417,6 +419,8 @@ const migrations: Record<string, Migration> = {
   "192-task-board-verdict-nudge-activity":
     migration192taskboardverdictnudgeactivity,
   "193-task-board-status-column-fk": migration193taskboardstatuscolumnfk,
+  "194-jira-link-sprint": migration194jiralinksprint,
+  "195-task-board-sprint-activity": migration195taskboardsprintactivity,
 };
 
 export default migrations;

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -6,7 +6,7 @@
   "file-storage/dbos-org-repo-sync.ts": "32c606976916fde2be7abe3084f7388744bdb610c178e9c2a07a8080f764904e",
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",
   "harnesses/decopilot/background-tool-workflow.ts": "1ae73b5a614ae6439942c1e52de52deeb3e18d1bb7e528be820720b592cfe833",
-  "jira/dbos-jira-sync.ts": "4befebae160cf7cb88b8b8f1412d1f68fbcb55edc58c890193bc3175da1387d9",
+  "jira/dbos-jira-sync.ts": "a95e7c979eefaf2ee32aeb7491d24c14c973a8cb8fe16a872489d10d143c6812",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
   "notifications/dbos-digest.ts": "673bc164593266704d2918a0bcaaf838a2480dfb46d1d19c02bdb38c73ecc370",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -20,6 +20,7 @@ import {
   findSprintFieldIds,
   type JiraSprintRef,
   parseSprintRefs,
+  pickIssueSprint,
   stripOrderBy,
 } from "./sprint-field";
 import {
@@ -562,6 +563,48 @@ export class JiraClient {
         method: "POST",
         body: JSON.stringify({ transition: { id: transitionId } }),
       },
+      { idempotent: false },
+    );
+  }
+
+  /**
+   * The sprint an issue currently sits in, or null for the backlog.
+   *
+   * Read before a sprint push for the reason `getStatusName` is: a crash
+   * between the POST and the bookkeeping leaves Jira right and our link stale,
+   * so the retry has to ask the world rather than re-POST blind.
+   */
+  async getIssueSprintId(issueId: string): Promise<string | null> {
+    const fieldIds = await this.sprintFieldIds();
+    if (fieldIds.length === 0) return null;
+    const issue = await this.request<{ fields?: Record<string, unknown> }>(
+      `/rest/api/3/issue/${encodeURIComponent(issueId)}?fields=${fieldIds.join(",")}`,
+    );
+    const fields = issue.fields ?? {};
+    // Only the issue's own project's Sprint field is populated; the rest come
+    // back null. Same first-non-empty rule `searchIssues` uses.
+    const refs =
+      fieldIds
+        .map((field) => parseSprintRefs(fields[field]))
+        .find((found) => found.length > 0) ?? [];
+    return pickIssueSprint(refs)?.id ?? null;
+  }
+
+  /** Put an issue into a sprint. Jira moves it out of whatever sprint or
+   *  backlog it was in, so this is the whole of "pull into the sprint". */
+  async addIssueToSprint(sprintId: string, issueId: string): Promise<void> {
+    await this.request<void>(
+      `/rest/agile/1.0/sprint/${encodeURIComponent(sprintId)}/issue`,
+      { method: "POST", body: JSON.stringify({ issues: [issueId] }) },
+      { idempotent: false },
+    );
+  }
+
+  /** Take an issue out of every sprint, back to the board's backlog. */
+  async moveIssueToBacklog(issueId: string): Promise<void> {
+    await this.request<void>(
+      "/rest/agile/1.0/backlog/issue",
+      { method: "POST", body: JSON.stringify({ issues: [issueId] }) },
       { idempotent: false },
     );
   }

--- a/apps/api/src/jira/dbos-jira-sync.ts
+++ b/apps/api/src/jira/dbos-jira-sync.ts
@@ -16,6 +16,7 @@ import { buildOrgContext } from "@/tools/task-board/org-context";
 import type { Database, TaskBoardItem } from "@/storage/types";
 import { JiraIntegrationStorage } from "@/storage/jira-integrations";
 import { TaskBoardStorage } from "@/storage/task-board";
+import { SprintStorage } from "@/storage/sprints";
 import { CredentialVault } from "@/encryption/credential-vault";
 import type { StudioContext } from "@/core/studio-context";
 import { JIRA_PUSH_QUEUE } from "@/dispatch-queue/queue-names";
@@ -65,6 +66,10 @@ function storageFromRuntime(): JiraIntegrationStorage {
 
 function taskBoardFromRuntime(): TaskBoardStorage {
   return new TaskBoardStorage(requireRuntime().db);
+}
+
+function sprintsFromRuntime(): SprintStorage {
+  return new SprintStorage(requireRuntime().db);
 }
 
 /** One integration, folded to a result — the step body must never throw.
@@ -411,6 +416,115 @@ async function executeStatusTransition(
   await storage.touchLink(params.itemId, { jiraStatus: plan.targetName });
 }
 
+/** No sprint snapshot on purpose, same as `JiraStatusPushParams` — the
+ *  workflow reads the card's current sprint. */
+interface JiraSprintPushParams {
+  organizationId: string;
+  itemId: string;
+}
+
+interface SprintMovePlan {
+  jiraIssueId: string;
+  jiraIssueKey: string;
+  /** Jira sprint id to put the issue in, or null for the backlog. */
+  targetSprintId: string | null;
+}
+
+/**
+ * Step 1: plan the move. Null = nothing to do — integration off, card
+ * unlinked, the card's sprint was never mirrored from Jira, or the issue is
+ * already where the card says.
+ */
+async function resolveSprintMove(
+  params: JiraSprintPushParams,
+): Promise<SprintMovePlan | null> {
+  const storage = storageFromRuntime();
+  const integration = await storage.getByOrg(params.organizationId);
+  if (!integration?.enabled) return null;
+  const link = await storage.getLinkByItemId(
+    params.itemId,
+    params.organizationId,
+  );
+  if (!link) return null;
+  // The card's CURRENT sprint, never one captured at enqueue time: the enqueue
+  // runs after an await, so two quick moves can reach the queue out of order
+  // and the stale leg would put the issue back and stick — the pull won't undo
+  // it, because Jira then agrees with `jira_sprint_id`.
+  const item = await taskBoardFromRuntime().getById(
+    params.itemId,
+    params.organizationId,
+  );
+  if (!item) return null;
+  const targetSprintId = item.sprintId
+    ? await sprintsFromRuntime().jiraIdFor(params.organizationId, item.sprintId)
+    : null;
+  // A local-only sprint has no Jira id, and posting the card into the backlog
+  // instead would be inventing a move nobody asked for.
+  if (item.sprintId && targetSprintId === null) {
+    console.warn(
+      `[jira] ${link.jiraIssueKey} is in a sprint that did not come from Jira — not pushing`,
+    );
+    return null;
+  }
+  if (link.jiraSprintId === targetSprintId) return null;
+  return {
+    jiraIssueId: link.jiraIssueId,
+    jiraIssueKey: link.jiraIssueKey,
+    targetSprintId,
+  };
+}
+
+/** Step 2: execute it. Re-checks the link first so a retry after a
+ *  crash-past-the-POST is a no-op instead of a second move. */
+async function executeSprintMove(
+  params: JiraSprintPushParams,
+  plan: SprintMovePlan,
+): Promise<void> {
+  const storage = storageFromRuntime();
+  const integration = await storage.getByOrg(params.organizationId);
+  if (!integration?.enabled) return;
+  const link = await storage.getLinkByItemId(
+    params.itemId,
+    params.organizationId,
+  );
+  if (!link || link.jiraSprintId === plan.targetSprintId) return;
+  const client = new JiraClient(
+    integration.siteUrl,
+    integration.email,
+    integration.apiToken,
+  );
+  // A crash between the POST below and the `touchLink` that records it leaves
+  // the issue moved but the link stale, so ask Jira where the issue actually
+  // is before pushing again.
+  const current = await client.getIssueSprintId(plan.jiraIssueId);
+  if (current !== plan.targetSprintId) {
+    if (plan.targetSprintId === null) {
+      await client.moveIssueToBacklog(plan.jiraIssueId);
+    } else {
+      await client.addIssueToSprint(plan.targetSprintId, plan.jiraIssueId);
+    }
+  }
+  await storage.touchLink(params.itemId, {
+    jiraSprintId: plan.targetSprintId,
+  });
+}
+
+async function jiraSprintPushWorkflowFn(
+  params: JiraSprintPushParams,
+): Promise<void> {
+  const plan = await DBOS.runStep(() => resolveSprintMove(params), {
+    name: "resolveSprintMove",
+    retriesAllowed: true,
+    maxAttempts: 3,
+  });
+  if (!plan) return;
+  await DBOS.runStep(() => executeSprintMove(params, plan), {
+    name: "executeSprintMove",
+    retriesAllowed: true,
+    maxAttempts: 3,
+  });
+}
+
 async function jiraStatusPushWorkflowFn(
   params: JiraStatusPushParams,
 ): Promise<void> {
@@ -431,6 +545,7 @@ let registeredWorkflow: typeof jiraSyncWorkflowFn | null = null;
 let registeredCommentPushWorkflow: typeof jiraCommentPushWorkflowFn | null =
   null;
 let registeredStatusPushWorkflow: typeof jiraStatusPushWorkflowFn | null = null;
+let registeredSprintPushWorkflow: typeof jiraSprintPushWorkflowFn | null = null;
 
 /**
  * Mirror a board card's status onto its linked Jira issue — called from
@@ -460,6 +575,41 @@ export function maybeEnqueueJiraStatusPush(
   })().catch((err) => {
     console.warn(
       `[jira] status push enqueue failed for ${item.id}:`,
+      err instanceof Error ? err.message : err,
+    );
+  });
+}
+
+/**
+ * Mirror a board card's sprint onto its linked Jira issue — same funnel and
+ * same cheap declines as {@link maybeEnqueueJiraStatusPush}, so pulling a card
+ * out of the backlog in Studio reaches Jira.
+ *
+ * Without this the move is undone: the pull only leaves a card's sprint alone
+ * while Jira's sprint matches what we last saw, and nothing else would ever
+ * make Jira agree.
+ */
+export function maybeEnqueueJiraSprintPush(
+  organizationId: string,
+  item: TaskBoardItem,
+): void {
+  if (item.updatedBy === JIRA_SYNC_ACTOR) return;
+  if (!registeredSprintPushWorkflow || !runtime) return;
+  const workflow = registeredSprintPushWorkflow;
+  void (async () => {
+    const link = await storageFromRuntime().getLinkByItemId(
+      item.id,
+      organizationId,
+    );
+    if (!link) return;
+    await DBOS.startWorkflow(workflow, {
+      queueName: JIRA_PUSH_QUEUE,
+      workflowID: `jira-sprint:${item.id}:${item.sprintId ?? "backlog"}:${Date.parse(item.updatedAt)}`,
+      enqueueOptions: { queuePartitionKey: organizationId },
+    })({ organizationId, itemId: item.id });
+  })().catch((err) => {
+    console.warn(
+      `[jira] sprint push enqueue failed for ${item.id}:`,
       err instanceof Error ? err.message : err,
     );
   });
@@ -518,5 +668,9 @@ export function registerJiraSyncWorkflow(): void {
   registeredStatusPushWorkflow = DBOS.registerWorkflow(
     jiraStatusPushWorkflowFn,
     { name: "jiraStatusPushWorkflow" },
+  );
+  registeredSprintPushWorkflow = DBOS.registerWorkflow(
+    jiraSprintPushWorkflowFn,
+    { name: "jiraSprintPushWorkflow" },
   );
 }

--- a/apps/api/src/jira/sync.test.ts
+++ b/apps/api/src/jira/sync.test.ts
@@ -4,6 +4,7 @@ import {
   buildJql,
   isUnchanged,
   rescanContinues,
+  rewritesSprint,
   rewritesStatus,
   runTruncated,
   vanishedLinks,
@@ -223,6 +224,36 @@ describe("runTruncated", () => {
  * holding one of Studio's lanes while the columns are suddenly the tracker's,
  * and a card nobody touched in Jira would render nowhere at all.
  */
+describe("rewritesSprint", () => {
+  const rewrites = (
+    lastSeenJiraSprintId: string | null,
+    jiraSprintId: string | null,
+  ) => rewritesSprint({ lastSeenJiraSprintId, jiraSprintId });
+
+  it("writes when Jira moved the issue to another sprint", () => {
+    expect(rewrites("41", "42")).toBe(true);
+  });
+
+  it("writes when Jira moved the issue out of every sprint", () => {
+    expect(rewrites("42", null)).toBe(true);
+  });
+
+  it("writes when Jira pulled a backlog issue into a sprint", () => {
+    expect(rewrites(null, "42")).toBe(true);
+  });
+
+  /**
+   * The whole point. Someone pulls a card into the sprint in Studio, the push
+   * records its target on the link, and the next tick reads Jira agreeing.
+   * Writing here would be a no-op at best; before the push lands it would undo
+   * the person who moved the card.
+   */
+  it("leaves the card alone when Jira agrees with what we last set", () => {
+    expect(rewrites("42", "42")).toBe(false);
+    expect(rewrites(null, null)).toBe(false);
+  });
+});
+
 describe("rewritesStatus", () => {
   const columns = new Set(["BACKLOG", "Fazendo", "Code Review"]);
 

--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -177,6 +177,30 @@ async function mirrorBoardColumns(
  * those cards and stops for each one the moment it lands somewhere real, so it
  * is a conversion path rather than a standing override.
  */
+/**
+ * Whether the pull writes the card's sprint, or leaves it where it is.
+ *
+ * Only when Jira's own sprint changed since we last looked, so someone pulling
+ * a card into the sprint from Studio is not undone by the next tick reading
+ * Jira's not-yet-updated sprint back over them. The pull used to write it
+ * unconditionally, which cost nothing while the sync was the only writer.
+ *
+ * Deliberately NOT the mirror of {@link rewritesStatus}: that one re-homes a
+ * card stranded in a column the board does not have, because a card has to be
+ * SOMEWHERE. A card in no sprint is in the backlog, which is a real place.
+ */
+export function rewritesSprint({
+  lastSeenJiraSprintId,
+  jiraSprintId,
+}: {
+  /** `jira_sprint_id` on the link: the sprint we last saw or set on Jira. */
+  lastSeenJiraSprintId: string | null;
+  /** Where the issue is in Jira right now. Null is the backlog. */
+  jiraSprintId: string | null;
+}): boolean {
+  return lastSeenJiraSprintId !== jiraSprintId;
+}
+
 export function rewritesStatus({
   jiraStatusChanged,
   currentStatus,
@@ -665,11 +689,11 @@ async function runSync(
       }
 
       const jiraStatusName = issue.fields.status.name;
+      const jiraSprint = pickIssueSprint(issue.sprints);
       const fields = {
         title: issue.fields.summary,
         description: await cardDescription(integration.siteUrl, issue, users),
         priority: mapPriority(issue),
-        sprintId: await sprints.localIdFor(pickIssueSprint(issue.sprints)),
         // Asked of the board, not recomputed from the flag: one answer for
         // every writer, so a card cannot be guarded by one path and not by
         // another. A card the sync has not reached yet stays unguarded rather
@@ -680,6 +704,13 @@ async function runSync(
       if (link) {
         // Status applies only when it changed ON JIRA'S SIDE, so an unrelated issue edit can't yank back a card the agent already advanced.
         const statusChangedOnJira = link.jiraStatus !== jiraStatusName;
+        // Sprint gets the same guard for the same reason: someone pulling a
+        // card into the sprint from Studio must not have it undone by the next
+        // tick reading Jira's not-yet-updated sprint back over them.
+        const sprintChangedOnJira = rewritesSprint({
+          lastSeenJiraSprintId: link.jiraSprintId,
+          jiraSprintId: jiraSprint?.id ?? null,
+        });
         const before = await ctx.storage.taskBoard.getById(link.itemId, orgId);
         const writeStatus = rewritesStatus({
           jiraStatusChanged: statusChangedOnJira,
@@ -689,11 +720,18 @@ async function runSync(
         let item = await ctx.storage.taskBoard.update(
           link.itemId,
           orgId,
-          { ...fields, ...(writeStatus ? { status } : {}) },
+          {
+            ...fields,
+            ...(writeStatus ? { status } : {}),
+            ...(sprintChangedOnJira
+              ? { sprintId: await sprints.localIdFor(jiraSprint) }
+              : {}),
+          },
           JIRA_SYNC_ACTOR,
         );
         await ctx.storage.jiraIntegrations.touchLink(link.itemId, {
           jiraStatus: jiraStatusName,
+          jiraSprintId: jiraSprint?.id ?? null,
         });
         if (before && writeStatus && before.status !== status) {
           await ctx.storage.taskBoard.recordActivity({
@@ -729,6 +767,7 @@ async function runSync(
           organizationId: orgId,
           ...fields,
           status,
+          sprintId: await sprints.localIdFor(jiraSprint),
           by: JIRA_SYNC_ACTOR,
         });
         try {
@@ -743,6 +782,7 @@ async function runSync(
             // unchanged even if the comment pull below never finished.
             jiraUpdatedAt: new Date(0),
             jiraStatus: jiraStatusName,
+            jiraSprintId: jiraSprint?.id ?? null,
           });
         } catch (err) {
           // 23505: a concurrent run won the link's UNIQUE — drop our orphan card.

--- a/apps/api/src/storage/jira-integrations.integration.test.ts
+++ b/apps/api/src/storage/jira-integrations.integration.test.ts
@@ -198,7 +198,7 @@ describe("linked issues still on the board", () => {
       itemId: item.id,
       organizationId: ORG_R,
       jiraIssueId: issueId,
-      jiraIssueKey: `EX-${issueId}`,
+      jiraIssueKey: `OS-${issueId}`,
       jiraUpdatedAt: new Date(),
       jiraStatus: "BACKLOG",
       jiraSprintId: null,

--- a/apps/api/src/storage/jira-integrations.integration.test.ts
+++ b/apps/api/src/storage/jira-integrations.integration.test.ts
@@ -198,9 +198,10 @@ describe("linked issues still on the board", () => {
       itemId: item.id,
       organizationId: ORG_R,
       jiraIssueId: issueId,
-      jiraIssueKey: `OS-${issueId}`,
+      jiraIssueKey: `EX-${issueId}`,
       jiraUpdatedAt: new Date(),
       jiraStatus: "BACKLOG",
+      jiraSprintId: null,
     });
     return item;
   }

--- a/apps/api/src/storage/jira-integrations.ts
+++ b/apps/api/src/storage/jira-integrations.ts
@@ -44,6 +44,8 @@ export interface TaskBoardItemJiraLink {
   jiraIssueKey: string;
   jiraUpdatedAt: string;
   jiraStatus: string | null;
+  /** Jira sprint id, or null for the backlog. See `jira_sprint_id`. */
+  jiraSprintId: string | null;
 }
 
 export class JiraIntegrationStorage {
@@ -280,6 +282,7 @@ export class JiraIntegrationStorage {
           jiraIssueKey: row.jira_issue_key,
           jiraUpdatedAt: toIso(row.jira_updated_at),
           jiraStatus: row.jira_status,
+          jiraSprintId: row.jira_sprint_id,
         },
       ]),
     );
@@ -292,6 +295,7 @@ export class JiraIntegrationStorage {
     jiraIssueKey: string;
     jiraUpdatedAt: Date;
     jiraStatus: string;
+    jiraSprintId: string | null;
   }): Promise<void> {
     await this.db
       .insertInto("task_board_item_jira_links")
@@ -302,13 +306,20 @@ export class JiraIntegrationStorage {
         jira_issue_key: params.jiraIssueKey,
         jira_updated_at: params.jiraUpdatedAt,
         jira_status: params.jiraStatus,
+        jira_sprint_id: params.jiraSprintId,
       })
       .execute();
   }
 
   async touchLink(
     itemId: string,
-    patch: { jiraUpdatedAt?: Date; jiraStatus?: string },
+    patch: {
+      jiraUpdatedAt?: Date;
+      jiraStatus?: string;
+      /** Explicit null moves the issue to the backlog, so `undefined` (leave
+       *  alone) and `null` (no sprint) are different patches here. */
+      jiraSprintId?: string | null;
+    },
   ): Promise<void> {
     await this.db
       .updateTable("task_board_item_jira_links")
@@ -318,6 +329,9 @@ export class JiraIntegrationStorage {
           : {}),
         ...(patch.jiraStatus !== undefined
           ? { jira_status: patch.jiraStatus }
+          : {}),
+        ...(patch.jiraSprintId !== undefined
+          ? { jira_sprint_id: patch.jiraSprintId }
           : {}),
       })
       .where("item_id", "=", itemId)
@@ -342,6 +356,7 @@ export class JiraIntegrationStorage {
       jiraIssueKey: row.jira_issue_key,
       jiraUpdatedAt: toIso(row.jira_updated_at),
       jiraStatus: row.jira_status,
+      jiraSprintId: row.jira_sprint_id,
     };
   }
 

--- a/apps/api/src/storage/sprints.ts
+++ b/apps/api/src/storage/sprints.ts
@@ -61,6 +61,24 @@ export class SprintStorage {
   }
 
   /**
+   * A sprint's id in Jira, or null when we have no such sprint or it was never
+   * mirrored from one. The sprint push's translation step: our ids are local,
+   * and the Agile API only speaks Jira's.
+   */
+  async jiraIdFor(
+    organizationId: string,
+    sprintId: string,
+  ): Promise<string | null> {
+    const row = await this.db
+      .selectFrom("task_board_sprints")
+      .select("jira_sprint_id")
+      .where("organization_id", "=", organizationId)
+      .where("id", "=", sprintId)
+      .executeTakeFirst();
+    return row?.jira_sprint_id ?? null;
+  }
+
+  /**
    * Mirror a whole board's sprints in one statement, returning Jira sprint id
    * → local id.
    *

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -2145,6 +2145,15 @@ export interface TaskBoardItemJiraLinkTable {
     string | null | undefined,
     string | null
   >;
+  /** Last Jira sprint id SEEN OR SET on the Jira side, same job as
+   *  `jira_status` one field over: the pull applies sprint only when this
+   *  changed, and the sprint push records its target here so the echo is a
+   *  no-op. Null means never seen, so the next pull is authoritative. */
+  jira_sprint_id: ColumnType<
+    string | null,
+    string | null | undefined,
+    string | null
+  >;
   created_at: ColumnType<Date, Date | string | undefined, never>;
 }
 

--- a/apps/api/src/tools/task-board/activity-actions.test.ts
+++ b/apps/api/src/tools/task-board/activity-actions.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { expect, test } from "bun:test";
-import { ACTIONS as MIGRATION_ACTIONS } from "../../../migrations/192-task-board-verdict-nudge-activity";
+import { ACTIONS as MIGRATION_ACTIONS } from "../../../migrations/195-task-board-sprint-activity";
 import { TASK_BOARD_ACTIVITY_ACTIONS } from "./schema";
 
 test("the DB CHECK constraint allows exactly the actions TypeScript declares", () => {

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -68,7 +68,8 @@ function captureTaskRunEvent(
 
 /** Push a task board item change to every SSE listener on its org. Also the
  *  one funnel every board write passes through, so it feeds the Jira status
- *  push — dynamic import because the jira sync itself imports this module. */
+ *  and sprint pushes — dynamic import because the jira sync itself imports
+ *  this module. */
 export function emitTaskBoardUpdated(orgId: string, item: TaskBoardItem): void {
   sseHub.emit(orgId, {
     id: crypto.randomUUID(),
@@ -79,11 +80,14 @@ export function emitTaskBoardUpdated(orgId: string, item: TaskBoardItem): void {
     time: new Date().toISOString(),
   });
   void import("@/jira/dbos-jira-sync")
-    .then((jira) => jira.maybeEnqueueJiraStatusPush(orgId, item))
+    .then((jira) => {
+      jira.maybeEnqueueJiraStatusPush(orgId, item);
+      jira.maybeEnqueueJiraSprintPush(orgId, item);
+    })
     .catch((err) => {
-      // Swallowing this silently would make the whole Jira status push dead on
-      // arrival with no signal anywhere — the enqueue logs its own failures.
-      console.warn("[jira] status push hook unavailable:", err);
+      // Swallowing this silently would make the whole Jira push dead on
+      // arrival with no signal anywhere — the enqueues log their own failures.
+      console.warn("[jira] push hooks unavailable:", err);
     });
 }
 

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -182,7 +182,9 @@ export const TaskBoardItemSchema = z.object({
   repo: z.string().nullable(),
   dueDate: z.string().datetime().nullable(),
   /** The sprint this card belongs to — an id from `TASK_BOARD_ITEM_LIST`'s
-   *  `sprints`. Null = backlog. Mirrored from the tracker, not writable here. */
+   *  `sprints`. Null = backlog. The sprints themselves are mirrored from the
+   *  tracker and cannot be authored here; which one a card is IN is writable
+   *  through `TASK_BOARD_ITEM_UPDATE`, and pushed onward. */
   sprintId: z.string().nullable(),
   // Manual drag-to-reorder position within a lane, ascending.
   sortOrder: z.number(),

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -246,6 +246,7 @@ export const TASK_BOARD_ACTIVITY_ACTIONS = [
   "merge_conflict_resolution",
   "merge_failed",
   "type_changed",
+  "sprint_changed",
 ] as const;
 
 export type TaskBoardActivityAction =

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -36,7 +36,14 @@ import {
  * links.
  */
 const LOGGED_FIELDS: {
-  field: "status" | "assigneeId" | "priority" | "dueDate" | "title" | "type";
+  field:
+    | "status"
+    | "assigneeId"
+    | "priority"
+    | "dueDate"
+    | "title"
+    | "type"
+    | "sprintId";
   action: TaskBoardActivityAction;
 }[] = [
   { field: "status", action: "status_changed" },
@@ -45,6 +52,7 @@ const LOGGED_FIELDS: {
   { field: "type", action: "type_changed" },
   { field: "dueDate", action: "due_date_changed" },
   { field: "title", action: "title_changed" },
+  { field: "sprintId", action: "sprint_changed" },
 ];
 
 /**
@@ -63,6 +71,7 @@ const UPDATABLE_FIELDS = [
   "repo",
   "dueDate",
   "sortOrder",
+  "sprintId",
   "tagIds",
 ] as const;
 
@@ -215,6 +224,10 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     dueDate: z.string().datetime().nullable().optional(),
     /** New drag-to-reorder position within its lane (ascending). */
     sortOrder: z.number().optional(),
+    /** Move the card to this sprint, or null for the backlog. On a card linked
+     *  to a tracker this is pushed there, so pulling one into the sprint here
+     *  is the same act as pulling it there. */
+    sprintId: z.string().nullable().optional(),
     /** Replaces the task's tags with this exact set (org tag ids). */
     tagIds: z.array(z.string()).max(1000).optional(),
     /** Link an existing chat thread to this task (many-to-many, idempotent). */
@@ -404,6 +417,7 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
           repo: input.repo,
           dueDate: input.dueDate,
           sortOrder: input.sortOrder,
+          sprintId: input.sprintId,
         },
         getUserId(ctx)!,
       );

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -263,6 +263,17 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
       );
     }
 
+    // Checked here rather than left to the foreign key: an unknown id would
+    // otherwise surface as `violates foreign key constraint
+    // "task_board_items_sprint_id_fkey"`, which names our schema at a caller
+    // who asked a reasonable question. Null is the backlog and always valid.
+    if (input.sprintId) {
+      const sprints = await ctx.storage.sprints.listByOrg(organizationId);
+      if (!sprints.some((sprint) => sprint.id === input.sprintId)) {
+        throw new Error("sprintId is not a sprint on this board");
+      }
+    }
+
     if (input.assigneeId) {
       await assertValidAssignee(ctx, organizationId, input.assigneeId);
     }

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -211,6 +211,7 @@ export const taskBoard = {
   "taskBoard.taskDialog.deleteTask": "Delete",
   "taskBoard.taskDialog.setPriorityButton": "Set priority",
   "taskBoard.taskDialog.someoneLabel": "someone",
+  "taskBoard.taskDialog.sprintGoneLabel": "a sprint that is gone",
   "taskBoard.taskDialog.startedByLabel": "started by",
   "taskBoard.taskDialog.reviewerLabel": "Reviewer",
   // The two-reviewer era's names, still on older cards' timelines.

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -221,6 +221,7 @@ export const taskBoard = {
   "taskBoard.taskDialog.deleteTask": "Excluir",
   "taskBoard.taskDialog.setPriorityButton": "Definir prioridade",
   "taskBoard.taskDialog.someoneLabel": "alguém",
+  "taskBoard.taskDialog.sprintGoneLabel": "uma sprint que n\u00e3o existe mais",
   "taskBoard.taskDialog.startedByLabel": "iniciado por",
   "taskBoard.taskDialog.reviewerLabel": "Reviewer",
   "taskBoard.taskDialog.qaAgentLabel": "QA Agent",

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -90,6 +90,7 @@ import {
   DEFAULT_TASK_TYPE,
   laneHeader,
   laneVisual,
+  type Sprint,
   STATUS_CONFIG,
   moveTargets,
   statusIconClassName,
@@ -2286,6 +2287,7 @@ function describeActivity(
   a: TaskBoardActivity,
   t: ReturnType<typeof useT>,
   memberByUserId: Map<string, Member>,
+  sprintById: Map<string, Sprint>,
 ): ReactNode {
   const statusChip = (s: unknown) => {
     const cfg =
@@ -2371,6 +2373,19 @@ function describeActivity(
     <ValueChip
       icon={<ReviewerIcon size={14} />}
       label={reviewerName(reviewer, t)}
+    />
+  );
+  /** A sprint by its local id. Null is the backlog, and a sprint the board no
+   *  longer has still gets a chip — the move happened either way. */
+  const sprintChip = (sprintId: unknown) => (
+    <ValueChip
+      icon={<Repeat04 size={14} />}
+      label={
+        typeof sprintId === "string"
+          ? (sprintById.get(sprintId)?.name ??
+            t("taskBoard.taskDialog.sprintGoneLabel"))
+          : t("taskBoard.taskFilters.sprintBacklog")
+      }
     />
   );
 
@@ -2513,6 +2528,11 @@ function describeActivity(
             : t("taskBoard.taskDialog.activityMergeFailed");
       }
     }
+    case "sprint_changed":
+      return interleaveChips(
+        t("taskBoard.taskDialog.activityMovedFromTo", { from, to }),
+        { from: sprintChip(d.from), to: sprintChip(d.to) },
+      );
     default: {
       const _exhaustive: never = a.action;
       return String(_exhaustive);
@@ -2535,6 +2555,7 @@ function TimelineBlock({
   memberByUserId: Map<string, Member>;
 }) {
   const t = useT();
+  const sprintById = useBoardSprintIndex();
   const [expanded, setExpanded] = useState(false);
 
   const actorName = (actorId: string | null) => {
@@ -2583,7 +2604,8 @@ function TimelineBlock({
         <div key={a.id} className="relative flex items-center gap-2.5">
           {actorAvatar(a.actorId)}
           <span className="min-w-0 truncate text-xs text-muted-foreground">
-            {actorName(a.actorId)} {describeActivity(a, t, memberByUserId)}
+            {actorName(a.actorId)}{" "}
+            {describeActivity(a, t, memberByUserId, sprintById)}
             <span className="text-muted-foreground/60">
               {" · "}
               {formatTimeAgo(new Date(a.occurredAt))}

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -1237,8 +1237,10 @@ function TaskBoardItemEditor({
                 </PopoverContent>
               </Popover>
 
-              {/* Read-only: sprint membership is owned by the tracker the
-                  board mirrors (see apps/api/src/jira/sync.ts). */}
+              {/* Read-only HERE, not read-only in principle: a card's sprint
+                  is writable and pushes to the tracker, but planning is a
+                  backlog gesture rather than a field on one card, so this
+                  stays a label until that surface exists. */}
               {cardSprint && (
                 <span className={cn(PROPERTY_BUTTON, "cursor-default")}>
                   <Repeat04 size={16} className="text-muted-foreground" />

--- a/packages/e2e/tests/task-board-sprints.spec.ts
+++ b/packages/e2e/tests/task-board-sprints.spec.ts
@@ -21,9 +21,14 @@ interface BoardList {
 
 /**
  * Sprints are mirrored from the tracker the board syncs with, never authored
- * here — so what this tier can assert is the shape of that contract and the
- * fact that nothing in Studio can write a card into a sprint. An org with no
- * Jira connected has no sprints, which is exactly the state under test.
+ * here. Which sprint a card is IN is a different question, and one Studio now
+ * answers: pulling a card out of the backlog is a thing a person does here and
+ * the sync pushes onward.
+ *
+ * An org with no Jira connected has no sprints, which is exactly the state
+ * under test — so what this tier reaches is the shape of the contract and the
+ * refusals. That a real sprint sticks is the sync's own ground, covered by
+ * `rewritesSprint` and the push workflow.
  */
 test.describe("task board sprints", () => {
   test("the board read carries a sprint list, and every card names its sprint", async ({
@@ -49,9 +54,9 @@ test.describe("task board sprints", () => {
     expect(listed?.sprintId).toBe(null);
   });
 
-  /** Both the old input name and the column's own: accepting either would let a
-   *  card point at a sprint the tracker never put it in. */
-  test("a card's sprint cannot be set from Studio, however it is spelled", async ({
+  /** A card is born in the backlog. Create takes no sprint, under either the
+   *  old input name or the column's own: planning is a move, not a birth. */
+  test("a card cannot be created straight into a sprint", async ({
     authedPage,
   }) => {
     const { page, orgSlug } = authedPage;
@@ -65,14 +70,60 @@ test.describe("task board sprints", () => {
     );
     expect(created.sprintId).toBe(null);
 
-    const { item: updated } = await call<{ item: TaskBoardItem }>(
-      "TASK_BOARD_ITEM_UPDATE",
-      { id: created.id, sprint: 5, sprintId: "sprint_made_up" },
-    );
-    expect(updated.sprintId).toBe(null);
-
     const board = await call<BoardList>("TASK_BOARD_ITEM_LIST", {});
     expect(board.items.find((i) => i.id === created.id)?.sprintId).toBe(null);
+  });
+
+  /**
+   * Inverted from "a card's sprint cannot be set from Studio". It can now, and
+   * that is the point of the backlog screen. What must not happen is a card
+   * pointing at a sprint that does not exist, and the refusal has to say so in
+   * words rather than leak `violates foreign key constraint
+   * "task_board_items_sprint_id_fkey"` at whoever asked.
+   */
+  test("a sprint this board does not have is refused, in words", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const request = page.context().request;
+    const call = <T>(name: string, args: unknown) =>
+      callSelfMcpTool<T>(request, orgSlug, name, args);
+
+    const { item } = await call<{ item: TaskBoardItem }>(
+      "TASK_BOARD_ITEM_CREATE",
+      { title: "Waiting to be planned" },
+    );
+
+    await expect(
+      call("TASK_BOARD_ITEM_UPDATE", {
+        id: item.id,
+        sprintId: "sprint_made_up",
+      }),
+    ).rejects.toThrow(/not a sprint on this board/);
+
+    const board = await call<BoardList>("TASK_BOARD_ITEM_LIST", {});
+    expect(board.items.find((i) => i.id === item.id)?.sprintId).toBe(null);
+  });
+
+  /** Null is the backlog, and always a place a card may go — it needs no
+   *  sprint to exist, so it works on a board that has none. */
+  test("sending a card back to the backlog is always allowed", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const request = page.context().request;
+    const call = <T>(name: string, args: unknown) =>
+      callSelfMcpTool<T>(request, orgSlug, name, args);
+
+    const { item } = await call<{ item: TaskBoardItem }>(
+      "TASK_BOARD_ITEM_CREATE",
+      { title: "Already in the backlog" },
+    );
+    const { item: updated } = await call<{ item: TaskBoardItem }>(
+      "TASK_BOARD_ITEM_UPDATE",
+      { id: item.id, sprintId: null },
+    );
+    expect(updated.sprintId).toBe(null);
   });
 
   /** The cadence write used to replace a stored `sprint_config` whole. There is

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -482,6 +482,7 @@ export interface StudioToolIO {
       repo?: string | null | undefined;
       dueDate?: string | null | undefined;
       sortOrder?: number | undefined;
+      sprintId?: string | null | undefined;
       tagIds?: string[] | undefined;
       linkThreadId?: string | undefined;
       prUrl?: string | null | undefined;
@@ -638,7 +639,8 @@ export interface StudioToolIO {
           | "tags_changed"
           | "review_verdict_requested"
           | "merge_conflict_resolution"
-          | "type_changed";
+          | "type_changed"
+          | "sprint_changed";
         actorId: string | null;
         data: Record<string, unknown>;
         occurredAt: string;


### PR DESCRIPTION
Prerequisite for the backlog screen. Split out because it stands alone, and
because the screen is useless without it.

## The problem

A card's sprint was pull-only, in two ways that reinforced each other. The sync
overwrote `sprintId` on every tick with no guard, and `sprintId` was not in
`TASK_BOARD_ITEM_UPDATE` at all. The schema said so out loud:

> Mirrored from the tracker, not writable here.

That cost nothing, because the sync was the only writer of the field (verified:
one call site). It becomes data loss the moment someone can pull a card out of
the backlog from Studio, because the next tick reads Jira's not-yet-updated
sprint back over them.

## The fix

Status already solved this exact problem, so this copies it field for field
rather than inventing a second mechanism.

**`jira_sprint_id` on the link row.** Documented like `jira_status` sitting
beside it: the last sprint SEEN OR SET on the Jira side. The pull reads it, the
push writes it, and that is what makes the echo a no-op.

**`rewritesSprint` gates the pull.** A local move survives until Jira agrees.
Deliberately not a mirror of `rewritesStatus`: that one re-homes a card
stranded in a column the board does not have, because a card has to be
somewhere. A card in no sprint is in the backlog, which is a real place.

**A sprint push workflow** on the same org-partitioned queue, with the same
two-step plan/execute shape and the same read-the-world-before-retrying guard,
so a crash between the POST and the bookkeeping cannot move the issue twice.
`POST /rest/agile/1.0/sprint/{id}/issue` to pull in, `POST /backlog/issue` to
send back. It reads the card's current sprint rather than a snapshot, for the
reason the status push does: two quick moves can reach the queue out of order,
and the stale leg would stick.

**`sprintId` writable** on the update tool, logging `sprint_changed`, rendered
on the timeline with sprint names instead of ids.

## Two judgement calls

No backfill on `jira_sprint_id`, and that is safe rather than lucky. Null reads
as "no sprint", so the first pull rewrites the sprint of every card whose issue
is in one and skips every card whose issue is not. Both land on exactly what
the unconditional pull had already written.

A card in a sprint that never came from Jira pushes nothing and warns. Posting
it to the backlog instead would invent a move nobody asked for.

## Verification

Ran both migrations against real Postgres and asserted the result rather than
the log line, which was worth doing: the first run printed "Migrations
completed" and applied nothing, because `migrations/index.ts` is an explicit
registry and I had not added them.

- `jira_sprint_id` exists and is nullable
- the rebuilt CHECK accepts a `sprint_changed` insert, probed in a rolled-back
  transaction

Unit tests cover `rewritesSprint` across all four transitions. The
`activity-actions` guard test now reads migration 195, which is what proves the
SQL constraint and the TS union still agree. `check`, `lint`, `fmt` and `knip`
are clean.

## Not covered

No end-to-end run against a live Jira. The push path is exercised only by its
unit-level guards, so the first real sprint move is worth watching.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Jira sprint two-way, the way status already is — the prerequisite for a backlog screen: sprint was pull-only, so the sync overwrote any local move on the next tick.

**Sprint sync**
- The pull now writes sprint only when Jira's sprint actually changed, gated by `jira_sprint_id` on the link row.
- A sprint push workflow on the same queue as status pushes local moves to Jira; it reads the issue's current sprint before retrying so a crash can't double-move it.
- `sprintId` is now writable in the update tool, logs `sprint_changed`, and the timeline shows sprint names.
- The update tool rejects a sprint id this board does not have with a clear message instead of a foreign-key error; cards are still born in the backlog.
- No backfill on `jira_sprint_id`: null reads as "no sprint", landing on exactly what the old pull had already written.
- A card in a sprint that never came from Jira warns and pushes nothing instead of inventing a move.

<sup>Written for commit f45b9c6420bbc509bb25c0cb34eb11dac3720b7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

