### PR TITLE
fix(native): probe both loopback families for preview-fetch/preview-invoke

### DIFF
--- a/apps/native/crates/local-api/src/routes/intercept/dev_server.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/dev_server.rs
@@ -21,24 +21,35 @@ use crate::error::ApiError;
 /// hop.
 const DEV_SERVER_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Sends `request` to the dev server and mirrors its response back: status,
-/// `Content-Type` (falling back to `default_content_type` when the dev server
-/// sent none — `None` omits the header instead), and the full body. A send or
-/// body-read failure — including a timeout — is the family's uniform 502
-/// `Preview unreachable`.
+/// Tries `[::1]` then `127.0.0.1`, matching `routes/proxy.rs`'s
+/// `send_to_loopback` and `setup/dev.rs`'s `probe_loopback` — some dev
+/// servers (Vite on macOS) bind IPv6-only, some IPv4-only. Only a
+/// connect-phase failure falls through to the next host; a request whose
+/// connection succeeded is never retried, since re-sending a non-idempotent
+/// invoke risks a double write upstream.
+const LOOPBACK_HOSTS: [&str; 2] = ["[::1]", "127.0.0.1"];
+
+/// Builds and sends a request to the dev server and mirrors its response
+/// back: status, `Content-Type` (falling back to `default_content_type` when
+/// the dev server sent none — `None` omits the header instead), and the full
+/// body. A send or body-read failure — including a timeout — is the family's
+/// uniform 502 `Preview unreachable`.
+///
+/// `build(host)` constructs the request against one candidate loopback host
+/// (e.g. `format!("http://{host}:{port}/...")`); called once per host tried.
 pub(super) async fn send_and_mirror(
-    request: reqwest::RequestBuilder,
+    build: impl Fn(&str) -> reqwest::RequestBuilder,
     default_content_type: Option<HeaderValue>,
 ) -> Response {
-    send_and_mirror_with_timeout(request, default_content_type, DEV_SERVER_TIMEOUT).await
+    send_and_mirror_with_timeout(build, default_content_type, DEV_SERVER_TIMEOUT).await
 }
 
 async fn send_and_mirror_with_timeout(
-    request: reqwest::RequestBuilder,
+    build: impl Fn(&str) -> reqwest::RequestBuilder,
     default_content_type: Option<HeaderValue>,
     timeout: Duration,
 ) -> Response {
-    let Ok(response) = request.timeout(timeout).send().await else {
+    let Ok(response) = send_to_loopback(build, timeout).await else {
         return ApiError::new(StatusCode::BAD_GATEWAY, "Preview unreachable").into_response();
     };
     let status =
@@ -58,6 +69,27 @@ async fn send_and_mirror_with_timeout(
         res.headers_mut().insert(header::CONTENT_TYPE, content_type);
     }
     res
+}
+
+async fn send_to_loopback(
+    build: impl Fn(&str) -> reqwest::RequestBuilder,
+    timeout: Duration,
+) -> Result<reqwest::Response, String> {
+    let mut last_err: Option<String> = None;
+    for (idx, host) in LOOPBACK_HOSTS.iter().enumerate() {
+        match build(host).timeout(timeout).send().await {
+            Ok(response) => return Ok(response),
+            Err(error) => {
+                let is_last = idx == LOOPBACK_HOSTS.len() - 1;
+                if !is_last && error.is_connect() {
+                    last_err = Some(error.to_string());
+                    continue;
+                }
+                return Err(error.to_string());
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| "upstream unreachable".to_string()))
 }
 
 #[cfg(test)]
@@ -95,13 +127,35 @@ mod tests {
         let port = spawn_upstream(app).await;
 
         let res = send_and_mirror(
-            reqwest::Client::new().get(format!("http://127.0.0.1:{port}/x")),
+            |host| reqwest::Client::new().get(format!("http://{host}:{port}/x")),
             None,
         )
         .await;
         assert_eq!(res.status(), StatusCode::CREATED);
         assert_eq!(res.headers()[header::CONTENT_TYPE], "text/plain");
         assert!(res.headers().get(header::SET_COOKIE).is_none());
+        let body = axum::body::to_bytes(res.into_body(), 1024).await.unwrap();
+        assert_eq!(&body[..], b"payload");
+    }
+
+    /// Vite binds `localhost`, which resolves to `[::1]` first on macOS — a
+    /// dev server reachable only over IPv6 (the exact failure `#6599` fixed
+    /// for the boot probe) must still be reachable here.
+    #[tokio::test]
+    async fn reaches_a_dev_server_bound_ipv6_only() {
+        let app = axum::Router::new().route("/x", get(|| async { "payload" }));
+        let listener = TcpListener::bind("[::1]:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let res = send_and_mirror(
+            |host| reqwest::Client::new().get(format!("http://{host}:{port}/x")),
+            None,
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::OK);
         let body = axum::body::to_bytes(res.into_body(), 1024).await.unwrap();
         assert_eq!(&body[..], b"payload");
     }
@@ -120,14 +174,14 @@ mod tests {
 
         let default = Some(HeaderValue::from_static("application/json"));
         let res = send_and_mirror(
-            reqwest::Client::new().get(format!("http://127.0.0.1:{port}/none")),
+            |host| reqwest::Client::new().get(format!("http://{host}:{port}/none")),
             default.clone(),
         )
         .await;
         assert_eq!(res.headers()[header::CONTENT_TYPE], "application/json");
 
         let res = send_and_mirror(
-            reqwest::Client::new().get(format!("http://127.0.0.1:{port}/none")),
+            |host| reqwest::Client::new().get(format!("http://{host}:{port}/none")),
             None,
         )
         .await;
@@ -141,7 +195,7 @@ mod tests {
             listener.local_addr().unwrap().port()
         };
         let res = send_and_mirror(
-            reqwest::Client::new().get(format!("http://127.0.0.1:{free_port}/x")),
+            |host| reqwest::Client::new().get(format!("http://{host}:{free_port}/x")),
             None,
         )
         .await;
@@ -166,7 +220,7 @@ mod tests {
         let port = spawn_upstream(app).await;
 
         let res = send_and_mirror_with_timeout(
-            reqwest::Client::new().get(format!("http://127.0.0.1:{port}/slow")),
+            |host| reqwest::Client::new().get(format!("http://{host}:{port}/slow")),
             None,
             Duration::from_millis(50),
         )

--- a/apps/native/crates/local-api/src/routes/intercept/preview_invoke.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/preview_invoke.rs
@@ -96,27 +96,28 @@ async fn invoke(state: &AppState, virtual_mcp_id: &str, branch: &str, body: &Byt
         return ApiError::new(StatusCode::BAD_GATEWAY, "Preview not available").into_response();
     };
 
-    let url = format!(
-        "http://127.0.0.1:{port}/deco/invoke/{}",
-        // RAW in the path, slashes intact: the deco runtime routes
-        // `/deco/invoke/*` on the UN-decoded path, so a percent-encoded key
-        // never matches a loader. `parse_invoke` has already rejected
-        // anything that could escape the path.
-        parsed.resolve_type
-    );
     let payload = match serde_json::to_vec(&parsed.payload) {
         Ok(bytes) => bytes,
         Err(_) => {
             return ApiError::internal("could not re-encode the invoke payload").into_response()
         }
     };
+    // RAW in the path, slashes intact: the deco runtime routes
+    // `/deco/invoke/*` on the UN-decoded path, so a percent-encoded key
+    // never matches a loader. `parse_invoke` has already rejected anything
+    // that could escape the path.
+    let resolve_type = parsed.resolve_type;
 
-    let request = reqwest::Client::new()
-        .post(&url)
-        .header(header::CONTENT_TYPE, "application/json")
-        .body(payload);
-    super::dev_server::send_and_mirror(request, Some(HeaderValue::from_static("application/json")))
-        .await
+    super::dev_server::send_and_mirror(
+        |host| {
+            reqwest::Client::new()
+                .post(format!("http://{host}:{port}/deco/invoke/{resolve_type}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(payload.clone())
+        },
+        Some(HeaderValue::from_static("application/json")),
+    )
+    .await
 }
 
 struct Invoke {

--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_ops.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_ops.rs
@@ -231,8 +231,12 @@ async fn preview_fetch(target: &AppState, query: Option<&str>) -> Response {
         return ApiError::new(StatusCode::BAD_GATEWAY, "Preview not available").into_response();
     };
 
-    let url = format!("http://127.0.0.1:{port}/{}", path.trim_start_matches('/'));
-    super::dev_server::send_and_mirror(reqwest::Client::new().get(&url), None).await
+    let path = path.trim_start_matches('/').to_string();
+    super::dev_server::send_and_mirror(
+        |host| reqwest::Client::new().get(format!("http://{host}:{port}/{path}")),
+        None,
+    )
+    .await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Follows #6599 hardening.

`#6599` fixed the boot-probe path (`confirm_running`) so it tries `[::1]` then `127.0.0.1` when checking a sandbox's dev server, because Vite binds `localhost`, which resolves to `[::1]` first on macOS. That PR's own commit message says it audited every loopback consumer in the crate and found this to be "the one loopback consumer in the crate that never got the dual-stack treatment" — but two other call sites in the same intercept family were missed: `preview_fetch` (`routes/intercept/sandbox_ops.rs`) and `invoke` (`routes/intercept/preview_invoke.rs`) both still dial `http://127.0.0.1:{port}` directly.

**Failure scenario:** on a machine where the sandbox's dev server binds `[::1]` only (the exact repro in #6599 — `curl http://[::1]:PORT/` succeeds, `curl http://127.0.0.1:PORT/` refuses), the CMS/blog editor's `preview-fetch` and `preview-invoke` intercept routes fail with a `502 Preview unreachable` even though the dev server is up and the main preview proxy (`routes/proxy.rs`, already dual-stack) works fine.

**Fix:** `dev_server::send_and_mirror` now takes a per-host request-builder closure and tries `[::1]` then `127.0.0.1`, falling through only on a connect-phase failure (never after a connection succeeds, to avoid double-sending a non-idempotent invoke) — the exact contract `routes/proxy.rs`'s `send_to_loopback` already uses. Both call sites updated to build their request per host instead of hardcoding `127.0.0.1`.

**Regression test:** added `reaches_a_dev_server_bound_ipv6_only` in `dev_server.rs`, which binds a real `[::1]`-only listener and fails against the old single-host `send_and_mirror`.

**To confirm:** `cd apps/native && cargo test -p local-api dev_server::tests` (and `sandbox_ops::`, `preview_invoke::` for the untouched-behavior coverage).

Locally verified: `cargo check -p local-api`, `cargo clippy -p local-api --all-targets -- -D warnings` (clean, no new warnings), `cargo fmt -p local-api -- --check` (clean), and the three targeted test modules above all pass. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `preview-fetch` and `preview-invoke` returning a 502 when the sandbox dev server binds IPv6-only (e.g. Vite on macOS resolving `localhost` to `[::1]`). `send_and_mirror` now probes `[::1]` then `127.0.0.1`, matching the dual-stack handling already used by `routes/proxy.rs`.

- Retries the other loopback host only on a connect-phase failure, never re-sending a non-idempotent invoke after a connection succeeds.
- Adds a regression test that binds a real IPv6-only listener.

<sup>Written for commit acdab7297a47f942879b6007717c43076f8b3168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

