### PR TITLE
perf(preview): dedupe getAllSections() recompute in the CMS editor hover/click path

### DIFF
--- a/apps/web/src/components/sandbox/preview/cms-editor-script.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.ts
@@ -115,7 +115,7 @@ export const CMS_EDITOR_SCRIPT = `(function() {
   // Resolve to the OUTERMOST page-level section (clicking nested content still
   // maps to the top-level section the panel indexes); null if it isn't in the
   // aligned editable set (a framework section deco injected).
-  var findSection = function(el) {
+  var findSection = function(el, out) {
     var node = el;
     var found = null;
     while (node && node !== document.body) {
@@ -125,7 +125,9 @@ export const CMS_EDITOR_SCRIPT = `(function() {
       node = node.parentElement;
     }
     if (!found) return null;
-    return getAllSections().indexOf(found) >= 0 ? found : null;
+    var sections = getAllSections();
+    if (out) out.sections = sections;
+    return sections.indexOf(found) >= 0 ? found : null;
   };
 
   // A Lazy wrapper's key is just the loader — show the inner section's instead.
@@ -150,13 +152,13 @@ export const CMS_EDITOR_SCRIPT = `(function() {
   // global inside async rendering); kinds: section type that drives the color.
   var sectionLabels = [];
   var sectionKinds = [];
-  var labelFor = function(section) {
-    var idx = getAllSections().indexOf(section);
+  var labelFor = function(section, sections) {
+    var idx = (sections || getAllSections()).indexOf(section);
     if (idx >= 0 && sectionLabels[idx]) return sectionLabels[idx];
     return displayKey(section);
   };
-  var kindFor = function(section) {
-    var idx = getAllSections().indexOf(section);
+  var kindFor = function(section, sections) {
+    var idx = (sections || getAllSections()).indexOf(section);
     return (idx >= 0 && sectionKinds[idx]) || "normal";
   };
 
@@ -204,7 +206,8 @@ export const CMS_EDITOR_SCRIPT = `(function() {
     requestAnimationFrame(function() {
       rafPending = false;
       if (!target || target === highlight || target === badge) return;
-      var section = findSection(target);
+      var out = {};
+      var section = findSection(target, out);
       if (section === lastSection) return;
       lastSection = section;
       if (!section) {
@@ -212,8 +215,8 @@ export const CMS_EDITOR_SCRIPT = `(function() {
         badge.style.display = "none";
         return;
       }
-      lastLabel = labelFor(section);
-      lastKind = kindFor(section);
+      lastLabel = labelFor(section, out.sections);
+      lastKind = kindFor(section, out.sections);
       applyColor(lastKind);
       positionHighlight(section);
     });
@@ -251,11 +254,11 @@ export const CMS_EDITOR_SCRIPT = `(function() {
   var clickHandler = function(e) {
     var target = e.target;
     if (!target || target === highlight || target === badge) return;
-    var section = findSection(target);
+    var out = {};
+    var section = findSection(target, out);
     if (!section) return;
 
-    var sections = getAllSections();
-    var sectionIndex = sections.indexOf(section);
+    var sectionIndex = out.sections.indexOf(section);
     var manifestKey = section.getAttribute("data-manifest-key") || "";
 
     var c = COLORS[lastKind] || COLORS.normal;


### PR DESCRIPTION
**Source:** a reduction found while auditing `cms-editor-script.ts` (the CMS-mode iframe script) for redundant work in `apps/web/src/components/sandbox/preview/` — not a fix for any tracked issue.

**Payoff:** `getAllSections()` is a `document.querySelectorAll("section[data-manifest-key]")` scan followed by the full section-alignment algorithm (`alignSections`, running against the decofile's manifest-key sequence). `moveHandler` (the mousemove/hover path, rAF-throttled) called it up to 3 times per hover change — once inside `findSection()`, once more in `labelFor()`, once more in `kindFor()`. `clickHandler` called it twice — once inside `findSection()`, once again for the click payload's `sectionIndex`. On a page with many top-level sections this is a real, avoidable multiple of the same DOM scan + alignment pass on every hover/click.

**Change:** `findSection()` now optionally hands its already-computed sections list back to the caller through an out-param, so `moveHandler`/`clickHandler` compute the list once and pass it into `labelFor`/`kindFor`/the index lookup. The short-circuit is preserved: hovering an element with no `section[data-manifest-key]` ancestor still returns early without calling `getAllSections()` at all, exactly as before. Every other call site of `labelFor`/`kindFor`/`findSection` (the `set-labels` postMessage handler) keeps working unchanged since the new params default via `||` when omitted.

Behavior-preserving — same lookups, same results, just not recomputed redundantly within a single event.

**To verify:** `bun test apps/web/src/components/sandbox/preview/cms-editor-script.test.ts` (11/11 pass, including the syntactic-validity and embedded-alignment checks, which parse and execute the stringified script the same way the browser would).

**Checks run locally:** `bun run fmt`, `bun test apps/web/src/components/sandbox/preview/cms-editor-script.test.ts`, `bunx oxlint apps/web/src/components/sandbox/preview/cms-editor-script.ts` (0 warnings/errors). Full CI validates the rest; this touches only the one `.ts` file (a template-literal script, not itself typechecked by `tsc`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces redundant `getAllSections()` calls in the CMS editor hover and click paths by reusing the sections list already computed by `findSection()`.

- `moveHandler` previously recomputed the DOM scan plus alignment pass up to three times per hover change, and `clickHandler` did it twice.
- `findSection()` now hands its computed sections list back through an out-param, which `labelFor`/`kindFor` and the click payload accept as a defaulted argument.
- Behavior is unchanged: the early return for elements outside any section still skips the computation, and other call sites keep working via the defaults.

<sup>Written for commit 494cfe8100ce7643deef255b09801c5a74deed23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

