### PR TITLE
fix(sections-editor): narrow to loader when adding an item to a block-ref array

### DIFF
--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -675,6 +675,115 @@ describe("resolveActiveFieldKey", () => {
     ).toBeNull();
   });
 
+  test("narrows to a loader when a freshly-added array item has only a generic label", () => {
+    // Minicart > Product Shelf: adding to the loader's `ids: ProductID[]` makes an empty `{ productID: "" }` labelled generic "Item 1"; ownership must fall back to the array KEY the crumb records, else the whole loader form shows.
+    const properties = {
+      products: {
+        title: "Products Loader",
+        type: "block-ref",
+        anyOfRefs: [
+          { resolveType: "vtex/loaders/productList.ts", title: "Product List" },
+        ],
+      },
+    } satisfies Record<string, SchemaProperty>;
+    const objValue = {
+      products: {
+        __resolveType: "vtex/loaders/productList.ts",
+        ids: [{ productID: "" }],
+        hideUnavailableItems: false,
+      },
+    };
+    const crumb = buildArrayDrillDownBreadcrumb([], "Ids", "Item 1", 0, {
+      arrayKey: "ids",
+    });
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(properties),
+        properties,
+        objValue,
+        crumb,
+      ),
+    ).toBe("products");
+  });
+
+  test("narrows to an embedded-union field whose branch owns a generic-labelled item", () => {
+    // Same scenario one level deeper: `ids` lives in an embedded block-ref union ("Select products by") inside the loader; resolution must cascade by the recorded array KEY.
+    const branchProps = {
+      ids: {
+        type: "array",
+        title: "Ids",
+        items: {
+          type: "object",
+          properties: { productID: { type: "string" } },
+        },
+      },
+    } satisfies Record<string, SchemaProperty>;
+    const loaderProps = {
+      selectBy: {
+        type: "block-ref",
+        title: "Select products by",
+        anyOfRefs: [
+          {
+            resolveType: "#embedded/ProductIDs",
+            title: "Product IDs",
+            schema: { type: "object", properties: branchProps },
+          },
+        ],
+      },
+      hideUnavailableItems: { type: "boolean", title: "Hide Unavailable" },
+    } satisfies Record<string, SchemaProperty>;
+    const loaderValue = {
+      selectBy: { ids: [{ productID: "" }] },
+      hideUnavailableItems: false,
+    };
+    const crumb = buildArrayDrillDownBreadcrumb([], "Ids", "Item 1", 0, {
+      arrayKey: "ids",
+    });
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(loaderProps),
+        loaderProps,
+        loaderValue,
+        crumb,
+      ),
+    ).toBe("selectBy");
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(branchProps),
+        branchProps,
+        loaderValue.selectBy,
+        crumb,
+      ),
+    ).toBe("ids");
+  });
+
+  test("does not narrow to a block-ref by array key when it holds no such array", () => {
+    // Guard: the recorded key must not claim a loader whose config has no `ids`.
+    const properties = {
+      enableCta: { title: "Ativar CTA", type: "boolean" },
+      loader: {
+        title: "Loader",
+        type: "block-ref",
+        anyOfRefs: [{ resolveType: "shelf/loader.ts", title: "Shelf" }],
+      },
+    } satisfies Record<string, SchemaProperty>;
+    const objValue = {
+      enableCta: true,
+      loader: { __resolveType: "shelf/loader.ts", banners: [] },
+    };
+    const crumb = buildArrayDrillDownBreadcrumb([], "Ids", "Item 1", 0, {
+      arrayKey: "ids",
+    });
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(properties),
+        properties,
+        objValue,
+        crumb,
+      ),
+    ).toBeNull();
+  });
+
   test("narrows to a loader whose extensions[] item is labelled by __resolveType", () => {
     // ALS /flashsale: the extensions[] item's "DetailsPage" label comes from __resolveType (no name/label/title/alt), so ownership must see it.
     const properties = {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -778,6 +778,10 @@ function resolveActiveFieldKeyInScope(
   const foldedArrayLabels = breadcrumbPath
     .map(crumbArrayLabel)
     .filter((l): l is string => l != null);
+  // The array's own key recorded on each item crumb — a label-free owner probe that still identifies the owning block-ref when a freshly-added (empty) item carries only the generic "Item N" label `valueOwnsItemCrumb` rejects.
+  const crumbFieldKeys = breadcrumbPath
+    .map(crumbFieldKey)
+    .filter((k): k is string => k != null);
   for (const key of keys) {
     const schema = properties[key];
     if (schema?.type !== "block-ref") continue;
@@ -797,6 +801,11 @@ function resolveActiveFieldKeyInScope(
       const data = saved?.data ?? rawVal;
       if (
         valueOwnsItemCrumb(data, head) ||
+        crumbFieldKeys.some(
+          (fk) =>
+            valueOwnsItemCrumb(data, fk) ||
+            blockRefSchemaOwnsArrayLabel(data, fk, meta),
+        ) ||
         foldedArrayLabels.some(
           (al) =>
             valueOwnsItemCrumb(data, al) ||


### PR DESCRIPTION
## Summary

Clicking **"Adicionar item"** on a loader/union **block-ref** array (e.g. VTEX Product Shelf `ids: ProductID[]`) drilled the breadcrumb into "Item 1" but re-rendered the **entire** section form (Variantes / Regra / Products Loader / Select products by / toggles) with the array item inline — instead of a clean item-only screen. It looked like the field wasn't an array at all.

| Antes | Depois (esperado) |
|---|---|
| Adiciona item → form inteiro re-renderiza com o item embutido | Navega para "Item 1", tela só com o item; voltar → o array |

## Root cause

The breadcrumb resolver (`resolveActiveFieldKeyInScope`, `schema-form-breadcrumb.ts`) narrows the panel to the field owning the open item. For **block-ref** containers (a loader, or an embedded block-ref union like "Select products by"), ownership is matched **by the item's display label** (`valueOwnsItemCrumb`).

A freshly-added item is empty (`{ productID: "" }`) and the item schema has no `title`, so `getArrayItemLabel` falls back to the generic **"Item N"** — which `itemOwnershipLabel` deliberately rejects. So no ancestor narrows and the whole form stays visible. Reproduces **only** when the array lives inside a block-ref container; object + inline-union containers already narrow via the structural `fieldKey` fast-path.

## Fix

The item crumb already records the array's own key (`fieldKey`) at drill-in (via `buildArrayDrillDownBreadcrumb` `opts.arrayKey`). Collect those `crumbFieldKeys` from the trail and feed them through the same `valueOwnsItemCrumb` / `blockRefSchemaOwnsArrayLabel` ownership probes already used for the folded array labels — a label-free, structural owner match. Resolution now cascades **section → loader → union → array** even for empty, generic-labelled items. Guarded by the existing `valueOwners.length > 1 → null` ambiguity check.

Same recurring class as the earlier "resolver guesses ownership from display labels" breadcrumb bugs — the durable fix is always to use the structural `fieldKey`, not the label.

## Tests

Added 3 tests to `schema-form-breadcrumb.test.ts`:
- narrows to a loader (block-ref) when a freshly-added item has only a generic label
- narrows to an embedded-union field whose branch owns a generic-labelled item, and cascades down to the array
- negative guard: the recorded key must not claim a block-ref that holds no such array

## Verification
- `bun test src/components/sections-editor/` → **750 pass, 0 fail**
- `bun run --cwd=apps/web check` (tsc) → clean
- `bun run lint` → 0 errors
- `bun run fmt` → applied

## Follow-up (not in this PR)
When "Select products by" is an **embedded** union (not a module loader), the union's own dropdown still shows alongside the drilled item after narrowing (sibling toggles do disappear). Making embedded unions drop their chrome full-width when drilled — like module loaders already do in `AnyOfField` — is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sections-editor breadcrumb navigation so adding an item to a block-ref array (e.g. VTEX Product Shelf `ids: ProductID[]`) opens the item-only screen instead of re-rendering the whole section form.

Previously, ownership was matched by the item's display label, and a freshly-added empty item only has the generic "Item N" label, which was rejected — so no ancestor narrowed. The resolver now also probes the array's own key recorded on the item crumb, giving a label-free structural match that cascades section → loader → union → array.

**Bug Fixes**
- Added 3 tests covering loader narrowing, embedded-union cascading, and a negative guard where the recorded key claims no matching block-ref.

<sup>Written for commit 9dda836469d1d769ff1ec5519f0b63075f62e4a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

