### PR TITLE
fix(task-board): write board_column_org when a PR-open reaction creates a card

### DIFF
--- a/apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.integration.test.ts
@@ -80,6 +80,7 @@ describe("applyBoardDecision", () => {
       pr: PR,
       lanes: CANON_LANES,
       columns: CANON_COLUMNS,
+      columnOwner: null,
       decision,
       openCards,
     });

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -18,8 +18,7 @@ import type { BoardColumn } from "@decocms/shared/task-board";
 import {
   type BoardLanes,
   boardCan,
-  boardColumnsOf,
-  boardLanes,
+  boardFor,
   canAdvance,
 } from "./board-handler";
 import { z } from "zod";
@@ -140,10 +139,23 @@ export async function applyBoardDecision(
     /** Its columns, in the board's own order — what decides whether a card has
      *  already got past the lane a PR-open would move it to. */
     columns: readonly BoardColumn[];
+    /** What a freshly-created card's `board_column_org` must carry — see
+     *  {@link BoardHandler.columnOwner}. Null wakes nothing; the org id wakes
+     *  the FK guard for a board whose lanes are the org's own columns. */
+    columnOwner: string | null;
   },
 ): Promise<TaskBoardItem | null> {
-  const { orgId, userId, threadId, pr, decision, openCards, lanes, columns } =
-    params;
+  const {
+    orgId,
+    userId,
+    threadId,
+    pr,
+    decision,
+    openCards,
+    lanes,
+    columns,
+    columnOwner,
+  } = params;
 
   const linkPr = (taskBoardItemId: string) =>
     storage.linkPr({
@@ -208,6 +220,8 @@ export async function applyBoardDecision(
       // A card born mid-review with no in-progress column starts at intake —
       // the one lane every board has.
       status: lanes.progress ?? lanes.intake,
+      // Same `{ status, boardColumnOrg }` pairing `shippedPatch` enforces elsewhere.
+      boardColumnOrg: columnOwner,
       assigneeId: SUPER_AGENT_ASSIGNEE_ID,
       assignedBy: userId,
       by: userId,
@@ -268,9 +282,11 @@ export async function reactToPrOpenedForBoard(
     );
     if (!decision) return;
 
+    const board = await boardFor(ctx, orgId);
     await applyBoardDecision(ctx.storage.taskBoard, {
-      lanes: await boardLanes(ctx, orgId),
-      columns: await boardColumnsOf(ctx, orgId),
+      lanes: await board.lanes(),
+      columns: await board.columns(),
+      columnOwner: board.columnOwner(),
       orgId,
       userId,
       threadId,


### PR DESCRIPTION
Same FK-violation bug class as #6837/#6725/#6739, one file those sweeps missed.

`applyBoardDecision`'s create branch (the ad-hoc-agent PR-open reaction, `pr-open-board-reaction.ts`) writes a brand-new card with `status: lanes.progress ?? lanes.intake` but never sets `board_column_org`. On a board whose columns are the org's own (`org_board_columns` flag, Jira-mirrored via `OrgBoardHandler`), `lanes.progress` names a row in `task_board_columns`, not one of Studio's built-in lanes — migration 193's optional FK exists exactly to catch a card landing on that lane with `board_column_org` still null (see `board-handler.ts`'s `shippedPatch` helper, added after #6725/#6739 for the identical gap in the ship/archive paths). `storage.create()` defaults `boardColumnOrg` to `null` when the caller omits it, so this write either violates the FK loudly or — if column-role checks let it slide — silently files the card under a column that renders nowhere.

Fixed by asking the board itself for `columnOwner()` (the same primitive `create.ts`, `merge-pr.ts`, `review-decision.ts`, and `promote-to-production.ts` already use) and threading it through `applyBoardDecision`'s params into the create call, replacing the ad-hoc `boardLanes`/`boardColumnsOf` calls in the caller with a single `boardFor()` so lanes/columns/columnOwner can't drift from each other.

Reviewer check: `rg columnOwner apps/api/src/tools/task-board` — this call site now matches the others. Behavior for every org NOT on `org_board_columns` is unchanged (`columnOwner()` returns null there, same as before).

Verification: `bunx tsc --noEmit` in apps/api is clean, `bunx oxlint` on both touched files is clean. The one test covering this path (`pr-open-board-reaction.integration.test.ts`) needs real Postgres this sandbox doesn't have — updated its call site with the new required param (`columnOwner: null`, matching the canonical-board fixture it already uses); it runs in CI's Storage Integration workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where a card created from a PR-open reaction didn't set `board_column_org`, causing foreign-key violations or cards landing in unmapped columns on boards with org-owned lanes. The create call now receives the board's `columnOwner()` value via `applyBoardDecision`'s new `columnOwner` param, and `reactToPrOpenedForBoard` uses `boardFor()` to fetch lanes, columns, and column owner consistently. Behavior is unchanged for orgs not using `org_board_columns` since `columnOwner()` returns null there.

- Updated the integration test to pass the new required `columnOwner: null` param.

<sup>Written for commit e1c05f328d8641723c9d6c45142707ef618f21a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

