### PR TITLE
fix(jira): guard the vanished-issue archive write with boardColumnOrg

### DIFF
--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -25,7 +25,11 @@
  */
 
 import { orgFlagEnabled } from "@decocms/shared/organization/schema";
-import { boardFor } from "@/tools/task-board/board-handler";
+import {
+  type BoardHandler,
+  boardFor,
+  shippedPatch,
+} from "@/tools/task-board/board-handler";
 import type { StudioContext } from "@/core/studio-context";
 import type {
   OrgJiraIntegration,
@@ -535,6 +539,7 @@ async function reconcileVanishedIssues(
   integration: OrgJiraIntegration,
   client: JiraClient,
   scopeJql: string,
+  board: BoardHandler,
 ): Promise<number> {
   const orgId = integration.organizationId;
   const live = await client.searchIssueIds(
@@ -558,7 +563,7 @@ async function reconcileVanishedIssues(
     const item = await ctx.storage.taskBoard.update(
       link.itemId,
       orgId,
-      { status: "archived" },
+      shippedPatch(board, "archived"),
       JIRA_SYNC_ACTOR,
     );
     await ctx.storage.taskBoard.recordActivity({
@@ -839,6 +844,7 @@ async function runSync(
       integration,
       client,
       scopeJql,
+      board,
     );
   }
 


### PR DESCRIPTION
`reconcileVanishedIssues` in `apps/api/src/jira/sync.ts` wrote `{ status: "archived" }` directly instead of going through `shippedPatch`, the helper #6725/#6739 introduced specifically so every ship/archive write stamps `boardColumnOrg` alongside `status` — every other archive/ship path (`merge-pr.ts`, `review-decision.ts`, `promote-to-production.ts`, `archive-merged.ts`, `reconcile-merged.ts`, `prs-get.ts`) already uses it. This was the one remaining site that didn't.

**Why it matters:** on an org-owned board (`org_board_columns` flag), an issue that leaves Jira's scope gets archived by this path without the org discriminator, leaving the card unguarded — the same bug class #6725/#6739 fixed elsewhere, just in the Jira-sync leg instead of the board-mutation tools.

**Fix:** thread the already-computed `board` handle into `reconcileVanishedIssues` and build the patch with `shippedPatch(board, "archived")` like every sibling call site.

**To confirm:** read `apps/api/src/tools/task-board/board-handler.ts`'s `shippedPatch` and diff this file's `reconcileVanishedIssues` against the callers listed above — all now build the archive/ship patch the same way.

**Verification run locally:**
- `bun test apps/api/src/jira/sync.test.ts` — 34 pass, unchanged
- `bunx tsc --noEmit` in `apps/api`
- `bunx oxlint apps/api/src/jira/sync.ts`

`shippedPatch` already has full unit coverage in `board-handler.test.ts` (including the org-owner case); this change only wires the existing, tested helper into the one call site that skipped it, so no new test was needed to prove behavior — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the vanished-issue archive write in `apps/api/src/jira/sync.ts` so it goes through `shippedPatch` like every other archive/ship path, stamping `boardColumnOrg` alongside `status` and keeping archived cards guarded on org-owned boards.

<sup>Written for commit 520a448f3cdcfd8270a14b8476cfe9c0d1857054. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

