### PR TITLE
feat(admin): org site-ownership editor in the deployment-admin surface

### DIFF
--- a/apps/api/src/api/routes/admin.ts
+++ b/apps/api/src/api/routes/admin.ts
@@ -25,6 +25,8 @@ import { isAlreadyMemberError } from "@/auth/is-already-member-error";
 import { BUILTIN_ROLES, type BuiltinRole } from "@decocms/shared/auth/roles";
 import { getDb } from "@/database";
 import { OrganizationSettingsStorage } from "@/storage/organization-settings";
+import { OrgSiteConflictError, OrgSiteStorage } from "@/storage/org-sites";
+import { isValidSiteSlug } from "@decocms/shared/site-slug";
 import {
   flagsResponse,
   type OrgFlagsPatch,
@@ -498,6 +500,146 @@ export function createAdminRoutes(): Hono<Env> {
     });
 
     return c.json(flagsResponse(settings?.flags ?? null));
+  });
+
+  // Site ownership (org_sites): which org owns a globally-unique slug, the gate behind Hosting/E2E/Analytics/Monitor.
+  app.get("/orgs/:orgId/sites", async (c) => {
+    const orgId = c.req.param("orgId");
+    const db = getDb().db;
+    const org = await db
+      .selectFrom("organization")
+      .select("id")
+      .where("id", "=", orgId)
+      .executeTakeFirst();
+    if (!org) {
+      return c.json({ error: "Organization not found" }, 404);
+    }
+    const sites = await new OrgSiteStorage(db).listByOrg(orgId);
+    return c.json({ sites });
+  });
+
+  app.post("/orgs/:orgId/sites", async (c) => {
+    const orgId = c.req.param("orgId");
+    const raw = await c.req.json().catch(() => null);
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      return c.json({ error: "Invalid body" }, 400);
+    }
+    const body = raw as { slug?: unknown; reassign?: unknown };
+    const slug = typeof body.slug === "string" ? body.slug.trim() : "";
+    if (!isValidSiteSlug(slug)) {
+      return c.json({ error: "Invalid site slug" }, 400);
+    }
+    const reassign = body.reassign === true;
+
+    const db = getDb().db;
+    const org = await db
+      .selectFrom("organization")
+      .select("id")
+      .where("id", "=", orgId)
+      .executeTakeFirst();
+    if (!org) {
+      return c.json({ error: "Organization not found" }, 404);
+    }
+
+    const { actorId: effectiveActorId, impersonatedBy } =
+      await getAuditActor(c);
+    const actorId = impersonatedBy ?? effectiveActorId;
+    if (!actorId) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    const storage = new OrgSiteStorage(db);
+
+    const audit = (action: string, extra: Record<string, unknown>) => {
+      auditAdminAction(action, {
+        actor_user_id: actorId,
+        ...(impersonatedBy ? { impersonated_user_id: effectiveActorId } : {}),
+        organization_id: orgId,
+        slug,
+        ...extra,
+      });
+      posthog.capture({
+        distinctId: actorId,
+        event: `deployment_admin_${action}`,
+        groups: { organization: orgId },
+        properties: { actor_user_id: actorId, organization_id: orgId, slug },
+      });
+    };
+
+    try {
+      const site = await storage.claimSite({
+        slug,
+        organizationId: orgId,
+        source: "manual",
+        by: actorId,
+      });
+      audit("org_site_claim", {});
+      return c.json({ site });
+    } catch (error) {
+      if (!(error instanceof OrgSiteConflictError)) throw error;
+      // Owned by another org: refuse unless the caller explicitly confirms the move.
+      if (!reassign) {
+        const owner = await db
+          .selectFrom("organization")
+          .select(["name", "slug"])
+          .where("id", "=", error.ownerOrganizationId)
+          .executeTakeFirst();
+        return c.json(
+          {
+            error: "owned_by_other_org",
+            ownerOrganizationId: error.ownerOrganizationId,
+            ownerOrganizationName: owner?.name ?? null,
+            ownerOrganizationSlug: owner?.slug ?? null,
+          },
+          409,
+        );
+      }
+      const site = await storage.reassignSite({
+        slug,
+        organizationId: orgId,
+        source: "manual",
+        by: actorId,
+      });
+      audit("org_site_reassign", {
+        from_organization_id: error.ownerOrganizationId,
+      });
+      return c.json({ site, reassignedFrom: error.ownerOrganizationId });
+    }
+  });
+
+  app.delete("/orgs/:orgId/sites/:slug", async (c) => {
+    const orgId = c.req.param("orgId");
+    const slug = c.req.param("slug");
+    const db = getDb().db;
+    const org = await db
+      .selectFrom("organization")
+      .select("id")
+      .where("id", "=", orgId)
+      .executeTakeFirst();
+    if (!org) {
+      return c.json({ error: "Organization not found" }, 404);
+    }
+    const released = await new OrgSiteStorage(db).releaseSite(slug, orgId);
+    if (!released) {
+      return c.json({ error: "Site not found for this organization" }, 404);
+    }
+
+    const { actorId: effectiveActorId, impersonatedBy } =
+      await getAuditActor(c);
+    const actorId = impersonatedBy ?? effectiveActorId;
+    auditAdminAction("org_site_release", {
+      actor_user_id: actorId,
+      ...(impersonatedBy ? { impersonated_user_id: effectiveActorId } : {}),
+      organization_id: orgId,
+      slug,
+    });
+    posthog.capture({
+      distinctId: actorId ?? orgId,
+      event: "deployment_admin_org_site_release",
+      groups: { organization: orgId },
+      properties: { actor_user_id: actorId, organization_id: orgId, slug },
+    });
+
+    return c.json({ ok: true });
   });
 
   // The agent-prompt editor (reads/writes decocms/studio over GitHub) — its own

