### PR TITLE
fix(preview): reject forged postMessages to the CMS editor bridge

### DIFF
--- a/apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
@@ -134,6 +134,29 @@ describe("CMS_EDITOR_SCRIPT", () => {
     expect(CMS_EDITOR_SCRIPT).toContain("cms-editor::render-end");
   });
 
+  it("drops a bridge message whose source isn't this frame's parent", () => {
+    const start = CMS_EDITOR_SCRIPT.indexOf(
+      'window.addEventListener("message", function(e)',
+    );
+    const bodyStart = CMS_EDITOR_SCRIPT.indexOf("{", start) + 1;
+    const guardEnd = CMS_EDITOR_SCRIPT.indexOf(
+      "if (e.data && e.data.type",
+      bodyStart,
+    );
+    expect(bodyStart).toBeGreaterThan(0);
+    expect(guardEnd).toBeGreaterThan(bodyStart);
+    const guard = CMS_EDITOR_SCRIPT.slice(bodyStart, guardEnd);
+    const runGuard = new Function(
+      "window",
+      "e",
+      `${guard}; return "reached";`,
+    ) as (window: unknown, e: unknown) => string | undefined;
+
+    const parent = {};
+    expect(runGuard({ parent }, { source: { evil: true } })).toBeUndefined();
+    expect(runGuard({ parent }, { source: parent })).toBe("reached");
+  });
+
   it("runs the embedded alignment against a stubbed DOM", () => {
     // The embedded copy, on the regression case (a section that rendered no node).
     const start = CMS_EDITOR_SCRIPT.indexOf("var alignSections = ");

--- a/apps/web/src/components/sandbox/preview/cms-editor-script.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.ts
@@ -354,6 +354,8 @@ export const CMS_EDITOR_SCRIPT = `(function() {
   };
 
   window.addEventListener("message", function(e) {
+    // Only Studio's own postMessage (source === this frame's parent) may drive the bridge — forged senders can't trigger the render fetch/swap.
+    if (e.source !== window.parent) return;
     if (e.data && e.data.type === "cms-editor::render" && typeof e.data.src === "string") {
       renderInPlace(e.data.src, e.data.body);
       return;


### PR DESCRIPTION
Follows #6786 (Fast Preview in-place render).

The CMS editor script injected into the preview iframe (`cms-editor-script.ts`) listens for `window.addEventListener("message", ...)` with no sender check at all. #6786 added a `cms-editor::render` handler to that same listener: it takes `e.data.src`/`e.data.body` straight from the message, POSTs them, and swaps the response into `document.documentElement.innerHTML`. Since the listener never checked `e.origin`/`e.source`, any window holding a reference to the previewed iframe (e.g. a same-named popup opened via `window.open`) could forge that message and make the previewed page fetch an attacker-controlled URL and render the response over the whole document — arbitrary content injection into the previewed site's origin.

Studio only ever talks to this bridge through `previewIframeRef.current.contentWindow` (see `preview.tsx`'s `win.postMessage(...)` calls), so from inside the iframe a legitimate sender's `e.source` is always `window.parent`. The fix adds one guard at the top of the listener: `if (e.source !== window.parent) return;` — behavior-preserving for every real caller, since that's exactly what Studio already does.

Failure scenario: a page an attacker controls opens/frames the preview URL and posts `{type: "cms-editor::render", src: "https://evil.example", body: ...}` to it; before this fix the script fetches that URL and replaces the whole page with the response.

Regression test added in `cms-editor-script.test.ts`: extracts the guard from the built script string and runs it with a stubbed `window`/event, asserting a message from a fake `source` is dropped and one from `window.parent` passes through.

Reviewer check: `bun test apps/web/src/components/sandbox/preview/cms-editor-script.test.ts`.

Locally verified: `bun run fmt`, `bunx oxlint` on both touched files (0 warnings/errors), `bunx tsc --noEmit -p apps/web` (one pre-existing unrelated error in `mention-suggestion.tsx` from a prosemirror-model version mismatch, untouched by this change), and the targeted test file (11 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards the CMS editor bridge against forged postMessages so only Studio's own parent frame can trigger the render fetch and swap.

Previously, the listener accepted any `e.source`; an attacker-controlled window could forge a `cms-editor::render` message and inject arbitrary content into the previewed origin. Now the listener drops any message whose `e.source` is not `window.parent`, which is the only legitimate sender (Studio posts via the iframe's `contentWindow`). Real callers are unaffected.

Adds a regression test that extracts the guard and confirms a forged source is dropped while `window.parent` passes through.

<sup>Written for commit c04a3bdb784ec7495214ea6445e05194d409272a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

