### PR TITLE
fix(sections-editor): constrain field selects to container width

### DIFF
--- a/apps/web/src/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/any-of-field.tsx
@@ -438,7 +438,7 @@ export function AnyOfField({
             virtualMcpId={sandbox?.virtualMcpId}
           />
           <Select value={activeRt || undefined} onValueChange={handleRefChange}>
-            <SelectTrigger id={path}>
+            <SelectTrigger id={path} className="w-full min-w-0">
               <SelectValue
                 placeholder={t("sectionsEditor.anyOfField.selectPlaceholder")}
               />

--- a/apps/web/src/components/sections-editor/fields/enum-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/enum-field.tsx
@@ -43,7 +43,7 @@ export function EnumField({
         value={selectValue}
         onValueChange={(v) => onChange(selectValueToFormValue(v, options))}
       >
-        <SelectTrigger id={path} className="h-10">
+        <SelectTrigger id={path} className="h-10 w-full min-w-0">
           <SelectValue
             placeholder={t("sectionsEditor.enumField.selectPlaceholder")}
           />

--- a/apps/web/src/components/sections-editor/fields/inline-union-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/inline-union-field.tsx
@@ -96,7 +96,7 @@ export function InlineUnionField(props: FieldProps) {
           />
         )}
         <Select value={String(activeIndex)} onValueChange={handleBranchChange}>
-          <SelectTrigger id={path}>
+          <SelectTrigger id={path} className="w-full min-w-0">
             <SelectValue
               placeholder={t(
                 "sectionsEditor.inlineUnionField.selectPlaceholder",


### PR DESCRIPTION
## Summary

The "Data" (and sibling) selects in the sections/content editor overflow their panel horizontally when an option label is long — e.g. the loader picker showing **"Product Listing Page - Intelligent Search"** pushes the select box past the right edge of the LOADER CONFIGURATION panel.

**Cause:** the shared `SelectTrigger` (`packages/ui/src/components/select.tsx`) defaults to `w-fit whitespace-nowrap`, so with a long label the trigger sizes to its content and grows past the container instead of truncating. The sections-editor field selects didn't pass a width class (unlike `seo-type-select.tsx`, which uses `w-full` and doesn't overflow).

**Fix:** add `w-full min-w-0` to the three sections-editor selects that omitted a width:
- `any-of-field.tsx` — the loader/Resolvable picker in the screenshot ("Data")
- `inline-union-field.tsx` — same inline-union pattern
- `enum-field.tsx` — previously set `h-10` only

With `w-full`, the trigger fills the container and the existing `line-clamp-1` on the inner `SelectValue` truncates the long label.

## Testing

- `bun run fmt`
- Visual check recommended: open a section with a loader that has a long resolve-type title and confirm the "Data" select stays within the panel and truncates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sections editor select fields so long option labels truncate inside the panel instead of overflowing horizontally.

**Bug Fixes**
- Adds `w-full min-w-0` to the loader, enum, and inline-union field selects so the trigger fills its container.
- Long labels now truncate via the existing `line-clamp-1` on the select value instead of expanding past the panel edge.

<sup>Written for commit 14833c60f0b3c6c65ef36b73078cecbad8503a96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

