### PR TITLE
fix(task-board): resolve the PR-open reaction's archive lane from the board

### DIFF
--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -270,9 +270,18 @@ export async function reactToPrOpenedForBoard(
     const pr = extractPrFromValue(source);
     if (!pr) return;
 
+    // Resolved up front: an org-owned board's archive column isn't literally "archived".
+    const board = await boardFor(ctx, orgId);
+    const lanes = await board.lanes();
+
     const cards = await ctx.storage.taskBoard.list(orgId);
     const openCards = cards
-      .filter((t) => t.status !== "done" && t.status !== "archived")
+      .filter(
+        (t) =>
+          t.status !== "done" &&
+          t.status !== "archived" &&
+          t.status !== lanes.archive,
+      )
       .slice(0, MAX_OPEN_CARDS_FOR_DECISION);
     const thread = await ctx.storage.threads.get(threadId);
 
@@ -285,9 +294,8 @@ export async function reactToPrOpenedForBoard(
     );
     if (!decision) return;
 
-    const board = await boardFor(ctx, orgId);
     await applyBoardDecision(ctx.storage.taskBoard, {
-      lanes: await board.lanes(),
+      lanes,
       columns: await board.columns(),
       columnOwner: board.columnOwner(),
       orgId,


### PR DESCRIPTION
Same bug class #6858 (in this batch) fixed in `review-sweeper.ts`: a hardcoded canonical-status literal that no longer holds for an org-owned (mirrored) board, where a card's `status` is that board's own column key, not Studio's fixed vocabulary.

`reactToPrOpenedForBoard` (in `pr-open-board-reaction.ts`, predates the org-board-columns work — added in #6344 on Aug 21) filters the candidate cards it hands to the LLM with `t.status !== "done" && t.status !== "archived"`. On an org-owned board, the column playing the "archived" role can have any key (e.g. a mirrored Jira status), so that literal never matches — every closed/archived card on that board leaks into the "open cards" list sent to the model, which can then pick one to `update`, re-linking a PR onto a card that's already done.

Fix: resolve `board.lanes()` before building the candidate list and also exclude `t.status === lanes.archive` (the board's actual archive column, `null` on a board with none — a no-op filter in that case, same as before). `board.lanes()` was already being fetched later in the function for `applyBoardDecision`; moved it earlier and reused it instead of computing twice.

Behavior-preserving for Studio's own board: `lanes.archive` there is literally `"archived"`, already covered by the existing check, so nothing changes for the common case — only org-owned boards are affected, and only by excluding cards that shouldn't have been candidates in the first place.

To confirm: `cd apps/api && bunx tsc --noEmit` (clean) and `bunx oxlint apps/api/src/tools/task-board/pr-open-board-reaction.ts` (clean). No test added — this function (`reactToPrOpenedForBoard`) takes a full `StudioContext` and calls `generateObject`, so exercising it needs e2e infra (real Postgres + a model provider), not a unit test; the extracted pure half (`applyBoardDecision`, unaffected by this change) already has Postgres integration coverage in `pr-open-board-reaction.integration.test.ts`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the PR-open reaction's candidate filter so archived cards on org-owned (mirrored) boards no longer leak into the list sent to the LLM.

- The filter previously excluded only the literal `"archived"` status, which never matches an org-owned board's archive column.
- Resolves `board.lanes()` before building candidates and excludes the actual archive lane (a no-op on boards with none).
- Moves the existing `board.lanes()` call earlier and reuses it instead of computing twice.
- Behavior is unchanged for Studio's own board, where the archive lane is literally `"archived"`.

<sup>Written for commit 1c6edbb498ee562573bd882bee40d92049f5b0c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

