### PR TITLE
fix(drafts): guard the start-draft CTA against a double-click double-fire

### DIFF
--- a/apps/web/src/components/thread/github/start-draft-cta.tsx
+++ b/apps/web/src/components/thread/github/start-draft-cta.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { ArrowRight, Lock01 } from "@untitledui/icons";
 import { cn } from "@decocms/ui/lib/utils.ts";
 import { useT } from "@/i18n/use-t.ts";
@@ -19,13 +20,25 @@ export function StartDraftCta({
 }) {
   const t = useT();
   const createDraft = useCreateDraft(virtualMcpId);
+  const [pending, setPending] = useState(false);
+
+  const handleClick = async () => {
+    if (pending) return;
+    setPending(true);
+    try {
+      await createDraft();
+    } finally {
+      setPending(false);
+    }
+  };
 
   return (
     <button
       type="button"
-      onClick={() => void createDraft()}
+      disabled={pending}
+      onClick={() => void handleClick()}
       className={cn(
-        "group flex items-center gap-3 rounded-2xl border border-border bg-background/60 px-4 py-3.5 text-left shadow-sm backdrop-blur-sm transition-colors hover:bg-background/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "group flex items-center gap-3 rounded-2xl border border-border bg-background/60 px-4 py-3.5 text-left shadow-sm backdrop-blur-sm transition-colors hover:bg-background/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-60",
         variant === "composer" ? "w-full" : "mx-auto my-10 w-full max-w-md",
       )}
     >


### PR DESCRIPTION
Follows #6851 (Draft & Releases mode).

`StartDraftCta` (shown wherever editing is blocked because the current version is production — chat composer + CMS panel) fired `createDraft()` on click with no pending guard and no disabled state: the button stayed fully clickable while the async draft-creation mutation was in flight.

**Failure scenario:** a user double-clicks (or clicks again on a slow connection) before the first `createDraft()` resolves. Each click calls `useCreateDraft`'s closure independently, so two branches get minted and two entries get appended to `metadata.releases` for a single user intent — a stray duplicate draft with no way to tell which one is "real".

**Fix:** track `pending` locally, ignore re-entrant clicks while a create is in flight, and disable the button visually (`disabled:opacity-60`) so it reads as busy. Same pattern already used by other mutation-driven actions in this file tree (e.g. `publishCompletion` in `cms-header-actions.tsx`, which uses `mutation.isPending`).

To confirm: click the CTA rapidly (or throttle network) and verify only one branch/release is created — `apps/web/src/components/thread/github/use-releases.ts`'s `createRelease` should only fire once per intended click.

Ran locally: `bun run fmt`, `bunx tsc --noEmit` in `apps/web` (no new errors), `bunx oxlint` on the touched file (0 warnings/errors). No dedicated test added — this is a UI-only debounce guard on an existing hook, not new business logic; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the start-draft CTA so a double-click no longer fires multiple draft creations. The button now ignores re-entrant clicks while a draft is being created and disables itself visually during the request.

<sup>Written for commit cbd200bcece95e44bc35f163ccd83cf790010868. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

