### PR TITLE
refactor(web): remove dead monitoringStats/monitoringLogs query keys

### DIFF
--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -362,7 +362,6 @@ export const KEYS = {
     ] as const,
 
   // Monitoring queries
-  monitoringStats: () => ["monitoring", "stats"] as const,
   monitoringStatsToolCalls: (orgId: string, paramsKey: string) =>
     ["MONITORING_STATS", orgId, "tool-calls", paramsKey] as const,
   monitoringStatsLlm: (orgId: string, paramsKey: string) =>
@@ -371,13 +370,6 @@ export const KEYS = {
     ["MONITORING_HEATMAP", orgId, paramsKey] as const,
   monitoringThreadUsage: (locator: string, paramsKey: string) =>
     ["MONITORING_THREAD_USAGE", locator, paramsKey] as const,
-  monitoringLogs: (filters: {
-    connectionId?: string;
-    toolName?: string;
-    isError?: boolean;
-    limit?: number;
-    offset?: number;
-  }) => ["monitoring", "logs", filters] as const,
   monitoringLogsInfinite: (locator: string, paramsKey: string) =>
     ["monitoring", "logs-infinite", locator, paramsKey] as const,
   monitoringLogDetail: (logId: string) =>


### PR DESCRIPTION
Dead-code reduction found while auditing `apps/web/src/lib/query-keys.ts` for stale/unused cache keys (query-keys consistency focus area).

`KEYS.monitoringStats` and `KEYS.monitoringLogs` have zero callers anywhere in `apps/web/src` — confirmed via `grep -rn "KEYS.monitoringStats\b\|KEYS\.monitoringLogs\b" apps/web/src` (no matches, and no matches in `apps/api`/`packages` either). The monitoring views (`apps/web/src/components/monitoring/hooks.ts`, `apps/web/src/routes/orgs/monitoring/audit.tsx`) only use the still-live siblings `monitoringStatsToolCalls`, `monitoringStatsLlm`, `monitoringHeatmap`, `monitoringThreadUsage`, `monitoringLogsInfinite`, and `monitoringLogDetail`, which are untouched.

Net: -16 / +0 lines. No behavior change — these two key factories were never invoked, so removing them can't affect any query's cache key or invalidation.

To confirm: `grep -rn "KEYS.monitoringStats\b\|KEYS\.monitoringLogs\b" apps/web/src` returns nothing (pre- or post-change, since they were already dead).

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (only a pre-existing, unrelated prosemirror-model duplicate-version error in `mention-suggestion.tsx`, not touched by this change), and `bunx oxlint apps/web/src/lib/query-keys.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the dead `monitoringStats` and `monitoringLogs` query keys from `apps/web/src/lib/query-keys.ts`. Neither key had any callers, so removing them doesn't change cache behavior.

<sup>Written for commit 08405aa3fb63022f9f3fa6a5e0a6b2855f415584. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

