### PR TITLE
fix(docs): align helm preview environment chart version with declared variable

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
@@ -470,7 +470,7 @@ helm template studio-previews deploy/helm/studio-previews \
   --set applicationSet.repo.name=your-fork \
   --set applicationSet.repo.tokenSecret.name=preview-github-token \
   --set studioChart.repoURL=oci://ghcr.io/decocms \
-  --set studioChart.version=0.14.0 \
+  --set studioChart.version="$STUDIO_CHART_VERSION" \
   --set studioChart.valuesRepo.url=https://github.com/your-org/your-fork.git \
   --set images.api=ghcr.io/your-org/studio-preview \
   --set images.nginx=ghcr.io/your-org/studio-nginx-preview \

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
@@ -472,7 +472,7 @@ helm template studio-previews deploy/helm/studio-previews \
   --set applicationSet.repo.name=seu-fork \
   --set applicationSet.repo.tokenSecret.name=preview-github-token \
   --set studioChart.repoURL=oci://ghcr.io/decocms \
-  --set studioChart.version=0.14.0 \
+  --set studioChart.version="$STUDIO_CHART_VERSION" \
   --set studioChart.valuesRepo.url=https://github.com/sua-org/seu-fork.git \
   --set images.api=ghcr.io/sua-org/studio-preview \
   --set images.nginx=ghcr.io/sua-org/studio-nginx-preview \


### PR DESCRIPTION
## Issue
The Kubernetes deployment documentation hardcoded the Studio chart version as `0.14.0` in the per-PR preview environments section, but the version-declaration section earlier in the same file declares `STUDIO_CHART_VERSION=0.13.1`. This version mismatch creates inconsistency and could lead users to deploy the wrong chart version.

## Fix
Replace the hardcoded version `0.14.0` with `"$STUDIO_CHART_VERSION"` so the preview environment template reuses the declared variable, keeping versions in sync across both English and Portuguese documentation.

## Verification
- Inspected both `apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx` and the Portuguese variant
- Confirmed hardcoded version divergence (line 54 declares 0.13.1, line 473 hardcodes 0.14.0)
- Applied fix to both files: replaced `0.14.0` with `"$STUDIO_CHART_VERSION"`
- Ran `bun run fmt` with no additional changes

## Scope
- Files: 2 MDX documentation files (English + Portuguese)
- Lines changed: 2 (one per file)
- Concern: Version consistency in deployment docs
- **Run to confirm**: No tests needed for docs; visual inspection confirms alignment with declared version variable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a version mismatch in the Kubernetes deployment docs where the preview environment template hardcoded Studio chart version `0.14.0` while the file declares `STUDIO_CHART_VERSION=0.13.1`. Replaces the hardcoded version with `$STUDIO_CHART_VERSION` in both English and Portuguese docs so the preview environment always uses the declared version.

<sup>Written for commit 0efd04d0aeb3fdf98150585dbdc552968afc079f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

