### PR TITLE
fix(sandbox): give the sandbox restart-menu chevron an accessible name

### DIFF
--- a/apps/web/src/components/sandbox/preview/drawer/toolbar.tsx
+++ b/apps/web/src/components/sandbox/preview/drawer/toolbar.tsx
@@ -262,6 +262,7 @@ function SandboxActionControls({
                 variant="outline"
                 size="xs"
                 className="rounded-l-none px-1"
+                aria-label={t("sandbox.toolbar.moreActions")}
               >
                 <ChevronDown className="size-3" />
               </Button>

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -736,6 +736,7 @@ export const sandbox = {
   "sandbox.submoduleCredentialsField.tokenLabel": "Personal access token",
   "sandbox.submoduleCredentialsField.tokenPlaceholder": "ghp_…",
   "sandbox.toolbar.closeTab": "Close {tab}",
+  "sandbox.toolbar.moreActions": "More actions",
   "sandbox.toolbar.noScriptsFound": "No scripts found",
   "sandbox.toolbar.restart": "Restart",
   "sandbox.toolbar.resume": "Resume",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -766,6 +766,7 @@ export const sandbox = {
   "sandbox.submoduleCredentialsField.tokenLabel": "Token de acesso pessoal",
   "sandbox.submoduleCredentialsField.tokenPlaceholder": "ghp_…",
   "sandbox.toolbar.closeTab": "Fechar {tab}",
+  "sandbox.toolbar.moreActions": "Mais ações",
   "sandbox.toolbar.noScriptsFound": "Nenhum script encontrado",
   "sandbox.toolbar.restart": "Reiniciar",
   "sandbox.toolbar.resume": "Retomar",


### PR DESCRIPTION
**Source:** bug found while hunting the sandbox-preview UI (apps/web/src/components/sandbox/preview/) for accessibility lapses, per this run's focus area.

**Why:** `apps/web/src/components/sandbox/preview/drawer/toolbar.tsx`'s `SandboxActionControls` renders a chevron-only dropdown trigger next to the Stop button (the "Restart" menu, shown when a sandbox is `running`). It has no `aria-label` and no visible text — just a `ChevronDown` icon — so a screen reader announces it as an unnamed button, and it's the only interactive control in that toolbar section without an accessible name (every sibling Button/icon-button in the file has one).

**Fix:** added `sandbox.toolbar.moreActions` ("More actions" / "Mais ações") to the en/pt-br i18n dictionaries and wired it as `aria-label` on the trigger `Button`, matching the existing pattern used by the adjacent `closeTab`/`runScript` aria-labels in the same file.

**To verify:** open a running sandbox's drawer toolbar with a screen reader (or inspect the accessibility tree) and confirm the chevron button next to Stop now announces "More actions" instead of nothing.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` in `apps/web` (pre-existing unrelated prosemirror-version error only, nothing in the touched files), `bunx oxlint` on the three changed files (0 warnings/errors). Full CI validates the rest (i18n key-completeness check via `bun run check` will confirm the pt-br key satisfies the en shape).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives the sandbox toolbar's restart-menu chevron an accessible name so screen readers announce it as "More actions" instead of an unnamed button. Adds the `sandbox.toolbar.moreActions` i18n key to en and pt-br and wires it as the trigger's `aria-label`.

<sup>Written for commit d93846b85608026d6929d02e507a1227ef809d83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

