### PR TITLE
refactor(storage): use Kysely's Selectable<OrgSiteTable> in org-sites

### DIFF
--- a/apps/api/src/storage/org-sites.ts
+++ b/apps/api/src/storage/org-sites.ts
@@ -1,6 +1,6 @@
-import type { Kysely } from "kysely";
+import type { Kysely, Selectable } from "kysely";
 import { isValidSiteSlug } from "@decocms/shared/site-slug";
-import type { Database, OrgSite } from "./types";
+import type { Database, OrgSite, OrgSiteTable } from "./types";
 import type { OrgSiteStoragePort } from "./ports";
 
 /**
@@ -24,17 +24,7 @@ function toIso(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : String(value);
 }
 
-type OrgSiteRow = {
-  slug: string;
-  organization_id: string;
-  source: string;
-  created_by: string;
-  created_at: Date | string;
-  updated_by: string;
-  updated_at: Date | string;
-};
-
-function toEntity(row: OrgSiteRow): OrgSite {
+function toEntity(row: Selectable<OrgSiteTable>): OrgSite {
   return {
     slug: row.slug,
     organizationId: row.organization_id,
@@ -78,7 +68,7 @@ export class OrgSiteStorage implements OrgSiteStoragePort {
       .returningAll()
       .executeTakeFirst();
 
-    if (inserted) return toEntity(inserted as OrgSiteRow);
+    if (inserted) return toEntity(inserted);
 
     // Slug already exists — only the owning org may re-claim (idempotent).
     const existing = await this.getBySlug(params.slug);
@@ -102,7 +92,7 @@ export class OrgSiteStorage implements OrgSiteStoragePort {
       .returningAll()
       .executeTakeFirstOrThrow();
 
-    return toEntity(updated as OrgSiteRow);
+    return toEntity(updated);
   }
 
   async reassignSite(params: {
@@ -139,7 +129,7 @@ export class OrgSiteStorage implements OrgSiteStoragePort {
       )
       .returningAll()
       .executeTakeFirstOrThrow();
-    return toEntity(row as OrgSiteRow);
+    return toEntity(row);
   }
 
   async releaseSite(slug: string, organizationId: string): Promise<boolean> {
@@ -157,7 +147,7 @@ export class OrgSiteStorage implements OrgSiteStoragePort {
       .selectAll()
       .where("slug", "=", slug)
       .executeTakeFirst();
-    return row ? toEntity(row as OrgSiteRow) : null;
+    return row ? toEntity(row) : null;
   }
 
   async listByOrg(organizationId: string): Promise<OrgSite[]> {
@@ -167,7 +157,7 @@ export class OrgSiteStorage implements OrgSiteStoragePort {
       .where("organization_id", "=", organizationId)
       .orderBy("slug", "asc")
       .execute();
-    return rows.map((row) => toEntity(row as OrgSiteRow));
+    return rows.map((row) => toEntity(row));
   }
 
   async isOwnedBy(slug: string, organizationId: string): Promise<boolean> {


### PR DESCRIPTION
**Source**: type-safety cleanup in the org-sites storage layer (this tick's focus area).

**Payoff**: `org-sites.ts` hand-rolled a duplicate `OrgSiteRow` type that mirrored `OrgSiteTable` field-for-field, then cast every insert/update/select result to it with `as OrgSiteRow` — four unchecked casts that would silently paper over a real schema/row mismatch instead of surfacing as a compile error. Using Kysely's own `Selectable<OrgSiteTable>` (already exported from `kysely`) drops the duplicate type and all four casts; the shapes were identical so this is behavior-preserving, and tsc now enforces the mapping instead of trusting an unverified cast.

**Net change**: -18 / +8 lines in `apps/api/src/storage/org-sites.ts`, no logic touched (only `toEntity`'s parameter type and the callers that fed it).

**How to confirm**: `cd apps/api && bunx tsc --noEmit` — clean. No test file exists for this module (pure storage adapter, no branching logic changed), and there is nothing new to assert on: this is a type-only refactor of an existing behavior-preserving mapping.

**Checks run locally**: `bunx tsc --noEmit` (apps/api workspace, clean), `bunx oxlint apps/api/src/storage/org-sites.ts` (0 warnings/errors), `bun run fmt`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hand-rolled `OrgSiteRow` type in `apps/api/src/storage/org-sites.ts` with Kysely's `Selectable<OrgSiteTable>` and removes four unsafe `as OrgSiteRow` casts. Behavior is unchanged, but tsc now enforces the row mapping instead of an unchecked cast silently hiding schema/row mismatches.

<sup>Written for commit d60bb0c973e4df89be81fcdef0b8f1968c1533fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

