### PR TITLE
fix(decofile): accept %2F-encoded slash in block keys (slash-named pages)

### DIFF
--- a/apps/web/src/components/sections-editor/deco-block-key.test.ts
+++ b/apps/web/src/components/sections-editor/deco-block-key.test.ts
@@ -42,12 +42,21 @@ describe("deco-block-key", () => {
     ).not.toThrow();
   });
 
-  it("rejects percent-encoded slashes in block keys", () => {
-    expect(() => assertSafeDecoBlockKey("foo%2fbar")).toThrow(
-      /Invalid block key/,
-    );
-    expect(() => assertSafeDecoBlockKey("foo%2Fbar")).toThrow(
-      /Invalid block key/,
-    );
+  it("allows percent-encoded slashes (deco slash-named page keys)", () => {
+    expect(() => assertSafeDecoBlockKey("foo%2fbar")).not.toThrow();
+    expect(() => assertSafeDecoBlockKey("foo%2Fbar")).not.toThrow();
+    expect(() =>
+      assertSafeDecoBlockKey(
+        "pages-Joias%2Fcolecao%2Freligiosos%2Fcruz-862158",
+      ),
+    ).not.toThrow();
+  });
+
+  it("round-trips a slash-named page key through the file stem", () => {
+    const key = "pages-Joias%2Fcolecao%2Freligiosos%2Fcruz-862158";
+    const stem = "pages-Joias%252Fcolecao%252Freligiosos%252Fcruz-862158";
+    expect(blockKeyToFileStem(key)).toBe(stem);
+    expect(decoBlockKeyFromFileStem(stem)).toBe(key);
+    expect(decoBlockFilePath(key)).toBe(`.deco/blocks/${stem}.json`);
   });
 });

