### PR TITLE
fix(web): tie the /watch SSE pool's HMR teardown to its own module

### DIFF
--- a/apps/web/src/components/chat/store/hooks.test.ts
+++ b/apps/web/src/components/chat/store/hooks.test.ts
@@ -18,6 +18,7 @@ import {
 
 const noopSse: SSESubscription = {
   subscribe: () => () => {},
+  dispose: () => {},
 };
 
 afterEach(() => {

--- a/apps/web/src/components/chat/store/thread-manager-store.test.ts
+++ b/apps/web/src/components/chat/store/thread-manager-store.test.ts
@@ -30,6 +30,7 @@ function makeFakePool(): FakePool {
   }
   const subs = new Map<string, Sub>();
   return {
+    dispose() {},
     subscribe(key, handler, onReconnect) {
       subs.set(key, { handler, onReconnect });
       return () => {

--- a/apps/web/src/hooks/create-sse-subscription.test.ts
+++ b/apps/web/src/hooks/create-sse-subscription.test.ts
@@ -12,7 +12,9 @@ class FakeEventSource {
     FakeEventSource.instances.push(this);
   }
   addEventListener(): void {}
-  close(): void {}
+  close(): void {
+    this.readyState = FakeEventSource.CLOSED;
+  }
 }
 
 describe("createSSESubscription", () => {
@@ -44,5 +46,23 @@ describe("createSSESubscription", () => {
     expect(FakeEventSource.instances[0]?.url).toBe("/watch/org1");
 
     unsubscribe();
+  });
+
+  it("dispose() closes every live connection", () => {
+    // Lets a call site's own import.meta.hot tear this down on reload.
+    const sub = createSSESubscription({
+      buildUrl: (key) => `/watch/${key}`,
+      eventTypes: ["foo"],
+    });
+
+    sub.subscribe("org1", () => {});
+    sub.subscribe("org2", () => {});
+    expect(FakeEventSource.instances.length).toBe(2);
+
+    sub.dispose();
+
+    for (const es of FakeEventSource.instances) {
+      expect(es.readyState).toBe(FakeEventSource.CLOSED);
+    }
   });
 });

--- a/apps/web/src/hooks/create-sse-subscription.ts
+++ b/apps/web/src/hooks/create-sse-subscription.ts
@@ -59,6 +59,15 @@ export interface SSESubscription {
     handler: Handler,
     onReconnect?: () => void,
   ) => () => void;
+  /**
+   * Tear down every live connection this subscription owns (closes each
+   * EventSource, releases any held Web Lock, closes each BroadcastChannel).
+   * For a module-scoped singleton, the caller's own `import.meta.hot.dispose`
+   * should call this — `import.meta.hot` here belongs to THIS file, so it only
+   * fires when create-sse-subscription.ts itself is edited, never when the
+   * call site (e.g. watch-sse-pool.ts) is hot-replaced.
+   */
+  dispose: () => void;
 }
 
 export function createSSESubscription(
@@ -241,17 +250,10 @@ export function createSSESubscription(
     connections.delete(conn.key);
   }
 
-  // HMR: release locks / channels so a dev reload doesn't orphan the Web Lock.
-  const hot = (
-    import.meta as unknown as { hot?: { dispose: (cb: () => void) => void } }
-  ).hot;
-  if (hot) {
-    hot.dispose(() => {
-      for (const conn of [...connections.values()]) teardown(conn);
-    });
-  }
-
   return {
+    dispose() {
+      for (const conn of [...connections.values()]) teardown(conn);
+    },
     subscribe(key, handler, onReconnect) {
       const isNew = !connections.has(key);
       const conn = getOrCreate(key);
@@ -284,6 +286,8 @@ export function filterEventTypes(
 ): SSESubscription {
   const allow = new Set(types);
   return {
+    // A view owns no connections of its own — disposing it disposes the base.
+    dispose: () => base.dispose(),
     subscribe(key, handler, onReconnect) {
       const wrapped: Handler = (e) => {
         if (allow.has(e.type)) handler(e);

--- a/apps/web/src/hooks/watch-sse-pool.ts
+++ b/apps/web/src/hooks/watch-sse-pool.ts
@@ -39,6 +39,11 @@ const watchSSE: SSESubscription = createSSESubscription({
   crossTab: true,
 });
 
+// This module's own `import.meta.hot` — fires when THIS file hot-reloads.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => watchSSE.dispose());
+}
+
 /** Decopilot thread events (step / finish / thread.status). */
 export const decopilotWatchView: SSESubscription = filterEventTypes(watchSSE, [
   ...ALL_DECOPILOT_EVENT_TYPES,


### PR DESCRIPTION
Bug found while hunting the "chat hot-reload resilient" area (issue #2711's original scope no longer applies — it targets the removed `apps/mesh` paths and was already flagged too-large by a maintainer; see prior session notes). The chat sidebar's live-update stream (`watch-sse-pool.ts`, consumed by `thread-manager-store.ts` for the thread list and `use-decopilot-events.ts` for step/finish events) shares one cross-tab `EventSource` + Web Lock + BroadcastChannel created by `createSSESubscription()`.

**The bug**: that factory registered its HMR teardown on `import.meta.hot` *inside create-sse-subscription.ts itself* — which only fires when that file is edited. The actual call site, `watch-sse-pool.ts`, is the file someone edits in normal dev work (e.g. adding a new watched event type), and hot-reloading it never triggered that teardown. Each such reload created a brand-new `EventSource`/Web-Lock/BroadcastChannel instance without releasing the previous one — an orphaned connection and a stale Web Lock the new instance then has to contend with, silently degrading live chat/task-board/notification updates in dev until a full page reload.

**Fix**: `SSESubscription` now exposes a `dispose()` method that tears down every live connection it owns. `watch-sse-pool.ts` calls it from its *own* `import.meta.hot.dispose`, so the module that actually gets hot-replaced is the one responsible for tearing itself down.

Failure scenario before the fix: edit `watch-sse-pool.ts` while `bun run dev` is running with the chat sidebar open → old EventSource left open, new one races it for the Web Lock → live thread-status/task-board updates can silently stop until a hard reload.

Regression test: `apps/web/src/hooks/create-sse-subscription.test.ts` — asserts `dispose()` closes every EventSource created by a subscription (previously nothing exercised teardown at all beyond the module's own edit).

Reviewer check: `cd apps/web && bun test src/hooks/create-sse-subscription.test.ts`.

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (no new errors in touched files), `bun test apps/web/src/hooks/create-sse-subscription.test.ts` (pass), `bunx oxlint` on the three touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the /watch SSE pool's hot-reload teardown so editing `watch-sse-pool.ts` during dev no longer leaves orphaned `EventSource` connections and stale Web Locks.

Teardown was previously registered in `create-sse-subscription.ts`'s own `import.meta.hot`, which only fires when that file is edited — hot-reloading the call site created a new connection without releasing the previous one. `SSESubscription` now exposes a `dispose()` method that closes every live connection, and `watch-sse-pool.ts` calls it from its own `import.meta.hot.dispose`.

**Bug Fixes**
- Editing `watch-sse-pool.ts` no longer leaks connections or orphans the Web Lock.
- Adds a regression test verifying `dispose()` closes every `EventSource` owned by a subscription.
- Test fakes now implement `dispose()` to match the extended interface.

<sup>Written for commit ebd96379633041d3aed42d1f2a23434b2cbb6cc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

