### PR TITLE
fix(connections): i18n the connection agents panel heading

### DIFF
--- a/apps/web/src/components/details/connection/connection-agents-panel.tsx
+++ b/apps/web/src/components/details/connection/connection-agents-panel.tsx
@@ -1,6 +1,7 @@
 import { useProjectContext, useVirtualMCPs } from "@/sdk";
 import type { ConnectionEntity } from "@/sdk";
 import { ConnectionVirtualMCPsSection } from "./settings-tab/connection-virtual-mcps-section";
+import { useT } from "@/i18n/use-t.ts";
 
 interface ConnectionAgentsPanelProps {
   connection: ConnectionEntity;
@@ -9,6 +10,7 @@ interface ConnectionAgentsPanelProps {
 export function ConnectionAgentsPanel({
   connection,
 }: ConnectionAgentsPanelProps) {
+  const t = useT();
   const { org } = useProjectContext();
 
   const virtualMcps = useVirtualMCPs({
@@ -25,7 +27,7 @@ export function ConnectionAgentsPanel({
     <div className="rounded-xl border border-border bg-card overflow-hidden">
       <div className="px-5 py-4 border-b border-border">
         <h3 className="text-sm font-semibold text-foreground">
-          Used by agents
+          {t("details.connectionAgentsPanel.usedByAgents")}
         </h3>
       </div>
       <div className="px-5 py-4">

--- a/apps/web/src/i18n/en/details.ts
+++ b/apps/web/src/i18n/en/details.ts
@@ -30,6 +30,7 @@ export const details = {
     "No activity in this period",
   "details.connectionActivity.toolCalls": "Tool calls",
   "details.connectionActivity.topErrors": "Top errors",
+  "details.connectionAgentsPanel.usedByAgents": "Used by agents",
   "details.connectionCapabilities.capabilities": "Capabilities",
   "details.connectionCapabilities.noCapabilitiesDiscovered":
     "No capabilities discovered yet. The connection may still be connecting.",

--- a/apps/web/src/i18n/pt-br/details.ts
+++ b/apps/web/src/i18n/pt-br/details.ts
@@ -32,6 +32,7 @@ export const details = {
     "Nenhuma atividade neste período",
   "details.connectionActivity.toolCalls": "Chamadas de ferramenta",
   "details.connectionActivity.topErrors": "Principais erros",
+  "details.connectionAgentsPanel.usedByAgents": "Usado por agentes",
   "details.connectionCapabilities.capabilities": "Capacidades",
   "details.connectionCapabilities.noCapabilitiesDiscovered":
     "Nenhuma capacidade descoberta ainda. A conexão ainda pode estar se conectando.",


### PR DESCRIPTION
The "Used by agents" heading in `ConnectionAgentsPanel` (rendered on the connection detail page whenever the connection is used by one or more Virtual MCPs) was hardcoded English JSX text, missed by the i18n migration that already covers its sibling panels (`connectionInstancesPanel`, `connectionCapabilities`, etc.) in the same `apps/web/src/components/details/connection/` tree.

Per repo convention (CLAUDE.md i18n section), every user-facing string in `apps/web/src` must go through `t()`. This adds the `details.connectionAgentsPanel.usedByAgents` key to both `en/details.ts` and `pt-br/details.ts` (kept `satisfies Record<keyof typeof detailsEn, string>`-complete) and swaps the component to use it.

Reviewer check: `bunx tsc --noEmit` in `apps/web` (no new errors from this change) and `bunx oxlint` on the 3 touched files (0 warnings/errors). No test needed — pure string externalization, no logic change.

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (confirmed no errors in touched files), `bunx oxlint` on the touched files. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Externalizes the hardcoded "Used by agents" heading in the connection agents panel so it follows the i18n convention used by sibling panels on the connection detail page.

- Adds the `details.connectionAgentsPanel.usedByAgents` key to the English and Brazilian Portuguese translation files.
- No behavior or logic changes; no tests needed.

<sup>Written for commit 902c4f8014262699d70f2362c86c827108df4006. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

