### PR TITLE
fix(preview): send matcher override on Fast Preview in-place render

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1035,8 +1035,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
       pathTemplate: currentPath,
     });
     if (!req) return;
+    // Carry the selected variant like the reload-based `iframeSrc` does; else the runtime renders the default variant.
+    const src = withVariantMatcherOverride(
+      req.src,
+      workspace.state.variantOverride ?? [],
+    );
     win.postMessage(
-      { type: "cms-editor::render", src: req.src, body: req.body },
+      { type: "cms-editor::render", src, body: req.body },
       origin,
     );
   };


### PR DESCRIPTION
## Summary

The `matchers-override` isn't gone from the code — it still lives in `variant-matcher-override.ts` and is applied to the reload-based `iframeSrc`. The gap was in the **experimental Fast Preview in-place render** path (#6786): `renderPreviewInPlace()` POSTs its own `/live/previews/:pageResolveType` URL (built by `buildPageRenderRequest`) but, unlike `iframeSrc`, never appended `x-deco-matchers-override`.

Result: with in-place editing on (`fastPreviewInPlace` per-agent flag), editing content under a selected page/section variant rendered the **default** variant, because the render POST carried no variant context.

## Fix

Thread `workspace.state.variantOverride` through `withVariantMatcherOverride` onto the render POST `src`, matching the reload-based path. `withVariantMatcherOverride` only touches the query and the deco runtime's `matcher.ts` reads request params, so the same `/live/previews` endpoint honours it.

Pure variant switches already reload the frame via the React-controlled `iframeSrc` (unchanged); this fix closes the specific hole for content edits under a variant during in-place render.

## Testing

- `tsc --noEmit` clean (apps/web)
- `variant-matcher-override.test.ts` + `section-preview-url.test.ts` — 32 pass
- `bun run fmt` clean

Affected area: `apps/web/src/components/sandbox/preview/preview.tsx` (`renderPreviewInPlace`). Scoped to the in-place render path (behind the `fastPreviewInPlace` flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Fast Preview in-place render so it sends the selected variant matcher override, preventing content edits under a variant from rendering the default variant. The in-place render POST now carries `x-deco-matchers-override` via `withVariantMatcherOverride`, matching the reload-based `iframeSrc` path. This only affects the in-place render path behind the `fastPreviewInPlace` flag.

<sup>Written for commit dadc0a6dee10f8d95aad20beb73ecc7652fb3ac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

