### PR TITLE
fix(sections-editor): validate the make-global block name even while decofile is loading

### DIFF
--- a/apps/web/src/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/any-of-field.tsx
@@ -409,9 +409,8 @@ export function AnyOfField({
     const handleMakeGlobalSubmit = (blockId: string) => {
       if (!onSaveReferencedBlock) return;
       const trimmed = blockId.trim();
-      const validationError = decofile
-        ? validateBlockId(trimmed, decofile)
-        : null;
+      // Never skip validation just because decofile hasn't loaded yet.
+      const validationError = validateBlockId(trimmed, decofile ?? {});
       if (validationError) {
         toast.error(validationError);
         return;


### PR DESCRIPTION
**Bug**, found while reading `AnyOfField`'s "Make global" flow (`apps/web/src/components/sections-editor/fields/any-of-field.tsx`).

`handleMakeGlobalSubmit` only ran `validateBlockId` `if (decofile)`, falling back to `null` (no error) whenever `decofile` was falsy. `decofile` is TanStack Query data (`useDecofile`) and is `undefined` on first load and can go back to `undefined` while refetching (e.g. right after switching branches) even though the editor stays mounted and interactive. During that window, submitting the "Save as global block" dialog skipped validation entirely — an empty name, a name containing `/`, or a name colliding with an existing block could be written straight into the decofile via `onSaveReferencedBlock`, instead of surfacing the usual toast error.

**Fix**: always call `validateBlockId(trimmed, decofile ?? {})` instead of gating the call on `decofile` being truthy. Behavior when `decofile` is loaded is unchanged; when it isn't loaded yet, validation now runs against an empty decofile (so duplicate-name detection is skipped only in that narrow window, but the empty/slash/character checks — which don't need decofile — always run).

**To confirm**: read `handleMakeGlobalSubmit` in `any-of-field.tsx` and `validateBlockId` in `page-sections.ts` — the validation error can no longer be silently bypassed by a falsy `decofile`.

Checks run locally: `bun run fmt`, `bunx tsc --noEmit` in `apps/web` (only pre-existing, unrelated errors in `mention-suggestion.tsx` from a prosemirror-model version mismatch — confirmed absent from `any-of-field.tsx`), `bunx oxlint` on the changed file (0 warnings/errors). No existing unit test covers this UI submit handler; full CI (typecheck/lint across the workspace) will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the make-global block name validation in the sections editor so invalid names can no longer be silently saved while the decofile is still loading.

**Bug Fixes**
- Validation previously ran only when `decofile` was loaded; it now runs against an empty decofile when the data is unavailable, so the empty, slash, and character checks always execute.
- Duplicate-name detection still requires the loaded decofile and is skipped only during that narrow loading window.

<sup>Written for commit bdf9e6b41d4891953eadd312e7c96f80973ff877. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

