### PR TITLE
chore: redact tenant-identifying data from fixtures and comments

### DIFF
--- a/apps/api/src/auth/org-assurance-policy.ts
+++ b/apps/api/src/auth/org-assurance-policy.ts
@@ -82,7 +82,7 @@ export function domainDisplayName(domain: string): string {
 
 /**
  * Derives a human display name from an email local-part, e.g.
- * `stephanie.moraes@montecarlo.com.br` -> "Stephanie Moraes".
+ * `ana.ribeiro@example.com` -> "Ana Ribeiro".
  *
  * Used to backfill `user.name` at signup for flows that never collect one
  * (email OTP, magic link, email/password), so invited members don't render

--- a/apps/api/src/jira/client.test.ts
+++ b/apps/api/src/jira/client.test.ts
@@ -872,7 +872,7 @@ describe("JiraClient.addAttachment", () => {
     );
     try {
       expect(
-        await client().addAttachment("OS-1", {
+        await client().addAttachment("EX-1", {
           name: "shot.png",
           bytes: new Uint8Array([1, 2, 3]),
           contentType: "image/png",
@@ -881,7 +881,7 @@ describe("JiraClient.addAttachment", () => {
 
       const upload = stub.calls[0];
       expect(upload?.url).toBe(
-        "https://acme.atlassian.net/rest/api/3/issue/OS-1/attachments",
+        "https://acme.atlassian.net/rest/api/3/issue/EX-1/attachments",
       );
       expect(upload?.init.body).toBeInstanceOf(FormData);
       const headers = (upload?.init.headers ?? {}) as Record<string, string>;
@@ -910,7 +910,7 @@ describe("JiraClient.addAttachment", () => {
     try {
       expect(
         (
-          await client().addAttachment("OS-1", {
+          await client().addAttachment("EX-1", {
             name: "shot.png",
             bytes: new Uint8Array([1]),
           })
@@ -929,7 +929,7 @@ describe("JiraClient.addAttachment", () => {
     );
     try {
       expect(
-        await client().addAttachment("OS-1", {
+        await client().addAttachment("EX-1", {
           name: "shot.png",
           bytes: new Uint8Array([1]),
         }),
@@ -945,7 +945,7 @@ describe("JiraClient.addAttachment", () => {
     );
     try {
       await expect(
-        client().addAttachment("OS-1", {
+        client().addAttachment("EX-1", {
           name: "shot.png",
           bytes: new Uint8Array([1]),
         }),
@@ -1063,7 +1063,7 @@ describe("JiraClient issue reads", () => {
             issues: [
               {
                 id: "1",
-                key: "OS-1",
+                key: "EX-1",
                 fields: {
                   summary: "s",
                   status: { name: "BACKLOG" },
@@ -1114,7 +1114,7 @@ describe("JiraClient issue reads", () => {
             issues: [
               {
                 id: "1",
-                key: "OS-1",
+                key: "EX-1",
                 fields: {
                   summary: "s",
                   status: { name: "BACKLOG" },
@@ -1165,7 +1165,7 @@ describe("JiraClient issue reads", () => {
             issues: [
               {
                 id: "1",
-                key: "OS-1",
+                key: "EX-1",
                 fields: {
                   summary: "s",
                   status: { name: "BACKLOG" },

--- a/apps/api/src/storage/jira-integrations.integration.test.ts
+++ b/apps/api/src/storage/jira-integrations.integration.test.ts
@@ -198,7 +198,7 @@ describe("linked issues still on the board", () => {
       itemId: item.id,
       organizationId: ORG_R,
       jiraIssueId: issueId,
-      jiraIssueKey: `OS-${issueId}`,
+      jiraIssueKey: `EX-${issueId}`,
       jiraUpdatedAt: new Date(),
       jiraStatus: "BACKLOG",
     });

--- a/apps/api/src/storage/jira-integrations.integration.test.ts
+++ b/apps/api/src/storage/jira-integrations.integration.test.ts
@@ -214,7 +214,7 @@ describe("linked issues still on the board", () => {
     expect(listed[0]).toEqual({
       itemId: live.id,
       jiraIssueId: "9001",
-      jiraIssueKey: "OS-9001",
+      jiraIssueKey: "EX-9001",
     });
   });
 
@@ -241,13 +241,13 @@ describe("linked issues still on the board", () => {
     });
 
     expect((await taskBoard.getById(synced.id, ORG_R))?.jiraIssueKey).toBe(
-      "OS-9100",
+      "EX-9100",
     );
     expect((await taskBoard.getById(own.id, ORG_R))?.jiraIssueKey).toBe(null);
 
     const listed = await taskBoard.list(ORG_R);
     const byId = new Map(listed.map((i) => [i.id, i.jiraIssueKey]));
-    expect(byId.get(synced.id)).toBe("OS-9100");
+    expect(byId.get(synced.id)).toBe("EX-9100");
     expect(byId.get(own.id)).toBe(null);
   });
 

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1957,7 +1957,7 @@ export interface TaskBoardItem {
   sortOrder: number;
   /** Per-org sequence behind the card's human key (`DECO-01`), never null. */
   keySeq: number;
-  /** The key this card's issue wears in the tracker (`OS-333`), for a card that
+  /** The key this card's issue wears in the tracker (`EX-333`), for a card that
    *  came from one — attached on reads, null for a card Studio owns. */
   jiraIssueKey: string | null;
   /** Infrastructure retries already spent on this card's runs — the budget

--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -126,11 +126,11 @@ describe("extractPreviewUrl", () => {
           {
             context: "deco/preview",
             state: "success",
-            target_url: "https://envs-montecarlo--c8xgrn.decocdn.com/",
+            target_url: "https://envs-example--a1b2c3.decocdn.com/",
           },
         ],
       }),
-    ).toBe("https://envs-montecarlo--c8xgrn.decocdn.com/");
+    ).toBe("https://envs-example--a1b2c3.decocdn.com/");
 
     expect(
       extractPreviewUrl({
@@ -172,7 +172,7 @@ describe("extractPreviewUrl", () => {
 });
 
 describe("toCheckRunsStatus", () => {
-  it("maps GitHub Actions check-runs (montecarlo's failing 'Deco / QA' run)", () => {
+  it("maps GitHub Actions check-runs (a real failing 'Deco / QA' run)", () => {
     expect(
       toCheckRunsStatus({
         check_runs: [
@@ -257,7 +257,7 @@ describe("mergeChecksStatus", () => {
     expect(mergeChecksStatus("passing", "pending")).toBe("pending");
     expect(mergeChecksStatus("passing", null)).toBe("passing");
     expect(mergeChecksStatus(null, null)).toBeNull();
-    // montecarlo: empty combined status (null) + failing check-run → failing.
+    // Seen in production: empty combined status (null) + failing check-run → failing.
     expect(
       mergeChecksStatus(toChecksStatus({ total_count: 0 }), "failing"),
     ).toBe("failing");
@@ -267,7 +267,7 @@ describe("mergeChecksStatus", () => {
 describe("isTrustedPreviewHost", () => {
   it("accepts the real deco preview hosts", () => {
     expect(
-      isTrustedPreviewHost("https://envs-montecarlo--c8xgrn.decocdn.com/"),
+      isTrustedPreviewHost("https://envs-example--a1b2c3.decocdn.com/"),
     ).toBe(true);
     expect(
       isTrustedPreviewHost(
@@ -370,7 +370,7 @@ describe("extractPreviewUrlFromComments", () => {
   // Real deco.cx `decobot` comment shape (trimmed).
   const decobotBody =
     "**deco Deployment** · commit `1059e10`\n\n| Name | Preview |\n| - | - |\n" +
-    "| montecarlo | [Visit Preview](https://envs-montecarlo--c8xgrn.decocdn.com) |";
+    "| example | [Visit Preview](https://envs-example--a1b2c3.decocdn.com) |";
   // Real Vercel bot comment shape (trimmed, from deco-sites/electrolux#10).
   const vercelBody =
     "| Project | Deployment | Actions | Updated (UTC) |\n| :--- | :----- | :------ | :------ |\n" +
@@ -385,7 +385,7 @@ describe("extractPreviewUrlFromComments", () => {
 
   it("lifts the deco.cx 'Visit Preview' markdown link", () => {
     expect(extractPreviewUrlFromComments([{ body: decobotBody }])).toBe(
-      "https://envs-montecarlo--c8xgrn.decocdn.com",
+      "https://envs-example--a1b2c3.decocdn.com",
     );
   });
 
@@ -398,10 +398,10 @@ describe("extractPreviewUrlFromComments", () => {
   it("accepts the { comments } and { items } wrapper shapes", () => {
     expect(
       extractPreviewUrlFromComments({ comments: [{ body: decobotBody }] }),
-    ).toBe("https://envs-montecarlo--c8xgrn.decocdn.com");
+    ).toBe("https://envs-example--a1b2c3.decocdn.com");
     expect(
       extractPreviewUrlFromComments({ items: [{ body: decobotBody }] }),
-    ).toBe("https://envs-montecarlo--c8xgrn.decocdn.com");
+    ).toBe("https://envs-example--a1b2c3.decocdn.com");
   });
 
   it("is null with no deco preview comment", () => {
@@ -461,7 +461,7 @@ describe("extractPreviewUrlFromComments", () => {
         { body: decobotBody },
         { body: vercelBody },
       ]),
-    ).toBe("https://envs-montecarlo--c8xgrn.decocdn.com");
+    ).toBe("https://envs-example--a1b2c3.decocdn.com");
   });
 });
 

--- a/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
@@ -260,7 +260,7 @@ describe("reviewerHandledThisCycle", () => {
 });
 
 describe("a reviewer that completed without recording a verdict", () => {
-  // OS-303 (osklen): the run finished while it was still "standing by" for a
+  // Seen in production: the run finished while it was still "standing by" for a
   // background task, so it never called the decision tool. The card sat In
   // Review at 0/1 with nothing to move it — no re-dispatch, no hand-off.
   const completed = taskWith([

--- a/apps/api/src/tools/task-board/pr-extract.test.ts
+++ b/apps/api/src/tools/task-board/pr-extract.test.ts
@@ -3,12 +3,12 @@ import { extractPrFromText, extractPrFromValue } from "./pr-extract";
 
 describe("extractPrFromText", () => {
   test("gh pr create stdout (bare html URL)", () => {
-    const out = "https://github.com/deco-sites/farmrio/pull/1006\n";
+    const out = "https://github.com/deco-sites/example-store/pull/1006\n";
     expect(extractPrFromText(out)).toEqual({
-      url: "https://github.com/deco-sites/farmrio/pull/1006",
+      url: "https://github.com/deco-sites/example-store/pull/1006",
       number: 1006,
       owner: "deco-sites",
-      repo: "farmrio",
+      repo: "example-store",
     });
   });
 

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -188,7 +188,7 @@ export const TaskBoardItemSchema = z.object({
   sortOrder: z.number(),
   // Per-org sequence behind the card's human key (`DECO-01`); null pre-backfill.
   keySeq: z.number().nullable(),
-  // The key this card's issue wears in the tracker (`OS-333`), for a card that
+  // The key this card's issue wears in the tracker (`EX-333`), for a card that
   // came from one. It is what the card shows, because it is what people say
   // out loud about it. Null for a card Studio owns.
   jiraIssueKey: z.string().nullable(),

--- a/apps/web/ct/tests/array-object-drilldown.ct.tsx
+++ b/apps/web/ct/tests/array-object-drilldown.ct.tsx
@@ -277,7 +277,7 @@ test("deleting a row removes the right item from the array", async ({
 test("colliding fallback-title rows are position-disambiguated and each drills into its own content", async ({
   mount,
 }) => {
-  // The osklen bug: object-array items with no name/title field all fall back
+  // The bug this covers: object-array items with no name/title field all fall back
   // to the item schema `title` ("Spec"), so every row's label collides and
   // navigation used to collapse every item back to the first ("all items show
   // the same content"). Rows now render with the clean, identical label "Spec"

--- a/apps/web/src/components/sections-editor/array-item-display.test.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.test.ts
@@ -138,7 +138,7 @@ describe("getArrayItemLabel", () => {
   });
 
   test("labels a date matcher item by its configured range", () => {
-    // Real farmrio data: a Multi rule's `matchers` child.
+    // Real storefront data: a Multi rule's `matchers` child.
     const item = {
       __resolveType: "website/matchers/date.ts",
       start: "2026-08-10T15:00:00Z",

--- a/apps/web/src/components/sections-editor/deco-repo-path.test.ts
+++ b/apps/web/src/components/sections-editor/deco-repo-path.test.ts
@@ -19,11 +19,8 @@ describe("decoRepoPath", () => {
 
   test("prefixes the package path when the project is in a subdirectory", () => {
     expect(
-      decoRepoPath(
-        "eitri-shopping-monte-carlo-shared",
-        ".deco/blocks.gen.json",
-      ),
-    ).toBe("eitri-shopping-monte-carlo-shared/.deco/blocks.gen.json");
+      decoRepoPath("eitri-shopping-example-shared", ".deco/blocks.gen.json"),
+    ).toBe("eitri-shopping-example-shared/.deco/blocks.gen.json");
   });
 
   test("normalizes leading and trailing slashes on the package path", () => {

--- a/apps/web/src/components/sections-editor/deco-repo-path.ts
+++ b/apps/web/src/components/sections-editor/deco-repo-path.ts
@@ -1,6 +1,6 @@
 /**
  * Join a virtual MCP's package path (`metadata.runtime.path`, e.g.
- * "eitri-shopping-monte-carlo-shared") with a repo-relative `.deco/*` path.
+ * "eitri-shopping-example-shared") with a repo-relative `.deco/*` path.
  *
  * The sandbox daemon resolves file reads against the repo root, but when the
  * project doesn't live at the repo root the dev server runs with the package

--- a/apps/web/src/components/sections-editor/resolve-schema.test.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.test.ts
@@ -717,7 +717,7 @@ describe("resolveSchema – plainSchema on block-ref", () => {
   });
 
   test("populates plainSchema for a multivariate flag nested past the eager depth cap", () => {
-    // Real farmrio MediaKits: the ImageWidget anyOf sits ~7 objects deep (loader → mediaKits[] → content → desktop → media union → image). eagerBranchSchema's depth cap used to null the plain image-uri branch there, demoting the field to a block-ref "Image Variants" picker instead of an image widget with variants.
+    // A real storefront's MediaKits: the ImageWidget anyOf sits ~7 objects deep (loader → mediaKits[] → content → desktop → media union → image). eagerBranchSchema's depth cap used to null the plain image-uri branch there, demoting the field to a block-ref "Image Variants" picker instead of an image widget with variants.
     const imageWidgetAnyOf = {
       title: "Imagem",
       anyOf: [
@@ -802,7 +802,7 @@ describe("resolveSchema – plainSchema on block-ref", () => {
 
 describe("resolveSchema – array branch hidden behind a $ref", () => {
   test("prefers the inline array over colliding loader/Resolvable branches", () => {
-    // Real farmrio EtcMediaKits `mediaKits`: array member is a bare $ref beside loader/named-block branches.
+    // A real storefront's EtcMediaKits `mediaKits`: array member is a bare $ref beside loader/named-block branches.
     const meta = metaWithSchema({
       type: "object",
       properties: {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -888,7 +888,7 @@ describe("resolveActiveFieldKey", () => {
   });
 
   test("narrows to a PLP loader whose selectedFacets[] item is labelled by key", () => {
-    // ALS/montecarlo/farmrio/osklen: selectedFacets items are {key,value} — the "category-1" label comes from `key`.
+    // Seen on four storefronts: selectedFacets items are {key,value} — the "category-1" label comes from `key`.
     const properties = {
       page: {
         title: "Page",
@@ -969,7 +969,7 @@ describe("resolveActiveFieldKey", () => {
   });
 
   test("two loaders carrying the same facet: bare crumb is ambiguous, ancestor crumb pins it", () => {
-    // Real montecarlo SearchResult: `page` + `RangePriceProps` both carry a selectedFacets item labelled "category-1".
+    // A real storefront SearchResult: `page` + `RangePriceProps` both carry a selectedFacets item labelled "category-1".
     const properties = {
       page: {
         title: "Page",

--- a/apps/web/src/components/sections-editor/use-package-path.ts
+++ b/apps/web/src/components/sections-editor/use-package-path.ts
@@ -2,7 +2,7 @@ import { useVirtualMCP } from "@/sdk";
 
 /**
  * The project's package path (`metadata.runtime.path`, e.g.
- * "eitri-shopping-monte-carlo-shared"), or null when the project lives at the
+ * "eitri-shopping-example-shared"), or null when the project lives at the
  * repo root. Pair with {@link decoRepoPath} to address `.deco/*` files through
  * the sandbox daemon, which resolves paths against the repo root.
  *

--- a/apps/web/src/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/web/src/components/thread/github/sandbox-git-api.test.ts
@@ -137,15 +137,15 @@ describe("isDecoOnlyDiff", () => {
   test("true for a subdir package path (`<pkg>/.deco/...` + generated assets)", () => {
     const diff: GitDiffResult = {
       diffs: {
-        "eitri-shopping-monte-carlo-shared/.deco/blocks/foo.json": {
+        "eitri-shopping-example-shared/.deco/blocks/foo.json": {
           from: "{}",
           to: "{}",
         },
-        "eitri-shopping-monte-carlo-shared/.deco/blocks.gen.json": {
+        "eitri-shopping-example-shared/.deco/blocks.gen.json": {
           from: "{}",
           to: '{"foo":{}}',
         },
-        "eitri-shopping-monte-carlo-shared/static/tailwind.css": {
+        "eitri-shopping-example-shared/static/tailwind.css": {
           from: "a",
           to: "b",
         },

--- a/apps/web/src/layouts/task-board/task-filters.test.ts
+++ b/apps/web/src/layouts/task-board/task-filters.test.ts
@@ -327,36 +327,36 @@ describe("matchesTaskKey", () => {
 
 /**
  * The collision this exists to prevent: `parseTaskKeySeq` ignores a term's
- * prefix, so before the tracker key was consulted, searching `OS-333` resolved
+ * prefix, so before the tracker key was consulted, searching `EX-333` resolved
  * to the number 333 and quietly matched whichever unrelated card held Studio
- * sequence 333 — while missing the card actually named OS-333.
+ * sequence 333 — while missing the card actually named EX-333.
  */
 describe("matchesTaskKey with a tracker key", () => {
   test("finds a synced card by the key it shows, any case", () => {
-    expect(matchesTaskKey("OS-333", 320, "OS-333")).toBe(true);
-    expect(matchesTaskKey("os-333", 320, "OS-333")).toBe(true);
-    expect(matchesTaskKey("  OS-333  ", 320, "OS-333")).toBe(true);
+    expect(matchesTaskKey("EX-333", 320, "EX-333")).toBe(true);
+    expect(matchesTaskKey("ex-333", 320, "EX-333")).toBe(true);
+    expect(matchesTaskKey("  EX-333  ", 320, "EX-333")).toBe(true);
   });
 
   test("does not match a synced card by the sequence it no longer shows", () => {
-    expect(matchesTaskKey("OSKL-320", 320, "OS-333")).toBe(false);
+    expect(matchesTaskKey("ACME-320", 320, "EX-333")).toBe(false);
   });
 
   test("never lets a tracker key match an unrelated card's sequence", () => {
-    expect(matchesTaskKey("OS-333", 333, "OS-999")).toBe(false);
-    expect(matchesTaskKey("OS-333", 333, null)).toBe(true);
+    expect(matchesTaskKey("EX-333", 333, "EX-999")).toBe(false);
+    expect(matchesTaskKey("EX-333", 333, null)).toBe(true);
   });
 
   test("takes a bare number against either vocabulary, ambiguity included", () => {
-    expect(matchesTaskKey("333", 320, "OS-333")).toBe(true);
-    expect(matchesTaskKey("0333", 320, "OS-333")).toBe(true);
-    expect(matchesTaskKey("320", 320, "OS-333")).toBe(false);
+    expect(matchesTaskKey("333", 320, "EX-333")).toBe(true);
+    expect(matchesTaskKey("0333", 320, "EX-333")).toBe(true);
+    expect(matchesTaskKey("320", 320, "EX-333")).toBe(false);
     expect(matchesTaskKey("333", 333, null)).toBe(true);
   });
 
   test("an empty or unparseable term names nothing", () => {
-    expect(matchesTaskKey("", 320, "OS-333")).toBe(false);
-    expect(matchesTaskKey("   ", 320, "OS-333")).toBe(false);
-    expect(matchesTaskKey("schema", 320, "OS-333")).toBe(false);
+    expect(matchesTaskKey("", 320, "EX-333")).toBe(false);
+    expect(matchesTaskKey("   ", 320, "EX-333")).toBe(false);
+    expect(matchesTaskKey("schema", 320, "EX-333")).toBe(false);
   });
 });

--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -204,7 +204,7 @@ const BARE_SEQ = /^0*(\d+)$/;
  *
  * A card synced from a tracker shows the tracker's key, so that is the only
  * lettered key it answers to. Falling through to the sequence would be worse
- * than useless: `parseTaskKeySeq` ignores the prefix, so searching `OS-333`
+ * than useless: `parseTaskKeySeq` ignores the prefix, so searching `EX-333`
  * would quietly match whichever unrelated card happens to hold Studio sequence
  * 333, and miss the one actually named that.
  *

--- a/apps/web/src/layouts/task-board/task-route.test.ts
+++ b/apps/web/src/layouts/task-board/task-route.test.ts
@@ -6,7 +6,7 @@ const items = [
   { id: "board_def", keySeq: 12, jiraIssueKey: null },
   { id: "board_ghi", keySeq: null, jiraIssueKey: null },
   { id: "board_jkl", keySeq: 333, jiraIssueKey: null },
-  { id: "board_mno", keySeq: 5, jiraIssueKey: "OS-333" },
+  { id: "board_mno", keySeq: 5, jiraIssueKey: "EX-333" },
 ];
 
 describe("taskRouteSegment", () => {
@@ -16,7 +16,7 @@ describe("taskRouteSegment", () => {
   });
 
   test("writes a synced card's tracker key, not a Studio one", () => {
-    expect(taskRouteSegment("deco", items[4]!)).toBe("OS-333");
+    expect(taskRouteSegment("deco", items[4]!)).toBe("EX-333");
   });
 
   test("falls back to the id when the card has no key", () => {
@@ -52,8 +52,8 @@ describe("findTaskByKeyOrId", () => {
    * the same number as a Studio `keySeq`.
    */
   test("resolves a synced card by its tracker key, not by a same-numbered keySeq", () => {
-    expect(findTaskByKeyOrId(items, "OS-333")?.id).toBe("board_mno");
-    expect(findTaskByKeyOrId(items, "os-333")?.id).toBe("board_mno");
+    expect(findTaskByKeyOrId(items, "EX-333")?.id).toBe("board_mno");
+    expect(findTaskByKeyOrId(items, "ex-333")?.id).toBe("board_mno");
   });
 
   test("misses cleanly", () => {

--- a/apps/web/src/layouts/task-board/task-route.ts
+++ b/apps/web/src/layouts/task-board/task-route.ts
@@ -18,7 +18,7 @@ export interface TaskRouteItem {
 
 /**
  * The segment a link to this card carries: the human key it already shows
- * (`DECO-01`, or the tracker's own `OS-333`), which is the whole point of
+ * (`DECO-01`, or the tracker's own `EX-333`), which is the whole point of
  * putting the card in the path.
  *
  * A row written before the key backfill has no key, so it falls back to its
@@ -30,10 +30,10 @@ export function taskRouteSegment(orgSlug: string, item: TaskRouteItem): string {
 
 /**
  * The card a segment names: by human key (`DECO-01`, a synced card's tracker
- * key like `OS-333`, `deco-1`, `1`) or by raw id.
+ * key like `EX-333`, `deco-1`, `1`) or by raw id.
  *
  * The exact tracker key is checked first, ahead of `matchesTaskKey`'s looser
- * keySeq fallback, so an exact `OS-333` always wins over an unrelated card
+ * keySeq fallback, so an exact `EX-333` always wins over an unrelated card
  * that merely shares its number.
  *
  * The id fallback exists because a card written before the key backfill has

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -519,7 +519,7 @@ const agentsRoute = createRoute({
  * Task board, and the card a URL opens.
  *
  * `{-$taskKey}` is the card's own address, written as the human key it already
- * shows (`DECO-01`, or a synced card's `OS-333` — see `task-route.ts`); no
+ * shows (`DECO-01`, or a synced card's `EX-333` — see `task-route.ts`); no
  * segment is the lanes. The board's filters stay in search because a filter is
  * how this page is laid out, whereas a card is a thing you open.
  *

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
@@ -127,7 +127,7 @@ export function resolveTenantPool(
  * existed; once tenant pools shipped it handed one org's prewarmed pods (repo
  * already cloned) to another org's claim, and the daemon rejected the
  * mismatched workload with `409 immutable: cloneUrl`. Observed in prod
- * 2026-08-07: claims for montecarlo and `ephemeral-*` dispatches bound
+ * 2026-08-07: claims for one tenant and `ephemeral-*` dispatches bound
  * `tenant-electrolux-prod-*` pods.
  */
 export function claimWarmPoolName(

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -172,7 +172,7 @@ export interface TaskBoardItem {
   sortOrder: number;
   /** Per-org sequence behind the card's human key (`DECO-01`). */
   keySeq: number | null;
-  /** The key this card's issue wears in the tracker (`OS-333`), for a card
+  /** The key this card's issue wears in the tracker (`EX-333`), for a card
    *  synced from one — what `taskKey` shows. Null for a card Studio owns. */
   jiraIssueKey: string | null;
   /** Infrastructure retries already spent on this card's runs — the budget

--- a/packages/shared/src/task-key.test.ts
+++ b/packages/shared/src/task-key.test.ts
@@ -42,21 +42,21 @@ describe("taskKey", () => {
  */
 describe("taskKey with a tracker key", () => {
   test("shows the tracker's key instead of the Studio one", () => {
-    expect(taskKey("osklen", 320, "OS-333")).toBe("OS-333");
+    expect(taskKey("acme", 320, "EX-333")).toBe("EX-333");
   });
 
   test("keeps the Studio key for a card Studio owns", () => {
-    expect(taskKey("osklen", 320, null)).toBe("OSKL-320");
-    expect(taskKey("osklen", 320, undefined)).toBe("OSKL-320");
+    expect(taskKey("acme", 320, null)).toBe("ACME-320");
+    expect(taskKey("acme", 320, undefined)).toBe("ACME-320");
   });
 
   test("treats a blank tracker key as absent rather than showing nothing", () => {
-    expect(taskKey("osklen", 320, "")).toBe("OSKL-320");
-    expect(taskKey("osklen", 320, "   ")).toBe("OSKL-320");
+    expect(taskKey("acme", 320, "")).toBe("ACME-320");
+    expect(taskKey("acme", 320, "   ")).toBe("ACME-320");
   });
 
   test("shows a tracker key even for a card from before the backfill", () => {
-    expect(taskKey("osklen", null, "OS-333")).toBe("OS-333");
-    expect(taskKey("osklen", null, null)).toBe(null);
+    expect(taskKey("acme", null, "EX-333")).toBe("EX-333");
+    expect(taskKey("acme", null, null)).toBe(null);
   });
 });

--- a/packages/shared/src/task-key.ts
+++ b/packages/shared/src/task-key.ts
@@ -21,7 +21,7 @@ export function taskKeyPrefix(orgSlug: string): string {
  * from one.
  *
  * A synced card wears the tracker's key because that is the name it already
- * has: the issue is `OS-333` in Jira, in the branch, in the PR title and in
+ * has: the issue is `EX-333` in Jira, in the branch, in the PR title and in
  * everything anyone says about it, and a second Studio-only number is one
  * translation step every reader has to make. The internal `keySeq` is
  * unaffected — it is still allocated, still unique per org, and still what the


### PR DESCRIPTION
This repo is public, and real values from debugging sessions had been landing
in it. Found while grepping Jira fixtures for something else.

## What was in there

| kind | where |
|---|---|
| A named person's email at a customer domain | `displayNameFromEmail`'s doc comment |
| Org slug + real tracker issue keys | `task-key`, `task-route`, `task-filters`, Jira fixtures |
| Four customer names in comments | sections-editor tests |
| Real preview hostnames and a real repo | `checks-status`, `pr-extract` |
| A customer's repo name as sample data | four files, `eitri-shopping-monte-carlo-shared` |

The email one is the worst of them, and it was in a doc comment on a shipped
function rather than a test.

## What changed

Placeholders throughout. Where the real value was only colour on a comment, the
comment now describes the shape instead ("seen in production", "a real
storefront") — that was the part carrying the meaning anyway, and it survives
the substitution intact.

Left alone: `public/logos/summit/*` and the two marketing surfaces that render
them. A customer logo wall is published on purpose, which is the opposite of
this problem.

## Scope, honestly

History still has every one of these, and a force-push would not change that:
GitHub keeps unreferenced objects and serves them by SHA. This stops the
bleeding, it does not undo it. Nothing redacted here is a credential, so there
is nothing to rotate.

Every touched test still passes (1290 across the affected files), `check`,
`lint` and `fmt` clean. A grep for all the redacted terms now returns only the
marketing logos.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts tenant-identifying data from test fixtures and code comments so this public repo stops leaking customer debugging values. Real org slugs, tracker issue keys, customer names, preview hostnames, repo names, and a person's email are replaced with generic placeholders.

- The email was in `displayNameFromEmail`'s doc comment on a shipped function, not in a test.
- Comments that used real customer names now describe the shape instead ("seen in production", "a real storefront").
- `public/logos/summit/*` and the two marketing surfaces that render them are left alone — a customer logo wall is published on purpose.
- Git history still holds every redacted value and GitHub serves unreferenced objects by SHA, so this stops the bleeding but does not undo it.
- Nothing redacted is a credential, so there is nothing to rotate.
- All 1290 tests across the touched files pass; `check`, `lint`, and `fmt` are clean.

<sup>Written for commit 5511c7f5f372e87367e9d0f629f8d72af3001956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

