### PR TITLE
feat(web): make skill delete and import optimistic

### DIFF
--- a/apps/web/src/routes/orgs/settings/skills-import.test.ts
+++ b/apps/web/src/routes/orgs/settings/skills-import.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   groupByDestination,
   importable,
+  optimisticEntry,
   relativePath,
   slugify,
   uploadAllGroups,
@@ -102,5 +103,30 @@ describe("uploadAllGroups", () => {
     await expect(uploadAllGroups(groups, put)).rejects.toThrow("quota");
     // Not the `Promise.all` behaviour: the slow PUTs are done, not in flight.
     expect(landed.toSorted()).toEqual(["skills/s/a", "skills/s/b"]);
+  });
+});
+
+describe("optimisticEntry", () => {
+  test("matches the catalog row the server builds for a home skill", () => {
+    expect(
+      optimisticEntry(
+        "seo-audit",
+        "---\nname: SEO Audit\ndescription: Audits a page.\n---\n\nbody",
+      ),
+    ).toEqual({
+      id: "home/skills/seo-audit",
+      name: "SEO Audit",
+      description: "Audits a page.",
+      source: "home",
+      volume: "home",
+      path: "skills/seo-audit",
+      sandboxPath: "org/home/skills/seo-audit",
+    });
+  });
+
+  test("falls back to the slug when SKILL.md has no frontmatter name", () => {
+    const entry = optimisticEntry("my-skill", "# Heading\n\nWhat it does.");
+    expect(entry.name).toBe("my-skill");
+    expect(entry.description).toBe("What it does.");
   });
 });

--- a/apps/web/src/routes/orgs/settings/skills-import.ts
+++ b/apps/web/src/routes/orgs/settings/skills-import.ts
@@ -3,6 +3,10 @@
  * page so it can be unit-tested without the route's React module graph.
  */
 
+import { parseSkillMd } from "@decocms/shared/harness/skill-md";
+import { HOME_MOUNT_PATH } from "@decocms/shared/organization/home-mount";
+import type { OrgFsSkillCatalogEntry } from "@/hooks/use-org-fs";
+
 /** One PUT per file, so a stray `node_modules` would fan out to thousands. */
 export const MAX_IMPORT_FILES = 200;
 
@@ -69,4 +73,28 @@ export async function uploadAllGroups(
     (r): r is PromiseRejectedResult => r.status === "rejected",
   );
   if (failure) throw failure.reason;
+}
+
+/**
+ * The catalog row the server will return for a just-imported skill, built from
+ * the same `SKILL.md` bytes it will parse — so the optimistic card carries the
+ * skill's real name and description instead of a placeholder that changes
+ * under the user once the refetch lands.
+ */
+export function optimisticEntry(
+  slug: string,
+  skillMd: string,
+): OrgFsSkillCatalogEntry {
+  const meta = parseSkillMd(skillMd);
+  const path = `skills/${slug}`;
+  return {
+    id: `home/${path}`,
+    name: meta.name ?? slug,
+    description: meta.description,
+    // Wire token, not a path — it just happens to spell the volume too.
+    source: "home",
+    volume: HOME_MOUNT_PATH,
+    path,
+    sandboxPath: `org/${HOME_MOUNT_PATH}/${path}`,
+  };
 }

