### PR TITLE
fix(agent-nav): surface Settings/Automations tabs when viewing them

### DIFF
--- a/apps/web/src/components/project-card.tsx
+++ b/apps/web/src/components/project-card.tsx
@@ -1,6 +1,7 @@
 import {
   DotsVertical,
   Home02,
+  Lightning01,
   Pin01,
   Settings02,
   Trash01,
@@ -109,7 +110,15 @@ export function ProjectCard({
                     }
                   >
                     <Settings02 size={16} />
-                    Settings
+                    {t("home.projectCard.settings")}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() =>
+                      navigateToAgent(project.id, { panel: "automations" })
+                    }
+                  >
+                    <Lightning01 size={16} />
+                    {t("home.projectCard.automations")}
                   </DropdownMenuItem>
                   {canSetMainAgent && (
                     <DropdownMenuItem
@@ -146,7 +155,7 @@ export function ProjectCard({
                       }}
                     >
                       <Trash01 size={16} />
-                      Delete
+                      {t("home.projectCard.delete")}
                     </DropdownMenuItem>
                   )}
                 </DropdownMenuContent>

--- a/apps/web/src/i18n/en/home.ts
+++ b/apps/web/src/i18n/en/home.ts
@@ -114,4 +114,7 @@ export const home = {
   "home.projectCard.mainAgentError": "Couldn't update the main agent",
   "home.projectCard.pinToSidebar": "Pin to sidebar",
   "home.projectCard.unpinFromSidebar": "Unpin from sidebar",
+  "home.projectCard.settings": "Settings",
+  "home.projectCard.automations": "Automations",
+  "home.projectCard.delete": "Delete",
 } as const;

--- a/apps/web/src/i18n/pt-br/home.ts
+++ b/apps/web/src/i18n/pt-br/home.ts
@@ -120,4 +120,7 @@ export const home = {
     "Não foi possível atualizar o agente principal",
   "home.projectCard.pinToSidebar": "Fixar na barra lateral",
   "home.projectCard.unpinFromSidebar": "Desafixar da barra lateral",
+  "home.projectCard.settings": "Configurações",
+  "home.projectCard.automations": "Automações",
+  "home.projectCard.delete": "Excluir",
 } satisfies Record<keyof typeof homeEn, string>;

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -374,11 +374,12 @@ export function useMainPanelTabs(ctx: {
       title: t("common.mainPanelTabs.reviewChanges"),
     });
   }
-  // Only shown once you're actually on one of these views, not on every screen.
+  // activeTab defaults to "settings" while chat is showing, so also require the panel to be open.
   const onSettingsOrAutomations =
-    activeTab === "settings" ||
-    activeTab === "automations" ||
-    automationTabParsed !== null;
+    mainOpen &&
+    (activeTab === "settings" ||
+      activeTab === "automations" ||
+      automationTabParsed !== null);
   if (onSettingsOrAutomations) {
     if (canManageAgents) {
       systemTabs.push({

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -65,6 +65,7 @@ import { resolveAgentSiteSlug } from "@decocms/shared/site-slug";
 import { resolveCmsMode, type CmsMode } from "@decocms/shared/sdk/types";
 import { useIsDesktopApp } from "@/hooks/use-is-desktop-app";
 import { useReportsOnly } from "@/hooks/use-organization-settings";
+import { useCapability } from "@/hooks/use-capability";
 import { useT } from "@/i18n/use-t.ts";
 
 export type AgentTabDef = {
@@ -169,6 +170,7 @@ export function useMainPanelTabs(ctx: {
     agentHasClonableSource(entity?.metadata) ||
     agentHasClonableSource(metadata);
   const reportsOnly = useReportsOnly();
+  const { granted: canManageAgents } = useCapability("agents:manage");
   const connections = useConnections({ includeVirtual: true });
 
   // Show "Content" only when decofile/meta confirm editable pages or sections
@@ -370,6 +372,23 @@ export function useMainPanelTabs(ctx: {
     systemTabs.push({
       id: "git",
       title: t("common.mainPanelTabs.reviewChanges"),
+    });
+  }
+  // Only shown once you're actually on one of these views, not on every screen.
+  const onSettingsOrAutomations =
+    activeTab === "settings" ||
+    activeTab === "automations" ||
+    automationTabParsed !== null;
+  if (onSettingsOrAutomations) {
+    if (canManageAgents) {
+      systemTabs.push({
+        id: "settings",
+        title: t("common.mainPanelTabs.settings"),
+      });
+    }
+    systemTabs.push({
+      id: "automations",
+      title: t("common.mainPanelTabs.automations"),
     });
   }
   // Merge pinned views + per-task expanded tools into a single list keyed


### PR DESCRIPTION
## Summary
- The agents grid's "..." menu (`/settings/agents`) only had a Settings item — added an Automations item next to it.
- The per-agent top tab bar had its Settings/Automations pills removed in a recent nav redesign, with no entry point left to switch between them once on either view — restored the pills, but scoped to only appear while you're actually on the Settings or Automations view (not on every screen like chat/preview).
- Ordered Settings before Automations in the tab bar per design feedback.

## Testing notes
- `bun run fmt` and `bun run --cwd=apps/web check` pass.
- No UI smoke test run in this session (no dev server/browser available) — please verify the "..." menu and tab-switching behavior on an agent's Settings/Automations view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Settings/Automations tab pills on the agent view and adds an Automations entry to the agent card's "..." menu, so you can switch between the two after the recent nav redesign removed the entry point. Settings comes first and requires the `agents:manage` capability.

- Pills only show on the Settings or Automations views with the panel open; without that gate, the default `settings` active tab leaked them into plain chat.

<sup>Written for commit efba5a368d9a7d1baac1bc41c1d8603e631afe5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

