### PR TITLE
refactor(sdk): dedupe virtual-mcp metadata field definitions

### DIFF
--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -710,6 +710,75 @@ const draftsModeMetadataField = z
   );
 
 /**
+ * Shared metadata definition for VirtualMCP entity. Used in VirtualMCPEntitySchema,
+ * VirtualMCPCreateDataSchema, and VirtualMCPUpdateDataSchema to avoid duplication.
+ * Note: instructions is optional here; VirtualMCPEntitySchema makes it required.
+ */
+const VirtualMcpMetadataFields = {
+  instructions: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Instructions also used as system prompt"),
+  enabled_plugins: z
+    .array(z.string())
+    .nullable()
+    .optional()
+    .describe("List of enabled plugin IDs"),
+  subAgents: z
+    .array(z.string())
+    .nullable()
+    .optional()
+    .describe(
+      "Allowlist of Virtual MCP (agent) or concrete MCP connection IDs this agent may delegate to via subtask. Concrete connections create ephemeral subagents. null/absent = all active org targets; empty array = itself only.",
+    ),
+  liveAgentId: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "ID of the live agent this (dev) agent develops. Set only on dev agents; powers the Develop/Live toggle. A dev agent is hidden from the sidebar (reached via the toggle on its live counterpart).",
+    ),
+  ui: VirtualMcpUISchema.nullable()
+    .optional()
+    .describe("UI customization settings"),
+  githubRepo: GithubRepoSchema.nullable()
+    .optional()
+    .describe("Linked GitHub repository"),
+  runtime: RuntimeMetadataSchema.nullable()
+    .optional()
+    .describe(
+      "User-pinned runtime config (package manager, dev port). Empty fields = autodetect.",
+    ),
+  knowledge: knowledgeMetadataField,
+  siteSlug: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Linked asset site slug (managed storage tenancy)"),
+  publishPolicy: publishPolicyMetadataField,
+  previewServerUrl: previewServerUrlMetadataField,
+  productionUrl: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "Legacy key for previewServerUrl — still read as a fallback. New writes use previewServerUrl.",
+    ),
+  fieldDescriptionTooltips: z
+    .boolean()
+    .nullable()
+    .optional()
+    .describe(
+      "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
+    ),
+  fastPreview: fastPreviewMetadataField,
+  releases: releasesMetadataField,
+  draftsMode: draftsModeMetadataField,
+  fastPreviewInPlace: fastPreviewInPlaceMetadataField,
+} as const satisfies z.ZodRawShape;
+
+/**
  * Virtual MCP entity schema - single source of truth
  * Compliant with collections binding pattern
  */
