### PR TITLE
fix(task-board): keep delegated cards under the member who delegated them

### DIFF
--- a/apps/web/src/layouts/task-board/task-filters.test.ts
+++ b/apps/web/src/layouts/task-board/task-filters.test.ts
@@ -125,6 +125,70 @@ describe("taskMatchesFilters — sprint", () => {
   });
 });
 
+describe("taskMatchesFilters — assignee", () => {
+  const SUPER_AGENT = "super-agent";
+
+  test("a member filter keeps the cards assigned to them", () => {
+    expect(
+      taskMatchesFilters(item({ assigneeId: "user-2" }), {
+        ...EMPTY_FILTERS,
+        assignee: "user-2",
+      }),
+    ).toBe(true);
+  });
+
+  /**
+   * The regression: a card handed to the Super Agent renders the delegator's
+   * avatar beside the capybara, so it reads as assigned to both — and used to
+   * vanish the moment you filtered by yourself.
+   */
+  test("a member filter keeps the cards they handed to the Super Agent", () => {
+    expect(
+      taskMatchesFilters(
+        item({ assigneeId: SUPER_AGENT, assignedBy: "user-2" }),
+        { ...EMPTY_FILTERS, assignee: "user-2" },
+      ),
+    ).toBe(true);
+  });
+
+  test("a member filter excludes a Super Agent card someone else delegated", () => {
+    expect(
+      taskMatchesFilters(
+        item({ assigneeId: SUPER_AGENT, assignedBy: "user-3" }),
+        { ...EMPTY_FILTERS, assignee: "user-2" },
+      ),
+    ).toBe(false);
+  });
+
+  /** `assignedBy` is stamped on every assignee change, delegation or not. */
+  test("assigning a card to a teammate does not keep it under the assigner", () => {
+    expect(
+      taskMatchesFilters(item({ assigneeId: "user-3", assignedBy: "user-2" }), {
+        ...EMPTY_FILTERS,
+        assignee: "user-2",
+      }),
+    ).toBe(false);
+  });
+
+  test("the Super Agent filter keeps every card it holds, whoever delegated", () => {
+    expect(
+      taskMatchesFilters(
+        item({ assigneeId: SUPER_AGENT, assignedBy: "user-2" }),
+        { ...EMPTY_FILTERS, assignee: SUPER_AGENT },
+      ),
+    ).toBe(true);
+  });
+
+  test("'unassigned' excludes a card the Super Agent holds", () => {
+    expect(
+      taskMatchesFilters(
+        item({ assigneeId: SUPER_AGENT, assignedBy: "user-2" }),
+        { ...EMPTY_FILTERS, assignee: "__unassigned__" },
+      ),
+    ).toBe(false);
+  });
+});
+
 describe("taskMatchesFilters — due date", () => {
   test("'week' excludes a task that is already overdue", () => {
     const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();

--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -227,6 +227,22 @@ export function matchesTaskKey(
   return keySeq != null && parseTaskKeySeq(term) === keySeq;
 }
 
+/**
+ * Whether a card belongs to `userId`, delegation included.
+ *
+ * Handing a card to the Super Agent does not hand it away: the board renders
+ * the delegator's avatar beside the capybara, so a card that reads as "mine and
+ * the Super Agent's" has to survive filtering by me. Delegation counts only on
+ * Super Agent cards — `assignedBy` is stamped on every assignee change, so a
+ * card one teammate assigned to another is the assignee's, not the assigner's.
+ */
+function assignedTo(item: TaskBoardItem, userId: string): boolean {
+  if (item.assigneeId === userId) return true;
+  return (
+    item.assigneeId === SUPER_AGENT_ASSIGNEE_ID && item.assignedBy === userId
+  );
+}
+
 export function taskMatchesFilters(
   item: TaskBoardItem,
   f: TaskFilters,
@@ -244,7 +260,7 @@ export function taskMatchesFilters(
   if (f.assignee !== null) {
     if (f.assignee === UNASSIGNED_FILTER) {
       if (item.assigneeId !== null) return false;
-    } else if (item.assigneeId !== f.assignee) {
+    } else if (!assignedTo(item, f.assignee)) {
       return false;
     }
   }


### PR DESCRIPTION
## Summary

Filtering the task board by a member dropped every card that member had handed
to the Super Agent — including cards the board itself draws as theirs.

A card carries a single `assignee_id`. Delegating to the Super Agent sets it to
the agent and records the delegator in `assigned_by`; the board then renders
both, the delegator's avatar beside the capybara (`AssigneeDisplay`), so the
card reads as "mine and the Super Agent's". The filter compared `assignee_id`
alone, so it disagreed with what the card shows.

`taskMatchesFilters` now matches a member against the delegation as well. That
counts only on Super Agent cards: `assigned_by` is stamped on *every* assignee
change (`TASK_BOARD_ITEM_UPDATE`), so without the guard a card you assigned to a
teammate would come back under your own filter. The Super Agent and
"unassigned" filters are unchanged.

Reported by a user whose card, assigned to them and the Super Agent, was absent
from the results when they filtered by their own user. Confirmed against the
row: `assignee_id = 'super-agent'`, `assigned_by = <the reporter>`.

## Testing

- New `taskMatchesFilters — assignee` block in `task-filters.test.ts`: the
  regression, plus the negative cases (a card someone *else* delegated, and a
  card assigned to a teammate not matching the assigner) and the unchanged
  Super Agent / unassigned behaviour.
- `bun test --cwd apps/web src/layouts/task-board/task-filters.test.ts` — 43 pass.
- `bun run --cwd apps/web check`, `bun run fmt`, `bun run lint` clean.
- Two failures in `task-filters-search.test.tsx` appear only when the whole
  directory runs together (locale bleeding across files); they reproduce on an
  unmodified tree and are unrelated to this change.

## Affected areas

`apps/web` task board only — the assignee filter is applied client-side, so
there is no API or storage change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the task board assignee filter dropping cards a member delegated to the Super Agent. The filter now matches the delegator in `assigned_by` on Super Agent cards, so filtering by yourself keeps every card that shows your avatar next to the capybara.

- Only Super Agent cards match the delegator; cards assigned to teammates still only match the assignee.
- No API or storage changes; the filter runs client-side.

<sup>Written for commit e8e78ba109ec71145c22959b0372fb01c3db9355. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

