### PR TITLE
fix(settings): drop task-prompt descriptions, move field up

### DIFF
--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -521,11 +521,7 @@ export const settings = {
     "Tasks created from a report are delegated to the Super Agent automatically instead of landing unassigned.",
   "settings.review.updateError": "Couldn't update the setting",
   "settings.taskPrompt.title": "System prompt",
-  "settings.taskPrompt.description":
-    "Extra instructions appended to the system prompt of every agent run started from a task on the board.",
   "settings.taskPrompt.fieldLabel": "Instructions",
-  "settings.taskPrompt.fieldDescription":
-    "House rules that apply to all board work \u2014 conventions, tools to prefer, things never to touch. Leave it empty for none.",
   "settings.taskPrompt.placeholder":
     "e.g. Use pnpm, never npm. Never edit files under src/generated/.",
   "settings.taskPrompt.save": "Save",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -539,11 +539,7 @@ export const settings = {
   "settings.review.updateError":
     "N\u00e3o foi poss\u00edvel atualizar a configura\u00e7\u00e3o",
   "settings.taskPrompt.title": "System prompt",
-  "settings.taskPrompt.description":
-    "Instru\u00e7\u00f5es extras anexadas ao system prompt de todo run de agente iniciado por uma tarefa do quadro.",
   "settings.taskPrompt.fieldLabel": "Instru\u00e7\u00f5es",
-  "settings.taskPrompt.fieldDescription":
-    "Regras que valem para todo trabalho do quadro \u2014 conven\u00e7\u00f5es, ferramentas preferidas, o que nunca tocar. Deixe vazio para nenhuma.",
   "settings.taskPrompt.placeholder":
     "ex.: Use pnpm, nunca npm. Nunca edite arquivos em src/generated/.",
   "settings.taskPrompt.save": "Salvar",

--- a/apps/web/src/views/settings/task-system-prompt.tsx
+++ b/apps/web/src/views/settings/task-system-prompt.tsx
@@ -42,12 +42,12 @@ export function TaskSystemPromptSettings() {
       <SettingsCard>
         <SettingsCardItem title={t("settings.taskPrompt.fieldLabel")}>
           {isPending ? (
-            <Skeleton className="h-28 w-full" />
+            <Skeleton className="h-44 w-full" />
           ) : (
             <div className="flex flex-col items-start gap-2">
               <Textarea
                 value={draft}
-                rows={6}
+                rows={10}
                 maxLength={TASK_SYSTEM_PROMPT_MAX_LENGTH}
                 placeholder={t("settings.taskPrompt.placeholder")}
                 onChange={(e) => setDraft(e.target.value)}

--- a/apps/web/src/views/settings/task-system-prompt.tsx
+++ b/apps/web/src/views/settings/task-system-prompt.tsx
@@ -38,19 +38,13 @@ export function TaskSystemPromptSettings() {
   }
 
   return (
-    <SettingsSection
-      title={t("settings.taskPrompt.title")}
-      description={t("settings.taskPrompt.description")}
-    >
+    <SettingsSection title={t("settings.taskPrompt.title")}>
       <SettingsCard>
-        <SettingsCardItem
-          title={t("settings.taskPrompt.fieldLabel")}
-          description={t("settings.taskPrompt.fieldDescription")}
-        >
+        <SettingsCardItem title={t("settings.taskPrompt.fieldLabel")}>
           {isPending ? (
-            <Skeleton className="h-28 w-full mt-3" />
+            <Skeleton className="h-28 w-full" />
           ) : (
-            <div className="flex flex-col items-start gap-2 mt-3">
+            <div className="flex flex-col items-start gap-2">
               <Textarea
                 value={draft}
                 rows={6}


### PR DESCRIPTION
Removes the section and field descriptions from Settings → Tasks → System prompt, keeping only the two titles, and drops the now-dead top margin so Instructions sits right under the heading.

Testing: bunx biome format on the changed files; no other references to the removed i18n keys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the description text from Settings → Tasks → System prompt so only the titles remain, tightens the layout so the Instructions field sits directly under the heading, and makes the textarea taller.

<sup>Written for commit 4450529248344b99cb0ca478146c182ea79540c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

