### PR TITLE
Fix/jira comment table cell images

### DIFF
--- a/apps/api/src/jira/markdown-adf.test.ts
+++ b/apps/api/src/jira/markdown-adf.test.ts
@@ -585,6 +585,16 @@ describe("markdownToAdf images", () => {
     ]);
   });
 
+  it("embeds inside a table cell", () => {
+    // Inline-only cells used to drop a QA before/after table's shots to links.
+    const [table] = markdownToAdf(
+      [`| before |`, `| --- |`, `| ![x](${target}) |`].join("\n"),
+      { media },
+    ).content;
+    const cell = table?.content?.[1]?.content?.[0];
+    expect(cell?.content?.map((node) => node.type)).toEqual(["mediaSingle"]);
+  });
+
   it("still keeps alt text when a media node cannot live in the parent", () => {
     // A heading is inline-only, so nothing is uploaded for it in the first
     // place and the label survives as text.
@@ -609,7 +619,7 @@ describe("collectImageTargets", () => {
       "",
       "# ![heading](/out/skip-heading.png)",
       "",
-      "| ![cell](/out/skip-cell.png) |",
+      "| ![cell](/out/4.png) |",
       "| --- |",
       "| x |",
       "",
@@ -621,6 +631,7 @@ describe("collectImageTargets", () => {
       "/out/1.png",
       "/out/2.png",
       "/out/3.png",
+      "/out/4.png",
     ]);
   });
 

--- a/apps/api/src/jira/markdown-adf.test.ts
+++ b/apps/api/src/jira/markdown-adf.test.ts
@@ -504,7 +504,8 @@ describe("markdownToAdf images", () => {
     expect(markdownToAdf(`![shot](${target})`, { media }).content).toEqual([
       {
         type: "mediaSingle",
-        attrs: { layout: "align-start" },
+        // Full width, not a floated thumbnail: a screenshot is the evidence.
+        attrs: { layout: "center", width: 100 },
         content: [
           {
             type: "media",

--- a/apps/api/src/jira/markdown-adf.ts
+++ b/apps/api/src/jira/markdown-adf.ts
@@ -828,7 +828,16 @@ function linkNodes(link: LinkMatch, marks: AdfMark[], ctx: Ctx): AdfNode[] {
  * which resolves one to the other. Both `type: "file"` and `collection` are
  * load-bearing: the numeric id fails `ATTACHMENT_VALIDATION_ERROR`, and
  * omitting `collection` fails `INVALID_INPUT`, so `""` is spelled out.
+ *
+ * `layout`/`width` decide how big Jira draws it. `align-start` floats the image
+ * at a fraction of the line and is meant for a thumbnail beside text, which is
+ * what a full-page screenshot was rendering as — unreadable next to a column of
+ * empty space. A screenshot is the evidence, so it gets the full width.
  */
+const MEDIA_LAYOUT = "center";
+/** Percent of the containing block — the line, or a table cell's column. */
+const MEDIA_WIDTH = 100;
+
 function imageNodes(image: LinkMatch, marks: AdfMark[], ctx: Ctx): AdfNode[] {
   if (ctx.allowMedia) {
     ctx.onImage?.(image.href);
@@ -838,7 +847,7 @@ function imageNodes(image: LinkMatch, marks: AdfMark[], ctx: Ctx): AdfNode[] {
       return [
         {
           type: "mediaSingle",
-          attrs: { layout: "align-start" },
+          attrs: { layout: MEDIA_LAYOUT, width: MEDIA_WIDTH },
           content: [
             {
               type: "media",

--- a/apps/api/src/jira/markdown-adf.ts
+++ b/apps/api/src/jira/markdown-adf.ts
@@ -135,8 +135,8 @@ interface Ctx {
   media: ReadonlyMap<string, AdfMedia>;
   /**
    * `mediaSingle` is a block node, so only a paragraph-bearing context can
-   * emit one. A heading or a table cell is inline-only and keeps the link —
-   * and reports nothing to `onImage`, so nothing is uploaded for it.
+   * emit one. A heading is inline-only and keeps the link — and reports nothing
+   * to `onImage`, so nothing is uploaded for it.
    */
   allowMedia: boolean;
   onImage?: (target: string) => void;
@@ -496,7 +496,9 @@ function splitRow(line: string): string[] | null {
 }
 
 /** Rows are padded and truncated to the header's width: ADF accepts a ragged
- *  table, but Jira's own editor then treats it as broken. */
+ *  table, but Jira's own editor then treats it as broken. A cell is block
+ *  content, so `liftMedia` applies as it does to a paragraph — a before/after
+ *  table of screenshots is the shape a QA comment posts. */
 function tableRow(
   cells: string[],
   cellType: string,
@@ -508,7 +510,7 @@ function tableRow(
     content: Array.from({ length: width }, (_unused, column) => ({
       type: cellType,
       attrs: {},
-      content: [paragraph(inlineNodes(cells[column] ?? "", inlineOnly(ctx)))],
+      content: liftMedia(inlineNodes(cells[column] ?? "", ctx)),
     })),
   };
 }


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## How did you verify your code works?
> Name the tests you ran or added and what you observed. "Verified manually" or "existing tests" without specifics doesn't count.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Jira comment images so screenshots inside table cells are embedded and rendered full-width, not as links or floated thumbnails.

- Table cells now accept `mediaSingle` nodes, so images in cells are uploaded and shown as attachments.
- Screenshots use `center` layout at 100% width instead of `align-start`, which displayed them as small thumbnails with empty space.

<sup>Written for commit 7ba66ec56595c6631a26d988e927e8a369c03d1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

