### PR TITLE
fix(docs): repair broken pt-br anchor link from Library to Decopilot overview

### DIFF
--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/library.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/library.mdx
@@ -96,5 +96,5 @@ A Library e o sandbox do agent são duas visões do mesmo filesystem. A Library 
 Arquivos escritos na sua pasta home e em outputs sincronizam com o cloud storage da sua organização e ficam visíveis para todos os membros e agents. Mudanças externas aparecem dentro de um sandbox em execução em cerca de um segundo.
 
 <Callout type="info">
-  Para entender como os agents usam essas pastas em runtime — registrando conhecimento durável, lendo anexos de chat, escrevendo o output de uma execução — veja [Decopilot → Visão geral](/pt-br/studio/decopilot/overview#built-in-tools).
+  Para entender como os agents usam essas pastas em runtime — registrando conhecimento durável, lendo anexos de chat, escrevendo o output de uma execução — veja [Decopilot → Visão geral](/pt-br/studio/decopilot/overview#tools-built-in).
 </Callout>


### PR DESCRIPTION
Fixes a broken in-page anchor link in the pt-br docs, found by cross-checking every `[text](/en|pt-br/...#anchor)` link in `apps/docs/client/src/content/deco-studio/**` against the actual heading slugs in the target file.

`pt-br/studio/library.mdx` links to `/pt-br/studio/decopilot/overview#built-in-tools`, but the pt-br translation of that heading is "Tools built-in" (the English source is "Built-in tools"), which slugifies to `#tools-built-in`. The link therefore points at a non-existent anchor on that page — a reader clicking it lands at the top of the page instead of the built-in-tools section.

Fix: point the link at the pt-br file's actual heading slug (`#tools-built-in`) rather than the English one. I deliberately did not retranslate the heading itself ("Tools built-in" reads awkwardly but is a separate, larger content change outside this fix's scope).

How I verified: wrote a one-off script walking every `.mdx` file under `apps/docs/client/src/content/deco-studio`, extracting all internal `/en/...` and `/pt-br/...` links (including `#fragment`s), and checking each resolves to an existing file and — for fragment links — an existing heading slug in that file. Before the fix this was the only broken anchor found across all 70 files (all plain file-to-file links already resolved cleanly). After the fix, zero broken links/anchors remain.

A reviewer can re-run the same check by walking the mdx tree and slugifying headings, or simply open the rendered pt-br Library page and confirm the Decopilot overview link jumps to the "Tools built-in" section.

Ran `bun run fmt` (no changes needed beyond the edit). This is docs content only, no code/type/test surface to check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a broken in-page anchor link in the pt-br docs so the Library page now jumps to the "Tools built-in" section instead of landing at the top of the Decopilot overview page.

<sup>Written for commit 245d90b8bc8a5950c5e81bf685c1d40ef434c5ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

