### PR TITLE
fix(preview): hide the CMS editor overlay on an in-place render swap

### DIFF
--- a/apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
@@ -134,6 +134,16 @@ describe("CMS_EDITOR_SCRIPT", () => {
     expect(CMS_EDITOR_SCRIPT).toContain("cms-editor::render-end");
   });
 
+  it("hides the stale overlay on swap instead of leaving it floating over the new page", () => {
+    const start = CMS_EDITOR_SCRIPT.indexOf("var swap = function()");
+    const end = CMS_EDITOR_SCRIPT.indexOf("var headHtml = html.slice", start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const swap = CMS_EDITOR_SCRIPT.slice(start, end);
+    expect(swap).toContain('highlight.style.display = "none"');
+    expect(swap).toContain('badge.style.display = "none"');
+  });
+
   it("drops a bridge message whose source isn't this frame's parent", () => {
     const start = CMS_EDITOR_SCRIPT.indexOf(
       'window.addEventListener("message", function(e)',

--- a/apps/web/src/components/sandbox/preview/cms-editor-script.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.ts
@@ -328,6 +328,9 @@ export const CMS_EDITOR_SCRIPT = `(function() {
           document.documentElement.innerHTML = html.replace("</head>", TRANSITION_TAG);
           document.body.appendChild(highlight);
           document.body.appendChild(badge);
+          // Old section is gone; hide the overlay until the next hover repositions it.
+          highlight.style.display = "none";
+          badge.style.display = "none";
           lastSection = null;
         };
         var headHtml = html.slice(html.indexOf("<head>"), html.indexOf("</head>") + 7);


### PR DESCRIPTION
**Source**: bug found while auditing the Fast Preview in-place render path (`cms-editor-script.ts`), hardened repeatedly this week by #6789/#6795/#6802.

**Payoff**: `renderInPlace`'s `swap()` replaces `document.documentElement.innerHTML` and re-appends the hover `highlight`/badge overlay nodes, but never resets their `display` style. If a section was hovered right before an autosave-triggered in-place render fires, or before a variant switch re-renders the frame (#6802's new path), the highlight box and its label stay visible at their pre-swap coordinates floating over the new page's content until the next `mousemove` happens to recompute them — a wrong/dangling highlight the editor never asked for.

**Fix**: `swap()` now sets `highlight.style.display = "none"` and `badge.style.display = "none"`, mirroring what the existing `mouseout` handler already does when the pointer leaves the frame. Added a regression test (`cms-editor-script.test.ts`) asserting the `swap` function body contains both hides.

**Verify**: `cd apps/web && bun test src/components/sandbox/preview/cms-editor-script.test.ts`

**Checks run locally**: `bun run fmt`, `bunx oxlint` on both touched files, the targeted test file above (12 pass). No type changes, so no `tsc --noEmit` needed. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CMS editor overlay lingering over the wrong content after an in-place render swap. The highlight and badge now hide when `swap()` replaces the document, instead of floating at their old coordinates until the next mousemove.

- Adds a regression test for the swap path.

<sup>Written for commit 7534be5f244234c121dcc064f171e5704a188e35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

