### PR TITLE
fix(connection-details): expose activity timeframe toggle state to assistive tech

### DIFF
--- a/apps/web/src/components/details/connection/connection-activity.tsx
+++ b/apps/web/src/components/details/connection/connection-activity.tsx
@@ -238,6 +238,7 @@ export function ConnectionActivity({ connectionId }: ConnectionActivityProps) {
             <button
               key={tf.value}
               type="button"
+              aria-pressed={timeframe === tf.value}
               onClick={() => setTimeframe(tf.value)}
               className={cn(
                 "px-2.5 py-1 text-xs font-medium rounded-md transition-colors",


### PR DESCRIPTION
**Source:** C-DEBT/C3 accessibility gap found while auditing `apps/web/src/components/details/connection/` for stale-state and a11y regressions per this tick's focus area (connection-details-ui).

**Payoff:** The 7d/14d/30d timeframe buttons in the connection Activity chart form a toggle group (only one active at a time, visually indicated by background/shadow), but had no `aria-pressed` — a screen-reader user gets no indication of which range is selected. This mirrors the established pattern already used for every other toggle-button group in the codebase (`home/toggle-button.tsx`, `chat/highlight/approval.tsx`, `sandbox/preview/preview.tsx`, `dev-agent-control.tsx`, etc.) — this one component was missed.

**Fix:** Added `aria-pressed={timeframe === tf.value}` to the timeframe button, matching the existing `timeframe === tf.value` check already used for its visual active state.

**Verify:** Render Connection Details, open the Activity card, inspect the 7d/14d/30d buttons — the currently-selected one should have `aria-pressed="true"`.

**Checks run locally:** `bun run fmt` (clean), `bunx oxlint apps/web/src/components/details/connection/connection-activity.tsx` (0 warnings/errors). Skipped `bunx tsc --noEmit` verification of this specific change beyond confirming it's a type-inert JSX attribute add — the workspace-wide typecheck has a pre-existing, unrelated prosemirror-version-mismatch error in `mention-suggestion.tsx`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `aria-pressed` to the connection Activity timeframe buttons so assistive tech announces which range (7d/14d/30d) is selected, matching the toggle-group pattern used elsewhere in the codebase.

<sup>Written for commit c662007662814b17742734d6bf4c38c11417fc75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

