### PR TITLE
fix(preview): fire in-place render on page/path switch, not just content

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1047,12 +1047,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   };
 
   /**
-   * Refresh the in-place render when the current page's content changes (the
-   * autosave optimistically updates KEYS.decofile before the commit lands).
-   * Deduped by content signature so onMutate + onSuccess render once, not twice.
+   * Refresh the in-place render on a content or page/path change. The frame's
+   * `src` is pinned here, so a page switch can't navigate it — the signature
+   * folds in page + path to fire a render, deduped so onMutate + onSuccess
+   * render once.
    */
   const renderSigRef = useRef<string | null>(null);
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- imperative postMessage refresh of a cross-origin frame on content change
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- imperative postMessage refresh of a cross-origin frame on content/page change
   useEffect(() => {
     if (
       !inPlaceRenderActive ||
@@ -1064,7 +1065,11 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
       renderSigRef.current = null;
       return;
     }
-    const sig = JSON.stringify(decofile);
+    const sig = JSON.stringify({
+      page: currentPageKey,
+      path: resolvedPath,
+      decofile,
+    });
     if (renderSigRef.current === sig) return;
     const isBaseline = renderSigRef.current === null;
     renderSigRef.current = sig;


### PR DESCRIPTION
## Summary

No modo **Instant preview** (`fastPreviewInPlace`), trocar de página não disparava um novo request para `/live/previews` — o preview ficava preso na página anterior.

**Causa raiz:** nesse modo o `src` do iframe fica pinado, então uma troca de página nunca navega o frame. A atualização depende de um `useEffect` que faz `postMessage`/`renderPreviewInPlace()`, mas ele deduplicava pela assinatura `JSON.stringify(decofile)` — e o `decofile` mesclado é **independente de página**. Ao trocar de página o effect re-executava, mas a assinatura era idêntica → early-return → nenhum POST para `/live/previews`.

**Fix:** incluir a identidade da página (`page` + `path`) na assinatura de dedup, seguindo o mesmo padrão "page-scoped signature" do effect irmão de variantes.

```ts
const sig = JSON.stringify({ page: currentPageKey, path: resolvedPath, decofile });
```

## Fluxo bônus coberto

A mesma mudança corrige um segundo caso com o mesmo formato (frame pinado + decofile inalterado): mudar um **path-param numa rota dinâmica** (`/blog/:slug`, `/products/:slug`) muda `resolvedPath` mas não o decofile — antes também não re-renderizava, agora sim.

Todas as dimensões de entrada de `renderPreviewInPlace` ficam cobertas: `page`/`path`/`decofile` pela assinatura, `variantOverride` pelo effect de variante já existente.

## Testing

- `bun run fmt` ✅
- `bun run --cwd=apps/web check` (tsc) ✅
- Manual: com Instant preview ligado, alternar entre páginas deve gerar um novo request `/live/previews` a cada troca (verificável na aba Network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Fast Preview in-place mode so switching pages (or changing a path-param on a dynamic route) now fires a fresh render request to `/live/previews`; previously the preview stayed stuck on the previous page.

- The dedup signature now includes the page key and resolved path alongside the decofile, which was page-independent and caused an early return on page switch.
- Also covers `/blog/:slug` and `/products/:slug` routes, where an amended path-param changes `resolvedPath` but not the decofile.

<sup>Written for commit 069bff5fae4083eb71716c9acc466e1defd3e70c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

