### PR TITLE
feat(preview): experimental in-place Fast Preview render behind per-agent flag

### DIFF
--- a/apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
@@ -121,6 +121,19 @@ describe("CMS_EDITOR_SCRIPT", () => {
     expect(CMS_EDITOR_SCRIPT).not.toMatch(/alignSections\s*=\s*\(0,/);
   });
 
+  it("handles the in-place render message and swaps the document via POST", () => {
+    expect(CMS_EDITOR_SCRIPT).toContain('e.data.type === "cms-editor::render"');
+    expect(CMS_EDITOR_SCRIPT).toContain("var renderInPlace = function");
+    // The swap and its no-reload contract: POST for HTML, replace the document.
+    expect(CMS_EDITOR_SCRIPT).toContain('method: "POST"');
+    expect(CMS_EDITOR_SCRIPT).toContain("document.documentElement.innerHTML");
+    // The overlay nodes live on the old body — re-attach after the swap.
+    expect(CMS_EDITOR_SCRIPT).toContain("document.body.appendChild(highlight)");
+    // Status contract the parent listens for to drive the nav indicator.
+    expect(CMS_EDITOR_SCRIPT).toContain("cms-editor::render-start");
+    expect(CMS_EDITOR_SCRIPT).toContain("cms-editor::render-end");
+  });
+
   it("runs the embedded alignment against a stubbed DOM", () => {
     // The embedded copy, on the regression case (a section that rendered no node).
     const start = CMS_EDITOR_SCRIPT.indexOf("var alignSections = ");

--- a/apps/web/src/components/sandbox/preview/cms-editor-script.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.ts
@@ -304,7 +304,60 @@ export const CMS_EDITOR_SCRIPT = `(function() {
   var submitBlocker = function(e) { e.preventDefault(); };
   document.addEventListener("submit", submitBlocker, true);
 
+  // Fast Preview in-place render: POST merged decofile to /live/previews, swap the HTML in (document/window listeners survive; overlay nodes get re-attached).
+  var renderCtrl = null;
+  var renderQueue = Promise.resolve();
+  var TRANSITION_TAG =
+    "<style id=\\"deco-disable-transitions\\">* { transition: none !important; }</style></head>";
+  var renderInPlace = function(src, body) {
+    if (renderCtrl) renderCtrl.abort();
+    var ctrl = new AbortController();
+    renderCtrl = ctrl;
+    window.parent.postMessage({ type: "cms-editor::render-start" }, "*");
+    renderQueue = renderQueue.then(function() {
+      return fetch(src, {
+        method: "POST",
+        body: body,
+        signal: ctrl.signal,
+        headers: { accept: "text/html", "content-type": "application/json" }
+      }).then(function(res) {
+        if (!res.ok) throw new Error("render " + res.status);
+        return res.text();
+      }).then(function(html) {
+        var swap = function() {
+          document.documentElement.innerHTML = html.replace("</head>", TRANSITION_TAG);
+          document.body.appendChild(highlight);
+          document.body.appendChild(badge);
+          lastSection = null;
+        };
+        var headHtml = html.slice(html.indexOf("<head>"), html.indexOf("</head>") + 7);
+        var doc = new DOMParser().parseFromString(headHtml, "text/html");
+        var sheets = Array.prototype.map.call(
+          doc.head.querySelectorAll("link[rel=\\"stylesheet\\"]"),
+          function(el) { return el.href ? fetch(el.href).catch(function() {}) : null; }
+        );
+        return Promise.all(sheets).then(function() {
+          if (typeof document.startViewTransition === "function") {
+            return document.startViewTransition(swap).finished;
+          }
+          swap();
+        });
+      }).then(function() {
+        var t = document.getElementById("deco-disable-transitions");
+        if (t) t.remove();
+        window.parent.postMessage({ type: "cms-editor::render-end" }, "*");
+      }).catch(function(err) {
+        if (err && err.name === "AbortError") return;
+        window.parent.postMessage({ type: "cms-editor::render-error" }, "*");
+      });
+    });
+  };
+
   window.addEventListener("message", function(e) {
+    if (e.data && e.data.type === "cms-editor::render" && typeof e.data.src === "string") {
+      renderInPlace(e.data.src, e.data.body);
+      return;
+    }
     if (e.data && e.data.type === "cms-editor::set-labels" && Array.isArray(e.data.labels)) {
       sectionLabels = e.data.labels;
       if (Array.isArray(e.data.kinds)) sectionKinds = e.data.kinds;

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -85,6 +85,7 @@ import { decoBlockFileViewPath } from "@/components/sections-editor/deco-block-k
 import { findLivePageResolveType } from "@/components/sections-editor/section-catalog";
 import {
   buildGlobalSectionPreviewUrl,
+  buildPageRenderRequest,
   DRAFT_OFF,
   resolveSectionPreviewBase,
   withDraftPointer,
@@ -748,6 +749,34 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
       ? productionOrigin
       : previewOrigin(previewUrl);
 
+  /**
+   * Fast Preview in-place editing: while the Blocks panel is open on a Fast
+   * Preview (production) frame, edits refresh the frame by POSTing the merged
+   * decofile to /live/previews (an in-place DOM swap, no commit, no reload — see
+   * the `cms-editor::render` trigger below). The autosave commit still runs, but
+   * its version bump must NOT reload the frame — that reload is the ~15s round
+   * trip this path avoids — so the draft URL's version is pinned while editing in
+   * place, and re-tracks live once the panel closes.
+   */
+  const inPlaceRenderEnabled =
+    inset?.entity?.id === virtualMcpId &&
+    inset.entity.metadata?.fastPreviewInPlace === true;
+  const inPlaceRenderActive =
+    display.mode === "production" &&
+    fastPreviewEnabled &&
+    inPlaceRenderEnabled &&
+    editingMode === "blocks";
+  const pinnedDraftUrlRef = useRef<string | null>(null);
+  if (!inPlaceRenderActive) {
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- track the live draft URL while not editing in place; pin it while editing
+    pinnedDraftUrlRef.current = draftPreviewUrl;
+  }
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read the value pinned during this same render (written just above when inactive)
+  const pinnedDraftUrl = pinnedDraftUrlRef.current;
+  const effectiveDraftPreviewUrl = inPlaceRenderActive
+    ? (pinnedDraftUrl ?? draftPreviewUrl)
+    : draftPreviewUrl;
+
   const iframeSrc = withDecoFBT(
     display.mode === "sandbox"
       ? withVariantMatcherOverride(
@@ -766,7 +795,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
               // Waking pill up ⇒ no draft is renderable yet, so ask for published.
               withDraftPointer(
                 directPreviewUrl ??
-                  draftPreviewUrl ??
+                  effectiveDraftPreviewUrl ??
                   resolvePreviewUrl(resolvedPath, display.iframeBase!) ??
                   display.iframeBase!,
                 display.showWakingPill ? DRAFT_OFF : null,
@@ -991,6 +1020,63 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     }
   }, [draftPreviewUrl, iframeSrc]);
 
+  // Post the current page's merged decofile to the frame for an in-place render.
+  const renderPreviewInPlace = () => {
+    const win = previewIframeRef.current?.contentWindow;
+    const origin = editorBridgeOrigin;
+    if (!win || !origin || !decofile || !currentPageKey) return;
+    const pageBlock = decofile[currentPageKey];
+    if (!pageBlock || typeof pageBlock !== "object") return;
+    const req = buildPageRenderRequest({
+      previewBaseUrl: origin,
+      pageBlock: pageBlock as Record<string, unknown>,
+      decofile: decofile as Record<string, unknown>,
+      path: resolvedPath,
+      pathTemplate: currentPath,
+    });
+    if (!req) return;
+    win.postMessage(
+      { type: "cms-editor::render", src: req.src, body: req.body },
+      origin,
+    );
+  };
+
+  /**
+   * Refresh the in-place render when the current page's content changes (the
+   * autosave optimistically updates KEYS.decofile before the commit lands).
+   * Deduped by content signature so onMutate + onSuccess render once, not twice.
+   */
+  const renderSigRef = useRef<string | null>(null);
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- imperative postMessage refresh of a cross-origin frame on content change
+  useEffect(() => {
+    if (
+      !inPlaceRenderActive ||
+      activeGlobalSection ||
+      activeLoaderKey ||
+      !currentPageKey ||
+      !decofile
+    ) {
+      renderSigRef.current = null;
+      return;
+    }
+    const sig = JSON.stringify(decofile);
+    if (renderSigRef.current === sig) return;
+    const isBaseline = renderSigRef.current === null;
+    renderSigRef.current = sig;
+    // The frame already shows this content via its src; only edits after it render.
+    if (isBaseline) return;
+    renderPreviewInPlace();
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps -- renderPreviewInPlace reads live values; retrigger only on content/page change
+  }, [
+    decofile,
+    inPlaceRenderActive,
+    activeGlobalSection,
+    activeLoaderKey,
+    currentPageKey,
+    resolvedPath,
+    currentPath,
+  ]);
+
   // Daemon is reachable independent of the dev script: ready claim, handle
   // still present, not user-stopped. Gates surfaces (FileExplorer,
   // terminal) that talk to the daemon's HTTP API and don't need a dev server.
@@ -1027,6 +1113,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             index: result.data.sectionIndex,
             seq: result.data.clickSeq,
           });
+      } else if (e.data?.type === "cms-editor::render-start") {
+        beginNavigation();
+      } else if (
+        e.data?.type === "cms-editor::render-end" ||
+        e.data?.type === "cms-editor::render-error"
+      ) {
+        endNavigation();
       }
     };
     window.addEventListener("message", handler);

--- a/apps/web/src/components/sandbox/runtime-card/in-place-render-field.tsx
+++ b/apps/web/src/components/sandbox/runtime-card/in-place-render-field.tsx
@@ -1,0 +1,58 @@
+import {
+  Controller,
+  type Control,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form";
+import { Label } from "@decocms/ui/components/label.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
+import { useT } from "@/i18n/use-t.ts";
+
+/**
+ * The experimental in-place-render switch (`metadata.fastPreviewInPlace`).
+ * Layered on Fast Preview: it only changes HOW edits refresh (an in-place
+ * /live/previews render vs. a commit + re-navigation), so it's inert — and
+ * hidden — unless Fast Preview is on. `fastPreview` is passed by the parent from
+ * `form.watch("metadata.fastPreview")` so the switch reacts to that toggle
+ * without this leaf owning the form type. Mirrors `FastPreviewField`.
+ */
+export interface InPlaceRenderFieldProps<T extends FieldValues> {
+  control: Control<T>;
+  /** Current `metadata.fastPreview` value (watched by the parent). */
+  fastPreview: boolean | null | undefined;
+}
+
+export function InPlaceRenderField<T extends FieldValues>({
+  control,
+  fastPreview,
+}: InPlaceRenderFieldProps<T>) {
+  const t = useT();
+  if (!fastPreview) return null;
+  return (
+    <Controller
+      control={control}
+      name={"metadata.fastPreviewInPlace" as FieldPath<T>}
+      render={({ field }) => (
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-0.5 min-w-0">
+            <Label
+              htmlFor="fast-preview-in-place"
+              className="font-normal text-foreground"
+            >
+              {t("sandbox.cmsSettings.fastPreviewInPlace.label")}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {t("sandbox.cmsSettings.fastPreviewInPlace.description")}
+            </p>
+          </div>
+          <Switch
+            id="fast-preview-in-place"
+            className="shrink-0"
+            checked={!!field.value}
+            onCheckedChange={(checked) => field.onChange(checked)}
+          />
+        </div>
+      )}
+    />
+  );
+}

--- a/apps/web/src/components/sections-editor/section-preview-url.test.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   buildFastPreviewDraftUrl,
+  buildPageRenderRequest,
   DRAFT_OFF,
   resolveSectionPreviewBase,
   withDraftPointer,
@@ -216,5 +217,63 @@ describe("DRAFT_OFF", () => {
       ),
     );
     expect(url.searchParams.getAll("__draft")).toEqual(["off"]);
+  });
+});
+
+describe("buildPageRenderRequest", () => {
+  const PAGE_BLOCK = {
+    __resolveType: "website/pages/Page.tsx",
+    path: "/",
+    sections: [{ __resolveType: "site/sections/Hero.tsx" }],
+  };
+  const DECOFILE = {
+    "pages-Home-1": PAGE_BLOCK,
+    "site/sections/Hero.tsx": { title: "edited" },
+  };
+
+  it("POSTs to /live/previews/:pageResolveType on the frame origin", () => {
+    const req = buildPageRenderRequest({
+      previewBaseUrl: `${PROD}/whatever?ignored=1`,
+      pageBlock: PAGE_BLOCK,
+      decofile: DECOFILE,
+      path: "/",
+      pathTemplate: "/",
+    });
+    const url = new URL(req!.src);
+    expect(url.origin).toBe(PROD);
+    expect(url.pathname).toBe(
+      `/live/previews/${encodeURIComponent("website/pages/Page.tsx")}`,
+    );
+    expect(url.searchParams.get("__decoFBT")).toBe("0");
+    expect(url.searchParams.get("path")).toBe("/");
+    expect(url.searchParams.get("pathTemplate")).toBe("/");
+  });
+
+  it("carries the merged decofile and the page props (sans __resolveType) in the body", () => {
+    const req = buildPageRenderRequest({
+      previewBaseUrl: PROD,
+      pageBlock: PAGE_BLOCK,
+      decofile: DECOFILE,
+      path: "/",
+      pathTemplate: "/",
+    });
+    const body = JSON.parse(req!.body);
+    expect(body.__props).toEqual({
+      path: "/",
+      sections: [{ __resolveType: "site/sections/Hero.tsx" }],
+    });
+    expect(body.__props.__resolveType).toBeUndefined();
+    expect(body.__decofile).toEqual(DECOFILE);
+  });
+
+  it("returns null when the page block has no __resolveType", () => {
+    const req = buildPageRenderRequest({
+      previewBaseUrl: PROD,
+      pageBlock: { path: "/" },
+      decofile: DECOFILE,
+      path: "/",
+      pathTemplate: "/",
+    });
+    expect(req).toBeNull();
   });
 });

--- a/apps/web/src/components/sections-editor/section-preview-url.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.ts
@@ -101,6 +101,54 @@ export function buildFastPreviewDraftUrl(
   return url.toString();
 }
 
+/**
+ * Fast Preview in-place render request — the old admin's `/live/previews` POST,
+ * revived for the main canvas.
+ *
+ * Instead of committing to git and re-navigating the iframe to a `?__draft=@sha`
+ * URL (a ~15s GitHub round-trip), this POSTs the CURRENT page block plus the
+ * merged-with-unsaved decofile to the deco runtime's
+ * `/live/previews/:pageResolveType`. The runtime builds a throwaway resolver
+ * from the inline `__decofile` and server-renders the page from unsaved state,
+ * returning HTML the injected editor script swaps into the frame in place. No
+ * commit, no reload.
+ *
+ * Body shape matches the runtime's `getPropsFromRequest` + inline-decofile
+ * branch: `{ __props, __decofile }`, where the handler renders `:pageResolveType`
+ * with `__props` and resolves the page's section `$ref`s against `__decofile`.
+ * `__decoFBT=0` disables deferred rendering so one POST returns the whole page.
+ *
+ * Returns null when the page block has no `__resolveType` (nothing to render).
+ * deco-runtime only — the same assumption `resolveSectionPreviewBase` documents.
+ */
+export function buildPageRenderRequest(input: {
+  /** The frame's own origin (Fast Preview production deployment). */
+  previewBaseUrl: string;
+  /** The current page block from the merged decofile: `{ __resolveType, path, sections, … }`. */
+  pageBlock: Record<string, unknown>;
+  /** The full merged decofile, including the unsaved edit (KEYS.decofile). */
+  decofile: Record<string, unknown>;
+  /** Resolved path (`:param`s filled) for matcher/routing context. */
+  path: string;
+  /** Path template, so the page stays matched. */
+  pathTemplate: string;
+}): { src: string; body: string } | null {
+  const resolveType = input.pageBlock.__resolveType;
+  if (typeof resolveType !== "string" || !resolveType) return null;
+  const origin = new URL(input.previewBaseUrl).origin;
+  const url = new URL(
+    `/live/previews/${encodeURIComponent(resolveType)}`,
+    origin,
+  );
+  url.searchParams.set("__decoFBT", "0");
+  url.searchParams.set("__d", "");
+  url.searchParams.set("path", input.path);
+  url.searchParams.set("pathTemplate", input.pathTemplate);
+  const { __resolveType: _resolveType, ...props } = input.pageBlock;
+  const body = JSON.stringify({ __props: props, __decofile: input.decofile });
+  return { src: url.toString(), body };
+}
+
 export function buildSectionPreviewUrl(
   previewBaseUrl: string,
   livePageResolveType: string,

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -567,6 +567,10 @@ export const sandbox = {
     "New chats start as CMS sessions, previewed on your preview server instead of a sandbox. Existing chats keep the mode they were created with.",
   "sandbox.cmsSettings.fastPreview.needsPreviewServerUrl":
     "Set a preview server above to enable Fast Preview.",
+  "sandbox.cmsSettings.fastPreviewInPlace.label":
+    "Instant preview (experimental)",
+  "sandbox.cmsSettings.fastPreviewInPlace.description":
+    "Refresh edits in place, without waiting for a save — much faster, but only works on deco-runtime preview servers.",
   "sandbox.cmsSettings.contentEditing.title": "Content editing",
   "sandbox.cmsSettings.contentEditing.description":
     "Whether this agent offers a CMS, and where the preview lands when it does.",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -591,6 +591,10 @@ export const sandbox = {
     "Novos chats começam como sessões de CMS, pré-visualizadas no seu servidor de preview em vez de um sandbox. Chats existentes mantêm o modo com que foram criados.",
   "sandbox.cmsSettings.fastPreview.needsPreviewServerUrl":
     "Defina um servidor de preview acima para ativar o Preview Rápido.",
+  "sandbox.cmsSettings.fastPreviewInPlace.label":
+    "Preview instantâneo (experimental)",
+  "sandbox.cmsSettings.fastPreviewInPlace.description":
+    "Atualiza as edições no lugar, sem esperar o salvamento — bem mais rápido, mas só funciona em servidores de preview com runtime deco.",
   "sandbox.cmsSettings.contentEditing.title": "Edição de conteúdo",
   "sandbox.cmsSettings.contentEditing.description":
     "Se este agente oferece um CMS e onde o preview abre quando oferece.",

--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -83,6 +83,7 @@ import { PreviewServerUrlField } from "@/components/sandbox/runtime-card/preview
 import { resolvePreviewServerUrl } from "@decocms/shared/deco-site-production-url";
 import { FieldDescriptionTooltipsField } from "@/components/sandbox/runtime-card/field-description-tooltips-field";
 import { FastPreviewField } from "@/components/sandbox/runtime-card/fast-preview-field";
+import { InPlaceRenderField } from "@/components/sandbox/runtime-card/in-place-render-field";
 import { PublishPolicyField } from "./publish-policy-field";
 import { ContentEditingField } from "./content-editing-field";
 import { resolveCmsMode } from "@decocms/shared/sdk/types";
@@ -1124,6 +1125,10 @@ function VirtualMcpDetailViewWithData({
                         previewServerUrl={form.watch(
                           "metadata.previewServerUrl",
                         )}
+                      />
+                      <InPlaceRenderField
+                        control={form.control}
+                        fastPreview={form.watch("metadata.fastPreview")}
                       />
                     </CardContent>
 

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -643,6 +643,24 @@ const fastPreviewMetadataField = z
   );
 
 /**
+ * Reusable `metadata.fastPreviewInPlace` field — EXPERIMENTAL, per-agent opt-in
+ * layered on Fast Preview. When on, content edits refresh the preview by POSTing
+ * the merged (unsaved) decofile to the site runtime's `/live/previews` and
+ * swapping the returned HTML into the frame in place — no git commit, no reload
+ * — instead of committing and re-navigating to a `?__draft=@sha` URL. Requires
+ * `fastPreview` (and thus `previewServerUrl`); inert on its own. Deco-runtime
+ * only: the render target must serve `POST /live/previews` with inline
+ * `__decofile`, so this stays a flag to trial per site.
+ */
+const fastPreviewInPlaceMetadataField = z
+  .boolean()
+  .nullable()
+  .optional()
+  .describe(
+    "EXPERIMENTAL: with Fast Preview on, refresh content edits via an in-place /live/previews render (no commit, no reload) instead of a commit + re-navigation. Deco-runtime preview targets only. Requires fastPreview.",
+  );
+
+/**
  * Reusable `metadata.previewServerUrl` field — the deployment the CMS preview
  * renders against. Usually the live production site, but any deco-runtime
  * deployment works (a local `https://localhost:3100` during development, a
@@ -744,6 +762,7 @@ export const VirtualMCPEntitySchema = z.object({
           "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
         ),
       fastPreview: fastPreviewMetadataField,
+      fastPreviewInPlace: fastPreviewInPlaceMetadataField,
     })
     .loose()
     .describe("Metadata"),
@@ -856,6 +875,7 @@ export const VirtualMCPCreateDataSchema = z.object({
           "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
         ),
       fastPreview: fastPreviewMetadataField,
+      fastPreviewInPlace: fastPreviewInPlaceMetadataField,
     })
     .loose()
     .superRefine((metadata, ctx) => {
@@ -958,6 +978,7 @@ export const VirtualMCPUpdateDataSchema = z.object({
           "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
         ),
       fastPreview: fastPreviewMetadataField,
+      fastPreviewInPlace: fastPreviewInPlaceMetadataField,
     })
     .loose()
     .superRefine((metadata, ctx) => {


### PR DESCRIPTION
## Summary

Revives the old admin's `/live/previews` **POST render** for the Fast Preview canvas, **decoupled from the git commit**. Today, every content edit under Fast Preview triggers a `PATCH decofile` → a coalesced GitHub commit (6–8 sequential Git Data API calls) → a version bump → a full cross-origin iframe re-navigation → production re-SSR. That round-trip is the ~15s users feel.

With this flag on, an edit instead POSTs the merged **unsaved** decofile to the site runtime's `/live/previews`, and the injected editor script swaps the returned HTML into the frame **in place** (crossfade, no reload). No commit, no navigation. The autosave commit still runs in the background for persistence and the shareable `?__draft` link; its version bump is pinned while editing so it can't reload the frame.

This is the same mechanism the old Fresh admin used (`Embedded.tsx` inject + `enqueue`), ported entirely onto the Studio side — the storefront half (the runtime's `POST /live/previews` with inline `__decofile`) already exists.

## Gating — experimental, off by default

Per-agent flag `metadata.fastPreviewInPlace` (sibling of `metadata.fastPreview`), surfaced as an **"Instant preview (experimental)"** switch in the agent's CMS settings, shown only when Fast Preview is on. **Unchanged behaviour for every existing site** — the new path runs only when a maintainer opts a site in, so it can be trialled on a few sites first.

## Changes

- **`cms-editor-script.ts`** — `renderInPlace` + `cms-editor::render` handler: POST for HTML, stylesheet prefetch, `startViewTransition` innerHTML swap, overlay nodes re-attached (document/window listeners survive the swap). AbortController drops the in-flight render on a newer edit.
- **`section-preview-url.ts`** — `buildPageRenderRequest`: builds `{ src, body }` with a `{ __props, __decofile }` body matching the runtime's inline-decofile branch.
- **`preview.tsx`** — edit-driven render trigger (fires off the optimistically-updated `KEYS.decofile`, deduped by content signature so onMutate+onSuccess render once); pins the draft URL's version while editing so the background commit's bump can't reload the frame; `render-start`/`-end` wired to the nav indicator.
- **`virtual-mcp.ts`** — `fastPreviewInPlace` metadata field (3 schemas).
- **`in-place-render-field.tsx`** + `virtual-mcp/index.tsx` + i18n (en/pt-br) — the settings switch.

## Testing notes

- Unit: `buildPageRenderRequest` (origin/path/body shape) + the injected-script render contract. `bun test` green (629 pass across the touched suites), `tsc` (web + shared) clean, lint 0 errors, `fmt` applied.
- **Manual, required:** enable the switch on a real Fast Preview site and edit a section field — the preview should refresh in place with no reload. This path depends on the preview target being a **deco-runtime** deployment that serves `POST /live/previews` with inline `__decofile`; if a site doesn't refresh in place (only reconciles on panel close), that deployment's runtime is too old — untick the flag there.

## Known limitations (prototype)

- Overlay labels go stale after add/remove section until the next real load.
- Hydration/interactivity is not re-run on the swap (matches the old admin; `__decoFBT=0`, a static content render).
- Deco-runtime preview targets only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an experimental "Instant preview" option that makes Fast Preview content edits refresh the frame in place instead of the current ~15s round-trip of git commit, version bump, and full iframe re-navigation.

When a site opts in via `metadata.fastPreviewInPlace`, edits POST the merged unsaved decofile to the site runtime's `/live/previews` and the injected editor script swaps the returned HTML into the frame with no commit or navigation. The autosave commit still runs in the background for persistence and `?__draft` links; its version bump is pinned while editing so it can't reload the frame.

**Gating**
- Off by default; behavior is unchanged for every existing site.
- Surfaced as an "Instant preview (experimental)" switch in agent CMS settings, shown only when Fast Preview is on.
- Requires a deco-runtime preview deployment; on older runtimes the preview only reconciles when the panel closes.

**Known limitations**
- Overlay labels go stale after add/remove section until the next real load.
- Hydration and interactivity aren't re-run on the swap (matches the old admin).

<sup>Written for commit f354ef4329f7b0ed239634b36dd8b8ca0d9a55de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

