### PR TITLE
fix(release): bump the sandbox manifest when the harness runner changes

### DIFF
--- a/scripts/release-changes.test.ts
+++ b/scripts/release-changes.test.ts
@@ -66,6 +66,19 @@ describe("release change classification", () => {
     }
   });
 
+  /** The harness runner is packed into the sandbox image, which is tagged from
+   *  packages/sandbox/package.json. Bumping only the runner leaves the tag
+   *  where it is, the rebuild overwrites it in place, and nodes holding the
+   *  cached layer keep running the old code — #6816 reached 4 of 21 prod pods. */
+  test("a harness-runner change also bumps the sandbox manifest", () => {
+    expect(
+      releaseManifestCandidates(["packages/harness-runner/main.ts"]),
+    ).toEqual([
+      "packages/harness-runner/package.json",
+      "packages/sandbox/package.json",
+    ]);
+  });
+
   test("maps release inputs to sorted, deduplicated manifests", () => {
     const files = [
       "packages/ui/src/button.tsx",

--- a/scripts/release-changes.ts
+++ b/scripts/release-changes.ts
@@ -11,6 +11,9 @@ const API_MANIFEST = "apps/api/package.json";
 // .github/workflows/release-native.yaml keys the DMG/zip release and the
 // Homebrew cask off.
 const NATIVE_MANIFEST = "apps/native/package.json";
+// Tags the sandbox image and, via release-tagging.yaml's CHART_IMAGE_LOCKSTEP,
+// the sandbox-env chart's image.tag.
+const SANDBOX_MANIFEST = "packages/sandbox/package.json";
 
 export type DeployScope = "both" | "server" | "web" | "none";
 
@@ -60,6 +63,16 @@ export function releaseManifestCandidates(files: readonly string[]): string[] {
     if (file.startsWith("deploy/helm/studio/files/")) {
       addReleaseLine();
       continue;
+    }
+
+    // The harness runner is packed INTO the sandbox image
+    // (packages/sandbox/image/Dockerfile), and that image is tagged from
+    // packages/sandbox/package.json. Without this the version stays put, the
+    // rebuild overwrites the live tag in place, and every node that already
+    // cached it keeps serving the old runner — #6816's fix reached 4 of 21
+    // prod sandbox pods that way.
+    if (file.startsWith("packages/harness-runner/")) {
+      manifests.add(SANDBOX_MANIFEST);
     }
 
     const packageMatch = /^packages\/([^/]+)\//.exec(file);


### PR DESCRIPTION
## Summary

`#6816` fixed the duplicated text block after a thinking block. It is still happening in prod, because the fix never reached most sandbox pods.

`releaseManifestCandidates` maps a changed file to its **own** workspace manifest only. `packages/harness-runner` is packed *into* the sandbox image (`packages/sandbox/image/Dockerfile:182`), and `release-studio-sandbox.yaml:42` tags that image from **`packages/sandbox/package.json`** — so the release bot bumped `@decocms/harness-runner` 0.9.1 → 0.9.2 and left `packages/sandbox` at 1.60.4.

The image workflow *does* trigger on `packages/harness-runner/**`, so it rebuilt and pushed to the same tag. Chart pins `tag: "1.60.4"` with `imagePullPolicy: IfNotPresent` — a node that already cached that tag never re-pulls.

## Prod at the time of writing

One tag, two digests, live side by side in `agent-sandbox-system`:

```
17 pods  studio-sandbox-go@sha256:e6679c6b…   pre-fix
 4 pods  studio-sandbox-go@sha256:b79b2f6a…   has the fix
```

Pods created 90 minutes after the rebuild were still landing on the pre-fix digest. `thread_message_parts` for a run on one of them (`thrd_BMG1KF32…`, seq 15-17) shows the exact `#6816` signature — an empty `{"text":""}` reasoning part followed by two byte-identical adjacent `text` parts.

## The change

Map `packages/harness-runner/**` onto `packages/sandbox/package.json` as well. The bump then cuts a **new** image tag, and `release-tagging.yaml`'s existing `CHART_IMAGE_LOCKSTEP` carries it into `sandbox-env`'s `image.tag` and chart version on its own.

## Testing

`scripts/release-changes.test.ts` gains one case. Verified it fails without the source change and passes with it. `bun test scripts/` → 62 pass. `bun run fmt` clean.

## Follow-up (not in this PR)

`release-studio-sandbox.yaml`'s "tag already exists → skip push" guard did not fire on run `33536865681` — it curls GHCR with the raw `GITHUB_TOKEN` and no manifest `Accept` header, so it always reads "missing" and lets a live tag be overwritten in place. That is what turned a missed bump into a split fleet instead of a harmless no-op.

The 17 stale pods need draining regardless — this PR only stops the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADjtheZzLxwHBF8z1wru5j

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release manifest mapping so changes to `packages/harness-runner/**` also bump `packages/sandbox/package.json`, which is what the sandbox image is tagged from.

Previously a runner-only change bumped `@decocms/harness-runner` and left `packages/sandbox` untouched. The image workflow still rebuilt and pushed to the same tag, and nodes with `imagePullPolicy: IfNotPresent` kept serving the cached old runner — that's how the #6816 fix reached only 4 of 21 prod pods. Now the bump cuts a new image tag, and `CHART_IMAGE_LOCKSTEP` carries it into `sandbox-env`'s `image.tag` and chart version.

Adds a test case covering harness-runner changes mapping to the sandbox manifest. Existing pods on the old digest still need to be drained; this only prevents future occurrences.

<sup>Written for commit 389b23f143fde5ca099df65635aad89dda9b554b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