--- a/apps/web/src/routes/orgs/settings/skills.tsx
+++ b/apps/web/src/routes/orgs/settings/skills.tsx
@@ -25,6 +25,7 @@ import { Button } from "@decocms/ui/components/button.tsx";
 import { Card } from "@decocms/ui/components/card.tsx";
 import { SearchInput } from "@decocms/ui/components/search-input.tsx";
 import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -101,10 +102,13 @@ function skillOrigin(source: string, orgName: string) {
  */
 function SkillCard({
   entry,
+  pending,
   onOpen,
   onDelete,
 }: {
   entry: OrgFsSkillCatalogEntry;
+  /** Optimistic row whose files are still uploading — inert until they land. */
+  pending?: boolean;
   onOpen: () => void;
   onDelete?: () => void;
 }) {
@@ -115,14 +119,25 @@ function SkillCard({
   const editable = isEditable(entry);
 
   return (
-    <Card className="relative transition-colors group overflow-hidden flex flex-col h-full hover:bg-muted/50">
-      {/* Overlay button — the whole card opens the preview */}
-      <button
-        type="button"
-        onClick={onOpen}
-        className="absolute inset-0 z-0"
-        aria-label={entry.name}
-      />
+    <Card
+      aria-busy={pending}
+      className={cn(
+        "relative transition-colors group overflow-hidden flex flex-col h-full",
+        pending ? "opacity-60" : "hover:bg-muted/50",
+      )}
+    >
+      {/* Overlay button — the whole card opens the preview. Absent while the
+          upload is in flight: the preview's file reads cache a miss for a
+          minute, so a card opened too early stays empty after the import
+          succeeds. */}
+      {!pending && (
+        <button
+          type="button"
+          onClick={onOpen}
+          className="absolute inset-0 z-0"
+          aria-label={entry.name}
+        />
+      )}
 
       {/* pointer-events-none lets clicks fall through to the overlay button */}
       <div className="flex flex-col flex-1 pointer-events-none">
@@ -172,7 +187,9 @@ function SkillCard({
 
         <div className="border-t border-border mt-auto">
           <div className="h-10 flex items-center px-4.5">
-            <p className="text-xs text-muted-foreground truncate">{label}</p>
+            <p className="text-xs text-muted-foreground truncate">
+              {pending ? t("settings.skills.importing") : label}
+            </p>
           </div>
         </div>
       </div>
@@ -202,6 +219,10 @@ export default function SettingsSkillsPage() {
   const [previewPath, setPreviewPath] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] =
     useState<OrgFsSkillCatalogEntry | null>(null);
+  // Catalog id of the row whose files are still uploading, so the grid can
+  // keep it inert: an early preview would cache a miss, and an early delete
+  // would race the PUTs still to come.
+  const [uploadingId, setUploadingId] = useState<string | null>(null);
 
   const refreshCatalog = () => {
     queryClient.invalidateQueries({ queryKey: KEYS.slashSkills(org.id) });
@@ -270,6 +291,7 @@ export default function SettingsSkillsPage() {
       // the very bytes we're about to upload.
       const optimistic = optimisticEntry(slug, await skillMd.text());
       patchCatalog((prev) => [optimistic, ...prev]);
+      setUploadingId(optimistic.id);
       await uploadAllGroups(
         groupByDestination(files, slug),
         upload.mutateAsync,
@@ -283,6 +305,7 @@ export default function SettingsSkillsPage() {
         err instanceof Error ? err.message : t("settings.skills.importError"),
       );
     } finally {
+      setUploadingId(null);
       refreshCatalog();
       setImporting(false);
     }
@@ -457,18 +480,22 @@ export default function SettingsSkillsPage() {
             ) : (
               <div className="@container">
                 <SkillsGrid>
-                  {filtered.map((entry) => (
-                    <SkillCard
-                      key={entry.id}
-                      entry={entry}
-                      onOpen={() => openPreview(entry)}
-                      onDelete={
-                        isEditable(entry)
-                          ? () => setPendingDelete(entry)
-                          : undefined
-                      }
-                    />
-                  ))}
+                  {filtered.map((entry) => {
+                    const pending = entry.id === uploadingId;
+                    return (
+                      <SkillCard
+                        key={entry.id}
+                        entry={entry}
+                        pending={pending}
+                        onOpen={() => openPreview(entry)}
+                        onDelete={
+                          isEditable(entry) && !pending
+                            ? () => setPendingDelete(entry)
+                            : undefined
+                        }
+                      />
+                    );
+                  })}
                 </SkillsGrid>
               </div>
             )}

--- a/apps/web/src/routes/orgs/settings/skills.tsx
+++ b/apps/web/src/routes/orgs/settings/skills.tsx
@@ -60,6 +60,7 @@ import {
   groupByDestination,
   importable,
   MAX_IMPORT_FILES,
+  optimisticEntry,
   relativePath,
   slugify,
   uploadAllGroups,
@@ -207,6 +208,21 @@ export default function SettingsSkillsPage() {
     queryClient.invalidateQueries({ queryKey: KEYS.orgFsSkills(org.id) });
   };
 
+  /**
+   * Show the delete/import result before the round trip lands, by patching the
+   * one cache the grid reads. Every path ends in `refreshCatalog()`, so the
+   * server is still the source of truth — the patch only covers the wait, and
+   * a failure resyncs rather than replaying a rollback we'd have to keep
+   * correct.
+   */
+  const patchCatalog = (
+    update: (prev: OrgFsSkillCatalogEntry[]) => OrgFsSkillCatalogEntry[],
+  ) =>
+    queryClient.setQueryData<OrgFsSkillCatalogEntry[]>(
+      KEYS.slashSkills(org.id),
+      (prev) => update(prev ?? []),
+    );
+
   async function handleImport(fileList: FileList | null) {
     const picked = [...(fileList ?? [])];
     // Reset first: picking the same folder twice must re-fire `change`.
@@ -223,7 +239,8 @@ export default function SettingsSkillsPage() {
 
     const folder = root.split("/")[0] ?? "";
     const files = picked.filter(importable);
-    if (!files.some((f) => relativePath(f) === "SKILL.md")) {
+    const skillMd = files.find((f) => relativePath(f) === "SKILL.md");
+    if (!skillMd) {
       toast.error(t("settings.skills.importMissingSkillMd"));
       return;
     }
@@ -249,21 +266,24 @@ export default function SettingsSkillsPage() {
         return;
       }
       created = true;
+      // The card appears now, carrying the metadata the server will parse from
+      // the very bytes we're about to upload.
+      const optimistic = optimisticEntry(slug, await skillMd.text());
+      patchCatalog((prev) => [optimistic, ...prev]);
       await uploadAllGroups(
         groupByDestination(files, slug),
         upload.mutateAsync,
       );
-      refreshCatalog();
       toast.success(t("settings.skills.importSuccess", { name: slug }));
     } catch (err) {
       // A half-written tree would serve agents a broken skill, and its bare
       // directory would block the retry on the slug probe above.
       if (created) await remove.mutateAsync(dir).catch(() => {});
-      refreshCatalog();
       toast.error(
         err instanceof Error ? err.message : t("settings.skills.importError"),
       );
     } finally {
+      refreshCatalog();
       setImporting(false);
     }
   }
@@ -313,16 +333,18 @@ export default function SettingsSkillsPage() {
 
   const confirmDelete = async () => {
     if (!pendingDelete) return;
-    const { path } = pendingDelete;
+    const { id, path } = pendingDelete;
     setPendingDelete(null);
+    patchCatalog((prev) => prev.filter((e) => e.id !== id));
     try {
       await remove.mutateAsync(path);
-      refreshCatalog();
       toast.success(t("settings.skills.deleteSuccess"));
     } catch (err) {
       toast.error(
         err instanceof Error ? err.message : t("settings.skills.deleteError"),
       );
+    } finally {
+      refreshCatalog();
     }
   };
 


### PR DESCRIPTION
## Summary

`/settings/skills` waited on a full round trip before the grid reflected either action — deleting left the card sitting there until the DELETE + catalog refetch landed, importing showed nothing until the last PUT resolved.

Both now patch the one cache the grid reads (`KEYS.slashSkills`) up front:

- **Delete** — the card disappears on confirm; the DELETE runs behind it.
- **Import** — the card appears right after the slug probe clears, before the PUTs. Its row is built by a new `optimisticEntry()` from the `SKILL.md` bytes we're about to upload, parsed with the same `parseSkillMd` the server's catalog uses — so the card doesn't rename itself or swap its description when the refetch arrives.

Every path (success, failure, the slug-taken bail) now ends in `refreshCatalog()` via `finally`, so the server stays the source of truth and a failure resyncs rather than replaying a hand-maintained rollback.

## Testing

- `bun test apps/web/src/routes/orgs/settings/skills-import.test.ts` — 11 pass, including two new cases pinning `optimisticEntry` to the exact shape `buildHomeEntries` returns (id/source/volume/path/sandboxPath) and its no-frontmatter fallback.
- `bun run --cwd=apps/web check`, `bun run fmt`, `bun run lint` (0 errors) clean.

## Notes

The optimistic patch is `setQueryData` without a preceding `cancelQueries`, so an already-in-flight catalog refetch could briefly resurrect a deleted card before the success invalidation removes it again. The window is a 60s-staleTime settings page; not worth the extra await.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes and imports on `/settings/skills` now update the grid before the round trip lands; deletion used to leave the card until the DELETE and refetch landed, and imports showed nothing until the last PUT resolved.

**Skills settings**
- Delete removes the card on confirm; import adds it once the slug probe passes, before the uploads finish.
- The import placeholder is parsed from the `SKILL.md` bytes with the same parser the server catalog uses, so the card keeps its name and description after refetch.
- The optimistic import card stays inert while its uploads run: no preview or delete, and the footer reads "Importing…" until they settle.
- Every path ends in `refreshCatalog()`, so failures resync instead of replaying a hand-rolled rollback.
- An in-flight refetch could briefly resurrect a deleted card; the window isn't worth the extra await.

<sup>Written for commit 5ded713c00e1f732fc100bb51878ae3691eea82e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

