### PR TITLE
fix(task-board): don't stomp a human claim in the PR-open board reaction

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1730,6 +1730,51 @@ export class TaskBoardStorage {
   }
 
   /**
+   * Atomically move a card into its in-progress lane when a PR opens, claiming
+   * it for the Super Agent in the SAME statement when nobody owns it yet.
+   *
+   * Both writes are fenced on `fromLane`, the status the caller decided
+   * against: that decision is made from a card snapshot taken before an LLM
+   * call, so by the time it lands a human may have dragged the card to Done or
+   * a reviewer may have moved it on. Replaying the stale advance would drag a
+   * finished card back to In Progress — the very regression `canAdvance`
+   * exists to prevent. Losing the race returns null and the caller leaves the
+   * live card alone. One statement, so the status and the claim can't disagree.
+   */
+  async advanceToProgressOnPrOpen(
+    id: string,
+    organizationId: string,
+    fromLane: string,
+    toLane: string,
+    by: string,
+  ): Promise<TaskBoardItem | null> {
+    const row = await this.db
+      .updateTable("task_board_items")
+      .set({
+        status: toLane,
+        // Column reads on the right-hand side are the row's OLD values, so this
+        // claims only an unowned card and leaves a human's ownership intact.
+        assignee_id: sql`coalesce(assignee_id, ${SUPER_AGENT_ASSIGNEE_ID})`,
+        assigned_by: sql`case when assignee_id is null then ${by} else assigned_by end`,
+        // Same rule as `update()`: leaving the review phase ends the cycle.
+        ...(REVIEW_PHASE_LANES.has(toLane)
+          ? {}
+          : { review_cycle_started_at: null }),
+        updated_by: by,
+        updated_at: new Date().toISOString(),
+      })
+      .where("id", "=", id)
+      .where("organization_id", "=", organizationId)
+      .where("status", "=", fromLane)
+      .returningAll()
+      .executeTakeFirst();
+    if (!row) return null;
+    const item = this.itemFromDbRow(row);
+    await this.attachRefs([item], organizationId);
+    return item;
+  }
+
+  /**
    * Atomically hand a task from the Super Agent to a human: clear
    * `assigneeId` and `assignedBy` ONLY if it's still the Super Agent — an
    * unassigned card keeps no delegation metadata — returning the updated

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts
@@ -65,6 +65,7 @@ describe("applyBoardDecision", () => {
     "thr_fallback",
     "thr_done",
     "thr_race",
+    "thr_moved",
   ];
 
   const apply = (
@@ -208,6 +209,31 @@ describe("applyBoardDecision", () => {
     );
     expect(item!.id).toBe(card.id);
     expect(item!.assigneeId).toBe(USER);
+  });
+
+  it("update doesn't drag back a card moved past the lane after the snapshot", async () => {
+    const card = await taskBoard.create({
+      organizationId: ORG,
+      title: "raced move",
+      status: "todo",
+      by: USER,
+    });
+    // Stale snapshot: still To Do, before the card ships below.
+    const staleSnapshot = card;
+    await taskBoard.update(card.id, ORG, { status: "done" }, USER);
+    const item = await apply(
+      { action: "update", taskId: card.id },
+      [staleSnapshot],
+      "thr_moved",
+    );
+    // The advance was decided against To Do and lost the race: the shipped card
+    // stays shipped, unclaimed, and still gets the PR linked.
+    expect(item!.id).toBe(card.id);
+    expect(item!.status).toBe("done");
+    expect(item!.assigneeId).toBeNull();
+    expect(item!.reviewCycleStartedAt).toBeNull();
+    const prs = await taskBoard.listPrs(card.id, ORG);
+    expect(prs.map((p) => p.number)).toEqual([7]);
   });
 
   it("update with an unknown taskId falls back to creating a card", async () => {

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts
@@ -64,6 +64,7 @@ describe("applyBoardDecision", () => {
     "thr_human",
     "thr_fallback",
     "thr_done",
+    "thr_race",
   ];
 
   const apply = (
@@ -187,6 +188,25 @@ describe("applyBoardDecision", () => {
     expect(item!.status).toBe("in_progress");
     expect(item!.reviewCycleStartedAt).not.toBeNull();
     // A human owns it — the claim must not steal the card from them.
+    expect(item!.assigneeId).toBe(USER);
+  });
+
+  it("update doesn't stomp a human claim raced in after the openCards snapshot", async () => {
+    const card = await taskBoard.create({
+      organizationId: ORG,
+      title: "raced claim",
+      status: "in_progress",
+      by: USER,
+    });
+    // Stale snapshot: still unassigned, before a human claims it below.
+    const staleSnapshot = card;
+    await taskBoard.update(card.id, ORG, { assigneeId: USER }, USER);
+    const item = await apply(
+      { action: "update", taskId: card.id },
+      [staleSnapshot],
+      "thr_race",
+    );
+    expect(item!.id).toBe(card.id);
     expect(item!.assigneeId).toBe(USER);
   });
 

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -164,10 +164,8 @@ export async function applyBoardDecision(
   let item: TaskBoardItem | null;
   if (target) {
     // Enter the review phase only from an earlier lane; never regress a finished
-    // card — and only onto a lane this board HAS. Folded into `advancing` rather
-    // than left to a null status: `undefined` already means "leave the status
-    // alone" here, so reusing it for "nowhere to advance to" would also skip the
-    // Super Agent claim and the review cycle without saying why.
+    // card — and only onto a lane this board HAS. A null `advanceTo` is
+    // "nowhere to advance to", and skips the claim and the review cycle with it.
     const progressLane = lanes.progress;
     // The LANE, not a boolean: `boardCan` narrows `progressLane` inside this
     // expression, and a boolean would not carry that to the write below.
@@ -180,32 +178,28 @@ export async function applyBoardDecision(
       ) && canAdvance(columns, target.status, progressLane)
         ? progressLane
         : null;
-    const advancing = advanceTo !== null;
-    // Claim an unowned card for the Super Agent (reviewer dispatch gates on it); never a human's — re-fenced on the live row since `target` predates the LLM call above.
-    const claimSuperAgent = advancing && target.assigneeId == null;
-    if (claimSuperAgent) {
-      await storage.claimUnassignedForSuperAgent(
-        target.id,
-        orgId,
-        userId,
-        userId,
-        target.status,
-      );
-    }
-    item = await storage.update(
-      target.id,
-      orgId,
-      {
-        // In Progress, not In Review: a reviewer is about to work on this PR,
-        // and In Review is what the board says once it is a person's turn.
-        // The open cycle below is what puts it on the reviewer's work list.
-        status: advanceTo ?? undefined,
-      },
-      userId,
-    );
-    if (advancing) {
+    // In Progress, not In Review: a reviewer is about to work on this PR, and
+    // In Review is what the board says once it is a person's turn. The open
+    // cycle below is what puts it on the reviewer's work list. The move also
+    // claims an unowned card for the Super Agent (reviewer dispatch gates on
+    // it) — never a human's. One fenced write, because `target` predates the
+    // LLM call above: a card someone moved since must not be dragged back.
+    const advanced =
+      advanceTo === null
+        ? null
+        : await storage.advanceToProgressOnPrOpen(
+            target.id,
+            orgId,
+            target.status,
+            advanceTo,
+            userId,
+          );
+    if (advanced) {
       await storage.openReviewCycleIfInProgress(target.id, orgId, lanes);
     }
+    // Lost the race (or nowhere to advance): link the PR onto the card as it
+    // now stands rather than dropping the whole reaction.
+    item = advanced ?? (await storage.getById(target.id, orgId));
   } else {
     // Create (also the unknown-taskId fallback), owned by the Super Agent so reviewers pick it up.
     item = await storage.create({

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -181,8 +181,17 @@ export async function applyBoardDecision(
         ? progressLane
         : null;
     const advancing = advanceTo !== null;
-    // Claim an unowned card for the Super Agent (reviewer dispatch gates on it); never a human's.
+    // Claim an unowned card for the Super Agent (reviewer dispatch gates on it); never a human's — re-fenced on the live row since `target` predates the LLM call above.
     const claimSuperAgent = advancing && target.assigneeId == null;
+    if (claimSuperAgent) {
+      await storage.claimUnassignedForSuperAgent(
+        target.id,
+        orgId,
+        userId,
+        userId,
+        target.status,
+      );
+    }
     item = await storage.update(
       target.id,
       orgId,
@@ -191,9 +200,6 @@ export async function applyBoardDecision(
         // and In Review is what the board says once it is a person's turn.
         // The open cycle below is what puts it on the reviewer's work list.
         status: advanceTo ?? undefined,
-        ...(claimSuperAgent
-          ? { assigneeId: SUPER_AGENT_ASSIGNEE_ID, assignedBy: userId }
-          : {}),
       },
       userId,
     );


### PR DESCRIPTION
Follows #6828's fix in `runColumnAutomation` — same race, different call site.

`applyBoardDecision` (wired into `reactToPrOpenedForBoard`) reads `openCards` (and `target.assigneeId`) *before* calling the LLM to decide create-vs-update, which can take seconds. It then wrote `claimSuperAgent` based on that stale `assigneeId` through a plain `storage.update()` — no WHERE fence — so if a human claimed the card while the LLM call was in flight, this write silently reverted their claim back to the Super Agent.

`storage.taskBoard.claimUnassignedForSuperAgent()` is the exact primitive #6828 just used to fix the identical race in `runColumnAutomation` (a conditional UPDATE requiring `assignee_id IS NULL` and the card's original status). Reused it here: the claim now happens through that fence, and the follow-up `storage.update()` call only touches `status`, never assignee fields — so if the fence loses, the human's assignment is simply left untouched.

Failure scenario before the fix: `reactToPrOpenedForBoard` snapshots an unassigned card into `openCards`, the LLM call runs for a couple seconds, a person assigns themselves to the card via `TASK_BOARD_ITEM_UPDATE` in that window, then `applyBoardDecision` runs its stale-snapshot `claimSuperAgent` check (still true) and overwrites `assigneeId` back to the Super Agent — the human's claim silently disappears.

Regression test added: `pr-open-board-reaction.integration.test.ts` — creates a card, takes a stale `openCards` snapshot, assigns it to a human (simulating the race), then runs `applyBoardDecision` with the stale snapshot and asserts the human's assignment survives.

Reviewer check: `bun test apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts` (needs local Postgres, not available in this sandbox — same caveat as #6828).

Locally verified: `bunx tsc --noEmit` (apps/api) and `bunx oxlint` on both touched files are clean. Full CI runs the integration suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `applyBoardDecision` (the PR-open board reaction) where a stale card snapshot, taken before the LLM call, could overwrite a human's claim back to the Super Agent or drag a card someone had since moved to an earlier lane.

The status advance and Super Agent claim now happen in one fenced `UPDATE` that requires the card's original status and an unowned card. Losing the race leaves the live card untouched and still links the PR onto it as it now stands.

- Adds `advanceToProgressOnPrOpen()` to `TaskBoardStorage` for the atomic status advance and claim.
- Adds integration tests covering both the human-claim race and the moved-card race.

<sup>Written for commit 33a9db7fb709583f0a681b63d41e74f42860aa74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

