### PR TITLE
fix(sandbox): add retry logic to daemon client for transient network failures

### DIFF
--- a/packages/sandbox/server/daemon-client.ts
+++ b/packages/sandbox/server/daemon-client.ts
@@ -5,6 +5,7 @@
 
 import type { ConfigPatch, TenantConfig } from "../daemon-protocol";
 import { sleep } from "../shared";
+import { retry, type RetryOptions } from "@decocms/shared/std";
 
 export type { ConfigPatch };
 
@@ -21,9 +22,24 @@ export class ConfigRequestError extends Error {
   }
 }
 
+/** Returns true if an error is transient and should be retried. Distinguishes
+ * network/timeout failures (retriable) from other errors (permanent). */
+function isTransientError(err: unknown): boolean {
+  // Network errors (DNS, connection refused, etc.) are transient
+  if (err instanceof TypeError) {
+    return true;
+  }
+  // AbortError from timeout is transient
+  if (err instanceof DOMException && err.name === "AbortError") {
+    return true;
+  }
+  return false;
+}
+
 /**
  * Call a daemon endpoint and read its whole body, labelling any transport
- * failure with the endpoint that failed.
+ * failure with the endpoint that failed. Retries on transient errors
+ * (network timeouts, connection failures) with exponential backoff.
  *
  * `AbortSignal.timeout()` rejects with a bare DOMException whose message is
  * "The operation timed out." — no URL, no endpoint, no hint that a sandbox was
@@ -44,8 +60,19 @@ async function daemonRequest(
   endpoint: string,
 ): Promise<{ status: number; ok: boolean; body: string }> {
   try {
-    const res = await fetch(url, init);
-    return { status: res.status, ok: res.ok, body: await res.text() };
+    const retryOpts: RetryOptions = {
+      maxAttempts: 3,
+      minTimeout: 50,
+      maxTimeout: 500,
+      multiplier: 2,
+      jitter: 0.5,
+      isRetriable: isTransientError,
+    };
+
+    return await retry(async () => {
+      const res = await fetch(url, init);
+      return { status: res.status, ok: res.ok, body: await res.text() };
+    }, retryOpts);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(


### PR DESCRIPTION
## Problem
When the sandbox daemon experiences temporary network issues (connection reset, DNS resolution failure, brief timeout), the daemon client fails immediately instead of reconnecting. This reduces resilience during infrastructure blips.

## Solution
Added exponential backoff retry logic to `daemonRequest()` with:
- **3 retry attempts** on transient errors (network timeouts, connection failures)
- **Exponential backoff**: 50ms–500ms min/max with 2x multiplier and 0.5 jitter
- **Transient error detection**: Retries only TypeErrors (network errors) and AbortErrors (timeouts); permanent errors like 4xx throw immediately
- **Clear error labeling**: When all retries fail, error still includes `[SANDBOX_UNREACHABLE]` label + endpoint name for diagnostics

This benefits all daemon endpoints that use `daemonRequest()`: `postConfig()`, `postSetupStep()`, and `postOrgFsConfig()`.

## Verification
✓ All existing tests pass (24 tests in daemon-client.test.ts)
✓ No type errors: `bunx tsc --noEmit` passes
✓ No lint issues: `bunx oxlint packages/sandbox/server/daemon-client.ts` clean
✓ Minimal diff: +30/-3 lines, focused change to one file

## Run to confirm
`bun test packages/sandbox/server/daemon-client.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds retry logic to `daemonRequest()` so the sandbox daemon client recovers from transient network failures instead of failing immediately. Previously, any network timeout or connection error threw right away; now those errors are retried with exponential backoff (3 attempts, 50–500ms) before the `[SANDBOX_UNREACHABLE]` error is thrown. Permanent errors like 4xx still fail immediately. All daemon endpoints that use `daemonRequest()` benefit.

<sup>Written for commit b714195d02b761785c2871d5e6d832f66fbc027b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

