### PR TITLE
fix(sections-editor): stop autosave from shadowing native resolvers with hidden global blocks

### DIFF
--- a/apps/api/src/api/routes/decofile.ts
+++ b/apps/api/src/api/routes/decofile.ts
@@ -22,7 +22,10 @@
 
 import { resolvePreviewServerUrl } from "@decocms/shared/deco-site-production-url";
 import type { GithubRepo } from "@decocms/shared/sdk/types";
-import { assertSafeDecoBlockKey } from "@decocms/shared/decofile";
+import {
+  assertSafeDecoBlockKey,
+  isReservedResolverBlockKey,
+} from "@decocms/shared/decofile";
 import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { createMiddleware } from "hono/factory";
@@ -348,6 +351,15 @@ export function createDecofileRoutes() {
     for (const [key, value] of Object.entries(patch.set ?? {})) {
       if (typeof value !== "object" || value === null || Array.isArray(value)) {
         return c.json({ error: `Block "${key}" must be a JSON object` }, 400);
+      }
+      // Deletes of resolver-shaped keys stay allowed above so a shadow is repairable.
+      if (isReservedResolverBlockKey(key)) {
+        return c.json(
+          {
+            error: `Block key "${key}" collides with a framework resolver module and cannot be written`,
+          },
+          400,
+        );
       }
     }
 

--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -35,7 +35,7 @@ import {
 import { extractPages, findPageForPath, globalSectionLabel } from "./page-list";
 import { SectionList, parseSections } from "./section-list";
 import { isLazyResolveType } from "./section-lazy";
-import { unwrapSection } from "./unwrap-section";
+import { savedBlockKey, unwrapSection } from "./unwrap-section";
 import { arrayMove } from "@dnd-kit/sortable";
 import type { ParsedSection } from "./section-list";
 import { resolveSchema } from "./resolve-schema";
@@ -742,12 +742,10 @@ export function SectionsEditor({
       const parsed = latestParsedSections[sectionIndex];
       if (!parsed) return;
 
-      // Saved block: write the block entry directly
+      // Saved block: write the block entry directly (savedBlockKey unwraps hidden wrappers).
       if (parsed.isSavedBlock) {
-        const blockKey = parsed.isLazy
-          ? ((rawSection.section?.__resolveType as string) ??
-            rawSection.__resolveType)
-          : rawSection.__resolveType;
+        const blockKey = savedBlockKey(rawSection, parsed);
+        if (!blockKey) return;
         saveBlock.mutate(
           { blockKey, data: nextValue },
           {

--- a/apps/web/src/components/sections-editor/unwrap-section.test.ts
+++ b/apps/web/src/components/sections-editor/unwrap-section.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import { parseSections } from "./parse-sections";
-import { unwrapBlockReference, unwrapSection } from "./unwrap-section";
+import {
+  savedBlockKey,
+  unwrapBlockReference,
+  unwrapSection,
+} from "./unwrap-section";
 
 const HERO = "site/sections/Hero/Hero.tsx";
 const LAZY = "website/sections/Rendering/Lazy.tsx";
@@ -182,5 +186,54 @@ describe("unwrapSection", () => {
     };
     const parsed = parseSections([raw], {})[0]!;
     expect(unwrapSection(raw, parsed, {})).toBeNull();
+  });
+});
+
+describe("savedBlockKey", () => {
+  it("returns the block id for a plain saved block", () => {
+    const raw = { __resolveType: "Header" };
+    const decofile = { Header: { __resolveType: HERO } };
+    const parsed = parseSections([raw], decofile)[0]!;
+    expect(savedBlockKey(raw, parsed)).toBe("Header");
+  });
+
+  // Regression: a hidden global block must key on its inner id, not the wrapper.
+  it("returns the inner block id for a hidden saved block, NOT the wrapper", () => {
+    const raw = {
+      __resolveType: MV,
+      variants: [
+        { value: { __resolveType: "Header" }, rule: { __resolveType: NEVER } },
+      ],
+    };
+    const decofile = { Header: { __resolveType: HERO, title: "Site Header" } };
+    const parsed = parseSections([raw], decofile)[0]!;
+    expect(parsed.isSavedBlock).toBe(true);
+    expect(parsed.isHidden).toBe(true);
+    expect(savedBlockKey(raw, parsed)).toBe("Header");
+    expect(savedBlockKey(raw, parsed)).not.toBe(MV);
+  });
+
+  it("returns the inner block id for a lazy-outer hidden saved block", () => {
+    const raw = {
+      __resolveType: LAZY,
+      section: {
+        __resolveType: MV,
+        variants: [
+          {
+            value: { __resolveType: "Header" },
+            rule: { __resolveType: NEVER },
+          },
+        ],
+      },
+    };
+    const decofile = { Header: { __resolveType: HERO } };
+    const parsed = parseSections([raw], decofile)[0]!;
+    expect(savedBlockKey(raw, parsed)).toBe("Header");
+  });
+
+  it("returns null for non-saved-block sections", () => {
+    const raw = { __resolveType: HERO, title: "Inline" };
+    const parsed = parseSections([raw], {})[0]!;
+    expect(savedBlockKey(raw, parsed)).toBeNull();
   });
 });

--- a/apps/web/src/components/sections-editor/unwrap-section.ts
+++ b/apps/web/src/components/sections-editor/unwrap-section.ts
@@ -95,6 +95,41 @@ export function unwrapBlockReference(
 }
 
 /**
+ * The decofile key a saved-block section writes back to. For a hidden saved
+ * block, `raw.__resolveType` is the multivariate+never wrapper, not the block
+ * key — the real key lives in the wrapped variant value. Returns null when the
+ * section isn't a saved block.
+ */
+export function savedBlockKey(
+  raw: RawSection,
+  parsed: ParsedSection,
+): string | null {
+  if (!parsed.isSavedBlock) return null;
+
+  if (parsed.isHidden) {
+    const wrapperIsLazy = isLazyResolveType(raw.__resolveType);
+    const mvObj = wrapperIsLazy ? (raw.section as RawSection | undefined) : raw;
+    const innerValue = mvObj?.variants?.[0]?.value as
+      | Record<string, unknown>
+      | undefined;
+    if (!innerValue) return null;
+    const innerRt = (innerValue.__resolveType as string) ?? "";
+    if (!isLazyResolveType(innerRt)) return innerRt || null;
+    return (
+      ((innerValue.section as Record<string, unknown> | undefined)
+        ?.__resolveType as string) ??
+      innerRt ??
+      null
+    );
+  }
+
+  const key = parsed.isLazy
+    ? ((raw.section?.__resolveType as string) ?? raw.__resolveType)
+    : raw.__resolveType;
+  return key || null;
+}
+
+/**
  * Unwrap a raw section to get the actual editable data and its resolveType.
  * Handles lazy wrappers, hidden (multivariate+never), saved blocks, and
  * multivariate sections — mirrors admin-mcp's handleCmsSelectSection.

--- a/packages/shared/src/decofile/block-key.test.ts
+++ b/packages/shared/src/decofile/block-key.test.ts
@@ -4,6 +4,7 @@ import {
   blockKeyToFileStem,
   decoBlockFilePath,
   decoBlockKeyFromFileStem,
+  isReservedResolverBlockKey,
 } from "./block-key";
 
 describe("blockKeyToFileStem / decoBlockKeyFromFileStem", () => {
@@ -39,6 +40,32 @@ describe("assertSafeDecoBlockKey", () => {
   it("rejects traversal and control characters", () => {
     for (const bad of ["", "..", "a\\b", "a\0b", "%2e%2e", "a%2fb"]) {
       expect(() => assertSafeDecoBlockKey(bad)).toThrow();
+    }
+  });
+});
+
+describe("isReservedResolverBlockKey", () => {
+  it("flags framework resolver module paths", () => {
+    for (const key of [
+      "website/flags/multivariate/section.ts",
+      "website/flags/multivariate.ts",
+      "site/sections/UI/VerticalCardsWithTabs.tsx",
+      "apps/deco/mod.ts",
+      "deco-sites/std/loaders/x.js",
+    ]) {
+      expect(isReservedResolverBlockKey(key)).toBe(true);
+    }
+  });
+
+  it("allows ordinary block ids and names", () => {
+    for (const key of [
+      "Compre Junto",
+      "Navegue por categoria",
+      "pages-Home%20Page-123",
+      "Estampas / Flags",
+      "site",
+    ]) {
+      expect(isReservedResolverBlockKey(key)).toBe(false);
     }
   });
 });

--- a/packages/shared/src/decofile/block-key.ts
+++ b/packages/shared/src/decofile/block-key.ts
@@ -45,6 +45,19 @@ export function assertSafeDecoBlockKey(blockKey: string): void {
   }
 }
 
+/**
+ * A block key that collides with a framework resolver module — e.g.
+ * `website/flags/multivariate/section.ts`, `site/sections/Foo.tsx`,
+ * `apps/deco/mod.ts`. Real decofile block ids are names/ids and never carry a
+ * source-file extension, so a `set` under such a key writes a
+ * `.deco/blocks/<encoded>.json` that shadows the native resolver for the whole
+ * site. Writes (create/update) must reject these; deletes must NOT — an
+ * already-shadowed resolver has to be removable to repair the site.
+ */
+export function isReservedResolverBlockKey(blockKey: string): boolean {
+  return /\.(?:tsx?|jsx?|mts|cts|mjs|cjs)$/.test(blockKey);
+}
+
 /** Block key from an on-disk `.deco/blocks/<stem>.json` filename stem. */
 export function decoBlockKeyFromFileStem(stem: string): string {
   try {

--- a/packages/shared/src/decofile/index.ts
+++ b/packages/shared/src/decofile/index.ts
@@ -3,6 +3,7 @@ export {
   blockKeyToFileStem,
   decoBlockFilePath,
   decoBlockKeyFromFileStem,
+  isReservedResolverBlockKey,
 } from "./block-key";
 export {
   BLOCK_PATH_RE,


### PR DESCRIPTION
## Summary

A saved (global) section that was **hidden** could get its data written to a block keyed on the multivariate wrapper's `__resolveType` — `website/flags/multivariate/section.ts` — instead of the block's real id. That produced `.deco/blocks/website%2Fflags%2Fmultivariate%2Fsection.ts.json`, which **shadowed the native deco resolver site-wide**: every `{ "__resolveType": "website/flags/multivariate/section.ts", "variants": [...] }` reference stopped running multivariate logic and instead rendered the saved section (observed on `deco-sites/montecarlo`, commit `e376a14169` — "Navegue por categoria" leaking into ~274 wrapper references, duplicating on `/something-blue`).

### Root cause

A hidden section is wrapped as `{ __resolveType: "website/flags/multivariate/section.ts", variants: [{ rule: { never }, value: { __resolveType: <blockId> } }] }`. `parseSections` classifies such a section as **both** `isSavedBlock` and `isHidden`, with `resolveType` set to the outer wrapper.

`scheduleAutoSave`'s `parsed.isSavedBlock` branch derived the write key straight from `rawSection.__resolveType` — which, for a hidden section, is the wrapper, not the block id. `unwrapSection` already guards this exact trap (`isSavedBlock && !isHidden`, with a comment: *"a hidden section's raw.__resolveType is the never-matcher wrapper, not the block key"*), but the autosave path was missing the same guard.

### Fix

1. **Root cause** — extract a shared `savedBlockKey(raw, parsed)` (in `unwrap-section.ts`) that unwraps the hidden (and lazy) cases to the real inner block id, and use it in `scheduleAutoSave`. A hidden global block now correctly writes to its own block file; the page keeps its wrapper reference untouched.
2. **Defense in depth** — `isReservedResolverBlockKey()` + a `set`-only guard at the decofile `PATCH` route rejects any write whose key looks like a framework resolver module (ends in `.ts/.tsx/.js/.jsx/.mts/.cts/.mjs/.cjs`). **Deletes stay allowed** so an already-shadowed resolver can be removed to repair a site.

### Tests
- `savedBlockKey` returns the inner block id (not the wrapper) for hidden/lazy-hidden saved blocks — the direct regression for this bug.
- `isReservedResolverBlockKey` flags resolver module paths and leaves ordinary block ids/names (incl. slash-named ones like `Estampas / Flags`) alone.

## Testing notes
- `bun test apps/web/src/components/sections-editor/ packages/shared/src/decofile/` → 763 pass
- `bun run --workspaces check` → clean · `bun run lint` → clean · `bun run fmt` applied

## Follow-up
Existing shadow blocks already committed to a repo (e.g. montecarlo's) still need a one-off cleanup (delete the `website%2F…%2Fsection.ts.json` block) — the write guard prevents new ones but doesn't retroactively remove committed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sections editor autosave so editing a hidden global section writes to the block's own file instead of the multivariate wrapper key, which was shadowing the native resolver site-wide.

- Adds `savedBlockKey` to unwrap hidden and lazy wrappers to the inner block id.
- Rejects writes to resolver-like keys (e.g. `website/flags/multivariate/section.ts`) at the decofile route; deletes stay allowed so existing shadows can be removed.
- Adds unit tests for both behaviors.

**Migration**

- Existing shadow blocks committed to a repo still need a one-off cleanup: delete the encoded `.json` file (e.g. `website%2F...%2Fsection.ts.json`) manually.

<sup>Written for commit 20188fdff1af4e5234a4e35f0348c28290800742. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

