### PR TITLE
fix(task-board): don't stomp a human reassignment when un-delegating a column-rule claim

### DIFF
--- a/apps/api/src/storage/task-board-column-claim.integration.test.ts
+++ b/apps/api/src/storage/task-board-column-claim.integration.test.ts
@@ -130,6 +130,27 @@ describe("claimUnassignedForSuperAgent (real Postgres)", () => {
     ).toBeNull();
   });
 
+  /** The un-delegate side of the same fence: a rejected claim must not leave
+   *  the failed delegation's `assigned_by` on a now-unassigned card, and must
+   *  not touch the card at all once a human has taken it. */
+  it("clears assignedBy when it wins, and leaves a human's card alone", async () => {
+    const task = await card("Fazendo");
+    await taskBoard.claimUnassignedForSuperAgent(
+      task.id,
+      ORG,
+      USER,
+      USER,
+      "Fazendo",
+    );
+    const undelegated = await taskBoard.unassignSuperAgent(task.id, ORG, USER);
+    expect(undelegated?.assigneeId).toBeNull();
+    expect(undelegated?.assignedBy).toBeNull();
+
+    await taskBoard.update(task.id, ORG, { assigneeId: USER }, USER);
+    expect(await taskBoard.unassignSuperAgent(task.id, ORG, USER)).toBeNull();
+    expect((await taskBoard.getById(task.id, ORG))?.assigneeId).toBe(USER);
+  });
+
   /** Null is "this board has no such column", which cannot be claimed in. */
   it("refuses when the board has no column for the rule", async () => {
     const task = await card("Fazendo");

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1731,7 +1731,8 @@ export class TaskBoardStorage {
 
   /**
    * Atomically hand a task from the Super Agent to a human: clear
-   * `assigneeId` ONLY if it's still the Super Agent, returning the updated
+   * `assigneeId` and `assignedBy` ONLY if it's still the Super Agent — an
+   * unassigned card keeps no delegation metadata — returning the updated
    * item, or null if it already changed. `handTaskToHuman`'s caller re-checks
    * a stale, previously-read `item.assigneeId` before calling this — several
    * dead-end paths (a bounce limit, a burned reviewer retry, a PR-less card)
@@ -1749,6 +1750,7 @@ export class TaskBoardStorage {
       .updateTable("task_board_items")
       .set({
         assignee_id: null,
+        assigned_by: null,
         updated_by: by,
         updated_at: new Date().toISOString(),
       })

--- a/apps/api/src/tools/task-board/run-column-automation.ts
+++ b/apps/api/src/tools/task-board/run-column-automation.ts
@@ -79,7 +79,13 @@ export async function runColumnAutomation(
       orgId,
       by.actor,
     );
-    return undelegated ?? delegated;
+    // Fence lost: a human owns the card now. Returning `delegated` would emit a
+    // snapshot that reads as their reassignment reverted, so re-read the row.
+    return (
+      undelegated ??
+      (await ctx.storage.taskBoard.getById(item.id, orgId)) ??
+      delegated
+    );
   }
   return delegated;
 }

--- a/apps/api/src/tools/task-board/run-column-automation.ts
+++ b/apps/api/src/tools/task-board/run-column-automation.ts
@@ -73,12 +73,13 @@ export async function runColumnAutomation(
       `[task-board] column rule on ${item.status} rejected for ${item.id}, un-delegating:`,
       err instanceof Error ? err.message : err,
     );
-    return await ctx.storage.taskBoard.update(
+    // Same conditional fence as `handTaskToHuman` — never stomp a concurrent reassignment.
+    const undelegated = await ctx.storage.taskBoard.unassignSuperAgent(
       item.id,
       orgId,
-      { assigneeId: null, assignedBy: null },
       by.actor,
     );
+    return undelegated ?? delegated;
   }
   return delegated;
 }


### PR DESCRIPTION
Follows #6800 (`runColumnAutomation`), which introduced the shared column-rule claim path both the Jira sync and a manual drag now go through.

**Bug:** `runColumnAutomation()` claims an unassigned card for the Super Agent with a conditional UPDATE (`WHERE assignee_id IS NULL`), then calls `reactToSuperAgentDelegation()`, which can take a while (dispatch/quota check) or throw `TaskQuotaError`. On that throw it un-delegated with a *plain* `update({ assigneeId: null, assignedBy: null })` — unconditional. If a human reassigned the card in that window (e.g. via `TASK_BOARD_ITEM_UPDATE`, in the gap between the claim and the quota check), this write silently wiped their reassignment back to `null`, losing the human's edit.

**Fix:** `storage.taskBoard` already has the right primitive for exactly this race — `unassignSuperAgent()`, a conditional UPDATE (`WHERE assignee_id = SUPER_AGENT_ASSIGNEE_ID`) already used by `handTaskToHuman()` to solve the identical problem (see its doc comment: "a plain `update()` would stomp that human's reassignment back to null"). Swapped the plain `update()` for it in `run-column-automation.ts` too, so un-delegation only takes effect if the card is still assigned to the Super Agent; otherwise it leaves the human's reassignment alone.

**Failure scenario:** column rule claims card X for the Super Agent → dispatch is mid-flight and the org's quota is exhausted → a teammate manually reassigns X to themselves in the meantime → the quota rejection's un-delegate write lands after and clobbers the teammate's assignment back to unassigned, silently losing their action.

**How a reviewer confirms:** `rg unassignSuperAgent apps/api/src/tools/task-board` — both call sites (`run-reactions.ts`'s `handTaskToHuman`, and now `run-column-automation.ts`) share the same conditional fence and doc-comment rationale.

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/tools/task-board/run-column-automation.ts` (0 warnings/errors). No new test: this reuses `unassignSuperAgent()`, an existing storage primitive already exercised by `handTaskToHuman()`'s integration coverage — this sandbox has no Postgres to add a new DB-backed test, and the fix is a one-line swap onto an already-tested method. Full CI validates the integration suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where un-delegating a column-rule claim could overwrite a human's concurrent reassignment, reusing the conditional `unassignSuperAgent()` primitive instead of a plain update.

- On a lost fence, re-reads the card before returning so the response doesn't render the human's reassignment as reverted.
- The conditional un-delegate now also clears `assignedBy`, fixing stale delegation metadata on unassigned cards (also on the `handTaskToHuman` path).
- Adds a real-Postgres integration test covering both the winning clear and the lost-fence case.

<sup>Written for commit 325903af584ec3f2eea4c6d2a8a2a08582063f44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

