### PR TITLE
fix(web): stop empty "New chat" rows from piling up in the sidebar

### DIFF
--- a/apps/web/src/components/sidebar/task-groups/use-threads-panel.tsx
+++ b/apps/web/src/components/sidebar/task-groups/use-threads-panel.tsx
@@ -22,6 +22,9 @@ import {
 } from "@/layouts/thread-route";
 import { track } from "@/lib/posthog-client";
 import type { Task } from "@/components/chat/task/types";
+import { findReusableNewChat } from "@/lib/reusable-new-chat";
+import { hideAbandonedNewChats } from "@/lib/thread-list-visibility";
+import { useProjectDefaultRuntime } from "@/sdk/project-default-runtime";
 import { forgetThreadLayout } from "@/lib/thread-layout-memory";
 import { useStudioTools } from "@/lib/studio-tools";
 import { isDesktopAppEnvironment } from "@/hooks/use-is-desktop-app";
@@ -97,6 +100,7 @@ export function useThreadsPanel({
   const currentUserId = session?.user?.id;
   const { org } = useProjectContext();
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
+  const projectDefaultRuntime = useProjectDefaultRuntime();
 
   const {
     threads: allThreads,
@@ -198,10 +202,17 @@ export function useThreadsPanel({
     return threads;
   };
 
-  /** Every agent's threads, mixed — an agent's own list lives on its home view. */
-  const visibleScopedThreads = showAll
-    ? typeFiltered(sortedThreads)
-    : typeFiltered(mineFiltered(sortedThreads));
+  /**
+   * Every agent's threads, mixed — an agent's own list lives on its home view.
+   * Abandoned empty "New chat" rows are dropped (the active one is kept) so the
+   * list isn't buried under chats that were opened but never used.
+   */
+  const visibleScopedThreads = hideAbandonedNewChats(
+    showAll
+      ? typeFiltered(sortedThreads)
+      : typeFiltered(mineFiltered(sortedThreads)),
+    activeTaskId,
+  );
 
   /**
    * The archive itself. Nothing here runs until the reclaim confirm (if any)
@@ -301,17 +312,23 @@ export function useThreadsPanel({
     setTaskId(task.id, task.virtual_mcp_id);
   };
 
-  /**
-   * ALWAYS create a fresh chat on the currently selected agent (the active
-   * thread's agent, else decopilot), inheriting the active thread's branch so it
-   * lands on the same sandbox. We do not reuse an existing empty "New chat".
-   */
+  /** New chat on the current agent — reuse its empty one if any, else create. */
   const newThread = () => {
     const currentAgentId = activeAgentId ?? decopilotId;
-    const currentBranch =
-      allThreads.find((thread) => thread.id === activeTaskId)?.branch ?? null;
     track("sidebar_new_thread_clicked", { virtual_mcp_id: currentAgentId });
     closeAfterNavigation();
+    const existing = findReusableNewChat(
+      allThreads,
+      currentAgentId,
+      currentUserId,
+      projectDefaultRuntime(currentAgentId),
+    );
+    if (existing) {
+      setTaskId(existing.id, existing.virtual_mcp_id);
+      return;
+    }
+    const currentBranch =
+      allThreads.find((thread) => thread.id === activeTaskId)?.branch ?? null;
     createNewTask(currentAgentId, currentBranch);
   };
 

--- a/apps/web/src/lib/thread-list-visibility.test.ts
+++ b/apps/web/src/lib/thread-list-visibility.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import type { Task } from "@/components/chat/task/types";
+import { hideAbandonedNewChats } from "./thread-list-visibility";
+
+const task = (over: Partial<Task>): Task =>
+  ({
+    id: over.id ?? crypto.randomUUID(),
+    title: over.title ?? "New chat",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    virtual_mcp_id: "agent-1",
+    created_by: "user-1",
+    ...over,
+  }) as Task;
+
+describe("hideAbandonedNewChats", () => {
+  it("drops an empty New chat that is not the active thread", () => {
+    const t = task({ id: "a" });
+    expect(hideAbandonedNewChats([t], "other")).toEqual([]);
+  });
+
+  it("keeps the active empty New chat so it never vanishes under the user", () => {
+    const t = task({ id: "a" });
+    expect(hideAbandonedNewChats([t], "a")).toEqual([t]);
+  });
+
+  it("keeps a chat with a message (harness_id pinned)", () => {
+    const t = task({ id: "a", harness_id: "h1" });
+    expect(hideAbandonedNewChats([t], "other")).toEqual([t]);
+  });
+
+  it("keeps a chat that was auto-titled after a successful turn", () => {
+    const t = task({ id: "a", title: "Fix the login bug" });
+    expect(hideAbandonedNewChats([t], "other")).toEqual([t]);
+  });
+
+  it("keeps an un-started automation row even when empty", () => {
+    const t = task({ id: "a", trigger_id: "trig-1" });
+    expect(hideAbandonedNewChats([t], "other")).toEqual([t]);
+  });
+});

--- a/apps/web/src/lib/thread-list-visibility.ts
+++ b/apps/web/src/lib/thread-list-visibility.ts
@@ -1,0 +1,28 @@
+import type { Task } from "@/components/chat/task/types";
+import { threadHasMessages } from "./thread-has-messages";
+
+/**
+ * Drop the user's abandoned empty "New chat" rows from a rendered thread list.
+ *
+ * A fresh chat is persisted to the DB the moment "New chat" is opened — before
+ * anything is typed — so without this filter every abandoned "New chat" piles
+ * up in the list forever. `threadHasMessages` is the shared emptiness test
+ * (`harness_id` pinned on the first message, or a non-default title).
+ *
+ * Two kinds of empty row are kept:
+ *  - the ACTIVE thread (`activeTaskId`) — it may be the empty chat the user is
+ *    about to type into, and it must not vanish from under them.
+ *  - automation rows (`trigger_id`) — a scheduled run can legitimately sit
+ *    un-started with the default title; it is activity, not user clutter.
+ */
+export function hideAbandonedNewChats(
+  threads: Task[],
+  activeTaskId: string | null | undefined,
+): Task[] {
+  return threads.filter(
+    (thread) =>
+      thread.id === activeTaskId ||
+      Boolean(thread.trigger_id) ||
+      threadHasMessages(thread),
+  );
+}


### PR DESCRIPTION
## Summary

The chat list was filling up with empty **"New chat"** rows (see below). A thread is persisted to the DB the moment "New chat" is opened — before anything is typed — so every abandoned "New chat" accumulated as a permanent row, and the sidebar button deliberately never reused an existing empty one.

This PR does two things (no change to the eager-create architecture):

- **Reuse instead of duplicate** — the sidebar "New chat" button now reuses the current agent's existing empty "New chat" (`findReusableNewChat`), matching what the breadcrumb / org-home / repo-switcher already do. This reverts the always-create opt-out introduced in #6117. A freshly created chat still inherits the active thread's branch.
- **Hide abandoned empties from the list** — the rendered thread list drops empty "New chat" rows via the new pure helper `hideAbandonedNewChats`. Two exceptions are kept: the **active** thread (so the chat you're about to type into never vanishes) and **automation** rows (`trigger_id`, a scheduled run may sit un-started with the default title).

The two compose cleanly: the list filter only affects rendering, while reuse searches the full store, so a hidden empty chat is still reusable.

## Notes
- Emptiness reuses the single shared test `threadHasMessages` (`harness_id` pinned, or a non-default title) — no duplicate definition.
- Out of scope: the empty rows still exist in the DB. Not persisting until the first message ("don't save empty chats at all") fights the route loader's create-on-404 fallback and is left for a follow-up.

## Testing
- New unit test `thread-list-visibility.test.ts` — 5 cases (active / abandoned / harness / titled / automation).
- `bun run fmt`, `bun run check` (tsc apps/web), `bun run lint` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops abandoned empty "New chat" rows from piling up in the sidebar. The "New chat" button now reuses the current agent's existing empty chat instead of always creating a new one, and the rendered thread list hides abandoned empty rows.

- The list keeps the active empty thread and automation rows (`trigger_id`) so chats don't vanish mid-use.
- Empty chats are still persisted to the DB; deferring persistence until the first message is a follow-up.

<sup>Written for commit b37e236e788fe0c299e9f83f775e6315e6fa205b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