@@ -732,72 +801,16 @@ export const VirtualMCPEntitySchema = z.object({
   status: z.enum(["active", "inactive"]).describe("Current status"),
   pinned: z.boolean().describe("Whether this space is pinned to the sidebar"),
   // Metadata (stored in connections.metadata)
-  // Normalize null/undefined to { instructions: null } for consistent form tracking
   metadata: z
-    .object({
+    .object(VirtualMcpMetadataFields)
+    .extend({
       instructions: z
         .string()
         .nullable()
         .describe("Instructions also used as system prompt"),
-      enabled_plugins: z
-        .array(z.string())
-        .nullable()
-        .optional()
-        .describe("List of enabled plugin IDs"),
-      subAgents: z
-        .array(z.string())
-        .nullable()
-        .optional()
-        .describe(
-          "Allowlist of Virtual MCP (agent) or concrete MCP connection IDs this agent may delegate to via subtask. Concrete connections create ephemeral subagents. null/absent = all active org targets; empty array = itself only.",
-        ),
-      liveAgentId: z
-        .string()
-        .nullable()
-        .optional()
-        .describe(
-          "ID of the live agent this (dev) agent develops. Set only on dev agents; powers the Develop/Live toggle. A dev agent is hidden from the sidebar (reached via the toggle on its live counterpart).",
-        ),
-      ui: VirtualMcpUISchema.nullable()
-        .optional()
-        .describe("UI customization settings"),
-      githubRepo: GithubRepoSchema.nullable()
-        .optional()
-        .describe("Linked GitHub repository"),
-      runtime: RuntimeMetadataSchema.nullable()
-        .optional()
-        .describe(
-          "User-pinned runtime config (package manager, dev port). Empty fields = autodetect.",
-        ),
       sandboxMap: SandboxMapSchema.optional().describe(
         "Per-user, per-branch sandbox mapping: sandboxMap[userId][branch] -> { sandboxHandle, previewUrl }",
       ),
-      knowledge: knowledgeMetadataField,
-      siteSlug: z
-        .string()
-        .nullable()
-        .optional()
-        .describe("Linked asset site slug (managed storage tenancy)"),
-      publishPolicy: publishPolicyMetadataField,
-      previewServerUrl: previewServerUrlMetadataField,
-      productionUrl: z
-        .string()
-        .nullable()
-        .optional()
-        .describe(
-          "Legacy key for previewServerUrl — still read as a fallback. New writes use previewServerUrl.",
-        ),
-      fieldDescriptionTooltips: z
-        .boolean()
-        .nullable()
-        .optional()
-        .describe(
-          "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
-        ),
-      fastPreview: fastPreviewMetadataField,
-      releases: releasesMetadataField,
-      draftsMode: draftsModeMetadataField,
-      fastPreviewInPlace: fastPreviewInPlaceMetadataField,
     })
     .loose()
     .describe("Metadata"),
@@ -851,69 +864,7 @@ export const VirtualMCPCreateDataSchema = z.object({
     .describe("Initial status"),
   pinned: z.boolean().optional().default(false).describe("Pin to sidebar"),
   metadata: z
-    .object({
-      instructions: z
-        .string()
-        .nullable()
-        .optional()
-        .describe("MCP server instructions"),
-      enabled_plugins: z
-        .array(z.string())
-        .nullable()
-        .optional()
-        .describe("List of enabled plugin IDs"),
-      subAgents: z
-        .array(z.string())
-        .nullable()
-        .optional()
-        .describe(
-          "Allowlist of Virtual MCP (agent) or concrete MCP connection IDs this agent may delegate to via subtask. Concrete connections create ephemeral subagents. null/absent = all active org targets; empty array = itself only.",
-        ),
-      liveAgentId: z
-        .string()
-        .nullable()
-        .optional()
-        .describe(
-          "ID of the live agent this (dev) agent develops. Set only on dev agents; powers the Develop/Live toggle. A dev agent is hidden from the sidebar (reached via the toggle on its live counterpart).",
-        ),
-      ui: VirtualMcpUISchema.nullable()
-        .optional()
-        .describe("UI customization settings"),
-      githubRepo: GithubRepoSchema.nullable()
-        .optional()
-        .describe("Linked GitHub repository"),
-      runtime: RuntimeMetadataSchema.nullable()
-        .optional()
-        .describe(
-          "User-pinned runtime config (package manager, dev port). Empty fields = autodetect.",
-        ),
-      knowledge: knowledgeMetadataField,
-      siteSlug: z
-        .string()
-        .nullable()
-        .optional()
-        .describe("Linked asset site slug (managed storage tenancy)"),
-      publishPolicy: publishPolicyMetadataField,
-      previewServerUrl: previewServerUrlMetadataField,
-      productionUrl: z
-        .string()
-        .nullable()
-        .optional()
-        .describe(
-          "Legacy key for previewServerUrl — still read as a fallback. New writes use previewServerUrl.",
-        ),
-      fieldDescriptionTooltips: z
-        .boolean()
-        .nullable()
-        .optional()
-        .describe(
-          "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
-        ),
-      fastPreview: fastPreviewMetadataField,
-      releases: releasesMetadataField,
-      draftsMode: draftsModeMetadataField,
-      fastPreviewInPlace: fastPreviewInPlaceMetadataField,
-    })
+    .object(VirtualMcpMetadataFields)
     .loose()
     .superRefine((metadata, ctx) => {
       if ("sandboxMap" in metadata) {
@@ -956,69 +907,7 @@ export const VirtualMCPUpdateDataSchema = z.object({
   status: z.enum(["active", "inactive"]).optional().describe("New status"),
   pinned: z.boolean().optional().describe("Pin/unpin from sidebar"),
   metadata: z
-    .object({
-      instructions: z
-        .string()
-        .nullable()
-        .optional()
-        .describe("MCP server instructions"),
-      enabled_plugins: z
-        .array(z.string())
-        .nullable()
-        .optional()
-        .describe("List of enabled plugin IDs"),
-      subAgents: z
-        .array(z.string())
-        .nullable()
-        .optional()
-        .describe(
-          "Allowlist of Virtual MCP (agent) or concrete MCP connection IDs this agent may delegate to via subtask. Concrete connections create ephemeral subagents. null/absent = all active org targets; empty array = itself only.",
-        ),
-      liveAgentId: z
-        .string()
-        .nullable()
-        .optional()
-        .describe(
-          "ID of the live agent this (dev) agent develops. Set only on dev agents; powers the Develop/Live toggle. A dev agent is hidden from the sidebar (reached via the toggle on its live counterpart).",
-        ),
-      ui: VirtualMcpUISchema.nullable()
-        .optional()
-        .describe("UI customization settings"),
-      githubRepo: GithubRepoSchema.nullable()
-        .optional()
-        .describe("Linked GitHub repository"),
-      runtime: RuntimeMetadataSchema.nullable()
-        .optional()
-        .describe(
-          "User-pinned runtime config (package manager, dev port). Empty fields = autodetect.",
-        ),
-      knowledge: knowledgeMetadataField,
-      siteSlug: z
-        .string()
-        .nullable()
-        .optional()
-        .describe("Linked asset site slug (managed storage tenancy)"),
-      publishPolicy: publishPolicyMetadataField,
-      previewServerUrl: previewServerUrlMetadataField,
-      productionUrl: z
-        .string()
-        .nullable()
-        .optional()
-        .describe(
-          "Legacy key for previewServerUrl — still read as a fallback. New writes use previewServerUrl.",
-        ),
-      fieldDescriptionTooltips: z
-        .boolean()
-        .nullable()
-        .optional()
-        .describe(
-          "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
-        ),
-      fastPreview: fastPreviewMetadataField,
-      releases: releasesMetadataField,
-      draftsMode: draftsModeMetadataField,
-      fastPreviewInPlace: fastPreviewInPlaceMetadataField,
-    })
+    .object(VirtualMcpMetadataFields)
     .loose()
     .superRefine((metadata, ctx) => {
       if ("sandboxMap" in metadata) {


### PR DESCRIPTION
## Summary

Extracts the 16-field metadata object definition into a shared `VirtualMcpMetadataFields` constant, eliminating ~140 lines of copy-paste across three schemas: `VirtualMCPEntitySchema`, `VirtualMCPCreateDataSchema`, and `VirtualMCPUpdateDataSchema`.

## Details

**Problem**: The metadata object was defined in full three times in the file (lines 736–803, 853–916, 958–1021), differing only in whether `instructions` was required or optional.

**Solution**: Extract a shared `VirtualMcpMetadataFields` constant with optional `instructions`. Entity schema uses `.extend()` to override it as required; create/update inherit the optional version directly.

**Net reduction**: -111 lines (73 added, 184 removed).

## Verification

- ✅ `bun run fmt` — passed  
- ✅ `bunx tsc --noEmit` in packages/shared — passed  
- ✅ `bun test packages/shared/src/sdk/types/virtual-mcp.test.ts` — 27 tests passed  
- ✅ `bunx oxlint packages/shared/src/sdk/types/virtual-mcp.ts` — 0 errors  

All exports and validation behavior unchanged; behavior-preserving refactor of duplication (C1 reduction).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the Virtual MCP metadata schema in `packages/shared` to remove ~140 lines of duplicated field definitions.

Extracts the shared 16-field metadata object into a `VirtualMcpMetadataFields` constant used by `VirtualMCPEntitySchema`, `VirtualMCPCreateDataSchema`, and `VirtualMCPUpdateDataSchema`. The entity schema keeps `instructions` required by extending the shared definition; create and update schemas inherit it as optional. All exports and validation behavior are unchanged.

<sup>Written for commit d7ec19f8517902c0555ea3520e5044ec81e16e00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

