### PR TITLE
fix(task-board): delegate onto the board's own queue lane, not Studio's "todo"

### DIFF
--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -1,7 +1,7 @@
 {
   "auth/install-studio-pack-workflow.ts": "6f6c4fe37f2163dcf6a521164185fd364a22b1e5617653d14d1d5de40110a7ab",
   "automations/dbos-workflow.ts": "dd8535f7577bbd3c0270c60f14f480d4fb42e366666245c3efa77f0ce73a9da2",
-  "dispatch-queue/hosted-harness-workflow.ts": "76b1eaad5eeef0d00a4e3ece6413d9bbde662f1a8793a466292723d7bb73bd9d",
+  "dispatch-queue/hosted-harness-workflow.ts": "99360d94dbf09d5974ccaa7dbe958b2b803e67b31c2ab9e7002e4753dadc674d",
   "dispatch-queue/thread-gate-workflow.ts": "86728557a444719d6761c26632e94ed28bcadce72abbd826b7d38a473054a604",
   "file-storage/dbos-org-repo-sync.ts": "32c606976916fde2be7abe3084f7388744bdb610c178e9c2a07a8080f764904e",
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",

--- a/apps/api/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/api/src/dispatch-queue/hosted-harness-workflow.ts
@@ -232,7 +232,7 @@ export async function runHostedHarness(
 
   // Fire-and-forget: moving the card must not delay the loop.
   try {
-    void advanceTaskBoardForRun(studioCtx, "in_progress", input.threadId);
+    void advanceTaskBoardForRun(studioCtx, "progress", input.threadId);
 
     // If the user re-engaged a task that had moved to In Review, pull it back to
     // In Progress. Link-based (`task_board_item_threads`), so it fires for a

--- a/apps/api/src/tools/task-board/board-handler.integration.test.ts
+++ b/apps/api/src/tools/task-board/board-handler.integration.test.ts
@@ -271,6 +271,36 @@ describe("boardHandler — a board whose columns are the org's own", () => {
     expect(card.status).toBe("not_a_column");
   });
 
+  /** Delegation used to write Studio's `"todo"` here regardless of whose
+   *  columns the board has — the shape that made assigning to the Super Agent
+   *  fail outright once the key was awake. */
+  it("refuses Studio's queue lane on a guarded card, and takes the board's own", async () => {
+    await boardColumns.replaceAll(ORG_M, [
+      { key: "BACKLOG", title: "Backlog", trackerStatuses: [] },
+      { key: "Refinamento", title: "Refinamento", trackerStatuses: [] },
+    ]);
+    await boardColumns.setRole(ORG_M, "Refinamento", "todo");
+    const card = await taskBoard.create({
+      organizationId: ORG_M,
+      title: "delegated",
+      status: "BACKLOG",
+      boardColumnOrg: ORG_M,
+      by: USER_M,
+    });
+    await expect(
+      taskBoard.update(card.id, ORG_M, { status: "todo" }, USER_M),
+    ).rejects.toThrow(/foreign key|violates/i);
+    const queue = (await board().lanes()).queue;
+    expect(queue).toBe("Refinamento");
+    const queued = await taskBoard.update(
+      card.id,
+      ORG_M,
+      { status: queue!, boardColumnOrg: ORG_M },
+      USER_M,
+    );
+    expect(queued.status).toBe("Refinamento");
+  });
+
   /** The value every writer asks for instead of recomputing. Getting it from
    *  the board is what stops one path guarding a card and another not. */
   it("names itself as the owner a guarded card is held to", () => {

--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -102,6 +102,11 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
     }
 
     const delegatedToSuperAgent = input.assigneeId === SUPER_AGENT_ASSIGNEE_ID;
+    // Lanes named by the board: Studio's keys are not columns on an org's own.
+    const lanes = await board.lanes();
+    const status = delegatedToSuperAgent
+      ? (lanes.queue ?? lanes.intake)
+      : (input.status ?? lanes.intake);
 
     if (input.tagIds?.length) {
       const orgTags = await ctx.storage.tags.listOrgTags(organizationId);
@@ -117,8 +122,7 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
       organizationId,
       title: input.title,
       description: input.description ?? null,
-      // A task handed to the Super Agent is queued to run — land it in To Do.
-      status: delegatedToSuperAgent ? "todo" : input.status,
+      status,
       // Guarded from birth, not from whenever a sync first touches it.
       boardColumnOrg: board.columnOwner(),
       priority: input.priority,

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -140,23 +140,27 @@ export async function resolveRunTaskTargets(
 }
 
 /**
- * Advance the run's linked task board item(s) forward to `status` and
+ * Advance the run's linked task board item(s) forward to this board's `lane` and
  * broadcast each move. Resolves the linked item(s) from `runMetadata` first
  * (set at enqueue for the task's own run), falling back to the
  * `task_board_item_threads` link by `threadId` — the fallback is what makes
  * this fire for a re-prompted, repo-backed task's second PR, which carries no
- * run metadata. No-op when neither resolves, when an item is gone, or when
- * the target status wouldn't move its card forward. Best-effort: a failure
+ * run metadata. No-op when neither resolves, when this board has no column for
+ * `lane`, when an item is gone, or when the target wouldn't move the card
+ * forward. Best-effort: a failure
  * here never disturbs the agent run.
  */
 export async function advanceTaskBoardForRun(
   ctx: StudioContext,
-  status: string,
+  lane: keyof BoardLanes,
   threadId?: string,
 ): Promise<void> {
   const orgId = ctx.organization?.id;
   if (!orgId) return;
   try {
+    const status = (await boardLanes(ctx, orgId))[lane];
+    // Null: this board has no column meaning `lane`, so there is nowhere to go.
+    if (!status) return;
     for (const itemId of await resolveRunTaskTargets(ctx, orgId, threadId)) {
       const current = await ctx.storage.taskBoard.getById(itemId, orgId);
       // ponytail: read-then-write rank guard. A single run's transitions are
@@ -190,7 +194,7 @@ export async function advanceTaskBoardForRun(
       // The PR-open hook no longer comes through here — it opens a review
       // cycle instead (`openReviewCycleForRun`) and emits its own event — so
       // the only advance left to report is the run starting.
-      if (status === "in_progress") {
+      if (lane === "progress") {
         captureTaskRunEvent("task_run_started", orgId, item, {
           from: current.status,
         });

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -31,7 +31,13 @@ import { captureOrgEvent } from "@/posthog";
 import type { OrganizationBillingStorage } from "@/storage/organization-billing";
 import { TERMINAL_THREAD_STATUSES } from "@/storage/task-board";
 import type { StudioContext } from "@/core/studio-context";
-import { type BoardLanes, boardCan, boardLanes } from "./board-handler";
+import {
+  type BoardLanes,
+  boardCan,
+  boardFor,
+  boardLanes,
+  canAdvance,
+} from "./board-handler";
 import { extractPrFromValue } from "./pr-extract";
 import { retryBudgetFor } from "./transient-failure";
 import { exponentialBackoffWithJitter } from "@decocms/shared/std";
@@ -158,20 +164,28 @@ export async function advanceTaskBoardForRun(
   const orgId = ctx.organization?.id;
   if (!orgId) return;
   try {
-    const status = (await boardLanes(ctx, orgId))[lane];
+    const board = await boardFor(ctx, orgId);
+    const [columns, lanes] = await Promise.all([
+      board.columns(),
+      board.lanes(),
+    ]);
+    const status = lanes[lane];
     // Null: this board has no column meaning `lane`, so there is nowhere to go.
     if (!status) return;
     for (const itemId of await resolveRunTaskTargets(ctx, orgId, threadId)) {
       const current = await ctx.storage.taskBoard.getById(itemId, orgId);
-      // ponytail: read-then-write rank guard. A single run's transitions are
-      // sequential, so the race window is negligible; it buys idempotency (a
-      // repeated PR tool call, or in_progress re-fired on a DBOS retry, won't
-      // regress a card that's already further along). A status with no rank is
-      // a column Studio did not define, and inventing an order for someone
-      // else's columns would be worse than not guarding.
-      const to = laneRank(status);
-      const from = laneRank(current?.status ?? "");
-      if (!current || (to !== null && from !== null && to <= from)) continue;
+      if (!current) continue;
+      // ponytail: read-then-write guard, ordered by the board's own columns. A
+      // single run's transitions are sequential, so the race window is
+      // negligible; it buys idempotency — a repeated PR tool call, or a run
+      // start re-fired on a DBOS retry, must not drag a card that is already
+      // further right back to this lane.
+      if (
+        current.status === status ||
+        !canAdvance(columns, current.status, status)
+      ) {
+        continue;
+      }
       const item = await ctx.storage.taskBoard.update(
         itemId,
         orgId,

--- a/apps/api/src/tools/task-board/update.test.ts
+++ b/apps/api/src/tools/task-board/update.test.ts
@@ -169,6 +169,7 @@ describe("delegatesToSuperAgent", () => {
       delegatesToSuperAgent(
         SUPER_AGENT_ASSIGNEE_ID,
         item({ assigneeId: null, status: "todo" }),
+        "todo",
       ),
     ).toBe(true);
   });
@@ -181,6 +182,7 @@ describe("delegatesToSuperAgent", () => {
       delegatesToSuperAgent(
         SUPER_AGENT_ASSIGNEE_ID,
         item({ assigneeId: SUPER_AGENT_ASSIGNEE_ID, status: "todo" }),
+        "todo",
       ),
     ).toBe(true);
   });
@@ -191,6 +193,7 @@ describe("delegatesToSuperAgent", () => {
         delegatesToSuperAgent(
           SUPER_AGENT_ASSIGNEE_ID,
           item({ assigneeId: SUPER_AGENT_ASSIGNEE_ID, status }),
+          "todo",
         ),
       ).toBe(false);
     }
@@ -198,13 +201,35 @@ describe("delegatesToSuperAgent", () => {
 
   it("does not delegate for any other assignee, or when none was passed", () => {
     const previous = item({ assigneeId: null, status: "todo" });
-    expect(delegatesToSuperAgent("user_2", previous)).toBe(false);
-    expect(delegatesToSuperAgent(null, previous)).toBe(false);
-    expect(delegatesToSuperAgent(undefined, previous)).toBe(false);
+    expect(delegatesToSuperAgent("user_2", previous, "todo")).toBe(false);
+    expect(delegatesToSuperAgent(null, previous, "todo")).toBe(false);
+    expect(delegatesToSuperAgent(undefined, previous, "todo")).toBe(false);
   });
 
   it("does not delegate without a pre-update item", () => {
-    expect(delegatesToSuperAgent(SUPER_AGENT_ASSIGNEE_ID, null)).toBe(false);
+    expect(delegatesToSuperAgent(SUPER_AGENT_ASSIGNEE_ID, null, "todo")).toBe(
+      false,
+    );
+  });
+
+  it("re-delegates a parked card on the lane THIS board queues to", () => {
+    expect(
+      delegatesToSuperAgent(
+        SUPER_AGENT_ASSIGNEE_ID,
+        item({ assigneeId: SUPER_AGENT_ASSIGNEE_ID, status: "Refinement" }),
+        "Refinement",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not re-delegate when the board has no queue column at all", () => {
+    expect(
+      delegatesToSuperAgent(
+        SUPER_AGENT_ASSIGNEE_ID,
+        item({ assigneeId: SUPER_AGENT_ASSIGNEE_ID, status: "Backlog" }),
+        null,
+      ),
+    ).toBe(false);
   });
 });
 

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -139,12 +139,14 @@ export function diffTaskActivityEntries(
 export function delegatesToSuperAgent(
   inputAssigneeId: string | null | undefined,
   previous: Pick<TaskBoardItem, "assigneeId" | "status"> | null,
+  /** This board's queue column — see `BoardLanes.queue`. */
+  queueLane: string | null,
 ): boolean {
   if (inputAssigneeId !== SUPER_AGENT_ASSIGNEE_ID) return false;
   if (!previous) return false;
   return previous.assigneeId !== SUPER_AGENT_ASSIGNEE_ID
     ? true
-    : previous.status === "todo";
+    : queueLane !== null && previous.status === queueLane;
 }
 
 /** Forward-only terminal lanes (see the activity comment above): once a card
@@ -342,12 +344,13 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     }
 
     const isTaskRun = taskRunContextStore.getStore() !== undefined;
+    const lanes = await board.lanes();
     if (
       closesOwnReview(
         input.status,
         previous ?? undefined,
         isTaskRun,
-        (await board.lanes()).review,
+        lanes.review,
       )
     ) {
       throw new Error(
@@ -361,9 +364,16 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     const assigneeChanged =
       input.assigneeId !== undefined &&
       input.assigneeId !== (previous?.assigneeId ?? null);
-    // Delegating a task to the Super Agent queues it to run — force To Do,
-    // overriding any status the caller passed alongside the reassignment.
-    const becameSuperAgent = delegatesToSuperAgent(input.assigneeId, previous);
+    // Delegating queues the card onto this board's queue lane, if it has one.
+    const becameSuperAgent = delegatesToSuperAgent(
+      input.assigneeId,
+      previous,
+      lanes.queue,
+    );
+    const queuedStatus = becameSuperAgent
+      ? (lanes.queue ?? undefined)
+      : undefined;
+    const nextStatus = queuedStatus ?? input.status;
 
     if (previous && isReportsTask(previous)) {
       // Reports-pushed tasks are the report's findings — their CONTENT is
@@ -421,10 +431,10 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
         {
           title: input.title,
           description: input.description,
-          status: becameSuperAgent ? "todo" : input.status,
+          status: nextStatus,
           // Written with the status it describes, so a card cannot end up in a
           // column of the org's own while still unguarded.
-          ...(input.status !== undefined || becameSuperAgent
+          ...(nextStatus !== undefined
             ? { boardColumnOrg: board.columnOwner() }
             : {}),
           priority: input.priority,


### PR DESCRIPTION
## What

Assigning a card to the Super Agent on a board whose columns are the org's own (Jira-mirrored, `org_board_columns`) fails with:

```
insert or update on table "task_board_items" violates foreign key constraint "task_board_items_board_column_fkey"
```

`TASK_BOARD_ITEM_UPDATE` forced `status: "todo"` on delegation while also writing `board_column_org` — Studio's lane vocabulary on a board that has no `todo` column. Migration 193's optional FK exists to catch exactly that, so a write that used to be silently wrong (card filed under a column that renders nowhere) now fails in the user's face.

Every status on the delegation path now comes from `board.lanes()`:

- `update.ts` queues to `lanes.queue`, and leaves the card where it is when the board has no column meaning "queue" — the same null-means-do-nothing rule the ship/archive paths already follow. `boardColumnOrg` is written with whatever status is actually written.
- `delegatesToSuperAgent()` compares a parked card against this board's queue lane instead of the literal `"todo"`, so re-delegation (Auto fix on a parked card) works on a mirrored board.
- `create.ts` lands a delegated card on `lanes.queue`, else `lanes.intake`, and passes `lanes.intake` instead of letting storage default to `"triage"` — the same FK violation on a create with no status.
- `advanceTaskBoardForRun()` takes a `keyof BoardLanes` and resolves it through the board. The run-start advance passed `"in_progress"`, so on a mirrored board the FK rejected it and the card sat in its intake column for the whole run (best-effort, so it only logged).

## Testing

- Unit: `delegatesToSuperAgent` re-delegates on the board's own queue column; refuses when the board has no queue column at all.
- Real-Postgres: `"todo"` on a guarded card violates the FK; the board's own queue lane is accepted. **Not run locally** (no throwaway PG on this machine) — it runs in the Storage Integration workflow.
- `bun test` on the touched unit files, `bunx tsc --noEmit -p apps/api`, `bun run lint`, `bun run fmt` all clean.

## Affected areas

Task board delegation (assign to Super Agent), task create, run-start card advance. No change for orgs on the canonical board — `STUDIO_LANES` returns the same literals that were hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBipRmhiQxw5YjhRoxuQFM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes assigning a card to the Super Agent (and run-start card moves) failing with a foreign-key violation on boards whose columns are the org's own, because the delegation paths wrote Studio's lane names (`"todo"`, `"in_progress"`) onto a board that has no such columns.

**Lane resolution**
- All delegation, create, and run-start statuses now come from `board.lanes()`.
- A delegated card queues to `lanes.queue`; `create` falls back to `lanes.intake` instead of storage's default `"triage"`, and an update with no queue lane leaves the card where it is.
- `delegatesToSuperAgent()` only re-delegates a parked card on this board's queue lane, so Auto fix still works on a mirrored board.
- `advanceTaskBoardForRun()` takes a `keyof BoardLanes`, resolves it through the board, and guards forward moves by the board's own column order, so a run start no longer writes `"in_progress"` or pulls a card back from a later column.
- Orgs on the canonical board see no change — `STUDIO_LANES` matches the old literals.
- The workflow-source guard snapshot was re-baselined for the `hosted-harness-workflow.ts` call-site change; it's recovery-compatible, so no `DBOS_WORKFLOW_VERSION` bump.

**PR-open race fence**
- The update that opens a review cycle is now one conditional UPDATE fenced on the card's pre-LLM status and `assignee_id`, so a human claim landing mid-call isn't overwritten and a card shipped since the snapshot isn't dragged back to In Progress.
- Losing the race leaves the live card untouched and still links the PR onto it.

<sup>Written for commit 6478da424bc0731389fa75f6ee8a24e92c49c3e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

