### PR TITLE
fix(decopilot): surface a missing model credential as a clear permanent error

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.test.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.test.ts
@@ -6,12 +6,15 @@ import {
   isRunSuperseded,
   RunSupersededError,
 } from "@/harnesses/sandbox-dispatch-client";
+import { PermanentRunError } from "@/core/dispatch-errors";
+import type { StudioContext } from "@/core/studio-context";
 import {
   assertHostedDispatchHarness,
   assertSinglePersistedRequestMessage,
   buildAgentSandboxUiStream,
   buildDurableDispatchInput,
   resolveAgentInstructions,
+  resolveSecretModelSource,
 } from "./dispatch-run";
 import type { ChatMessage } from "./types";
 
@@ -412,5 +415,29 @@ describe("resolveAgentInstructions", () => {
   test("stays undefined when there is nothing to say", () => {
     expect(resolveAgentInstructions({}, null)).toBeUndefined();
     expect(resolveAgentInstructions({}, { instructions: 42 })).toBeUndefined();
+  });
+});
+
+describe("resolveSecretModelSource", () => {
+  test("surfaces an unconfigured credential as a permanent, readable error", async () => {
+    const ctx = {
+      storage: {
+        aiProviderKeys: {
+          resolve: () => Promise.reject(new Error("no result")),
+        },
+      },
+    } as unknown as StudioContext;
+
+    const rejection = resolveSecretModelSource(
+      ctx,
+      "org-1",
+      "cred-missing",
+      "model-1",
+    );
+
+    await expect(rejection).rejects.toThrow(PermanentRunError);
+    await expect(rejection).rejects.toMatchObject({
+      code: "model_credential_not_found",
+    });
   });
 });

--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -266,7 +266,7 @@ export function buildAgentSandboxUiStream(
   });
 }
 
-async function resolveSecretModelSource(
+export async function resolveSecretModelSource(
   ctx: StudioContext,
   organizationId: string,
   credentialId: string,
@@ -278,10 +278,15 @@ async function resolveSecretModelSource(
    *  run on the org's own key. */
   subsidyApiKey?: string,
 ): Promise<DecopilotSecretModelSource> {
-  const { keyInfo, apiKey } = await ctx.storage.aiProviderKeys.resolve(
-    credentialId,
-    organizationId,
-  );
+  // Replace Kysely's raw NoResultError with a clear, permanent one (#2265).
+  const { keyInfo, apiKey } = await ctx.storage.aiProviderKeys
+    .resolve(credentialId, organizationId)
+    .catch(() => {
+      throw new PermanentRunError(
+        "model_credential_not_found",
+        `Model credential ${credentialId} was not found — configure a model provider before running this agent`,
+      );
+    });
   const source = applySubsidizedBilling(
     createSecretModelSource({
       providerId: keyInfo.providerId,

--- a/apps/api/src/core/dispatch-errors.ts
+++ b/apps/api/src/core/dispatch-errors.ts
@@ -2,6 +2,7 @@ export type PermanentRunErrorCode =
   | "empty_request"
   | "agent_not_found"
   | "model_not_allowed"
+  | "model_credential_not_found"
   | "not_thread_owner";
 
 export class PermanentRunError extends Error {


### PR DESCRIPTION
Follows #2265 ("Workflow creation not working before MCP-Studio setup") — the reported root cause there was a raw Postgres error ("relation ... does not exist") reaching the user because a required piece of org setup was incomplete. The same class of bug exists in the dispatch path: `resolveSecretModelSource` in `apps/api/src/api/routes/decopilot/dispatch-run.ts` called `ctx.storage.aiProviderKeys.resolve(credentialId, organizationId)`, which uses Kysely's `executeTakeFirstOrThrow()` — if the credential isn't configured yet (org mid-setup) or was deleted, that throws a raw `NoResultError` ("no result") straight through to the user instead of an actionable message.

**Why a maintainer wants this**: it's the exact user-facing symptom from #2265 (a bare DB error instead of a clear "go configure this" message), scoped to a spot the original issue's file hints pointed at (dispatch-run.ts), and it plugs into the existing `PermanentRunError` taxonomy that automations/dispatch already special-case (e.g. `dbos-workflow.ts` deactivates an automation on a permanent error instead of retrying forever — appropriate here since a missing credential won't fix itself on retry).

**Failure scenario**: dispatch a run against a `credentialId` that doesn't exist in `ai_provider_keys` for the org (unconfigured provider, or a stale reference). Before: the user sees "no result" bubbling from Kysely. After: they get `PermanentRunError("model_credential_not_found", "Model credential <id> was not found — configure a model provider before running this agent")`, and the error is marked permanent so automations/dbos treat it as non-retriable instead of looping.

**Regression test**: `apps/api/src/api/routes/decopilot/dispatch-run.test.ts` — new `resolveSecretModelSource` describe block asserts a rejected credential lookup surfaces as a `PermanentRunError` with code `model_credential_not_found`, exported the function to make it directly testable.

**To confirm**: `bun test apps/api/src/api/routes/decopilot/dispatch-run.test.ts`

**Locally verified**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean on touched files), the targeted test file (21 pass), and `bunx oxlint` on all three changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dispatch path so a missing or unconfigured model credential surfaces as a clear permanent error instead of a raw Kysely `NoResultError` ("no result"). The new `model_credential_not_found` code gives users an actionable message and lets automations treat the failure as non-retriable instead of looping forever.

- Adds `model_credential_not_found` to the permanent error codes in `dispatch-errors.ts`.
- Exports `resolveSecretModelSource` and adds a regression test for the missing-credential case.

<sup>Written for commit 141aae7aa15588b048cd1d54713036d0d78a58c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

