### PR TITLE
fix(task-board): move the board settings cog to the right of the sprint filter

### DIFF
--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -972,7 +972,6 @@ function FilterControls({
           onChange={(repo) => onChange({ ...filters, repo })}
         />
       )}
-      <BoardSettingsButton block={block} onClick={onOpenBoardSettings} />
       {/* Same reasoning as the repo control: an active sprint filter keeps its
           chip visible even when the board mirrors no sprints, so the hidden
           cards can be brought back. */}
@@ -984,6 +983,7 @@ function FilterControls({
           onChange={(sprint) => onChange({ ...filters, sprint })}
         />
       )}
+      <BoardSettingsButton block={block} onClick={onOpenBoardSettings} />
     </>
   );
 }


### PR DESCRIPTION
Swaps the render order in `FilterControls` so the board-settings cog sits after the sprint filter instead of before it.

Applies to both the desktop bar and the mobile drawer (same component).

## Testing
- `bun run fmt` clean; one-line JSX reorder, no logic touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes streaming so text after a thinking block isn't duplicated and reasoning that only streams signatures is restated in full. Moves the board settings cog to the right of the sprint filter.

**Bug Fixes**
- The SDK sends one `assistant` message per content block, so the skip set was checked against the wrong index; a `restatedBlocks` cursor now maps them correctly.
- Thinking blocks that only sent `signature_delta` opened an empty part and suppressed the restatement; the part now opens on the first renderable delta.
- The board settings cog now appears after the sprint filter in both desktop and mobile layouts.

<sup>Written for commit ddc16b6221e99cc16c3a14101cb402a7207f3e8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

