### PR TITLE
fix(jira): embed comment images written inside a markdown table cell

### DIFF
--- a/apps/api/src/jira/markdown-adf.test.ts
+++ b/apps/api/src/jira/markdown-adf.test.ts
@@ -585,6 +585,16 @@ describe("markdownToAdf images", () => {
     ]);
   });
 
+  it("embeds inside a table cell", () => {
+    // Inline-only cells used to drop a QA before/after table's shots to links.
+    const [table] = markdownToAdf(
+      [`| before |`, `| --- |`, `| ![x](${target}) |`].join("\n"),
+      { media },
+    ).content;
+    const cell = table?.content?.[1]?.content?.[0];
+    expect(cell?.content?.map((node) => node.type)).toEqual(["mediaSingle"]);
+  });
+
   it("still keeps alt text when a media node cannot live in the parent", () => {
     // A heading is inline-only, so nothing is uploaded for it in the first
     // place and the label survives as text.
@@ -609,7 +619,7 @@ describe("collectImageTargets", () => {
       "",
       "# ![heading](/out/skip-heading.png)",
       "",
-      "| ![cell](/out/skip-cell.png) |",
+      "| ![cell](/out/4.png) |",
       "| --- |",
       "| x |",
       "",
@@ -621,6 +631,7 @@ describe("collectImageTargets", () => {
       "/out/1.png",
       "/out/2.png",
       "/out/3.png",
+      "/out/4.png",
     ]);
   });
 

--- a/apps/api/src/jira/markdown-adf.ts
+++ b/apps/api/src/jira/markdown-adf.ts
@@ -135,8 +135,8 @@ interface Ctx {
   media: ReadonlyMap<string, AdfMedia>;
   /**
    * `mediaSingle` is a block node, so only a paragraph-bearing context can
-   * emit one. A heading or a table cell is inline-only and keeps the link —
-   * and reports nothing to `onImage`, so nothing is uploaded for it.
+   * emit one. A heading is inline-only and keeps the link — and reports nothing
+   * to `onImage`, so nothing is uploaded for it.
    */
   allowMedia: boolean;
   onImage?: (target: string) => void;
@@ -496,7 +496,9 @@ function splitRow(line: string): string[] | null {
 }
 
 /** Rows are padded and truncated to the header's width: ADF accepts a ragged
- *  table, but Jira's own editor then treats it as broken. */
+ *  table, but Jira's own editor then treats it as broken. A cell is block
+ *  content, so `liftMedia` applies as it does to a paragraph — a before/after
+ *  table of screenshots is the shape a QA comment posts. */
 function tableRow(
   cells: string[],
   cellType: string,
@@ -508,7 +510,7 @@ function tableRow(
     content: Array.from({ length: width }, (_unused, column) => ({
       type: cellType,
       attrs: {},
-      content: [paragraph(inlineNodes(cells[column] ?? "", inlineOnly(ctx)))],
+      content: liftMedia(inlineNodes(cells[column] ?? "", ctx)),
     })),
   };
 }


### PR DESCRIPTION
## Summary

A board comment mirrored to Jira lost **every screenshot it put in a markdown table**. `tableRow` built its cells with `inlineOnly(ctx)`, which clears `allowMedia`, and that does two things:

1. the image degrades to a link, and
2. it is never reported to `onImage` — so `collectImageTargets` returns nothing, the upload step in `jiraCommentPushWorkflowFn` never runs, and the Jira comment ends up carrying a member-gated relative URL (`/api/<org>/fs/outputs/read?path=…`) that nobody reading the issue can fetch.

A before/after table of screenshots is the exact shape a QA reviewer posts — `enqueue-reviewer.ts` asks for one — so this hit the comments that most needed their images.

`mediaSingle` is legal in an ADF `tableCell`, the same as the `listItem` and `blockquote` cases already probed against Jira Cloud, so a cell now gets the same `liftMedia` treatment as a paragraph.

## Repro

Real prod comment `cmt_pFkQ7jYqMeUTRcydOeiJz` on `osklen` / OS-310 (Jira comment `53372`), whose body is:

```markdown
| Before (produção, mobile) | After (preview, mobile) |
| --- | --- |
| ![before](/api/osklen/fs/outputs/read?path=…before-mobile.png) | ![after](…after-mobile.png) |
```

Running `collectImageTargets` + `plannedAttachments` + `markdownToAdf` over that exact body:

| | before | after |
| --- | --- | --- |
| `collectImageTargets` | `[]` | 3 targets |
| `plannedAttachments` | `[]` | 3 uploads |
| `mediaSingle` nodes | 0 | 3 |

Nothing was logged when this happened — no `[jira] could not attach`, no `[jira] comment rejected as ADF` — because the pipeline correctly concluded there were no images to attach.

## Testing

- `bun test apps/api/src/jira/markdown-adf.test.ts` → 38 pass.
- The old behaviour was pinned by a `collectImageTargets` case asserting a table cell was **skipped** (`skip-cell.png`); that expectation is **inverted**, not appended to.
- Added an embed test asserting a cell's content is `["mediaSingle"]`.
- The 11 failures elsewhere under `apps/api/src/tools/task-board` are `ECONNREFUSED 127.0.0.1:5432` integration tests, identical on a clean tree.

## Affected areas

Jira comment mirroring only. Headings stay inline-only (unchanged).

## Follow-ups (not in this PR)

- `dbos-jira-sync.ts:262` truncates a pushed body at 30k chars silently — images past the cut vanish with no trace on the issue.
- `MAX_UPLOADS = 8` caps embeds per comment; the rest stay links, warned to the log only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Jira comment mirroring so screenshots inside a markdown table cell are uploaded and embedded instead of degrading to member-gated links nobody can fetch.

- Table cells now use the same `liftMedia` treatment as paragraphs; `mediaSingle` is valid in an ADF `tableCell`.
- The test that pinned the old skip-table-cell behavior is inverted, and a new test asserts a cell embeds `mediaSingle`.
- Headings remain inline-only, so their image handling is unchanged.

<sup>Written for commit ebc4ddd6f16cb1b3270c3b8e8929402ca74e1867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

