### PR TITLE
fix(preview): keep the CMS editor overlay hidden through an in-flight render swap

### DIFF
--- a/apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
@@ -144,6 +144,30 @@ describe("CMS_EDITOR_SCRIPT", () => {
     expect(swap).toContain('badge.style.display = "none"');
   });
 
+  it("hides the overlay as soon as a render starts, so a hover during the fetch can't re-show it before the swap's view transition snapshots it", () => {
+    const start = CMS_EDITOR_SCRIPT.indexOf("var renderInPlace = function");
+    const end = CMS_EDITOR_SCRIPT.indexOf(
+      'postMessage({ type: "cms-editor::render-start"',
+      start,
+    );
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const setup = CMS_EDITOR_SCRIPT.slice(start, end);
+    expect(setup).toContain("renderPending = true");
+    expect(setup).toContain('highlight.style.display = "none"');
+    expect(setup).toContain('badge.style.display = "none"');
+    // moveHandler must not reposition/show the overlay while a render is pending.
+    const moveStart = CMS_EDITOR_SCRIPT.indexOf(
+      "var moveHandler = function(e)",
+    );
+    const moveGuardEnd = CMS_EDITOR_SCRIPT.indexOf(
+      "rafPending = true",
+      moveStart,
+    );
+    const moveGuard = CMS_EDITOR_SCRIPT.slice(moveStart, moveGuardEnd);
+    expect(moveGuard).toContain("renderPending");
+  });
+
   it("drops a bridge message whose source isn't this frame's parent", () => {
     const start = CMS_EDITOR_SCRIPT.indexOf(
       'window.addEventListener("message", function(e)',

--- a/apps/web/src/components/sandbox/preview/cms-editor-script.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.ts
@@ -180,6 +180,8 @@ export const CMS_EDITOR_SCRIPT = `(function() {
   var lastLabel = "";
   var lastKind = "normal";
   var rafPending = false;
+  // True while an in-place render fetch/swap is in flight; suppresses hover so it can't re-show the overlay right before the swap snapshots it.
+  var renderPending = false;
 
   // Document-relative coordinates (rect + scroll) on absolutely-positioned
   // nodes, so the browser scrolls the highlight together with the page
@@ -200,7 +202,7 @@ export const CMS_EDITOR_SCRIPT = `(function() {
   };
 
   var moveHandler = function(e) {
-    if (rafPending) return;
+    if (renderPending || rafPending) return;
     rafPending = true;
     var target = e.target;
     requestAnimationFrame(function() {
@@ -316,6 +318,9 @@ export const CMS_EDITOR_SCRIPT = `(function() {
     if (renderCtrl) renderCtrl.abort();
     var ctrl = new AbortController();
     renderCtrl = ctrl;
+    renderPending = true;
+    highlight.style.display = "none";
+    badge.style.display = "none";
     window.parent.postMessage({ type: "cms-editor::render-start" }, "*");
     renderQueue = renderQueue.then(function() {
       return fetch(src, {
@@ -351,8 +356,10 @@ export const CMS_EDITOR_SCRIPT = `(function() {
       }).then(function() {
         var t = document.getElementById("deco-disable-transitions");
         if (t) t.remove();
+        if (ctrl === renderCtrl) renderPending = false;
         window.parent.postMessage({ type: "cms-editor::render-end" }, "*");
       }).catch(function(err) {
+        if (ctrl === renderCtrl) renderPending = false;
         if (err && err.name === "AbortError") return;
         window.parent.postMessage({ type: "cms-editor::render-error" }, "*");
       });


### PR DESCRIPTION
Follows #6805, which hides the CMS editor overlay inside the `swap()` callback once the new DOM is in place. That leaves a gap: if the mouse moves during the fetch/stylesheet wait *before* swap, `moveHandler` re-shows the highlight/badge over the old page — so it's visible again exactly when `document.startViewTransition()` takes its "before" snapshot, and the browser's default crossfade then flickers a stale highlight over the new page during the transition.

Why a maintainer wants it: this is the direct remaining edge case in the exact feature #6805 just hardened — the overlay-hide fix only covers the post-swap state, not the pre-swap window where a hover can put it right back.

Failure scenario: hover a section, then trigger an in-place render (edit a field) while still hovering/moving the mouse before the fetch resolves — the highlight box flickers over the newly-swapped page during the view transition instead of staying hidden.

Fix: `renderInPlace` now hides the overlay and sets a `renderPending` flag synchronously at the start of the render (before the fetch), and `moveHandler` skips repositioning/showing the overlay while `renderPending` is true, so a hover during the wait can't re-arm it before the swap's transition snapshot.

Regression test added in `cms-editor-script.test.ts`: asserts `renderInPlace` hides the overlay and sets `renderPending` before the render-start postMessage, and that `moveHandler` checks `renderPending`.

To verify: `bun test apps/web/src/components/sandbox/preview/cms-editor-script.test.ts`

Checked locally: `bun run fmt`, `bunx oxlint` on both changed files, and the targeted test file above (all pass). Did not run the full `apps/web` typecheck — a pre-existing, unrelated prosemirror-version type error exists on main in `mention-suggestion.tsx`; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flicker where the CMS editor overlay could re-shown by a hover during an in-place render's fetch wait, then get captured in the view-transition snapshot and flash over the new page after the swap.

- Hides the overlay and sets a `renderPending` flag synchronously when a render starts; `moveHandler` now skips showing it while the flag is set.
- Adds a regression test in `cms-editor-script.test.ts` asserting both behaviors.

<sup>Written for commit 2eece6081e59b4622dab7d84b4f7e5fde9f2aee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

