### PR TITLE
fix(preview): re-render in place on variant switch under instant preview

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1082,6 +1082,43 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     currentPath,
   ]);
 
+  /**
+   * Re-run the in-place render on a variant switch. Under Fast Preview in-place
+   * mode the frame is pinned (no reload on the reload-based `iframeSrc`), and a
+   * variant switch only changes `x-deco-matchers-override` — a query param, not
+   * the decofile — so the content-change effect above never fires for it. Post a
+   * fresh `/live/previews` render instead, so each variant selection reaches the
+   * frame. Page-scoped baseline: a page switch (which clears the override) is not
+   * a switch to render — the frame's own src already carries the new page's variant.
+   */
+  const variantRenderRef = useRef<{ page: string; sig: string } | null>(null);
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- imperative in-place re-render on variant change; the pinned frame won't reload
+  useEffect(() => {
+    if (
+      !inPlaceRenderActive ||
+      activeGlobalSection ||
+      activeLoaderKey ||
+      !currentPageKey ||
+      !decofile
+    ) {
+      variantRenderRef.current = null;
+      return;
+    }
+    const sig = JSON.stringify(workspace.state.variantOverride ?? null);
+    const prev = variantRenderRef.current;
+    variantRenderRef.current = { page: currentPageKey, sig };
+    // Baseline (first run or page switch): the frame's src already reflects this variant.
+    if (!prev || prev.page !== currentPageKey || prev.sig === sig) return;
+    renderPreviewInPlace();
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps -- renderPreviewInPlace reads live values; retrigger only on variant change
+  }, [
+    workspace.state.variantOverride,
+    inPlaceRenderActive,
+    activeGlobalSection,
+    activeLoaderKey,
+    currentPageKey,
+  ]);
+
   // Daemon is reachable independent of the dev script: ready claim, handle
   // still present, not user-stopped. Gates surfaces (FileExplorer,
   // terminal) that talk to the daemon's HTTP API and don't need a dev server.

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -570,7 +570,7 @@ export const sandbox = {
   "sandbox.cmsSettings.fastPreviewInPlace.label":
     "Instant preview (experimental)",
   "sandbox.cmsSettings.fastPreviewInPlace.description":
-    "Refresh edits in place, without waiting for a save — much faster, but only works on deco-runtime preview servers.",
+    "Refresh edits in place, without waiting for a save — much faster, but only works on websites that have /live/previews route.",
   "sandbox.cmsSettings.contentEditing.title": "Content editing",
   "sandbox.cmsSettings.contentEditing.description":
     "Whether this agent offers a CMS, and where the preview lands when it does.",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -594,7 +594,7 @@ export const sandbox = {
   "sandbox.cmsSettings.fastPreviewInPlace.label":
     "Preview instantâneo (experimental)",
   "sandbox.cmsSettings.fastPreviewInPlace.description":
-    "Atualiza as edições no lugar, sem esperar o salvamento — bem mais rápido, mas só funciona em servidores de preview com runtime deco.",
+    "Atualiza as edições no lugar, sem esperar o salvamento — bem mais rápido, mas só funciona em sites que têm a rota /live/previews.",
   "sandbox.cmsSettings.contentEditing.title": "Edição de conteúdo",
   "sandbox.cmsSettings.contentEditing.description":
     "Se este agente oferece um CMS e onde o preview abre quando oferece.",


### PR DESCRIPTION
## Summary

Under **Instant preview** (Fast Preview in-place render), switching a section/page variant did **not** update the frame. The `/live/previews` POST request carried no `x-deco-matchers-override`, so the runtime rendered the default variant.

**Root cause:** in-place mode pins the iframe (no reload). `renderPreviewInPlace` correctly appends the override to the POST URL, but it was only triggered by the content-change effect (keyed on `decofile`). A variant switch only changes the `x-deco-matchers-override` query param — not the decofile — so no render was ever triggered for it. The POST therefore only reflected whatever variant happened to be selected during the last content edit, or none at all.

## Change

- Add a dedicated effect in `preview.tsx` that re-runs `renderPreviewInPlace()` whenever `workspace.state.variantOverride` changes while in-place render is active. Each variant selection now fires its own `/live/previews` POST carrying the override — no longer dependent on an iframe reload.
  - **Page-scoped baseline** (`variantRenderRef` keyed on `{ page, sig }`): the first run and any page switch are treated as baseline and skipped (the frame's own `src` already reflects the page's variant; a page switch clears the override via the `select` reducer). Only a same-page variant change re-POSTs.
  - The content-change effect is untouched, and a variant switch doesn't mutate `decofile`, so there's a single POST — no double render.
- Update the instant-preview toggle description copy (en + pt-br) to describe the requirement as "websites that have /live/previews route".

## Testing

- `bun run --cwd=apps/web check` — passes
- `bun run lint` — 0 errors
- `bun run fmt` — clean

Behavioral effect/DOM change; per `TESTING.md` an assertion that the variant-switch POST carries `x-deco-matchers-override` belongs in the Playwright e2e tier — happy to add it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Instant preview not re-rendering when switching section/page variants. The `/live/previews` POST now carries the variant override on every variant switch, so the pinned iframe updates without a reload.

- Adds an effect that re-runs the in-place render whenever `variantOverride` changes, with a page-scoped baseline to skip page switches.
- Updates the Instant preview toggle description (en and pt-br) to mention the `/live/previews` route requirement.

<sup>Written for commit 963c4f7b3c7359fbb2bbb18477e9f168836e95e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

