### PR TITLE
fix(decopilot): don't mislabel a transient credential-lookup failure as permanent

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.test.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { UIMessageChunk } from "ai";
+import { NoResultError } from "kysely";
 import {
   isRunSuperseded,
   RunSupersededError,
@@ -423,7 +424,7 @@ describe("resolveSecretModelSource", () => {
     const ctx = {
       storage: {
         aiProviderKeys: {
-          resolve: () => Promise.reject(new Error("no result")),
+          resolve: () => Promise.reject(new NoResultError({} as never)),
         },
       },
     } as unknown as StudioContext;
@@ -439,5 +440,25 @@ describe("resolveSecretModelSource", () => {
     await expect(rejection).rejects.toMatchObject({
       code: "model_credential_not_found",
     });
+  });
+
+  test("propagates a transient lookup failure unchanged, not as permanent", async () => {
+    const dbError = new Error("connection terminated unexpectedly");
+    const ctx = {
+      storage: {
+        aiProviderKeys: {
+          resolve: () => Promise.reject(dbError),
+        },
+      },
+    } as unknown as StudioContext;
+
+    const rejection = resolveSecretModelSource(
+      ctx,
+      "org-1",
+      "cred-1",
+      "model-1",
+    );
+
+    await expect(rejection).rejects.toBe(dbError);
   });
 });

--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -35,6 +35,7 @@ import {
 } from "@/billing/subsidized-runs";
 import type { StudioContext } from "@/core/studio-context";
 import { PermanentRunError } from "@/core/dispatch-errors";
+import { NoResultError } from "kysely";
 import { posthog } from "@/posthog";
 import type { UIMessage, UIMessageChunk } from "ai";
 import { CLAUDE_SUBSCRIPTION_PROVIDER_ID } from "@/harnesses/claude-code-env";
@@ -278,10 +279,11 @@ export async function resolveSecretModelSource(
    *  run on the org's own key. */
   subsidyApiKey?: string,
 ): Promise<DecopilotSecretModelSource> {
-  // Replace Kysely's raw NoResultError with a clear, permanent one (#2265).
+  // Replace Kysely's raw NoResultError with a clear, permanent one (#2265) — any other rejection (a transient DB/vault failure) propagates unchanged.
   const { keyInfo, apiKey } = await ctx.storage.aiProviderKeys
     .resolve(credentialId, organizationId)
-    .catch(() => {
+    .catch((err) => {
+      if (!(err instanceof NoResultError)) throw err;
       throw new PermanentRunError(
         "model_credential_not_found",
         `Model credential ${credentialId} was not found — configure a model provider before running this agent`,


### PR DESCRIPTION
**Source:** hardening follow-up to #6829 ("surface a missing model credential as a clear permanent error"), merged this tick.

**Bug:** `resolveSecretModelSource` wraps `ctx.storage.aiProviderKeys.resolve(...)` in a bare `.catch(() => { throw new PermanentRunError("model_credential_not_found", ...) })`. That catch fires on ANY rejection from `resolve()` — not just Kysely's `NoResultError` when the row genuinely doesn't exist. `resolve()` also does a `vault.decrypt(...)` call and a raw DB query, either of which can reject with a transient error (DB blip, KMS hiccup). #6829's own commit message says callers "special-case permanent errors (e.g. automations deactivating themselves)" on this code path — so a transient outage during credential lookup gets relabeled `model_credential_not_found` and can cause an automation to deactivate itself over a blip that would have succeeded on retry, instead of surfacing/retrying as the transient failure it actually was.

**Fix:** gate the rewrite on `err instanceof NoResultError` (from `kysely`, the same type Kysely's `executeTakeFirstOrThrow()` throws); anything else now propagates unchanged.

**Regression test:** `apps/api/src/api/routes/decopilot/dispatch-run.test.ts` — updated the existing "surfaces an unconfigured credential" test to reject with a real `NoResultError` (previously a plain `Error`, which would have passed even without the fix), and added "propagates a transient lookup failure unchanged, not as permanent" asserting a plain `Error` from `resolve()` rejects as itself, not as a `PermanentRunError`.

**To verify:** `bun test apps/api/src/api/routes/decopilot/dispatch-run.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above (22 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes transient credential-lookup failures (like DB or vault blips) being mislabeled as permanent `model_credential_not_found` errors. Previously any rejection from `resolve()` was rewritten to permanent; now only Kysely's `NoResultError` is, and other transient errors propagate unchanged so retries and automations can handle them correctly.

**Bug Fixes**
- Updated the existing permanent-error test to reject with a real `NoResultError` so it exercises the new guard.
- Added a test asserting a plain transient error from `resolve()` rejects unchanged, not as a `PermanentRunError`.

<sup>Written for commit daf53a48b131deedb36621b1cd33e076023afce7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

