### PR TITLE
refactor(mcp-utils): dedupe GatewayClient's tool/prompt target resolution

### DIFF
--- a/packages/mcp-utils/src/aggregate/gateway-client.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.ts
@@ -239,13 +239,15 @@ export class GatewayClient extends Client {
   }
 
   /**
-   * Resolve a tool name to [clientKey, originalName].
-   * Fast path: parse namespace prefix. Fallback: search aggregated tools
-   * for an un-namespaced match (supports callers that don't know about
-   * namespacing, e.g. workflow tool steps).
+   * Resolve a namespaced tool/prompt name to [clientKey, originalName].
+   * Fast path: parse namespace prefix. Fallback: search the aggregated
+   * `items` for an un-namespaced match (supports callers that don't know
+   * about namespacing, e.g. workflow tool steps).
    */
-  private async resolveToolTarget(
+  private async resolveNamespacedTarget(
     name: string,
+    kind: "tool" | "prompt",
+    items: () => Promise<Array<{ name: string; _meta?: unknown }>>,
   ): Promise<[clientKey: string, originalName: string]> {
     // Fast path: namespace prefix matches a known client
     const sep = name.indexOf("_");
@@ -257,12 +259,11 @@ export class GatewayClient extends Client {
       }
     }
 
-    // Fallback: search aggregated tools by original (un-namespaced) name
-    const { tools } = await this.listTools();
-    for (const tool of tools) {
-      const clientId = getGatewayClientId(tool._meta);
+    // Fallback: search aggregated items by original (un-namespaced) name
+    for (const item of await items()) {
+      const clientId = getGatewayClientId(item._meta);
       if (!clientId) continue;
-      if (stripToolNamespace(tool.name, clientId) === name) {
+      if (stripToolNamespace(item.name, clientId) === name) {
         return [clientId, name];
       }
     }
@@ -270,7 +271,7 @@ export class GatewayClient extends Client {
     // Nothing matched — throw the original-style error
     if (sep === -1) {
       throw new Error(
-        `GatewayClient: could not resolve tool "${name}" — no namespace prefix and not found in any client`,
+        `GatewayClient: could not resolve ${kind} "${name}" — no namespace prefix and not found in any client`,
       );
     }
     throw new Error(
@@ -278,40 +279,23 @@ export class GatewayClient extends Client {
     );
   }
 
-  /**
-   * Resolve a prompt name to [clientKey, originalName].
-   * Same logic as resolveToolTarget but searches prompts.
-   */
-  private async resolvePromptTarget(
+  private resolveToolTarget(
     name: string,
   ): Promise<[clientKey: string, originalName: string]> {
-    // Fast path: namespace prefix matches a known client
-    const sep = name.indexOf("_");
-    if (sep !== -1) {
-      const slug = name.slice(0, sep);
-      const clientKey = this.slugToKey.get(slug);
-      if (clientKey) {
-        return [clientKey, name.slice(sep + 1)];
-      }
-    }
+    return this.resolveNamespacedTarget(
+      name,
+      "tool",
+      async () => (await this.listTools()).tools,
+    );
+  }
 
-    // Fallback: search aggregated prompts by original (un-namespaced) name
-    const { prompts } = await this.listPrompts();
-    for (const prompt of prompts) {
-      const clientId = getGatewayClientId(prompt._meta);
-      if (!clientId) continue;
-      if (stripToolNamespace(prompt.name, clientId) === name) {
-        return [clientId, name];
-      }
-    }
-
-    if (sep === -1) {
-      throw new Error(
-        `GatewayClient: could not resolve prompt "${name}" — no namespace prefix and not found in any client`,
-      );
-    }
-    throw new Error(
-      `GatewayClient: unknown namespace "${name.slice(0, sep)}" in "${name}" and not found by original name in any client`,
+  private resolvePromptTarget(
+    name: string,
+  ): Promise<[clientKey: string, originalName: string]> {
+    return this.resolveNamespacedTarget(
+      name,
+      "prompt",
+      async () => (await this.listPrompts()).prompts,
     );
   }
 


### PR DESCRIPTION
**Source:** C1 net-code-reduction, found while auditing `packages/mcp-utils/src/aggregate/gateway-client.ts` (assigned focus area: MCP-mesh simplification).

**What:** `resolveToolTarget` and `resolvePromptTarget` were byte-identical logic (namespace-prefix fast path, fallback linear search over the aggregated list, same two error messages) apart from which list method they called (`listTools`/`listPrompts`) and the noun in the error message ("tool"/"prompt"). Collapsed both into one `resolveNamespacedTarget(name, kind, items)` private helper that both now call.

**Why a maintainer wants it:** one code path to read and fix instead of two that must be kept in sync by hand — the kind of drift this file's own header comment (`Key features: ...`) documents it works hard to avoid elsewhere.

**Net line delta:** -42 / +26 (net -16 lines) in the one file touched. Behavior-preserving: same fast-path logic, same fallback search, same two error message strings for both tools and prompts (verified by the existing `gateway-client.test.ts` suite, which asserts on both, still passing unmodified).

**Reviewer command:** `bun test packages/mcp-utils/src/aggregate/gateway-client.test.ts`

**Checks run locally:**
- `bun run fmt`
- `cd packages/mcp-utils && bunx tsc --noEmit` — clean
- `bun test packages/mcp-utils/src/aggregate/gateway-client.test.ts` — 51 pass / 0 fail (unmodified test file)
- `bunx oxlint packages/mcp-utils/src/aggregate/gateway-client.ts` — 0 warnings, 0 errors

Full CI validates the rest of the monorepo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `GatewayClient` so tool and prompt target resolution share one code path instead of two byte-identical methods.

- Replaces `resolveToolTarget` and `resolvePromptTarget` with a single `resolveNamespacedTarget(name, kind, items)` helper.
- Behavior is unchanged: same namespace fast path, same fallback search, same error messages.
- Existing `gateway-client.test.ts` suite passes unmodified.

<sup>Written for commit 55310fd076fe963ae3ae567c9b88eb66a6286f2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

