### PR TITLE
fix(errors): surface which upstream provider failed and why, and stop retrying what can't succeed

### DIFF
--- a/apps/api/src/harnesses/lib/stream-error.test.ts
+++ b/apps/api/src/harnesses/lib/stream-error.test.ts
@@ -4,6 +4,8 @@ import {
   isCreditError,
   mcpConnectionErrorMessage,
   sanitizeStreamError,
+  stringifyError,
+  upstreamProviderError,
 } from "./stream-error";
 
 describe("sanitizeStreamError", () => {
@@ -108,5 +110,90 @@ describe("classifyStreamError", () => {
       metadata: { error_type: "timeout" },
     };
     expect(classifyStreamError(err)).toBe("timeout");
+  });
+});
+
+describe("upstreamProviderError", () => {
+  /** The exact body OpenRouter returned for the production failure. */
+  const openaiRouteBody = JSON.stringify({
+    error: {
+      message: "Provider returned error",
+      code: 400,
+      metadata: {
+        raw:
+          'data: {"error":{"code":"invalid_parameter_error","message":' +
+          "\"'messages' must contain the word 'json' in some form, to use " +
+          "'response_format' of type 'json_object'.\"}}\n\n",
+        provider_name: "Alibaba",
+      },
+    },
+  });
+
+  it("lifts the provider and its own message out of a relayed 400", () => {
+    const error = Object.assign(new Error("Provider returned error"), {
+      responseBody: openaiRouteBody,
+      statusCode: 400,
+    });
+    expect(upstreamProviderError(error)).toBe(
+      "[Alibaba] 'messages' must contain the word 'json' in some form, to " +
+        "use 'response_format' of type 'json_object'.",
+    );
+  });
+
+  it("reads the Anthropic-skin shape, where metadata sits beside error", () => {
+    const error = Object.assign(new Error("Provider returned error"), {
+      responseBody: JSON.stringify({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message: "Provider returned error",
+        },
+        metadata: {
+          provider_name: "Amazon Bedrock",
+          raw: JSON.stringify({
+            error: {
+              message:
+                "A maximum of 4 blocks with cache_control may be provided. Found 6.",
+            },
+          }),
+        },
+      }),
+    });
+    expect(upstreamProviderError(error)).toBe(
+      "[Amazon Bedrock] A maximum of 4 blocks with cache_control may be " +
+        "provided. Found 6.",
+    );
+  });
+
+  it("leaves a gateway's own error alone (402 has no upstream)", () => {
+    const error = Object.assign(
+      new Error("This request requires more credits"),
+      {
+        responseBody: JSON.stringify({
+          error: {
+            message: "This request requires more credits",
+            code: 402,
+            metadata: {
+              limit_source: "openrouter_key_limit",
+              provider_name: null,
+            },
+          },
+        }),
+      },
+    );
+    expect(upstreamProviderError(error)).toBeNull();
+  });
+
+  it("ignores errors that carry no response body", () => {
+    expect(upstreamProviderError(new Error("boom"))).toBeNull();
+    expect(upstreamProviderError("boom")).toBeNull();
+    expect(upstreamProviderError(null)).toBeNull();
+  });
+
+  it("stringifyError surfaces it, so the pod log names the culprit", () => {
+    const error = Object.assign(new Error("Provider returned error"), {
+      responseBody: openaiRouteBody,
+    });
+    expect(stringifyError(error)).toStartWith("[Alibaba] 'messages' must");
   });
 });

--- a/apps/api/src/harnesses/lib/stream-error.test.ts
+++ b/apps/api/src/harnesses/lib/stream-error.test.ts
@@ -184,10 +184,64 @@ describe("upstreamProviderError", () => {
     expect(upstreamProviderError(error)).toBeNull();
   });
 
