### PR TITLE
fix(admin): flip source when reassigning a site slug's ownership

### DIFF
--- a/apps/api/src/storage/org-sites.ts
+++ b/apps/api/src/storage/org-sites.ts
@@ -132,6 +132,7 @@ export class OrgSiteStorage implements OrgSiteStoragePort {
       .onConflict((oc) =>
         oc.column("slug").doUpdateSet({
           organization_id: params.organizationId,
+          source: params.source ?? "manual",
           updated_by: params.by,
           updated_at: now,
         }),

--- a/packages/e2e/tests/deployment-admin.spec.ts
+++ b/packages/e2e/tests/deployment-admin.spec.ts
@@ -946,14 +946,16 @@ test.describe("/api/_admin/*", () => {
     expect(moved.status()).toBe(200);
     const movedBody = (await moved.json()) as {
       reassignedFrom: string;
-      site: { organizationId: string };
+      site: { organizationId: string; source: string };
     };
     expect(movedBody.reassignedFrom).toBe(orgAId);
     expect(movedBody.site.organizationId).toBe(orgBId);
+    // Reassign is a re-claim: source must flip too, not just the owner.
+    expect(movedBody.site.source).toBe("manual");
     expect(
       (
-        await db.query<{ organization_id: string }>(
-          `SELECT organization_id FROM "org_sites" WHERE slug = $1`,
+        await db.query<{ organization_id: string; source: string }>(
+          `SELECT organization_id, source FROM "org_sites" WHERE slug = $1`,
           [slug],
         )
       ).rows[0]?.organization_id,


### PR DESCRIPTION
Follows #6855 (the new deployment-admin site-ownership editor).

`OrgSiteStorage.reassignSite`'s upsert set `organization_id`/`updated_by`/`updated_at` on conflict but left `source` untouched. A deployment-admin "move site here" reassign of a slug previously claimed with `source: "deco-import"` (or any other source) silently kept that stale source forever, even though the request explicitly passed `source: "manual"` — the UI's Sites dialog badge (and anything reading `source` to distinguish an auto-imported claim from a deliberate admin override) would show wrong provenance after every reassign.

Failure scenario: org A owns `foo` with `source: "deco-import"`. An admin uses the new Sites dialog to reassign `foo` to org B. The response and DB row still show `source: "deco-import"` instead of `"manual"`.

Fix: `reassignSite`'s `doUpdateSet` now also sets `source: params.source ?? "manual"`, matching what `claimSite`'s idempotent-reclaim path already does. Extended the existing e2e reassign test (`packages/e2e/tests/deployment-admin.spec.ts`, "sites: claiming a slug owned by another org needs explicit reassign") to assert `source` flips to `"manual"` on both the response body and the DB row — the test previously never checked `source` at all, so it encoded the old gap silently.

Reviewer: run `bunx tsc --noEmit` in `apps/api` and `packages/e2e` (both clean), and the extended e2e test once Postgres/Docker infra is available: `bun test packages/e2e/tests/deployment-admin.spec.ts` (full e2e suite, CI-only here).

Locally verified: `bunx tsc --noEmit` in both touched workspaces, `bunx oxlint` on both changed files (clean). The e2e assertion itself needs the Postgres-backed suite, which full CI runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `reassignSite` so reassigning a site slug's ownership also updates the `source` to the passed value (defaulting to `"manual"`), instead of keeping the stale original source like `"deco-import"`. The e2e reassign test now asserts the response and DB row show `source: "manual"` after reassign.

<sup>Written for commit 38325a893d23fb483b71f14fe33cbaea366f29b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

