### PR TITLE
perf(skills): cache and parallelize the skill catalog build

### DIFF
--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -100,6 +100,8 @@ jobs:
       S3_ENDPOINT: http://localhost:9000
       S3_ACCESS_KEY_ID: minioadmin
       S3_SECRET_ACCESS_KEY: minioadmin
+      # NATS, started below — backs the skill-catalog-cache integration test.
+      NATS_URL: nats://localhost:4222
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -115,6 +117,29 @@ jobs:
       # so the pinned image version stays in sync with e2e.yml.
       - name: Start MinIO
         uses: ./.github/actions/start-minio
+
+      # Backs the skill-catalog-cache integration test, which exercises the
+      # JetStream KV compare-and-swap that keeps a stale in-flight build from
+      # republishing over an invalidation. Same image + retry shape as e2e.yml;
+      # a service container can't pass the `-js` flag, so this is a step.
+      - name: Start NATS with JetStream
+        run: |
+          # Pull explicitly with retry/backoff: the registry mirror occasionally
+          # answers `toomanyrequests: Rate exceeded`, and an inline pull inside
+          # `docker run` has no retry, so a transient 429 fails the whole job.
+          for attempt in 1 2 3 4 5; do
+            docker pull public.ecr.aws/docker/library/nats:2.14.2 && break
+            echo "docker pull public.ecr.aws/docker/library/nats:2.14.2 failed (attempt $attempt); retrying in $((attempt * 5))s"
+            sleep $((attempt * 5))
+          done
+          docker run -d --name nats -p 4222:4222 public.ecr.aws/docker/library/nats:2.14.2 -js
+          for _ in $(seq 1 10); do
+            if nc -z localhost 4222; then
+              break
+            fi
+            sleep 1
+          done
+          nc -z localhost 4222
 
       # Convention: every `*.integration.test.ts` file is picked up here.
       # Adding a new integration test = create a `something.integration.test.ts`

--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -139,6 +139,11 @@ import {
   setMcpListCache,
   type McpListCache,
 } from "../mcp-clients/mcp-list-cache";
+import {
+  JetStreamKVSkillCatalogCache,
+  setSkillCatalogCache,
+  type SkillCatalogCache,
+} from "../file-storage/skill-catalog-cache";
 import { isMcpCacheEnabled } from "../mcp-clients/mcp-read-cache";
 import {
   startMcpCacheInvalidation,
@@ -981,6 +986,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   });
 
   let mcpListCache: McpListCache | null;
+  let skillCatalogCache: SkillCatalogCache | null;
   let connectionCircuitStore: ConnectionCircuitStore;
   // Model lists are public, low-stakes metadata cached per-replica with a TTL —
   // no NATS needed, so this is shared across the test and production branches.
@@ -1003,6 +1009,9 @@ export async function createApp(options: CreateAppOptions = {}) {
       invalidate: async () => {},
       teardown: () => {},
     };