+  it("reads a multi-line SSE body, not just a lone `data:` frame", () => {
+    const error = Object.assign(new Error("Provider returned error"), {
+      responseBody: JSON.stringify({
+        error: {
+          message: "Provider returned error",
+          metadata: {
+            provider_name: "Google Vertex",
+            raw:
+              "event: error\n" +
+              'data: {"error":{"message":"Publisher Model is not found."}}\n\n',
+          },
+        },
+      }),
+    });
+    expect(upstreamProviderError(error)).toBe(
+      "[Google Vertex] Publisher Model is not found.",
+    );
+  });
+
+  it("prefers the raw responseBody — the SDK's parsed `data` strips metadata", () => {
+    // Exactly what the AI SDK produces: `data` is the body zod-parsed against
+    // the provider's error schema, which does not declare `metadata`.
+    const error = Object.assign(new Error("Provider returned error"), {
+      responseBody: openaiRouteBody,
+      data: { error: { message: "Provider returned error", code: 400 } },
+      statusCode: 400,
+    });
+    expect(upstreamProviderError(error)).toStartWith("[Alibaba] 'messages'");
+  });
+
   it("ignores errors that carry no response body", () => {
     expect(upstreamProviderError(new Error("boom"))).toBeNull();
     expect(upstreamProviderError("boom")).toBeNull();
     expect(upstreamProviderError(null)).toBeNull();
+  });
+
+  it("classifies on the upstream detail, so a relayed 429 is a rate limit", () => {
+    const error = Object.assign(new Error("Provider returned error"), {
+      responseBody: JSON.stringify({
+        error: {
+          message: "Provider returned error",
+          metadata: {
+            provider_name: "Anthropic",
+            raw: JSON.stringify({
+              error: { message: "rate limit exceeded, please retry" },
+            }),
+          },
+        },
+      }),
+    });
+    expect(classifyStreamError(error)).toBe("rate_limit");
+  });
+
+  it("still classifies an unrecognised relayed detail as model_error", () => {
+    const error = Object.assign(new Error("Provider returned error"), {
+      responseBody: openaiRouteBody,
+    });
+    expect(classifyStreamError(error)).toBe("model_error");
   });
 
   it("stringifyError surfaces it, so the pod log names the culprit", () => {

--- a/apps/api/src/harnesses/lib/stream-error.ts
+++ b/apps/api/src/harnesses/lib/stream-error.ts
@@ -51,9 +51,17 @@ export function classifyStreamError(
   | "tool_error"
   | "unknown" {
   if (error instanceof Error && error.name === "AbortError") return "aborted";
-  const msg = (
-    error instanceof Error ? error.message : stringifyError(error)
-  ).toLowerCase();
+  // Both halves: the upstream detail is what distinguishes a relayed rate
+  // limit or auth failure from a plain model error, and the relay's own
+  // wording ("provider returned error") is what keeps an unrecognised detail
+  // classified as `model_error` rather than `unknown`.
+  const msg = [
+    upstreamProviderError(error),
+    error instanceof Error ? error.message : stringifyError(error),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
   if (
     /insufficient|no credits|out of credits|balance|payment|quota exceeded|key limit|402/i.test(
       msg,
@@ -90,9 +98,14 @@ export function classifyStreamError(
  */
 export function upstreamProviderError(error: unknown): string | null {
   if (typeof error !== "object" || error === null) return null;
+  // `responseBody` first, not `data`: the AI SDK builds `data` by zod-parsing
+  // the body against the provider's error schema, and neither the OpenAI nor
+  // the Anthropic schema declares `metadata` — so zod strips exactly the field
+  // we came for. `data` stays a fallback for a provider whose schema passes
+  // unknown keys through.
   const body =
-    (error as { responseBody?: unknown; data?: unknown }).data ??
-    (error as { responseBody?: unknown }).responseBody;
+    (error as { responseBody?: unknown }).responseBody ??
+    (error as { data?: unknown }).data;
   const parsed = typeof body === "string" ? safeParse(body) : body;
   if (typeof parsed !== "object" || parsed === null) return null;
   const outer = parsed as {
@@ -123,11 +136,25 @@ function safeParse(text: string): unknown {
 
 /**
  * The upstream's own message out of `metadata.raw`, which is that provider's
- * verbatim error body — JSON on the blocking route, and a single `data: {...}`
- * SSE frame when the request was streaming.
+ * verbatim error body — plain JSON on the blocking route, and an SSE body when
+ * the request was streaming. That SSE body is not always the one bare
+ * `data: {...}` line: it can carry `event:`/`id:` lines around it, or several
+ * frames. Try each `data:` frame and take the first that names a message,
+ * falling back to treating the whole raw as JSON.
  */
 function upstreamMessage(raw: string): string | null {
-  const parsed = safeParse(raw.trim().replace(/^data:\s*/, ""));
+  const frames = raw
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.replace(/^data:\s*/, ""));
+  for (const candidate of frames.length > 0 ? frames : [raw.trim()]) {
+    const message = messageOf(safeParse(candidate));
+    if (message) return message;
+  }
+  return null;
+}
+
+function messageOf(parsed: unknown): string | null {
   if (typeof parsed !== "object" || parsed === null) return null;
   const obj = parsed as { error?: { message?: unknown }; message?: unknown };
   const message = obj.error?.message ?? obj.message;

--- a/apps/api/src/harnesses/lib/stream-error.ts
+++ b/apps/api/src/harnesses/lib/stream-error.ts
@@ -10,6 +10,8 @@
  */
 
 export function stringifyError(error: unknown): string {
+  const upstream = upstreamProviderError(error);
+  if (upstream) return upstream;
   if (error instanceof Error) return error.message;
   if (typeof error === "object" && error !== null) {
     try {
@@ -70,6 +72,69 @@ export function classifyStreamError(
 }
 
 /**
+ * OpenRouter relays EVERY upstream failure as the same opaque
+ * `"Provider returned error"` and puts what actually happened — which upstream
+ * served the request, and that upstream's own message — in `metadata`. The AI
+ * SDK keeps the whole body on the error (`responseBody`, and `data` for the
+ * parsed form) and sets `message` to the opaque half, so reading only `message`
+ * throws away the one part of the failure anybody can act on.
+ *
+ * That discard is why a real production bug hid for a month: 169 identical
+ * `400 Provider returned error` over 30 days, every one of them Alibaba
+ * rejecting `response_format: json_object` on a prompt with no "json" in it —
+ * visible only by opening a pod log and reading the raw error dump.
+ *
+ * Returns `"[<provider>] <upstream message>"`, or null when the error carries
+ * no such body (a non-gateway failure, or a gateway error of its own like a
+ * 402 credit limit, whose `message` is already the real one).
+ */
+export function upstreamProviderError(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) return null;
+  const body =
+    (error as { responseBody?: unknown; data?: unknown }).data ??
+    (error as { responseBody?: unknown }).responseBody;
+  const parsed = typeof body === "string" ? safeParse(body) : body;
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const outer = parsed as {
+    error?: { metadata?: unknown };
+    metadata?: unknown;
+  };
+  // Two shapes carry it: `{error:{metadata}}` on the OpenAI-compatible route,
+  // `{error, metadata}` on the Anthropic-skin one.
+  const metadata = (outer.error?.metadata ?? outer.metadata) as
+    | { provider_name?: unknown; raw?: unknown }
+    | undefined;
+  if (typeof metadata !== "object" || metadata === null) return null;
+  const provider =
+    typeof metadata.provider_name === "string" ? metadata.provider_name : null;
+  const upstream =
+    typeof metadata.raw === "string" ? upstreamMessage(metadata.raw) : null;
+  if (!provider && !upstream) return null;
+  return `[${provider ?? "upstream provider"}] ${upstream ?? "no detail returned"}`;
+}
+
+function safeParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The upstream's own message out of `metadata.raw`, which is that provider's
+ * verbatim error body — JSON on the blocking route, and a single `data: {...}`
+ * SSE frame when the request was streaming.
+ */
+function upstreamMessage(raw: string): string | null {
+  const parsed = safeParse(raw.trim().replace(/^data:\s*/, ""));
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as { error?: { message?: unknown }; message?: unknown };
+  const message = obj.error?.message ?? obj.message;
+  return typeof message === "string" && message.length > 0 ? message : null;
+}
+
+/**
  * Pull a human-readable message + HTTP status out of an unknown error.
  * Gateway/provider errors frequently arrive as plain objects rather than
  * `Error` instances (e.g. the `{ code, message, metadata }` shape a 504 idle
@@ -81,9 +146,10 @@ function extractErrorParts(error: unknown): {
   message: string;
   statusCode?: number;
 } {
+  const upstream = upstreamProviderError(error);
   if (error instanceof Error) {
     return {
-      message: error.message,
+      message: upstream ?? error.message,
       statusCode: (error as { statusCode?: number }).statusCode,
     };
   }
@@ -94,7 +160,8 @@ function extractErrorParts(error: unknown): {
       code?: unknown;
     };
     const message =
-      typeof obj.message === "string" ? obj.message : stringifyError(error);
+      upstream ??
+      (typeof obj.message === "string" ? obj.message : stringifyError(error));
     const statusCode =
       typeof obj.statusCode === "number"
         ? obj.statusCode

--- a/apps/api/src/harnesses/lib/title-generator.test.ts
+++ b/apps/api/src/harnesses/lib/title-generator.test.ts
@@ -120,6 +120,43 @@ describe("genTitle model fallback chain", () => {
     expect(result).toBe("Built by the second slot");
   });
 
+  test("a non-retryable rejection still rotates — the next model is a different request", async () => {
+    const handle = genTitle({
+      abortSignal: new AbortController().signal,
+      models: [
+        () =>
+          makeFailingModel(
+            Object.assign(new Error("Provider returned error"), {
+              isRetryable: false,
+            }),
+          ),
+        () => makeSucceedingModel("Second model title"),
+      ],
+      userMessage: "does not matter",
+    });
+    expect(await handle.promise).toBe("Second model title");
+  });
+
+  test("a non-retryable rejection on the last model is not retried into itself", async () => {
+    let calls = 0;
+    const handle = genTitle({
+      abortSignal: new AbortController().signal,
+      models: [
+        () => {
+          calls++;
+          return makeFailingModel(
+            Object.assign(new Error("Provider returned error"), {
+              isRetryable: false,
+            }),
+          );
+        },
+      ],
+      userMessage: "Fix the login button on mobile devices please",
+    });
+    expect(await handle.promise).toBe("Fix the login button on mobile d");
+    expect(calls).toBe(1);
+  });
+
   test("empty model list falls back to clamped user message (never a broken title)", async () => {
     const handle = genTitle({
       abortSignal: new AbortController().signal,

--- a/apps/api/src/harnesses/lib/title-generator.ts
+++ b/apps/api/src/harnesses/lib/title-generator.ts
@@ -152,8 +152,14 @@ export function genTitle(config: {
           maxAttempts,
           minTimeout: 200,
           maxTimeout: 2_000,
-          // Don't retry a cancel/timeout — only genuine model failures.
-          isRetriable: (err) => (err as Error)?.name !== "AbortError",
+          // Don't retry a cancel/timeout — only genuine model failures. Nor a
+          // call the AI SDK itself marked non-retryable: a provider that
+          // rejected the REQUEST (a 400 on the schema or the prompt) returns
+          // the identical 400 to every attempt, so the retries only delay the
+          // fallback title.
+          isRetriable: (err) =>
+            (err as Error)?.name !== "AbortError" &&
+            (err as { isRetryable?: boolean })?.isRetryable !== false,
           signal: titleAbortController.signal,
         },
       );

--- a/apps/api/src/harnesses/lib/title-generator.ts
+++ b/apps/api/src/harnesses/lib/title-generator.ts
@@ -152,14 +152,16 @@ export function genTitle(config: {
           maxAttempts,
           minTimeout: 200,
           maxTimeout: 2_000,
-          // Don't retry a cancel/timeout — only genuine model failures. Nor a
-          // call the AI SDK itself marked non-retryable: a provider that
-          // rejected the REQUEST (a 400 on the schema or the prompt) returns
-          // the identical 400 to every attempt, so the retries only delay the
-          // fallback title.
+          // Don't retry a cancel/timeout — only genuine model failures. A call
+          // the AI SDK itself marked non-retryable (a provider that rejected
+          // the REQUEST — a 400 on the schema or the prompt) returns the
+          // identical 400 to every attempt against the SAME model, so stop
+          // once the model list is exhausted; until then the next attempt is a
+          // different model, i.e. a different request, and worth making.
           isRetriable: (err) =>
             (err as Error)?.name !== "AbortError" &&
-            (err as { isRetryable?: boolean })?.isRetryable !== false,
+            ((err as { isRetryable?: boolean })?.isRetryable !== false ||
+              attempt < models.length - 1),
           signal: titleAbortController.signal,
         },
       );

--- a/apps/api/src/lib/judge-requires-review.ts
+++ b/apps/api/src/lib/judge-requires-review.ts
@@ -40,7 +40,8 @@ Do NOT require review (requiresReview = false) when the changes are low-risk, su
 
 When unsure between the two, lean toward NOT requiring review for small frontend-only diffs, and toward requiring it for anything backend or large.
 
-Respond with the structured verdict and a short reason.`;
+Respond with ONLY a JSON object of this shape, and nothing else:
+{"requiresReview": true | false, "reason": "one short sentence, max ~120 chars"}`;
 
 /**
  * Map a UI locale to a language name for the model. The `reason` is shown to

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -74,7 +74,10 @@ const SYSTEM = `You maintain a team's task board. A coding agent just opened a p
 - If no existing card covers it, choose \`create\` and return a short \`title\` describing the change.
 - Optionally add a one-line \`comment\` for the reviewer. Leave it empty when there is nothing worth saying.
 
-Be conservative about creating: when a plausible card already exists, prefer \`update\`.`;
+Be conservative about creating: when a plausible card already exists, prefer \`update\`.
+
+Respond with ONLY a JSON object of this shape, and nothing else:
+{"action": "create" | "update", "taskId": string | null, "title": string | null, "comment": string | null}`;
 
 /**
  * Ask the org's cheap "fast" tier whether this PR maps to an existing card.

--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -413,6 +413,9 @@ describe("isTransientProviderRejection", () => {
     expect(
       isTransientProviderRejection("API Error: 429 Provider returned error"),
     ).toBe(true);
+    expect(
+      isTransientProviderRejection("API Error: 408 Provider returned error"),
+    ).toBe(true);
   });
 
   // Inverts the previous "whatever the status" case: OpenRouter now flattens a
@@ -429,6 +432,15 @@ describe("isTransientProviderRejection", () => {
 
   test("an unparseable status keeps the benefit of the doubt", () => {
     expect(isTransientProviderRejection("Provider returned error")).toBe(true);
+  });
+
+  test("only a 5xx retries — a 2xx/3xx relay is not a server failure", () => {
+    expect(
+      isTransientProviderRejection("API Error: 302 Provider returned error"),
+    ).toBe(false);
+    expect(
+      isTransientProviderRejection("API Error: 200 Provider returned error"),
+    ).toBe(false);
   });
 
   test("a 400 that describes the request stays fatal", () => {

--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -403,13 +403,32 @@ describe("mcpServersFor", () => {
 });
 
 describe("isTransientProviderRejection", () => {
-  test("matches OpenRouter's upstream relay, whatever the status", () => {
-    expect(
-      isTransientProviderRejection("API Error: 400 Provider returned error"),
-    ).toBe(true);
+  test("matches OpenRouter's upstream relay on a server-side status", () => {
     expect(
       isTransientProviderRejection("API Error: 502 Provider returned error"),
     ).toBe(true);
+    expect(
+      isTransientProviderRejection("API Error: 529 Provider returned error"),
+    ).toBe(true);
+    expect(
+      isTransientProviderRejection("API Error: 429 Provider returned error"),
+    ).toBe(true);
+  });
+
+  // Inverts the previous "whatever the status" case: OpenRouter now flattens a
+  // malformed request to the same relay wording, and fails over across its
+  // upstreams before answering, so a 4xx is one every upstream refused.
+  test("a 4xx relay is fatal — every upstream already refused it", () => {
+    expect(
+      isTransientProviderRejection("API Error: 400 Provider returned error"),
+    ).toBe(false);
+    expect(
+      isTransientProviderRejection("API Error: 404 Provider returned error"),
+    ).toBe(false);
+  });
+
+  test("an unparseable status keeps the benefit of the doubt", () => {
+    expect(isTransientProviderRejection("Provider returned error")).toBe(true);
   });
 
   test("a 400 that describes the request stays fatal", () => {

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -440,7 +440,7 @@ export function isTransientProviderRejection(message: string): boolean {
   if (!Number.isInteger(status)) return true;
   // 408/429 are the 4xx that mean "ask again", not "you asked wrong".
   if (status === 408 || status === 429) return true;
-  return !(status >= 400 && status < 500);
+  return status >= 500 && status < 600;
 }
 
 /**

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -413,13 +413,34 @@ const PROVIDER_BACKOFF_BASE_MS = 1_000;
  * Whether an SDK throw is the upstream provider failing rather than the request
  * being wrong.
  *
- * Matched on OpenRouter's own relay wording, not on the status code: a 400 whose
- * body describes the request (`messages.0: text content blocks must be
- * non-empty`) is a bug a retry would only repeat, and must stay fatal. Exported
- * for the unit test — pure.
+ * The wording alone no longer decides it. OpenRouter used to relay the
+ * upstream's own message (`messages.0: text content blocks must be non-empty`),
+ * which is what the status-blind match here was built on; it now flattens EVERY
+ * upstream rejection — a malformed request included — to the same
+ * `Provider returned error`, and moves the real reason into a `metadata` object
+ * the `claude` CLI drops before this ever sees it. Verified against all ten
+ * upstreams of `anthropic/claude-opus-5`: an empty text block and a 5th
+ * `cache_control` breakpoint both come back as `400 Provider returned error`
+ * from every one of them.
+ *
+ * So the status is the only signal left, and it is enough. OpenRouter fails
+ * over across upstreams on its own before answering (the relayed body carries
+ * the ones it already tried as `previous_errors`), so a 4xx that survived that
+ * is a request every upstream refused — retrying it burns the budget and the
+ * backoff to arrive at the identical 400. A 5xx or a 429 is the upstream, not
+ * the request, and is exactly what the retry exists for.
+ *
+ * Exported for the unit test — pure.
  */
 export function isTransientProviderRejection(message: string): boolean {
-  return /provider returned error/i.test(message);
+  if (!/provider returned error/i.test(message)) return false;
+  const status = Number(/\bAPI Error: (\d{3})\b/.exec(message)?.[1]);
+  // An unparseable status keeps the old benefit of the doubt: one wasted retry
+  // beats refusing a run over a message shape the CLI changed.
+  if (!Number.isInteger(status)) return true;
+  // 408/429 are the 4xx that mean "ask again", not "you asked wrong".
+  if (status === 408 || status === 429) return true;
+  return !(status >= 400 && status < 500);
 }
 
 /**


### PR DESCRIPTION
## Summary

We only ever surfaced `Provider returned error`. OpenRouter relays **every** upstream failure as that one opaque string and puts the real reason — which upstream served the request, and that upstream's own message — in a `metadata` object we discarded by reading only `error.message`.

That discard hid a live bug for a month.

## The bug it was hiding

**169 identical `400 Provider returned error` in 30 days**, still firing today. Every one is `judge-requires-review` calling `generateObject` against `qwen/qwen3.5-flash-02-23` → routed to **Alibaba**, which rejects `response_format: json_object` unless the prompt contains the word "json". The prompt didn't.

```
[judge-requires-review] LLM failed, allowing direct publish AI_APICallError: [Alibaba] ...
  "'messages' must contain the word 'json' in some form, to use 'response_format' of type 'json_object'."
```

It **fails open** (`ALLOW_FALLBACK`), so each one silently bypassed the review gate before a direct publish. Nobody saw it because the only readable form of the error lived in a raw pod-log dump.

The other 92 logged bodies in the same window are 402 key-limit errors — a known, separate issue, left alone.

## Changes

**1. Stop the discard** — `apps/api/src/harnesses/lib/stream-error.ts`
New `upstreamProviderError()` lifts `metadata.provider_name` + the upstream's verbatim message off the AI SDK error's `responseBody`/`data`, and `stringifyError`/`extractErrorParts` prefer it. Handles both body shapes (`{error:{metadata}}` on the OpenAI-compatible route, `{error, metadata}` on the Anthropic skin), and the SSE-framed `metadata.raw`. A gateway error of its own — a 402 credit limit, where `provider_name` is null — is left untouched, so `isCreditError` and the `[CREDITS]` path are unaffected.

Before → after, on a real AI SDK error against real OpenRouter:
```
old: [Alibaba] data: {"error":{"code":"invalid_parameter_error","param":null,"message…
new: [Alibaba] 'messages' must contain the word 'json' in some form, to use 'response_format' of type 'json_object'.
```

**2. Fix the code causing the 400s** — `judge-requires-review.ts`, `pr-open-board-reaction.ts`
Both `generateObject` prompts now spell the JSON shape out. `title-generator` already did; these two never had it.

**3. Stop retrying what can never succeed**
- `title-generator.ts` — `isRetriable` excluded only `AbortError`, so a rejected *request* was retried into the identical rejection. Now honours the AI SDK's own `isRetryable: false`.
- `packages/harness-runner/claude-code.ts` — `isTransientProviderRejection` matched on wording alone, written when OpenRouter still relayed the upstream's message. It no longer does, so that predicate now matches permanently-broken requests and burns the full budget plus backoff to arrive at the identical 400. Retries 5xx/408/429; a 4xx is fatal.

## Testing

`bun test` (135 pass), `bun run check`, `bun run lint` (0 errors), `bun run fmt`.

Live, against real OpenRouter with the production request bodies:

- **The prompt fix removes the 400.** `qwen/qwen3.5-flash-02-23` → Alibaba: `400` → `200` with a conforming verdict, 3/3. `anthropic/claude-sonnet-4.5` unchanged.
- **The un-discard works on a real `AI_APICallError`**, not a hand-built one (see before/after above).
- **The 4xx rule is evidence-based.** Replayed a captured 118 KB / 278-message / 21-tool production Claude Code body against **all ten** upstreams of `anthropic/claude-opus-5` (Anthropic ×2, Azure ×2, Vertex ×3, Bedrock ×2, Claude-on-AWS). An empty text block and a 5th `cache_control` breakpoint come back `400 Provider returned error` from every one of them, and the relayed body's `previous_errors` shows OpenRouter had already failed over across upstreams before answering — so a 4xx is one every upstream refused.

Test inverted rather than appended: `isTransientProviderRejection > matches OpenRouter's upstream relay, whatever the status` asserted the old behaviour and is now `a 4xx relay is fatal — every upstream already refused it`.

## Also checked, and clean

Ran real `harness-runner` turns pinned to each of the ten upstreams (via a local proxy injecting `provider.only`), plus a divergence battery (thinking modes, `tool_choice`, 60 tools, 250k context, document blocks, cache breakpoints). **No upstream is systematically broken** — thinking-block signatures are portable across all of them, prompt caching hits on all of them, and routing is sticky in practice. Studio's 400s are Studio's requests, not the providers'.

## Follow-ups (not in this PR)

- `qwen/qwen3.5-flash-02-23` emits its reasoning as plain prose, so even without the 400 it can fail `generateObject` with `No object generated`. OpenRouter reports the model **does** support `structured_outputs`; the AI SDK is picking `json_object` mode anyway. Forcing `json_schema` mode would fix this properly, and would also fix `title-generator` for the same org. That's why the title prompt is untouched here — I couldn't verify a change to it helps.
- The `claude` CLI drops OpenRouter's `metadata` before the harness sees it, so on the sandbox path only the status is recoverable. Recovering the provider name there needs an in-pod proxy — deliberately out of scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces which upstream provider failed and why in error messages, and stops retrying requests every upstream already refused. Previously all OpenRouter failures surfaced as the opaque `Provider returned error`; the real reason — which upstream served the request and its own message — lived in a `metadata` object that was discarded. That hid a live bug: 169 identical `400 Provider returned error` in 30 days, each silently bypassing the review gate because `judge-requires-review` fails open.

- Errors now read `[<provider>] <upstream message>`, e.g. `[Alibaba] 'messages' must contain the word 'json'...`; the upstream detail also drives classification, so a relayed 429 is treated as a rate limit.
- `judge-requires-review` and `pr-open-board-reaction` prompts now spell out the JSON response shape; verified the 400 became a 200.
- `title-generator` honours the AI SDK's own `isRetryable: false`: a rejected request isn't retried into the identical 400, but the chain still rotates to the next model.
- `harness-runner` treats a 4xx relay as fatal and retries only 5xx/408/429, since OpenRouter already failed over across upstreams before answering. Verified against all ten upstreams of `anthropic/claude-opus-5`.

<sup>Written for commit 0cb13ac83c6b04401a11ea23a7062170a201cc3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

