### PR TITLE
refactor(storage): dedupe the org-settings upsert's per-field JSON stringify

### DIFF
--- a/apps/api/src/storage/organization-settings.ts
+++ b/apps/api/src/storage/organization-settings.ts
@@ -11,6 +11,11 @@ function parseJsonColumn<T>(value: unknown): T | null {
   return (typeof value === "string" ? JSON.parse(value) : value) as T;
 }
 
+/** Stringify a JSON column's write value, or null when it's absent/empty. */
+function toJsonColumn(value: unknown): string | null {
+  return value ? JSON.stringify(value) : null;
+}
+
 export class OrganizationSettingsStorage
   implements OrganizationSettingsStoragePort
 {
@@ -67,50 +72,35 @@ export class OrganizationSettingsStorage
     >,
   ): Promise<OrganizationSettings> {
     const now = new Date().toISOString();
-    const sidebarItemsJson = data?.sidebar_items
-      ? JSON.stringify(data.sidebar_items)
-      : null;
-    const enabledPluginsJson = data?.enabled_plugins
-      ? JSON.stringify(data.enabled_plugins)
-      : null;
-    const registryConfigJson = data?.registry_config
-      ? JSON.stringify(data.registry_config)
-      : null;
-    const simpleModeJson = data?.simple_mode
-      ? JSON.stringify(data.simple_mode)
-      : null;
-    const defaultHomeAgentsJson = data?.default_home_agents
-      ? JSON.stringify(data.default_home_agents)
-      : null;
-    const flagsJson = data?.flags ? JSON.stringify(data.flags) : null;
+    const json = {
+      sidebar_items: toJsonColumn(data?.sidebar_items),
+      enabled_plugins: toJsonColumn(data?.enabled_plugins),
+      registry_config: toJsonColumn(data?.registry_config),
+      simple_mode: toJsonColumn(data?.simple_mode),
+      default_home_agents: toJsonColumn(data?.default_home_agents),
+      flags: toJsonColumn(data?.flags),
+    };
     await this.db
       .insertInto("organization_settings")
       .values({
         organizationId,
-        sidebar_items: sidebarItemsJson,
-        enabled_plugins: enabledPluginsJson,
-        registry_config: registryConfigJson,
-        simple_mode: simpleModeJson,
-        default_home_agents: defaultHomeAgentsJson,
-        flags: flagsJson,
+        ...json,
         main_agent_id: data?.main_agent_id ?? null,
         createdAt: now,
         updatedAt: now,
       })
       .onConflict((oc) =>
         oc.column("organizationId").doUpdateSet({
-          sidebar_items: sidebarItemsJson ? sidebarItemsJson : undefined,
-          enabled_plugins: enabledPluginsJson ? enabledPluginsJson : undefined,
-          registry_config: registryConfigJson ? registryConfigJson : undefined,
-          simple_mode: simpleModeJson ? simpleModeJson : undefined,
-          default_home_agents: defaultHomeAgentsJson
-            ? defaultHomeAgentsJson
-            : undefined,
+          sidebar_items: json.sidebar_items ?? undefined,
+          enabled_plugins: json.enabled_plugins ?? undefined,
+          registry_config: json.registry_config ?? undefined,
+          simple_mode: json.simple_mode ?? undefined,
+          default_home_agents: json.default_home_agents ?? undefined,
           // Flags shallow-merge atomically: keys in the update win, omitted
           // keys keep their stored value (explicit `false` persists — merge,
           // not spread-and-replace). Absent field skips the column.
-          flags: flagsJson
-            ? sql<string>`coalesce("organization_settings"."flags", '{}'::jsonb) || ${flagsJson}::jsonb`
+          flags: json.flags
+            ? sql<string>`coalesce("organization_settings"."flags", '{}'::jsonb) || ${json.flags}::jsonb`
             : undefined,
           // Nullable id: explicit `null` clears the main agent; `undefined`
           // (field absent) skips the column so partial updates don't wipe it.


### PR DESCRIPTION
**Source**: reduction found while auditing `apps/api/src/storage/organization-settings.ts` (assigned focus area: API storage core types & org settings) for config-merging simplification opportunities. No linked issue.

**Why**: `upsert()` had six near-identical `data?.field ? JSON.stringify(data.field) : null` blocks, each field's stringified value then re-tested with `fooJson ? fooJson : undefined` a few lines later for the `onConflict().doUpdateSet()` call. That's six copies of the same two-step pattern in one function — a new settings field means copy-pasting it a seventh time. Collapsed into one `toJsonColumn` helper plus a single `json` object literal reused for both the insert `values()` and the conflict `doUpdateSet()`.

**Net diff**: -31 / +21 lines in one file, one function.

**Behavior preserved** (verified by reading, not guessing):
- Insert path: `...json` spreads the same six string-or-null values previously assigned individually — identical values, same keys.
- Update path: `json.field ?? undefined` is equivalent to the old `fooJson ? fooJson : undefined` because `toJsonColumn` only ever returns `null` or a non-empty JSON string (`JSON.stringify` of a truthy value is never `""`), so `??` and the truthy-ternary agree on every possible value.
- `flags`' shallow-merge SQL (`coalesce(...) || ...::jsonb`) and `main_agent_id`'s explicit-null-clears/absent-skips handling are untouched — both still branch on the same conditions as before.

**How to confirm**: read the diff — it's a pure extract-and-reuse, same field list, same null semantics. The existing flags-merge and main_agent_id nullability integration tests in `apps/api/src/storage/organization-settings.integration.test.ts` (Postgres-only, not run in this environment) cover the invariants this refactor must not disturb.

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/tools/organization/settings-update.test.ts` (6 pass — mocked, doesn't exercise this function directly but guards the caller), `bunx oxlint apps/api/src/storage/organization-settings.ts` (0 warnings/errors). Full CI (including the Postgres-backed integration test) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the org-settings upsert so six near-identical JSON stringify blocks become one `toJsonColumn` helper and a single `json` object reused for both the insert values and the conflict update. Behavior stays the same—same field list, same null semantics.

**Refactors**
- `json.field ?? undefined` matches the old `fooJson ? fooJson : undefined` because `JSON.stringify` of a truthy value is never an empty string.
- Flags' shallow-merge SQL and `main_agent_id` nullability handling are untouched.
- Existing Postgres integration tests cover the invariants this refactor must not disturb.

<sup>Written for commit e18e3a312c339ea3f8d0a0e158928246944d6c3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

