### PR TITLE
refactor(native): simplify a nonminimal-bool expression in TaskRegistry

### DIFF
--- a/apps/native/crates/local-api/src/tasks/registry.rs
+++ b/apps/native/crates/local-api/src/tasks/registry.rs
@@ -585,10 +585,10 @@ impl TaskRegistry {
     /// the live send.
     pub async fn append_output(&self, id: &str, stream: OutputStream, data: &str) -> bool {
         if data.is_empty()
-            || !self
+            || self
                 .lock()
                 .get(id)
-                .is_some_and(|entry| !entry.summary.status.is_terminal())
+                .is_none_or(|entry| entry.summary.status.is_terminal())
         {
             return false;
         }


### PR DESCRIPTION
`cargo clippy` (default `clippy::all` lints, the same set `native.yml`'s `cargo clippy -D warnings` job runs) currently flags `!self.lock().get(id).is_some_and(|entry| !entry.summary.status.is_terminal())` in `TaskRegistry::append_output` as `clippy::nonminimal_bool`. It doesn't fail CI *yet* only because the `is_none_or`-based suggestion this lint now offers is newer than the clippy build that last ran against this code (`native.yml` pins `dtolnay/rust-toolchain@stable`, which floats forward) — the next CI run on a fresh `stable` toolchain will hit it and fail the `rust-checks` job with `-D warnings`.

Fixed by De Morgan's law: `!Option::is_some_and(f)` == `Option::is_none_or(!f)`. Behavior is identical (`is_none_or` returns `true` for `None`, same as the negated `is_some_and`), so the `data.is_empty() || <this>` short-circuit and the function's no-op-for-unknown/terminal-task contract are unchanged.

Verified with:
- `cargo clippy -p local-api --all-targets` — zero warnings (was 1 before the fix)
- `cargo test -p local-api --lib tasks::registry` — all 26 tests pass, including `append_output_is_a_noop_for_an_unknown_task` and `append_output_updates_buffer_and_truncated_flag`, which directly exercise this branch
- `cargo fmt -p local-api -- --check` — clean

Full CI validates the rest of the workspace (this PR touches only `apps/native/crates/local-api/src/tasks/registry.rs`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites a boolean condition in `TaskRegistry::append_output` to satisfy clippy's `nonminimal_bool` lint, which will otherwise fail the `rust-checks` CI job once the stable toolchain catches up to the suggested `is_none_or` form. Behavior is unchanged.

<sup>Written for commit 61e0e16f072a50013950ccd241df1aee2d8b34fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

