### PR TITLE
feat(task-board): give tasks an externalUrl, keep the tracker link out of the description

### DIFF
--- a/apps/api/migrations/198-task-board-external-url.ts
+++ b/apps/api/migrations/198-task-board-external-url.ts
@@ -1,0 +1,58 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * The card's issue in the tracker it came from, as a link of its own.
+ *
+ * The Jira pull used to write that link as the FIRST LINE of the card's
+ * description (`{site}/browse/{KEY}\n\n{body}`), which is the only place the
+ * board had to put it. But a card's description is not a place to keep
+ * metadata: it is quoted verbatim into every agent run's prompt (see
+ * `buildSuperAgentTaskPrompt`), so the URL leaked into the model's context and
+ * from there into the work it produced — orgs were writing board prompts
+ * telling the agent to ignore it. As a column it is structured data the UI can
+ * render as a link and the prompt simply never reads.
+ *
+ * Not `external_key`, the column next to it: that one is a reports-minted
+ * finding IDENTITY used to dedupe imports. This is a URL for a human to open.
+ *
+ * Backfilled here, in both halves, so no card has to wait for its issue to be
+ * touched in Jira again: the link table plus the integration's `site_url` give
+ * the URL for every synced card, and stripping the prefix is anchored on that
+ * exact string, so a description that never carried one is left alone.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_items")
+    .addColumn("external_url", "text")
+    .execute();
+
+  await sql`
+    UPDATE task_board_items i
+       SET external_url = t.url,
+           description = CASE
+             WHEN left(i.description, length(t.url)) = t.url
+               THEN nullif(
+                      btrim(substr(i.description, length(t.url) + 1), E' \\t\\r\\n'),
+                      ''
+                    )
+             ELSE i.description
+           END
+      FROM (
+            SELECT l.item_id,
+                   g.site_url || '/browse/' || l.jira_issue_key AS url
+              FROM task_board_item_jira_links l
+              JOIN org_jira_integrations g
+                ON g.organization_id = l.organization_id
+           ) t
+     WHERE t.item_id = i.id
+  `.execute(db);
+}
+
+/** Descriptions keep their stripped prefix: the next sync rewrites every one
+ *  it owns, and re-prepending a URL to a since-edited description is worse. */
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_items")
+    .dropColumn("external_url")
+    .execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -196,6 +196,7 @@ import * as migration194jiralinksprint from "./194-jira-link-sprint.ts";
 import * as migration195taskboardsprintactivity from "./195-task-board-sprint-activity.ts";
 import * as migration196taskboardcolumntrackerstatuses from "./196-task-board-column-tracker-statuses.ts";
 import * as migration197taskboardprompts from "./197-task-board-prompts.ts";
+import * as migration198taskboardexternalurl from "./198-task-board-external-url.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -426,6 +427,7 @@ const migrations: Record<string, Migration> = {
   "196-task-board-column-tracker-statuses":
     migration196taskboardcolumntrackerstatuses,
   "197-task-board-prompts": migration197taskboardprompts,
+  "198-task-board-external-url": migration198taskboardexternalurl,
 };
 
 export default migrations;

--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -309,17 +309,27 @@ function isCardIssue(issue: JiraIssue): boolean {
   return typeof level !== "number" || level === 0;
 }
 
