### PR TITLE
fix(branch-picker): give the rename input a label and stop Escape closing the popover

### DIFF
--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -305,11 +305,17 @@ export function BranchPicker({
                     <input
                       // biome-ignore lint/a11y/noAutofocus: opened by an explicit click
                       autoFocus
+                      aria-label={t("thread.branchPicker.rename")}
                       value={editName}
                       onChange={(e) => setEditName(e.target.value)}
                       onKeyDown={(e) => {
                         if (e.key === "Enter") void saveRename(r.branch);
-                        if (e.key === "Escape") setEditing(null);
+                        if (e.key === "Escape") {
+                          // Don't let Escape also close the popover behind it.
+                          e.preventDefault();
+                          e.stopPropagation();
+                          setEditing(null);
+                        }
                       }}
                       className="h-8 flex-1 rounded-md border bg-transparent px-2 text-sm outline-none focus:ring-1 focus:ring-ring"
                     />


### PR DESCRIPTION
Bug found while auditing the branch-picker for tooltip/keyboard/focus issues after #6864 (the double-click tooltip fix).

Two issues in the inline rename `<input>` for a draft/release row:

1. **No accessible name.** It renders bare with no `aria-label`, so a screen reader announces nothing useful when autofocus lands on it. Fixed by reusing the existing `thread.branchPicker.rename` translation key as the label.
2. **Escape closes the whole popover, not just the rename.** The input's `onKeyDown` handled `Escape` to cancel rename mode, but never called `preventDefault`/`stopPropagation`. Radix's `Popover` dismissable layer also listens for `Escape` on the document and closes the popover unless the event was prevented — so today, pressing Escape while renaming a draft both exits rename mode *and* closes the entire branch picker, dropping the user back to the trigger button instead of leaving them in the list. Fixed by stopping propagation so Escape only cancels the rename.

Both are scoped to the same `<input>`, one concern (rename-input keyboard/a11y correctness).

To confirm: open the branch picker, click the ⋯ menu on a draft → Rename, press Escape — the popover should stay open with the row back in its normal (non-editing) state, not close entirely. A screen reader (or the accessibility tree in devtools) should now report a name on the rename textbox.

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in `apps/web` (clean for this file — one pre-existing, unrelated prosemirror version-mismatch error elsewhere in the workspace), `bunx oxlint apps/web/src/components/thread/github/branch-picker.tsx` (0 warnings/errors). No existing test file for this component; full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the branch picker rename input so it has an accessible name and pressing Escape no longer closes the popover.

**Bug Fixes**
- Screen readers now announce a label for the rename textbox.
- Escape during rename cancels rename mode only and keeps the popover open.

<sup>Written for commit adde3d5edc75818f50d2f8715c4e2d4f6f2b0036. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

