### PR TITLE
fix(connections): refuse to delete a connection a thread is pinned to as its repo

### DIFF
--- a/apps/api/src/tools/connection/delete.test.ts
+++ b/apps/api/src/tools/connection/delete.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, mock } from "bun:test";
+import { COLLECTION_CONNECTIONS_DELETE } from "./delete";
+
+function makeCtx(options: { referencedByThread: boolean }) {
+  const connection = {
+    id: "conn_repo",
+    organization_id: "org_123",
+    metadata: null,
+  };
+  const deleteConnection = mock(async () => {});
+  const isReferencedByThread = mock(async () => options.referencedByThread);
+  const ctx = {
+    auth: { user: { id: "user_123" } },
+    organization: { id: "org_123" },
+    access: { check: mock(async () => {}) },
+    storage: {
+      connections: {
+        findById: mock(async () => connection),
+        delete: deleteConnection,
+        isReferencedByThread,
+      },
+      virtualMcps: { listByConnectionId: mock(async () => []) },
+      organizationSettings: { get: mock(async () => null) },
+    },
+  } as unknown as Parameters<typeof COLLECTION_CONNECTIONS_DELETE.handler>[1];
+  return { ctx, deleteConnection, isReferencedByThread };
+}
+
+describe("COLLECTION_CONNECTIONS_DELETE", () => {
+  it("refuses to delete a connection a thread is pinned to as its repo", async () => {
+    // Regression: deleting it would strand the thread's sandbox permanently.
+    const { ctx, deleteConnection } = makeCtx({ referencedByThread: true });
+
+    await expect(
+      COLLECTION_CONNECTIONS_DELETE.handler({ id: "conn_repo" }, ctx),
+    ).rejects.toThrow(/CONNECTION_IN_USE_BY_THREAD/);
+
+    expect(deleteConnection).not.toHaveBeenCalled();
+  });
+
+  it("deletes a connection with no thread pinned to it", async () => {
+    const { ctx, deleteConnection } = makeCtx({ referencedByThread: false });
+
+    const result = await COLLECTION_CONNECTIONS_DELETE.handler(
+      { id: "conn_repo" },
+      ctx,
+    );
+
+    expect(result.item.id).toBe("conn_repo");
+    expect(deleteConnection).toHaveBeenCalledWith("conn_repo");
+  });
+});

--- a/apps/api/src/tools/connection/delete.ts
+++ b/apps/api/src/tools/connection/delete.ts
@@ -92,6 +92,11 @@ export const COLLECTION_CONNECTIONS_DELETE = defineTool({
       }
     }
 
+    // A thread pinned to this connection as its repo would be stranded — same case VIRTUAL_MCP_DELETE guards.
+    if (await ctx.storage.connections.isReferencedByThread(input.id)) {
+      throw new Error(JSON.stringify({ code: "CONNECTION_IN_USE_BY_THREAD" }));
+    }
+
     // Delete connection
     await ctx.storage.connections.delete(input.id);
 


### PR DESCRIPTION
**Bug**: `COLLECTION_CONNECTIONS_DELETE` (`apps/api/src/tools/connection/delete.ts`) only guarded against deleting a connection referenced by a Virtual MCP. It never checked `ConnectionStorage.isReferencedByThread` — the same guard `VIRTUAL_MCP_DELETE`'s cascade path already applies (see `apps/api/src/tools/virtual/delete.ts`, which cites a prior incident where 152 prod threads were stranded on a sandbox that could never boot again).

**Why it matters**: a thread pins a repo connection via `metadata.githubRepo.connectionId`, with no FK behind that pointer. If a user (or any caller) deletes that connection directly through the connections UI/API — not via agent deletion — the thread is silently orphaned and its sandbox can never boot again. The cascade path already treats this as unsafe; the direct delete path did not.

**Failure scenario**: user opens a connection's detail page and deletes it directly (no Virtual MCP references it, so the existing guard passes), while a thread still has `metadata.githubRepo.connectionId` pointing at it — the thread's sandbox is now permanently stranded.

**Fix**: added a check for `isReferencedByThread` before deleting, mirroring the existing Virtual MCP guard's error shape (`CONNECTION_IN_USE_BY_THREAD`). Unlike the Virtual MCP case, `force` doesn't bypass this — there's no safe auto-unlink for a thread's pinned repo pointer.

**Test**: `apps/api/src/tools/connection/delete.test.ts` (new) exercises the handler directly with a mocked `ctx.storage`, covering both the blocked case and the normal-delete case.

**To verify**: `cd apps/api && bun test src/tools/connection/delete.test.ts`

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/api, no new errors in touched files), `bunx oxlint` on both touched files (0 warnings/errors), targeted `bun test` above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes connection deletion so it no longer orphans threads pinned to the connection as their repo.

Previously, `COLLECTION_CONNECTIONS_DELETE` only checked for Virtual MCP references, not thread references via `metadata.githubRepo.connectionId`. Deleting such a connection left the thread's sandbox permanently unusable. Now the handler checks `isReferencedByThread` and throws `CONNECTION_IN_USE_BY_THREAD`, matching the existing Virtual MCP guard. Unlike the Virtual MCP case, `force` does not bypass this check because there is no safe auto-unlink.

Added tests covering both blocked and normal deletion cases.

<sup>Written for commit e040b126b6da1047fcd899ac14879c022ba631c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