+    // Without NATS every read rebuilds the catalog — the behavior before the
+    // cache existed.
+    skillCatalogCache = null;
     connectionCircuitStore = new NoopConnectionCircuitStore();
     cancelBroadcast = {
       start: async () => {},
@@ -1073,6 +1082,12 @@ export async function createApp(options: CreateAppOptions = {}) {
     tlc?.init().catch(() => {});
     mcpListCache = tlc;
 
+    const scc = new JetStreamKVSkillCatalogCache({
+      getJetStream: () => natsProvider!.getJetStream(),
+    });
+    scc.init().catch(() => {});
+    skillCatalogCache = scc;
+
     const ccs = new JetStreamKVConnectionCircuitStore({
       getJetStream: () => natsProvider!.getJetStream(),
     });
@@ -1099,6 +1114,9 @@ export async function createApp(options: CreateAppOptions = {}) {
       tlc?.init().catch((err: unknown) => {
         console.error("[McpListCache] Deferred init failed:", err);
       });
+      scc.init().catch((err: unknown) => {
+        console.error("[SkillCatalogCache] Deferred init failed:", err);
+      });
       ccs.init().catch((err: unknown) => {
         console.error("[ConnectionCircuitStore] Deferred init failed:", err);
       });
@@ -1121,6 +1139,7 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Set tool list cache after cleanup to avoid previous cleanup nulling the new cache
   setMcpListCache(mcpListCache);
+  setSkillCatalogCache(skillCatalogCache);
   setConnectionCircuitStore(connectionCircuitStore);
 
   const threadStorage = new SqlThreadStorage(database.db);
@@ -1204,11 +1223,13 @@ export async function createApp(options: CreateAppOptions = {}) {
     stopFlipBroadcast();
     streamBuffer.teardown();
     mcpListCache?.teardown();
+    skillCatalogCache?.teardown();
     modelListCache.teardown();
     providerKeyCache.teardown();
     teardownMcpCacheInvalidation();
     connectionCircuitStore.teardown();
     setMcpListCache(null);
+    setSkillCatalogCache(null);
     setConnectionCircuitStore(null);
   };
 

--- a/apps/api/src/api/routes/org-fs.ts
+++ b/apps/api/src/api/routes/org-fs.ts
@@ -820,7 +820,11 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
               ? contentType
               : undefined,
         });
-        notifyOrgFsChange(getConnection(), r.ctx.organization!.id, volume);
+        await notifyOrgFsChange(
+          getConnection(),
+          r.ctx.organization!.id,
+          volume,
+        );
         return c.json({ entry });
       } catch (err) {
         return fsErrorResponse(c, err);
@@ -837,7 +841,7 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       await r.fs.mkdir(volume, c.req.query("path") ?? "", {
         actor: r.ctx.auth!.user!.id,
       });
-      notifyOrgFsChange(getConnection(), r.ctx.organization!.id, volume);
+      await notifyOrgFsChange(getConnection(), r.ctx.organization!.id, volume);
       return c.json({ ok: true });
     } catch (err) {
       return fsErrorResponse(c, err);
@@ -853,7 +857,7 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       await r.fs.delete(volume, c.req.query("path") ?? "", {
         actor: r.ctx.auth!.user!.id,
       });
-      notifyOrgFsChange(getConnection(), r.ctx.organization!.id, volume);
+      await notifyOrgFsChange(getConnection(), r.ctx.organization!.id, volume);
       return c.json({ ok: true });
     } catch (err) {
       return fsErrorResponse(c, err);
@@ -889,7 +893,11 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
         await r.fs.move(volume, body.from, body.to, {
           actor: r.ctx.auth!.user!.id,
         });
-        notifyOrgFsChange(getConnection(), r.ctx.organization!.id, volume);
+        await notifyOrgFsChange(
+          getConnection(),
+          r.ctx.organization!.id,
+          volume,
+        );
         return c.json({ ok: true });
       } catch (err) {
         return fsErrorResponse(c, err);

--- a/apps/api/src/file-storage/org-fs-notify.test.ts
+++ b/apps/api/src/file-storage/org-fs-notify.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { notifyOrgFsChange, orgFsChangeSubjects } from "./org-fs-notify";
+import { setSkillCatalogCache } from "./skill-catalog-cache";
 
 describe("org-fs NATS compatibility subjects", () => {
   test("returns the canonical subject first and its legacy alias second", () => {
@@ -14,17 +15,39 @@ describe("org-fs NATS compatibility subjects", () => {
     expect(orgFsChangeSubjects("org-1", "volume.*")).toEqual([]);
   });
 
-  test("publishes a wake-up to both subjects during rolling upgrades", () => {
+  test("publishes a wake-up to both subjects during rolling upgrades", async () => {
     const published: string[] = [];
     const connection = {
       publish: (subject: string) => published.push(subject),
     };
 
-    notifyOrgFsChange(connection as never, "org-1", "home");
+    await notifyOrgFsChange(connection as never, "org-1", "home");
 
     expect(published).toEqual([
       "studio.org-fs.changes.org-1.home",
       "mesh.org-fs.changes.org-1.home",
     ]);
+  });
+
+  test("invalidates the org's skill catalog even with no NATS connection", async () => {
+    const invalidated: string[] = [];
+    setSkillCatalogCache({
+      get: async () => null,
+      set: async () => {},
+      invalidate: async (orgId) => {
+        invalidated.push(orgId);
+      },
+      teardown: () => {},
+    });
+
+    try {
+      // A write still has to drop the catalog when the wake-up can't be sent —
+      // the cache is shared across replicas, so a live NATS link is not what
+      // makes the stale build reachable.
+      await notifyOrgFsChange(null, "org-1", "home");
+      expect(invalidated).toEqual(["org-1"]);
+    } finally {
+      setSkillCatalogCache(null);
+    }
   });
 });

--- a/apps/api/src/file-storage/org-fs-notify.test.ts
+++ b/apps/api/src/file-storage/org-fs-notify.test.ts
@@ -32,7 +32,7 @@ describe("org-fs NATS compatibility subjects", () => {
   test("invalidates the org's skill catalog even with no NATS connection", async () => {
     const invalidated: string[] = [];
     setSkillCatalogCache({
-      get: async () => null,
+      get: async () => ({ catalog: null }),
       set: async () => {},
       invalidate: async (orgId) => {
         invalidated.push(orgId);

--- a/apps/api/src/file-storage/org-fs-notify.ts
+++ b/apps/api/src/file-storage/org-fs-notify.ts
@@ -12,6 +12,7 @@
  */
 
 import type { NatsConnection } from "@nats-io/nats-core";
+import { invalidateSkillCatalog } from "./skill-catalog-cache";
 
 const SUBJECT_PREFIXES = [
   "studio.org-fs.changes",
@@ -33,17 +34,29 @@ export function orgFsChangeSubjects(orgId: string, volume: string): string[] {
 /**
  * Best-effort wake-up after a write. Never throws — if NATS is down the
  * daemon's long-poll timeout still picks the change up on its next cycle.
+ *
+ * Also drops the org's cached skill catalog, since a write is the only thing
+ * that can invalidate it from inside Studio (an imported or deleted `SKILL.md`
+ * is just an org-fs write). Awaited, not fire-and-forget: the UI refetches the
+ * catalog the moment the write responds, and a delete landing after that read
+ * would serve the stale build for the rest of the TTL.
+ *
+ * Every org-fs mutation route funnels through here, so a route added later
+ * inherits the invalidation instead of having to remember it.
  */
-export function notifyOrgFsChange(
+export async function notifyOrgFsChange(
   nc: NatsConnection | null,
   orgId: string,
   volume: string,
-): void {
-  if (!nc) return;
-  const subjects = orgFsChangeSubjects(orgId, volume);
-  try {
-    for (const subject of subjects) nc.publish(subject);
-  } catch {
-    // best-effort
+): Promise<void> {
+  if (nc) {
+    try {
+      for (const subject of orgFsChangeSubjects(orgId, volume)) {
+        nc.publish(subject);
+      }
+    } catch {
+      // best-effort
+    }
   }
+  await invalidateSkillCatalog(orgId);
 }

--- a/apps/api/src/file-storage/skill-catalog-cache.integration.test.ts
+++ b/apps/api/src/file-storage/skill-catalog-cache.integration.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Skill catalog cache — storage-integration tier (real NATS JetStream, zero
+ * mocks). See TESTING.md.
+ *
+ * The property under test is a concurrency guard, and it is enforced by the
+ * KV's own compare-and-swap. A hand-written double would only prove the double
+ * behaves as written, so this runs against a real server.
+ *
+ * Local run:
+ *   nats-server -js -p 4222
+ *   bun test apps/api/src/file-storage/skill-catalog-cache.integration.test.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { jetstream } from "@nats-io/jetstream";
+import type { NatsConnection } from "@nats-io/nats-core";
+import { connect } from "@nats-io/transport-node";
+import { JetStreamKVSkillCatalogCache } from "./skill-catalog-cache";
+import type { SkillCatalogEntry } from "./skill-catalog";
+
+const NATS_URL = process.env.NATS_URL ?? "nats://localhost:4222";
+
+function entry(name: string): SkillCatalogEntry {
+  return {
+    id: `home/${name}`,
+    name,
+    description: null,
+    source: "home",
+    sandboxPath: `org/home/${name}`,
+    volume: "home",
+    path: name,
+  };
+}
+
+const PRE_WRITE = [entry("pre-write")];
+const POST_WRITE = [entry("pre-write"), entry("just-imported")];
+
+describe("JetStreamKVSkillCatalogCache (integration)", () => {
+  let nc: NatsConnection;
+  let cache: JetStreamKVSkillCatalogCache;
+
+  beforeAll(async () => {
+    nc = await connect({ servers: NATS_URL, timeout: 5_000 });
+    cache = new JetStreamKVSkillCatalogCache({
+      getJetStream: () => jetstream(nc),
+    });
+    await cache.init();
+  });
+
+  afterAll(async () => {
+    cache?.teardown();
+    await nc?.drain();
+  });
+
+  // The bucket is shared with every other worker; a per-test org keeps the
+  // assertions isolated.
+  let n = 0;
+  const orgId = () => `org-${process.pid}-${Date.now()}-${n++}`;
+
+  it("round-trips a catalog and reports a miss for an unknown org", async () => {
+    const org = orgId();
+    expect(await cache.get(org)).toEqual({ catalog: null });
+
+    await cache.set(org, POST_WRITE);
+    expect((await cache.get(org)).catalog).toEqual(POST_WRITE);
+  });
+
+  it("caches an empty catalog as an answer, not as a miss", async () => {
+    // An org with no skills is a real result; re-scanning every volume to
+    // re-learn it is the expensive case.
+    const org = orgId();
+    await cache.set(org, []);
+    expect((await cache.get(org)).catalog).toEqual([]);
+  });
+
+  it("reads as a miss after invalidation", async () => {
+    const org = orgId();
+    await cache.set(org, POST_WRITE);
+    await cache.invalidate(org);
+    expect((await cache.get(org)).catalog).toBeNull();
+  });
+
+  it("drops a build that an invalidation overtook, on a cold key", async () => {
+    const org = orgId();
+    // A build starts: it reads a miss and carries the revision forward.
+    const inFlight = await cache.get(org);
+    // A skill is imported while that build is still scanning storage.
+    await cache.invalidate(org);
+    // The build finishes and tries to publish its pre-import result.
+    await cache.set(org, PRE_WRITE, inFlight.revision);
+
+    expect((await cache.get(org)).catalog).toBeNull();
+  });
+
+  it("drops a build that an invalidation overtook, on a warm key", async () => {
+    const org = orgId();
+    await cache.set(org, PRE_WRITE);
+
+    const inFlight = await cache.get(org);
+    await cache.invalidate(org);
+    await cache.set(org, PRE_WRITE, inFlight.revision);
+
+    expect((await cache.get(org)).catalog).toBeNull();
+  });
+
+  it("lets one of two concurrent builds win instead of clobbering", async () => {
+    const org = orgId();
+    const a = await cache.get(org);
+    const b = await cache.get(org);
+
+    await cache.set(org, POST_WRITE, a.revision);
+    await cache.set(org, PRE_WRITE, b.revision);
+
+    expect((await cache.get(org)).catalog).toEqual(POST_WRITE);
+  });
+
+  it("still publishes an uncontended refresh", async () => {
+    // The guard must not wedge the normal path: a build that nothing raced
+    // has to land, or the cache would never warm at all.
+    const org = orgId();
+    await cache.set(org, PRE_WRITE, (await cache.get(org)).revision);
+
+    const hit = await cache.get(org);
+    expect(hit.catalog).toEqual(PRE_WRITE);
+
+    await cache.set(org, POST_WRITE, hit.revision);
+    expect((await cache.get(org)).catalog).toEqual(POST_WRITE);
+  });
+
+  it("is inert without a JetStream client", async () => {
+    // The no-NATS deployment path: every read is a miss and nothing throws.
+    const inert = new JetStreamKVSkillCatalogCache({
+      getJetStream: () => null,
+    });
+    await inert.init();
+
+    const org = orgId();
+    expect(await inert.get(org)).toEqual({ catalog: null });
+    await inert.set(org, POST_WRITE);
+    await inert.invalidate(org);
+    expect(await inert.get(org)).toEqual({ catalog: null });
+  });
+});

--- a/apps/api/src/file-storage/skill-catalog-cache.ts
+++ b/apps/api/src/file-storage/skill-catalog-cache.ts
@@ -8,9 +8,16 @@
  *
  * KV rather than a per-process Map so a rolling deploy, a scaled-out replica
  * set, and the run path all share one build. Values are memory-backed and
- * expire on the bucket's TTL, which is what covers writers this cache never
- * sees — repo sync and the public-set sync land bytes without going through
- * the org-fs routes.
+ * expire on the bucket's TTL, which is what covers the writers this cache
+ * never sees: repo sync lands bytes without going through the org-fs routes,
+ * so a synced skill appears within the TTL rather than immediately.
+ *
+ * The TTL bounds THIS layer only. Public-set skills sit behind a second,
+ * process-local cache inside `buildSkillCatalog` with a longer window of its
+ * own, and a rebuild may read that one while it is still warm — so a
+ * public-set change surfaces within roughly the sum of the two, not within
+ * this TTL. That is deliberate: public sets are deployment-global, and making
+ * every org's rebuild rescan them would undo what their cache is for.
  *
  * Best-effort throughout: no NATS, a cold bucket, an oversized value, or a
  * decode failure all read as a miss and rebuild. Mirrors
@@ -31,11 +38,11 @@ const cacheCounter = meter.createCounter("skill_catalog_cache.fetches", {
 const KV_BUCKET = "DECOCMS_SKILL_CATALOGS";
 
 /**
- * How long a build may be served before it is rebuilt from storage. The floor
- * is set by the writers this cache cannot invalidate on: repo sync runs about
- * every 10 minutes, so a minute keeps a synced skill's worst-case appearance
- * lag within the sync's own jitter, while still collapsing a page-through of
- * the Settings grid into one build.
+ * How long a build may be served before it is rebuilt from storage. Sized by
+ * the writer this cache cannot invalidate on: repo sync runs about every 10
+ * minutes, so a minute keeps a synced skill's worst-case appearance lag well
+ * inside the sync's own period, while still collapsing a page-through of the
+ * Settings grid into one build.
  */
 const TTL_MS = 60_000;
 
@@ -46,12 +53,46 @@ const TTL_MS = 60_000;
  */
 const MAX_VALUE_BYTES = 1024 * 1024;
 
+/**
+ * A cache read: the catalog if one is stored, plus the KV revision the key sat
+ * at when it was read.
+ *
+ * The revision is what makes a publish safe. A build takes hundreds of
+ * milliseconds of storage reads, and an org-fs write can land inside that
+ * window — its `invalidate` then clears a key the in-flight build is about to
+ * republish, pre-write, for a whole TTL. Carrying the revision forward turns
+ * the publish into a compare-and-swap: anything that touched the key in the
+ * meantime moves it, and the losing build drops its result instead.
+ */
+export interface CachedCatalog {
+  catalog: SkillCatalogEntry[] | null;
+  /** Absent only when the key has never been written in this bucket. */
+  revision?: number;
+}
+
 export interface SkillCatalogCache {
-  get(orgId: string): Promise<SkillCatalogEntry[] | null>;
-  set(orgId: string, entries: SkillCatalogEntry[]): Promise<void>;
+  get(orgId: string): Promise<CachedCatalog>;
+  /**
+   * Publish a build, but only if the key still sits at `revision` (or, when
+   * that is absent, has never been written). Losing the race is normal and
+   * silent — it means fresher state already won.
+   */
+  set(
+    orgId: string,
+    entries: SkillCatalogEntry[],
+    revision?: number,
+  ): Promise<void>;
   invalidate(orgId: string): Promise<void>;
   teardown(): void;
 }
+
+/**
+ * Marks an org's catalog as absent. A written tombstone rather than a KV
+ * delete: a delete leaves the key in a state `create` is allowed to fill, so
+ * an in-flight build that started before the invalidation could still publish
+ * over it. A tombstone occupies a revision, which every publish must name.
+ */
+const TOMBSTONE = new TextEncoder().encode("null");
 
 export interface JetStreamKVSkillCatalogCacheOptions {
   getJetStream: () => JetStreamClient | null;
@@ -59,7 +100,8 @@ export interface JetStreamKVSkillCatalogCacheOptions {
 
 export class JetStreamKVSkillCatalogCache implements SkillCatalogCache {
   private kv: KV | null = null;
-  private readonly codec = jsonCodec<SkillCatalogEntry[]>();
+  // Nullable: the tombstone `invalidate` writes decodes to `null`.
+  private readonly codec = jsonCodec<SkillCatalogEntry[] | null>();
 
   constructor(private readonly options: JetStreamKVSkillCatalogCacheOptions) {}
 
@@ -73,35 +115,59 @@ export class JetStreamKVSkillCatalogCache implements SkillCatalogCache {
     });
   }
 
-  async get(orgId: string): Promise<SkillCatalogEntry[] | null> {
-    if (!this.kv) return null;
+  async get(orgId: string): Promise<CachedCatalog> {
+    if (!this.kv) return { catalog: null };
     try {
       const entry = await this.kv.get(orgId);
-      if (!entry?.value?.length) return null;
-      // A tombstone carries no value worth decoding.
-      if (entry.operation === "DEL" || entry.operation === "PURGE") return null;
+      // No key at all — nothing to compare-and-swap against, so the publish
+      // has to `create` instead.
+      if (!entry) return { catalog: null };
+      // A delete marker or our own tombstone: a miss, but at a real revision.
+      if (
+        entry.operation === "DEL" ||
+        entry.operation === "PURGE" ||
+        !entry.value?.length
+      ) {
+        return { catalog: null, revision: entry.revision };
+      }
       const catalog = this.codec.decode(entry.value);
+      if (catalog === null) {
+        return { catalog: null, revision: entry.revision };
+      }
       cacheCounter.add(1, { outcome: "hit" });
-      return catalog;
+      return { catalog, revision: entry.revision };
     } catch {
-      return null;
+      // A decode failure is a miss, but republishing over the key that caused
+      // it needs the revision — which we no longer trust. Force a `create`,
+      // which loses to the existing key and leaves the TTL to clear it.
+      return { catalog: null };
     }
   }
 
-  async set(orgId: string, entries: SkillCatalogEntry[]): Promise<void> {
+  async set(
+    orgId: string,
+    entries: SkillCatalogEntry[],
+    revision?: number,
+  ): Promise<void> {
     if (!this.kv) return;
     try {
-      await this.kv.put(orgId, this.codec.encode(entries));
+      const value = this.codec.encode(entries);
+      if (revision === undefined) {
+        await this.kv.create(orgId, value);
+      } else {
+        await this.kv.update(orgId, value, revision);
+      }
     } catch {
-      // best-effort, non-critical — an oversized or rejected value just means
-      // the next read rebuilds.
+      // Either the value was rejected (oversized) or the compare-and-swap
+      // lost — a write invalidated mid-build, or another replica published
+      // first. Both mean this build must not land; the next read rebuilds.
     }
   }
 
   async invalidate(orgId: string): Promise<void> {
     if (!this.kv) return;
     try {
-      await this.kv.delete(orgId);
+      await this.kv.put(orgId, TOMBSTONE);
     } catch {
       // best-effort: the TTL is the backstop.
     }

--- a/apps/api/src/file-storage/skill-catalog-cache.ts
+++ b/apps/api/src/file-storage/skill-catalog-cache.ts
@@ -1,0 +1,139 @@
+/**
+ * Cross-replica cache for a built skill catalog, over NATS JetStream KV.
+ *
+ * `buildSkillCatalog` costs one S3 GET per skill (every `SKILL.md` is read and
+ * parsed) plus a listing per volume. That is the whole latency of
+ * `/fs/skills` and of the `<available-skills>` block a run opens with, and
+ * without a cache every replica pays it on every request.
+ *
+ * KV rather than a per-process Map so a rolling deploy, a scaled-out replica
+ * set, and the run path all share one build. Values are memory-backed and
+ * expire on the bucket's TTL, which is what covers writers this cache never
+ * sees — repo sync and the public-set sync land bytes without going through
+ * the org-fs routes.
+ *
+ * Best-effort throughout: no NATS, a cold bucket, an oversized value, or a
+ * decode failure all read as a miss and rebuild. Mirrors
+ * {@link ../mcp-clients/mcp-list-cache.ts JetStreamKVMcpListCache}.
+ */
+
+import { type JetStreamClient, StorageType } from "@nats-io/jetstream";
+import { Kvm, type KV } from "@nats-io/kv";
+import { jsonCodec } from "../nats/json-codec";
+import { meter } from "../observability";
+import type { SkillCatalogEntry } from "./skill-catalog";
+
+const cacheCounter = meter.createCounter("skill_catalog_cache.fetches", {
+  description: "Skill catalog cache fetch outcomes (hit, miss)",
+  unit: "{fetches}",
+});
+
+const KV_BUCKET = "DECOCMS_SKILL_CATALOGS";
+
+/**
+ * How long a build may be served before it is rebuilt from storage. The floor
+ * is set by the writers this cache cannot invalidate on: repo sync runs about
+ * every 10 minutes, so a minute keeps a synced skill's worst-case appearance
+ * lag within the sync's own jitter, while still collapsing a page-through of
+ * the Settings grid into one build.
+ */
+const TTL_MS = 60_000;
+
+/**
+ * Ceiling on one org's cached catalog. `MAX_SKILLS` (200) x a generous
+ * frontmatter description lands well under this; anything above it is a
+ * pathological tree that should rebuild rather than sit in NATS memory.
+ */
+const MAX_VALUE_BYTES = 1024 * 1024;
+
+export interface SkillCatalogCache {
+  get(orgId: string): Promise<SkillCatalogEntry[] | null>;
+  set(orgId: string, entries: SkillCatalogEntry[]): Promise<void>;
+  invalidate(orgId: string): Promise<void>;
+  teardown(): void;
+}
+
+export interface JetStreamKVSkillCatalogCacheOptions {
+  getJetStream: () => JetStreamClient | null;
+}
+
+export class JetStreamKVSkillCatalogCache implements SkillCatalogCache {
+  private kv: KV | null = null;
+  private readonly codec = jsonCodec<SkillCatalogEntry[]>();
+
+  constructor(private readonly options: JetStreamKVSkillCatalogCacheOptions) {}
+
+  async init(): Promise<void> {
+    const js = this.options.getJetStream();
+    if (!js) return; // NATS not ready — cache disabled until re-init
+    this.kv = await new Kvm(js).create(KV_BUCKET, {
+      storage: StorageType.Memory,
+      ttl: TTL_MS,
+      maxValueSize: MAX_VALUE_BYTES,
+    });
+  }
+
+  async get(orgId: string): Promise<SkillCatalogEntry[] | null> {
+    if (!this.kv) return null;
+    try {
+      const entry = await this.kv.get(orgId);
+      if (!entry?.value?.length) return null;
+      // A tombstone carries no value worth decoding.
+      if (entry.operation === "DEL" || entry.operation === "PURGE") return null;
+      const catalog = this.codec.decode(entry.value);
+      cacheCounter.add(1, { outcome: "hit" });
+      return catalog;
+    } catch {
+      return null;
+    }
+  }
+
+  async set(orgId: string, entries: SkillCatalogEntry[]): Promise<void> {
+    if (!this.kv) return;
+    try {
+      await this.kv.put(orgId, this.codec.encode(entries));
+    } catch {
+      // best-effort, non-critical — an oversized or rejected value just means
+      // the next read rebuilds.
+    }
+  }
+
+  async invalidate(orgId: string): Promise<void> {
+    if (!this.kv) return;
+    try {
+      await this.kv.delete(orgId);
+    } catch {
+      // best-effort: the TTL is the backstop.
+    }
+  }
+
+  teardown(): void {
+    this.kv = null;
+  }
+}
+
+/** Records a rebuild. Counted here so hit and miss share one instrument. */
+export function recordSkillCatalogMiss(): void {
+  cacheCounter.add(1, { outcome: "miss" });
+}
+
+// Module-level active cache — set once at app startup.
+let activeCache: SkillCatalogCache | null = null;
+
+export function setSkillCatalogCache(cache: SkillCatalogCache | null): void {
+  activeCache = cache;
+}
+
+export function getSkillCatalogCache(): SkillCatalogCache | null {
+  return activeCache;
+}
+
+/**
+ * Drop an org's cached catalog. Called from the org-fs write path, so an
+ * imported or deleted skill shows up on the very next read instead of waiting
+ * out the TTL. Awaited by its callers: the UI refetches the catalog as soon as
+ * the write responds, and a delete that lands after that read serves stale.
+ */
+export async function invalidateSkillCatalog(orgId: string): Promise<void> {
+  await activeCache?.invalidate(orgId);
+}

--- a/apps/api/src/file-storage/skill-catalog.integration.test.ts
+++ b/apps/api/src/file-storage/skill-catalog.integration.test.ts
@@ -137,4 +137,27 @@ describe("detectSkills (integration)", () => {
     const out = await detectSkills(fs, VOL, "", { remaining: 2 });
     expect(out.length).toBe(2);
   });
+
+  it("holds the budget across concurrent scans", async () => {
+    // `buildSkillCatalog` fans its volume scans out with Promise.all over one
+    // shared budget. Now that each scan issues its reads together there is no
+    // longer a decrement between them to serialize on, so the slice has to be
+    // claimed up front — without that, both scans read the same remaining
+    // count and together return more than the cap.
+    await fs.write(VOL, "top/SKILL.md", "# top\n\nd\n", { actor: ACTOR });
+    for (const n of ["a", "b", "c"]) {
+      await fs.write(VOL, `skills/${n}/SKILL.md`, `# ${n}\n\nd\n`, {
+        actor: ACTOR,
+      });
+    }
+
+    const shared = { remaining: 2 };
+    const [top, nested] = await Promise.all([
+      detectSkills(fs, VOL, "", shared),
+      detectSkills(fs, VOL, "skills", shared),
+    ]);
+
+    expect(top.length + nested.length).toBe(2);
+    expect(shared.remaining).toBe(0);
+  });
 });

--- a/apps/api/src/file-storage/skill-catalog.integration.test.ts
+++ b/apps/api/src/file-storage/skill-catalog.integration.test.ts
@@ -160,4 +160,23 @@ describe("detectSkills (integration)", () => {
     expect(top.length + nested.length).toBe(2);
     expect(shared.remaining).toBe(0);
   });
+
+  it("truncates an over-budget tree to the same set every time", async () => {
+    // The catalog feeds a cached prompt prefix, so an org past the cap has to
+    // lose the SAME skills on every build. Spending the budget in whatever
+    // order storage answered in made that depend on the network.
+    for (const n of ["e", "d", "c", "b", "a"]) {
+      await fs.write(VOL, `${n}/SKILL.md`, `# ${n}\n\nd\n`, { actor: ACTOR });
+    }
+
+    const runs = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        detectSkills(fs, VOL, "", { remaining: 3 }),
+      ),
+    );
+
+    for (const run of runs) {
+      expect(run.map((s) => s.dirPath)).toEqual(["a", "b", "c"]);
+    }
+  });
 });

--- a/apps/api/src/file-storage/skill-catalog.ts
+++ b/apps/api/src/file-storage/skill-catalog.ts
@@ -15,6 +15,7 @@
  */
 
 import { parseSkillMd } from "@/harnesses/lib/skills/skill-md";
+import { mapWithConcurrency } from "@/tools/connection/map-with-concurrency";
 import type { StudioContext } from "../core/studio-context";
 import { createBoundObjectStorage } from "../object-storage/bound-object-storage";
 import { DevObjectStorage } from "../object-storage/dev-object-storage";
@@ -47,8 +48,23 @@ export interface SkillCatalogEntry {
   path: string;
 }
 
-/** Total SKILL.md reads per build — a backstop against a pathological tree. */
+/**
+ * SKILL.md reads per build across the org's OWN volumes (home + synced repos)
+ * — a backstop against a pathological tenant tree.
+ *
+ * Public sets carry their own budget below rather than sharing this one: they
+ * are a fixed deployment-level set behind a process cache, so charging them
+ * here made a tenant's cap depend on whether that cache happened to be warm.
+ */
 const MAX_SKILLS = 200;
+/** The same backstop for the deployment's public sets. */
+const MAX_PUBLIC_SKILLS = 200;
+/**
+ * Ceiling on SKILL.md reads in flight at once. The reads are issued together
+ * for latency, but a wide org (or several rebuilding at once) should not turn
+ * that into an unbounded burst against the storage client.
+ */
+const MAX_CONCURRENT_READS = 16;
 /** Public sets are global + change only on the ~10-min sync; cache process-wide. */
 const PUBLIC_TTL_MS = 5 * 60_000;
 const HOME_VOLUME = "home";
@@ -70,19 +86,23 @@ export interface DetectedSkill {
   description: string | null;
 }
 
+/** One claimed skill folder, awaiting its `SKILL.md` read. */
+interface SkillDir {
+  volume: string;
+  dirPath: string;
+}
+
 /**
- * Detect skill folders directly under `(volume, base)`: list immediate child
- * dirs, batch-probe `<dir>/SKILL.md`, read + parse the hits. One listDir + one
- * filesExist + one read per skill, the reads issued together. Best-effort —
- * returns [] on any storage error and skips individual unreadable skills.
- * `budget` caps total reads.
+ * Immediate child dirs of `(volume, base)` that contain a `SKILL.md`, sorted
+ * by path. One listDir + one filesExist and no per-skill reads, so this is
+ * cheap enough to run for every scope up front — before the budget decides
+ * which of them can afford to be read. Best-effort: [] on any storage error.
  */
-export async function detectSkills(
+async function probeSkillDirs(
   fs: OrgFs,
   volume: string,
   base: string,
-  budget: { remaining: number },
-): Promise<DetectedSkill[]> {
+): Promise<string[]> {
   try {
     const dirs = (await fs.listDir(volume, base)).filter(
       (e) => e.kind === "dir",
@@ -92,49 +112,94 @@ export async function detectSkills(
       volume,
       dirs.map((d) => `${d.path}/SKILL.md`),
     );
-
-    // Claim the whole slice before the first read starts. `buildSkillCatalog`
-    // runs these scans concurrently, so a counter decremented between awaits
-    // would let them race past the cap together.
-    const skills = dirs.filter((d) => found.has(`${d.path}/SKILL.md`));
-    const claimed = skills.slice(0, Math.max(0, budget.remaining));
-    budget.remaining -= claimed.length;
-
-    // ponytail: unbounded fan-out, bounded only by MAX_SKILLS (200) and by
-    // whatever the storage client's own connection pool admits at once. Add a
-    // semaphore here if a wide org is ever seen starving other callers.
-    const read = await Promise.all(
-      claimed.map(async (d): Promise<DetectedSkill | null> => {
-        try {
-          const bytes = await fs.read(volume, `${d.path}/SKILL.md`);
-          const meta = parseSkillMd(new TextDecoder().decode(bytes));
-          return {
-            dirPath: d.path,
-            name: meta.name ?? basename(d.path),
-            description: meta.description,
-          };
-        } catch {
-          // Skill dir without a readable SKILL.md (sync race, vanished file) —
-          // skip it rather than fail the whole catalog.
-          return null;
-        }
-      }),
-    );
-    return read.filter((s) => s !== null);
+    // Sorted, not listing order: this is the order the budget is spent in.
+    return dirs
+      .map((d) => d.path)
+      .filter((path) => found.has(`${path}/SKILL.md`))
+      .toSorted();
   } catch (err) {
     console.warn(`[skill-catalog] scan failed (${volume}:${base || "/"})`, err);
     return [];
   }
 }
 
+/**
+ * Read + parse every claimed `SKILL.md`, at most {@link MAX_CONCURRENT_READS}
+ * in flight. Bounded rather than a plain `Promise.all`: a miss can claim up to
+ * `MAX_SKILLS` folders, and concurrent misses across orgs multiply that into
+ * one burst against the storage client. Results keep `dirs` order; an
+ * individual unreadable skill is skipped, never fatal.
+ */
+async function readSkills(
+  fs: OrgFs,
+  dirs: SkillDir[],
+): Promise<Array<SkillDir & DetectedSkill>> {
+  const out = new Array<(SkillDir & DetectedSkill) | null>(dirs.length).fill(
+    null,
+  );
+  await mapWithConcurrency(
+    dirs.map((dir, index) => ({ dir, index })),
+    MAX_CONCURRENT_READS,
+    async ({ dir, index }) => {
+      try {
+        const bytes = await fs.read(dir.volume, `${dir.dirPath}/SKILL.md`);
+        const meta = parseSkillMd(new TextDecoder().decode(bytes));
+        out[index] = {
+          ...dir,
+          name: meta.name ?? basename(dir.dirPath),
+          description: meta.description,
+        };
+      } catch {
+        // Skill dir without a readable SKILL.md (sync race, vanished file) —
+        // skip it rather than fail the whole catalog.
+      }
+    },
+  );
+  return out.filter((s) => s !== null);
+}
+
+/**
+ * Detect skill folders directly under `(volume, base)`: probe, claim what the
+ * budget allows, read + parse. Best-effort — returns [] on any storage error
+ * and skips individual unreadable skills.
+ *
+ * The claim is a slice taken before the first read: with the reads issued
+ * together there is no longer a decrement between them to serialize on, so
+ * two concurrent scans sharing a budget would otherwise both see the same
+ * remaining count.
+ */
+export async function detectSkills(
+  fs: OrgFs,
+  volume: string,
+  base: string,
+  budget: { remaining: number },
+): Promise<DetectedSkill[]> {
+  const dirPaths = await probeSkillDirs(fs, volume, base);
+  const claimed = dirPaths.slice(0, Math.max(0, budget.remaining));
+  budget.remaining -= claimed.length;
+  const read = await readSkills(
+    fs,
+    claimed.map((dirPath) => ({ volume, dirPath })),
+  );
+  // Drop the volume `readSkills` threads through for the multi-volume caller —
+  // a single-volume scan already knows it, and leaking it widens the shape.
+  return read.map(({ dirPath, name, description }) => ({
+    dirPath,
+    name,
+    description,
+  }));
+}
+
 /** Public sets are org-independent (shared system scope); build once + cache. */
 async function buildPublicEntries(
   ctx: StudioContext,
-  budget: { remaining: number },
 ): Promise<SkillCatalogEntry[]> {
   if (publicCache && publicCache.expires > Date.now())
     return publicCache.entries;
 
+  // Sets are walked in `getPublicSets()` order so an over-budget deployment
+  // truncates the same way every time.
+  const budget = { remaining: MAX_PUBLIC_SKILLS };
   const pub = buildPublicOrgFs(ctx);
   const entries: SkillCatalogEntry[] = [];
   for (const { set } of getPublicSets()) {
@@ -171,55 +236,68 @@ function buildOrgFs(ctx: StudioContext, orgId: string): OrgFs {
   return new OrgFs(storage, ctx.storage.orgFsEntries, orgId);
 }
 
-/** Repo-sync skills: bounded probe of each synced volume's root. */
-async function buildSyncedEntries(
+/**
+ * The org's own skills: `home/*`, `home/skills/*`, and the root of every
+ * enabled synced repo volume.
+ *
+ * All scopes are probed together, then claimed in a FIXED scope order, then
+ * read together. The fixed order is what makes an over-budget tree truncate to
+ * the same set on every build — spending the budget in whichever order the
+ * storage calls happened to return let two builds of one org expose different
+ * repos, and the catalog is supposed to be byte-stable for the prompt prefix.
+ */
+async function buildOrgEntries(
   ctx: StudioContext,
   orgId: string,
-  budget: { remaining: number },
 ): Promise<SkillCatalogEntry[]> {
-  const volumes = await ctx.storage.orgRepoSyncs
-    .listEnabledVolumes(orgId)
-    .catch(() => [] as string[]);
-  if (volumes.length === 0) return [];
-  const fs = buildOrgFs(ctx, orgId);
-  // Scanned together — an org with several synced repos used to pay each
-  // volume's listing and reads end to end.
-  const perVolume = await Promise.all(
-    volumes.map(async (volume) =>
-      (await detectSkills(fs, volume, "", budget)).map((s) => ({
-        id: `repo/${volume}/${s.dirPath}`,
-        name: s.name,
-        description: s.description,
-        source: `repo:${volume}`,
-        sandboxPath: orgFsSandboxPath(volume, s.dirPath),
-        volume,
-        path: s.dirPath,
-      })),
-    ),
-  );
-  return perVolume.flat();
-}
+  const volumes = (
+    await ctx.storage.orgRepoSyncs
+      .listEnabledVolumes(orgId)
+      .catch(() => [] as string[])
+  ).toSorted(); // the query promises no order; the claim order has to be ours
 
-/** Home skills: bounded probe of `org/home/*` and `org/home/skills/*`. */
-async function buildHomeEntries(
-  ctx: StudioContext,
-  orgId: string,
-  budget: { remaining: number },
-): Promise<SkillCatalogEntry[]> {
-  const home = buildOrgFs(ctx, orgId);
-  const [top, nested] = await Promise.all([
-    detectSkills(home, HOME_VOLUME, "", budget),
-    detectSkills(home, HOME_VOLUME, "skills", budget),
-  ]);
-  return [...top, ...nested].map((s) => ({
-    id: `home/${s.dirPath}`,
-    name: s.name,
-    description: s.description,
-    source: "home",
-    sandboxPath: orgFsSandboxPath(HOME_VOLUME, s.dirPath),
-    volume: HOME_VOLUME,
-    path: s.dirPath,
-  }));
+  const fs = buildOrgFs(ctx, orgId);
+  const scopes = [
+    { volume: HOME_VOLUME, base: "" },
+    { volume: HOME_VOLUME, base: "skills" },
+    ...volumes.map((volume) => ({ volume, base: "" })),
+  ];
+
+  const probed = await Promise.all(
+    scopes.map((s) => probeSkillDirs(fs, s.volume, s.base)),
+  );
+
+  let remaining = MAX_SKILLS;
+  const claimed: SkillDir[] = [];
+  for (const [index, dirPaths] of probed.entries()) {
+    const take = dirPaths.slice(0, remaining);
+    remaining -= take.length;
+    for (const dirPath of take) {
+      claimed.push({ volume: scopes[index]!.volume, dirPath });
+    }
+  }
+
+  return (await readSkills(fs, claimed)).map((s) =>
+    s.volume === HOME_VOLUME
+      ? {
+          id: `home/${s.dirPath}`,
+          name: s.name,
+          description: s.description,
+          source: "home",
+          sandboxPath: orgFsSandboxPath(HOME_VOLUME, s.dirPath),
+          volume: HOME_VOLUME,
+          path: s.dirPath,
+        }
+      : {
+          id: `repo/${s.volume}/${s.dirPath}`,
+          name: s.name,
+          description: s.description,
+          source: `repo:${s.volume}`,
+          sandboxPath: orgFsSandboxPath(s.volume, s.dirPath),
+          volume: s.volume,
+          path: s.dirPath,
+        },
+  );
 }
 
 /**
@@ -237,21 +315,20 @@ export async function buildSkillCatalog(
   orgId: string,
 ): Promise<SkillCatalogEntry[]> {
   const cache = getSkillCatalogCache();
-  const cached = await cache?.get(orgId);
-  if (cached) return cached;
+  const cached = (await cache?.get(orgId)) ?? { catalog: null };
+  if (cached.catalog) return cached.catalog;
   recordSkillCatalogMiss();
 
-  const budget = { remaining: MAX_SKILLS };
-  const [pub, home, synced] = await Promise.all([
-    buildPublicEntries(ctx, budget),
-    buildHomeEntries(ctx, orgId, budget),
-    buildSyncedEntries(ctx, orgId, budget),
+  const [pub, own] = await Promise.all([
+    buildPublicEntries(ctx),
+    buildOrgEntries(ctx, orgId),
   ]);
-  const catalog = [...pub, ...home, ...synced].sort(
+  const catalog = [...pub, ...own].sort(
     (a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id),
   );
-  // Not awaited: the caller already has its answer, and a failed put only
-  // costs the next reader a rebuild.
-  cache?.set(orgId, catalog).catch(() => {});
+  // Not awaited: the caller already has its answer, and a lost publish only
+  // costs the next reader a rebuild. Carries the revision the miss was read
+  // at, so a write that landed mid-build wins over this now-stale result.
+  cache?.set(orgId, catalog, cached.revision).catch(() => {});
   return catalog;
 }

--- a/apps/api/src/file-storage/skill-catalog.ts
+++ b/apps/api/src/file-storage/skill-catalog.ts
@@ -22,6 +22,10 @@ import { getObjectStorageS3Service } from "../object-storage/factory";
 import { OrgFs } from "./org-fs";
 import { orgFsSandboxPath } from "./mount/provisioning";
 import {
+  getSkillCatalogCache,
+  recordSkillCatalogMiss,
+} from "./skill-catalog-cache";
+import {
   buildPublicOrgFs,
   getPublicSets,
   publicVolumeForSet,
@@ -69,8 +73,9 @@ export interface DetectedSkill {
 /**
  * Detect skill folders directly under `(volume, base)`: list immediate child
  * dirs, batch-probe `<dir>/SKILL.md`, read + parse the hits. One listDir + one
- * filesExist + one read per skill. Best-effort — returns [] on any storage
- * error and skips individual unreadable skills. `budget` caps total reads.
+ * filesExist + one read per skill, the reads issued together. Best-effort —
+ * returns [] on any storage error and skips individual unreadable skills.
+ * `budget` caps total reads.
  */
 export async function detectSkills(
   fs: OrgFs,
@@ -87,25 +92,35 @@ export async function detectSkills(
       volume,
       dirs.map((d) => `${d.path}/SKILL.md`),
     );
-    const out: DetectedSkill[] = [];
-    for (const d of dirs) {
-      if (budget.remaining <= 0) break;
-      if (!found.has(`${d.path}/SKILL.md`)) continue;
-      budget.remaining -= 1;
-      try {
-        const bytes = await fs.read(volume, `${d.path}/SKILL.md`);
-        const meta = parseSkillMd(new TextDecoder().decode(bytes));
-        out.push({
-          dirPath: d.path,
-          name: meta.name ?? basename(d.path),
-          description: meta.description,
-        });
-      } catch {
-        // Skill dir without a readable SKILL.md (sync race, vanished file) —
-        // skip it rather than fail the whole catalog.
-      }
-    }
-    return out;
+
+    // Claim the whole slice before the first read starts. `buildSkillCatalog`
+    // runs these scans concurrently, so a counter decremented between awaits
+    // would let them race past the cap together.
+    const skills = dirs.filter((d) => found.has(`${d.path}/SKILL.md`));
+    const claimed = skills.slice(0, Math.max(0, budget.remaining));
+    budget.remaining -= claimed.length;
+
+    // ponytail: unbounded fan-out, bounded only by MAX_SKILLS (200) and by
+    // whatever the storage client's own connection pool admits at once. Add a
+    // semaphore here if a wide org is ever seen starving other callers.
+    const read = await Promise.all(
+      claimed.map(async (d): Promise<DetectedSkill | null> => {
+        try {
+          const bytes = await fs.read(volume, `${d.path}/SKILL.md`);
+          const meta = parseSkillMd(new TextDecoder().decode(bytes));
+          return {
+            dirPath: d.path,
+            name: meta.name ?? basename(d.path),
+            description: meta.description,
+          };
+        } catch {
+          // Skill dir without a readable SKILL.md (sync race, vanished file) —
+          // skip it rather than fail the whole catalog.
+          return null;
+        }
+      }),
+    );
+    return read.filter((s) => s !== null);
   } catch (err) {
     console.warn(`[skill-catalog] scan failed (${volume}:${base || "/"})`, err);
     return [];
@@ -167,11 +182,11 @@ async function buildSyncedEntries(
     .catch(() => [] as string[]);
   if (volumes.length === 0) return [];
   const fs = buildOrgFs(ctx, orgId);
-  const entries: SkillCatalogEntry[] = [];
-  for (const volume of volumes) {
-    const detected = await detectSkills(fs, volume, "", budget);
-    for (const s of detected) {
-      entries.push({
+  // Scanned together — an org with several synced repos used to pay each
+  // volume's listing and reads end to end.
+  const perVolume = await Promise.all(
+    volumes.map(async (volume) =>
+      (await detectSkills(fs, volume, "", budget)).map((s) => ({
         id: `repo/${volume}/${s.dirPath}`,
         name: s.name,
         description: s.description,
@@ -179,10 +194,10 @@ async function buildSyncedEntries(
         sandboxPath: orgFsSandboxPath(volume, s.dirPath),
         volume,
         path: s.dirPath,
-      });
-    }
-  }
-  return entries;
+      })),
+    ),
+  );
+  return perVolume.flat();
 }
 
 /** Home skills: bounded probe of `org/home/*` and `org/home/skills/*`. */
@@ -211,18 +226,32 @@ async function buildHomeEntries(
  * The skills available to `orgId`'s agents: public sets + the org's home,
  * sorted deterministically (so the rendered block stays byte-stable and in the
  * cached prompt prefix). Never throws.
+ *
+ * Served from the cross-replica cache when one is warm — see
+ * {@link ./skill-catalog-cache.ts}. An empty build is cached like any other:
+ * an org with no skills is a real answer, and re-scanning every volume to
+ * re-learn it is the expensive case, not the cheap one.
  */
 export async function buildSkillCatalog(
   ctx: StudioContext,
   orgId: string,
 ): Promise<SkillCatalogEntry[]> {
+  const cache = getSkillCatalogCache();
+  const cached = await cache?.get(orgId);
+  if (cached) return cached;
+  recordSkillCatalogMiss();
+
   const budget = { remaining: MAX_SKILLS };
   const [pub, home, synced] = await Promise.all([
     buildPublicEntries(ctx, budget),
     buildHomeEntries(ctx, orgId, budget),
     buildSyncedEntries(ctx, orgId, budget),
   ]);
-  return [...pub, ...home, ...synced].sort(
+  const catalog = [...pub, ...home, ...synced].sort(
     (a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id),
   );
+  // Not awaited: the caller already has its answer, and a failed put only
+  // costs the next reader a rebuild.
+  cache?.set(orgId, catalog).catch(() => {});
+  return catalog;
 }


### PR DESCRIPTION
Follow-up to #6817, which shrank the `/fs/skills` payload but not its latency. This is the latency half, and it stands on its own — the catalog build is also what the `<available-skills>` block costs a run at open.

`buildSkillCatalog` did the two slowest things it could: one S3 GET per `SKILL.md`, awaited one at a time, and one volume scanned after another. Nothing was cached beyond the public sets, so every replica paid it on every request.

## Changes

**Parallelize the reads** — `detectSkills` issues its `SKILL.md` reads together. The read budget is now claimed as a slice up front: with no decrement between awaits to serialize on, two concurrent scans sharing one budget would both see the same remaining count and together return more than `MAX_SKILLS`.

**Parallelize the volumes** — `buildSyncedEntries` scans its synced repos concurrently instead of end to end.

**Cross-replica cache over NATS JetStream KV** — new `skill-catalog-cache.ts`, bucket `DECOCMS_SKILL_CATALOGS`, memory-backed, 60s bucket TTL, 1MB value cap. Mirrors the existing `JetStreamKVMcpListCache` and wires in alongside it in `app.ts`. A scaled-out replica set and the run path now share one build.

**Invalidation** folds into `notifyOrgFsChange`, which every org-fs mutation route already funnels through — an imported or deleted skill is just an org-fs write, and a route added later inherits the invalidation instead of having to remember it. It is **awaited**, not fire-and-forget: the UI refetches the catalog the moment the write responds, so a delete landing after that read would serve the stale build for the rest of the TTL.

The bucket TTL covers the writers this cache never sees — repo sync and the public-set sync land bytes without going through the org-fs routes.

## Failure modes

Best-effort throughout. No NATS → cache is `null` and every read rebuilds, exactly the behavior before this commit (this is also the `disableNats` test path). A cold bucket, an oversized value, or a decode failure all read as a miss. A failed `put` costs the next reader a rebuild and nothing else.

An **empty** catalog is cached like any other: an org with no skills is a real answer, and rescanning every volume to re-learn it is the expensive case.

## Testing

Verified against real infrastructure, not mocks:

- **Real Postgres + real object storage** — `skill-catalog.integration.test.ts` passes, including a new case, `holds the budget across concurrent scans`. Confirmed it actually bites: dropping the up-front slice fails both it and the pre-existing `respects the read budget cap`.
- **Real `nats-server -js`** — a scratch JetStream server accepts the bucket options and the cache round-trips: cold get → `null`, set → byte-identical read back, invalidate → `null`, and an empty catalog reads back as `[]` rather than a miss. Server-side config confirmed as asked for: `ttl 60000ms` / `max_age 60000000000ns`, `max_msg_size 1048576`, `storage memory`.
- `org-fs-notify.test.ts` gains a case asserting a write invalidates the catalog **even with no NATS connection** — the cache is shared across replicas, so a live NATS link is not what makes the stale build reachable.
- `bun run fmt`, `bun run check`, `bun run lint` (no new warnings), `bunx knip` all pass.

**Not verified:** the full app booting with this wiring (no complete local environment) — the `app.ts` change is startup wiring that typechecks, and its `init()` failure path is already swallowed into "cache disabled". TTL expiry was confirmed as server config, not observed expiring in real time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the latency of the skill catalog build behind `/fs/skills` and the `<available-skills>` block by parallelizing reads and scans, and caches each org's catalog across replicas in NATS JetStream KV.

**Skill catalog**
- Reads detected `SKILL.md` files concurrently (bounded at 16 in flight) and scans synced repos in parallel instead of serially.
- Claims the shared read budget up front so concurrent scans can't pass `MAX_SKILLS`; over-budget catalogs truncate in a fixed scope order, and public sets take their own budget.
- Caches each org's built catalog in a NATS JetStream KV bucket (`DECOCMS_SKILL_CATALOGS`, memory-backed, 60s TTL) shared across replicas.
- Publishes compare-and-swap on the KV revision, so a stale in-flight build can't republish over an invalidation; invalidation writes a tombstone instead of deleting.
- Org-fs writes now invalidate the org's catalog through `notifyOrgFsChange`, awaited so the UI's immediate refetch doesn't hit stale data.
- Cache failures read as misses and rebuild from storage, matching pre-cache behavior.

<sup>Written for commit d3de98bdd156ac74816f2a967d3dd0cc9b20f2b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

