### PR TITLE
fix(task-board): cap open cards sent to the PR-open decision prompt

### DIFF
--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -30,6 +30,9 @@ import type { TaskBoardItem } from "@/storage/types";
 import { extractPrFromValue, type ExtractedPr } from "./pr-extract";
 import { resolveRunTaskTargets, emitTaskBoardUpdated } from "./run-reactions";
 
+// Cap on cards sent to the LLM prompt, so a large backlog doesn't inflate cost per PR-open.
+export const MAX_OPEN_CARDS_FOR_DECISION = 50;
+
 export interface BoardDecision {
   action: "create" | "update";
   /** The existing card to update. Required for `update`, ignored for `create`. */
@@ -268,9 +271,9 @@ export async function reactToPrOpenedForBoard(
     if (!pr) return;
 
     const cards = await ctx.storage.taskBoard.list(orgId);
-    const openCards = cards.filter(
-      (t) => t.status !== "done" && t.status !== "archived",
-    );
+    const openCards = cards
+      .filter((t) => t.status !== "done" && t.status !== "archived")
+      .slice(0, MAX_OPEN_CARDS_FOR_DECISION);
     const thread = await ctx.storage.threads.get(threadId);
 
     const decision = await decideBoardActionForPr(

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -31,7 +31,7 @@ import { extractPrFromValue, type ExtractedPr } from "./pr-extract";
 import { resolveRunTaskTargets, emitTaskBoardUpdated } from "./run-reactions";
 
 // Cap on cards sent to the LLM prompt, so a large backlog doesn't inflate cost per PR-open.
-export const MAX_OPEN_CARDS_FOR_DECISION = 50;
+const MAX_OPEN_CARDS_FOR_DECISION = 50;
 
 export interface BoardDecision {
   action: "create" | "update";


### PR DESCRIPTION
Follows the #6835/#6837/#6845 hardening wave on `pr-open-board-reaction.ts`.

`reactToPrOpenedForBoard` loads every open card on the org's board and formats all of them into a single LLM prompt (`decideBoardActionForPr`) on every PR that a chat-driven agent opens. There is no cap: an org with a large backlog (hundreds of open cards, easily reached over time since only `done`/`archived` are excluded) pays a prompt-size and token-cost hit that scales with total board size on every single PR-open event, not with the size of the PR.

This caps the open-card list fed into the decision to the board's own `sort_order` top 50 (`MAX_OPEN_CARDS_FOR_DECISION`) before it reaches both the LLM prompt and the `taskId` validation in `applyBoardDecision`, matching the same bounded-collection pattern already applied to comment/description/tag lists elsewhere in `task-board/` (e.g. `enqueue-reviewer.ts`, `pr-extract.ts`'s `MAX_SCAN`).

Net effect: -0 behavior change for boards under 50 open cards (the overwhelming common case), and a hard ceiling on prompt size for large ones. `openCards` is capped once and reused for both the prompt and the `find`-by-id validation, so the two stay consistent (the LLM can only pick a `taskId` it was actually shown).

Reviewer check: `cd apps/api && bunx tsc --noEmit` (clean) and `bunx oxlint apps/api/src/tools/task-board/pr-open-board-reaction.ts` (0 warnings/errors) — both run locally. No existing unit test covers this file (integration-test only, needs Postgres); the change is a single bounded `.slice()`, not new branching logic, so it isn't a new trust-boundary case warranting a standalone test. Full CI validates the integration test still passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the open-card list sent to the PR-open decision prompt at 50 cards, so large boards no longer inflate prompt size and token cost on every PR-open event.

- Boards with 50 or fewer open cards see no behavior change; larger boards now only show the top 50 by `sort_order`.
- The same capped list is used for both the LLM prompt and `taskId` validation, so the model can only pick a card it was actually shown.

<sup>Written for commit f178188faaafe09d2be94592e9e5e19167b7a328. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

