### PR TITLE
fix(storage): honor an explicit limit: 0 in ConnectionStorage.list

### DIFF
--- a/apps/api/src/storage/connection.integration.test.ts
+++ b/apps/api/src/storage/connection.integration.test.ts
@@ -386,6 +386,15 @@ describe("ConnectionStorage", () => {
       expect(page2.items.every((c) => !page1Ids.has(c.id))).toBe(true);
     });
 
+    it("should return zero items for an explicit limit of 0, not the whole page", async () => {
+      const { items, totalCount } = await storage.list("org_123", {
+        limit: 0,
+        offset: 0,
+      });
+      expect(items).toHaveLength(0);
+      expect(totalCount).toBeGreaterThanOrEqual(3);
+    });
+
     it("should return correct totalCount with filters", async () => {
       const { totalCount } = await storage.list("org_123", {
         where: { field: ["connection_type"], operator: "eq", value: "HTTP" },

--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -384,8 +384,8 @@ export class ConnectionStorage implements ConnectionStoragePort {
       }
     }
 
-    // Apply pagination
-    if (options?.limit) {
+    // Apply pagination. `!== undefined`, not truthiness — an explicit `limit: 0` must return zero rows, not "no limit".
+    if (options?.limit !== undefined) {
       query = query.limit(options.limit);
     }
     if (options?.offset) {


### PR DESCRIPTION
Bug found while hardening the MCP connection storage layer (`apps/api/src/storage/connection.ts`, this tick's focus area).

**The bug:** `list()`'s pagination guard was `if (options?.limit) { query = query.limit(options.limit); }`. Since `0` is falsy, an explicit `limit: 0` is silently treated as "no limit" and the SQL LIMIT clause is skipped entirely — the query returns every connection row in the organization instead of zero.

**Why it's reachable in production, not just theoretical:** `CONNECTION_LIST` (`apps/api/src/tools/connection/list.ts`) calls `resolveDevAssetsSqlWindow(offset, limit, devAssetsQualifies)` (`apps/api/src/tools/connection/dev-assets-page.ts:45`), which computes `sqlLimit = Math.max(limit - 1, 0)` when the synthetic dev-assets entry consumes the page's only slot. For a caller requesting `limit: 1` on the first page, `sqlLimit` is exactly `0` — meaning `ConnectionStorage.list()` gets called with `limit: 0` and, instead of correctly returning zero real connections for that page, returns the org's entire connection list.

**Fix:** switch the guard to `!== undefined`, matching the pattern already used for `where`/`orderBy` in the same function.

**Regression test:** added `"should return zero items for an explicit limit of 0, not the whole page"` in `connection.integration.test.ts`, alongside the existing pagination tests, asserting `items` is empty while `totalCount` still reflects the real row count.

**To verify:** `bun test apps/api/src/storage/connection.integration.test.ts` (needs Postgres — CI runs this; I don't have Docker/Postgres in this worktree).

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both touched files (0 warnings/errors). Full CI (including the integration suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ConnectionStorage.list()` so an explicit `limit: 0` returns zero items instead of being treated as "no limit" and returning every connection in the organization.

**Bug Fixes**
- Changed the pagination guard from a truthiness check to `!== undefined`, matching the pattern already used for `where` and `orderBy`.
- This was reachable from `CONNECTION_LIST`: the dev-assets window computes `sqlLimit: 0` when a caller requests `limit: 1` on the first page, so the whole org list was returned instead of an empty page.
- Added a regression test asserting zero items with `totalCount` still reflecting the real row count.

<sup>Written for commit eda707f1df70ad43a6b824191fb88d006fdec707. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

