### PR TITLE
feat(skills): paginate the Settings skills grid

### DIFF
--- a/apps/api/src/api/routes/org-fs.ts
+++ b/apps/api/src/api/routes/org-fs.ts
@@ -58,7 +58,10 @@ import {
   isPublicVolume,
   publicVolumeForSet,
 } from "@/file-storage/public-sets";
-import { buildSkillCatalog } from "@/file-storage/skill-catalog";
+import {
+  buildSkillCatalog,
+  paginateSkillCatalog,
+} from "@/file-storage/skill-catalog";
 import {
   SKILL_TAR_MAX_BYTES,
   selectSkillFiles,
@@ -553,6 +556,11 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
   // <available-skills> (buildSkillCatalog: home + home/skills + public sets), so
   // the agent link picker and the run can never drift on what "a skill" is.
   // Volume-less; lives above the `/:volume/*` routes. Member-gated read.
+  //
+  // `?limit=` opts into the paged envelope ({ skills, nextCursor, sources },
+  // narrowed by `q` + `source`) that the Settings grid scrolls through. Without
+  // it the response is the whole catalog, unchanged — the shape the link picker
+  // and the chat "/" picker read.
   app.get("/skills", async (c) => {
     const ctx = c.get("studioContext");
     if (!ctx.auth?.user?.id) {
@@ -564,9 +572,19 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
     const denied = await checkPermission(c, ctx, "ORG_FS_READ");
     if (denied) return denied;
     try {
-      return c.json({
-        skills: await buildSkillCatalog(ctx, ctx.organization.id),
-      });
+      const catalog = await buildSkillCatalog(ctx, ctx.organization.id);
+      const limit = Number(c.req.query("limit"));
+      if (!Number.isFinite(limit) || limit <= 0) {
+        return c.json({ skills: catalog });
+      }
+      return c.json(
+        paginateSkillCatalog(catalog, {
+          limit,
+          cursor: c.req.query("cursor"),
+          q: c.req.query("q"),
+          source: c.req.query("source"),
+        }),
+      );
     } catch (err) {
       return fsErrorResponse(c, err);
     }

--- a/apps/api/src/file-storage/skill-catalog.test.ts
+++ b/apps/api/src/file-storage/skill-catalog.test.ts
@@ -1,0 +1,94 @@
+/** `paginateSkillCatalog` — pure list logic, so the unit tier. See TESTING.md. */
+
+import { describe, expect, it } from "bun:test";
+import { paginateSkillCatalog, type SkillCatalogEntry } from "./skill-catalog";
+
+function entry(
+  name: string,
+  source = "home",
+  description: string | null = null,
+): SkillCatalogEntry {
+  return {
+    id: `${source}/${name}`,
+    name,
+    description,
+    source,
+    sandboxPath: `org/home/${name}`,
+    volume: "home",
+    path: name,
+  };
+}
+
+const CATALOG = [
+  entry("zulu"),
+  entry("alpha", "public:core", "makes slides"),
+  entry("mike", "repo:docs"),
+  entry("bravo"),
+];
+
+describe("paginateSkillCatalog", () => {
+  it("sorts alphabetically by name and walks the cursor to the end", () => {
+    const first = paginateSkillCatalog(CATALOG, { limit: 2 });
+    expect(first.skills.map((s) => s.name)).toEqual(["alpha", "bravo"]);
+    expect(first.nextCursor).toBe("2");
+
+    const second = paginateSkillCatalog(CATALOG, {
+      limit: 2,
+      cursor: first.nextCursor,
+    });
+    expect(second.skills.map((s) => s.name)).toEqual(["mike", "zulu"]);
+    expect(second.nextCursor).toBeUndefined();
+  });
+
+  it("breaks name ties on id so a cursor can't skip or repeat an entry", () => {
+    const dupes = [entry("same", "repo:b"), entry("same", "public:a")];
+    const page = paginateSkillCatalog(dupes, { limit: 1 });
+    expect(page.skills[0]?.id).toBe("public:a/same");
+    expect(
+      paginateSkillCatalog(dupes, { limit: 1, cursor: page.nextCursor })
+        .skills[0]?.id,
+    ).toBe("repo:b/same");
+  });
+
+  it("searches name and description, case-insensitively", () => {
+    expect(
+      paginateSkillCatalog(CATALOG, { limit: 10, q: "SLIDES" }).skills.map(
+        (s) => s.name,
+      ),
+    ).toEqual(["alpha"]);
+  });
+
+  it("filters by source without narrowing the chips", () => {
+    const page = paginateSkillCatalog(CATALOG, { limit: 10, source: "home" });
+    expect(page.skills.map((s) => s.name)).toEqual(["bravo", "zulu"]);
+    expect(page.sources).toEqual([
+      { source: "home", count: 2 },
+      { source: "public:core", count: 1 },
+      { source: "repo:docs", count: 1 },
+    ]);
+  });
+
+  it("keeps a source charted at 0 when the search empties it", () => {
+    const page = paginateSkillCatalog(CATALOG, { limit: 10, q: "zulu" });
+    expect(page.sources).toEqual([
+      { source: "home", count: 1 },
+      { source: "public:core", count: 0 },
+      { source: "repo:docs", count: 0 },
+    ]);
+  });
+
+  it("clamps a junk cursor and an oversized limit", () => {
+    expect(
+      paginateSkillCatalog(CATALOG, { limit: 1e6, cursor: "-5" }).skills,
+    ).toHaveLength(4);
+    expect(
+      paginateSkillCatalog(CATALOG, { limit: 10, cursor: "nonsense" }).skills,
+    ).toHaveLength(4);
+  });
+
+  it("reports no next page when the cursor lands past the end", () => {
+    const page = paginateSkillCatalog(CATALOG, { limit: 2, cursor: "99" });
+    expect(page.skills).toEqual([]);
+    expect(page.nextCursor).toBeUndefined();
+  });
+});

--- a/apps/api/src/file-storage/skill-catalog.ts
+++ b/apps/api/src/file-storage/skill-catalog.ts
@@ -226,3 +226,66 @@ export async function buildSkillCatalog(
     (a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id),
   );
 }
+
+/** One page of the catalog, as `/fs/skills` serves it when given a `limit`. */
+export interface SkillCatalogPage {
+  skills: SkillCatalogEntry[];
+  /** Opaque cursor for the next page; absent on the last one. */
+  nextCursor?: string;
+  /**
+   * Every source in the catalog with how many entries match `q` — the filter
+   * chips, which must keep listing a source even when the search empties it.
+   */
+  sources: Array<{ source: string; count: number }>;
+}
+
+/** Hard ceiling on `limit`, so a caller can't ask for the whole catalog back. */
+const MAX_PAGE_SIZE = 100;
+
+/**
+ * Search, filter, sort and slice a built catalog for the Settings → Skills
+ * grid. Alphabetical by display name (`id` breaks ties, since two sets may
+ * ship the same skill name) — the order a member scans, unlike the
+ * `(source, id)` order `buildSkillCatalog` emits for the prompt block.
+ */
+export function paginateSkillCatalog(
+  entries: SkillCatalogEntry[],
+  opts: { q?: string; source?: string; limit: number; cursor?: string },
+): SkillCatalogPage {
+  const q = (opts.q ?? "").trim().toLowerCase();
+  const searched = q
+    ? entries.filter(
+        (e) =>
+          e.name.toLowerCase().includes(q) ||
+          (e.description ?? "").toLowerCase().includes(q),
+      )
+    : entries;
+
+  // Seeded from the whole catalog so a source that `q` empties still shows a
+  // chip (reading 0), rather than vanishing and stranding it as the active tab.
+  const counts = new Map<string, number>(entries.map((e) => [e.source, 0]));
+  for (const e of searched) {
+    counts.set(e.source, (counts.get(e.source) ?? 0) + 1);
+  }
+
+  const matching = (
+    opts.source ? searched.filter((e) => e.source === opts.source) : searched
+  ).sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+
+  // ponytail: offset cursor. The catalog is rescanned per request, so a skill
+  // imported or deleted mid-scroll shifts the window by one entry. Swap for a
+  // (name, id) keyset cursor if that ever actually bites.
+  const offset = Math.max(0, Math.trunc(Number(opts.cursor)) || 0);
+  const limit = Math.min(Math.max(1, Math.trunc(opts.limit)), MAX_PAGE_SIZE);
+  const skills = matching.slice(offset, offset + limit);
+  const end = offset + skills.length;
+
+  return {
+    skills,
+    nextCursor: end < matching.length ? String(end) : undefined,
+    // Sorted, not catalog order: the chips must not reshuffle between pages.
+    sources: [...counts]
+      .map(([source, count]) => ({ source, count }))
+      .sort((a, b) => a.source.localeCompare(b.source)),
+  };
+}

--- a/apps/web/src/hooks/use-org-fs.ts
+++ b/apps/web/src/hooks/use-org-fs.ts
@@ -5,7 +5,12 @@
  * uploads/downloads move raw bytes, which the HTTP routes are built for.
  */
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useProjectContext } from "@/sdk";
 import { KEYS } from "@/lib/query-keys";
 
@@ -282,16 +287,55 @@ export async function fetchOrgFsSkillCatalog(
   return skills;
 }
 
-/** react-query wrapper around {@link fetchOrgFsSkillCatalog} — same cache key
- *  the chat "/" picker uses (`KEYS.slashSkills`), so both surfaces share one
- *  fetch of the org's full skill catalog (home + public sets + synced repos). */
-export function useOrgFsSkillCatalog() {
+/** One page of the catalog, as `/fs/skills?limit=` serves it. */
+export interface OrgFsSkillCatalogPage {
+  skills: OrgFsSkillCatalogEntry[];
+  nextCursor?: string;
+  /** Every source in the catalog with its count under the active search. */
+  sources: Array<{ source: string; count: number }>;
+}
+
+/** Cards per request — one screen of the widest grid is 4 columns x ~3 rows. */
+const SKILL_PAGE_SIZE = 24;
+
+/**
+ * The catalog one page at a time, for the Settings grid's infinite scroll.
+ * Search and the source filter run server-side (so the whole catalog never
+ * reaches the client), which makes each combination its own cached query.
+ *
+ * Deliberately NOT sharing the chat "/" picker's `KEYS.slashSkills`: same
+ * endpoint, but a paged envelope under a different sort — one writer per shape.
+ */
+export function useOrgFsSkillCatalogPages(filters: {
+  search: string;
+  source?: string;
+}) {
   const { org } = useProjectContext();
-  return useQuery({
-    queryKey: KEYS.slashSkills(org.id),
-    queryFn: () => fetchOrgFsSkillCatalog(org.slug),
-    // Same window as the picker: a build rescans home + every synced volume.
+  return useInfiniteQuery({
+    queryKey: KEYS.orgFsSkillPages(
+      org.id,
+      filters.search,
+      filters.source ?? "",
+    ),
+    initialPageParam: "",
+    getNextPageParam: (last: OrgFsSkillCatalogPage) => last.nextCursor,
+    // Same window as the unpaged catalog: a build rescans every volume.
     staleTime: 60_000,
+    // Hold the previous grid while the next filter loads, so typing doesn't
+    // flash skeletons — but only within the same org, which this hook does not
+    // remount across.
+    placeholderData: (previousData, previousQuery) =>
+      previousQuery?.queryKey[1] === org.id ? previousData : undefined,
+    queryFn: async ({ pageParam }): Promise<OrgFsSkillCatalogPage> => {
+      const params = new URLSearchParams({ limit: String(SKILL_PAGE_SIZE) });
+      if (pageParam) params.set("cursor", pageParam);
+      if (filters.search) params.set("q", filters.search);
+      if (filters.source) params.set("source", filters.source);
+      const res = await fsFetch(
+        `/api/${encodeURIComponent(org.slug)}/fs/skills?${params}`,
+      );
+      return (await res.json()) as OrgFsSkillCatalogPage;
+    },
   });
 }
 

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -564,6 +564,12 @@ export const KEYS = {
   // Skill folders (dirs with SKILL.md) across home + public sets — the
   // attachable-skill set for agent knowledge.
   orgFsSkills: (orgId: string) => ["org-fs-skills", orgId] as const,
+  // The same catalog paged for the Settings grid, narrowed server-side. The
+  // root key is the prefix invalidations use; per-filter queries nest under it.
+  orgFsSkillPagesRoot: (orgId: string) =>
+    ["org-fs-skill-pages", orgId] as const,
+  orgFsSkillPages: (orgId: string, search: string, source: string) =>
+    ["org-fs-skill-pages", orgId, search, source] as const,
 
   // Full skill catalog for the chat "/" picker. Distinct from `orgFsSkills`
   // (same endpoint, but that caches a stripped {volume,path} shape) — reusing

--- a/apps/web/src/routes/orgs/settings/skills.tsx
+++ b/apps/web/src/routes/orgs/settings/skills.tsx
@@ -1,7 +1,11 @@
 /**
  * Settings → Build → Skills: an org-wide view of every skill available to the
- * org's agents (the same catalog `<available-skills>` surfaces at runtime —
- * see `useOrgFsSkillCatalog`), plus importing new ones.
+ * org's agents (the same catalog `<available-skills>` surfaces at runtime),
+ * plus importing new ones.
+ *
+ * The grid scrolls a page at a time (`useOrgFsSkillCatalogPages`): the search
+ * box, the origin chips and the alphabetical sort are all server-side, so only
+ * the cards on screen are ever on the wire.
  *
  * Skills are just `SKILL.md` folders on the org filesystem, so importing one is
  * the Library's upload with the skill format enforced: pick a folder containing
@@ -52,8 +56,10 @@ import {
   fetchOrgFsStat,
   type OrgFsSkillCatalogEntry,
   useOrgFsMutations,
-  useOrgFsSkillCatalog,
+  useOrgFsSkillCatalogPages,
 } from "@/hooks/use-org-fs";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
 import { browsePathForEntry } from "@/layouts/library/location";
 import { SkillPreviewDialog } from "@/layouts/library/skill-preview";
 import {
@@ -190,7 +196,6 @@ function SkillsGrid({ children }: { children: React.ReactNode }) {
 export default function SettingsSkillsPage() {
   const t = useT();
   const { org } = useProjectContext();
-  const catalog = useOrgFsSkillCatalog();
   const { remove, upload } = useOrgFsMutations("home");
   const queryClient = useQueryClient();
   const folderInputRef = useRef<HTMLInputElement>(null);
@@ -202,9 +207,20 @@ export default function SettingsSkillsPage() {
   const [pendingDelete, setPendingDelete] =
     useState<OrgFsSkillCatalogEntry | null>(null);
 
+  // Searching and filtering happen server-side now, so every keystroke would
+  // otherwise be a catalog rescan.
+  const debouncedSearch = useDebouncedValue(search, 250);
+  const catalog = useOrgFsSkillCatalogPages({
+    search: debouncedSearch,
+    source: source === ALL_SOURCES ? undefined : source,
+  });
+
   const refreshCatalog = () => {
     queryClient.invalidateQueries({ queryKey: KEYS.slashSkills(org.id) });
     queryClient.invalidateQueries({ queryKey: KEYS.orgFsSkills(org.id) });
+    queryClient.invalidateQueries({
+      queryKey: KEYS.orgFsSkillPagesRoot(org.id),
+    });
   };
 
   async function handleImport(fileList: FileList | null) {
@@ -268,45 +284,45 @@ export default function SettingsSkillsPage() {
     }
   }
 
-  const lowerSearch = search.toLowerCase();
-  // The org's own skills lead; the rest follow alphabetically.
-  const matching = (catalog.data ?? [])
-    .filter(
-      (e) =>
-        e.name.toLowerCase().includes(lowerSearch) ||
-        (e.description ?? "").toLowerCase().includes(lowerSearch),
-    )
-    .sort(
-      (a, b) =>
-        Number(isEditable(b)) - Number(isEditable(a)) ||
-        a.name.localeCompare(b.name),
-    );
+  // Already searched, source-filtered and alphabetized by the server; pages
+  // concatenate in cursor order, so the grid stays alphabetical as it grows.
+  const loaded = catalog.data?.pages.flatMap((p) => p.skills) ?? [];
 
-  // Chips come from the whole catalog; only their counts narrow with the search.
-  const allSources = new Set((catalog.data ?? []).map((e) => e.source));
-  const counts = new Map<string, number>();
-  for (const e of matching) {
-    counts.set(e.source, (counts.get(e.source) ?? 0) + 1);
-  }
+  // Chips ride along on every page and are identical across them (they cover
+  // the whole catalog, not the page), so the first page is as good as any.
+  const sources = catalog.data?.pages[0]?.sources ?? [];
   const tabs = [
     {
       id: ALL_SOURCES,
       label: t("settings.skills.filterAll"),
-      count: matching.length,
+      count: sources.reduce((sum, s) => sum + s.count, 0),
     },
-    ...[...allSources].map((entrySource) => ({
+    ...sources.map(({ source: entrySource, count }) => ({
       id: entrySource,
       label: skillOrigin(entrySource, org.name).label,
-      count: counts.get(entrySource) ?? 0,
+      count,
     })),
   ];
 
-  // Only a source the catalog no longer has at all falls back to All.
-  const activeSource = allSources.has(source) ? source : ALL_SOURCES;
-  const filtered =
-    activeSource === ALL_SOURCES
-      ? matching
-      : matching.filter((e) => e.source === activeSource);
+  const loadMoreRef = useInfiniteScroll(
+    () => void catalog.fetchNextPage(),
+    catalog.hasNextPage,
+    // `isFetching`, not `isFetchingNextPage`: while a filter change is in
+    // flight the grid still shows the previous filter's pages, and its cursor
+    // does not address the new query.
+    catalog.isFetching,
+  );
+
+  // A source can vanish under the filter (deleting its last skill), which would
+  // strand the grid empty on a chip that is no longer rendered. `sources` spans
+  // the whole catalog, so its absence there is proof — snap back to All.
+  if (
+    source !== ALL_SOURCES &&
+    sources.length > 0 &&
+    !sources.some((s) => s.source === source)
+  ) {
+    setSource(ALL_SOURCES);
+  }
 
   const openPreview = (entry: OrgFsSkillCatalogEntry) =>
     setPreviewPath(browsePathForEntry(entry.volume, entry.path));
@@ -375,7 +391,7 @@ export default function SettingsSkillsPage() {
             {tabs.length > 2 && (
               <CollectionTabs
                 tabs={tabs}
-                activeTab={activeSource}
+                activeTab={source}
                 onTabChange={setSource}
               />
             )}
@@ -415,27 +431,31 @@ export default function SettingsSkillsPage() {
                   }
                 />
               </div>
-            ) : filtered.length === 0 ? (
+            ) : loaded.length === 0 ? (
+              /* Keyed off the search that was actually queried, so the copy
+                 can't claim "no results for X" while X is still debouncing. */
               <div className="flex items-center justify-center py-20">
                 <EmptyState
                   image={<Zap size={48} className="text-muted-foreground" />}
                   title={
-                    search
+                    debouncedSearch
                       ? t("settings.skills.noResultsTitle")
                       : t("settings.skills.emptyTitle")
                   }
                   description={
-                    search
-                      ? t("settings.skills.noResultsDescription", { search })
+                    debouncedSearch
+                      ? t("settings.skills.noResultsDescription", {
+                          search: debouncedSearch,
+                        })
                       : t("settings.skills.emptyDescription")
                   }
-                  actions={!search && importButton}
+                  actions={!debouncedSearch && importButton}
                 />
               </div>
             ) : (
               <div className="@container">
                 <SkillsGrid>
-                  {filtered.map((entry) => (
+                  {loaded.map((entry) => (
                     <SkillCard
                       key={entry.id}
                       entry={entry}
@@ -447,7 +467,15 @@ export default function SettingsSkillsPage() {
                       }
                     />
                   ))}
+                  {catalog.isFetchingNextPage &&
+                    Array.from({ length: 4 }, (_, i) => (
+                      <Skeleton key={i} className="h-[168px] rounded-xl" />
+                    ))}
                 </SkillsGrid>
+                {/* Sentinel sits after the last card. Left on the default
+                    viewport root — `Page.Content` is the actual scroller, but
+                    IntersectionObserver already accounts for its clipping. */}
+                <div ref={loadMoreRef} aria-hidden className="h-px" />
               </div>
             )}
           </div>


### PR DESCRIPTION
The Settings → Skills page fetched the whole org skill catalog in one response and did its searching, filtering and sorting in the browser.

## Changes

**API** — `GET /:org/fs/skills` now takes `limit` (plus `cursor`, `q`, `source`) and answers with `{ skills, nextCursor, sources }`, sorted alphabetically by skill name (`id` breaks ties). Without `limit` the response is the full catalog exactly as before — the shape the agent link picker and the chat `/` picker read, so neither moves.

The paging itself is a pure function, `paginateSkillCatalog`, so it is unit-tested rather than mocked.

**Web** — the grid scrolls that with `useInfiniteQuery` + the existing `useInfiniteScroll` sentinel, 24 cards a request, search debounced at 250ms. The origin chips ride along on every page: their counts cover the whole catalog under the active search, not the loaded page, so the chips read the same as before (including a source sitting at 0 under a search, rather than vanishing).

`useOrgFsSkillCatalog` had this page as its only caller and is deleted.

## Notes

- **Cursor is an offset.** The catalog is rescanned per request, so a skill imported or deleted mid-scroll shifts the window by one entry. Marked with a `ponytail:` comment and the upgrade path (a `(name, id)` keyset cursor).
- **This shrinks the response, not the server work.** `buildSkillCatalog` still scans every volume per request to build the list it then slices — that was already true and is unchanged.
- The catalog is capped at 200 entries server-side (`MAX_SKILLS`), so the previous response was bounded; the win here is the wire payload and the DOM, not an unbounded fetch.

## Testing

- `apps/api/src/file-storage/skill-catalog.test.ts` — 7 cases: alphabetical order + cursor walk, name-tie ordering (a cursor must not skip or repeat), case-insensitive search over name and description, source filter leaving the chips intact, a source held at 0 by the search, junk cursor / oversized limit clamping, cursor past the end.
- `bun run fmt`, `bun run check`, `bun run lint` (no new warnings) and `bunx knip` all pass.
- **Not verified in a running app** — no local Postgres in this environment, so the route wiring (query-param parsing into the tested pure function) and the scroll behavior have not been exercised against a live server.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Settings → Skills page now loads the skill catalog one page at a time instead of fetching the whole thing and searching, filtering, and sorting in the browser. `GET /:org/fs/skills?limit=` answers with `{ skills, nextCursor, sources }` sorted by skill name; without `limit` it returns the full catalog as before, so the agent link picker and chat `/` picker are unaffected.

**Notes**
- The cursor is an offset, so a skill imported or deleted mid-scroll shifts the window by one entry.
- The origin chips still cover the whole catalog under the active search, not the loaded page, so their counts read the same as before.
- Pagination shrinks the wire payload and the DOM, not the server work — each request still rescans every volume before slicing.
- Not verified against a live server; no local Postgres, so the route wiring and scroll behavior weren't exercised.

<sup>Written for commit 76d26ce26e2e84d42f6ea79732035cedbc4c53a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

