### PR TITLE
Add Wake to the commerce companion cards, and gate it on a token

### DIFF
--- a/apps/web/src/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/web/src/routes/commerce-onboarding/companions-core.test.ts
@@ -229,6 +229,41 @@ describe("isCompanionConfigured", () => {
       }),
     ).toBe(true);
   });
+  it("accepts a Wake connection carrying only the storefront token", () => {
+    // The two Wake tokens gate different lanes independently (catalog vs
+    // orders), so either alone is usable — commerce-discovery's
+    // WakeStudioVaultState refines on the same OR.
+    expect(
+      isCompanionConfigured({
+        bindingType: "wake",
+        boundVia: "oauth",
+        companionConfig: { storefrontToken: "tcs_abc" },
+        cdConfig: null,
+      }),
+    ).toBe(true);
+  });
+  it("accepts a Wake connection carrying only the admin token", () => {
+    expect(
+      isCompanionConfigured({
+        bindingType: "wake",
+        boundVia: "oauth",
+        companionConfig: { apiToken: "basic_abc" },
+        cdConfig: null,
+      }),
+    ).toBe(true);
+  });
+  it("refuses a Wake connection with neither token (linked ≠ usable)", () => {
+    // Before `case "wake"` existed this fell to `default: true`, so a linked
+    // Wake with no credentials read as "connected".
+    expect(
+      isCompanionConfigured({
+        bindingType: "wake",
+        boundVia: "oauth",
+        companionConfig: { account: "example-store" },
+        cdConfig: null,
+      }),
+    ).toBe(false);
+  });
   it("requires a VTEX account name (linked ≠ usable)", () => {
     expect(
       isCompanionConfigured({

--- a/apps/web/src/routes/commerce-onboarding/companions-core.ts
+++ b/apps/web/src/routes/commerce-onboarding/companions-core.ts
@@ -111,6 +111,15 @@ export function isCompanionConfigured(args: {
     case "shopify":
       // The token is on connection_token — storeDomain is the visible signal.
       return isMeaningfulConfigValue(companionConfig?.storeDomain);
+    case "wake":
+      // Wake mints STATIC tokens in the merchant's panel, so both live in
+      // configuration state — and the two gate different lanes independently
+      // (storefrontToken ⇒ catalog, apiToken ⇒ orders). Either one alone makes
+      // the connection useful, which is why this is an OR and not an AND.
+      return (
+        isMeaningfulConfigValue(companionConfig?.storefrontToken) ||
+        isMeaningfulConfigValue(companionConfig?.apiToken)
+      );
     case "google-analytics":
       return isMeaningfulConfigValue(companionConfig?.propertyId);
     case "google-search-console":
@@ -140,6 +149,10 @@ function getConnectedDetail(args: {
     case "shopify":
       return typeof companionConfig?.storeDomain === "string"
         ? companionConfig.storeDomain
+        : null;
+    case "wake":
+      return typeof companionConfig?.account === "string"
+        ? companionConfig.account
         : null;
     case "google-analytics":
       return typeof companionConfig?.propertyId === "string"
@@ -197,13 +210,14 @@ export function parseBindingRequirements(
  *
  * `fieldKey` is the CD `configuration_state` key and `bindingType` is the
  * binding `__type` (== the curated COMMERCE_COMPANION_MCPS key). Kept in sync
- * with commerce-discovery's CONNECTION_PROVIDERS (vtex/ga4/gsc/github); if the
+ * with commerce-discovery's CONNECTION_PROVIDERS (vtex/shopify/wake/ga4/gsc/github); if the
  * CD schema gains a binding it still appears via the live schema — this
  * fallback only applies when the schema is unreachable.
  */
 export const FALLBACK_COMPANION_REQUIREMENTS: BindingRequirement[] = [
   { fieldKey: "vtex", bindingType: "vtex" },
   { fieldKey: "shopify", bindingType: "shopify" },
+  { fieldKey: "wake", bindingType: "wake" },
   { fieldKey: "ga4", bindingType: "google-analytics" },
   { fieldKey: "gsc", bindingType: "google-search-console" },
   { fieldKey: "github", bindingType: "github" },

--- a/apps/web/src/routes/commerce-onboarding/companions.ts
+++ b/apps/web/src/routes/commerce-onboarding/companions.ts
@@ -26,6 +26,11 @@ export const COMMERCE_COMPANION_MCPS: Record<string, CompanionCopy> = {
     area: "Catálogo",
     headline: "Pedidos, estoque e catálogo direto da sua Shopify.",
   },
+  wake: {
+    registryAppId: "deco/wake",
+    area: "Catálogo",
+    headline: "Pedidos, estoque e catálogo direto da sua Wake.",
+  },
   "google-analytics": {
     registryAppId: "deco/google-analytics",
     area: "Funil",


### PR DESCRIPTION
Wake was the one commerce platform with no entry in `COMMERCE_COMPANION_MCPS`. Two consequences, and the second is the one worth reviewing.

## 1. The card could silently not exist

Without a curated entry, `buildCompanionCards` falls back to `itemsByName[req.bindingType]` — looking the registry item up by `server_json->>'name'`. So the card renders only if the published app name equals the binding id exactly; otherwise `if (!item) continue` drops it, and the merchant sees no Wake card at all with nothing in the UI to explain it. `resolveCandidate` has the same coupling on `connections.app_name`, so even a rendered card would have had nothing to pick.

That is not hypothetical — an app published with its scope inside `server_json.name` (`<scope>/<name>` rather than `<name>`) hits both. Matching by the curated `registryAppId` makes the card independent of that field.

## 2. A Wake connection with no credentials read as "connected"

`isCompanionConfigured` had no `case "wake"`, so Wake fell through to `default: true` — linked was treated as usable, which is exactly what the `satisfied` / `configured` split exists to prevent.

Wake mints **static** tokens in the merchant's panel, so both live in configuration state (no `getAccessToken` lane), and the two gate different capabilities **independently**:

- `storefrontToken` → catalog reads
- `apiToken` → the admin order lane

Either one alone makes the connection useful, so the guard is an `OR`, not an `AND`. That mirrors the refine on the consumer side, where requiring both would make a catalog-only connection fail the orders lane instead of leaving it ineligible.

## Changes

- `companions.ts` — curated `wake` entry (`registryAppId`, area, headline)
- `companions-core.ts` — `wake` in `FALLBACK_COMPANION_REQUIREMENTS` so the card survives a CD proxy 401; `case "wake"` in `isCompanionConfigured` and in `getConnectedDetail` (shows the account instead of a gear once configured)
- `companions-core.test.ts` — 3 tests: either token alone configures, neither does not

## Test

`bun test src/routes/commerce-onboarding/companions-core.test.ts` → 52 pass / 0 fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Wake to the commerce companion cards so it no longer silently disappears when the published app name doesn't match the binding id, and treats a Wake connection as configured only when it carries at least one of its two static tokens.

- Adds a curated `wake` entry with `registryAppId` to decouple the card from the app name.
- Adds a `case "wake"` to `isCompanionConfigured` that requires either `storefrontToken` or `apiToken`; previously it defaulted to true, misreading a linked-but-unconfigured connection as usable.
- Includes `wake` in `FALLBACK_COMPANION_REQUIREMENTS` and shows the account in the connected detail.

<sup>Written for commit a8090d1184b4a75b9a0310aa47fca32adf42bc46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

