### PR TITLE
fix(deco-sites): enforce connections:create permission on the import route

### DIFF
--- a/apps/api/src/api/routes/deco-sites.ts
+++ b/apps/api/src/api/routes/deco-sites.ts
@@ -11,6 +11,7 @@
  */
 
 import { Hono } from "hono";
+import { ForbiddenError, UnauthorizedError } from "../../core/access-control";
 import type { StudioContext } from "../../core/studio-context";
 import { getUserId, requireOrganization } from "../../core/studio-context";
 import { generatePrefixedId } from "@decocms/shared/utils/generate-id";
@@ -512,6 +513,19 @@ export const createDecoSitesOrgRoutes = () => {
     const userId = getUserId(ctx);
     if (!email || !userId) {
       return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    // Same permission gate as COLLECTION_CONNECTIONS_CREATE.
+    try {
+      await ctx.access.check("COLLECTION_CONNECTIONS_CREATE");
+    } catch (err) {
+      if (err instanceof UnauthorizedError) {
+        return c.json({ error: err.message }, 401);
+      }
+      if (err instanceof ForbiddenError) {
+        return c.json({ error: err.message }, 403);
+      }
+      throw err;
     }
 
     let body: { siteName: string; orgId?: string };

--- a/packages/e2e/tests/deco-sites-connection-scope.spec.ts
+++ b/packages/e2e/tests/deco-sites-connection-scope.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * E2E: POST /api/:org/deco-sites/connection must enforce the same
+ * COLLECTION_CONNECTIONS_CREATE permission as the normal connection-create
+ * tool. This route writes a connection row directly instead of going through
+ * that tool's handler, so it previously had no permission check of its own —
+ * a member on a custom role with connections:create revoked could still
+ * create a connection through this deco.cx import flow.
+ */
+
+import type { Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+// Scoped role with no connection-management tool granted.
+const MONITORING_TOOLS = ["MONITORING_STATS"];
+
+async function orgIdForSlug(db: Client, slug: string): Promise<string> {
+  const row = await db.query<{ id: string }>(
+    `SELECT id FROM "organization" WHERE slug = $1`,
+    [slug],
+  );
+  const id = row.rows[0]?.id;
+  if (!id) throw new Error(`org not found for slug ${slug}`);
+  return id;
+}
+
+test.describe("deco-sites connection create — permission scope", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db?.end();
+  });
+
+  test("a member without connections:create is denied", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const orgId = await orgIdForSlug(db, owner.orgSlug);
+
+    const roleSlug = `no-connections-${Date.now()}`;
+    const createRole = await ownerCtx.post(
+      "/api/auth/organization/create-role",
+      {
+        data: {
+          organizationId: orgId,
+          role: roleSlug,
+          permission: { self: MONITORING_TOOLS },
+        },
+      },
+    );
+    expect(
+      createRole.ok(),
+      `create-role failed: ${await createRole.text().catch(() => "")}`,
+    ).toBe(true);
+
+    const memberCtx = await newApiContext(playwright);
+    const member = await signUpViaApi(memberCtx);
+
+    const invite = await ownerCtx.post("/api/auth/organization/invite-member", {
+      data: { organizationId: orgId, email: member.email, role: "user" },
+    });
+    expect(invite.ok()).toBe(true);
+    const inviteJson = (await invite.json()) as {
+      id?: string;
+      invitation?: { id?: string };
+    };
+    const invitationId = inviteJson.id ?? inviteJson.invitation?.id;
+
+    const accept = await memberCtx.post(
+      "/api/auth/organization/accept-invitation",
+      { data: { invitationId } },
+    );
+    expect(accept.ok()).toBe(true);
+
+    const memberRow = await db.query<{ id: string }>(
+      `SELECT id FROM "member" WHERE "userId" = $1 AND "organizationId" = $2`,
+      [member.userId, orgId],
+    );
+    const memberId = memberRow.rows[0]?.id;
+    if (!memberId) throw new Error("member row not found after accept");
+
+    const assign = await ownerCtx.post(
+      "/api/auth/organization/update-member-role",
+      { data: { organizationId: orgId, memberId, role: [roleSlug] } },
+    );
+    expect(
+      assign.ok(),
+      `update-member-role failed: ${await assign.text().catch(() => "")}`,
+    ).toBe(true);
+
+    const res = await memberCtx.post(
+      `/api/${encodeURIComponent(owner.orgSlug)}/deco-sites/connection`,
+      { data: { siteName: "some-site" } },
+    );
+    expect(res.status()).toBe(403);
+
+    await ownerCtx.dispose();
+    await memberCtx.dispose();
+  });
+});


### PR DESCRIPTION
**Source:** bug found while auditing api/routes permissions for the org-scoped route migration.

**The gap:** `POST /api/:org/deco-sites/connection` (deco.cx site import) writes a new `connection` row directly via `ctx.storage.connections.create(...)`, bypassing the `COLLECTION_CONNECTIONS_CREATE` tool handler entirely — including its `await ctx.access.check()` call. Every other connection-creation path in the codebase gates on that permission (see `apps/api/src/tools/connection/create.ts`), and other routes that write org data outside a tool handler follow the same pattern (e.g. `file-uploads.ts` gates its upload route on `FILE_CONFIG_UPDATE`). This route had no gate at all — only an authenticated-user check.

**Failure scenario:** an org member on a custom role with `connections:create` explicitly revoked (or any capability-scoped role that never granted it) can still create an arbitrary MCP connection — with a live deco.cx API key stored server-side — by hitting this import endpoint directly, sidestepping the role boundary the rest of the app enforces.

**Fix:** add `await ctx.access.check("COLLECTION_CONNECTIONS_CREATE")` right after the auth check, mapping `UnauthorizedError`/`ForbiddenError` to 401/403 the same way `tools-rest.ts` does for its generic tool-dispatch route.

**Regression test:** `packages/e2e/tests/deco-sites-connection-scope.spec.ts` — creates a capability-scoped role without any connection-management tool, assigns it to a member, and asserts `POST /api/:org/deco-sites/connection` now returns 403 for that member. Modeled on the existing `create-scoped-role.spec.ts` / `member-permission-parity.spec.ts` fixtures.

**To verify:** `cd apps/api && bunx tsc --noEmit` (clean) and `bunx oxlint apps/api/src/api/routes/deco-sites.ts packages/e2e/tests/deco-sites-connection-scope.spec.ts` (0 warnings/errors) — both run locally. The e2e spec itself needs the full Postgres/NATS stack (not available in this sandbox), so full CI validates it end-to-end.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `COLLECTION_CONNECTIONS_CREATE` permission check to the deco.cx site import endpoint so members on roles that revoke connection creation can no longer create connections through it.

- The route previously wrote a connection row directly to storage, bypassing the permission gate the connection-create tool applies and leaving only an authenticated-user check.
- Maps `UnauthorizedError` and `ForbiddenError` to 401 and 403 responses, matching the generic tool-dispatch route.
- Adds an e2e test that gives a member a role without connection tooling and asserts the import endpoint returns 403.
- Roles that relied on the old unrestricted endpoint now need the `connections:create` capability granted.

<sup>Written for commit 0d4a68c5569d4429d21074707763f93434034e99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