--- a/apps/api/src/storage/org-sites.ts
+++ b/apps/api/src/storage/org-sites.ts
@@ -105,6 +105,51 @@ export class OrgSiteStorage implements OrgSiteStoragePort {
     return toEntity(updated as OrgSiteRow);
   }
 
+  async reassignSite(params: {
+    slug: string;
+    organizationId: string;
+    source?: string;
+    by: string;
+  }): Promise<OrgSite> {
+    if (!isValidSiteSlug(params.slug)) {
+      throw new Error(
+        `Invalid site slug "${params.slug}" — must be 1-60 chars of lowercase letters, digits, or hyphens, starting with a letter or digit`,
+      );
+    }
+    const now = new Date();
+    // Unconditional override (deployment-admin only): take the slug from whatever org owns it.
+    const row = await this.db
+      .insertInto("org_sites")
+      .values({
+        slug: params.slug,
+        organization_id: params.organizationId,
+        source: params.source ?? "manual",
+        created_by: params.by,
+        created_at: now,
+        updated_by: params.by,
+        updated_at: now,
+      })
+      .onConflict((oc) =>
+        oc.column("slug").doUpdateSet({
+          organization_id: params.organizationId,
+          updated_by: params.by,
+          updated_at: now,
+        }),
+      )
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    return toEntity(row as OrgSiteRow);
+  }
+
+  async releaseSite(slug: string, organizationId: string): Promise<boolean> {
+    const res = await this.db
+      .deleteFrom("org_sites")
+      .where("slug", "=", slug)
+      .where("organization_id", "=", organizationId)
+      .executeTakeFirst();
+    return Number(res.numDeletedRows ?? 0n) > 0;
+  }
+
   async getBySlug(slug: string): Promise<OrgSite | null> {
     const row = await this.db
       .selectFrom("org_sites")

--- a/apps/api/src/storage/ports.ts
+++ b/apps/api/src/storage/ports.ts
@@ -791,6 +791,18 @@ export interface OrgSiteStoragePort {
     source?: string;
     by: string;
   }): Promise<OrgSite>;
