### PR TITLE
feat(jira): put the PR and its deploy preview on the issue as web links

### DIFF
--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -6,7 +6,7 @@
   "file-storage/dbos-org-repo-sync.ts": "32c606976916fde2be7abe3084f7388744bdb610c178e9c2a07a8080f764904e",
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",
   "harnesses/decopilot/background-tool-workflow.ts": "1ae73b5a614ae6439942c1e52de52deeb3e18d1bb7e528be820720b592cfe833",
-  "jira/dbos-jira-sync.ts": "ceaf32d75681da37867315c32409181a861aa62ab5b1e912a6f84735e7cba892",
+  "jira/dbos-jira-sync.ts": "1377bb5a15e4e03ab56e9ab47eac79abe2de08116f5f59bc86418dcd2be625e1",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
   "notifications/dbos-digest.ts": "673bc164593266704d2918a0bcaaf838a2480dfb46d1d19c02bdb38c73ecc370",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -16,6 +16,7 @@
 
 import { retry } from "@decocms/shared/std";
 import { type AdfMedia, markdownToAdf } from "./markdown-adf";
+import type { JiraRemoteLink } from "./remote-links";
 import {
   findSprintFieldIds,
   type JiraSprintRef,
@@ -662,6 +663,33 @@ export class JiraClient {
       console.warn(`[jira] comment rejected as ADF, posting flat: ${err}`);
       return post(textToAdf(header ? `${header}\n${markdown}` : markdown));
     }
+  }
+
+  /**
+   * Upsert a remote link on the issue — the "Web links" panel.
+   *
+   * `idempotent: true` unlike the other writes here: Jira keys the link on
+   * `globalId` and REPLACES a match rather than appending, so a retry after a
+   * timeout cannot leave two.
+   */
+  async upsertRemoteLink(issueId: string, link: JiraRemoteLink): Promise<void> {
+    await this.request<{ id: number }>(
+      `/rest/api/3/issue/${encodeURIComponent(issueId)}/remotelink`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          globalId: link.globalId,
+          object: {
+            url: link.url,
+            title: link.title,
+            ...(link.iconUrl
+              ? { icon: { url16x16: link.iconUrl, title: link.title } }
+              : {}),
+          },
+        }),
+      },
+      { idempotent: true },
+    );
   }
 
   /** Attachments already on the issue — the dedup check for a re-push. */

--- a/apps/api/src/jira/dbos-jira-sync.ts
+++ b/apps/api/src/jira/dbos-jira-sync.ts
@@ -8,6 +8,7 @@
  * boot via `setJiraSyncRuntime` BEFORE `DBOS.launch()`.
  */
 
+import { createHash } from "node:crypto";
 import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
 import type { Kysely } from "kysely";
 import { isMaxStepRetriesError } from "@/dbos/step-errors";
@@ -34,6 +35,11 @@ import {
   plannedAttachments,
 } from "./comment-media";
 import { type AdfMedia, collectImageTargets } from "./markdown-adf";
+import {
+  type JiraRemoteLink,
+  type RemoteLinkInput,
+  remoteLinkPlan,
+} from "./remote-links";
 import { JIRA_SYNC_ACTOR, syncJiraIntegrationSafe } from "./sync";
 
 /** Every 10 minutes, offset from the public-sets (:04) and org-repo (:07)
@@ -573,11 +579,62 @@ async function jiraStatusPushWorkflowFn(
   });
 }
 
+export interface JiraRemoteLinkPushParams extends RemoteLinkInput {
+  organizationId: string;
+}
+
+/**
+ * One remote link → the issue's Web links panel. Re-reads the row so the
+ * credential never crosses a step boundary, and re-checks the issue link so a
+ * card unlinked since the enqueue is a no-op.
+ */
+async function pushRemoteLink(
+  params: JiraRemoteLinkPushParams,
+  link: JiraRemoteLink,
+): Promise<void> {
+  const storage = storageFromRuntime();
+  const integration = await storage.getByOrg(params.organizationId);
+  if (!integration?.enabled) return;
+  const issue = await storage.getLinkByItemId(
+    params.taskBoardItemId,
+    params.organizationId,
+  );
+  if (!issue) return;
+  const client = new JiraClient(
+    integration.siteUrl,
+    integration.email,
+    integration.apiToken,
+  );
+  await client.upsertRemoteLink(issue.jiraIssueId, link);
+}
+
+/**
+ * Mirror a card's PR and deploy preview onto its Jira issue as web links.
+ *
+ * `remoteLinkPlan` is pure over the params, so the workflow stays
+ * deterministic: the same params always drive the same steps in the same
+ * order, which is what lets a replay resume at the link that failed.
+ */
+async function jiraRemoteLinkPushWorkflowFn(
+  params: JiraRemoteLinkPushParams,
+): Promise<void> {
+  for (const link of remoteLinkPlan(params)) {
+    await DBOS.runStep(() => pushRemoteLink(params, link), {
+      name: `pushRemoteLink:${link.globalId}`,
+      retriesAllowed: true,
+      maxAttempts: 3,
+    });
+  }
+}
+
 let registeredWorkflow: typeof jiraSyncWorkflowFn | null = null;
 let registeredCommentPushWorkflow: typeof jiraCommentPushWorkflowFn | null =
   null;
 let registeredStatusPushWorkflow: typeof jiraStatusPushWorkflowFn | null = null;
 let registeredSprintPushWorkflow: typeof jiraSprintPushWorkflowFn | null = null;
