### PR TITLE
fix(details): translate the OAuth authenticate button's default label

### DIFF
--- a/apps/web/src/components/details/connection/settings-tab/index.tsx
+++ b/apps/web/src/components/details/connection/settings-tab/index.tsx
@@ -64,7 +64,7 @@ interface OAuthAuthenticationStateProps {
 
 export function OAuthAuthenticationState({
   onAuthenticate,
-  buttonText = "Authenticate",
+  buttonText,
 }: OAuthAuthenticationStateProps) {
   const t = useT();
   return (
@@ -79,7 +79,7 @@ export function OAuthAuthenticationState({
           </p>
         </div>
         <Button onClick={onAuthenticate} size="default">
-          {buttonText}
+          {buttonText ?? t("details.settingsTab.authenticate")}
         </Button>
       </div>
     </div>

--- a/apps/web/src/i18n/en/details.ts
+++ b/apps/web/src/i18n/en/details.ts
@@ -112,6 +112,7 @@ export const details = {
   "details.prompt.notFoundTitle": "Prompt not found",
   "details.prompt.title": "Title",
   "details.prompt.titlePlaceholder": "Untitled prompt",
+  "details.settingsTab.authenticate": "Authenticate",
   "details.settingsTab.authenticationRequired": "Authentication Required",
   "details.settingsTab.manualAuthenticationDescription":
     "This server requires an API key or token that must be configured manually. Check the server's documentation for instructions on obtaining credentials.",

--- a/apps/web/src/i18n/pt-br/details.ts
+++ b/apps/web/src/i18n/pt-br/details.ts
@@ -116,6 +116,7 @@ export const details = {
   "details.prompt.notFoundTitle": "Prompt não encontrado",
   "details.prompt.title": "Título",
   "details.prompt.titlePlaceholder": "Prompt sem título",
+  "details.settingsTab.authenticate": "Autenticar",
   "details.settingsTab.authenticationRequired": "Autenticação Obrigatória",
   "details.settingsTab.manualAuthenticationDescription":
     "Este servidor requer uma chave de API ou token que deve ser configurado manualmente. Verifique a documentação do servidor para instruções sobre como obter credenciais.",


### PR DESCRIPTION
Follows #6792 (i18n hardening of the connection details panels).

`OAuthAuthenticationState` (apps/web/src/components/details/connection/settings-tab/index.tsx) renders every one of its own strings through `t()` except its action button, which falls back to the raw literal `"Authenticate"` via a `buttonText = "Authenticate"` default prop. The only caller relying on that default — the connection settings tab's OAuth-required state — never passes `buttonText`, so the button always rendered untranslated English regardless of the user's language, while the sibling caller in `tool.tsx` (which does pass a translated string) worked fine.

Fix: drop the raw default and fall back to a new `details.settingsTab.authenticate` key (en: "Authenticate", pt-br: "Autenticar") when no `buttonText` is supplied.

How to confirm: switch the app language to pt-br, open a connection's Settings tab whose MCP requires OAuth, and the authenticate button should read "Autenticar" instead of "Authenticate".

Local checks run: `bun run fmt`, `bunx tsc --noEmit` in apps/web (only pre-existing, unrelated prosemirror version-mismatch errors remain — none in the touched files), `bunx oxlint` on the three changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OAuth authenticate button in connection settings so it renders translated text instead of always showing untranslated English. When no `buttonText` is passed, the button now falls back to the `details.settingsTab.authenticate` translation key instead of the raw literal `"Authenticate"`.

<sup>Written for commit 1b5741689ec14e3d0f232e6b449cb53fcdcab076. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

