### PR TITLE
fix(branch-picker): don't fire branch tooltip on popover open

### DIFF
--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -255,6 +255,8 @@ export function BranchPicker({
       <PopoverContent
         className="w-[min(300px,calc(100vw-2rem))] p-1.5"
         align="start"
+        // Don't steal focus onto the first row: it fires that row's branch tooltip.
+        onOpenAutoFocus={(e) => e.preventDefault()}
       >
         {spawnsNewChat && (
           <p className="px-2 pb-1.5 pt-1 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

Fixes a spurious tooltip that appeared automatically when opening the drafts/environment switcher menu.

When the popover opened, Radix auto-focused the first row (**Production**, whose branch is `main`). Since each row's button is also a `TooltipTrigger`, the tooltip fires on **focus** (not just hover) — so the `main` tooltip popped up on its own, and collision detection flipped it below the trigger, overlapping the next row (e.g. "Black Friday"). It read as a phantom hover.

## Fix

Add `onOpenAutoFocus={(e) => e.preventDefault()}` to the `PopoverContent` so the menu no longer steals focus onto the first item on open. No tooltip appears until the user actually hovers. Keyboard navigation (Tab) still works.

## Testing

- Manually verified the menu opens without the auto-tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a spurious branch tooltip that fired automatically when opening the drafts/environment switcher, caused by Radix auto-focusing the first row (whose button is also a `TooltipTrigger`).

- Prevents `PopoverContent` from stealing focus onto the first row on open.
- The tooltip now only appears on actual hover; keyboard navigation (Tab) still works.

<sup>Written for commit 88d47139e081ff3d9723c43214accbe2c5d13f9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

