### PR TITLE
perf(task-board): run attachRefs' four field reads concurrently

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1766,12 +1766,15 @@ export class TaskBoardStorage {
     organizationId: string,
   ): Promise<void> {
     if (items.length === 0) return;
-    await this.inTransaction(async (db) => {
-      await this.attachThreads(db, items, organizationId);
-      await this.attachTags(db, items);
-      await this.attachJiraKeys(db, items);
-      await this.attachReviewVerdicts(db, items);
-    });
+    // Four independent fields, no shared state — issue together, not serially.
+    await this.inTransaction((db) =>
+      Promise.all([
+        this.attachThreads(db, items, organizationId),
+        this.attachTags(db, items),
+        this.attachJiraKeys(db, items),
+        this.attachReviewVerdicts(db, items),
+      ]),
+    );
   }
 
   /**


### PR DESCRIPTION
Every task-board read (list/get) calls `attachRefs`, which populates `threads`, `tags`, `jiraIssueKey`, and `reviewVerdicts` on each item with four *sequential* `await`s inside one transaction — four independent, batched queries, each writing a different field on the same items with no shared state between them.

On a hot MCP-tool path (task-board tool calls proxy through this on every board read), each sequential await pays a full DB round-trip before the next query is even issued. Since the four attach calls read disjoint tables into disjoint fields, they don't need to run in program order — only the outer transaction's isolation matters (unchanged: still one `inTransaction` call, still commits/rolls back together).

Change: `Promise.all([...])` instead of four sequential `await`s inside the same transaction callback. Behavior is unchanged — same four queries, same transaction, same isolation guarantee described in the doc comment (a card can't read one field from before a concurrent edit and another from after); only the round-trip latency of issuing them changes from additive to overlapped.

To confirm: read `attachRefs` in `apps/api/src/storage/task-board.ts` — each of `attachThreads`/`attachTags`/`attachJiraKeys`/`attachReviewVerdicts` takes `items` (or `items` + `organizationId`) and writes only its own field per item, with no read of a field another attach call writes.

Locally verified: `bunx tsc --noEmit` in `apps/api` (clean), `bunx oxlint apps/api/src/storage/task-board.ts` (0 warnings/errors), `bun test apps/api/src/storage/task-board.test.ts` (14 pass). This is a pure-DB-timing change with no unit-testable surface (attachRefs needs a real Postgres transaction to exercise); full CI (including e2e/storage-integration) validates the DB-backed path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs `attachRefs`' four field reads concurrently instead of sequentially, cutting latency on every task-board read without changing behavior.

The four queries write disjoint fields (`threads`, `tags`, `jiraIssueKey`, `reviewVerdicts`) with no shared state, so they don't need to run in program order. The outer transaction still wraps all four, so isolation and commit/rollback behavior are unchanged.

<sup>Written for commit c81813f1c6544f058ba8e578086e1d4f6786ee44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

