### PR TITLE
feat(task-board): settings cog before the Sprint filter

### DIFF
--- a/apps/web/ct/harness/sprint-filter-harness.tsx
+++ b/apps/web/ct/harness/sprint-filter-harness.tsx
@@ -60,6 +60,7 @@ export function SprintFilterHarness() {
         repos={[]}
         sprints={SPRINTS}
         onChange={setFilters}
+        onOpenBoardSettings={() => {}}
       />
       <pre data-testid="sprint">{JSON.stringify(filters.sprint)}</pre>
     </div>

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -253,6 +253,7 @@ export const taskBoard = {
   "taskBoard.taskFilters.repoAnyRepo": "Any repo",
   "taskBoard.taskFilters.repoFilterPlaceholder": "Filter by repo…",
   "taskBoard.taskFilters.repoLabel": "Repo",
+  "taskBoard.taskFilters.boardSettingsLabel": "Board settings",
   "taskBoard.taskFilters.sprintLabel": "Sprint",
   "taskBoard.taskFilters.sprintAnySprint": "Any sprint",
   "taskBoard.taskFilters.sprintBacklog": "No sprint",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -262,6 +262,7 @@ export const taskBoard = {
   "taskBoard.taskFilters.repoAnyRepo": "Qualquer repositório",
   "taskBoard.taskFilters.repoFilterPlaceholder": "Filtrar por repositório…",
   "taskBoard.taskFilters.repoLabel": "Repositório",
+  "taskBoard.taskFilters.boardSettingsLabel": "Configurações do quadro",
   "taskBoard.taskFilters.sprintLabel": "Sprint",
   "taskBoard.taskFilters.sprintAnySprint": "Qualquer sprint",
   "taskBoard.taskFilters.sprintBacklog": "Sem sprint",

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -956,6 +956,12 @@ export function TaskBoardPage() {
   const studio = useStudioTools();
   const { org, locator } = useProjectContext();
   const navigate = useNavigate();
+  const openBoardSettings = () => {
+    navigate({
+      to: "/$org/settings/task-board",
+      params: { org: org.slug },
+    });
+  };
   /**
    * `/$org/tasks/DECO-01` renders that card in place of the lanes — the one
    * address a task has, whether it was reached by clicking its card, by the
@@ -1147,6 +1153,7 @@ export function TaskBoardPage() {
                   repos={repos}
                   sprints={sprints}
                   onChange={handleFiltersChange}
+                  onOpenBoardSettings={openBoardSettings}
                 />
               </div>
               <div className="hidden sm:block">
@@ -1157,6 +1164,7 @@ export function TaskBoardPage() {
                   repos={repos}
                   sprints={sprints}
                   onChange={handleFiltersChange}
+                  onOpenBoardSettings={openBoardSettings}
                 />
               </div>
             </>

--- a/apps/web/src/layouts/task-board/task-filters-search.test.tsx
+++ b/apps/web/src/layouts/task-board/task-filters-search.test.tsx
@@ -44,6 +44,7 @@ describe("task filter options — searchable value matches the displayed label",
         repos={[]}
         sprints={[]}
         onChange={() => {}}
+        onOpenBoardSettings={() => {}}
       />,
     );
     fireEvent.click(getByText("Responsável"));
@@ -63,6 +64,7 @@ describe("task filter options — searchable value matches the displayed label",
         repos={["acme/site"]}
         sprints={[]}
         onChange={() => {}}
+        onOpenBoardSettings={() => {}}
       />,
     );
     fireEvent.click(getByText("acme/site"));
@@ -88,6 +90,7 @@ describe("search toggle — collapses when cleared externally", () => {
         repos={[]}
         sprints={[]}
         onChange={() => {}}
+        onOpenBoardSettings={() => {}}
       />,
     );
 
@@ -102,6 +105,7 @@ describe("search toggle — collapses when cleared externally", () => {
         repos={[]}
         sprints={[]}
         onChange={() => {}}
+        onOpenBoardSettings={() => {}}
       />,
     );
 
@@ -117,6 +121,7 @@ describe("search toggle — collapses when cleared externally", () => {
         repos={[]}
         sprints={[]}
         onChange={() => {}}
+        onOpenBoardSettings={() => {}}
       />,
     );
 
@@ -131,6 +136,7 @@ describe("search toggle — collapses when cleared externally", () => {
         repos={[]}
         sprints={[]}
         onChange={() => {}}
+        onOpenBoardSettings={() => {}}
       />,
     );
 

--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -6,7 +6,9 @@
 
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { Link } from "@tanstack/react-router";
 import { useT, type TranslationKey } from "@/i18n/use-t.ts";
+import { useProjectContext } from "@/sdk/context/project-context.tsx";
 import { currentSprintId } from "@decocms/shared/sprints";
 import { parseTaskKeySeq } from "@decocms/shared/task-key";
 import { Avatar } from "@decocms/ui/components/avatar.tsx";
@@ -48,6 +50,7 @@ import {
   FilterLines,
   Repeat04,
   SearchSm,
+  Settings02,
   Tag01,
   User01,
   X,
@@ -864,6 +867,25 @@ function SearchToggle({
   );
 }
 
+/** Icon-only link to the board's settings page. */
+function BoardSettingsLink({ block }: { block?: boolean }) {
+  const t = useT();
+  const { org } = useProjectContext();
+  const label = t("taskBoard.taskFilters.boardSettingsLabel");
+  return (
+    <Link
+      to="/$org/settings/task-board"
+      params={{ org: org.slug }}
+      aria-label={label}
+      title={label}
+      className={cn(chipClass(false, block), block && "justify-start")}
+    >
+      <Settings02 size={14} className="shrink-0" />
+      {block && <span>{label}</span>}
+    </Link>
+  );
+}
+
 /** The filter controls, shared by the inline bar and the mobile drawer. */
 function FilterControls({
   filters,
@@ -925,6 +947,7 @@ function FilterControls({
       {/* Same reasoning as the repo control: an active sprint filter keeps its
           chip visible even when the board mirrors no sprints, so the hidden
           cards can be brought back. */}
+      <BoardSettingsLink block={block} />
       {(sprints.length > 0 || filters.sprint !== null) && (
         <SprintFilter
           block={block}

--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -872,27 +872,34 @@ function SearchToggle({
   );
 }
 
-/** Icon-only link to the board's settings page, labeled by a hover tooltip. */
+/**
+ * Link to the board's settings page. Icon-only with a hover tooltip in the
+ * inline bar; in the mobile drawer (`block`) the tooltip never shows (Radix
+ * tooltips are hover/focus-only, and drawer taps are touch), so it renders
+ * the label as text instead, like every other drawer control.
+ */
 function BoardSettingsLink({ block }: { block?: boolean }) {
   const t = useT();
   const { org } = useProjectContext();
   const label = t("taskBoard.taskFilters.boardSettingsLabel");
+  const link = (
+    <Link
+      to="/$org/settings/task-board"
+      params={{ org: org.slug }}
+      aria-label={label}
+      className={cn(
+        chipClass(false, block),
+        block ? "h-10 w-full" : "w-8 justify-center px-0",
+      )}
+    >
+      <Settings02 size={14} className="shrink-0" />
+      {block && <span>{label}</span>}
+    </Link>
+  );
+  if (block) return link;
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <Link
-          to="/$org/settings/task-board"
-          params={{ org: org.slug }}
-          aria-label={label}
-          className={cn(
-            chipClass(false, block),
-            "w-8 justify-center px-0",
-            block && "h-10 w-10",
-          )}
-        >
-          <Settings02 size={14} className="shrink-0" />
-        </Link>
-      </TooltipTrigger>
+      <TooltipTrigger asChild>{link}</TooltipTrigger>
       <TooltipContent side="top">{label}</TooltipContent>
     </Tooltip>
   );

--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -34,6 +34,11 @@ import {
   PopoverTrigger,
 } from "@decocms/ui/components/popover.tsx";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@decocms/ui/components/tooltip.tsx";
+import {
   Command,
   CommandEmpty,
   CommandGroup,
@@ -867,22 +872,29 @@ function SearchToggle({
   );
 }
 
-/** Icon-only link to the board's settings page. */
+/** Icon-only link to the board's settings page, labeled by a hover tooltip. */
 function BoardSettingsLink({ block }: { block?: boolean }) {
   const t = useT();
   const { org } = useProjectContext();
   const label = t("taskBoard.taskFilters.boardSettingsLabel");
   return (
-    <Link
-      to="/$org/settings/task-board"
-      params={{ org: org.slug }}
-      aria-label={label}
-      title={label}
-      className={cn(chipClass(false, block), block && "justify-start")}
-    >
-      <Settings02 size={14} className="shrink-0" />
-      {block && <span>{label}</span>}
-    </Link>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Link
+          to="/$org/settings/task-board"
+          params={{ org: org.slug }}
+          aria-label={label}
+          className={cn(
+            chipClass(false, block),
+            "w-8 justify-center px-0",
+            block && "h-10 w-10",
+          )}
+        >
+          <Settings02 size={14} className="shrink-0" />
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent side="top">{label}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -6,9 +6,7 @@
 
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { Link } from "@tanstack/react-router";
 import { useT, type TranslationKey } from "@/i18n/use-t.ts";
-import { useProjectContext } from "@/sdk/context/project-context.tsx";
 import { currentSprintId } from "@decocms/shared/sprints";
 import { parseTaskKeySeq } from "@decocms/shared/task-key";
 import { Avatar } from "@decocms/ui/components/avatar.tsx";
@@ -873,19 +871,28 @@ function SearchToggle({
 }
 
 /**
- * Link to the board's settings page. Icon-only with a hover tooltip in the
- * inline bar; in the mobile drawer (`block`) the tooltip never shows (Radix
- * tooltips are hover/focus-only, and drawer taps are touch), so it renders
- * the label as text instead, like every other drawer control.
+ * Button to the board's settings page. Navigation itself is the caller's
+ * job (passed in as `onClick`) — this component stays presentational like
+ * the rest of the bar, with no router or org dependency of its own.
+ *
+ * Icon-only with a hover tooltip in the inline bar; in the mobile drawer
+ * (`block`) the tooltip never shows (Radix tooltips are hover/focus-only,
+ * and drawer taps are touch), so it renders the label as text instead, like
+ * every other drawer control.
  */
-function BoardSettingsLink({ block }: { block?: boolean }) {
+function BoardSettingsButton({
+  block,
+  onClick,
+}: {
+  block?: boolean;
+  onClick: () => void;
+}) {
   const t = useT();
-  const { org } = useProjectContext();
   const label = t("taskBoard.taskFilters.boardSettingsLabel");
-  const link = (
-    <Link
-      to="/$org/settings/task-board"
-      params={{ org: org.slug }}
+  const button = (
+    <button
+      type="button"
+      onClick={onClick}
       aria-label={label}
       className={cn(
         chipClass(false, block),
@@ -894,12 +901,12 @@ function BoardSettingsLink({ block }: { block?: boolean }) {
     >
       <Settings02 size={14} className="shrink-0" />
       {block && <span>{label}</span>}
-    </Link>
+    </button>
   );
-  if (block) return link;
+  if (block) return button;
   return (
     <Tooltip>
-      <TooltipTrigger asChild>{link}</TooltipTrigger>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
       <TooltipContent side="top">{label}</TooltipContent>
     </Tooltip>
   );
@@ -913,6 +920,7 @@ function FilterControls({
   repos,
   sprints,
   onChange,
+  onOpenBoardSettings,
   block,
 }: {
   filters: TaskFilters;
@@ -921,6 +929,7 @@ function FilterControls({
   repos: string[];
   sprints: Sprint[];
   onChange: (next: TaskFilters) => void;
+  onOpenBoardSettings: () => void;
   block?: boolean;
 }) {
   return (
@@ -963,10 +972,10 @@ function FilterControls({
           onChange={(repo) => onChange({ ...filters, repo })}
         />
       )}
+      <BoardSettingsButton block={block} onClick={onOpenBoardSettings} />
       {/* Same reasoning as the repo control: an active sprint filter keeps its
           chip visible even when the board mirrors no sprints, so the hidden
           cards can be brought back. */}
-      <BoardSettingsLink block={block} />
       {(sprints.length > 0 || filters.sprint !== null) && (
         <SprintFilter
           block={block}
@@ -987,6 +996,7 @@ export function TaskFiltersBar({
   repos,
   sprints,
   onChange,
+  onOpenBoardSettings,
 }: {
   filters: TaskFilters;
   members: Member[];
@@ -994,6 +1004,7 @@ export function TaskFiltersBar({
   repos: string[];
   sprints: Sprint[];
   onChange: (next: TaskFilters) => void;
+  onOpenBoardSettings: () => void;
 }) {
   const t = useT();
   return (
@@ -1009,6 +1020,7 @@ export function TaskFiltersBar({
         repos={repos}
         sprints={sprints}
         onChange={onChange}
+        onOpenBoardSettings={onOpenBoardSettings}
       />
       {hasActiveFilters(filters, currentSprintId(sprints)) && (
         <button
@@ -1035,6 +1047,7 @@ export function TaskFiltersDrawer({
   repos,
   sprints,
   onChange,
+  onOpenBoardSettings,
 }: {
   filters: TaskFilters;
   members: Member[];
@@ -1042,6 +1055,7 @@ export function TaskFiltersDrawer({
   repos: string[];
   sprints: Sprint[];
   onChange: (next: TaskFilters) => void;
+  onOpenBoardSettings: () => void;
 }) {
   const t = useT();
   const [open, setOpen] = useState(false);
@@ -1073,6 +1087,7 @@ export function TaskFiltersDrawer({
             repos={repos}
             sprints={sprints}
             onChange={onChange}
+            onOpenBoardSettings={onOpenBoardSettings}
           />
         </div>
         <DrawerFooter className="flex-row gap-2">


### PR DESCRIPTION
## Summary
Adds a settings cog icon to the task board's filter bar, immediately left of the Sprint filter, linking to Settings → Board (`/$org/settings/task-board`).

## Testing
- `bun run fmt`
- `tsc --noEmit` (touched files clean)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a settings cog to the task board's filter bar, left of the Sprint filter, linking to Settings → Board. The inline bar shows an icon-only button with a hover tooltip; the mobile drawer renders the label as text since tooltips don't work on touch. Navigation lives in the page component so the filter bar stays presentational and keeps working in unit tests.

<sup>Written for commit 8956566aa5e238420051f5b232deb3f58825c420. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

