### PR TITLE
fix(sandbox): re-seed BlockDocument when its value prop changes externally

### DIFF
--- a/apps/web/src/components/sandbox/content/blog/block-document.tsx
+++ b/apps/web/src/components/sandbox/content/blog/block-document.tsx
@@ -52,13 +52,21 @@ export function BlockDocument({
   const [blockItems, setBlockItems] = useState<BlockItem[]>(() =>
     value.map((blk) => ({ id: uid(), block: blk })),
   );
+  // Re-seed when `value` changes for a reason other than our own onChange echo.
+  const [lastEmitted, setLastEmitted] = useState(value);
+  if (value !== lastEmitted) {
+    setLastEmitted(value);
+    setBlockItems(value.map((blk) => ({ id: uid(), block: blk })));
+  }
 
   const ids = blockItems.map((x) => x.id);
   const blocks = blockItems.map((x) => x.block);
 
   const syncBlocks = (items: BlockItem[]) => {
     setBlockItems(items);
-    onChange(items.map((x) => x.block));
+    const next = items.map((x) => x.block);
+    setLastEmitted(next);
+    onChange(next);
   };
 
   const insertAt = (index: number, resolveType: string) => {


### PR DESCRIPTION
**Source:** a bug found while auditing the blog content editor (`apps/web/src/components/sandbox/content/blog/`) for stale-prop regressions.

**The bug:** `BlockDocument` seeds its internal `blockItems` (id-keyed block list, used for dnd-kit identity and rendering) from its `value` prop only once, via `useState(() => value.map(...))`. Both callers — `PostEditor` and `CategoryEditor` — key the editor by `post:${id}`/`category:${id}`, so it stays mounted across re-renders of the same post/category, and its `block` prop (hence `post.sections`/`value`) can change reference underneath it — e.g. a decofile refetch landing while the post stays open, exactly the scenario `useAutosave`'s own doc comment already calls out ("a batch mutation patched this block's payload in the shared cache while it's open"). When that happens, `BlockDocument` kept rendering the blocks it had at mount time, silently diverging from the actual persisted content — edits made from elsewhere (or reverted by a failed save) never showed up in the open editor.

**The fix:** track the last array we handed to `onChange` in state (`lastEmitted`) and re-seed `blockItems` only when the incoming `value` differs from that reference. Self-driven edits echo the exact array reference we just emitted, so they don't trigger a re-seed (which would otherwise remount every block editor's local state — e.g. resetting focus inside the TipTap-backed `RichTextBlock` — on every keystroke). Only a genuinely external replacement of `value` triggers the re-seed.

**Payoff:** an open post/category editor stays in sync with its actual persisted content instead of silently showing stale blocks after an external refetch.

**How to confirm:** open a post in the block editor, then externally patch its `sections` (e.g. via another tab or a decofile write) — the open editor's blocks should refresh to match, rather than staying frozen at whatever was loaded on open.

**Verification run locally:**
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/web` — no new errors (one pre-existing, unrelated prosemirror version-mismatch error in `mention-suggestion.tsx`)
- `bunx oxlint apps/web/src/components/sandbox/content/blog/block-document.tsx` — 0 warnings, 0 errors

No component test tier exists in this repo for React components (unit tests are pure-logic-only per `TESTING.md`), so this wasn't covered by an automated regression test — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the block editor showing stale blocks when `BlockDocument`'s `value` prop changes externally (e.g., a decofile refetch while the post stays open). Previously it seeded its block list only on mount; now it re-seeds when the incoming value differs from the last value it emitted, so an open editor stays in sync with the actual persisted content without remounting block editors on every keystroke.

<sup>Written for commit 89db23985262a1c665e118d0937ece4fc44223c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

