### PR TITLE
fix(preview): include pathTemplate in render signature for correct re-render detection

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1068,6 +1068,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     const sig = JSON.stringify({
       page: currentPageKey,
       path: resolvedPath,
+      pathTemplate: currentPath,
       decofile,
     });
     if (renderSigRef.current === sig) return;


### PR DESCRIPTION
The in-place render detection signature did not include `currentPath` (pathTemplate), even though it's passed to `buildPageRenderRequest` and affects the preview render URL. When the path template changes, the render signature should update to trigger a re-render.

This is a hardening follow-up to PR #6841 which added `page` and `path` to the signature. The signature now includes `pathTemplate` to ensure renders fire when the page's path template changes.

Why: Ensures the in-place preview render is triggered whenever the rendering configuration changes, including path templates.

Verification: `bunx oxlint apps/web/src/components/sandbox/preview/preview.tsx` passes, `bun test apps/web/src/components/sandbox/preview/preview.test.ts` passes. The change maintains backward compatibility—existing preview functionality is unchanged; this only ensures more cases trigger re-renders.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Includes `pathTemplate` in the preview render signature so in-place previews re-render when the page's path template changes. Previously, changing the path template did not update the signature, so renders could be skipped even though the preview URL would change.

<sup>Written for commit bfae3aeb36799ec1d100bdfecead422fb26307cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

