### PR TITLE
fix(task-board): resolve the review sweeper's in-progress lane from the board

### DIFF
--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -336,9 +336,10 @@ export class TaskBoardReviewSweeper {
         const item = await this.taskBoard.getById(id, organizationId);
         // Re-read before spending a run: a human may have moved or reassigned
         // the card between the scan and here, and their move wins.
+        const lanes = await boardLanesForDb(this.db, organizationId);
         if (
           !item ||
-          item.status !== "in_progress" ||
+          item.status !== lanes.progress ||
           item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID
         ) {
           continue;
@@ -413,7 +414,7 @@ export class TaskBoardReviewSweeper {
     try {
       const lanes = await boardLanesForDb(this.db, organizationId);
       const item = await this.taskBoard.getById(id, organizationId);
-      if (!item || item.status !== "in_progress") return;
+      if (!item || item.status !== lanes.progress) return;
       const returned = await this.taskBoard.returnToTodoAfterFailure(
         id,
         organizationId,


### PR DESCRIPTION
Follows #6790 ("every lane decision goes through the board, not a literal") and #6854, which fixed the same bug pattern elsewhere in the task-board reactions but missed this file.

`TaskBoardReviewSweeper.dispatchDueRetries` and `.returnToTodo` in `review-sweeper.ts` compared `item.status` against the hardcoded literal `"in_progress"` instead of asking the board which column means "in progress" (`boardLanesForDb(...).progress`). For an org on `org_board_columns` (a board mirrored from a tracker, e.g. Jira), the in-progress column has a different key — so `dispatchDueRetries` would silently skip every due infrastructure retry it scanned (the re-read guard would always read `item.status !== lanes.progress` as true and `continue`), and `returnToTodo` would never park a permanently-failed card back on To Do. Both fail silently: no error, no log, the card just never recovers.

Fix: read `lanes.progress` from the board via the existing `boardLanesForDb` call (already present in `returnToTodo`; added to `dispatchDueRetries`) and compare against that instead of the literal.

Failure scenario: an org-owned board whose in-progress column key isn't literally `"in_progress"` has a Super Agent task fail with a transient/infrastructure error. `reactToFailedTaskRun` schedules a retry correctly (it already goes through `lanes.progress`), but the sweeper's `dispatchDueRetries` never re-dispatches it — the card sits stuck forever with no visible error, and a permanently-failed one never gets parked back on To Do for a human either.

Reviewer: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint src/tools/task-board/review-sweeper.ts` all pass. No existing pure-function unit test covers this (both methods need a live board handle from Postgres), so I didn't add one rather than fake a DB — full CI's integration tier is the right place to catch a regression here.

Locally verified: fmt, targeted tsc, targeted oxlint. Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the review sweeper to compare against the board's actual in-progress lane instead of the hardcoded `"in_progress"` status. Previously, on orgs with custom board columns (e.g., mirrored from Jira), due retries were silently skipped and permanently-failed cards were never parked back on To Do.

<sup>Written for commit fd54e7fcef1019a256a87e604ebe3d0764642cdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

