### PR TITLE
fix(harness): stop duplicating the text block that follows a thinking block

### DIFF
--- a/packages/harness-runner/to-ui-chunks.test.ts
+++ b/packages/harness-runner/to-ui-chunks.test.ts
@@ -154,6 +154,7 @@ describe("UiChunkTranslator — token streaming (includePartialMessages)", () =>
   test("a text block streams start/delta/end as the events arrive", () => {
     const t = new UiChunkTranslator();
     expect(t.translate(streamEvent({ type: "message_start" }))).toEqual([]);
+    // The part opens on the first delta, not on the block start.
     const start = t.translate(
       streamEvent({
         type: "content_block_start",
@@ -161,7 +162,7 @@ describe("UiChunkTranslator — token streaming (includePartialMessages)", () =>
         content_block: { type: "text", text: "" },
       }),
     );
-    expect(start).toEqual([{ type: "text-start", id: "stream-1" }]);
+    expect(start).toEqual([]);
     expect(
       t.translate(
         streamEvent({
@@ -170,7 +171,10 @@ describe("UiChunkTranslator — token streaming (includePartialMessages)", () =>
           delta: { type: "text_delta", text: "Hel" },
         }),
       ),
-    ).toEqual([{ type: "text-delta", id: "stream-1", delta: "Hel" }]);
+    ).toEqual([
+      { type: "text-start", id: "stream-1" },
+      { type: "text-delta", id: "stream-1", delta: "Hel" },
+    ]);
     expect(
       t.translate(
         streamEvent({
@@ -196,7 +200,7 @@ describe("UiChunkTranslator — token streaming (includePartialMessages)", () =>
           content_block: { type: "thinking", thinking: "" },
         }),
       ),
-    ).toEqual([{ type: "reasoning-start", id: "stream-1" }]);
+    ).toEqual([]);
     expect(
       t.translate(
         streamEvent({
@@ -205,7 +209,10 @@ describe("UiChunkTranslator — token streaming (includePartialMessages)", () =>
           delta: { type: "thinking_delta", thinking: "hmm" },
         }),
       ),
-    ).toEqual([{ type: "reasoning-delta", id: "stream-1", delta: "hmm" }]);
+    ).toEqual([
+      { type: "reasoning-start", id: "stream-1" },
+      { type: "reasoning-delta", id: "stream-1", delta: "hmm" },
+    ]);
     // Not renderable text — and it must not be appended to the reasoning part.
     expect(
       t.translate(
@@ -378,7 +385,7 @@ describe("UiChunkTranslator — token streaming (includePartialMessages)", () =>
     ]);
   });
 
-  test("a second message's indices are not skipped by the first's", () => {
+  test("a second API message's indices are not skipped by the first's", () => {
     const t = new UiChunkTranslator();
     t.translate(streamEvent({ type: "message_start" }));
     t.translate(
@@ -388,13 +395,99 @@ describe("UiChunkTranslator — token streaming (includePartialMessages)", () =>
         content_block: { type: "text", text: "" },
       }),
     );
+    t.translate(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "first" },
+      }),
+    );
     t.translate(streamEvent({ type: "content_block_stop", index: 0 }));
-    t.translate(assistant([{ type: "text", text: "first" }]));
-    // A message the SDK did NOT stream (index 0 again) must still be emitted.
+    expect(t.translate(assistant([{ type: "text", text: "first" }]))).toEqual(
+      [],
+    );
+    // An unstreamed new message still emits, though its block is at index 0 too.
+    t.translate(streamEvent({ type: "message_start" }));
     expect(t.translate(assistant([{ type: "text", text: "second" }]))).toEqual([
       { type: "text-start", id: "u1-2" },
       { type: "text-delta", id: "u1-2", delta: "second" },
       { type: "text-end", id: "u1-2" },
+    ]);
+  });
+
+  test("the text after a thinking block is streamed once, not twice", () => {
+    // One `assistant` message per block: the text arrives at local index 0.
+    const t = new UiChunkTranslator();
+    t.translate(streamEvent({ type: "message_start" }));
+    t.translate(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "thinking", thinking: "" },
+      }),
+    );
+    t.translate(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "thinking_delta", thinking: "weighing it" },
+      }),
+    );
+    t.translate(streamEvent({ type: "content_block_stop", index: 0 }));
+    expect(
+      t.translate(assistant([{ type: "thinking", thinking: "weighing it" }])),
+    ).toEqual([]);
+    t.translate(
+      streamEvent({
+        type: "content_block_start",
+        index: 1,
+        content_block: { type: "text", text: "" },
+      }),
+    );
+    t.translate(
+      streamEvent({
+        type: "content_block_delta",
+        index: 1,
+        delta: { type: "text_delta", text: "The answer." },
+      }),
+    );
+    t.translate(streamEvent({ type: "content_block_stop", index: 1 }));
+    expect(
+      t.translate(assistant([{ type: "text", text: "The answer." }])),
+    ).toEqual([]);
+  });
+
+  test("a thinking block that streamed no text is restated in full", () => {
+    // This SDK sends only `signature_delta`, so the text is the message's alone.
+    const t = new UiChunkTranslator();
+    t.translate(streamEvent({ type: "message_start" }));
+    expect(
+      t.translate(
+        streamEvent({
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "thinking", thinking: "" },
+        }),
+      ),
+    ).toEqual([]);
+    expect(
+      t.translate(
+        streamEvent({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "signature_delta", signature: "sig" },
+        }),
+      ),
+    ).toEqual([]);
+    expect(
+      t.translate(streamEvent({ type: "content_block_stop", index: 0 })),
+    ).toEqual([]);
+    expect(
+      t.translate(assistant([{ type: "thinking", thinking: "weighing it" }])),
+    ).toEqual([
+      { type: "reasoning-start", id: "u1-2" },
+      { type: "reasoning-delta", id: "u1-2", delta: "weighing it" },
+      { type: "reasoning-end", id: "u1-2" },
     ]);
   });
 });