+/**
+ * The issue's body as the card's description — the issue text and nothing else.
+ *
+ * The link to the issue used to lead this string, which put it in front of
+ * every agent run: `buildSuperAgentTaskPrompt` quotes the description verbatim.
+ * It rides `TaskBoardItem.externalUrl` now, where the UI can link it and the
+ * prompt never sees it.
+ */
 async function cardDescription(
-  siteUrl: string,
   issue: JiraIssue,
   users: JiraUserDirectory,
 ): Promise<string> {
   const body = issue.fields.description;
   const names = await users.resolve(collectMentionAccountIds(body));
-  const text = jiraBodyToText(body, names);
-  return `${siteUrl}/browse/${issue.key}\n\n${text}`
-    .trim()
-    .slice(0, MAX_DESCRIPTION_CHARS);
+  return jiraBodyToText(body, names).trim().slice(0, MAX_DESCRIPTION_CHARS);
+}
+
+/** Where a person opens this issue in Jira. `siteUrl` is normalized to
+ *  `https://<host>` on connect, so this is a plain join. */
+function issueUrl(siteUrl: string, issueKey: string): string {
+  return `${siteUrl}/browse/${issueKey}`;
 }
 
 function mapPriority(issue: JiraIssue): TaskBoardItemPriority {
@@ -708,7 +718,8 @@ async function runSync(
       const jiraSprint = pickIssueSprint(issue.sprints);
       const fields = {
         title: issue.fields.summary,
-        description: await cardDescription(integration.siteUrl, issue, users),
+        description: await cardDescription(issue, users),
+        externalUrl: issueUrl(integration.siteUrl, issue.key),
         priority: mapPriority(issue),
         // Asked of the board, not recomputed from the flag: one answer for
         // every writer, so a card cannot be guarded by one path and not by

--- a/apps/api/src/storage/task-board-external-url.integration.test.ts
+++ b/apps/api/src/storage/task-board-external-url.integration.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import { TaskBoardStorage } from "./task-board";
+
+/**
+ * Real-Postgres coverage for `external_url` — the link to the card's issue in
+ * the tracker it came from, which used to be the first line of the card's
+ * DESCRIPTION and therefore of every agent run's prompt.
+ *
+ * Real Postgres rather than a fake because `update()` writes through an
+ * explicit column whitelist: a fake accepts the field and hands back the object
+ * it was given, so it would agree with a version that silently drops the write
+ * — which is precisely how the Jira pull keeps the link current.
+ */
+const ORG = "org_external_url_1";
+const USER = "user_external_url";
+const URL = "https://example.atlassian.net/browse/EX-333";
+
+describe("TaskBoardStorage — externalUrl", () => {
+  let database: StudioDatabase;
+  let storage: TaskBoardStorage;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    const createdAt = new Date().toISOString();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${`${USER}@test.com`}, false, 'External Url', ${createdAt}, ${createdAt})
+    `.execute(database.db);
+    await database.db
+      .insertInto("organization")
+      .values({ id: ORG, name: ORG, slug: "external-url-one", createdAt })
+      .execute();
+    storage = new TaskBoardStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("persists the tracker link a synced card is created with", async () => {
+    const created = await storage.create({
+      organizationId: ORG,
+      title: "From Jira",
+      description: "The issue body, and nothing else.",
+      externalUrl: URL,
+      by: "jira",
+    });
+
+    expect(created.externalUrl).toBe(URL);
+    const read = await storage.getById(created.id, ORG);
+    expect(read?.externalUrl).toBe(URL);
+    expect(read?.description).toBe("The issue body, and nothing else.");
+  });
+
+  it("carries null for a card Studio owns", async () => {
+    const own = await storage.create({
+      organizationId: ORG,
+      title: "Written in Studio",
+      by: USER,
+    });
+
+    expect(own.externalUrl).toBeNull();
+    expect((await storage.getById(own.id, ORG))?.externalUrl).toBeNull();
+  });
+
+  it("updates the link, and clears it, through the column whitelist", async () => {
+    const item = await storage.create({
+      organizationId: ORG,
+      title: "Relinked",
+      by: "jira",
+    });
+
+    const linked = await storage.update(
+      item.id,
+      ORG,
+      { externalUrl: URL },
+      "jira",
+    );
+    expect(linked.externalUrl).toBe(URL);
+    expect((await storage.getById(item.id, ORG))?.externalUrl).toBe(URL);
+
+    const cleared = await storage.update(
+      item.id,
+      ORG,
+      { externalUrl: null },
+      "jira",
+    );
+    expect(cleared.externalUrl).toBeNull();
+    expect((await storage.getById(item.id, ORG))?.externalUrl).toBeNull();
+  });
+
+  it("leaves the link alone on an update that does not mention it", async () => {
+    const item = await storage.create({
+      organizationId: ORG,
+      title: "Untouched",
+      externalUrl: URL,
+      by: "jira",
+    });
+
+    const renamed = await storage.update(
+      item.id,
+      ORG,
+      { title: "Renamed" },
+      USER,
+    );
+
+    expect(renamed.externalUrl).toBe(URL);
+  });
+});

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -292,6 +292,8 @@ export class TaskBoardStorage {
     sprintId?: string | null;
     /** Sender-minted finding identity — see task-board-import. */
     externalKey?: string | null;
+    /** Link to the card's issue in the tracker it came from. */
+    externalUrl?: string | null;
     by: string;
   }): Promise<TaskBoardItem> {
     const id = generatePrefixedId("board");
@@ -323,6 +325,7 @@ export class TaskBoardStorage {
           due_date: params.dueDate ?? null,
           sprint_id: params.sprintId ?? null,
           external_key: params.externalKey ?? null,
+          external_url: params.externalUrl ?? null,
           sort_order: sql<number>`(
           select coalesce(min(sort_order), 0) - 1
           from task_board_items
@@ -373,6 +376,7 @@ export class TaskBoardStorage {
       repo?: string | null;
       dueDate?: string | null;
       sprintId?: string | null;
+      externalUrl?: string | null;
       sortOrder?: number;
     },
     by: string,
@@ -396,6 +400,9 @@ export class TaskBoardStorage {
         ...(data.repo !== undefined ? { repo: data.repo } : {}),
         ...(data.dueDate !== undefined ? { due_date: data.dueDate } : {}),
         ...(data.sprintId !== undefined ? { sprint_id: data.sprintId } : {}),
+        ...(data.externalUrl !== undefined
+          ? { external_url: data.externalUrl }
+          : {}),
         ...(data.boardColumnOrg !== undefined
           ? { board_column_org: data.boardColumnOrg }
           : {}),
@@ -2399,6 +2406,7 @@ export class TaskBoardStorage {
     repo: string | null;
     due_date: string | Date | null;
     sprint_id?: string | null;
+    external_url?: string | null;
     sort_order: number;
     key_seq: number;
     retry_attempts?: number;
@@ -2424,6 +2432,7 @@ export class TaskBoardStorage {
           ? row.due_date.toISOString()
           : row.due_date,
       sprintId: row.sprint_id ?? null,
+      externalUrl: row.external_url ?? null,
       sortOrder: row.sort_order,
       keySeq: row.key_seq,
       retryAttempts: row.retry_attempts ?? 0,

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1651,6 +1651,14 @@ export interface TaskBoardItemTable {
     Date | string | null | undefined,
     Date | string | null
   >;
+  /** The card's issue in the tracker it came from (`{site}/browse/{KEY}`), for
+   *  a human to open. Written by the Jira pull; null for a card Studio owns.
+   *  Deliberately NOT in the description — see migration 198. */
+  external_url: ColumnType<
+    string | null,
+    string | null | undefined,
+    string | null
+  >;
   /** Sender-minted finding identity (e.g. `diag:{domain}:{check_id}`) — the
    *  import refreshes an OPEN item with the same key instead of duplicating
    *  it. Null for human-created cards. */
@@ -1982,6 +1990,9 @@ export interface TaskBoardItem {
   /** The key this card's issue wears in the tracker (`EX-333`), for a card that
    *  came from one — attached on reads, null for a card Studio owns. */
   jiraIssueKey: string | null;
+  /** Link to that issue in the tracker, for a human to open. Never part of the
+   *  description, which is quoted into agent prompts verbatim. */
+  externalUrl: string | null;
   /** Infrastructure retries already spent on this card's runs — the budget
    *  `reactToFailedTaskRun` spends against `MAX_RUN_RETRIES`. */
   retryAttempts: number;

--- a/apps/api/src/tools/task-board/run-reactions.test.ts
+++ b/apps/api/src/tools/task-board/run-reactions.test.ts
@@ -221,6 +221,7 @@ function makeItem(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
     sortOrder: 0,
     keySeq: 1,
     jiraIssueKey: null,
+    externalUrl: null,
     retryAttempts: 0,
     reviewCycleStartedAt: null,
     threads: [],

--- a/apps/api/src/tools/task-board/schema.test.ts
+++ b/apps/api/src/tools/task-board/schema.test.ts
@@ -43,6 +43,7 @@ describe("TaskBoardItemSchema – proxy round-trip validation", () => {
     sortOrder: 0,
     keySeq: 1,
     jiraIssueKey: null,
+    externalUrl: null,
     retryAttempts: 0,
     reviewCycleStartedAt: null,
     threads: [],

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -194,6 +194,11 @@ export const TaskBoardItemSchema = z.object({
   // came from one. It is what the card shows, because it is what people say
   // out loud about it. Null for a card Studio owns.
   jiraIssueKey: z.string().nullable(),
+  /** Link to that issue in the tracker (`{site}/browse/{KEY}`), for the UI to
+   *  render as a link. Kept OUT of `description` on purpose: the description is
+   *  quoted verbatim into every agent run's prompt, and a URL there is context
+   *  the run does not need and used to act on. Null for a card Studio owns. */
+  externalUrl: z.string().nullable(),
   // Infrastructure retries already spent on this card's runs — the budget
   // `reactToFailedTaskRun` spends against `MAX_RUN_RETRIES`. Present on every
   // `TaskBoardItem` (see storage/types.ts), so it must be modeled here too:

--- a/apps/api/src/tools/task-board/update.test.ts
+++ b/apps/api/src/tools/task-board/update.test.ts
@@ -33,6 +33,7 @@ function item(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
     sortOrder: 0,
     keySeq: 1,
     jiraIssueKey: null,
+    externalUrl: null,
     retryAttempts: 0,
     reviewCycleStartedAt: null,
     threads: [],

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -199,6 +199,7 @@ export const taskBoard = {
   "taskBoard.taskDialog.showLess": "Show less",
   "taskBoard.taskDialog.copyIdAriaLabel": "Copy task ID",
   "taskBoard.taskDialog.idCopied": "Task ID copied",
+  "taskBoard.taskDialog.openInTrackerAriaLabel": "Open the original issue",
   "taskBoard.taskDialog.shareAriaLabel": "Copy link to this task",
   "taskBoard.taskDialog.shareTitle": "Copy link",
   "taskBoard.taskDialog.linkCopied": "Link copied",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -209,6 +209,7 @@ export const taskBoard = {
   "taskBoard.taskDialog.showLess": "Ver menos",
   "taskBoard.taskDialog.copyIdAriaLabel": "Copiar ID da tarefa",
   "taskBoard.taskDialog.idCopied": "ID da tarefa copiado",
+  "taskBoard.taskDialog.openInTrackerAriaLabel": "Abrir a issue original",
   "taskBoard.taskDialog.shareAriaLabel": "Copiar link desta tarefa",
   "taskBoard.taskDialog.shareTitle": "Copiar link",
   "taskBoard.taskDialog.linkCopied": "Link copiado",

--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -39,6 +39,7 @@ function item(id: string, sortOrder: number): TaskBoardItem {
     sortOrder,
     keySeq: 1,
     jiraIssueKey: null,
+    externalUrl: null,
     retryAttempts: 0,
     reviewCycleStartedAt: null,
     threads: [],

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -693,6 +693,23 @@ function TaskBoardItemEditor({
             {t("taskBoard.taskDialog.savingLabel")}
           </span>
         )}
+        {item?.externalUrl && (
+          /* The card's issue in the tracker it came from. It used to be the
+             first line of the description, which put it in every agent
+             prompt — it is a link for a person, so it lives here. */
+          <Button
+            asChild
+            variant="ghost"
+            size="icon-sm"
+            aria-label={t("taskBoard.taskDialog.openInTrackerAriaLabel")}
+            title={item.externalUrl}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <a href={item.externalUrl} target="_blank" rel="noreferrer">
+              <LinkExternal01 size={16} />
+            </a>
+          </Button>
+        )}
         {item && (
           <>
             <Button

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -175,6 +175,9 @@ export interface TaskBoardItem {
   /** The key this card's issue wears in the tracker (`EX-333`), for a card
    *  synced from one — what `taskKey` shows. Null for a card Studio owns. */
   jiraIssueKey: string | null;
+  /** Link to that issue in the tracker, for a human to open. Never folded into
+   *  `description`, which agent prompts quote verbatim. */
+  externalUrl: string | null;
   /** Infrastructure retries already spent on this card's runs — the budget
    *  `reactToFailedTaskRun` spends against `MAX_RUN_RETRIES`. */
   retryAttempts: number;

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -355,6 +355,7 @@ export interface StudioToolIO {
         sortOrder: number;
         keySeq: number | null;
         jiraIssueKey: string | null;
+        externalUrl: string | null;
         retryAttempts: number;
         reviewCycleStartedAt: string | null;
         threads: {
@@ -415,6 +416,7 @@ export interface StudioToolIO {
         sortOrder: number;
         keySeq: number | null;
         jiraIssueKey: string | null;
+        externalUrl: string | null;
         retryAttempts: number;
         reviewCycleStartedAt: string | null;
         threads: {
@@ -504,6 +506,7 @@ export interface StudioToolIO {
         sortOrder: number;
         keySeq: number | null;
         jiraIssueKey: string | null;
+        externalUrl: string | null;
         retryAttempts: number;
         reviewCycleStartedAt: string | null;
         threads: {


### PR DESCRIPTION
## What

Cards synced from Jira carried the issue link as the **first line of their description** (`{site}/browse/{KEY}\n\n{body}`). A description is quoted verbatim into every agent run's prompt (`buildSuperAgentTaskPrompt` / `buildClaudeCodeTaskPrompt`), so the URL leaked into model context and into the work it produced — enough that boards were carrying prompts telling the agent to ignore it.

This gives a task its own `externalUrl`: structured data the UI renders as a link and the prompt never reads.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/decocms/studio/assets/task-external-url/screenshots/task-external-url-before.png" width="480"> | <img src="https://raw.githubusercontent.com/decocms/studio/assets/task-external-url/screenshots/task-external-url-after.png" width="480"> |
| The link sits at the top of the body, and goes into every prompt | The body is the issue text; the link is the ↗ button in the header |

## How

- **`external_url` column** (migration 198) on `task_board_items`, surfaced as `TaskBoardItem.externalUrl` through the tool schema, shared entities and the storage layer. Sync-owned, like `jiraIssueKey`/`sprintId` — not writable via `TASK_BOARD_ITEM_UPDATE`.
- **Jira pull** (`apps/api/src/jira/sync.ts`) stops prefixing the description and writes `externalUrl` on every card it touches. That prefix was the only place in the codebase building a URL into a description.
- **Backfill, both halves**, so no card waits for its issue to be touched in Jira again: the URL comes from the link table joined to the integration's `site_url`, and the description prefix is stripped anchored on that exact string — a body that merely *mentions* the URL mid-text is left alone.
- **UI**: an "open the original issue" button next to Share on the task detail header (en + pt-BR strings).

Not to be confused with `external_key`, the column beside it — that one is a reports-minted finding identity used to dedupe imports. This is a URL for a human to open.

## Testing

- `bun run check`, `bun run lint` (0 errors), `bunx knip`, `bun run fmt` — clean.
- New real-Postgres test `task-board-external-url.integration.test.ts`: create/read, null for a Studio-owned card, update **and** clear through `update()`'s column whitelist (an in-memory fake would accept a write the whitelist drops), and untouched by an unrelated update.
- Migration 198's `up()` run against real Postgres over seeded rows covering every case: prefixed body → link extracted + body clean, link-only description → `NULL`, mid-body mention → untouched, null description, unlinked card → left alone.
- Screenshots above captured by driving the real app with Playwright (temporary spec, not committed).

## Follow-ups

- `externalUrl` is not settable through `TASK_BOARD_ITEM_CREATE`/`UPDATE`. Opening it up would let non-Jira sources (Linear, a GitHub issue, a reports finding) carry their source link too, and would make the header link assertable in e2e — today it can only be seeded through the Jira sync.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the Jira issue link out of the task description so agent prompts no longer carry the tracker URL into model context.

The Jira pull used to write `{site}/browse/{KEY}` as the first line of a card's description. The link now lives in a new `externalUrl` field; the UI renders it as an "open the original issue" button, and the prompt never reads it.

- Migration 198 adds the `external_url` column and backfills every synced card: the URL comes from the link table joined to the integration's `site_url`, and the description prefix is stripped only when it matches that exact string.
- The Jira sync now writes `externalUrl` on each card it touches.
- The task detail header shows an open-in-tracker button next to Share (en and pt-BR labels).
- `externalUrl` is sync-owned — not settable through `TASK_BOARD_ITEM_CREATE`/`UPDATE`.
- Not the `external_key` column beside it, which is a reports-minted finding identity for import dedupe.

<sup>Written for commit be124a57d539899221ff0f0bc4c2671caa55b36c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

