### PR TITLE
refactor(storage): use AbortSignal.timeout in testConnection's probe fetch

### DIFF
--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -524,13 +524,11 @@ export class ConnectionStorage implements ConnectionStoragePort {
       } | null;
 
       // Bound the probe — a hanging remote server shouldn't hang this call.
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), 10_000);
-      let response: Response;
-      try {
-        response = await createNoRedirectFetch()(connection.connection_url, {
+      const response = await createNoRedirectFetch()(
+        connection.connection_url,
+        {
           method: "POST",
-          signal: controller.signal,
+          signal: AbortSignal.timeout(10_000),
           headers: {
             "Content-Type": "application/json",
             ...(connection.connection_token && {
@@ -544,10 +542,8 @@ export class ConnectionStorage implements ConnectionStoragePort {
             method: "ping",
             id: 1,
           }),
-        });
-      } finally {
-        clearTimeout(timer);
-      }
+        },
+      );
 
       return {
         healthy: response.ok || response.status === 404,


### PR DESCRIPTION
Reduction/cleanup found while auditing `apps/api/src/storage/connection.ts` for storage-connection hardening.

`ConnectionStorage.testConnection()` hand-rolled its 10s probe timeout with `new AbortController()` + `setTimeout(() => controller.abort(), ...)` + a `finally { clearTimeout(timer) }` wrapper. The native `AbortSignal.timeout(ms)` does exactly this and is already the established pattern elsewhere in this codebase (e.g. `apps/api/src/tools/virtual/delete.ts`, `apps/api/src/oauth/refresh-access-token.ts`, `apps/api/src/tools/github/graphql.ts`).

Why it's worth landing: fewer moving parts on a probe path that already has an outer `catch` (an abort now just rejects the fetch, which the existing catch already turns into `{ healthy: false }`), and it deletes a manual timer-management pattern that has to be gotten right (leaked timer on early return, etc.) in favor of a one-liner.

Behavior preserved: same 10s bound, same fetch semantics, same error handling — the outer `try/catch` already converts an abort (or any other fetch failure) into `{ healthy: false, latencyMs }`, unchanged.

Net diff: -10 / +6, one file.

How to confirm: read the diff — it's a mechanical substitution, not new logic. No existing unit test covers this path (only an integration test requiring real Postgres, not run here).

Local checks run: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (no errors introduced), `bunx oxlint apps/api/src/storage/connection.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hand-rolled abort timer in `testConnection` with `AbortSignal.timeout`, keeping the same 10s timeout and error handling.

<sup>Written for commit d46129a3d9d906daf9f879729051e1c9439e8cd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

