### PR TITLE
fix(task-board): don't hand an already-approved card to a human for a stale preview

### DIFF
--- a/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
@@ -15,6 +15,7 @@ import {
   reviewerHandledThisCycle,
   spentAttemptsThisCycle,
   stalePreviewHandoffDue,
+  stalePreviewHandoffOwed,
   undecidedReviewerThread,
   verdictNudgedThreads,
   awaitingVerdictNudge,
@@ -577,6 +578,32 @@ describe("stalePreviewHandoffDue", () => {
   it("treats a card with no recorded cycle start as infinitely old", () => {
     expect(stalePreviewHandoffDue(0, at("2026-08-13T17:00:00.000Z"))).toBe(
       true,
+    );
+  });
+});
+
+describe("stalePreviewHandoffOwed", () => {
+  const cycle = Date.parse("2026-08-13T17:00:00.000Z");
+  const staleNow = Date.parse("2026-08-13T18:00:00.000Z");
+
+  it("hands off an undecided reviewer once the preview is stale", () => {
+    expect(stalePreviewHandoffOwed(false, false, cycle, staleNow)).toBe(true);
+  });
+
+  it("never hands off an already-approved card — the verdict already answered the question the preview gate protects", () => {
+    expect(stalePreviewHandoffOwed(true, false, cycle, staleNow)).toBe(false);
+  });
+
+  it("does nothing when the preview does match head", () => {
+    expect(stalePreviewHandoffOwed(false, true, cycle, staleNow)).toBe(false);
+    expect(stalePreviewHandoffOwed(false, undefined, cycle, staleNow)).toBe(
+      false,
+    );
+  });
+
+  it("waits out the grace even for an undecided reviewer", () => {
+    expect(stalePreviewHandoffOwed(false, false, cycle, cycle + 60_000)).toBe(
+      false,
     );
   });
 });

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -175,6 +175,26 @@ export function stalePreviewHandoffDue(
   return nowMs - cycleStartMs >= STALE_PREVIEW_HANDOFF_GRACE_MS;
 }
 
+/**
+ * True when a stale deploy preview should hand this card to a human.
+ *
+ * Only while the reviewer has NOT yet ruled on the current cycle. Once a
+ * verdict is recorded, the preview already served its purpose — re-litigating
+ * its staleness on every later sweep tick (auto-merge off, so the card sits In
+ * Review after approval waiting on a human to ship) would strand an already
+ * APPROVED card behind a "the Reviewer cannot verify this change" hand-off,
+ * even though it already did. Pure — unit-tested.
+ */
+export function stalePreviewHandoffOwed(
+  verdictRecorded: boolean,
+  previewMatchesHead: boolean | undefined,
+  lastInReviewAt: number,
+  now: number,
+): boolean {
+  if (verdictRecorded || previewMatchesHead !== false) return false;
+  return stalePreviewHandoffDue(lastInReviewAt, now);
+}
+
 export async function enqueueEnabledReviewers(
   ctx: StudioContext,
   task: TaskBoardItem,
@@ -262,7 +282,14 @@ export async function enqueueEnabledReviewers(
       }
       // Would be a verdict on the wrong bytes — see `previewMatchesHead`.
       if (opts?.previewMatchesHead === false) {
-        if (stalePreviewHandoffDue(lastInReviewAt, Date.now())) {
+        if (
+          stalePreviewHandoffOwed(
+            verdictRecorded,
+            opts.previewMatchesHead,
+            lastInReviewAt,
+            Date.now(),
+          )
+        ) {
           await handTaskToHuman(
             ctx,
             task,


### PR DESCRIPTION
Bug found while auditing `apps/api/src/tools/task-board/enqueue-reviewer.ts` (enqueue-reviewer workflow focus area).

**Why a maintainer wants this:** with `auto_merge` off (the common case — a human ships manually), a card stays In Review after the Reviewer approves, so `review-sweeper.ts`'s periodic sweep keeps calling `enqueueEnabledReviewers` on it every tick. `enqueueEnabledReviewers`'s `previewMatchesHead === false` branch ran unconditionally, with no check for whether this reviewer already recorded a verdict this cycle (`verdictRecorded`). So an already-APPROVED card, on any later tick where the deploy-preview check happens to read `false` (flaky/slow provider, checks re-running, etc.) and 30+ minutes have passed since the review cycle started, gets unassigned from the Super Agent and handed to a human with the reason "the pull request's deploy preview is not showing its latest commit ... so the Reviewer cannot verify this change" — even though the Reviewer already verified it and approved. That strands a genuinely-ready, approved card behind a false hand-off reason.

**Failure scenario:** org has `auto_merge` off. Reviewer approves a PR (verdict recorded). PR sits In Review waiting for a human to click ship. On a later sweep tick, `previewMatchesHead(live)` reads `false` (e.g. the CI/preview provider is re-running checks) and the cycle is >30min old — `enqueueEnabledReviewers` calls `handTaskToHuman` with the stale-preview reason, even though this reviewer's verdict already exists.

**Fix:** extracted the hand-off decision into a pure `stalePreviewHandoffOwed(verdictRecorded, previewMatchesHead, lastInReviewAt, now)` helper and gated the hand-off on `!verdictRecorded` — the preview-staleness gate only matters before a reviewer has ruled, not after. Added unit tests covering: hands off an undecided reviewer past the grace window, never hands off an already-approved card, no-op when the preview does match head, and respects the grace window.

**Verify:** `bun test apps/api/src/tools/task-board/enqueue-reviewer.test.ts` (45 pass). Also ran `bunx tsc --noEmit` in `apps/api` (clean) and `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops handing an already-approved card to a human with a stale-preview reason during later sweep ticks.

Previously the `previewMatchesHead === false` branch in `enqueueEnabledReviewers` ran unconditionally, so with `auto_merge` off, a card that stays In Review after approval could be unassigned and handed to a human on any later tick where the preview check read false and the grace window had passed. The hand-off is now gated on whether a verdict was already recorded this cycle; the preview-staleness gate only applies before a reviewer has ruled. Extracted this decision into a pure `stalePreviewHandoffOwed(verdictRecorded, previewMatchesHead, lastInReviewAt, now)` helper and added unit tests for the hand-off, the no-hand-off on approval, the matching-preview no-op, and the grace window.

<sup>Written for commit eae2de263f657c3808dde015fa7cbc600a9feddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

