### PR TITLE
fix(preview): recheck renderPending inside the already-scheduled hover rAF

### DIFF
--- a/apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
@@ -166,6 +166,14 @@ describe("CMS_EDITOR_SCRIPT", () => {
     );
     const moveGuard = CMS_EDITOR_SCRIPT.slice(moveStart, moveGuardEnd);
     expect(moveGuard).toContain("renderPending");
+    // The already-scheduled rAF callback must also recheck renderPending.
+    const rafBodyStart = CMS_EDITOR_SCRIPT.indexOf(
+      "rafPending = false;",
+      moveStart,
+    );
+    const rafBodyEnd = CMS_EDITOR_SCRIPT.indexOf("});", rafBodyStart);
+    const rafBody = CMS_EDITOR_SCRIPT.slice(rafBodyStart, rafBodyEnd);
+    expect(rafBody).toContain("if (renderPending) return;");
   });
 
   it("drops a bridge message whose source isn't this frame's parent", () => {

--- a/apps/web/src/components/sandbox/preview/cms-editor-script.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.ts
@@ -207,6 +207,7 @@ export const CMS_EDITOR_SCRIPT = `(function() {
     var target = e.target;
     requestAnimationFrame(function() {
       rafPending = false;
+      if (renderPending) return;
       if (!target || target === highlight || target === badge) return;
       var out = {};
       var section = findSection(target, out);


### PR DESCRIPTION
Follows #6807, which hid the CMS editor overlay when a Fast Preview in-place render starts, by guarding `moveHandler`'s entry point with a `renderPending` flag so a hover during the fetch can't re-show the overlay before the swap's view transition snapshots it.

That guard only runs when the mousemove event fires, not when the callback it schedules actually runs. A mousemove can schedule the `requestAnimationFrame` callback a few ms before the render starts; by the time that callback executes (next paint), `renderPending` is already true but the callback never checks it, so it repositions and re-shows the highlight/badge right as the transition is about to snapshot the page — reintroducing the exact flash #6807 set out to fix, just from a slightly later trigger.

**Fix**: recheck `renderPending` at the top of the rAF callback body in `moveHandler`, not just at the event-handler entry.

**Regression test**: extended the existing #6807 test in `cms-editor-script.test.ts` to also assert the rAF callback body contains `if (renderPending) return;`, in addition to the existing entry-guard assertion.

Reviewer check: `cd apps/web && bun test src/components/sandbox/preview/cms-editor-script.test.ts`

Locally ran: `bun run fmt`, targeted `bun test` (13 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Did not run the full `bunx tsc --noEmit` for apps/web — it fails on a pre-existing, unrelated prosemirror-model dual-install type conflict unrelated to this change; full CI covers typecheck.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition in the CMS editor hover overlay: a `mousemove` scheduled before an in-place render starts could re-show the highlight/badge right as the view transition snapshots the page, reintroducing the flash #6807 fixed. The rAF callback now rechecks `renderPending` before repositioning, not just the event-handler entry point.

- Extends the existing #6807 regression test in `cms-editor-script.test.ts` to assert the rAF callback contains the new guard.

<sup>Written for commit f1b335b7dc4c135073fd1efc5116a41858a7c2fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