+let registeredRemoteLinkPushWorkflow:
+  | typeof jiraRemoteLinkPushWorkflowFn
+  | null = null;
 
 /**
  * Mirror a board card's status onto its linked Jira issue — called from
@@ -680,6 +737,44 @@ export async function enqueueJiraCommentPush(
   }
 }
 
+/**
+ * Put a card's PR and deploy-preview URLs on its Jira issue as web links.
+ *
+ * Fire-and-forget with the same cheap declines as the other pushes (no Jira
+ * link, nothing worth linking). The `workflowID` is keyed on the PLAN, so an
+ * unchanged set of URLs never re-enqueues and a new deploy's preview does —
+ * that is the whole rate control, no cadence to tune.
+ */
+export function maybeEnqueueJiraRemoteLinkPush(
+  params: JiraRemoteLinkPushParams,
+): void {
+  if (!registeredRemoteLinkPushWorkflow || !runtime) return;
+  const plan = remoteLinkPlan(params);
+  if (plan.length === 0) return;
+  const workflow = registeredRemoteLinkPushWorkflow;
+  const fingerprint = createHash("sha1")
+    .update(plan.map((link) => `${link.globalId}\n${link.url}`).join("\n"))
+    .digest("hex")
+    .slice(0, 16);
+  void (async () => {
+    const issue = await storageFromRuntime().getLinkByItemId(
+      params.taskBoardItemId,
+      params.organizationId,
+    );
+    if (!issue) return;
+    await DBOS.startWorkflow(workflow, {
+      queueName: JIRA_PUSH_QUEUE,
+      workflowID: `jira-links:${params.taskBoardItemId}:${fingerprint}`,
+      enqueueOptions: { queuePartitionKey: params.organizationId },
+    })(params);
+  })().catch((err) => {
+    console.warn(
+      `[jira] remote-link push enqueue failed for ${params.taskBoardItemId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  });
+}
+
 /** Must run before `DBOS.launch()`; guarded so HMR repeats don't re-register.
  *  ⚠️ Durable workflows — changing a STEP SEQUENCE requires bumping
  *  DBOS_WORKFLOW_VERSION (apps/api/src/dbos/workflow-version.ts). */
@@ -704,5 +799,9 @@ export function registerJiraSyncWorkflow(): void {
   registeredSprintPushWorkflow = DBOS.registerWorkflow(
     jiraSprintPushWorkflowFn,
     { name: "jiraSprintPushWorkflow" },
+  );
+  registeredRemoteLinkPushWorkflow = DBOS.registerWorkflow(
+    jiraRemoteLinkPushWorkflowFn,
+    { name: "jiraRemoteLinkPushWorkflow" },
   );
 }

--- a/apps/api/src/jira/remote-links.test.ts
+++ b/apps/api/src/jira/remote-links.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { remoteLinkPlan } from "./remote-links";
+
+describe("remoteLinkPlan", () => {
+  const item = "board_abc";
+
+  it("plans a PR link keyed on the card and PR number", () => {
+    expect(
+      remoteLinkPlan({
+        taskBoardItemId: item,
+        prUrl: "https://github.com/o/r/pull/7",
+        prNumber: 7,
+      }),
+    ).toEqual([
+      {
+        globalId: `studio-pr:${item}:7`,
+        url: "https://github.com/o/r/pull/7",
+        title: "Pull request #7",
+        iconUrl: "https://github.githubassets.com/favicon.ico",
+      },
+    ]);
+  });
+
+  it("plans one preview link per card, so a re-deploy replaces it", () => {
+    const first = remoteLinkPlan({
+      taskBoardItemId: item,
+      previewUrl: "https://envs-x--aaa.decocdn.com",
+    });
+    const second = remoteLinkPlan({
+      taskBoardItemId: item,
+      previewUrl: "https://envs-x--bbb.decocdn.com",
+    });
+    expect(first[0]?.globalId).toBe(second[0]?.globalId);
+    expect(first[0]?.url).not.toBe(second[0]?.url);
+    expect(first[0]?.title).toBe("Deploy preview");
+  });
+
+  it("drops a preview on an untrusted host", () => {
+    // The preview is lifted from PR comments an outside contributor can write,
+    // and this link lands on a customer's issue.
+    expect(
+      remoteLinkPlan({
+        taskBoardItemId: item,
+        previewUrl: "https://evil.example.com/x?y=.decocdn.com",
+      }),
+    ).toEqual([]);
+  });
+
+  it("drops a non-http target and plans nothing when there is nothing to link", () => {
+    expect(
+      remoteLinkPlan({ taskBoardItemId: item, prUrl: "javascript:alert(1)" }),
+    ).toEqual([]);
+    expect(remoteLinkPlan({ taskBoardItemId: item })).toEqual([]);
+  });
+
+  it("plans both links in a stable order", () => {
+    const plan = remoteLinkPlan({
+      taskBoardItemId: item,
+      prUrl: "https://github.com/o/r/pull/7",
+      prNumber: 7,
+      previewUrl: "https://envs-x--aaa.decocdn.com",
+    });
+    expect(plan.map((l) => l.title)).toEqual([
+      "Pull request #7",
+      "Deploy preview",
+    ]);
+  });
+});

--- a/apps/api/src/jira/remote-links.ts
+++ b/apps/api/src/jira/remote-links.ts
@@ -1,0 +1,73 @@
+/**
+ * Board links → Jira remote links (the issue's "Web links" panel), so someone
+ * reading the ticket reaches the PR and its deploy preview without opening
+ * Studio.
+ *
+ * `globalId` is the upsert key: Jira replaces the link already carrying it
+ * instead of appending a duplicate. That is what makes the push a retriable
+ * step, and what lets a re-deploy's preview overwrite the previous one in
+ * place rather than stacking a link per deploy.
+ *
+ * Pure and deterministic, because the push workflow turns each entry into its
+ * own durable step and dedupes its enqueue on the plan — the same input must
+ * always yield the same links in the same order.
+ */
+
+import { isTrustedPreviewHost } from "../tools/task-board/prs-get";
+
+export interface JiraRemoteLink {
+  globalId: string;
+  url: string;
+  title: string;
+  iconUrl?: string;
+}
+
+const GITHUB_ICON = "https://github.githubassets.com/favicon.ico";
+
+export interface RemoteLinkInput {
+  taskBoardItemId: string;
+  prUrl?: string | null;
+  prNumber?: number | null;
+  previewUrl?: string | null;
+}
+
+export function remoteLinkPlan(input: RemoteLinkInput): JiraRemoteLink[] {
+  const links: JiraRemoteLink[] = [];
+  // Keyed by PR number, not by url: a card can link more than one PR and each
+  // gets its own row, while a re-push of the same PR updates in place.
+  if (input.prUrl && isHttpUrl(input.prUrl)) {
+    links.push({
+      globalId: `studio-pr:${input.taskBoardItemId}:${input.prNumber ?? input.prUrl}`,
+      url: input.prUrl,
+      title: input.prNumber
+        ? `Pull request #${input.prNumber}`
+        : "Pull request",
+      iconUrl: GITHUB_ICON,
+    });
+  }
+  // Host-checked at the write, not just where it was read: a preview is lifted
+  // from PR comments an external contributor can author, and this one lands on
+  // a customer's issue as a link people click.
+  if (
+    input.previewUrl &&
+    isHttpUrl(input.previewUrl) &&
+    isTrustedPreviewHost(input.previewUrl)
+  ) {
+    links.push({
+      // One preview link per card, so a new deploy replaces the old URL.
+      globalId: `studio-preview:${input.taskBoardItemId}`,
+      url: input.previewUrl,
+      title: "Deploy preview",
+    });
+  }
+  return links;
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
+}

