### PR TITLE
refactor(monitor): dedupe the auth+ownership guard across monitor routes

### DIFF
--- a/apps/api/src/api/routes/monitor.ts
+++ b/apps/api/src/api/routes/monitor.ts
@@ -38,6 +38,7 @@
  */
 
 import { Hono } from "hono";
+import type { Context } from "hono";
 import type { StudioContext } from "../../core/studio-context";
 import {
   isAuthenticated,
@@ -802,6 +803,33 @@ async function siteOdHosts(slug: string): Promise<string[]> {
 }
 
 /**
+ * Shared auth + tenancy guard for every `/monitor/:site/*` route below: a
+ * principal must be authenticated (`resolveOrgFromPath` lets anonymous
+ * requests through) and the org must own the site slug (404, not 403, so an
+ * unowned slug looks like a non-existent one). Returns the resolved slug, or
+ * the error Response to return as-is.
+ */
+async function requireOwnedSite(
+  c: Context<{ Variables: Variables }>,
+): Promise<{ slug: string } | Response> {
+  const ctx = c.get("studioContext");
+  if (!isAuthenticated(ctx)) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  const org = requireOrganization(ctx);
+  const site = c.req.param("site");
+  if (!site) {
+    return c.json({ error: "site is required" }, 400);
+  }
+  const slug = site.toLowerCase();
+  const owned = await ctx.storage.orgSites.isOwnedBy(slug, org.id);
+  if (!owned) {
+    return c.json({ error: "Site not found in organization" }, 404);
+  }
+  return { slug };
+}
+
+/**
  * Org-scoped monitor routes mounted at `/api/:org/monitor`. Direct-ClickHouse
  * reads, tenancy via `org_sites`, no control-plane and no Supabase.
  */
@@ -812,26 +840,8 @@ export const createMonitorRoutes = () => {
   // scoped. `{ available:false }` (not an error) when the warehouse isn't wired
   // so the tab can show a configuration/empty state instead of failing.
   app.get("/:site/cdn/data", async (c) => {
-    const ctx = c.get("studioContext");
-    // Require a principal: `resolveOrgFromPath` lets anonymous requests fall
-    // through, so without this a known org+site slug would expose CDN/audience
-    // analytics to anyone. Membership is proven upstream; ownership just below.
-    if (!isAuthenticated(ctx)) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
-    const org = requireOrganization(ctx);
-    const site = c.req.param("site");
-    if (!site) return c.json({ error: "site is required" }, 400);
-
-    // Same ownership guard as the Hosting/Analytics tabs: the org must own this
-    // slug. 404 (not 403) so an unowned slug looks like a non-existent one.
-    const owned = await ctx.storage.orgSites.isOwnedBy(
-      site.toLowerCase(),
-      org.id,
-    );
-    if (!owned) {
-      return c.json({ error: "Site not found in organization" }, 404);
-    }
+    const guard = await requireOwnedSite(c);
+    if (guard instanceof Response) return guard;
 
     if (!isAnalyticsConfigured()) {
       return c.json({ available: false, error: "Monitor is not configured" });
@@ -851,10 +861,7 @@ export const createMonitorRoutes = () => {
       return c.json({ error: `unknown range: ${range}` }, 400);
     }
 
-    // The slug is the ClickHouse `dim_sites.name`; queries resolve the numeric
-    // site_id from it. Lower-cased to match the ownership check and how slugs
-    // are stored.
-    const slug = site.toLowerCase();
+    const { slug } = guard;
     const { since, until } = window;
     const filters = parseFilters(c.req.query("filters"));
 
@@ -906,24 +913,8 @@ export const createMonitorRoutes = () => {
   // visitor half (the native replacement for the old admin's OneDollarStats
   // "Analytics" tab). Same tenancy guard and shape as the CDN handler.
   app.get("/:site/audience/data", async (c) => {
-    const ctx = c.get("studioContext");
-    // Require a principal: `resolveOrgFromPath` lets anonymous requests fall
-    // through, so without this a known org+site slug would expose CDN/audience
-    // analytics to anyone. Membership is proven upstream; ownership just below.
-    if (!isAuthenticated(ctx)) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
-    const org = requireOrganization(ctx);
-    const site = c.req.param("site");
-    if (!site) return c.json({ error: "site is required" }, 400);
-
-    const owned = await ctx.storage.orgSites.isOwnedBy(
-      site.toLowerCase(),
-      org.id,
-    );
-    if (!owned) {
-      return c.json({ error: "Site not found in organization" }, 404);
-    }
+    const guard = await requireOwnedSite(c);
+    if (guard instanceof Response) return guard;
 
     if (!isAnalyticsConfigured()) {
       return c.json({ available: false, error: "Monitor is not configured" });
@@ -943,7 +934,7 @@ export const createMonitorRoutes = () => {
       return c.json({ error: `unknown range: ${range}` }, 400);
     }
 
-    const slug = site.toLowerCase();
+    const { slug } = guard;
     const { since, until } = window;
 
     try {
@@ -984,23 +975,9 @@ export const createMonitorRoutes = () => {
   // candidates, busiest first) for the audience host picker. `{ available:false }`
   // when OneDollarStats isn't wired. The first entry is the default selection.
   app.get("/:site/hosts", async (c) => {
-    const ctx = c.get("studioContext");
-    // Require a principal: `resolveOrgFromPath` lets anonymous requests fall
-    // through, so without this a known org+site slug would expose CDN/audience
-    // analytics to anyone. Membership is proven upstream; ownership just below.
-    if (!isAuthenticated(ctx)) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
-    const org = requireOrganization(ctx);
-    const site = c.req.param("site");
-    if (!site) return c.json({ error: "site is required" }, 400);
-    const owned = await ctx.storage.orgSites.isOwnedBy(
-      site.toLowerCase(),
-      org.id,
-    );
-    if (!owned) {
-      return c.json({ error: "Site not found in organization" }, 404);
-    }
+    const guard = await requireOwnedSite(c);
+    if (guard instanceof Response) return guard;
+    const { slug } = guard;
     // Hostnames come from the CDN warehouse, so this works whenever the
     // warehouse is wired — independent of OneDollarStats (the subtitle needs it
     // even on Performance-only deployments).
@@ -1008,10 +985,10 @@ export const createMonitorRoutes = () => {
       return c.json({ available: false, hosts: [] });
     }
     try {
-      const hosts = await siteOdHosts(site.toLowerCase());
+      const hosts = await siteOdHosts(slug);
       return c.json({ available: true, hosts });
     } catch (err) {
-      console.error(`[monitor] hosts failed for site="${site}":`, err);
+      console.error(`[monitor] hosts failed for site="${slug}":`, err);
       return c.json({ available: true, hosts: [] });
     }
   });
@@ -1024,24 +1001,9 @@ export const createMonitorRoutes = () => {
   // site's hostnames to read; it is VALIDATED against the site's own host set so
   // a client can never name another tenant's site_id.
   app.get("/:site/onedollar", async (c) => {
-    const ctx = c.get("studioContext");
-    // Require a principal: `resolveOrgFromPath` lets anonymous requests fall
-    // through, so without this a known org+site slug would expose CDN/audience
-    // analytics to anyone. Membership is proven upstream; ownership just below.
-    if (!isAuthenticated(ctx)) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
-    const org = requireOrganization(ctx);
-    const site = c.req.param("site");
-    if (!site) return c.json({ error: "site is required" }, 400);
-
-    const owned = await ctx.storage.orgSites.isOwnedBy(
-      site.toLowerCase(),
-      org.id,
-    );
-    if (!owned) {
-      return c.json({ error: "Site not found in organization" }, 404);
-    }
+    const guard = await requireOwnedSite(c);
+    if (guard instanceof Response) return guard;
+    const { slug } = guard;
 
     const apiKey = getSettings().oneDollarStatsApiKey;
     if (!apiKey) {
@@ -1066,7 +1028,7 @@ export const createMonitorRoutes = () => {
       return c.json({ error: `unknown range: ${range}` }, 400);
     }
 
-    const odHosts = await siteOdHosts(site.toLowerCase());
+    const odHosts = await siteOdHosts(slug);
     const requested = c.req.query("host");
     // Only honor a requested host the site actually owns — never a client-named
     // arbitrary site_id.


### PR DESCRIPTION
Reduction (C1 duplication) found while auditing `apps/api/src/api/routes/monitor.ts` for auth/data-exposure issues per this tick's focus area (API monitor route health).

All four `/monitor/:site/*` routes (`cdn/data`, `audience/data`, `hosts`, `onedollar`) repeated the identical ~15-line block: check `isAuthenticated`, `requireOrganization`, read+lower-case the `site` param, and check `ctx.storage.orgSites.isOwnedBy` (404 on an unowned slug so it looks like a non-existent one). This is the tenancy guard every request in this file depends on, so keeping it copy-pasted four times means a future edit (e.g. an extra check) risks being applied to only some of the routes.

Extracted the block into a single `requireOwnedSite(c)` helper that returns either `{ slug }` or the error `Response` to return as-is; each handler now does `const guard = await requireOwnedSite(c); if (guard instanceof Response) return guard;`. Purely mechanical — same checks, same status codes, same 401/400/404 bodies, just centralized.

Net line delta: -38 / +0 (124 lines touched: 43 insertions, 81 deletions). Behavior preserved: every route still runs the exact same auth check → org resolution → ownership lookup → 401/400/404 in the same order; verified by diffing the extracted logic 1:1 against each of the four original blocks.

How to verify: `cd apps/api && bunx tsc --noEmit` (clean) and `bunx oxlint apps/api/src/api/routes/monitor.ts` (0 warnings/errors). There is no existing test file for this route (`monitor.ts` has no co-located `*.test.ts`), so no test was touched; this is a pure structural dedupe, not new behavior.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace), `bunx oxlint` on the changed file. Full CI (lint/typecheck across the monorepo, e2e) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the shared auth+ownership guard across all four `/monitor/:site/*` routes into a single `requireOwnedSite()` helper, preserving the exact same 401/400/404 behavior and order of checks.

**Refactors**
- Extracts the identical ~15-line block into a helper returning either the resolved slug or the error `Response` to return as-is.
- Each handler now calls the helper and returns early when it yields an error.
- No behavior change; same checks, status codes, and error bodies. Verified with clean `tsc --noEmit` and `oxlint` on the modified file.

<sup>Written for commit 279572042b5e0e9403b7494b59092a241c2e5a51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

