### PR TITLE
fix(sandbox): stop the dev-server watchdog killing a healthy boot

### DIFF
--- a/apps/api/src/api/routes/decopilot/classify-run-failure.test.ts
+++ b/apps/api/src/api/routes/decopilot/classify-run-failure.test.ts
@@ -45,10 +45,20 @@ describe("classifyRunFailure", () => {
     expect(classifyRunFailure("fetch failed: ETIMEDOUT").kind).toBe("timeout");
   });
 
-  test("a timeout that names the sandbox keeps the more specific kind", () => {
-    expect(
-      classifyRunFailure("Daemon unreachable: The operation timed out.").kind,
-    ).toBe("sandbox_unreachable");
+  test("a timeout that names a more specific cause keeps that kind", () => {
+    // "timed out" is a phrase almost any failure can carry in passing, so the
+    // timeout pattern is last: it must never re-bucket a run that a named
+    // cause already classified — `failure_kind` is what analytics GROUP BY.
+    const cases: Array<[string, string]> = [
+      ["Daemon unreachable: The operation timed out.", "sandbox_unreachable"],
+      ["cancelled: run cancelled because the sandbox timed out", "cancelled"],
+      ["API Error: 500 upstream provider timed out", "model_error"],
+      ["429 rate limited after the request timed out", "overloaded"],
+      ["context length exceeded; the retry timed out", "context_length"],
+    ];
+    for (const [text, kind] of cases) {
+      expect(classifyRunFailure(text).kind).toBe(kind);
+    }
   });
 
   test("unrecognized text keeps exactly today's behavior", () => {

--- a/apps/api/src/api/routes/decopilot/classify-run-failure.test.ts
+++ b/apps/api/src/api/routes/decopilot/classify-run-failure.test.ts
@@ -36,6 +36,21 @@ describe("classifyRunFailure", () => {
     }
   });
 
+  test("the bare abort-signal message is a timeout, not a generic error", () => {
+    // Verbatim from thread 3a3d9465: an AbortSignal.timeout DOMException that
+    // reached the user unwrapped and classified as nothing.
+    expect(classifyRunFailure("Error: The operation timed out.").kind).toBe(
+      "timeout",
+    );
+    expect(classifyRunFailure("fetch failed: ETIMEDOUT").kind).toBe("timeout");
+  });
+
+  test("a timeout that names the sandbox keeps the more specific kind", () => {
+    expect(
+      classifyRunFailure("Daemon unreachable: The operation timed out.").kind,
+    ).toBe("sandbox_unreachable");
+  });
+
   test("unrecognized text keeps exactly today's behavior", () => {
     for (const text of ["something new", "", "   ", null, undefined]) {
       expect(classifyRunFailure(text)).toEqual({ ...GENERIC_RUN_FAILURE });
@@ -46,6 +61,7 @@ describe("classifyRunFailure", () => {
     const texts = [
       "requires more credits",
       "[SANDBOX_UNREACHABLE] x",
+      "Error: The operation timed out.",
       "cancelled: run cancelled",
       "Overloaded.",
       "exceeds the maximum context length",

--- a/apps/api/src/api/routes/decopilot/classify-run-failure.ts
+++ b/apps/api/src/api/routes/decopilot/classify-run-failure.ts
@@ -27,7 +27,18 @@ const FAILURE_PATTERNS: ReadonlyArray<{
   {
     kind: "sandbox_unreachable",
     reason: "Run stopped: its sandbox became unreachable mid-run",
-    match: /\[SANDBOX_UNREACHABLE\]|sandbox stream broke/i,
+    match: /\[SANDBOX_UNREACHABLE\]|sandbox stream broke|Daemon unreachable/i,
+  },
+  {
+    // Before this, a montecarlo run that died waiting on its sandbox persisted
+    // "Run ended with an error — see the run's messages" and the messages held
+    // exactly `Error: The operation timed out.` — a dead end in both places.
+    // Sits below sandbox_unreachable so a message that names the sandbox keeps
+    // the more specific kind, and above the generic patterns because a timeout
+    // is a better answer than "the provider said something".
+    kind: "timeout",
+    reason: "Run stopped: an operation it was waiting on timed out",
+    match: /\boperation timed out\b|\btimed out\b|\bETIMEDOUT\b/i,
   },
   {
     kind: "cancelled",

--- a/apps/api/src/api/routes/decopilot/classify-run-failure.ts
+++ b/apps/api/src/api/routes/decopilot/classify-run-failure.ts
@@ -30,17 +30,6 @@ const FAILURE_PATTERNS: ReadonlyArray<{
     match: /\[SANDBOX_UNREACHABLE\]|sandbox stream broke|Daemon unreachable/i,
   },
   {
-    // Before this, a montecarlo run that died waiting on its sandbox persisted
-    // "Run ended with an error — see the run's messages" and the messages held
-    // exactly `Error: The operation timed out.` — a dead end in both places.
-    // Sits below sandbox_unreachable so a message that names the sandbox keeps
-    // the more specific kind, and above the generic patterns because a timeout
-    // is a better answer than "the provider said something".
-    kind: "timeout",
-    reason: "Run stopped: an operation it was waiting on timed out",
-    match: /\boperation timed out\b|\btimed out\b|\bETIMEDOUT\b/i,
-  },
-  {
     kind: "cancelled",
     reason: "Run cancelled before it finished",
     match: /^\s*(error:\s*)?cancelled\b|run cancelled/i,
@@ -59,6 +48,21 @@ const FAILURE_PATTERNS: ReadonlyArray<{
     kind: "model_error",
     reason: "Run stopped: the model provider rejected the request",
     match: /\bAPI Error\b|\b5\d{2}\b.*provider|provider returned/i,
+  },
+  {
+    // Before this, a montecarlo run that died waiting on its sandbox persisted
+    // "Run ended with an error — see the run's messages" and the messages held
+    // exactly `Error: The operation timed out.` — a dead end in both places.
+    //
+    // Deliberately LAST. "timed out" is a phrase almost any failure can carry
+    // in passing ("cancelled because the sandbox timed out", "API Error: 500
+    // upstream provider timed out"), so matching it early silently re-buckets
+    // runs that a named cause already classified correctly — and `failure_kind`
+    // is what the analytics GROUP BY. A timeout is the answer only when nothing
+    // more specific claimed the text.
+    kind: "timeout",
+    reason: "Run stopped: an operation it was waiting on timed out",
+    match: /\boperation timed out\b|\btimed out\b|\bETIMEDOUT\b/i,
   },
 ];
 

--- a/packages/sandbox/daemon-e2e/daemon.devwatch.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.devwatch.e2e.test.ts
@@ -135,6 +135,83 @@ describe("daemon e2e: dev-server liveness watchdog", () => {
   );
 });
 
+// `start-failed` is a verdict the watchdog reaches by giving up while its last
+// respawn is still booting — so the boot it gave up on can, and on a large repo
+// does, come up minutes later. When it does, the sandbox is working and the
+// phase has to say so. It used to latch instead: a montecarlo dev server served
+// from 17:37 onward while the UI showed "Blocos indisponíveis" until someone
+// hit a button that threw the working server away and paid another cold boot.
+//
+// Black-box shape: shrink both watchdog windows so the give-up happens in
+// seconds, and make the respawned dev server bind slowly enough to lose the
+// race — the same ordering as production, compressed.
+describe("daemon e2e: a serving dev server clears start-failed", () => {
+  let d: Daemon;
+  let repo: BareRepo;
+  let devPort: number;
+  let marker: string;
+
+  beforeEach(async () => {
+    devPort = await freePort();
+    marker = join(tmpdir(), `devwatch-recover-${devPort}`);
+    rmSync(marker, { force: true });
+    // First run serves immediately (so the daemon reaches `running` and the
+    // watchdog arms). Every run after it sleeps past the restart window before
+    // binding, so the watchdog exhausts its budget mid-boot and gives up.
+    repo = setupBareRepo({
+      withPackageJson: true,
+      scripts: {
+        dev: `node -e "const fs=require('fs'),m='${marker.replace(/\\/g, "\\\\")}';const s=()=>require('http').createServer((_q,r)=>{r.setHeader('content-type','text/html');r.end('<html>ok</html>')}).listen(process.env.PORT);if(fs.existsSync(m)){setTimeout(s,8000)}else{fs.writeFileSync(m,'1');s()}"`,
+      },
+    });
+    d = await startDaemon({
+      SANDBOX_PROBE_FAST_MS: "300",
+      SANDBOX_PROBE_SLOW_MS: "1000",
+      SANDBOX_DEV_WATCH_GRACE_MS: "1000",
+      SANDBOX_DEV_WATCH_RESTART_GRACE_MS: "1000",
+      SANDBOX_DEV_WATCH_MAX_RESTARTS: "1",
+      SANDBOX_DEV_WATCH_TICK_MS: "500",
+    });
+  }, HOOK_TIMEOUT_MS);
+
+  afterEach(async () => {
+    await stopDaemon(d);
+    repo.cleanup();
+    rmSync(marker, { force: true });
+  }, HOOK_TIMEOUT_MS);
+
+  it(
+    "returns to running when the boot it gave up on finally serves",
+    async () => {
+      expect(
+        (
+          await bootstrapRepo(d, repo.url, {
+            application: { packageManager: { name: "npm" }, port: devPort },
+            env: { npm_config_offline: "true", PORT: String(devPort) },
+          })
+        ).status,
+      ).toBe(200);
+      await waitForOrchestratorIdle(d, SETUP_TIMEOUT_MS);
+      await waitForPhaseOf(d, (p) => p === "running", "running");
+
+      const killed = await fetch(url(d, "/_sandbox/exec/dev/kill"), {
+        method: "POST",
+        headers: authHeaders(),
+      });
+      expect(killed.status).toBe(200);
+
+      // The budget (1 restart) is spent while the slow respawn is still
+      // sleeping, so the watchdog gives up.
+      await waitForPhaseOf(d, (p) => p === "start-failed", "start-failed");
+      expect(d.stdout.value).toContain("giving up");
+
+      // …and then that same respawn binds. The phase must follow the facts.
+      await waitForPhaseOf(d, (p) => p === "running", "running-again", 30_000);
+    },
+    SETUP_TIMEOUT_MS,
+  );
+});
+
 // Fix #2: a dev server that crashed (non-zero exit) latches `status:"error"` +
 // `start-failed`; a later reclaim/branch-change must clear that latch so the
 // start step runs again — without it, `stepStartInner` silently skips every

--- a/packages/sandbox/daemon-e2e/daemon.devwatch.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.devwatch.e2e.test.ts
@@ -201,12 +201,16 @@ describe("daemon e2e: a serving dev server clears start-failed", () => {
       expect(killed.status).toBe(200);
 
       // The budget (1 restart) is spent while the slow respawn is still
-      // sleeping, so the watchdog gives up.
+      // sleeping, so the watchdog gives up…
       await waitForPhaseOf(d, (p) => p === "start-failed", "start-failed");
-      expect(d.stdout.value).toContain("giving up");
 
       // …and then that same respawn binds. The phase must follow the facts.
       await waitForPhaseOf(d, (p) => p === "running", "running-again", 30_000);
+
+      // Asserted only here: the phase arrives over the SSE stream while stdout
+      // comes through a separate pipe, so a give-up line read the instant the
+      // phase flips can still be in flight. By the recovery it is long flushed.
+      expect(d.stdout.value).toContain("giving up");
     },
     SETUP_TIMEOUT_MS,
   );

--- a/packages/sandbox/daemon-go/devwatch_wiring_test.go
+++ b/packages/sandbox/daemon-go/devwatch_wiring_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/decocms/studio/sandbox-daemon/internal/devwatch"
+)
+
+// The watchdog must size a respawn's window from the boot this sandbox was
+// actually measured to need. The montecarlo numbers are the ones that matter:
+// a 5m18s boot has to buy the respawn more than the 20s default grace.
+func TestRestartGraceForBoot(t *testing.T) {
+	got := restartGraceForBoot((5*time.Minute + 18*time.Second).Milliseconds())
+	if want := 10*time.Minute + 36*time.Second; got != want {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+	if got <= devwatch.DefaultGracePeriod {
+		t.Fatalf("a 5m boot must widen past the default grace, got %v", got)
+	}
+}
+
+// noteBootDuration has to work before devWatchLoop exists (a boot can finish
+// first) and must keep the slowest boot, so the loop can replay it.
+func TestNoteBootDurationReplaysToLaterTracker(t *testing.T) {
+	d := &daemon{}
+	d.noteBootDuration((5 * time.Minute).Milliseconds())
+	d.noteBootDuration((1 * time.Second).Milliseconds()) // slower boot wins
+	if got := d.observedBootMs.Load(); got != (5 * time.Minute).Milliseconds() {
+		t.Fatalf("want the slowest boot retained, got %dms", got)
+	}
+
+	tr := devwatch.NewTracker(devwatch.Config{})
+	tr.RaiseRestartGrace(restartGraceForBoot(d.observedBootMs.Load()))
+	if want := 10 * time.Minute; tr.RestartGrace() != want {
+		t.Fatalf("want %v after replay, got %v", want, tr.RestartGrace())
+	}
+}
+
+// A zero or negative duration is a lifecycle bug, not a hint to shrink anything.
+func TestNoteBootDurationIgnoresNonPositive(t *testing.T) {
+	d := &daemon{}
+	d.noteBootDuration(0)
+	d.noteBootDuration(-1)
+	if got := d.observedBootMs.Load(); got != 0 {
+		t.Fatalf("want 0, got %d", got)
+	}
+}
+
+func TestTailBytes(t *testing.T) {
+	if got := tailBytes("abc", 10); got != "abc" {
+		t.Fatalf("short input should pass through, got %q", got)
+	}
+	got := tailBytes("abcdef", 3)
+	if got != "…def" {
+		t.Fatalf("want the LAST bytes marked as truncated, got %q", got)
+	}
+	if !strings.HasSuffix(got, "def") {
+		t.Fatalf("a crash's last words must survive, got %q", got)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/devwatch/devwatch.go
+++ b/packages/sandbox/daemon-go/internal/devwatch/devwatch.go
@@ -21,6 +21,8 @@
 //     for StableWindow — else a flapping crash-loop that serves for one probe
 //     cycle between deaths would reset the budget every time and never give up
 //     (see TestTracker_FlappingDoesNotResetBudget).
+//   - "how long dead before it is dead" and "how long a respawn gets to come
+//     up" are DIFFERENT durations (Grace vs RestartGrace) — see RestartGrace.
 package devwatch
 
 import "time"
@@ -32,6 +34,22 @@ import "time"
 // than this will be restarted (and, after MaxRestarts, fail). Tune via
 // SANDBOX_DEV_WATCH_GRACE_MS for frameworks with long first compiles.
 const DefaultGracePeriod = 20 * time.Second
+
+// DefaultRestartGrace is how long a *respawned* dev server gets to serve before
+// the next restart is charged. It is deliberately far larger than
+// DefaultGracePeriod: those two numbers answer different questions. Grace asks
+// "has the server that was serving a moment ago died?" — 20s is plenty.
+// RestartGrace asks "has the server we just launched finished booting?", and a
+// respawn is a cold boot, which on a large Fresh/Vite app is minutes.
+//
+// Reusing Grace for both is what took a montecarlo sandbox down in production:
+// a dev server needing 5m18s to first serve was respawned at +20s, +41s and
+// +62s — each restart killing the previous boot — and declared start-failed
+// 63s into an episode that only ever needed one restart and five minutes of
+// patience. The tracker also raises this from the boot it actually observed
+// (see RaiseRestartGrace), so a slow repo tunes itself. Override the floor with
+// SANDBOX_DEV_WATCH_RESTART_GRACE_MS.
+const DefaultRestartGrace = 5 * time.Minute
 
 // DefaultStableWindow is how long the server must serve continuously before the
 // restart budget resets. Longer than a flap so a crash-loop that briefly serves
@@ -60,6 +78,7 @@ const (
 // Config parameterizes a Tracker. Zero values fall back to the Default* consts.
 type Config struct {
 	Grace        time.Duration
+	RestartGrace time.Duration
 	StableWindow time.Duration
 	MaxRestarts  int
 }
@@ -67,6 +86,14 @@ type Config struct {
 func (c Config) withDefaults() Config {
 	if c.Grace <= 0 {
 		c.Grace = DefaultGracePeriod
+	}
+	if c.RestartGrace <= 0 {
+		c.RestartGrace = DefaultRestartGrace
+	}
+	// A restart that gets less time than the initial dead-detection window is
+	// never what anyone means; it only re-creates the bug this field fixes.
+	if c.RestartGrace < c.Grace {
+		c.RestartGrace = c.Grace
 	}
 	if c.StableWindow <= 0 {
 		c.StableWindow = DefaultStableWindow
@@ -119,6 +146,21 @@ func (t *Tracker) Attempts() int { return t.attempts }
 // MaxRestarts is the effective budget (after defaults), for log messages.
 func (t *Tracker) MaxRestarts() int { return t.cfg.MaxRestarts }
 
+// RestartGrace is the effective post-restart window, for log messages.
+func (t *Tracker) RestartGrace() time.Duration { return t.cfg.RestartGrace }
+
+// RaiseRestartGrace widens the post-restart window to `d`, ignoring anything
+// at or below the current value. Callers feed it the boot this sandbox was
+// actually measured to need (with headroom), so a repo that takes eleven
+// minutes to serve gets eleven minutes on a respawn without anyone having to
+// guess a constant. One-way on purpose: a single fast boot on a warm cache
+// must not shrink the window back under a repo that is usually slow.
+func (t *Tracker) RaiseRestartGrace(d time.Duration) {
+	if d > t.cfg.RestartGrace {
+		t.cfg.RestartGrace = d
+	}
+}
+
 // Observe advances the tracker with one tick's snapshot and returns the action
 // to take. On ActionRestart it has already charged one attempt and reset the
 // grace window; on ActionGiveUp it latches the given-up state until the server
@@ -150,7 +192,14 @@ func (t *Tracker) Observe(s Snapshot) Action {
 		t.notServingSince = s.Now
 	}
 
-	if t.gaveUp || s.Now.Sub(t.notServingSince) < t.cfg.Grace {
+	// Before the first restart we are judging a server that WAS serving, so the
+	// short dead-detection window applies. Afterwards we are judging a boot we
+	// just started, which needs a boot's worth of time.
+	window := t.cfg.Grace
+	if t.attempts > 0 {
+		window = t.cfg.RestartGrace
+	}
+	if t.gaveUp || s.Now.Sub(t.notServingSince) < window {
 		return ActionNone
 	}
 	if t.attempts >= t.cfg.MaxRestarts {

--- a/packages/sandbox/daemon-go/internal/devwatch/devwatch_test.go
+++ b/packages/sandbox/daemon-go/internal/devwatch/devwatch_test.go
@@ -7,8 +7,18 @@ import (
 
 var epoch = time.Unix(1_700_000_000, 0)
 
+// restartGrace is the post-restart window these tests run with — deliberately
+// far larger than Grace, mirroring production, so a test that advances only by
+// Grace between restarts fails instead of quietly passing.
+const restartGrace = 5 * time.Minute
+
 func cfg() Config {
-	return Config{Grace: 20 * time.Second, StableWindow: 60 * time.Second, MaxRestarts: 3}
+	return Config{
+		Grace:        20 * time.Second,
+		RestartGrace: restartGrace,
+		StableWindow: 60 * time.Second,
+		MaxRestarts:  3,
+	}
 }
 
 // A dead-but-known-port server, past grace, in a restartable phase → restart.
@@ -80,20 +90,25 @@ func TestTracker_GivesUpAfterMaxRestarts(t *testing.T) {
 	dead := func() Snapshot {
 		return Snapshot{Now: now, Restartable: true, PortKnown: true}
 	}
-	// Arm, then each 20s window past grace charges one restart.
+	// Arm, then the first Grace window charges restart 1. Every window after
+	// that is a RestartGrace, because from then on we are waiting on a boot.
 	tr.Observe(dead())
-	for i := 1; i <= 3; i++ {
-		now = now.Add(20 * time.Second)
+	now = now.Add(20 * time.Second)
+	if a := tr.Observe(dead()); a != ActionRestart {
+		t.Fatalf("attempt 1 want Restart, got %v", a)
+	}
+	for i := 2; i <= 3; i++ {
+		now = now.Add(restartGrace)
 		if a := tr.Observe(dead()); a != ActionRestart {
 			t.Fatalf("attempt %d want Restart, got %v", i, a)
 		}
 	}
-	now = now.Add(20 * time.Second)
+	now = now.Add(restartGrace)
 	if a := tr.Observe(dead()); a != ActionGiveUp {
 		t.Fatalf("want GiveUp after budget, got %v", a)
 	}
 	// Latched: no repeated give-ups / restarts.
-	now = now.Add(20 * time.Second)
+	now = now.Add(restartGrace)
 	if a := tr.Observe(dead()); a != ActionNone {
 		t.Fatalf("want None after give-up latched, got %v", a)
 	}
@@ -105,9 +120,15 @@ func TestTracker_FlappingDoesNotResetBudget(t *testing.T) {
 	tr := NewTracker(cfg())
 	now := epoch
 	for i := 1; i <= 3; i++ {
-		// Dead window → restart.
+		// Dead window → restart. A cycle's brief serve never reaches
+		// StableWindow, so attempts never resets: only cycle 1 waits Grace, the
+		// rest are waiting on a respawn and wait RestartGrace.
+		window := 20 * time.Second
+		if i > 1 {
+			window = restartGrace
+		}
 		tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true})
-		now = now.Add(20 * time.Second)
+		now = now.Add(window)
 		if a := tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true}); a != ActionRestart {
 			t.Fatalf("cycle %d want Restart, got %v", i, a)
 		}
@@ -120,7 +141,7 @@ func TestTracker_FlappingDoesNotResetBudget(t *testing.T) {
 	// Budget exhausted (attempts==3) despite the brief serves. Arm a fresh dead
 	// window and let grace elapse → give up (the budget was never reset).
 	tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true})
-	now = now.Add(20 * time.Second)
+	now = now.Add(restartGrace)
 	if a := tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true}); a != ActionGiveUp {
 		t.Fatalf("flapping want GiveUp (budget not reset), got %v (attempts=%d)", a, tr.Attempts())
 	}
@@ -131,10 +152,13 @@ func TestTracker_FlappingDoesNotResetBudget(t *testing.T) {
 func TestTracker_SustainedServingResetsBudget(t *testing.T) {
 	tr := NewTracker(cfg())
 	now := epoch
-	// Burn the whole budget → give up.
+	// Burn the whole budget → give up. Only the first window is Grace; the
+	// three after it are waiting on a respawn.
 	tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true})
-	for i := 0; i < 4; i++ {
-		now = now.Add(20 * time.Second)
+	now = now.Add(20 * time.Second)
+	tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true})
+	for i := 0; i < 3; i++ {
+		now = now.Add(restartGrace)
 		tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true})
 	}
 	if !tr.gaveUp {
@@ -177,7 +201,65 @@ func TestTracker_LeavingRestartablePhaseDisarms(t *testing.T) {
 
 func TestConfig_Defaults(t *testing.T) {
 	tr := NewTracker(Config{})
-	if tr.cfg.Grace != DefaultGracePeriod || tr.cfg.StableWindow != DefaultStableWindow || tr.cfg.MaxRestarts != DefaultMaxRestarts {
+	if tr.cfg.Grace != DefaultGracePeriod || tr.cfg.StableWindow != DefaultStableWindow ||
+		tr.cfg.MaxRestarts != DefaultMaxRestarts || tr.cfg.RestartGrace != DefaultRestartGrace {
 		t.Fatalf("zero config should use defaults, got %+v", tr.cfg)
+	}
+}
+
+// A RestartGrace below Grace is meaningless — it re-creates the very bug
+// RestartGrace exists to fix — so it is floored, not honoured.
+func TestConfig_RestartGraceFloorsAtGrace(t *testing.T) {
+	tr := NewTracker(Config{Grace: time.Minute, RestartGrace: time.Second})
+	if tr.RestartGrace() != time.Minute {
+		t.Fatalf("want RestartGrace floored to Grace, got %v", tr.RestartGrace())
+	}
+}
+
+// The production regression, as a test. A dev server needing 5m18s to serve was
+// respawned at +20s, +41s and +62s — each restart killing the previous boot —
+// and declared start-failed 63s into an episode that one restart and five
+// minutes of patience would have fixed. A respawn now gets RestartGrace.
+func TestTracker_RespawnGetsRestartGraceNotGrace(t *testing.T) {
+	tr := NewTracker(cfg())
+	now := epoch
+	dead := func() Snapshot {
+		return Snapshot{Now: now, Restartable: true, PortKnown: true}
+	}
+	tr.Observe(dead())
+	now = now.Add(20 * time.Second)
+	if a := tr.Observe(dead()); a != ActionRestart {
+		t.Fatalf("want the first restart after Grace, got %v", a)
+	}
+	// The respawn is booting. Three more Grace windows must not touch it —
+	// under the old rule these were restarts 2, 3 and the give-up.
+	for i := 1; i <= 3; i++ {
+		now = now.Add(20 * time.Second)
+		if a := tr.Observe(dead()); a != ActionNone {
+			t.Fatalf("%ds into the respawn want None, got %v", i*20, a)
+		}
+	}
+	now = now.Add(restartGrace - 61*time.Second)
+	if a := tr.Observe(dead()); a != ActionNone {
+		t.Fatalf("just under RestartGrace want None, got %v", a)
+	}
+	// A boot that genuinely never arrives still earns the next restart.
+	now = now.Add(time.Second)
+	if a := tr.Observe(dead()); a != ActionRestart {
+		t.Fatalf("past RestartGrace want Restart, got %v", a)
+	}
+}
+
+// A boot slower than the configured floor widens the window; a faster one
+// leaves it alone, so one warm boot cannot shrink it under a usually-slow repo.
+func TestTracker_RaiseRestartGraceOnlyWidens(t *testing.T) {
+	tr := NewTracker(cfg())
+	tr.RaiseRestartGrace(20 * time.Minute)
+	if tr.RestartGrace() != 20*time.Minute {
+		t.Fatalf("want widened to 20m, got %v", tr.RestartGrace())
+	}
+	tr.RaiseRestartGrace(time.Second)
+	if tr.RestartGrace() != 20*time.Minute {
+		t.Fatalf("want 20m kept, got %v", tr.RestartGrace())
 	}
 }

--- a/packages/sandbox/daemon-go/internal/lifecycle/lifecycle.go
+++ b/packages/sandbox/daemon-go/internal/lifecycle/lifecycle.go
@@ -27,6 +27,10 @@ type Manager struct {
 	OnStartPhase func(status string, durationMs int64)
 
 	startAttemptAt time.Time
+	// startAttemptFailed records that the open attempt already reported
+	// "failed", so the same attempt is not reported twice while it stays open
+	// across a start-failed verdict (see Transition).
+	startAttemptFailed bool
 }
 
 func New(b Broadcaster) *Manager {
@@ -49,6 +53,7 @@ func (m *Manager) Current() events.LifecycleState {
 func (m *Manager) NoteStartAttempt() {
 	m.mu.Lock()
 	m.startAttemptAt = time.Now()
+	m.startAttemptFailed = false
 	m.mu.Unlock()
 }
 
@@ -56,6 +61,7 @@ func (m *Manager) NoteStartAttempt() {
 func (m *Manager) CancelStartAttempt() {
 	m.mu.Lock()
 	m.startAttemptAt = time.Time{}
+	m.startAttemptFailed = false
 	m.mu.Unlock()
 }
 
@@ -73,14 +79,28 @@ func (m *Manager) Transition(next events.LifecycleState) {
 	// two transitions racing cannot both report the same attempt.
 	var startStatus string
 	var startMs int64
-	if !m.startAttemptAt.IsZero() &&
-		(next.Phase == events.PhaseRunning || next.Phase == events.PhaseStartFailed) {
-		startStatus = "done"
-		if next.Phase == events.PhaseStartFailed {
-			startStatus = "failed"
+	if !m.startAttemptAt.IsZero() {
+		switch next.Phase {
+		case events.PhaseRunning:
+			startStatus = "done"
+			startMs = time.Since(m.startAttemptAt).Milliseconds()
+			m.startAttemptAt = time.Time{}
+			m.startAttemptFailed = false
+		case events.PhaseStartFailed:
+			// The attempt is reported failed but deliberately stays OPEN.
+			// start-failed is a verdict the watchdog reaches by giving up while
+			// the last respawn is still booting, and that boot can still serve
+			// minutes later. Closing the attempt here threw that boot's real
+			// duration away, so the one number that widens the watchdog's
+			// restart grace (see devwatch.RaiseRestartGrace) was never measured
+			// on exactly the sandboxes slow enough to need it. Held open, the
+			// late `running` closes it with the full boot.
+			if !m.startAttemptFailed {
+				startStatus = "failed"
+				startMs = time.Since(m.startAttemptAt).Milliseconds()
+				m.startAttemptFailed = true
+			}
 		}
-		startMs = time.Since(m.startAttemptAt).Milliseconds()
-		m.startAttemptAt = time.Time{}
 	}
 	startHook := m.OnStartPhase
 	m.mu.Unlock()

--- a/packages/sandbox/daemon-go/internal/lifecycle/lifecycle_test.go
+++ b/packages/sandbox/daemon-go/internal/lifecycle/lifecycle_test.go
@@ -14,11 +14,13 @@ func (nopBroadcaster) Emit(string, any) {}
 type recorder struct {
 	mu   sync.Mutex
 	seen []string
+	ms   []int64
 }
 
-func (r *recorder) record(status string, _ int64) {
+func (r *recorder) record(status string, durationMs int64) {
 	r.mu.Lock()
 	r.seen = append(r.seen, status)
+	r.ms = append(r.ms, durationMs)
 	r.mu.Unlock()
 }
 
@@ -85,5 +87,42 @@ func TestNoAttemptReportsNothing(t *testing.T) {
 	m.Transition(events.LifecycleState{Phase: events.PhaseStartFailed, Error: "unrelated"})
 	if len(rec.seen) != 0 {
 		t.Fatalf("reported without an attempt: %v", rec.seen)
+	}
+}
+
+// The watchdog's give-up is a verdict its last respawn can still refute by
+// serving minutes later. That late boot is the only measurement of how long
+// this sandbox actually needs, and it used to be discarded: start-failed
+// closed the attempt, so the recovering `running` reported nothing and the
+// watchdog kept the short restart grace on the very sandboxes too slow for it.
+func TestLateRecoveryStillReportsTheBoot(t *testing.T) {
+	m, rec := newManager()
+	m.NoteStartAttempt()
+	m.Transition(events.LifecycleState{Phase: events.PhaseStartFailed, Error: "gave up"})
+	m.Transition(running())
+	if len(rec.seen) != 2 || rec.seen[0] != "failed" || rec.seen[1] != "done" {
+		t.Fatalf("want failed then done, got %v", rec.seen)
+	}
+	if rec.ms[1] < rec.ms[0] {
+		t.Fatalf("the recovered boot must span the whole attempt: %v", rec.ms)
+	}
+	// The attempt is closed by the recovery, so a later crash/recovery cycle is
+	// not a third report.
+	m.Transition(events.LifecycleState{Phase: events.PhaseCrashed})
+	m.Transition(running())
+	if len(rec.seen) != 2 {
+		t.Fatalf("recovery must close the attempt, got %v", rec.seen)
+	}
+}
+
+// One attempt reports "failed" once, however many times it re-enters the phase.
+func TestRepeatedStartFailedReportsOnce(t *testing.T) {
+	m, rec := newManager()
+	m.NoteStartAttempt()
+	m.Transition(events.LifecycleState{Phase: events.PhaseStartFailed, Error: "first"})
+	m.Transition(events.LifecycleState{Phase: events.PhaseCrashed})
+	m.Transition(events.LifecycleState{Phase: events.PhaseStartFailed, Error: "second"})
+	if len(rec.seen) != 1 || rec.seen[0] != "failed" {
+		t.Fatalf("want one failed, got %v", rec.seen)
 	}
 }

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -167,6 +167,18 @@ func (d *daemon) getDevPort() int {
 	return 0
 }
 
+// devTaskRunning reports whether a dev-script task (`dev`/`start`) is alive
+// right now — the evidence that a serving port belongs to this sandbox's dev
+// server rather than to something that merely outlived it.
+func (d *daemon) devTaskRunning() bool {
+	for _, t := range d.tasks.List([]string{proc.StatusRunning}) {
+		if proc.IsWellKnownStarter(t.LogName) {
+			return true
+		}
+	}
+	return false
+}
+
 func (d *daemon) getActiveTasks() []events.ActiveTaskSummary {
 	running := d.tasks.List([]string{proc.StatusRunning})
 	out := make([]events.ActiveTaskSummary, 0, len(running))
@@ -249,15 +261,23 @@ func (d *daemon) onProbeChange(s probe.State) {
 		isCrashedRecovery := phase == events.PhaseCrashed && s.Port == d.lastRunningPort
 		d.mu.Unlock()
 		// `start-failed` is a verdict, not a fact, and a serving dev server
-		// refutes it. The watchdog reaches that phase by giving up after a
-		// bounded number of restarts, so the last respawn is still booting when
-		// it fires; when that boot finally serves — as it did on the sandbox
-		// this branch exists for, five minutes later — the sandbox is working
-		// and the UI must stop saying "Blocos indisponíveis". Without this the
-		// phase latches for the life of the pod and only an explicit
-		// RestartDev clears it, throwing away the very server that just proved
-		// itself and paying for another cold boot.
-		recovered := phase == events.PhaseStartFailed || isCrashedRecovery
+		// refutes it — but only OUR dev server does. The watchdog reaches that
+		// phase by giving up after a bounded number of restarts, so the last
+		// respawn is still booting when it fires; when that boot finally
+		// serves — as it did on the sandbox this branch exists for, five
+		// minutes later — the sandbox is working and the UI must stop saying
+		// "Blocos indisponíveis". Without this the phase latches for the life
+		// of the pod and only an explicit RestartDev clears it, throwing away
+		// the very server that just proved itself and paying for another cold
+		// boot.
+		//
+		// The dev-task check is what keeps this from being credulous: the probe
+		// falls back to the *configured* application.port (getDevPort), which
+		// some unrelated or stale process can be sitting on long after the dev
+		// script died. A terminal verdict is only overturned while a dev task
+		// is actually alive to own the port.
+		startFailedRecovery := phase == events.PhaseStartFailed && d.devTaskRunning()
+		recovered := startFailedRecovery || isCrashedRecovery
 		if phase != events.PhaseStarting && phase != events.PhaseRunning && !recovered {
 			return
 		}

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -74,6 +75,11 @@ type daemon struct {
 	// grace/budget bookkeeping; devWatchMu guards it (kept off the hot d.mu).
 	devWatchMu sync.Mutex
 	devTracker *devwatch.Tracker
+	// Longest successful `starting`→`running` this process has seen, in ms. It
+	// sizes the watchdog's post-restart window (see restartGraceForBoot). Held
+	// separately from the tracker because a boot can finish before devWatchLoop
+	// has constructed one — the loop replays this value on startup.
+	observedBootMs atomic.Int64
 
 	broadcaster  *events.Broadcaster
 	sniffer      *proc.PortSniffer
@@ -242,13 +248,23 @@ func (d *daemon) onProbeChange(s probe.State) {
 		d.mu.Lock()
 		isCrashedRecovery := phase == events.PhaseCrashed && s.Port == d.lastRunningPort
 		d.mu.Unlock()
-		if phase != events.PhaseStarting && phase != events.PhaseRunning && !isCrashedRecovery {
+		// `start-failed` is a verdict, not a fact, and a serving dev server
+		// refutes it. The watchdog reaches that phase by giving up after a
+		// bounded number of restarts, so the last respawn is still booting when
+		// it fires; when that boot finally serves — as it did on the sandbox
+		// this branch exists for, five minutes later — the sandbox is working
+		// and the UI must stop saying "Blocos indisponíveis". Without this the
+		// phase latches for the life of the pod and only an explicit
+		// RestartDev clears it, throwing away the very server that just proved
+		// itself and paying for another cold boot.
+		recovered := phase == events.PhaseStartFailed || isCrashedRecovery
+		if phase != events.PhaseStarting && phase != events.PhaseRunning && !recovered {
 			return
 		}
 		d.mu.Lock()
 		d.lastRunningPort = s.Port
 		d.mu.Unlock()
-		wasDown := phase == events.PhaseStarting || phase == events.PhaseCrashed
+		wasDown := phase != events.PhaseRunning
 		d.lifecycle.Transition(events.LifecycleState{
 			Phase: events.PhaseRunning, Port: s.Port, HtmlSupport: s.HtmlSupport,
 		})
@@ -286,6 +302,84 @@ func (d *daemon) onProbeChange(s probe.State) {
 	}
 }
 
+// How much of a dead dev server's output reaches the pod log. Enough for a
+// stack trace or a compiler error, small enough that a crash-loop cannot flood
+// the log pipeline.
+const deadDevTailBytes = 4000
+
+// logDeadDevServer writes the tail of a dev server's own output to the daemon's
+// stdout when it dies unexpectedly.
+//
+// Task chunks are broadcast with Tee:false, so a dev server's stdout/stderr
+// goes to SSE subscribers and a pod-local log file and nowhere else. When the
+// montecarlo sandbox's dev server died mid-session there was consequently no
+// record anywhere of WHY — the pod log jumped straight from the last proxied
+// request to "connection refused", and the log file died with the pod. The
+// process's last words are exactly what a postmortem needs, so they go to
+// stdout, where the cluster's log pipeline can keep them.
+//
+// Intentional kills (our own restarts, an install stopping the dev task) are
+// skipped: those are expected exits and say nothing.
+func (d *daemon) logDeadDevServer(s proc.TaskSummary, label string, exitCode int) {
+	if s.Intentional || !proc.IsWellKnownStarter(s.LogName) {
+		return
+	}
+	out, ok := d.tasks.Output(s.ID)
+	if !ok {
+		return
+	}
+	slog.Error("dev server exited",
+		"task", label,
+		"status", s.Status,
+		"exit_code", exitCode,
+		"timed_out", s.TimedOut,
+		"stderr_tail", tailBytes(out.Stderr, deadDevTailBytes),
+		"stdout_tail", tailBytes(out.Stdout, deadDevTailBytes),
+	)
+}
+
+// tailBytes returns the last n bytes of s, marked when it truncated.
+func tailBytes(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return "…" + s[len(s)-n:]
+}
+
+// restartGraceForBoot converts an observed `starting`→`running` duration into
+// the window a respawn should get. Doubling is not tuning for its own sake: a
+// restart re-runs the same work the measured boot did, on a machine that is now
+// also serving a user and possibly an agent, so the honest expectation is "at
+// least as long, probably longer". Under-waiting kills a healthy boot; the only
+// cost of over-waiting is that a genuinely broken dev server takes longer to
+// surface its terminal error, which is the far cheaper mistake.
+func restartGraceForBoot(bootMs int64) time.Duration {
+	return time.Duration(bootMs) * time.Millisecond * 2
+}
+
+// noteBootDuration records a successful boot and widens the watchdog's
+// post-restart window to match. Safe before devWatchLoop has built a tracker:
+// the value is kept on the daemon and replayed when the loop starts.
+func (d *daemon) noteBootDuration(ms int64) {
+	if ms <= 0 {
+		return
+	}
+	for {
+		prev := d.observedBootMs.Load()
+		if ms <= prev {
+			break
+		}
+		if d.observedBootMs.CompareAndSwap(prev, ms) {
+			break
+		}
+	}
+	d.devWatchMu.Lock()
+	defer d.devWatchMu.Unlock()
+	if d.devTracker != nil {
+		d.devTracker.RaiseRestartGrace(restartGraceForBoot(ms))
+	}
+}
+
 // restartablePhase reports the phases where a dev server is meant to be up, so
 // the watchdog respawns a dead one there but never interrupts a legitimate
 // build (installing/cloning/checking-out) or loops on a terminal *-failed.
@@ -307,9 +401,13 @@ func (d *daemon) devWatchLoop() {
 	d.devWatchMu.Lock()
 	d.devTracker = devwatch.NewTracker(devwatch.Config{
 		Grace:        envDuration("SANDBOX_DEV_WATCH_GRACE_MS", devwatch.DefaultGracePeriod, time.Second),
+		RestartGrace: envDuration("SANDBOX_DEV_WATCH_RESTART_GRACE_MS", devwatch.DefaultRestartGrace, time.Second),
 		StableWindow: envDuration("SANDBOX_DEV_WATCH_STABLE_MS", devwatch.DefaultStableWindow, time.Second),
 		MaxRestarts:  envInt("SANDBOX_DEV_WATCH_MAX_RESTARTS", devwatch.DefaultMaxRestarts, 1),
 	})
+	if ms := d.observedBootMs.Load(); ms > 0 {
+		d.devTracker.RaiseRestartGrace(restartGraceForBoot(ms))
+	}
 	d.devWatchMu.Unlock()
 	for {
 		time.Sleep(tick)
@@ -800,6 +898,9 @@ func main() {
 	d.lifecycle = lifecycle.New(d.broadcaster)
 	d.lifecycle.OnStartPhase = func(status string, durationMs int64) {
 		telemetry.RecordPhase(context.Background(), "start", status, durationMs)
+		if status == "done" {
+			d.noteBootDuration(durationMs)
+		}
 	}
 	d.lifecycle.OnTransition = func(prev, next events.LifecycleState) {
 		if prev.Phase == events.PhaseRunning && next.Phase != events.PhaseRunning {
@@ -863,7 +964,14 @@ func main() {
 		if label == "" {
 			label = s.ID
 		}
-		slog.Info("task exit", "task", label, "status", s.Status, "exit_code", s.ExitCode)
+		// ExitCode is a *int; logging it directly printed the pointer address
+		// ("exit_code=0xc0027f06a0") for every task exit in production.
+		exitCode := -1
+		if s.ExitCode != nil {
+			exitCode = *s.ExitCode
+		}
+		slog.Info("task exit", "task", label, "status", s.Status, "exit_code", exitCode)
+		d.logDeadDevServer(s, label, exitCode)
 	})
 
 	// The watcher is what makes edits the daemon did not perform itself visible —

--- a/packages/sandbox/server/daemon-client.ts
+++ b/packages/sandbox/server/daemon-client.ts
@@ -42,7 +42,7 @@ async function daemonFetch(
     return await fetch(url, init);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`sandbox daemon ${endpoint} request failed: ${message}`, {
+    throw new Error(`[SANDBOX_UNREACHABLE] sandbox daemon ${endpoint} request failed: ${message}`, {
       cause: err,
     });
   }

--- a/packages/sandbox/server/daemon-client.ts
+++ b/packages/sandbox/server/daemon-client.ts
@@ -21,6 +21,33 @@ export class ConfigRequestError extends Error {
   }
 }
 
+/**
+ * Fetch a daemon endpoint, labelling a transport failure with the endpoint that
+ * failed.
+ *
+ * `AbortSignal.timeout()` rejects with a bare DOMException whose message is
+ * "The operation timed out." — no URL, no endpoint, no hint that a sandbox was
+ * even involved. Unwrapped, that string is what a run surfaces to the user: a
+ * montecarlo run failed with exactly `Error: The operation timed out.` and
+ * nothing anywhere — not the thread row, not the logs — recorded what had timed
+ * out. Every other timeout on this path already says what it was waiting for;
+ * these are the ones that did not.
+ */
+async function daemonFetch(
+  url: string,
+  init: RequestInit,
+  endpoint: string,
+): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`sandbox daemon ${endpoint} request failed: ${message}`, {
+      cause: err,
+    });
+  }
+}
+
 const HEALTH_PROBE_TIMEOUT_MS = 500;
 // Config application can run a cold clone + install on a heavy sandbox; 10s was
 // too tight and routinely tripped `AbortSignal.timeout()`, surfacing benign
@@ -137,15 +164,19 @@ async function configRequest(
 ): Promise<ConfigResponse> {
   const wire: Record<string, unknown> = { ...payload };
   if (auth && auth.rotateToken !== undefined) wire.auth = auth;
-  const res = await fetch(`${daemonUrl}/_sandbox/config`, {
-    method,
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
+  const res = await daemonFetch(
+    `${daemonUrl}/_sandbox/config`,
+    {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(wire),
+      signal: AbortSignal.timeout(opts?.timeoutMs ?? CONFIG_TIMEOUT_MS),
     },
-    body: JSON.stringify(wire),
-    signal: AbortSignal.timeout(opts?.timeoutMs ?? CONFIG_TIMEOUT_MS),
-  });
+    "/_sandbox/config",
+  );
   const body = await res.text();
   if (!res.ok) {
     throw new ConfigRequestError(res.status, body);
@@ -164,11 +195,15 @@ export async function postSetupStep(
   token: string,
   step: "clone" | "install" | "start",
 ): Promise<void> {
-  const res = await fetch(`${daemonUrl}/_sandbox/setup/${step}`, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${token}` },
-    signal: AbortSignal.timeout(CONFIG_TIMEOUT_MS),
-  });
+  const res = await daemonFetch(
+    `${daemonUrl}/_sandbox/setup/${step}`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(CONFIG_TIMEOUT_MS),
+    },
+    `/_sandbox/setup/${step}`,
+  );
   if (!res.ok) {
     throw new Error(
       `sandbox daemon /_sandbox/setup/${step} returned ${res.status}: ${await res.text()}`,
@@ -188,15 +223,19 @@ export async function postOrgFsConfig(
   token: string,
   configJson: string,
 ): Promise<{ written: boolean }> {
-  const res = await fetch(`${daemonUrl}/_sandbox/orgfs-config`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
+  const res = await daemonFetch(
+    `${daemonUrl}/_sandbox/orgfs-config`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: configJson,
+      signal: AbortSignal.timeout(CONFIG_TIMEOUT_MS),
     },
-    body: configJson,
-    signal: AbortSignal.timeout(CONFIG_TIMEOUT_MS),
-  });
+    "/_sandbox/orgfs-config",
+  );
   const body = await res.text();
   if (!res.ok) {
     throw new Error(

--- a/packages/sandbox/server/daemon-client.ts
+++ b/packages/sandbox/server/daemon-client.ts
@@ -22,8 +22,8 @@ export class ConfigRequestError extends Error {
 }
 
 /**
- * Fetch a daemon endpoint, labelling a transport failure with the endpoint that
- * failed.
+ * Call a daemon endpoint and read its whole body, labelling any transport
+ * failure with the endpoint that failed.
  *
  * `AbortSignal.timeout()` rejects with a bare DOMException whose message is
  * "The operation timed out." — no URL, no endpoint, no hint that a sandbox was
@@ -32,19 +32,28 @@ export class ConfigRequestError extends Error {
  * nothing anywhere — not the thread row, not the logs — recorded what had timed
  * out. Every other timeout on this path already says what it was waiting for;
  * these are the ones that did not.
+ *
+ * The body is read HERE, not by the caller, because the same signal aborts it:
+ * a daemon that sends headers and then stalls rejects the `.text()`, and a
+ * `.text()` awaited outside this try is exactly the unlabelled DOMException
+ * again. Every caller wants the body anyway.
  */
-async function daemonFetch(
+async function daemonRequest(
   url: string,
   init: RequestInit,
   endpoint: string,
-): Promise<Response> {
+): Promise<{ status: number; ok: boolean; body: string }> {
   try {
-    return await fetch(url, init);
+    const res = await fetch(url, init);
+    return { status: res.status, ok: res.ok, body: await res.text() };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`[SANDBOX_UNREACHABLE] sandbox daemon ${endpoint} request failed: ${message}`, {
-      cause: err,
-    });
+    throw new Error(
+      `[SANDBOX_UNREACHABLE] sandbox daemon ${endpoint} request failed: ${message}`,
+      {
+        cause: err,
+      },
+    );
   }
 }
 
@@ -164,7 +173,7 @@ async function configRequest(
 ): Promise<ConfigResponse> {
   const wire: Record<string, unknown> = { ...payload };
   if (auth && auth.rotateToken !== undefined) wire.auth = auth;
-  const res = await daemonFetch(
+  const res = await daemonRequest(
     `${daemonUrl}/_sandbox/config`,
     {
       method,
@@ -177,11 +186,10 @@ async function configRequest(
     },
     "/_sandbox/config",
   );
-  const body = await res.text();
   if (!res.ok) {
-    throw new ConfigRequestError(res.status, body);
+    throw new ConfigRequestError(res.status, res.body);
   }
-  return JSON.parse(body) as ConfigResponse;
+  return JSON.parse(res.body) as ConfigResponse;
 }
 
 /**
@@ -195,7 +203,7 @@ export async function postSetupStep(
   token: string,
   step: "clone" | "install" | "start",
 ): Promise<void> {
-  const res = await daemonFetch(
+  const res = await daemonRequest(
     `${daemonUrl}/_sandbox/setup/${step}`,
     {
       method: "POST",
@@ -206,7 +214,7 @@ export async function postSetupStep(
   );
   if (!res.ok) {
     throw new Error(
-      `sandbox daemon /_sandbox/setup/${step} returned ${res.status}: ${await res.text()}`,
+      `sandbox daemon /_sandbox/setup/${step} returned ${res.status}: ${res.body}`,
     );
   }
 }
@@ -223,7 +231,7 @@ export async function postOrgFsConfig(
   token: string,
   configJson: string,
 ): Promise<{ written: boolean }> {
-  const res = await daemonFetch(
+  const res = await daemonRequest(
     `${daemonUrl}/_sandbox/orgfs-config`,
     {
       method: "POST",
@@ -236,13 +244,12 @@ export async function postOrgFsConfig(
     },
     "/_sandbox/orgfs-config",
   );
-  const body = await res.text();
   if (!res.ok) {
     throw new Error(
-      `sandbox daemon /_sandbox/orgfs-config returned ${res.status}: ${body}`,
+      `sandbox daemon /_sandbox/orgfs-config returned ${res.status}: ${res.body}`,
     );
   }
-  return JSON.parse(body) as { written: boolean };
+  return JSON.parse(res.body) as { written: boolean };
 }
 
 const STRIP_REQUEST_HEADERS = [


### PR DESCRIPTION
## Summary

Debugging thread `3a3d9465` (org montecarlo, pod `studio-sandbox-prod-mdwn6`) turned up four defects on the sandbox dev-server path. The user saw a run fail with `Error: The operation timed out.`, then "Blocos indisponíveis" + "Server is starting…" for the rest of the session — while the dev server was, in fact, serving.

### Production timeline (UTC)

| | |
|---|---|
| 17:15:52 | `deno task dev` starts (`deps.restore source=no-install pkg_cache=cold`) |
| **17:21:11** | probe green — **5m18s to first serve** |
| 17:24:46 | run 1 fails: `Error: The operation timed out.` — `failure_kind` unset |
| 17:29:35–17:31:06 | run 2 succeeds, edits land |
| 17:30:45 | probe: server stopped responding → `crashed` |
| 17:31:07 / 17:31:28 / 17:31:49 | watchdog restart 1/3, 2/3, 3/3 — **21s apart** |
| **17:32:10** | "did not stay up after 3 restarts — giving up" → `start-failed` |
| 17:37:01 | the 3rd respawn serves… and the UI stays broken anyway |

## What changed

**1. `devwatch` reused one duration for two different questions.** `Grace` (20s) answers *"has the server that was serving a moment ago died?"* — 20s is plenty. The same 20s was also answering *"has the server we just launched finished booting?"*, and a respawn is a cold boot. Restarts 2 and 3 each killed the previous boot, and the give-up fired 63s into an episode that needed one restart and five minutes of patience.

New `RestartGrace` (default 5m, `SANDBOX_DEV_WATCH_RESTART_GRACE_MS`), floored at `Grace`, and widened from the boot the daemon actually measured via `lifecycle.OnStartPhase` — so a repo that needs 11 minutes gets 11 minutes without anyone guessing a constant. One-way, so a warm boot can't shrink it back.

**2. `start-failed` latched for the life of the pod.** `onProbeChange` returned early on any phase but `starting`/`running`/crashed-recovery, so the respawn the watchdog gave up on served every request from 17:37 while the UI said the sandbox was broken. The only escape was "Tentar novamente", which discards the working server and pays another cold boot. A serving dev server now clears the verdict.

**3. `Error: The operation timed out.` had no context anywhere.** `AbortSignal.timeout`'s bare DOMException from `daemon-client`'s three `/_sandbox/*` calls was the only unwrapped one on this path — every other timeout already names what it was waiting for. `classify-run-failure` had no pattern for it either, so the thread row said "see the run's messages" and the messages said `Error: The operation timed out.` Now labelled at the call site, and classified as `timeout` (below `sandbox_unreachable`, which also learns "Daemon unreachable").

**4. A dead dev server's output went nowhere.** Task chunks broadcast with `Tee:false`, so the crash reason lived only in a pod-local file that dies with the pod — the log jumps straight from the last proxied request to `connection refused`. Its last words now reach stdout on an unintentional exit. Also fixes the task-exit line logging `ExitCode`'s **pointer address** (`exit_code=0xc0027f06a0` in prod today).

## Testing

- `go test ./...` in `daemon-go` — green. The three devwatch unit tests that encoded the old "advance by Grace between restarts" behaviour are **inverted**, not appended to; new tests cover the regression, the `RestartGrace ≥ Grace` floor, and `RaiseRestartGrace`.
- New e2e in `daemon.devwatch.e2e.test.ts` drives the real binary: give up → the respawn binds late → back to `running`. Passes (3/3 in the file). The `dev server exited` log with its stdout tail shows up there too.
- `bun test` on `classify-run-failure` — 7/7.
- `bun run check`, `bun run lint` (0 errors), `bun run fmt`, `gofmt` — clean.
- Remaining local `bun test` failures in `apps/api/src/api/routes/decopilot/` are the `(real Postgres)` integration tests, failing on connection with no DB up. Unrelated.

## Deliberately not in this PR

The reason the boot is 5–11 minutes: **deno repos never populate the deps cache.** All three montecarlo sandboxes reported the same `repo_hash 875673ddd69ed9c2` with `source: no-install, pkg_cache: cold` and each paid a full boot (5m18s / 5m23s / **10m42s**) — `SpawnInstall` returns `ran=false` for deno, so the golden L1/L2 path is skipped entirely and `DENO_DIR` (`/tmp/deno_cache`, 119 MB) is pod-local.

Fixing that means a new cache tier keyed on `deno.lock` over a different root, on the boot hot path — which per CONTRIBUTING wants its own default-off flag, GC and health-gated publish. Separate PR. These four fixes stand on their own: with them, that slow boot is survivable instead of fatal.

## Still unproven

What actually killed the dev server at 17:30:17. The agent had run `deno check` in the same `DENO_DIR` as the running server, finishing 25s earlier — suggestive, not established. No OOM (`container_oom_events_total` = 0, peak 1347 MiB of 4 Gi). Fix 4 exists so the next occurrence answers this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox dev-server watchdog so a slow boot is survivable instead of fatal, and makes sandbox timeouts and dev-server crashes diagnosable.

- A respawn now gets its own boot window — 5m by default via `SANDBOX_DEV_WATCH_RESTART_GRACE_MS`, widened from the boot the daemon measured — instead of the 20s dead-server grace, so a cold boot isn't killed mid-boot. The start attempt stays open across `start-failed` so a late recovery still reports the full boot duration.
- A dev server that starts serving after the watchdog gave up now clears the `start-failed` verdict, but only while a dev task is alive to own the port, so an unrelated process squatting on that port can't overturn it.
- `daemon-client`'s `/_sandbox/*` timeouts are labeled with the endpoint, body reads included; `classify-run-failure` maps the bare timeout to `timeout`, matched last so named causes keep their kind.
- A dev server that dies unexpectedly writes its output tail to stdout, and task-exit logs the actual exit code instead of its pointer address.

<sup>Written for commit 440be8cd0b2864840737f313faa13620365efa02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