--- a/apps/api/src/tools/task-board/pr-link.ts
+++ b/apps/api/src/tools/task-board/pr-link.ts
@@ -25,6 +25,7 @@ import { z } from "zod";
 import { boardLanes } from "./board-handler";
 import { defineTool } from "@/core/define-tool";
 import { requireAuth, requireOrganization } from "@/core/studio-context";
+import { maybeEnqueueJiraRemoteLinkPush } from "@/jira/dbos-jira-sync";
 import { extractPrFromText } from "./pr-extract";
 import { resolveRunTaskTargets } from "./run-reactions";
 import { requireTaskRunContext } from "./task-run-context";
@@ -102,6 +103,15 @@ export const TASK_BOARD_ITEM_PR_LINK = defineTool({
         taskBoardItemId,
         organizationId,
       );
+      // The PR on the Jira issue as a web link, now rather than whenever
+      // someone next opens the card. No preview yet — the deploy has not run;
+      // `TASK_BOARD_ITEM_PRS_GET` adds it once one resolves.
+      maybeEnqueueJiraRemoteLinkPush({
+        organizationId,
+        taskBoardItemId,
+        prUrl: pr.url,
+        prNumber: pr.number,
+      });
     }
 
     return { url: pr.url, prNumber: pr.number, taskBoardItemIds };

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { maybeEnqueueJiraRemoteLinkPush } from "@/jira/dbos-jira-sync";
 import { defineTool } from "@/core/define-tool";
 import { requireAuth } from "@/core/studio-context";
 import type { StudioContext } from "@/core/studio-context";
