### PR TITLE
fix(jira): push status through the board's own columns, not a typed mapping

### DIFF
--- a/apps/api/migrations/196-task-board-column-tracker-statuses.ts
+++ b/apps/api/migrations/196-task-board-column-tracker-statuses.ts
@@ -1,0 +1,35 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * The tracker statuses a mirrored column groups, in the order the tracker
+ * declares them.
+ *
+ * A Jira board column is not a status: it is a bucket of them, and real boards
+ * use that. One customer's five columns cover ten statuses, with three in a
+ * single column.
+ *
+ * The pull never needed this — an issue has one status, the status sits in one
+ * column, so the card's lane is decided. The PUSH cannot move without it. "The
+ * card is in Em andamento" does not say whether the issue becomes `Em
+ * andamento`, `In Progress` or `Desenvolvimento`, and the answer is whichever
+ * the issue's workflow can reach right now. That is what the hand-written
+ * status mapping was for; this column is the same list, read from the board
+ * instead of typed by a person.
+ *
+ * Empty for Studio's own columns, which are constants and mirror nothing.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_columns")
+    .addColumn("tracker_statuses", "jsonb", (col) =>
+      col.notNull().defaultTo(sql`'[]'::jsonb`),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_columns")
+    .dropColumn("tracker_statuses")
+    .execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -194,6 +194,7 @@ import * as migration192taskboardverdictnudgeactivity from "./192-task-board-ver
 import * as migration193taskboardstatuscolumnfk from "./193-task-board-status-column-fk.ts";
 import * as migration194jiralinksprint from "./194-jira-link-sprint.ts";
 import * as migration195taskboardsprintactivity from "./195-task-board-sprint-activity.ts";
+import * as migration196taskboardcolumntrackerstatuses from "./196-task-board-column-tracker-statuses.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -421,6 +422,8 @@ const migrations: Record<string, Migration> = {
   "193-task-board-status-column-fk": migration193taskboardstatuscolumnfk,
   "194-jira-link-sprint": migration194jiralinksprint,
   "195-task-board-sprint-activity": migration195taskboardsprintactivity,
+  "196-task-board-column-tracker-statuses":
+    migration196taskboardcolumntrackerstatuses,
 };
 
 export default migrations;

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -6,7 +6,7 @@
   "file-storage/dbos-org-repo-sync.ts": "32c606976916fde2be7abe3084f7388744bdb610c178e9c2a07a8080f764904e",
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",
   "harnesses/decopilot/background-tool-workflow.ts": "1ae73b5a614ae6439942c1e52de52deeb3e18d1bb7e528be820720b592cfe833",
-  "jira/dbos-jira-sync.ts": "a95e7c979eefaf2ee32aeb7491d24c14c973a8cb8fe16a872489d10d143c6812",
+  "jira/dbos-jira-sync.ts": "ceaf32d75681da37867315c32409181a861aa62ab5b1e912a6f84735e7cba892",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
   "notifications/dbos-digest.ts": "673bc164593266704d2918a0bcaaf838a2480dfb46d1d19c02bdb38c73ecc370",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",

--- a/apps/api/src/jira/dbos-jira-sync.ts
+++ b/apps/api/src/jira/dbos-jira-sync.ts
@@ -17,11 +17,14 @@ import type { Database, TaskBoardItem } from "@/storage/types";
 import { JiraIntegrationStorage } from "@/storage/jira-integrations";
 import { TaskBoardStorage } from "@/storage/task-board";
 import { SprintStorage } from "@/storage/sprints";
+import { BoardColumnStorage } from "@/storage/task-board-columns";
 import { CredentialVault } from "@/encryption/credential-vault";
 import type { StudioContext } from "@/core/studio-context";
 import { JIRA_PUSH_QUEUE } from "@/dispatch-queue/queue-names";
 import {
+  type JiraStatusMapping,
   planStatusPush,
+  pushTargetsForLane,
   statusPushNoop,
 } from "@decocms/shared/jira-status-mapping";
 import { JiraClient } from "./client";
@@ -349,10 +352,13 @@ async function resolveStatusTransition(
     params.organizationId,
   );
   if (!item) return null;
+  const targets = await jiraTargetsForLane(
+    params.organizationId,
+    item.status,
+    integration.statusMapping,
+  );
   // Settles the common cases without paying for a `listTransitions` call.
-  if (statusPushNoop(integration.statusMapping, item.status, link.jiraStatus)) {
-    return null;
-  }
+  if (statusPushNoop(targets, link.jiraStatus)) return null;
 
   const client = new JiraClient(
     integration.siteUrl,
@@ -361,8 +367,7 @@ async function resolveStatusTransition(
   );
   const transitions = await client.listTransitions(link.jiraIssueId);
   const plan = planStatusPush({
-    mapping: integration.statusMapping,
-    lane: item.status,
+    targets,
     currentJiraStatus: link.jiraStatus,
     availableTransitions: transitions.map((t) => t.to.name),
   });
@@ -414,6 +419,33 @@ async function executeStatusTransition(
   }
   await client.transitionIssue(plan.jiraIssueId, plan.transitionId);
   await storage.touchLink(params.itemId, { jiraStatus: plan.targetName });
+}
+
+/**
+ * Which tracker statuses a lane accepts, best first.
+ *
+ * A mirrored board answers this itself: its columns ARE the tracker's columns,
+ * and a column carries the statuses it groups. The hand-written mapping is the
+ * fallback, and only a board still using Studio's lanes reaches it.
+ *
+ * Before this, the push always went through the mapping — which on a mirrored
+ * board is keyed by lanes that no longer exist, so every lookup came back
+ * empty and read as "unmapped". Moving a card in Studio silently never reached
+ * Jira, and the next pull put the card back where the issue still was.
+ */
+async function jiraTargetsForLane(
+  organizationId: string,
+  lane: string,
+  mapping: JiraStatusMapping,
+): Promise<readonly string[]> {
+  const columns = await new BoardColumnStorage(requireRuntime().db).listByOrg(
+    organizationId,
+  );
+  return pushTargetsForLane({
+    column: columns.find((c) => c.key === lane),
+    mapping,
+    lane,
+  });
 }
 
 /** No sprint snapshot on purpose, same as `JiraStatusPushParams` — the

--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -151,7 +151,13 @@ async function mirrorBoardColumns(
   const columns = await client.getBoardColumns(boardId);
   await ctx.storage.boardColumns.replaceAll(
     integration.organizationId,
-    columns.map((column) => ({ key: column.name, title: column.name })),
+    columns.map((column) => ({
+      key: column.name,
+      title: column.name,
+      // The push's whole reason for existing: a column groups several
+      // statuses, and only the tracker knows which and in what order.
+      trackerStatuses: column.statuses,
+    })),
   );
   const index = new Map<string, string>();
   for (const column of columns) {

--- a/apps/api/src/storage/task-board-columns.ts
+++ b/apps/api/src/storage/task-board-columns.ts
@@ -12,7 +12,16 @@ type Row = {
   title: string;
   position: number;
   role: string | null;
+  tracker_statuses: string[];
 };
+
+const toEntity = (row: Row): BoardColumn => ({
+  key: row.key,
+  title: row.title,
+  position: row.position,
+  role: row.role,
+  trackerStatuses: row.tracker_statuses,
+});
 
 export class BoardColumnStorage {
   constructor(private readonly db: Kysely<Database>) {}
@@ -21,11 +30,11 @@ export class BoardColumnStorage {
   async listByOrg(organizationId: string): Promise<BoardColumn[]> {
     const rows = await this.db
       .selectFrom("task_board_columns")
-      .select(["key", "title", "position", "role"])
+      .select(["key", "title", "position", "role", "tracker_statuses"])
       .where("organization_id", "=", organizationId)
       .orderBy("position", "asc")
       .execute();
-    return rows as Row[];
+    return (rows as Row[]).map(toEntity);
   }
 
   /**
@@ -38,12 +47,12 @@ export class BoardColumnStorage {
    */
   async replaceAll(
     organizationId: string,
-    columns: { key: string; title: string }[],
+    columns: { key: string; title: string; trackerStatuses: string[] }[],
   ): Promise<BoardColumn[]> {
     return await this.db.transaction().execute(async (tx) => {
       const existing = await tx
         .selectFrom("task_board_columns")
-        .select(["key", "title", "role"])
+        .select(["key", "title", "role", "tracker_statuses"])
         .where("organization_id", "=", organizationId)
         .execute();
       const roleOf = new Map(existing.map((r) => [r.key, r.role]));
@@ -83,9 +92,16 @@ export class BoardColumnStorage {
 
       const all = [
         ...columns,
+        // A kept-but-dropped column keeps the statuses it last mirrored. They
+        // are stale by definition, and that is the honest value: the tracker
+        // no longer says anything about this column at all.
         ...orphaned
           .filter((row) => keep.has(row.key))
-          .map((row) => ({ key: row.key, title: row.title })),
+          .map((row) => ({
+            key: row.key,
+            title: row.title,
+            trackerStatuses: row.tracker_statuses,
+          })),
       ];
       if (all.length === 0) return [];
 
@@ -96,6 +112,7 @@ export class BoardColumnStorage {
         title: column.title,
         position,
         role: roleOf.get(column.key) ?? null,
+        tracker_statuses: column.trackerStatuses,
       }));
       await tx
         .insertInto("task_board_columns")
@@ -104,16 +121,12 @@ export class BoardColumnStorage {
           oc.columns(["organization_id", "key"]).doUpdateSet((eb) => ({
             title: eb.ref("excluded.title"),
             position: eb.ref("excluded.position"),
+            tracker_statuses: eb.ref("excluded.tracker_statuses"),
             updated_at: new Date(),
           })),
         )
         .execute();
-      return rows.map(({ key, title, position, role }) => ({
-        key,
-        title,
-        position,
-        role,
-      }));
+      return rows.map(toEntity);
     });
   }
 

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1735,6 +1735,10 @@ export interface TaskBoardColumnTable {
   title: string;
   position: number;
   role: string | null;
+  /** Tracker statuses this column groups, in the tracker's own order. A Jira
+   *  column is a bucket of statuses, not one status, so the push needs the
+   *  whole list to pick a reachable transition. Empty for Studio's columns. */
+  tracker_statuses: ColumnType<string[], string[] | undefined, string[]>;
   created_at: ColumnType<Date, Date | string | undefined, Date | string>;
   updated_at: ColumnType<Date, Date | string | undefined, Date | string>;
 }

--- a/apps/api/src/tools/task-board/archive-merged.integration.test.ts
+++ b/apps/api/src/tools/task-board/archive-merged.integration.test.ts
@@ -199,7 +199,7 @@ describe("auto-archive sweep", () => {
       flags: { org_board_columns: true },
     });
     await ctx.storage.boardColumns.replaceAll(orgOwned, [
-      { key: "Retired", title: "Retired" },
+      { key: "Retired", title: "Retired", trackerStatuses: [] },
     ]);
     await ctx.storage.boardColumns.setRole(orgOwned, "Retired", "archived");
 

--- a/apps/api/src/tools/task-board/board-handler.integration.test.ts
+++ b/apps/api/src/tools/task-board/board-handler.integration.test.ts
@@ -151,9 +151,9 @@ describe("boardHandler — a board whose columns are the org's own", () => {
 
   it("renders the org's own columns, in the order given", async () => {
     await boardColumns.replaceAll(ORG_M, [
-      { key: "BACKLOG", title: "Backlog" },
-      { key: "Fazendo", title: "Em Progresso" },
-      { key: "Code Review", title: "Code Review" },
+      { key: "BACKLOG", title: "Backlog", trackerStatuses: [] },
+      { key: "Fazendo", title: "Em Progresso", trackerStatuses: [] },
+      { key: "Code Review", title: "Code Review", trackerStatuses: [] },
     ]);
     expect((await board().columns()).map((c) => c.title)).toEqual([
       "Backlog",
@@ -175,8 +175,8 @@ describe("boardHandler — a board whose columns are the org's own", () => {
    *  not wipe it — the tracker has no idea it exists. */
   it("keeps a role through a re-sync, and drops a column that vanished", async () => {
     await boardColumns.replaceAll(ORG_M, [
-      { key: "BACKLOG", title: "Backlog" },
-      { key: "Code Review", title: "Code Review" },
+      { key: "BACKLOG", title: "Backlog", trackerStatuses: [] },
+      { key: "Code Review", title: "Code Review", trackerStatuses: [] },
     ]);
     const after = await board().columns();
     expect(after.map((c) => c.key)).toEqual(["BACKLOG", "Code Review"]);
@@ -216,8 +216,8 @@ describe("boardHandler — a board whose columns are the org's own", () => {
    */
   it("keeps a dropped column that still holds cards, and drops it once empty", async () => {
     await boardColumns.replaceAll(ORG_M, [
-      { key: "BACKLOG", title: "Backlog" },
-      { key: "Retired", title: "Retired" },
+      { key: "BACKLOG", title: "Backlog", trackerStatuses: [] },
+      { key: "Retired", title: "Retired", trackerStatuses: [] },
     ]);
     const card = await taskBoard.create({
       organizationId: ORG_M,
@@ -227,7 +227,7 @@ describe("boardHandler — a board whose columns are the org's own", () => {
     });
 
     await boardColumns.replaceAll(ORG_M, [
-      { key: "BACKLOG", title: "Backlog" },
+      { key: "BACKLOG", title: "Backlog", trackerStatuses: [] },
     ]);
     expect((await board().columns()).map((c) => c.key)).toEqual([
       "BACKLOG",
@@ -236,7 +236,7 @@ describe("boardHandler — a board whose columns are the org's own", () => {
 
     await taskBoard.update(card.id, ORG_M, { status: "BACKLOG" }, USER_M);
     await boardColumns.replaceAll(ORG_M, [
-      { key: "BACKLOG", title: "Backlog" },
+      { key: "BACKLOG", title: "Backlog", trackerStatuses: [] },
     ]);
     expect((await board().columns()).map((c) => c.key)).toEqual(["BACKLOG"]);
   });
@@ -249,7 +249,7 @@ describe("boardHandler — a board whose columns are the org's own", () => {
    */
   it("refuses a card in a column the board does not have, once guarded", async () => {
     await boardColumns.replaceAll(ORG_M, [
-      { key: "BACKLOG", title: "Backlog" },
+      { key: "BACKLOG", title: "Backlog", trackerStatuses: [] },
     ]);
     const guarded = taskBoard.create({
       organizationId: ORG_M,

--- a/apps/api/src/tools/task-board/board-handler.ts
+++ b/apps/api/src/tools/task-board/board-handler.ts
@@ -62,6 +62,10 @@ const CANONICAL: BoardColumn[] = CANONICAL_COLUMN_KEYS.map((key, position) => ({
   title: key,
   position,
   role: key,
+  // Studio's board mirrors nothing, so it groups no tracker statuses. An org
+  // on this board that also syncs Jira still pushes through its hand-written
+  // status mapping; see `jiraTargetsForLane`.
+  trackerStatuses: [],
 }));
 
 /** The board Studio ships with: a fixed set of columns, and whatever rules the

--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -369,7 +369,12 @@ describe("laneHeader", () => {
   test("calls a mirrored column whatever its tracker calls it", () => {
     expect(
       laneHeader("Fazendo", t, [
-        { key: "Fazendo", title: "Em Progresso", position: 0, role: null },
+        {
+          key: "Fazendo",
+          title: "Em Progresso",
+          position: 0,
+          role: null,
+        },
       ]).label,
     ).toBe("Em Progresso");
   });
@@ -390,7 +395,12 @@ describe("laneHeader", () => {
    */
   test("borrows neither our name nor our icon for a status off the board", () => {
     const header = laneHeader("triage", t, [
-      { key: "BACKLOG", title: "BACKLOG", position: 0, role: null },
+      {
+        key: "BACKLOG",
+        title: "BACKLOG",
+        position: 0,
+        role: null,
+      },
     ]);
     expect(header.offBoard).toBe(true);
     expect(header.label).toBe("triage");

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -1,7 +1,4 @@
-import type {
-  BoardColumn,
-  CanonicalColumnKey,
-} from "@decocms/shared/task-board";
+import type { CanonicalColumnKey } from "@decocms/shared/task-board";
 import {
   AlertCircle,
   AlertOctagon,
@@ -36,6 +33,15 @@ export {
 } from "@decocms/shared/task-board";
 
 export type TaskBoardItem = ToolOutput<"TASK_BOARD_ITEM_LIST">["items"][number];
+/**
+ * A board column as the SERVER sends it.
+ *
+ * The wire type, not shared's `BoardColumn`: that one also carries the tracker
+ * statuses a column groups, which exist for the Jira push and are nobody's
+ * business in a browser. Deriving from the contract is what keeps the two from
+ * drifting apart silently.
+ */
+export type BoardColumn = ToolOutput<"TASK_BOARD_ITEM_LIST">["columns"][number];
 export type { Sprint };
 export type TaskBoardItemStatus = TaskBoardItem["status"];
 export type TaskBoardItemPriority = TaskBoardItem["priority"];

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -109,6 +109,7 @@ import {
   statusIconClassName,
   dropLane,
   LANE_DROPPABLE_PREFIX,
+  type BoardColumn,
   laneHeader,
   laneVisual,
   SUPER_AGENT_ASSIGNEE_ID,
@@ -124,7 +125,6 @@ import {
   useOrgFlag,
   useReviewerEnabled,
 } from "@/hooks/use-organization-settings";
-import type { BoardColumn } from "@decocms/shared/task-board";
 import type { Sprint } from "@decocms/shared/sprints";
 import { usePreferences } from "@/hooks/use-preferences";
 import {

--- a/packages/shared/src/jira-status-mapping.test.ts
+++ b/packages/shared/src/jira-status-mapping.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   jiraStatusesForLane,
+  pushTargetsForLane,
   laneIndex,
   normalizeStatusMapping,
   planStatusPush,
@@ -77,6 +78,69 @@ describe("jiraStatusesForLane", () => {
   });
 });
 
+describe("pushTargetsForLane", () => {
+  /**
+   * The case this exists for, and it is not the exotic one: a tracker's board
+   * column is named separately from the status it holds, so they routinely
+   * differ. A real board has a column "In Progress" whose only status is
+   * called "Doing". Our lane key is the COLUMN name, so without the column's
+   * own status list the push has no idea what to transition the issue to.
+   */
+  it("uses the column's tracker status, not the column's name", () => {
+    expect(
+      pushTargetsForLane({
+        column: { trackerStatuses: ["Doing"] },
+        mapping: MAPPING,
+        lane: "In Progress",
+      }),
+    ).toEqual(["Doing"]);
+  });
+
+  /** A column can group several statuses; order is the tracker's, and it is
+   *  what decides which one the push aims for first. */
+  it("keeps the tracker's order when a column groups several statuses", () => {
+    expect(
+      pushTargetsForLane({
+        column: { trackerStatuses: ["Doing", "In Progress", "Dev"] },
+        mapping: MAPPING,
+        lane: "In Progress",
+      }),
+    ).toEqual(["Doing", "In Progress", "Dev"]);
+  });
+
+  /**
+   * Studio's own columns are constants that mirror nothing, so their empty
+   * list means "not a mirrored column" rather than "accepts no status". Read
+   * the other way, every push on a board using Studio's lanes would die as
+   * `unmapped` — which is exactly the bug on the mirrored side, inverted.
+   */
+  it("falls back to the hand-written mapping for a column that mirrors nothing", () => {
+    expect(
+      pushTargetsForLane({
+        column: { trackerStatuses: [] },
+        mapping: MAPPING,
+        lane: "in_review",
+      }),
+    ).toEqual(["Code Review", "QA"]);
+  });
+
+  it("falls back for a lane this board has no column for at all", () => {
+    expect(
+      pushTargetsForLane({ column: undefined, mapping: MAPPING, lane: "done" }),
+    ).toEqual(["Released", "Closed"]);
+  });
+
+  it("has nothing to aim at when neither side knows the lane", () => {
+    expect(
+      pushTargetsForLane({
+        column: undefined,
+        mapping: MAPPING,
+        lane: "a lane nobody configured",
+      }),
+    ).toEqual([]);
+  });
+});
+
 describe("planStatusPush", () => {
   const plan = (over: {
     lane: string;
@@ -84,8 +148,7 @@ describe("planStatusPush", () => {
     availableTransitions?: string[];
   }) =>
     planStatusPush({
-      mapping: MAPPING,
-      lane: over.lane,
+      targets: jiraStatusesForLane(MAPPING, over.lane),
       currentJiraStatus: over.currentJiraStatus ?? null,
       availableTransitions: over.availableTransitions ?? [
         "Backlog",

--- a/packages/shared/src/jira-status-mapping.ts
+++ b/packages/shared/src/jira-status-mapping.ts
@@ -114,11 +114,10 @@ export type StatusPushPlan =
  * moving within its lane's own statuses hits `already-in-lane` every tick.
  */
 export function statusPushNoop(
-  mapping: JiraStatusMapping,
-  lane: string,
+  /** The tracker statuses this lane accepts, best first. */
+  targets: readonly string[],
   currentJiraStatus: string | null,
 ): "unmapped" | "already-in-lane" | null {
-  const targets = jiraStatusesForLane(mapping, lane);
   if (targets.length === 0) return "unmapped";
   if (currentJiraStatus && targets.includes(currentJiraStatus)) {
     return "already-in-lane";
@@ -126,24 +125,50 @@ export function statusPushNoop(
   return null;
 }
 
-export function planStatusPush(args: {
+/**
+ * Which tracker statuses a lane accepts, and who gets to say so.
+ *
+ * A mirrored board answers for itself: its columns ARE the tracker's columns,
+ * and a column carries the statuses it groups, in the tracker's order. Nobody
+ * types that list.
+ *
+ * The hand-written mapping is the fallback, reached only by a board still on
+ * Studio's own lanes. An EMPTY `trackerStatuses` falls through to it rather
+ * than reading as "this lane accepts nothing": Studio's columns are constants
+ * that mirror nothing, so empty there means "not a mirrored column", not "a
+ * mirrored column with no statuses".
+ */
+export function pushTargetsForLane(args: {
+  /** This board's column for the lane, or undefined when it has none. */
+  column: { trackerStatuses: readonly string[] } | undefined;
   mapping: JiraStatusMapping;
   lane: string;
+}): readonly string[] {
+  return args.column?.trackerStatuses.length
+    ? args.column.trackerStatuses
+    : jiraStatusesForLane(args.mapping, args.lane);
+}
+
+export function planStatusPush(args: {
+  /**
+   * The tracker statuses this lane accepts, best first.
+   *
+   * Passed in rather than looked up from a mapping, because where the list
+   * comes from is now the board's business: a mirrored board reads it off the
+   * tracker's own column configuration, and only a board using Studio's lanes
+   * still needs a person to have written one.
+   */
+  targets: readonly string[];
   /** Where the linked issue was last known to be. */
   currentJiraStatus: string | null;
   /** Status names the issue can transition to right now. */
   availableTransitions: string[];
 }): StatusPushPlan {
-  const reason = statusPushNoop(
-    args.mapping,
-    args.lane,
-    args.currentJiraStatus,
-  );
+  const reason = statusPushNoop(args.targets, args.currentJiraStatus);
   if (reason) return { kind: "noop", reason };
-  const targets = jiraStatusesForLane(args.mapping, args.lane);
   const reachable = new Set(args.availableTransitions);
-  const targetName = targets.find((t) => reachable.has(t));
+  const targetName = args.targets.find((t) => reachable.has(t));
   return targetName
     ? { kind: "transition", targetName }
-    : { kind: "unreachable", targets };
+    : { kind: "unreachable", targets: [...args.targets] };
 }

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -220,6 +220,18 @@ export interface BoardColumn {
   title: string;
   position: number;
   role: string | null;
+  /**
+   * The tracker statuses this column groups, in the tracker's own order.
+   *
+   * A tracker's board column is a bucket of statuses, not a status. The pull
+   * does not care — an issue has one status, which sits in one column — but
+   * the push cannot move without this: "the card is in Em andamento" does not
+   * say which of that column's statuses the issue should become, and the
+   * answer is whichever its workflow can reach.
+   *
+   * Empty for a column Studio defines, which mirrors nothing.
+   */
+  trackerStatuses: string[];
 }
 
 export type DeliveryLane = "approved" | "merged" | "post_deploy_validation";


### PR DESCRIPTION
Stacked on #6774. Base it on `main` once that merges.

## The bug

On a board mirrored from a tracker, moving a card in Studio never reached Jira.

The push translates the lane through `statusMapping`, the hand-written N:1
table keyed by Studio's canonical lanes. A mirrored board's lanes are the
tracker's column names, so every lookup came back empty, read as `unmapped`,
and the push quietly did nothing.

Then the next pull made it worse: `rewritesStatus` sees a status that is not a
column, re-homes the card to wherever the issue still is, and the move is not
just undelivered but undone. Same shape as the sprint bug in #6774, found the
same way.

## The fix

Stop asking a person what a lane means. Ask the board.

`task_board_columns` gains `tracker_statuses` — the statuses a column groups,
in the tracker's own order, filled by the mirror from the board configuration
the tracker already publishes. `pushTargetsForLane` takes that list when the
column has one and falls back to the typed mapping otherwise, so a board still
on Studio's lanes is untouched.

`planStatusPush` and `statusPushNoop` now take the target list rather than a
mapping plus a lane. Where the list comes from is the board's business.

## Why the list is needed even at one status per column

This is the part I had wrong at first, and it matters.

I assumed the motivation was columns that group several statuses. It is not.
The real reason is that **a column is named separately from the status it
holds, and on a real board they differ**:

| column | status it holds |
|---|---|
| Em Progresso | `Fazendo` |
| QA Deco | `Teste` |
| Concluido | `CONLCLUIDO` |

Our lane key is the COLUMN name. Without the column's own status list the push
has nothing to transition to, even when the mapping is strictly one to one. A
column grouping several statuses is then the same problem with a longer list,
and the ordered list handles both.

## Two judgement calls

An empty `tracker_statuses` falls THROUGH to the typed mapping rather than
reading as "this lane accepts nothing". Studio's columns are constants that
mirror nothing, and reading their emptiness the other way would kill every push
on a canonical board — the same bug, inverted.

A column the tracker dropped but that still holds cards keeps the statuses it
last mirrored. They are stale by definition, and that is the honest value: the
tracker no longer says anything about that column at all.

## Verification

Migration run against real Postgres, asserting the result rather than the log
line: the column lands `jsonb NOT NULL DEFAULT '[]'`, and a status array
round-trips as a JS array rather than a string.

Unit tests cover `pushTargetsForLane` across all five cases (mirrored column,
multi-status column, empty column, no column, neither side knows the lane), and
the existing `planStatusPush` suite is adapted to the new signature rather than
duplicated.

The web side now derives its `BoardColumn` from the wire contract instead of
the shared type. The wire deliberately omits `trackerStatuses`: it exists for
the push, and a tenant's Jira status names have no reason to reach a browser.

`check`, `lint`, `fmt`, `knip` clean; 692 tests pass across the touched areas.

## Not covered

No end-to-end run against a live Jira. The push path is exercised by unit-level
guards only, so the first real status move is worth watching.

Separately: the automations (`run-reactions`, `pr-open-board-reaction`,
`conflict-reaction`, the Super Agent hand-off, and the vanished-issue sweep)
still write Studio's canonical statuses straight onto cards, which strands them
off-board on a mirrored board. That is the next PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Jira status pushes from mirrored boards so moving a card in Studio actually reaches Jira. Previously the push looked up the lane in a hand-written status mapping keyed by Studio's canonical lanes, which never matched a mirrored board's column names, so every push was silently dropped and the next pull reverted the move.

**Bug Fixes**
- Adds `tracker_statuses` to `task_board_columns`, populated by the mirror from the tracker's own board configuration.
- The push now uses the column's tracker statuses when available, falling back to the typed mapping only for boards still on Studio's lanes.
- `planStatusPush` and `statusPushNoop` now take the target status list directly instead of a mapping and lane.
- The web side now derives its `BoardColumn` type from the wire contract, keeping the two from drifting.
- Re-baselines the workflow-source guard snapshot; no workflow version bump, so in-flight instances still recover.

<sup>Written for commit 5abb9fa9c8db6e38cc3d98aab40159b7af97f870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