--- a/apps/web/src/components/sections-editor/save-referenced-block.test.ts
+++ b/apps/web/src/components/sections-editor/save-referenced-block.test.ts
@@ -23,10 +23,14 @@ describe("save-referenced-block", () => {
 });
 
 describe("assertSafeDecoBlockKey encoded traversal", () => {
-  it("rejects percent-encoded path segments", () => {
+  it("rejects percent-encoded path traversal (decoded `..`)", () => {
     expect(() => assertSafeDecoBlockKey("%2e%2e")).toThrow(/Invalid block key/);
-    expect(() => assertSafeDecoBlockKey("pages-%2fhome")).toThrow(
+    expect(() => assertSafeDecoBlockKey("%2e%2e%2fHeader")).toThrow(
       /Invalid block key/,
     );
+  });
+
+  it("allows percent-encoded slashes (deco slash-named page keys)", () => {
+    expect(() => assertSafeDecoBlockKey("pages-%2fhome")).not.toThrow();
   });
 });

--- a/packages/e2e/tests/decofile-api.spec.ts
+++ b/packages/e2e/tests/decofile-api.spec.ts
@@ -619,6 +619,50 @@ test.describe("decofile API", () => {
     }
   });
 
+  test("PATCH accepts a slash-named page key (%2F) and stores it in a flat file", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    try {
+      const user = await signUpViaApi(ctx);
+      const org = user.orgSlug;
+      const owner = uniqueOwner();
+      const repo = "site";
+
+      await seedStubRepo(ctx, {
+        owner,
+        repo,
+        defaultBranch: "main",
+        branches: { main: { files: {} } },
+      });
+      const project = await createFastPreviewProject(ctx, org, { owner, repo });
+      const url = decofileUrl(project, "main");
+
+      // Deco keys a slash-named page as `pages-Joias%2Fcolecao-<id>`, like `%20` for a space.
+      const key = "pages-Joias%2Fcolecao%2Freligiosos%2Fcruz-862158";
+      const page = {
+        __resolveType: "website/pages/Page.tsx",
+        name: "/religiosos/cruz",
+        path: "/religiosos/cruz",
+      };
+      const patchRes = await ctx.patch(url, { data: { set: { [key]: page } } });
+      expect(patchRes.status()).toBe(200);
+
+      // The `%` is escaped in the on-disk stem — a single flat file, no escape.
+      const stem = "pages-Joias%252Fcolecao%252Freligiosos%252Fcruz-862158";
+      const inspected = await inspectStubRepo(ctx, owner, repo);
+      expect(
+        inspected.branches["main"]?.files[`.deco/blocks/${stem}.json`],
+      ).toBe(blockFileContent(page));
+
+      // The key round-trips back through GET exactly as sent.
+      const after = (await (await ctx.get(url)).json()) as DecofileGetBody;
+      expect(after.decofile[key]).toEqual(page);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
   test("PATCH batches set+delete into one commit and delete removes every alias file", async ({
     playwright,
   }) => {

--- a/packages/shared/src/decofile/block-key.test.ts
+++ b/packages/shared/src/decofile/block-key.test.ts
@@ -37,8 +37,15 @@ describe("assertSafeDecoBlockKey", () => {
   });
 
   it("rejects traversal and control characters", () => {
-    for (const bad of ["", "..", "a\\b", "a\0b", "%2e%2e", "a%2fb"]) {
+    for (const bad of ["", "..", "a\\b", "a\0b", "%2e%2e"]) {
       expect(() => assertSafeDecoBlockKey(bad)).toThrow();
     }
+  });
+
+  it("accepts percent-encoded slashes (deco slash-named page keys)", () => {
+    expect(() => assertSafeDecoBlockKey("a%2fb")).not.toThrow();
+    expect(() =>
+      assertSafeDecoBlockKey("pages-Joias%2Fcolecao-862158"),
+    ).not.toThrow();
   });
 });

--- a/packages/shared/src/decofile/block-key.ts
+++ b/packages/shared/src/decofile/block-key.ts
@@ -25,14 +25,7 @@ function containsPathTraversal(segment: string): boolean {
     ) {
       return true;
     }
-    // A percent-encoded slash (%2f/%2F) decodes to "/" — reject it.
-    // Literal slashes in the original key are safe (encodeURIComponent
-    // escapes them in the filename), but encoded ones indicate smuggling.
-    if (decoded !== segment && decoded.includes("/")) {
-      const originalSlashes = (segment.match(/\//g) ?? []).length;
-      const decodedSlashes = (decoded.match(/\//g) ?? []).length;
-      if (decodedSlashes > originalSlashes) return true;
-    }
+    // `%2F` is a legit deco key (slash-named page, like `%20` for a space); the whole key is re-encoded by blockKeyToFileStem, so only the `..`/`\`/NUL above can traverse.
     return false;
   } catch {
     return true;


### PR DESCRIPTION
## Summary

Fixes decofile `PATCH` returning `400 Invalid block key` for legitimate deco page keys that contain `%2F` — e.g. `pages-Joias%2Fcolecao%2Freligiosos%2Fcruz-862158`, the canonical key for a page named `Joias/colecao/religiosos/cruz`.

Deco derives block keys from a single `decodeURIComponent` of the on-disk filename stem, so a slash in a page name lives in the key as `%2F`, exactly like a space lives as `%20` in `pages-Home%20Page-<id>`. `assertSafeDecoBlockKey` allowed `%20` but rejected `%2F` as "path-traversal smuggling" — inconsistent and wrong.

The guard was also unnecessary: the only key→path mapping is `blockKeyToFileStem` = `encodeURIComponent(blockKey)`, which re-escapes `%` → `%25` (so `%2F` → `%252F`) and `/` → `%2F`. The resulting stem is always a flat file in `.deco/blocks/` and can never contain a real path separator. Only literal `..`/`\`/NUL (checked on both raw and decoded forms) can traverse — those checks remain.

## Where it started

The encoded-slash rejection shipped in #5951 (*sandbox-less Fast Preview — CMS over the GitHub API*), which created `block-key.ts`. Any slash-named page has been un-editable via Fast Preview since.

## Changes

- **`packages/shared/src/decofile/block-key.ts`** — drop the encoded-slash rejection; keep `..`/`\`/NUL guards.
- **Inverted the tests that encoded the old behavior** in all three tiers: `packages/shared/src/decofile/block-key.test.ts`, `apps/web/.../deco-block-key.test.ts` (+ round-trip of the exact failing key), `apps/web/.../save-referenced-block.test.ts`.
- **`packages/e2e/tests/decofile-api.spec.ts`** — new e2e: PATCH the exact failing key, assert it lands in the flat file `.deco/blocks/pages-Joias%252F…-862158.json` and round-trips through GET. The existing `..` / `../../etc/passwd` rejection e2e is unchanged.

## Testing

- 32 unit tests pass across the 4 block-key test files.
- `bun run fmt` clean; `bun run lint` → 0 errors.
- `tsc --noEmit` clean in `packages/shared`, `packages/e2e`, `apps/web`.
- The new e2e exercises real Postgres + git; not run locally (Playwright suite) — validated in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes decofile `PATCH` returning `400 Invalid block key` for page keys that contain `%2F`, which made slash-named pages like `pages-Joias%2Fcolecao%2Freligiosos%2Fcruz-862158` uneditable through Fast Preview. The guard rejected any key whose decode gained a `/`, but `blockKeyToFileStem` re-encodes the whole key, so `%2F` becomes `%252F` and files stay flat in `.deco/blocks/`; `..`, `\`, and NUL traversal checks remain on both raw and decoded forms.

**Tests**
- Inverted the unit tests in `packages/shared` and `apps/web` that encoded the old rejection, including a round-trip of the exact failing key.
- Added an e2e in `packages/e2e` that PATCHes the failing key and asserts flat-file storage and GET round-trip.
- Existing traversal-rejection tests are unchanged.

<sup>Written for commit 398306dbdc38564a587f2b8cc35e2a09dcd972dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