--- a/packages/harness-runner/to-ui-chunks.ts
+++ b/packages/harness-runner/to-ui-chunks.ts
@@ -123,21 +123,39 @@ export class UiChunkTranslator {
   private readonly announcedToolCalls = new Set<string>();
   private blockSeq = 0;
   /**
-   * Text/reasoning blocks opened from `stream_event` and not yet closed, keyed
+   * Text/reasoning blocks announced by `stream_event` and not yet closed, keyed
    * by the Anthropic content-block index. Holds the minted chunk id so the
    * deltas and the end land on the part the start opened.
+   *
+   * `started` is false until the block streams its first RENDERABLE delta, and
+   * the `-start` chunk waits for that. A thinking block whose only deltas are
+   * `signature_delta` — which is what this SDK sends — otherwise became an
+   * empty part that ALSO suppressed the `assistant` message's restatement, so
+   * the model's reasoning was dropped entirely.
    */
   private readonly openStreamBlocks = new Map<
     number,
-    { id: string; kind: "text" | "reasoning" }
+    { id: string; kind: "text" | "reasoning"; started: boolean }
   >();
   /**
-   * Content-block indices of the message currently streaming that were already
-   * emitted as deltas. The `assistant` message restates every block, so these
-   * are skipped there — the same index is positional in both, which is what
-   * makes the skip safe.
+   * Content-block indices of the message currently streaming that actually
+   * emitted deltas. The `assistant` message restates every block, so these are
+   * skipped there.
    */
   private readonly streamedIndices = new Set<number>();
+  /**
+   * How many of the current API message's content blocks the `assistant`
+   * messages have already restated.
+   *
+   * The SDK sends ONE `assistant` message per content block, each carrying a
+   * single-element `content` array — so a block's position inside that array is
+   * always 0, while `streamedIndices` holds its position inside the whole API
+   * message. The two coincide only for the message's FIRST block; every later
+   * one (the text after a thinking block, the second of two text blocks) looked
+   * un-streamed and was restated on top of its own deltas, duplicating it. This
+   * cursor maps the one space onto the other.
+   */
+  private restatedBlocks = 0;
   /**
    * Prompt tokens of the most recent API call — how full the model's context
    * actually was. Read by `turnFinishChunks`; `result.usage` cannot supply it
@@ -179,6 +197,7 @@ export class UiChunkTranslator {
     if (event.type === "message_start") {
       const chunks = this.closeOpenStreamBlocks();
       this.streamedIndices.clear();
+      this.restatedBlocks = 0;
       return chunks;
     }
     const index = event.index;
@@ -194,10 +213,13 @@ export class UiChunkTranslator {
             : null;
       // tool_use blocks are announced from the `assistant` message instead.
       if (!kind) return [];
-      const id = this.nextBlockId("stream");
-      this.openStreamBlocks.set(index, { id, kind });
-      this.streamedIndices.add(index);
-      return [{ type: `${kind}-start`, id } as UIMessageChunk];
+      // Opened by the first delta — see `started` on `openStreamBlocks`.
+      this.openStreamBlocks.set(index, {
+        id: this.nextBlockId("stream"),
+        kind,
+        started: false,
+      });
+      return [];
     }
     if (event.type === "content_block_delta") {
       const open = this.openStreamBlocks.get(index);
@@ -212,18 +234,27 @@ export class UiChunkTranslator {
       // `signature_delta` on a thinking block, `input_json_delta` on a tool
       // call: both arrive here and neither is renderable text.
       if (text === null || text.length === 0) return [];
-      return [
-        {
-          type: `${open.kind}-delta`,
+      const chunks: UIMessageChunk[] = [];
+      if (!open.started) {
+        open.started = true;
+        this.streamedIndices.add(index);
+        chunks.push({
+          type: `${open.kind}-start`,
           id: open.id,
-          delta: text,
-        } as UIMessageChunk,
-      ];
+        } as UIMessageChunk);
+      }
+      chunks.push({
+        type: `${open.kind}-delta`,
+        id: open.id,
+        delta: text,
+      } as UIMessageChunk);
+      return chunks;
     }
     if (event.type === "content_block_stop") {
       const open = this.openStreamBlocks.get(index);
       if (!open) return [];
       this.openStreamBlocks.delete(index);
+      if (!open.started) return [];
       return [{ type: `${open.kind}-end`, id: open.id } as UIMessageChunk];
     }
     return [];
@@ -245,6 +276,7 @@ export class UiChunkTranslator {
     if (this.openStreamBlocks.size === 0) return [];
     const chunks: UIMessageChunk[] = [];
     for (const open of this.openStreamBlocks.values()) {
+      if (!open.started) continue;
       chunks.push({ type: `${open.kind}-end`, id: open.id } as UIMessageChunk);
     }
     this.openStreamBlocks.clear();
@@ -267,10 +299,10 @@ export class UiChunkTranslator {
     // Anything the stream left open belongs to this message and must close
     // before its blocks are restated.
     const chunks: UIMessageChunk[] = this.closeOpenStreamBlocks();
-    for (const [index, block] of message.message.content.entries()) {
+    for (const [offset, block] of message.message.content.entries()) {
       if (!isRecord(block)) continue;
-      // Already emitted as deltas — restating it here would duplicate the text.
-      const streamed = this.streamedIndices.has(index);
+      // Already emitted as deltas — restating it would duplicate the text.
+      const streamed = this.streamedIndices.has(this.restatedBlocks + offset);
       if (block.type === "text" && typeof block.text === "string") {
         if (streamed) continue;
         // Empty text blocks are real in the SDK stream (a turn that only made
@@ -305,8 +337,8 @@ export class UiChunkTranslator {
         });
       }
     }
-    // This message is fully accounted for; the next one's indices are its own.
-    this.streamedIndices.clear();
+    // These blocks are accounted for; the next message restates the ones after.
+    this.restatedBlocks += message.message.content.length;
     return chunks;
   }
 


### PR DESCRIPTION
## What

The Claude Agent SDK emits **one `assistant` message per content block**, each carrying a single-element `content` array. `UiChunkTranslator.translateAssistant` compared that array's position against `streamedIndices`, which holds the block's index **in the whole API message**. The two only coincide for the message's *first* block.

So on the common `thinking@0, text@1` turn:

- thinking arrives as its own `assistant` message, local index 0 → matches → correctly skipped
- text arrives as its own `assistant` message, local index 0 → but it streamed at index 1 → looks un-streamed → **restated in full on top of its own deltas**

The answer is persisted twice, byte-identical, at adjacent `seq`, and the chat renders it twice.

Reproduced against the live SDK (`content_block_start idx=0 thinking` → `assistant ["thinking"]` → `content_block_start idx=1 text` → `assistant ["text"]`), and the translator emitted `stream-2` deltas followed by a full `…-3` restatement of the same text.

## Blast radius

Regression from #6670 (`includePartialMessages`, 2026-08-28). Prod `thread_message_parts`:

| day | claude-subscription dups | other providers |
|---|---|---|
| 08-21 … 08-27 | **0** | 0–3/day |
| 08-28 | 7 | 9 |
| 08-31 | 8 | 5 |
| 09-01 | 6 | 12 |

Zero before the reland, a steady stream after. (The non-claude-subscription column is a pre-existing ~2-3/day baseline on the decopilot/AI-SDK path — different mechanism, not touched here.)

Reported from https://studio.decocms.com/osklen/agents/vir_RIta1xMRqYmYPTsd2__rN?thread=330937e3-4654-4df9-8462-d0cde730657e — all four assistant turns duplicated. `usage.outputTokens` (642) is well under two copies of the 1426-char answer, so the model wrote it once.

## Fix

1. A `restatedBlocks` cursor maps the assistant-message space onto the stream space, so the skip set is consulted with the block's real index. `streamedIndices` is now cleared only at `message_start` — the actual API-message boundary — instead of after every `assistant` message.

2. **Second bug, same wrong assumption.** The `-start` chunk fired on `content_block_start`, which marked the block *streamed* even when its only deltas were `signature_delta` — which is all this SDK sends for thinking. The part stayed empty **and** the restatement was suppressed, so every reasoning part in prod today is `{"text": "", "state": "done"}` and the model's thinking is dropped outright. The part now opens on the first renderable delta, so an unstreamed block is restated in full and the reasoning survives.

## Tests

`packages/harness-runner/to-ui-chunks.test.ts`:

- **new** — `the text after a thinking block is streamed once, not twice` (the exact prod sequence)
- **new** — `a thinking block that streamed no text is restated in full`
- **inverted** — the two streaming tests that asserted `-start` on `content_block_start` now assert it rides the first delta
- **inverted** — `a second API message's indices are not skipped by the first's` had encoded the bug (a started-but-empty block suppressing restatement); it now drives a real second `message_start`

80 pass, 0 fail. `bun run fmt`, `bun run lint`, and `bun run --cwd=packages/harness-runner check` are clean.

## Deploy note

`packages/harness-runner` is packed into the sandbox image, so this needs an image build to reach running pods.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the harness UI chunk translator duplicating text that follows a thinking block, and restores reasoning text that was previously dropped.

- Assistant message positions are now mapped to stream indices, so only the correctly streamed block is skipped.
- Thinking blocks that stream only a signature delta no longer suppress the full restatement; the part opens on the first renderable delta.
- Adds regression tests for both scenarios.
- Requires a sandbox image build to reach running pods.

<sup>Written for commit ccf30343b5283417cf820a165d0941ca3d758516. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

