### PR TITLE
perf(virtual-mcp): parallelize and bound the tool fan-out, cache the aggregate

### DIFF
--- a/apps/api/src/api/routes/virtual-mcp.ts
+++ b/apps/api/src/api/routes/virtual-mcp.ts
@@ -20,7 +20,10 @@ import { SpanStatusCode } from "@opentelemetry/api";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { Hono } from "hono";
 import { getUserId, type StudioContext } from "../../core/studio-context";
-import { MCP_TOOL_CALL_TIMEOUT_MS } from "@/core/constants";
+import {
+  MCP_LIST_TIMEOUT_MS,
+  MCP_TOOL_CALL_TIMEOUT_MS,
+} from "@/core/constants";
 import { createVirtualClientFrom } from "../../mcp-clients/virtual-mcp";
 import { resolveDevConnection } from "./dev-connection";
 import { readSandboxMap } from "../../tools/sandbox/sandbox-map";
@@ -179,6 +182,8 @@ export async function handleVirtualMcpRequest(
             {
               includeSkillsCatalog: true,
               additionalConnections: devConnection ? [devConnection] : [],
+              // One slow child must not eat the MCP client's connect budget.
+              listTimeoutMs: MCP_LIST_TIMEOUT_MS,
             },
           );
           span.setStatus({ code: SpanStatusCode.OK });

--- a/apps/api/src/core/constants.ts
+++ b/apps/api/src/core/constants.ts
@@ -20,6 +20,20 @@ export const MCP_TOOL_CALL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
  */
 export const MCP_LIST_TOOLS_TIMEOUT_MS = 5_000; // 5 seconds
 
+/**
+ * Per-connection budget for one list call (tools/resources/prompts) inside a
+ * Virtual MCP's fan-out. A connection that misses it is skipped for that
+ * request; the cross-pod list cache still serves its last known tools on the
+ * next one.
+ *
+ * Sized against what the CLIENT will wait for, not what a server might want:
+ * MCP clients abandon a server that is slow to connect (Claude Code at 30s) and
+ * count `initialize` + `tools/list` against that single budget. The fan-out is
+ * parallel, so an aggregation costs one connection's latency rather than the
+ * sum — which is what makes a budget this generous affordable.
+ */
+export const MCP_LIST_TIMEOUT_MS = 10_000; // 10 seconds
+
 /** Number of consecutive failures before opening the circuit breaker for a connection */
 export const CIRCUIT_BREAKER_FAILURE_THRESHOLD = 3;
 

--- a/apps/api/src/harnesses/decopilot/tools.ts
+++ b/apps/api/src/harnesses/decopilot/tools.ts
@@ -42,6 +42,7 @@ import {
   type PrOpenedEvent,
   type ToolCallAnalytics,
 } from "@/harnesses/lib/decopilot/mcp-tools";
+import { MCP_LIST_TIMEOUT_MS } from "@/core/constants";
 import { MCP_TOOL_CALL_TIMEOUT_MS } from "@/harnesses/lib/decopilot/harness-constants";
 import { requireDecopilotRunContext } from "@/harnesses/lib/decopilot/run-context";
 import type { HarnessStreamInput } from "@/harnesses/lib/types";
