### PR TITLE
fix(sandbox): label a malformed 2xx daemon body instead of a bare SyntaxError

### DIFF
--- a/packages/sandbox/server/daemon-client.test.ts
+++ b/packages/sandbox/server/daemon-client.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { probeDaemonHealth, proxyDaemonRequest } from "./daemon-client";
+import {
+  postConfig,
+  postOrgFsConfig,
+  probeDaemonHealth,
+  proxyDaemonRequest,
+} from "./daemon-client";
 
 type FetchCall = {
   input: string;
@@ -90,6 +95,22 @@ describe("probeDaemonHealth", () => {
         }),
     );
     expect(await probeDaemonHealth("http://daemon:9000")).toBeNull();
+  });
+});
+
+describe("malformed 2xx bodies", () => {
+  it("postConfig labels a malformed JSON body instead of a bare SyntaxError", async () => {
+    installFetch(() => new Response("<html>not json</html>", { status: 200 }));
+    await expect(
+      postConfig("http://daemon:9000", "tok", { env: {} } as never),
+    ).rejects.toThrow("/_sandbox/config returned a malformed JSON body");
+  });
+
+  it("postOrgFsConfig labels a malformed JSON body instead of a bare SyntaxError", async () => {
+    installFetch(() => new Response("not json", { status: 200 }));
+    await expect(
+      postOrgFsConfig("http://daemon:9000", "tok", "{}"),
+    ).rejects.toThrow("/_sandbox/orgfs-config returned a malformed JSON body");
   });
 });
 

--- a/packages/sandbox/server/daemon-client.ts
+++ b/packages/sandbox/server/daemon-client.ts
@@ -189,7 +189,7 @@ async function configRequest(
   if (!res.ok) {
     throw new ConfigRequestError(res.status, res.body);
   }
-  return JSON.parse(res.body) as ConfigResponse;
+  return parseJsonResponse<ConfigResponse>(res.body, "/_sandbox/config");
 }
 
 /**
@@ -249,7 +249,27 @@ export async function postOrgFsConfig(
       `sandbox daemon /_sandbox/orgfs-config returned ${res.status}: ${res.body}`,
     );
   }
-  return JSON.parse(res.body) as { written: boolean };
+  return parseJsonResponse<{ written: boolean }>(
+    res.body,
+    "/_sandbox/orgfs-config",
+  );
+}
+
+/**
+ * A malformed 2xx body (truncated response, a proxy's HTML error page mistaken
+ * for success) must not surface as a bare, unlabelled `SyntaxError` — see the
+ * rationale on `daemonRequest` above for why every failure on this path names
+ * its endpoint.
+ */
+function parseJsonResponse<T>(body: string, endpoint: string): T {
+  try {
+    return JSON.parse(body) as T;
+  } catch (err) {
+    throw new Error(
+      `sandbox daemon ${endpoint} returned a malformed JSON body: ${body.slice(0, 200)}`,
+      { cause: err },
+    );
+  }
 }
 
 const STRIP_REQUEST_HEADERS = [


### PR DESCRIPTION
**What:** `postConfig` and `postOrgFsConfig` in `packages/sandbox/server/daemon-client.ts` `JSON.parse` the daemon's response body directly on a 2xx status. If that body is truncated or a proxy substitutes an HTML error page while still returning 200, `JSON.parse` throws a bare, unlabelled `SyntaxError` ("Unexpected token '<'...") with no mention of which endpoint or sandbox it came from.

**Why it matters:** this file's own doc comment on `daemonRequest` explains exactly this failure class for transport errors — every daemon call is meant to fail with a labelled `[SANDBOX_UNREACHABLE] sandbox daemon <endpoint> ...` message so a bad run is debuggable from the error string alone. The parse step of `postConfig`/`postOrgFsConfig` was the one place that fell through to a raw, unlabelled exception, matching a class of bug the team has fixed repeatedly on other outbound HTTP clients (#6613, #6668).

**Fix:** added a small `parseJsonResponse` helper that wraps `JSON.parse` and re-throws with the endpoint name and a body snippet on failure (`cause` preserved). Reused at both call sites.

**Regression test:** `packages/sandbox/server/daemon-client.test.ts` — new `malformed 2xx bodies` describe block asserts both `postConfig` and `postOrgFsConfig` reject with a message naming their endpoint when the daemon returns a 200 with a non-JSON body.

**To verify:** `bun test packages/sandbox/server/daemon-client.test.ts` (24/24 pass, including the 2 new cases).

**Checks run locally:** `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit` (clean), `bun test packages/sandbox/server/daemon-client.test.ts` (pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Labels malformed 2xx daemon response bodies in `postConfig` and `postOrgFsConfig` so a truncated response or a proxy's HTML error page fails with an error naming the endpoint instead of a bare `SyntaxError`.

- Adds regression tests for both endpoints with non-JSON 200 responses.

<sup>Written for commit c1c7667ef7e542a16cba14736c8eedf15cdea4a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

