### PR TITLE
fix(task-board): the new-task dialog defaults to the board's first column

### DIFF
--- a/apps/api/src/tools/task-board/board-handler.integration.test.ts
+++ b/apps/api/src/tools/task-board/board-handler.integration.test.ts
@@ -420,6 +420,23 @@ describe("a mirrored board answers with its own columns", () => {
     expect(Array.isArray(columns[0]?.trackerStatuses)).toBe(true);
   });
 
+  /**
+   * The case that reached production. A card created with no status fell
+   * through to storage's `"triage"` default, which is a column no mirrored
+   * board has — so the board could not create a card at all. `intake` is the
+   * answer every create path needs, and it is the leftmost column.
+   */
+  it("names an intake column a card can actually be born in", async () => {
+    await new BoardColumnStorage(database.db).replaceAll(ORG, [
+      { key: "Backlog", title: "Backlog", trackerStatuses: ["BACKLOG"] },
+      { key: "Fazendo", title: "Em Progresso", trackerStatuses: ["Fazendo"] },
+    ]);
+    const lanes = await board().lanes();
+    expect(lanes.intake).toBe("Backlog");
+    // Not one of Studio's names, which is the whole point.
+    expect(lanes.intake).not.toBe("triage");
+  });
+
   /** A board nothing has been mirrored onto cannot say where a card is born,
    *  and inventing an answer would strand whatever is created next. */
   it("refuses to invent an intake column for an empty board", async () => {

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -439,7 +439,9 @@ function TaskBoardItemEditor({
   const [form, setForm] = useState<TaskForm>({
     title: item?.title ?? "",
     description: item?.description ?? "",
-    status: item?.status ?? defaultStatus ?? "triage",
+    // The board's leftmost column, not `"triage"`: a mirrored board has no such
+    // column and the server refuses the create.
+    status: item?.status ?? defaultStatus ?? columns[0]?.key ?? "triage",
     priority: item?.priority ?? "medium",
     type: item?.type ?? DEFAULT_TASK_TYPE,
     assigneeId: item?.assigneeId ?? null,


### PR DESCRIPTION
Creating a card on a mirrored board failed outright:

```
This board has no column "triage" — it has Backlog, Em Progresso, Code Review,
QA Deco, QA Osklen, Realese, Deploy, Validação Pós Deploy, Product Ops, Concluido
```

## Where it actually was

I opened this thinking the server was at fault and found it already fixed —
#6837 landed the same `input.status ?? lanes.intake` line while this branch was
in flight. Rebased onto that, which left two lines and a test.

The bug is entirely client-side. `task-dialog.tsx` seeded its form with
`"triage"` whenever a card was not created from a specific lane, so the **New
task** button sent a column the board does not have and `assertBoardHasColumn`
refused it — correctly. #6837 fixed the half that was no longer being
exercised.

The dialog now defaults to the board's first column, the same answer
`intakeColumn` gives on the server.

## Verified end to end

Locally, with all ten of a real mirrored board's columns seeded and the flag on:

| | on `main` | with this |
|---|---|---|
| **New task**, no lane | `500 — no column "triage"` | card created in `Backlog` |

The server log goes from one `no column "triage"` to none.

## Why the tests missed it

Every lane decision in #6790 had a test. The one that decides where a card
*starts* did not — I tested `intakeColumn` on the handler and never tested that
anything calls it, on either side of the wire. A green suite around a function
nobody calls is exactly as green as one around a function everybody calls.

The regression test asserts a mirrored board's intake is its leftmost column
and specifically not `"triage"`. It would not have caught this one, which lived
in the client; that half is covered by the manual run above.