### PR TITLE
docs(decopilot): sync pt-br docs on connection-target subtasks with en

### DIFF
--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/decopilot/context-and-tasks.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/decopilot/context-and-tasks.mdx
@@ -77,11 +77,13 @@ Subtasks não podem fazer perguntas a você nem criar subtasks adicionais — el
 
 **Trabalho em paralelo** — se dois pedaços de trabalho não dependem um do outro, rode-os como subtasks separadas ao mesmo tempo.
 
-### Usando agents especialistas em subtasks
+### Usando agents especialistas e connections em subtasks
 
 Você pode rodar uma subtask com um [agent](/pt-br/studio/agents) específico — um configurado para um domínio em particular. O agent traz seu próprio conjunto focado de tools e instruções sem afetar sua conversa principal.
 
-**Exemplo**: sua main task é coordenar fulfillment de pedidos. Você inicia subtasks usando um **Inventory Agent** para checar estoque, um **Shipping Agent** para planejar logística e um **Customer Service Agent** para preparar notas de suporte. Cada um roda de forma independente; sua main task recebe os resumos e coordena o resultado.
+Você também pode direcionar uma concrete MCP connection diretamente. O Decopilot cria um subagent efêmero para aquela run com as tools da connection, então você não precisa criar um agent dedicado antes.
+
+**Exemplo**: sua main task é coordenar fulfillment de pedidos. Você inicia subtasks usando um **Inventory Agent** para checar estoque, uma ShipStation MCP connection diretamente para planejar logística e um **Customer Service Agent** para preparar notas de suporte. Cada um roda de forma independente; sua main task recebe os resumos e coordena o resultado.
 
 ---
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/decopilot/overview.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/decopilot/overview.mdx
@@ -57,7 +57,7 @@ O Decopilot funciona com múltiplos provedores de IA — Anthropic, Google, Open
 
 ## Agents e subtasks
 
-Quando uma tarefa precisa de um trabalho focado — uma pergunta de atendimento ao cliente, uma pesquisa aprofundada, uma análise de dados — o Decopilot pode delegá-la a um [agent](/pt-br/studio/agents) especialista em uma **subtask**. A subtask roda de forma independente com seu próprio contexto limpo, e então reporta um resumo de volta. Sua conversa principal permanece limpa.
+Quando uma tarefa precisa de um trabalho focado — uma pergunta de atendimento ao cliente, uma pesquisa aprofundada, uma análise de dados — o Decopilot pode delegá-la a um [agent](/pt-br/studio/agents) especialista ou diretamente a uma concrete MCP connection em uma **subtask**. Uma connection alvo roda como um subagent efêmero, então não requer uma configuração dedicada de agent. A subtask roda de forma independente com seu próprio contexto limpo, e então reporta um resumo de volta. Sua conversa principal permanece limpa.
 
 ## Tools built-in
 
@@ -65,7 +65,7 @@ O Decopilot vem com tools para coordenar trabalho em qualquer escopo:
 
 | Tool | O que faz |
 |---|---|
-| `subtask` | Delega trabalho a um agent especialista |
+| `subtask` | Delega trabalho a um agent especialista ou a uma concrete MCP connection |
 | `user_ask` | Faz uma pergunta a você quando precisa de esclarecimento |
 | `enable_tool` | Ativa uma scope tool para uso nos próximos passos |
 | `read_resource` | Lê documentação ou diretrizes disponíveis no escopo |


### PR DESCRIPTION
The pt-br Decopilot docs were stale relative to their English counterparts: the connection-target subtask feature (running a subtask directly against a concrete MCP connection as an ephemeral subagent, without a dedicated agent) is documented in en but was entirely missing from pt-br, in both `overview.mdx` and `context-and-tasks.mdx`.

Concretely:
- `overview.mdx`: the `subtask` built-in-tool table row and the "Agents e subtasks" section text described delegation only to an agent, dropping "or directly to a concrete MCP connection" and the ephemeral-subagent note present in en.
- `context-and-tasks.mdx`: the section heading was "Usando agents especialistas em subtasks" (missing "e connections", vs en's "Using specialist agents and connections in subtasks"), the whole paragraph explaining connection-target subtasks was missing, and the worked example still used a stale **Shipping Agent** placeholder instead of en's updated **ShipStation MCP connection** example that demonstrates the feature being documented.

This is a docs-only content sync, no code touched. Translated and added the missing sentences/table cells/example to match en, keeping existing pt-br phrasing conventions (English product terms like `task`/`subtask`/`connection`/`agent` kept untranslated, consistent with the rest of the file).

How to verify: read `apps/docs/client/src/content/deco-studio/en/studio/decopilot/{overview,context-and-tasks}.mdx` next to their pt-br counterparts — the two language versions now describe the same feature set.

Checks run locally: `bun run fmt` (no-op on these files, confirms no formatting drift). No types/tests apply to prose-only .mdx changes; full CI validates the docs build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the pt-br Decopilot docs with the English versions so they now describe connection-target subtasks. Adds the missing sentences and table cell about targeting a concrete MCP connection directly, and updates the example from a stale Shipping Agent to the ShipStation MCP connection. No code changes; docs-only content sync.

<sup>Written for commit 13919374fd3cfb297413f8548e50e2ade4dc002e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

