### PR TITLE
fix(preview): drop forged deactivate messages in the visual editor bridge

### DIFF
--- a/apps/web/src/components/sandbox/preview/visual-editor-script.test.ts
+++ b/apps/web/src/components/sandbox/preview/visual-editor-script.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { VISUAL_EDITOR_SCRIPT } from "./visual-editor-script";
+
+describe("VISUAL_EDITOR_SCRIPT", () => {
+  it("drops a bridge message whose source isn't this frame's parent", () => {
+    const start = VISUAL_EDITOR_SCRIPT.indexOf(
+      'window.addEventListener("message", function(e)',
+    );
+    const bodyStart = VISUAL_EDITOR_SCRIPT.indexOf("{", start) + 1;
+    const guardEnd = VISUAL_EDITOR_SCRIPT.indexOf(
+      "if (e.data && e.data.type",
+      bodyStart,
+    );
+    expect(bodyStart).toBeGreaterThan(0);
+    expect(guardEnd).toBeGreaterThan(bodyStart);
+    const guard = VISUAL_EDITOR_SCRIPT.slice(bodyStart, guardEnd);
+    const runGuard = new Function(
+      "window",
+      "e",
+      `${guard}; return "reached";`,
+    ) as (window: unknown, e: unknown) => string | undefined;
+
+    const parent = {};
+    expect(runGuard({ parent }, { source: { evil: true } })).toBeUndefined();
+    expect(runGuard({ parent }, { source: parent })).toBe("reached");
+  });
+});

--- a/apps/web/src/components/sandbox/preview/visual-editor-script.ts
+++ b/apps/web/src/components/sandbox/preview/visual-editor-script.ts
@@ -147,6 +147,8 @@ export const VISUAL_EDITOR_SCRIPT = `(function() {
   document.addEventListener("click", clickHandler, true);
 
   window.addEventListener("message", function(e) {
+    // Only Studio's own postMessage (source === this frame's parent) may drive the bridge — a nested/downstream frame's forged message can't deactivate the editor.
+    if (e.source !== window.parent) return;
     if (e.data && e.data.type === "visual-editor::deactivate") {
       highlight.remove();
       badge.remove();


### PR DESCRIPTION
The CMS editor iframe bridge (`cms-editor-script.ts`) checks `e.source === window.parent` before honoring a `postMessage` bridge command — added specifically so a nested/downstream frame's forged message can't drive Studio's own control channel (see the comment above its listener: "Only Studio's own postMessage ... may drive the bridge").

The visual editor bridge (`visual-editor-script.ts`) has the exact same `window.addEventListener("message", ...)` pattern for its `visual-editor::deactivate` command, but never got that guard — it accepts a message from any sender. Any frame embedded in the previewed page (or script running in it) can `postMessage({type: "visual-editor::deactivate"})` straight to the iframe window and silently kill the editor overlay mid-session, without going through Studio's own parent frame.

**Fix**: apply the identical `e.source !== window.parent` guard already used in `cms-editor-script.ts`.

**Regression test**: new `visual-editor-script.test.ts`, mirroring the existing `cms-editor-script.test.ts` "drops a bridge message whose source isn't this frame's parent" test — extracts the guard clause from the embedded script string and runs it against a forged vs. real parent source.

Reviewer check: `cd apps/web && bun test src/components/sandbox/preview/visual-editor-script.test.ts`

Locally ran: `bun run fmt`, the targeted test above (1 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI covers typecheck and the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the visual editor bridge from acting on `visual-editor::deactivate` messages sent by any frame; it now ignores postMessage events whose source isn't the parent frame, matching the CMS editor bridge, so embedded content can no longer silently turn off the editor mid-session. Adds a regression test for the source guard, mirroring the existing CMS editor bridge test.

<sup>Written for commit a97dc64166c6028e13f371c46106cc33c634fec4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

