### PR TITLE
feat(sections-editor): expose noIndexing in General SEO form

### DIFF
--- a/apps/web/src/components/sections-editor/seo-form-mode.test.ts
+++ b/apps/web/src/components/sections-editor/seo-form-mode.test.ts
@@ -48,6 +48,13 @@ describe("filterSeoSchema", () => {
     );
   });
 
+  test("general exposes noIndexing", () => {
+    const filtered = filterSeoSchema(sampleSchema, DEFAULT_SEO_RESOLVE_TYPE);
+    expect(filtered.properties?.noIndexing).toEqual(
+      sampleSchema.properties?.noIndexing as SchemaProperty,
+    );
+  });
+
   test("pdp keeps commerce PDP fields", () => {
     const filtered = filterSeoSchema(
       sampleSchema,

--- a/apps/web/src/components/sections-editor/seo-form-mode.ts
+++ b/apps/web/src/components/sections-editor/seo-form-mode.ts
@@ -7,6 +7,7 @@ export const GENERAL_SEO_FIELD_KEYS = [
   "title",
   "description",
   "canonical",
+  "noIndexing",
   "favicon",
   "image",
   "themeColor",


### PR DESCRIPTION
## Summary

The Studio "Edit SEO" **General** form (page/site SEO) curates its field set via a hardcoded allowlist, `GENERAL_SEO_FIELD_KEYS` in `seo-form-mode.ts`, which omitted `noIndexing` — even though the resolved deco `Seo` schema already carries it and the commerce **PDP/PLP** SEO forms already expose it. This adds `noIndexing` to the General allowlist so it renders in the General SEO panel too.

Because the field set is a hardcoded allowlist in this repo (not an external package), and `renderField` is schema-driven per field, no external/deco-package change is needed: the resolved boolean schema renders as a toggle, consistent with PDP/PLP.

## Changes
- `apps/web/src/components/sections-editor/seo-form-mode.ts` — add `"noIndexing"` to `GENERAL_SEO_FIELD_KEYS` (after `canonical`).
- `apps/web/src/components/sections-editor/seo-form-mode.test.ts` — add `general exposes noIndexing` test locking the behavior.

## Behavior
- "No Indexing" now appears in the General SEO form between Canonical and Favicon, as a boolean switch.
- It gets the per-field "Use default" (site-SEO inherit) toggle like the other General fields (all except `type`).
- Label comes from the resolved schema `title`; fallback humanizes to "No Indexing".

## Testing
- `bun test apps/web/src/components/sections-editor/seo-form-mode.test.ts` → 7 pass / 0 fail
- `bun run --cwd=apps/web check` (tsc) → clean
- `bun run fmt` → no pending changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `noIndexing` field to the General SEO form's hardcoded allowlist so the "No Indexing" toggle now appears between Canonical and Favicon, matching the PDP/PLP forms that already expose it.

<sup>Written for commit a53a4c369f5c5e683c9dfc9b3de85fc08e8d37ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

