### PR TITLE
fix(task-board): stop hardcoding 'in_progress' in the failed-run reaction

### DIFF
--- a/apps/api/src/tools/task-board/run-reactions.test.ts
+++ b/apps/api/src/tools/task-board/run-reactions.test.ts
@@ -322,4 +322,11 @@ describe("reactToFailedTaskRun on a card that already moved on", () => {
     await reactToFailedTaskRun(taskBoard, "thr-1", "org-1", CANON_LANES);
     expect(calls).toEqual(["retry"]);
   });
+
+  it("retries a card mid-work on an org-owned board whose progress column isn't named 'in_progress'", async () => {
+    const orgLanes = { ...CANON_LANES, progress: "col-doing" };
+    const { taskBoard, calls } = fakeBoard("col-doing");
+    await reactToFailedTaskRun(taskBoard, "thr-1", "org-1", orgLanes);
+    expect(calls).toEqual(["retry"]);
+  });
 });

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -417,7 +417,7 @@ export async function reactToFailedTaskRun(
           .relabelDeliveredFailure(threadId, orgId, DELIVERED_FAILURE_REASON)
           .catch(() => {});
       }
-      if (item.status !== "in_progress") continue;
+      if (item.status !== lanes.progress) continue;
       // A REVIEWER's run failed, not the author's: the card is In Progress only
       // because that is where a card under review sits now. Retrying it here
       // would dispatch a fresh Super Agent run over a PR that is waiting for a


### PR DESCRIPTION
Same class of bug as #6849 (advanceToReviewIfInProgress hardcoded in_progress/in_review) — found while hunting the same file's neighborhood (run-reactions.ts sits right next to pr-open-board-reaction.ts, the board-column-vocab gap this tick's focus area points at).

**Bug:** `reactToFailedTaskRun` already receives this org's resolved board lanes as a parameter (`lanes: BoardLanes`), and the storage calls it makes — `scheduleRunRetry(..., lanes.progress)` and `returnToTodoAfterFailure(..., lanes)` — are correctly lane-aware. But the guard right above them still compared `item.status !== "in_progress"` against the hardcoded literal instead of `lanes.progress`.

**Failure scenario:** on Studio's own board `lanes.progress === "in_progress"`, so this happened to work by coincidence. On an org-owned board (the `org_board_columns` feature, #6319/#6725/#6739/#6849), the in-progress column is named whatever the org named it — never the literal `"in_progress"`. The guard then never matches, so a failed run's card is silently never retried and never sent back to To Do on retry exhaustion: it just sits in progress forever with no failure reaction, and the person never sees why.

**Fix:** compare against `lanes.progress` instead of the literal, matching every other lane check in this same function.

**Regression test:** added a case in `run-reactions.test.ts` with a custom `progress: "col-doing"` lane, asserting the retry still fires — this reproduces the bug (fails on the old code, passes after the fix).

**To verify:** `bun test apps/api/src/tools/task-board/run-reactions.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` in `apps/api` (clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file (21/21 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `reactToFailedTaskRun` so failed runs are retried or sent back to To Do even when an org's progress column isn't named `in_progress`. Previously the guard compared against the hardcoded literal, so on `org_board_columns` boards a failed run's card silently sat in progress forever.

**Bug Fixes**
- Replaced the hardcoded `"in_progress"` literal with `lanes.progress` in the retry/return-to-todo gate.
- Added a regression test with a custom progress lane name (`"col-doing"`) to cover org-owned boards.

<sup>Written for commit 70ccffa0d0f8929f74e072d7416a6e6ee6dc720d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

