### PR TITLE
fix(sandbox): stop the dev-server probe leaking a keep-alive connection every tick

### DIFF
--- a/packages/sandbox/daemon-go/internal/probe/probe.go
+++ b/packages/sandbox/daemon-go/internal/probe/probe.go
@@ -168,10 +168,14 @@ func itoa(n int) string {
 }
 
 func head(port int) (status int, isHtml, up bool) {
+	// A fresh Transport is built (and discarded) on every tick, so keep-alive
+	// would leak an idle connection + its readLoop goroutine per tick for the
+	// life of the daemon instead of being reused.
 	client := &http.Client{
 		Timeout: HeadTimeout,
 		Transport: &http.Transport{
-			DialContext: DialLoopback,
+			DialContext:       DialLoopback,
+			DisableKeepAlives: true,
 		},
 	}
 	req, err := http.NewRequest("HEAD", "http://loopback:"+itoa(port)+"/", nil)

--- a/packages/sandbox/daemon-go/internal/probe/probe_test.go
+++ b/packages/sandbox/daemon-go/internal/probe/probe_test.go
@@ -1,0 +1,49 @@
+package probe
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestHeadDoesNotLeakKeepAliveGoroutine guards against regressing to a
+// per-tick Transport that leaves an idle keep-alive connection (and its
+// readLoop goroutine) open forever, since head() is called repeatedly for
+// the life of the daemon.
+func TestHeadDoesNotLeakKeepAliveGoroutine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	port, err := strconv.Atoi(srv.URL[len("http://127.0.0.1:"):])
+	if err != nil {
+		t.Fatalf("parse port from %q: %v", srv.URL, err)
+	}
+
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < 20; i++ {
+		status, _, up := head(port)
+		if !up || status != 200 {
+			t.Fatalf("head() = status=%d up=%v, want 200/true", status, up)
+		}
+	}
+
+	// Idle keep-alive readLoop goroutines don't exit synchronously; give them
+	// a moment, then assert we haven't accumulated one per call.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if runtime.NumGoroutine() <= before+5 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutine count grew from %d to %d after 20 head() calls — keep-alive connections are leaking",
+				before, runtime.NumGoroutine())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
**Source:** bug found while auditing `packages/sandbox/daemon-go` for resource leaks (my W3 focus area this tick).

**Payoff:** the daemon's dev-server prober (`internal/probe/probe.go`) polls the sandboxed app every 1s while it's booting/offline and every 30s once online, for the entire life of the sandbox process. Each `head()` call builds a brand-new `http.Transport` for a single HEAD request but never sets `DisableKeepAlives` or closes it. If the target server keeps the connection alive (the common case), the resulting idle `persistConn` and its `readLoop` goroutine stay open indefinitely, holding the discarded `Transport` (and a socket) alive with it — since nothing ever tells that connection to close. Over a long-running sandbox this leaks one goroutine + one file descriptor per successful probe tick, unbounded, which is exactly the kind of drip that eventually causes FD exhaustion or OOM in a daemon meant to stay up for the whole session (this daemon's own health probe kills the pod on a single miss, so a slow FD leak surfacing as a missed probe is a real production risk, not theoretical).

**Failure scenario:** long-running sandbox with a dev server that supports keep-alive (nearly all HTTP servers do by default) → each probe tick after the first leaves one more idle connection + goroutine open → goroutine/FD count grows without bound for the sandbox's lifetime.

**Fix:** set `DisableKeepAlives: true` on the per-tick `Transport` — correct here since the transport is discarded after a single request anyway, so there's no pooling benefit to lose, only the connection closes promptly instead of idling forever.

**Regression test:** `internal/probe/probe_test.go` — `TestHeadDoesNotLeakKeepAliveGoroutine` spins up an `httptest.Server`, calls `head()` 20 times, and asserts the goroutine count doesn't grow. Verified it fails without the fix (goroutine count went from 3 → 63 after 20 calls) and passes with it.

**Reviewer command:** `cd packages/sandbox/daemon-go && go test ./internal/probe/... -run TestHeadDoesNotLeakKeepAliveGoroutine -v`

**Locally verified:** `gofmt -l`, `go vet ./internal/probe/...`, `go build ./...`, and the targeted test above all pass. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the dev-server probe from leaking an idle keep-alive connection and its goroutine on every tick, which could exhaust file descriptors or memory in long-running sandboxes.

**Bug Fixes**
- Set `DisableKeepAlives: true` on the per-tick `Transport` so the connection closes after each HEAD request.
- Added `TestHeadDoesNotLeakKeepAliveGoroutine` to guard against regression.

<sup>Written for commit 3b7b80103a2d8874c6d8191fd429b5d29fee3597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