+  /**
+   * Move a slug to `organizationId` regardless of its current owner
+   * (deployment-admin override); insert it when unclaimed.
+   */
+  reassignSite(params: {
+    slug: string;
+    organizationId: string;
+    source?: string;
+    by: string;
+  }): Promise<OrgSite>;
+  /** Release a slug owned by this org; false when it wasn't owned by it. */
+  releaseSite(slug: string, organizationId: string): Promise<boolean>;
   getBySlug(slug: string): Promise<OrgSite | null>;
   /** Every slug this org owns, slug-ascending. */
   listByOrg(organizationId: string): Promise<OrgSite[]>;

--- a/apps/web/src/i18n/en/admin.ts
+++ b/apps/web/src/i18n/en/admin.ts
@@ -55,6 +55,27 @@ export const admin = {
   "admin.orgs.save": "Save",
   "admin.orgs.saving": "Saving...",
   "admin.orgs.searchPlaceholder": "Search organizations by name or slug...",
+  "admin.orgs.anotherOrg": "another organization",
+  "admin.orgs.close": "Close",
+  "admin.orgs.failedAddSite": "Failed to add site",
+  "admin.orgs.failedLoadSites": "Failed to load sites",
+  "admin.orgs.failedRemoveSite": "Failed to remove site",
+  "admin.orgs.invalidSiteSlug":
+    "Use lowercase letters, digits and hyphens (e.g. my-site)",
+  "admin.orgs.loading": "Loading...",
+  "admin.orgs.noSites": "This organization owns no sites.",
+  "admin.orgs.reassignConfirm": "Move site here",
+  "admin.orgs.remove": "Remove",
+  "admin.orgs.siteAdded": "Added {slug} to {org}",
+  "admin.orgs.siteReassigned": "Moved {slug} to {org}",
+  "admin.orgs.siteReassignWarning":
+    '"{slug}" belongs to {owner} and will be moved to this organization.',
+  "admin.orgs.siteRemoved": "Removed {slug} from {org}",
+  "admin.orgs.siteSlugPlaceholder": "my-site",
+  "admin.orgs.sites": "Sites",
+  "admin.orgs.sitesDescription":
+    "Slugs this organization owns. Owning a slug enables its Hosting, E2E, Analytics and Monitor tabs.",
+  "admin.orgs.sitesFor": "Site ownership for {org}",
   "admin.prompts.description":
     "These prompts are hardcoded in {repo}. Edits here are read from {branch} and committed back as a pull request, using the GitHub connection of your {org} organization.",
   "admin.prompts.failedToLoadDescription":

--- a/apps/web/src/i18n/pt-br/admin.ts
+++ b/apps/web/src/i18n/pt-br/admin.ts
@@ -58,6 +58,27 @@ export const admin = {
   "admin.orgs.save": "Salvar",
   "admin.orgs.saving": "Salvando...",
   "admin.orgs.searchPlaceholder": "Procure organizações por nome ou slug...",
+  "admin.orgs.anotherOrg": "outra organização",
+  "admin.orgs.close": "Fechar",
+  "admin.orgs.failedAddSite": "Falha ao adicionar site",
+  "admin.orgs.failedLoadSites": "Falha ao carregar sites",
+  "admin.orgs.failedRemoveSite": "Falha ao remover site",
+  "admin.orgs.invalidSiteSlug":
+    "Use letras minúsculas, dígitos e hifens (ex.: meu-site)",
+  "admin.orgs.loading": "Carregando...",
+  "admin.orgs.noSites": "Esta organização não é dona de nenhum site.",
+  "admin.orgs.reassignConfirm": "Mover site pra cá",
+  "admin.orgs.remove": "Remover",
+  "admin.orgs.siteAdded": "{slug} adicionado a {org}",
+  "admin.orgs.siteReassigned": "{slug} movido para {org}",
+  "admin.orgs.siteReassignWarning":
+    '"{slug}" pertence a {owner} e será movido para esta organização.',
+  "admin.orgs.siteRemoved": "{slug} removido de {org}",
+  "admin.orgs.siteSlugPlaceholder": "meu-site",
+  "admin.orgs.sites": "Sites",
+  "admin.orgs.sitesDescription":
+    "Slugs que esta organização possui. Ser dona de um slug habilita as abas de Hosting, E2E, Analytics e Monitor dele.",
+  "admin.orgs.sitesFor": "Posse de sites de {org}",
   "admin.prompts.description":
     "Estes prompts são fixos no código em {repo}. As edições aqui são lidas de {branch} e enviadas de volta como um pull request, usando a conexão do GitHub da sua organização {org}.",
   "admin.prompts.failedToLoadDescription":

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -565,6 +565,9 @@ export const KEYS = {
   // An org's feature flags (stored + effective) in the deployment-admin editor.
   deploymentAdminOrgFlags: (orgId: string) =>
     ["deployment-admin", "orgs", orgId, "flags"] as const,
+  // An org's owned site slugs (org_sites) in the deployment-admin editor.
+  deploymentAdminOrgSites: (orgId: string) =>
+    ["deployment-admin", "orgs", orgId, "sites"] as const,
 
   // Brand context (scoped by organization)
   defaultBrand: (organizationId: string) =>

--- a/apps/web/src/routes/admin/orgs.tsx
+++ b/apps/web/src/routes/admin/orgs.tsx
@@ -33,6 +33,7 @@ import {
   type OrgFlags,
   OrgFlagsSchema,
 } from "@decocms/shared/organization/schema";
+import { SITE_SLUG_RE } from "@decocms/shared/site-slug";
 import { adminFetch } from "@/lib/admin-fetch";
 import { formatDate } from "@/lib/format-time";
 import { KEYS } from "@/lib/query-keys";
@@ -406,6 +407,281 @@ function FlagsDialog({ org }: { org: DeploymentAdminOrg }) {
   );
 }
 
+interface AdminOrgSite {
+  slug: string;
+  source: string;
+}
+
+/** Thrown from the add mutation on 409, carrying the current owner for the warning. */
+class SiteConflictError extends Error {
+  constructor(
+    readonly slug: string,
+    readonly ownerName: string | null,
+    readonly ownerSlug: string | null,
+  ) {
+    super("owned_by_other_org");
+    this.name = "SiteConflictError";
+  }
+}
+
+function SitesDialog({ org }: { org: DeploymentAdminOrg }) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const [newSlug, setNewSlug] = useState("");
+  const [addError, setAddError] = useState<string | null>(null);
+  const [conflict, setConflict] = useState<{
+    slug: string;
+    ownerName: string | null;
+    ownerSlug: string | null;
+  } | null>(null);
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: KEYS.deploymentAdminOrgSites(org.id),
+    queryFn: () =>
+      adminFetch<{ sites: AdminOrgSite[] }>(`/api/_admin/orgs/${org.id}/sites`),
+    enabled: open,
+  });
+  const sites = data?.sites ?? [];
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({
+      queryKey: KEYS.deploymentAdminOrgSites(org.id),
+    });
+
+  const addMutation = useMutation({
+    mutationFn: async (vars: { slug: string; reassign?: boolean }) => {
+      // Raw fetch (not adminFetch) so the 409 body's owner fields survive.
+      const res = await fetch(`/api/_admin/orgs/${org.id}/sites`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(vars),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        ownerOrganizationName?: string | null;
+        ownerOrganizationSlug?: string | null;
+      };
+      if (res.status === 409 && body.error === "owned_by_other_org") {
+        throw new SiteConflictError(
+          vars.slug,
+          body.ownerOrganizationName ?? null,
+          body.ownerOrganizationSlug ?? null,
+        );
+      }
+      if (!res.ok) {
+        throw new Error(body.error || `Request failed (HTTP ${res.status})`);
+      }
+      return body;
+    },
+    onSuccess: (_result, vars) => {
+      toast.success(
+        vars.reassign
+          ? t("admin.orgs.siteReassigned", { slug: vars.slug, org: org.name })
+          : t("admin.orgs.siteAdded", { slug: vars.slug, org: org.name }),
+      );
+      invalidate();
+      setNewSlug("");
+      setAddError(null);
+      setConflict(null);
+    },
+    onError: (error) => {
+      if (error instanceof SiteConflictError) {
+        setConflict({
+          slug: error.slug,
+          ownerName: error.ownerName,
+          ownerSlug: error.ownerSlug,
+        });
+        return;
+      }
+      toast.error(
+        error instanceof Error ? error.message : t("admin.orgs.failedAddSite"),
+      );
+    },
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (slug: string) =>
+      adminFetch(
+        `/api/_admin/orgs/${org.id}/sites/${encodeURIComponent(slug)}`,
+        { method: "DELETE" },
+      ),
+    onSuccess: (_result, slug) => {
+      toast.success(t("admin.orgs.siteRemoved", { slug, org: org.name }));
+      invalidate();
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t("admin.orgs.failedRemoveSite"),
+      );
+    },
+  });
+
+  const busy = addMutation.isPending || removeMutation.isPending;
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) {
+      setNewSlug("");
+      setAddError(null);
+      setConflict(null);
+    }
+  };
+
+  const handleAdd = () => {
+    const slug = newSlug.trim().toLowerCase();
+    if (!SITE_SLUG_RE.test(slug)) {
+      setAddError(t("admin.orgs.invalidSiteSlug"));
+      return;
+    }
+    setAddError(null);
+    setConflict(null);
+    addMutation.mutate({ slug });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          {t("admin.orgs.sites")}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {t("admin.orgs.sitesFor", { org: org.name })}
+          </DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          {t("admin.orgs.sitesDescription")}
+        </p>
+
+        {isError ? (
+          <p className="text-sm text-destructive">
+            {t("admin.orgs.failedLoadSites")}
+          </p>
+        ) : (
+          <div className="space-y-3">
+            <div className="max-h-[45vh] space-y-2 overflow-y-auto pr-1">
+              {isLoading ? (
+                <p className="text-sm text-muted-foreground">
+                  {t("admin.orgs.loading")}
+                </p>
+              ) : sites.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  {t("admin.orgs.noSites")}
+                </p>
+              ) : (
+                sites.map((site) => (
+                  <div
+                    key={site.slug}
+                    className="flex items-center justify-between gap-3 rounded-md border border-border p-2"
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      <code className="truncate text-sm font-medium text-foreground">
+                        {site.slug}
+                      </code>
+                      <Badge variant="outline" size="default">
+                        {site.source}
+                      </Badge>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={busy}
+                      onClick={() => removeMutation.mutate(site.slug)}
+                    >
+                      {t("admin.orgs.remove")}
+                    </Button>
+                  </div>
+                ))
+              )}
+            </div>
+
+            <div className="space-y-1 border-t border-border pt-3">
+              <div className="flex items-center gap-2">
+                <Input
+                  value={newSlug}
+                  placeholder={t("admin.orgs.siteSlugPlaceholder")}
+                  disabled={addMutation.isPending}
+                  onChange={(e) => {
+                    setNewSlug(e.target.value);
+                    setAddError(null);
+                    setConflict(null);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleAdd();
+                  }}
+                  className="font-mono"
+                />
+                <Button
+                  variant="outline"
+                  disabled={!newSlug.trim() || addMutation.isPending}
+                  onClick={handleAdd}
+                >
+                  {t("admin.orgs.add")}
+                </Button>
+              </div>
+              {addError ? (
+                <p className="text-sm text-destructive">{addError}</p>
+              ) : null}
+              {conflict ? (
+                <div className="space-y-2 rounded-md border border-warning/50 bg-warning/10 p-3">
+                  <p className="text-sm text-foreground">
+                    {t("admin.orgs.siteReassignWarning", {
+                      slug: conflict.slug,
+                      owner:
+                        conflict.ownerName ||
+                        conflict.ownerSlug ||
+                        t("admin.orgs.anotherOrg"),
+                    })}
+                  </p>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={addMutation.isPending}
+                      onClick={() => setConflict(null)}
+                    >
+                      {t("admin.orgs.cancel")}
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      disabled={addMutation.isPending}
+                      onClick={() =>
+                        addMutation.mutate({
+                          slug: conflict.slug,
+                          reassign: true,
+                        })
+                      }
+                    >
+                      {t("admin.orgs.reassignConfirm")}
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={busy}
+          >
+            {t("admin.orgs.close")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function AddMemberDialog({ org }: { org: DeploymentAdminOrg }) {
   const t = useT();
   const [open, setOpen] = useState(false);
@@ -564,10 +840,11 @@ export default function AdminOrgsPage() {
       render: (org) => (
         <div className="flex items-center justify-end gap-2">
           <FlagsDialog org={org} />
+          <SitesDialog org={org} />
           <AddMemberDialog org={org} />
         </div>
       ),
-      cellClassName: "w-48 shrink-0",
+      cellClassName: "w-auto shrink-0",
     },
   ];
 

--- a/packages/e2e/tests/deployment-admin.spec.ts
+++ b/packages/e2e/tests/deployment-admin.spec.ts
@@ -826,6 +826,190 @@ test.describe("/api/_admin/*", () => {
     await outsiderCtx.dispose();
   });
 
+  test("sites: claim, list, release", async ({ playwright }) => {
+    const adminCtx = await newApiContext(playwright);
+    const admin = await ensureDeploymentAdmin(adminCtx);
+    await verifyDeploymentAdmin(db, admin.userId);
+
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const orgRow = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [owner.orgSlug],
+    );
+    const orgId = orgRow.rows[0]?.id;
+    if (!orgId) throw new Error("Org not found after signup");
+
+    const slug = `e2e-site-${Date.now()}`;
+
+    const claim = await adminCtx.post(`/api/_admin/orgs/${orgId}/sites`, {
+      data: { slug },
+    });
+    expect(claim.status()).toBe(200);
+    const claimBody = (await claim.json()) as {
+      site: { slug: string; organizationId: string; source: string };
+    };
+    expect(claimBody.site.slug).toBe(slug);
+    expect(claimBody.site.organizationId).toBe(orgId);
+    expect(claimBody.site.source).toBe("manual");
+
+    const ownerRow = await db.query<{ organization_id: string }>(
+      `SELECT organization_id FROM "org_sites" WHERE slug = $1`,
+      [slug],
+    );
+    expect(ownerRow.rows[0]?.organization_id).toBe(orgId);
+
+    const list = await adminCtx.get(`/api/_admin/orgs/${orgId}/sites`);
+    expect(list.status()).toBe(200);
+    const listBody = (await list.json()) as { sites: Array<{ slug: string }> };
+    expect(listBody.sites.some((s) => s.slug === slug)).toBe(true);
+
+    const release = await adminCtx.delete(
+      `/api/_admin/orgs/${orgId}/sites/${slug}`,
+    );
+    expect(release.status()).toBe(200);
+    const gone = await db.query(`SELECT 1 FROM "org_sites" WHERE slug = $1`, [
+      slug,
+    ]);
+    expect(gone.rows).toHaveLength(0);
+
+    // Releasing a slug the org doesn't own is a 404, not a silent success.
+    const releaseMissing = await adminCtx.delete(
+      `/api/_admin/orgs/${orgId}/sites/${slug}`,
+    );
+    expect(releaseMissing.status()).toBe(404);
+
+    await adminCtx.dispose();
+    await ownerCtx.dispose();
+  });
+
+  test("sites: claiming a slug owned by another org needs explicit reassign", async ({
+    playwright,
+  }) => {
+    const adminCtx = await newApiContext(playwright);
+    const admin = await ensureDeploymentAdmin(adminCtx);
+    await verifyDeploymentAdmin(db, admin.userId);
+
+    const orgACtx = await newApiContext(playwright);
+    const orgA = await signUpViaApi(orgACtx);
+    const orgAId = (
+      await db.query<{ id: string }>(
+        `SELECT id FROM "organization" WHERE slug = $1`,
+        [orgA.orgSlug],
+      )
+    ).rows[0]?.id;
+    const orgBCtx = await newApiContext(playwright);
+    const orgB = await signUpViaApi(orgBCtx);
+    const orgBId = (
+      await db.query<{ id: string }>(
+        `SELECT id FROM "organization" WHERE slug = $1`,
+        [orgB.orgSlug],
+      )
+    ).rows[0]?.id;
+    if (!orgAId || !orgBId) throw new Error("Org not found after signup");
+
+    const slug = `e2e-shared-${Date.now()}`;
+    expect(
+      (
+        await adminCtx.post(`/api/_admin/orgs/${orgAId}/sites`, {
+          data: { slug },
+        })
+      ).status(),
+    ).toBe(200);
+
+    // Org B claims the same slug without confirming: 409 naming the current owner.
+    const conflict = await adminCtx.post(`/api/_admin/orgs/${orgBId}/sites`, {
+      data: { slug },
+    });
+    expect(conflict.status()).toBe(409);
+    const conflictBody = (await conflict.json()) as {
+      error: string;
+      ownerOrganizationId: string;
+    };
+    expect(conflictBody.error).toBe("owned_by_other_org");
+    expect(conflictBody.ownerOrganizationId).toBe(orgAId);
+
+    // Still owned by A — the refused claim changed nothing.
+    expect(
+      (
+        await db.query<{ organization_id: string }>(
+          `SELECT organization_id FROM "org_sites" WHERE slug = $1`,
+          [slug],
+        )
+      ).rows[0]?.organization_id,
+    ).toBe(orgAId);
+
+    // With reassign:true it moves to B.
+    const moved = await adminCtx.post(`/api/_admin/orgs/${orgBId}/sites`, {
+      data: { slug, reassign: true },
+    });
+    expect(moved.status()).toBe(200);
+    const movedBody = (await moved.json()) as {
+      reassignedFrom: string;
+      site: { organizationId: string };
+    };
+    expect(movedBody.reassignedFrom).toBe(orgAId);
+    expect(movedBody.site.organizationId).toBe(orgBId);
+    expect(
+      (
+        await db.query<{ organization_id: string }>(
+          `SELECT organization_id FROM "org_sites" WHERE slug = $1`,
+          [slug],
+        )
+      ).rows[0]?.organization_id,
+    ).toBe(orgBId);
+
+    await adminCtx.dispose();
+    await orgACtx.dispose();
+    await orgBCtx.dispose();
+  });
+
+  test("sites: invalid slug 400, unknown org 404, non-admin blocked", async ({
+    playwright,
+  }) => {
+    const adminCtx = await newApiContext(playwright);
+    const admin = await ensureDeploymentAdmin(adminCtx);
+    await verifyDeploymentAdmin(db, admin.userId);
+
+    const outsiderCtx = await newApiContext(playwright);
+    const outsider = await signUpViaApi(outsiderCtx);
+    const orgId = (
+      await db.query<{ id: string }>(
+        `SELECT id FROM "organization" WHERE slug = $1`,
+        [outsider.orgSlug],
+      )
+    ).rows[0]?.id;
+    if (!orgId) throw new Error("Org not found after signup");
+
+    const badSlug = await adminCtx.post(`/api/_admin/orgs/${orgId}/sites`, {
+      data: { slug: "Bad Slug!" },
+    });
+    expect(badSlug.status()).toBe(400);
+
+    const unknownOrg = await adminCtx.post(
+      `/api/_admin/orgs/nonexistent-${Date.now()}/sites`,
+      { data: { slug: `e2e-x-${Date.now()}` } },
+    );
+    expect(unknownOrg.status()).toBe(404);
+
+    // Instance-admin surface: the org's own owner (not a deployment admin) is refused.
+    const outsiderGet = await outsiderCtx.get(
+      `/api/_admin/orgs/${orgId}/sites`,
+    );
+    expect([401, 403]).toContain(outsiderGet.status());
+    const outsiderPost = await outsiderCtx.post(
+      `/api/_admin/orgs/${orgId}/sites`,
+      {
+        data: { slug: `e2e-y-${Date.now()}` },
+        headers: { Origin: getE2EAppOrigin() },
+      },
+    );
+    expect([401, 403]).toContain(outsiderPost.status());
+
+    await adminCtx.dispose();
+    await outsiderCtx.dispose();
+  });
+
   test("the SSO-enforcement middleware exempts /api/_admin/*", async ({
     playwright,
   }) => {


### PR DESCRIPTION
## Summary

Second slice of the deployment-admin editor (after #6846). deco.cx staff can now manage **`org_sites`** — which org owns a globally-unique site slug — from **/_admin/orgs** ("Sites" button per row), instead of editing the table by hand in pgAdmin. Ownership is the gate behind each site's **Hosting / E2E / Analytics / Monitor** tabs (`ctx.storage.orgSites.isOwnedBy`), so this closes the Monitor-without-SQL case.

## Backend

- **`GET /api/_admin/orgs/:orgId/sites`** → `{ sites }` (`listByOrg`). 404 for unknown orgs.
- **`POST /api/_admin/orgs/:orgId/sites`** → `{ slug, reassign? }`. Validates via the shared `SITE_SLUG_RE` (→ 400). Claims the slug (`source: "manual"`). If it belongs to another org, returns **`409 { error: "owned_by_other_org", ownerOrganization* }`** and only moves it when `reassign: true` — reassignment is cross-tenant destructive, so it's a deliberate two-step, never a silent steal.
- **`DELETE /api/_admin/orgs/:orgId/sites/:slug`** → releases the slug (scoped to the owning org; 404 if not owned).
- All behind `requireDeploymentAdmin` + `rejectUntrustedOrigin`; audited (`org_site_claim` / `org_site_reassign` / `org_site_release`, stdout + PostHog) with real-actor-under-impersonation attribution.
- **Storage** (`org-sites.ts` + port): `reassignSite` (admin override — takes the slug from whatever org owns it, `INSERT ... ON CONFLICT (slug) DO UPDATE`) and `releaseSite` (delete scoped to the org). `claimSite` is unchanged (still refuses cross-org steals).

## Why /_admin and not org Settings

Slug ownership is **global** (`slug` is the PK across all orgs). Reassigning moves posse away from another tenant — no org can hold that power over itself. It's an instance-level decision, so it belongs on the deployment-admin surface, not in a tenant's settings.

## Frontend (`apps/web/src/routes/admin/orgs.tsx`)

A separate **"Sites"** dialog per org (kept distinct from the Flags dialog — different concern): list with the `source` badge, add (client-side `SITE_SLUG_RE` validation), remove, and an explicit **reassignment warning** naming the current owner with a `destructive` "Move site here" confirm before the move. i18n en + pt-br, new `deploymentAdminOrgSites` query key. No `useEffect`/`useMemo`, design-system tokens.

## Testing

- **E2E** (`deployment-admin.spec.ts`): claim → list → release (asserts `org_sites` rows), release-not-owned 404, 409-without-reassign leaves ownership unchanged, `reassign:true` moves it (asserts new owner in DB), invalid slug 400, unknown org 404, non-admin blocked. Real-Postgres coverage for the new storage methods per the storage-test rule.
- `bun run fmt`, `lint` (0 errors), `check` (all workspaces green), `knip` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a site-ownership editor to the deployment-admin org page so staff can manage `org_sites` from `/_admin/orgs` instead of editing the table in pgAdmin. Site ownership is the gate behind each site's Hosting, E2E, Analytics, and Monitor tabs, so this closes the Monitor-without-SQL case.

**New Features**
- Adds `GET`, `POST`, and `DELETE /api/_admin/orgs/:orgId/sites` to list, claim, and release an org's site slugs.
- Claiming a slug owned by another org returns `409` with the owner's details and moves it only when `reassign: true`; the UI shows a destructive confirmation naming the owner first.
- Keeps reassignment on the deployment-admin surface because slug ownership is global and no tenant should be able to take a slug from another org through its own settings.
- Adds a "Sites" dialog per org with source badges, add/remove, and en + pt-BR translations.
- All routes stay behind deployment-admin auth and record claim, reassign, and release actions for audit and PostHog.

<sup>Written for commit 80e164691f17d6587b55c67c70ec00f1fde8d437. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