@@ -1293,6 +1294,20 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
       } catch (err) {
         console.error("[task-board] merged-PR reconcile failed", err);
       }
+    }
+
+    // The PR and its deploy preview as Jira web links. Here because this is
+    // where a preview URL is resolved anyway — the reviewer polls this tool
+    // while waiting for the deploy — so the push costs no extra GitHub call.
+    // Enqueue dedupes on the URLs, so repeated views are free.
+    for (const pr of prs) {
+      maybeEnqueueJiraRemoteLinkPush({
+        organizationId,
+        taskBoardItemId,
+        prUrl: pr.url,
+        prNumber: pr.number,
+        previewUrl: pr.previewUrl,
+      });
     }
 
     return { prs };


### PR DESCRIPTION
## Summary

Someone reading a mirrored Jira issue had no way to reach the work — the PR and its deploy preview lived only on the Studio card. Both now land in the issue's **Web links** panel (`POST /rest/api/3/issue/{id}/remotelink`).

`globalId` is the upsert key, so Jira **replaces** the link carrying it instead of appending. That gives three things for free:

- the push is a safely retriable step;
- the preview is keyed per **card** (`studio-preview:<itemId>`), so a re-deploy overwrites the URL in place instead of stacking one link per deploy;
- the PR is keyed per **number** (`studio-pr:<itemId>:<n>`), so a card with two PRs shows two rows.

## Where it fires

Two enqueue points, both fire-and-forget with the same cheap declines as the existing status/sprint pushes (no Jira link → nothing enqueued):

| Call site | What it knows |
| --- | --- |
| `TASK_BOARD_ITEM_PR_LINK` | the PR, immediately — the deploy hasn't run, so no preview |
| `TASK_BOARD_ITEM_PRS_GET` | the PR **and** the preview, at no extra GitHub cost |

`PRS_GET` is the right home for the preview because it already resolves one — the reviewer polls that tool while waiting for the deploy (`enqueue-reviewer.ts:770`). No new GitHub calls, which matters: a per-card multiplier on that budget is what held the App's rate limit shut for 17 hours once.

The `workflowID` is keyed on the **plan's URLs**, so an unchanged set never re-enqueues and a new deploy's preview does. That's the entire rate control — no cadence to tune, and repeated card views are free.

## Security

The preview host is re-checked at the write with `isTrustedPreviewHost`, not only where it was read. A preview URL is lifted from PR comments an outside contributor can author, and this one lands on a **customer's** issue as a link people click. Non-http targets are dropped too.

## Testing

- `bun test apps/api/src/jira/remote-links.test.ts` → 5 pass, covering the two globalId keying rules, the untrusted-host drop, the non-http drop, and plan order (order is load-bearing: the workflow turns each entry into a durable step, so a replay must see the same sequence).
- `bun run --cwd=apps/api check` clean, `bun run lint` 0 errors.
- `bun test apps/api/src/dbos/` → 12 pass with the re-baselined source-guard snapshot.

## DBOS

**No `DBOS_WORKFLOW_VERSION` bump.** A newly registered workflow has no in-flight instances to strand, and no existing workflow's step sequence changed. `workflow-source-guard.snapshot.json` is re-baselined (13 hashes) as the guard requires.

## Affected areas

Jira mirroring. Orgs without a Jira integration enqueue nothing — the gate is a PK miss.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the PR and its deploy preview to mirrored Jira issues as web links, so someone reading a ticket can reach the work without opening Studio.

- `globalId` is the upsert key, so Jira replaces a matching link instead of appending; retries are safe and a re-deploy overwrites its preview URL in place.
- The preview link is keyed per card and the PR link per PR number, so a card with two PRs shows two rows.
- Enqueued from `TASK_BOARD_ITEM_PR_LINK` (PR only, immediately) and `TASK_BOARD_ITEM_PRS_GET` (adds the preview, at no extra GitHub cost).
- The workflow ID is keyed on the planned URLs, so unchanged sets never re-enqueue, which is the whole rate control.
- The preview host is re-checked with `isTrustedPreviewHost` at the write; non-http targets are dropped.
- No `DBOS_WORKFLOW_VERSION` bump needed; the source-guard snapshot is re-baselined.

<sup>Written for commit decc61c167af54efab10213cfa24e0e230063548. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

