### PR TITLE
docs(pt-br): translate the missing Windows section on the agents page

### DIFF
--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/agents.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/agents.mdx
@@ -88,6 +88,10 @@ Para usar as opções locais, abra a app nativa do Studio. O `local-api` embutid
   Cloud é o padrão certo para execuções sem supervisão e para colegas de time que não deveriam precisar de uma configuração local. Recorra à app desktop quando o agent precisar da sua máquina — seus arquivos, suas credenciais ou um coding harness como Claude Code, Codex ou OpenCode.
 </Callout>
 
+## Windows
+
+O daemon roda nativamente no Windows com um pré-requisito: **[Git for Windows](https://gitforwindows.org)** — ele fornece tanto o `git` quanto o shell bash usado para rodar os scripts de dev do seu projeto. Se o daemon reportar "POSIX shell (sh) not found", instale o Git for Windows ou defina a variável de ambiente `DECO_SHELL` para um shell compatível com bash. O WSL2 continua sendo uma alternativa totalmente suportada. Montagens de arquivos da org ainda não estão disponíveis no Windows.
+
 ## Um agent é um MCP virtual
 
 Cada agent no Studio é exposto como seu próprio **endpoint MCP**: um pacote curado de tools, resources e instruções ao qual qualquer client compatível com MCP pode se conectar. Você pode pensar em um agent como um "MCP server virtual" que você monta visualmente — escolha algumas tools das suas connections, adicione instruções, e você publicou um endpoint MCP focado que seu time (ou seus outros agents) pode usar.


### PR DESCRIPTION
Multilingual docs drift: `en/studio/agents.mdx` has a `## Windows` section (added at some point in the daily auto-update stream) documenting the Git-for-Windows prerequisite and the `DECO_SHELL` fallback, but the pt-br translation of the same page never got it — it jumps straight from "Um agent é um MCP virtual" past where "Windows" should sit, silently dropping a whole section for pt-br readers.

Found this by diffing heading counts between every en/pt-br `.mdx` pair under `apps/docs/client/src/content/deco-studio` (`en/studio/agents.mdx` had 12 `#`-headings, pt-br had 11) and confirming the gap was the `## Windows` section specifically.

Added the translated section in the same position as the English original, matching the existing pt-br tone/terminology used elsewhere on the page (e.g. "agent", "sandbox", "harness" left untranslated, consistent with the rest of the file).

How to verify: `diff <(grep -c '^#' apps/docs/client/src/content/deco-studio/en/studio/agents.mdx) <(grep -c '^#' apps/docs/client/src/content/deco-studio/pt-br/studio/agents.mdx)` — now matches (12/12).

Checks run locally: `bun run fmt` (no changes needed, pure content edit). No code/types touched, so no typecheck/test target applies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `## Windows` section to the pt-br translation of the agents page so it matches the English version and no longer drops documentation for Portuguese readers.

<sup>Written for commit 04af0b12da084ddea814ce277c5ffe0cc8a6e720. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