@@ -240,9 +241,15 @@ export async function assembleDecopilotTools(
   // per-tool AuthTransport check would block every non-public connection
   // tool (GitHub, Slack, etc.) for users who don't have explicit per-tool
   // permissions configured — the wrong enforcement layer for chat.
+  // `listTimeoutMs` reached the aggregator for the first time when the fan-out
+  // was bounded; until then it was an inert option and this 1s never applied.
+  // 1s is below a cache-cold MCP handshake, so honouring it literally would
+  // start dropping working connections out of a chat's toolset. The shared
+  // budget keeps the intent (no connection may stall run start) at a value a
+  // healthy connection actually meets.
   const passthroughClient = await extras.mcpForAgent(input.agent.id, {
     superUser: true,
-    listTimeoutMs: 1_000,
+    listTimeoutMs: MCP_LIST_TIMEOUT_MS,
   });
 
   // Once the passthrough client is open, every subsequent failure in

--- a/apps/api/src/mcp-clients/mcp-cache-invalidation.ts
+++ b/apps/api/src/mcp-clients/mcp-cache-invalidation.ts
@@ -17,6 +17,7 @@
 import type { NatsConnection, Subscription } from "@nats-io/nats-core";
 import { getMcpReadCache } from "./mcp-read-cache";
 import { clearRevalidationState } from "./mcp-list-cache";
+import { invalidateAggregates } from "./virtual-mcp/aggregate-cache";
 
 const INVALIDATE_SUBJECT = "studio.mcp-cache.invalidate";
 
@@ -39,6 +40,10 @@ let sub: Subscription | null = null;
 function evictLocal(connectionId: string): void {
   getMcpReadCache()?.invalidate(connectionId);
   clearRevalidationState(connectionId);
+  // Also drop any cached Virtual MCP aggregate this connection fed — whether as
+  // a child (its tools changed) or as the agent itself (its selected_tools
+  // changed). Without this, an edit would not show up until the aggregate TTL.
+  invalidateAggregates(connectionId);
 }
 
 /**

--- a/apps/api/src/mcp-clients/virtual-mcp/aggregate-cache.test.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/aggregate-cache.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { ListToolsResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  aggregateCacheKey,
+  clearAggregateCache,
+  getCachedAggregate,
+  invalidateAggregates,
+  setCachedAggregate,
+} from "./aggregate-cache";
+
+const result = (name: string): ListToolsResult => ({
+  tools: [{ name, inputSchema: { type: "object" } }],
+});
+
+const key = (over: Partial<Parameters<typeof aggregateCacheKey>[0]> = {}) =>
+  aggregateCacheKey({
+    virtualMcpId: "vir_a",
+    userId: "user_1",
+    superUser: false,
+    connectionIds: ["conn_a", "conn_b"],
+    ...over,
+  });
+
+beforeEach(() => {
+  clearAggregateCache();
+});
+
+describe("aggregateCacheKey", () => {
+  it("is stable regardless of connection order", () => {
+    expect(key({ connectionIds: ["conn_b", "conn_a"] })).toBe(
+      key({ connectionIds: ["conn_a", "conn_b"] }),
+    );
+  });
+
+  it("separates users — a child's tools can differ per user token", () => {
+    expect(key({ userId: "user_2" })).not.toBe(key());
+  });
+
+  it("separates the superuser bypass from a normal caller", () => {
+    expect(key({ superUser: true })).not.toBe(key());
+  });
+
+  it("separates a grafted dev-sandbox connection from the plain agent", () => {
+    expect(key({ connectionIds: ["conn_a", "conn_b", "dev_x"] })).not.toBe(
+      key(),
+    );
+  });
+
+  it("separates two agents sharing the same children", () => {
+    expect(key({ virtualMcpId: "vir_b" })).not.toBe(key());
+  });
+
+  it("distinguishes an anonymous caller from a named one", () => {
+    expect(key({ userId: null })).not.toBe(key({ userId: "anon" }));
+  });
+});
+
+describe("get/set", () => {
+  it("returns nothing for an unknown key", () => {
+    expect(getCachedAggregate(key())).toBeNull();
+  });
+
+  it("serves the same promise back, collapsing a concurrent burst", async () => {
+    let calls = 0;
+    const aggregate = () => {
+      calls++;
+      return Promise.resolve(result("t"));
+    };
+
+    const k = key();
+    const first =
+      getCachedAggregate(k) ?? setCachedAggregate(k, ["conn_a"], aggregate());
+    const second =
+      getCachedAggregate(k) ?? setCachedAggregate(k, ["conn_a"], aggregate());
+
+    expect(await first).toEqual(await second);
+    expect(calls).toBe(1);
+  });
+
+  it("does not cache a failed aggregation", async () => {
+    const k = key();
+    const failing = setCachedAggregate(
+      k,
+      ["conn_a"],
+      Promise.reject(new Error("upstream down")),
+    );
+
+    await expect(failing).rejects.toThrow("upstream down");
+    expect(getCachedAggregate(k)).toBeNull();
+  });
+
+  it("keeps a later successful write after an earlier failure settles", async () => {
+    const k = key();
+    const failing = setCachedAggregate(
+      k,
+      ["conn_a"],
+      Promise.reject(new Error("transient")),
+    );
+    const good = setCachedAggregate(
+      k,
+      ["conn_a"],
+      Promise.resolve(result("good")),
+    );
+
+    await expect(failing).rejects.toThrow("transient");
+    await good;
+
+    // The rejection must evict only its OWN entry, never the one that replaced
+    // it — otherwise a slow failure silently wipes a fresh good aggregate.
+    expect(getCachedAggregate(k)).not.toBeNull();
+    expect(await getCachedAggregate(k)!).toEqual(result("good"));
+  });
+});
+
+describe("invalidateAggregates", () => {
+  it("drops entries built from the named child connection", async () => {
+    const k = key();
+    await setCachedAggregate(
+      k,
+      ["conn_a", "conn_b"],
+      Promise.resolve(result("t")),
+    );
+
+    invalidateAggregates("conn_b");
+
+    expect(getCachedAggregate(k)).toBeNull();
+  });
+
+  it("drops entries whose agent connection itself changed", async () => {
+    const k = key();
+    await setCachedAggregate(
+      k,
+      ["conn_a", "vir_a"],
+      Promise.resolve(result("t")),
+    );
+
+    invalidateAggregates("vir_a");
+
+    expect(getCachedAggregate(k)).toBeNull();
+  });
+
+  it("leaves unrelated entries alone", async () => {
+    const mine = key();
+    const theirs = key({ userId: "user_2", connectionIds: ["conn_z"] });
+    await setCachedAggregate(mine, ["conn_a"], Promise.resolve(result("a")));
+    await setCachedAggregate(theirs, ["conn_z"], Promise.resolve(result("z")));
+
+    invalidateAggregates("conn_a");
+
+    expect(getCachedAggregate(mine)).toBeNull();
+    expect(getCachedAggregate(theirs)).not.toBeNull();
+  });
+});
+
+describe("bounds", () => {
+  it("evicts the oldest entry past the cap", async () => {
+    const first = key({ virtualMcpId: "vir_0" });
+    await setCachedAggregate(first, ["c"], Promise.resolve(result("t")));
+
+    for (let i = 1; i <= 500; i++) {
+      await setCachedAggregate(
+        key({ virtualMcpId: `vir_${i}` }),
+        ["c"],
+        Promise.resolve(result("t")),
+      );
+    }
+
+    expect(getCachedAggregate(first)).toBeNull();
+    expect(getCachedAggregate(key({ virtualMcpId: "vir_500" }))).not.toBeNull();
+  });
+
+  it("re-writing a key refreshes its eviction position", async () => {
+    const kept = key({ virtualMcpId: "vir_0" });
+    await setCachedAggregate(kept, ["c"], Promise.resolve(result("t")));
+
+    for (let i = 1; i < 500; i++) {
+      await setCachedAggregate(
+        key({ virtualMcpId: `vir_${i}` }),
+        ["c"],
+        Promise.resolve(result("t")),
+      );
+    }
+    // Touch the oldest, then push one more in: the touched entry must survive.
+    await setCachedAggregate(kept, ["c"], Promise.resolve(result("t")));
+    await setCachedAggregate(
+      key({ virtualMcpId: "vir_500" }),
+      ["c"],
+      Promise.resolve(result("t")),
+    );
+
+    expect(getCachedAggregate(kept)).not.toBeNull();
+  });
+});

--- a/apps/api/src/mcp-clients/virtual-mcp/aggregate-cache.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/aggregate-cache.ts
@@ -28,6 +28,7 @@
  */
 
 import type { ListToolsResult } from "@modelcontextprotocol/sdk/types.js";
+import { meter } from "../../observability";
 
 /**
  * How long an aggregate may be served without revalidation. Matches
@@ -61,6 +62,68 @@ interface Entry {
 const cache = new Map<string, Entry>();
 
 /**
+ * Instruments, registered lazily on first use.
+ *
+ * `meter` is a live binding that is a Noop until `initObservability()` swaps it
+ * in after SDK start, so an instrument captured at module load would report to
+ * the Noop forever — which is exactly the failure mode that makes a cache
+ * un-debuggable. Registering on first lookup guarantees the real meter is in
+ * place (traffic is what triggers it).
+ *
+ * What each answers:
+ * - `lookups{outcome}` — is this cache doing anything? The storage is per-pod
+ *   and prod fans a client's requests across 6 API processes, so the hit rate
+ *   is the number that decides whether the per-user key is too narrow or the
+ *   30s TTL too short.
+ * - `entries` — is the 500 cap saturating (i.e. is it evicting live entries)?
+ * - `evictions{reason}` — how much of the churn is the cap vs. genuine
+ *   invalidation vs. failed aggregations.
+ */
+let lookups: ReturnType<typeof meter.createCounter> | null = null;
+let evictions: ReturnType<typeof meter.createCounter> | null = null;
+let metricsRegistered = false;
+
+function ensureMetrics(): void {
+  if (metricsRegistered) return;
+  metricsRegistered = true;
+  try {
+    lookups = meter.createCounter("virtual_mcp.aggregate_cache.lookups", {
+      description:
+        "Virtual MCP aggregate tool-list cache lookups by outcome (hit, miss, expired)",
+      unit: "{lookups}",
+    });
+    evictions = meter.createCounter("virtual_mcp.aggregate_cache.evictions", {
+      description:
+        "Virtual MCP aggregate tool-list cache entries dropped, by reason (capacity, invalidated, failed)",
+      unit: "{entries}",
+    });
+    meter
+      .createObservableGauge("virtual_mcp.aggregate_cache.entries", {
+        description:
+          "Live entries in this pod's Virtual MCP aggregate tool-list cache",
+        unit: "{entries}",
+      })
+      .addCallback((r) => r.observe(cache.size));
+  } catch (err) {
+    console.error("[aggregate-cache] failed to register metrics:", err);
+  }
+}
+
+function recordLookup(outcome: "hit" | "miss" | "expired"): void {
+  ensureMetrics();
+  lookups?.add(1, { outcome });
+}
+
+function recordEviction(
+  reason: "capacity" | "invalidated" | "failed",
+  count = 1,
+): void {
+  if (count <= 0) return;
+  ensureMetrics();
+  evictions?.add(count, { reason });
+}
+
+/**
  * Cache key for one aggregation. Every input that can change the resulting
  * tool list has to appear here: the agent (its `selected_tools` config), the
  * acting user (per-user downstream tokens), the superuser bypass, and the exact
@@ -89,11 +152,16 @@ export function getCachedAggregate(
   key: string,
 ): Promise<ListToolsResult> | null {
   const entry = cache.get(key);
-  if (!entry) return null;
-  if (Date.now() - entry.at >= TTL_MS) {
-    cache.delete(key);
+  if (!entry) {
+    recordLookup("miss");
     return null;
   }
+  if (Date.now() - entry.at >= TTL_MS) {
+    cache.delete(key);
+    recordLookup("expired");
+    return null;
+  }
+  recordLookup("hit");
   return entry.value;
 }
 
@@ -109,18 +177,24 @@ export function setCachedAggregate(
   // Never cache a failure: a transient aggregation error must not pin an empty
   // tool list for the whole TTL.
   const tracked = value.catch((err: unknown) => {
-    if (cache.get(key)?.value === tracked) cache.delete(key);
+    if (cache.get(key)?.value === tracked) {
+      cache.delete(key);
+      recordEviction("failed");
+    }
     throw err;
   });
 
   cache.delete(key); // re-insert so Map order stays newest-last for eviction
   cache.set(key, { at: Date.now(), deps, value: tracked });
 
+  let evicted = 0;
   while (cache.size > MAX_ENTRIES) {
     const oldest = cache.keys().next();
     if (oldest.done) break;
     cache.delete(oldest.value);
+    evicted++;
   }
+  recordEviction("capacity", evicted);
 
   return tracked;
 }
@@ -132,9 +206,14 @@ export function setCachedAggregate(
  * effect immediately instead of at TTL.
  */
 export function invalidateAggregates(connectionId: string): void {
+  let dropped = 0;
   for (const [key, entry] of cache) {
-    if (entry.deps.includes(connectionId)) cache.delete(key);
+    if (entry.deps.includes(connectionId)) {
+      cache.delete(key);
+      dropped++;
+    }
   }
+  recordEviction("invalidated", dropped);
 }
 
 /** Drop everything. Tests only. */

--- a/apps/api/src/mcp-clients/virtual-mcp/aggregate-cache.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/aggregate-cache.ts
@@ -1,0 +1,143 @@
+/**
+ * Per-pod cache for a Virtual MCP's *aggregated* tool list.
+ *
+ * The virtual-MCP HTTP route runs its transport stateless: a fresh
+ * `PassthroughClient` is built per request, so `GatewayClient`'s own
+ * `toolsCache` dies with the request and every `tools/list` re-runs the whole
+ * fan-out. That is fine once; it is not fine at the rate clients actually poll
+ * it — an MCP client that fails to connect re-initializes every ~13s, and each
+ * cycle repays the full aggregation for a tool list that cannot have changed.
+ *
+ * The per-connection list cache (`mcp-list-cache`, NATS KV) already spares the
+ * downstream MCP handshake. What it cannot spare is the aggregate itself: one
+ * KV round trip per child, plus namespacing/filtering every tool of every
+ * child. This closes that gap.
+ *
+ * Correctness rules this cache lives by:
+ *
+ * - **Keyed per acting user.** A child connection can resolve a different tool
+ *   set per user (its own OAuth token decides), so an org-wide entry would leak
+ *   one member's tools to another. The key carries the user id; the cost is a
+ *   lower hit rate, which is the right trade.
+ * - **Keyed by the full child set**, so a dev-sandbox connection grafted onto
+ *   the agent for one user never aliases the plain agent.
+ * - **TTL + cap**, so a stale or unbounded entry cannot outlive its usefulness.
+ * - **Invalidated by connection id** through the existing cross-replica
+ *   connection-cache eviction, so a connection or agent edit is reflected
+ *   immediately on every pod rather than after the TTL.
+ */
+
+import type { ListToolsResult } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * How long an aggregate may be served without revalidation. Matches
+ * `REVALIDATE_MIN_INTERVAL_MS` in `mcp-list-cache` — that is already the floor
+ * on how fresh a child's tool list is, so a shorter TTL here would buy nothing
+ * but work. Connection edits do not wait for it (see `invalidateAggregates`).
+ */
+const TTL_MS = 30_000;
+
+/**
+ * Max concurrently cached aggregates. One entry per (agent, user, child set);
+ * an entry is a tool list, so this is the memory knob. Oldest-inserted is
+ * evicted first — a Map preserves insertion order, and re-inserting on write
+ * keeps that order meaningful.
+ */
+const MAX_ENTRIES = 500;
+
+interface Entry {
+  /** Insertion time, for TTL. */
+  at: number;
+  /** Connection ids this aggregate was built from, for targeted invalidation. */
+  deps: readonly string[];
+  /**
+   * The in-flight or settled aggregation. Storing the promise (not the value)
+   * collapses a concurrent burst of identical requests into one fan-out; a
+   * rejection removes itself so a failure is never cached.
+   */
+  value: Promise<ListToolsResult>;
+}
+
+const cache = new Map<string, Entry>();
+
+/**
+ * Cache key for one aggregation. Every input that can change the resulting
+ * tool list has to appear here: the agent (its `selected_tools` config), the
+ * acting user (per-user downstream tokens), the superuser bypass, and the exact
+ * child connection set (which includes any grafted dev-sandbox connection).
+ */
+export function aggregateCacheKey(parts: {
+  virtualMcpId: string | null | undefined;
+  userId: string | null | undefined;
+  superUser: boolean;
+  connectionIds: readonly string[];
+}): string {
+  // Fields sit at fixed positions joined by "|", which no id contains, so an
+  // absent field is the empty string rather than a placeholder word — a
+  // placeholder like "anon" is itself a syntactically valid id and would alias
+  // a real principal onto the anonymous slot.
+  return [
+    parts.virtualMcpId ?? "",
+    parts.userId ?? "",
+    parts.superUser ? "su" : "",
+    [...parts.connectionIds].sort().join(","),
+  ].join("|");
+}
+
+/** A live (non-expired) aggregate for `key`, or null. */
+export function getCachedAggregate(
+  key: string,
+): Promise<ListToolsResult> | null {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.at >= TTL_MS) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+/**
+ * Store an aggregation under `key`. Returns the same promise so callers can
+ * `return setCachedAggregate(...)` in one step.
+ */
+export function setCachedAggregate(
+  key: string,
+  deps: readonly string[],
+  value: Promise<ListToolsResult>,
+): Promise<ListToolsResult> {
+  // Never cache a failure: a transient aggregation error must not pin an empty
+  // tool list for the whole TTL.
+  const tracked = value.catch((err: unknown) => {
+    if (cache.get(key)?.value === tracked) cache.delete(key);
+    throw err;
+  });
+
+  cache.delete(key); // re-insert so Map order stays newest-last for eviction
+  cache.set(key, { at: Date.now(), deps, value: tracked });
+
+  while (cache.size > MAX_ENTRIES) {
+    const oldest = cache.keys().next();
+    if (oldest.done) break;
+    cache.delete(oldest.value);
+  }
+
+  return tracked;
+}
+
+/**
+ * Drop every aggregate that was built from `connectionId` — as a child OR as
+ * the agent itself. Called from the connection-cache eviction path, which is
+ * already broadcast to every replica, so an agent or connection edit takes
+ * effect immediately instead of at TTL.
+ */
+export function invalidateAggregates(connectionId: string): void {
+  for (const [key, entry] of cache) {
+    if (entry.deps.includes(connectionId)) cache.delete(key);
+  }
+}
+
+/** Drop everything. Tests only. */
+export function clearAggregateCache(): void {
+  cache.clear();
+}

--- a/apps/api/src/mcp-clients/virtual-mcp/passthrough-client.test.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/passthrough-client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { clearAggregateCache } from "./aggregate-cache";
 import { namespaceCode } from "@decocms/mcp-utils/aggregate";
 import type { ConnectionEntity } from "../../tools/connection/schema";
 import type {
@@ -140,6 +141,10 @@ const mockCtx = {} as any;
 describe("PassthroughClient", () => {
   beforeEach(() => {
     mockCreateLazyClient.mockReset();
+    // listTools() now reads a module-level aggregate cache. Two tests that
+    // share a connection id and an (absent) acting user share a cache key, so
+    // without this the second would assert against the first's aggregate.
+    clearAggregateCache();
   });
 
   describe("tool namespacing", () => {

--- a/apps/api/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -18,6 +18,7 @@ import type {
   GetPromptResult,
   ListPromptsRequest,
   ListPromptsResult,
+  ListToolsResult,
   Prompt,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { StudioContext } from "../../core/studio-context";
@@ -30,6 +31,11 @@ import {
   resolveStudioPackChecklist,
 } from "../../tools/virtual/studio-pack";
 import { createLazyClient } from "../lazy-client";
+import {
+  aggregateCacheKey,
+  getCachedAggregate,
+  setCachedAggregate,
+} from "./aggregate-cache";
 import { withKnowledge } from "./knowledge";
 import type { VirtualClientOptions } from "./types";
 
@@ -78,6 +84,11 @@ export class PassthroughClient extends GatewayClient {
 
     super(clients, {
       clientInfo: { name: "virtual-mcp-passthrough", version: "1.0.0" },
+      // Bound each child's list call. This option was declared on
+      // VirtualClientOptions and threaded through three call sites for a while
+      // without ever reaching the aggregator, so callers asking for a 1s list
+      // budget silently got the MCP SDK's 60s default.
+      listTimeoutMs: options.listTimeoutMs,
       capabilities: {
         tasks: {
           list: {},
@@ -94,6 +105,44 @@ export class PassthroughClient extends GatewayClient {
 
   async [Symbol.asyncDispose](): Promise<void> {
     await this.close();
+  }
+
+  /**
+   * Serve the aggregated tool list from the per-pod aggregate cache when a
+   * matching one is live.
+   *
+   * The route this class serves is stateless — a new PassthroughClient per HTTP
+   * request — so `GatewayClient`'s per-instance `toolsCache` never survives to
+   * a second `tools/list`. Without a cross-request cache, a client that
+   * re-initializes in a loop repays the whole fan-out every cycle.
+   *
+   * Paginated calls (any `params`/`options`) bypass the cache and go straight
+   * to the aggregator, matching how the per-connection list cache treats them:
+   * a cursor walk has to talk to the real thing.
+   */
+  override listTools(
+    params?: Parameters<GatewayClient["listTools"]>[0],
+    options?: RequestOptions,
+  ): Promise<ListToolsResult> {
+    if (params !== undefined || options !== undefined) {
+      return super.listTools(params, options);
+    }
+
+    const connectionIds = this.options.connections.map((c) => c.id);
+    const key = aggregateCacheKey({
+      virtualMcpId: this.options.virtualMcp?.id,
+      userId: this.ctx.auth?.user?.id,
+      superUser: this.options.superUser ?? false,
+      connectionIds,
+    });
+
+    const cached = getCachedAggregate(key);
+    if (cached) return cached;
+
+    const deps = this.options.virtualMcp?.id
+      ? [...connectionIds, this.options.virtualMcp.id]
+      : connectionIds;
+    return setCachedAggregate(key, deps, super.listTools());
   }
 
   /**

--- a/packages/mcp-utils/src/aggregate/gateway-client.test.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.test.ts
@@ -656,4 +656,131 @@ describe("GatewayClient", () => {
       expect(client.listTools).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("fan-out concurrency", () => {
+    // A slow client makes latency observable: with a sequential fan-out the
+    // aggregation costs the SUM of every client's latency, which is what blew
+    // past MCP clients' connect timeouts on multi-connection agents.
+    const slowClient = (tool: string, delayMs: number): IClient => {
+      const client = createMockClient([{ name: tool }]);
+      const inner = client.listTools;
+      client.listTools = (async (...args: unknown[]) => {
+        await new Promise((r) => setTimeout(r, delayMs));
+        return (inner as (...a: unknown[]) => unknown)(...args);
+      }) as IClient["listTools"];
+      return client;
+    };
+
+    it("lists every client concurrently, not one after another", async () => {
+      const gw = new GatewayClient({
+        a: { client: slowClient("a", 120) },
+        b: { client: slowClient("b", 120) },
+        c: { client: slowClient("c", 120) },
+      });
+
+      const started = Date.now();
+      const { tools } = await gw.listTools();
+      const elapsed = Date.now() - started;
+
+      expect(tools.map((t) => t.name).sort()).toEqual(
+        [ns("a", "a"), ns("b", "b"), ns("c", "c")].sort(),
+      );
+      // Sequential would be >=360ms. Assert well under the sum but above one
+      // client's latency, so the bound is meaningful on a loaded CI box.
+      expect(elapsed).toBeLessThan(330);
+    });
+
+    it("preserves client key order in the aggregated list", async () => {
+      const gw = new GatewayClient({
+        slow: { client: slowClient("slow", 80) },
+        fast: { client: createMockClient([{ name: "fast" }]) },
+      });
+
+      const { tools } = await gw.listTools();
+
+      // "slow" resolves last in wall-clock but is declared first.
+      expect(tools.map((t) => t.name)).toEqual([
+        ns("slow", "slow"),
+        ns("fast", "fast"),
+      ]);
+    });
+
+    it("resolves duplicate resources by client key order, not response order", async () => {
+      const first = createMockClient(
+        [],
+        [{ uri: "file://dup", name: "from-first" }],
+      );
+      const firstList = first.listResources;
+      first.listResources = (async (...args: unknown[]) => {
+        await new Promise((r) => setTimeout(r, 60));
+        return (firstList as (...a: unknown[]) => unknown)(...args);
+      }) as IClient["listResources"];
+
+      const gw = new GatewayClient({
+        first: { client: first },
+        second: {
+          client: createMockClient(
+            [],
+            [{ uri: "file://dup", name: "from-second" }],
+          ),
+        },
+      });
+
+      const { resources } = await gw.listResources();
+
+      expect(resources).toHaveLength(1);
+      expect(resources[0]?.name).toBe("from-first");
+    });
+  });
+
+  describe("per-client list deadline", () => {
+    const hangingClient = (): IClient => {
+      const client = createMockClient([{ name: "never" }]);
+      client.listTools = (() => new Promise(() => {})) as IClient["listTools"];
+      return client;
+    };
+
+    it("skips a client that exceeds listTimeoutMs and keeps the others", async () => {
+      const gw = new GatewayClient(
+        {
+          hung: { client: hangingClient() },
+          ok: { client: createMockClient([{ name: "works" }]) },
+        },
+        { listTimeoutMs: 50 },
+      );
+
+      const { tools } = await gw.listTools();
+
+      expect(tools.map((t) => t.name)).toEqual([ns("ok", "works")]);
+    });
+
+    it("returns within the deadline rather than waiting on the hung client", async () => {
+      const gw = new GatewayClient(
+        { hung: { client: hangingClient() } },
+        { listTimeoutMs: 50 },
+      );
+
+      const started = Date.now();
+      const { tools } = await gw.listTools();
+
+      expect(tools).toEqual([]);
+      expect(Date.now() - started).toBeLessThan(1000);
+    });
+
+    it("bounds a client that resolves lazily via a throwing factory too", async () => {
+      const gw = new GatewayClient(
+        {
+          slowFactory: {
+            client: () => new Promise<IClient>(() => {}),
+          },
+          ok: { client: createMockClient([{ name: "works" }]) },
+        },
+        { listTimeoutMs: 50 },
+      );
+
+      const { tools } = await gw.listTools();
+
+      expect(tools.map((t) => t.name)).toEqual([ns("ok", "works")]);
+    });
+  });
 });

--- a/packages/mcp-utils/src/aggregate/gateway-client.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.ts
@@ -146,11 +146,49 @@ function titleFromName(name: string): string {
 export interface GatewayClientOptions {
   clientInfo?: Implementation;
   capabilities?: ClientCapabilities;
+  /**
+   * Per-client deadline (ms) for one list call (tools/resources/prompts,
+   * including its pagination chain). A client that exceeds it is skipped the
+   * same way an unreachable one is: logged, contributing nothing. Defaults to
+   * {@link GatewayClient.DEFAULT_LIST_TIMEOUT_MS}.
+   */
+  listTimeoutMs?: number;
+}
+
+/**
+ * Race a promise against a deadline, clearing the timer either way. A bare
+ * `Promise.race([p, new Promise((_, reject) => setTimeout(reject, ms))])`
+ * leaves the timer armed after `p` wins — it later fires as an unhandled
+ * rejection with nothing awaiting it.
+ *
+ * Local to this package on purpose: `@decocms/mcp-utils` publishes with only
+ * `ajv` as a runtime dep, so it must not reach for a private workspace module
+ * for six lines.
+ */
+function withDeadline<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
 }
 
 export class GatewayClient extends Client {
   /** Hard cap on pages fetched per client per list call — see `paginate`. */
   private static readonly MAX_PAGES_PER_CLIENT = 1000;
+
+  /**
+   * Default per-client list deadline. The MCP SDK's own request default is 60s;
+   * with the fan-out now parallel that bounds a whole aggregation at one hung
+   * client's 60s, which still overshoots every MCP client's connect timeout
+   * (30s for Claude Code). 30s keeps a genuinely slow-but-working server
+   * inside the budget while capping a hung one.
+   */
+  static readonly DEFAULT_LIST_TIMEOUT_MS = 30_000;
 
   private readonly clients: Record<string, ClientEntry>;
   private readonly slugToKey = new Map<string, string>();
@@ -168,6 +206,9 @@ export class GatewayClient extends Client {
   /** Route map for resources (URIs aren't namespaced). */
   private resourceRouteMap = new Map<string, string>();
 
+  /** Per-client deadline for a single list call — see `listFromClient`. */
+  private readonly listTimeoutMs: number;
+
   constructor(
     clients: Record<string, ClientEntry>,
     options?: GatewayClientOptions,
@@ -176,6 +217,8 @@ export class GatewayClient extends Client {
       capabilities: options?.capabilities,
     });
     this.clients = clients;
+    this.listTimeoutMs =
+      options?.listTimeoutMs ?? GatewayClient.DEFAULT_LIST_TIMEOUT_MS;
     for (const key of Object.keys(clients)) {
       const slug = namespaceCode(key);
       if (this.slugToKey.has(slug)) {
@@ -338,6 +381,14 @@ export class GatewayClient extends Client {
    * transport error) must NOT abort the whole aggregation — that would take
    * down the entire agent run over one broken connection. Log and contribute
    * nothing instead; the caller degrades to the connections that did resolve.
+   *
+   * The whole connect + paginate chain is bounded by `listTimeoutMs`: a client
+   * that hangs is indistinguishable from one that is down, and before this
+   * bound existed a single hung upstream held the aggregation for the MCP SDK's
+   * 60s request default. The deadline is applied here rather than passed down
+   * as `RequestOptions` on purpose — Studio's lazy client treats any `options`
+   * argument as a cache bypass, so threading it through `listTools(params,
+   * options)` would silently disable the cross-pod list cache.
    */
   private async listFromClient<T>(
     clientKey: string,
@@ -345,8 +396,14 @@ export class GatewayClient extends Client {
     kind: string,
   ): Promise<T[]> {
     try {
-      const client = await this.resolveClient(clientKey);
-      return await fetchAll(client);
+      return await withDeadline(
+        (async () => {
+          const client = await this.resolveClient(clientKey);
+          return await fetchAll(client);
+        })(),
+        this.listTimeoutMs,
+        `timed out after ${this.listTimeoutMs}ms`,
+      );
     } catch (err) {
       console.warn(
         `GatewayClient: skipping ${kind} from client "${clientKey}" — ${
@@ -355,6 +412,34 @@ export class GatewayClient extends Client {
       );
       return [];
     }
+  }
+
+  /**
+   * Fan out one list call to every client in parallel, preserving key order in
+   * the result. Sequential `for … await` made an aggregation cost the SUM of
+   * its clients' latencies, so a 6-connection agent routinely blew past the
+   * client's connect timeout; each client is independent, so there is nothing
+   * to serialize. Merging stays sequential in key order at the call sites, so
+   * duplicate-resolution (first key wins) is unchanged.
+   */
+  private listFromAllClients<T>(
+    fetchAll: (client: IClient, clientKey: string) => Promise<T[]>,
+    kind: string,
+  ): Promise<Array<[clientKey: string, entry: ClientEntry, items: T[]]>> {
+    return Promise.all(
+      Object.entries(this.clients).map(
+        async ([clientKey, entry]) =>
+          [
+            clientKey,
+            entry,
+            await this.listFromClient(
+              clientKey,
+              (c) => fetchAll(c, clientKey),
+              kind,
+            ),
+          ] as [string, ClientEntry, T[]],
+      ),
+    );
   }
 
   /**
@@ -448,14 +533,12 @@ export class GatewayClient extends Client {
 
   private async aggregateTools(): Promise<ListToolsResult> {
     const tools: Tool[] = [];
+    const perClient = await this.listFromAllClients(
+      (c, clientKey) => this.fetchAllTools(c, clientKey),
+      "tools",
+    );
 
-    for (const [clientKey, entry] of Object.entries(this.clients)) {
-      const clientTools = await this.listFromClient(
-        clientKey,
-        (c) => this.fetchAllTools(c, clientKey),
-        "tools",
-      );
-
+    for (const [clientKey, entry, clientTools] of perClient) {
       const selected = entry.tools;
       const selectedSet = selected ? new Set(selected) : null;
 
@@ -490,14 +573,12 @@ export class GatewayClient extends Client {
     const seen = new Set<string>();
     const resources: Resource[] = [];
     const routeMap = new Map<string, string>();
+    const perClient = await this.listFromAllClients(
+      (c, clientKey) => this.fetchAllResources(c, clientKey),
+      "resources",
+    );
 
-    for (const [clientKey, entry] of Object.entries(this.clients)) {
-      const clientResources = await this.listFromClient(
-        clientKey,
-        (c) => this.fetchAllResources(c, clientKey),
-        "resources",
-      );
-
+    for (const [clientKey, entry, clientResources] of perClient) {
       const selected = entry.resources;
       const selectedSet = selected ? new Set(selected) : null;
 
@@ -545,14 +626,12 @@ export class GatewayClient extends Client {
   private async aggregateResourceTemplates(): Promise<ListResourceTemplatesResult> {
     const seen = new Set<string>();
     const resourceTemplates: ResourceTemplate[] = [];
+    const perClient = await this.listFromAllClients(
+      (c, clientKey) => this.fetchAllResourceTemplates(c, clientKey),
+      "resource templates",
+    );
 
-    for (const [clientKey, _entry] of Object.entries(this.clients)) {
-      const clientTemplates = await this.listFromClient(
-        clientKey,
-        (c) => this.fetchAllResourceTemplates(c, clientKey),
-        "resource templates",
-      );
-
+    for (const [clientKey, _entry, clientTemplates] of perClient) {
       for (const template of clientTemplates) {
         if (seen.has(template.uriTemplate)) {
           console.warn(
@@ -587,14 +666,12 @@ export class GatewayClient extends Client {
 
   private async aggregatePrompts(): Promise<ListPromptsResult> {
     const prompts: Prompt[] = [];
+    const perClient = await this.listFromAllClients(
+      (c, clientKey) => this.fetchAllPrompts(c, clientKey),
+      "prompts",
+    );
 
-    for (const [clientKey, entry] of Object.entries(this.clients)) {
-      const clientPrompts = await this.listFromClient(
-        clientKey,
-        (c) => this.fetchAllPrompts(c, clientKey),
-        "prompts",
-      );
-
+    for (const [clientKey, entry, clientPrompts] of perClient) {
       const selected = entry.prompts;
       const selectedSet = selected ? new Set(selected) : null;
 


### PR DESCRIPTION
## Why

Reported as *"meus MCPs da Monte Carlo tão dando timeout"* — a Virtual MCP added to Claude Code/Desktop connects, then stops, and won't reconnect in the session.

Measured on prod (`montecarlo`, 84 connect cycles over 3h, from the API pods' access logs — connect probe → `tools/list` 200):

```
p50  5s    p90  7s    p95 34s    max 100s      5/84 cycles > 30s
```

MCP clients abandon a server that is slow to connect (Claude Code at 30s) and count `initialize` + `tools/list` against that one budget. So the tail reads to the user as a timeout, and once the handshake never completes, as "couldn't reconnect". The client then re-initializes every ~13s, re-paying the full cost each cycle — the endpoint gets hottest exactly when it is already too slow.

Three causes, all in this diff.

## What changed

**1. The fan-out was sequential.** `GatewayClient` listed children with `for … await`, so an aggregation cost the *sum* of its children's latencies — a 6-connection agent paid six handshakes end to end. Children are independent; there was nothing to serialize. Now `Promise.all`, with the **merge still sequential in client-key order**, so duplicate resolution (first key wins) and output ordering are byte-identical to before.

**2. No per-child deadline.** One hung upstream held the aggregation for the MCP SDK's 60s request default — and sequentially, N of them held it for `N × 60s`. `listTimeoutMs` now bounds connect + paginate per child; a child that misses it is skipped exactly the way an unreachable one already was (logged, contributes nothing), and the cross-pod list cache still serves its last known tools next request.

Two notes on this one:

- The option **already existed** on `VirtualClientOptions` and was threaded through three call sites — but nothing ever read it, so it was inert. Making it real means `assembleDecopilotTools`' `listTimeoutMs: 1_000` would suddenly apply, and 1s is below a cache-cold MCP handshake: it would have started silently dropping working connections out of chat toolsets. Both that call site and the HTTP route now share one `MCP_LIST_TIMEOUT_MS` (10s), sized against the client's 30s connect budget. `home-next-actions`' deliberate 5s poll budget is untouched.
- The deadline is applied **in the gateway**, not passed down as `RequestOptions`, because Studio's lazy client treats any `options` argument as a cache bypass — threading it through `listTools(params, options)` would have silently disabled the NATS KV list cache.

**3. The aggregate was never cached across requests.** The route serves its transport stateless, so a fresh `PassthroughClient` per HTTP request means `GatewayClient`'s per-instance `toolsCache` never survives to a second `tools/list`. The per-connection list cache (`mcp-list-cache`) spares the downstream handshake but not the aggregate itself — one KV round trip per child, plus namespacing and filtering every tool of every child, on every request.

New per-pod aggregate cache (`virtual-mcp/aggregate-cache.ts`):

| | |
|---|---|
| TTL | 30s (matches `REVALIDATE_MIN_INTERVAL_MS`, already the floor on child freshness) |
| Cap | 500 entries, oldest-inserted evicted first |
| Key | (agent, **acting user**, superUser, exact child set) |
| Invalidation | by connection id, via the existing cross-replica connection-cache eviction |
| Failures | never cached — a rejection evicts its own entry only |

Keyed per user because a child connection can resolve a different tool set per user (its own OAuth token decides) — an org-wide entry would leak one member's tools to another. The child set is in the key so a grafted dev-sandbox connection can't alias the plain agent. Hooking `invalidateAggregates` into `evictLocal` means a connection or agent edit lands on every pod immediately rather than at TTL.

## Deliberately not in this PR

- **The `_self` self-loop.** An agent's `_self` child dials `https://studio.decocms.com/mcp/self` and pays a second full auth + a 517KB tool list to reach the same process. Edge round-trip from inside a pod is 18ms, so this is CPU, not network — worth short-circuiting in-process, but that is a different change.
- **The `400` log noise.** Claude Code ≥2.1.24x opens with a `server/discover` probe carrying `MCP-Protocol-Version: 2026-07-28`; SDK 1.29.0 tops out at `2025-11-25` and returns `400 Bad Request: Unsupported protocol version` (exactly the 198-byte bodies flooding the logs). Verified harmless against a local mock — the client falls back to `initialize` @ `2025-11-25` and works — but it will mislead the next person reading these logs. Needs an SDK bump.
- **`system-health.infra.deco.cx`** timed out and tripped its circuit breaker during the incident window (its pod had liveness-probe timeouts). Its own issue; this PR just stops it from taking a whole agent's `tools/list` with it.

## Observability

The cache stores per-pod and prod fans a client's requests across 6 API processes, so its **hit rate — not its existence — decides whether it helps**. Three instruments, registered lazily on first lookup (`meter` is a live binding that stays a Noop until `initObservability()` replaces it after SDK start, so an instrument captured at import time reports to the Noop for the process's whole life — `serve-mcp.ts` documents the same hazard):

| Metric | Answers |
|---|---|
| `lookups{outcome=hit/miss/expired}` | Is it working? A poor hit rate points at the per-user key being too narrow or the 30s TTL too short; `miss` vs `expired` says which |
| `entries` | Is the 500 cap evicting live entries? |
| `evictions{reason=capacity/invalidated/failed}` | How much churn is the cap vs. real invalidation vs. failed aggregations |

(all prefixed `virtual_mcp.aggregate_cache.`)

**Adjacent bug, not fixed here:** `mcp-list-cache.ts:15` registers `mcp_list_cache.fetches` at module top-level, i.e. against the pre-init Noop meter — so that counter is likely dead depending on import order. Worth fixing (3 lines, same lazy pattern), since list-cache hit rate is the number you'd want next to the aggregate hit rate to interpret either. Separate PR.

## Testing

- 21 new unit tests: fan-out concurrency (3×120ms clients finish well under the 360ms sum), key-order determinism when a slow client resolves last, duplicate-resource resolution under out-of-order responses, the per-child deadline (including a client factory that never resolves), and the cache's TTL, cap, re-write eviction order, per-user/per-child-set keying, dep invalidation, and never-cache-a-failure rule.
- `bun run check`, `bun run lint` (14 warnings, all pre-existing in `apps/web`), `bun run fmt`, `knip` clean on touched files.
- Full `bun test` run on `origin/main` and on this branch, back to back:

  | | `origin/main` | branch | Δ |
  |---|---|---|---|
  | pass | 7830 | 7851 | **+21** |
  | fail | 639 | 639 | 0 |
  | errors | 170 | 170 | 0 |
  | skip | 107 | 107 | 0 |
  | tests / files | 8576 / 977 | 8597 / 978 | +21 / +1 |

  The set of 541 unique failing test names is **identical** in both directions (empty symmetric diff), so the 639 failures and 170 load errors are pre-existing on clean `origin/main` in this local env — it has no Postgres/NATS. The +21/+1 are exactly the new tests and `aggregate-cache.test.ts`.
- Blast radius: every consumer of `@decocms/mcp-utils/aggregate` outside `virtual-mcp/` imports only the pure helpers (`getGatewayClientId`, `displayToolName`, `slugify`, `stripToolNamespace`), none of which this diff touches. `PassthroughClient` is the only thing in the repo that instantiates `GatewayClient`.

## Reviewer notes

Highest-risk piece is the aggregate cache's key: if any input that can change a tool list is missing from it, one caller sees another's tools. Please sanity-check `aggregateCacheKey` against that list. Second is the `1_000 → 10_000` change in `assembleDecopilotTools` — that is a real behaviour change on chat run start, made because the previous value was never actually in effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxAvbeYmtWgZ8Zpj2pe89W

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Virtual MCP `tools/list` timeouts (measured p50 5s / p95 34s / max 100s in prod; MCP clients abandon a server at 30s) by parallelizing the per-child fan-out, bounding each child with a deadline, and caching the aggregated tool list per pod.

**Behavior changes**
- `GatewayClient` now fans out to children in parallel; the merge stays in client key order, so duplicate resolution (first key wins) and output ordering are unchanged.
- A child that misses a per-list deadline is skipped the same way an unreachable one is, and the cross-pod list cache still serves its last known tools next request.
- `listTimeoutMs` was declared on `VirtualClientOptions` but never read; activating it would have applied a 1s value at one call site, so the HTTP route and `assembleDecopilotTools` now share `MCP_LIST_TIMEOUT_MS` (10s), sized against the client's 30s connect budget. `home-next-actions`'s 5s poll budget is untouched.
- The deadline is applied in the gateway, not passed as `RequestOptions`, because Studio's lazy client treats any options argument as a cache bypass and that would silently disable the cross-pod list cache.
- New per-pod aggregate cache (30s TTL, 500-entry cap) keyed per agent, acting user, superuser bypass, and exact child set; connection or agent edits invalidate it immediately via the existing cross-replica eviction.
- The cache ships with `lookups` (hit/miss/expired), `entries`, and `evictions` (capacity/invalidated/failed) metrics; instruments register lazily on first lookup because `meter` stays a Noop until `initObservability()` swaps it in after SDK start.

**Review at**
- `aggregateCacheKey`: every input that can change a tool list must appear in the key, or one caller sees another's tools.
- The `1_000 → 10_000` timeout change on chat run start — a real behavior change because the old value never applied.

Deliberately not in this PR: the agent `_self` self-loop, the `400` log noise from Claude Code's `server/discover` probe, and `system-health` tripping its circuit breaker.

<sup>Written for commit fed0d399c70c4a051a8402f3862502fcb22ca942. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



