### PR TITLE
fix(storage): strip identity/ownership fields in ConnectionStorage.update

### DIFF
--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -405,6 +405,16 @@ export class ConnectionStorage implements ConnectionStoragePort {
     id: string,
     data: Partial<ConnectionEntity>,
   ): Promise<ConnectionEntity> {
+    // Storage is the real trust boundary: never let identity/ownership columns reach the SET clause.
+    const {
+      id: _id,
+      organization_id: _organizationId,
+      created_by: _createdBy,
+      created_at: _createdAt,
+      ...safeData
+    } = data;
+    data = safeData;
+
     if (Object.keys(data).length === 0) {
       const connection = await this.findById(id);
       if (!connection) throw new Error("Connection not found");


### PR DESCRIPTION
**Source**: connection storage hardening (apps/api/src/storage/connection.ts) — not tied to an issue.

**Why**: `COLLECTION_CONNECTIONS_UPDATE` already strips `id`/`organization_id`/`created_by`/`created_at` from its input before calling `storage.connections.update()` (see `stripImmutableUpdateFields` in `apps/api/src/tools/connection/update.ts`, whose own comment spells out the exact risk: a caller could reassign a connection's org, forge its creator, backdate it, or rewrite its id). But that guard lives in one tool, not in storage itself. `ConnectionStorage.update()` blindly spreads whatever `Partial<ConnectionEntity>` it receives into the SQL `SET` clause, so any other or future caller of this storage method — a route, an admin tool, a script — inherits none of that protection. This moves the guard to the actual trust boundary (storage), which is where it belongs and where it protects every caller, not just one.

**Failure scenario prevented**: a caller of `ctx.storage.connections.update(id, data)` that forgets to strip `organization_id` before calling would silently move a connection to a different org, or forge `created_by`/`created_at`, or rewrite the row's `id` via the `SET` clause — with no error, no audit signal.

**Change**: `update()` now destructures `id`/`organization_id`/`created_by`/`created_at` out of the incoming `data` before doing anything else, so those columns can never appear in the generated `SET` clause. This does not change behavior for the existing sole caller (`COLLECTION_CONNECTIONS_UPDATE`), which already strips these fields before calling storage — its update payload never carries them, so the new destructure is a no-op there. Internally, `create()` calls `this.update(id, data)` when a matching id already exists in the same org; that `data` may still carry `organization_id`/`created_by`/`created_at` from the original caller, but since the row already exists with those exact values, stripping them here does not change the resulting row — it only prevents the outer `SET` from re-touching (or overriding) values that must stay fixed once a connection exists.

**Verify**: `cd apps/api && bunx tsc --noEmit` (green). The connection storage tests are integration tests requiring Postgres (`apps/api/src/storage/connection.integration.test.ts`), not runnable in this sandbox; I checked it exercises `update()` only with ordinary field changes (never `organization_id`/`created_by`/`created_at`/`id`), so this change doesn't alter any asserted behavior there — full CI runs it for real.

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/storage/connection.ts` (0 warnings/errors). Full CI (incl. the Postgres-backed integration suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the stripping of immutable identity/ownership fields (`id`, `organization_id`, `created_by`, `created_at`) into `ConnectionStorage.update()` so no caller can ever modify them via the SQL SET clause. Previously only the one existing caller stripped these fields, leaving other potential callers unprotected. This change is a no-op for the current caller and prevents future misassignment or forgery.

<sup>Written for commit e553c983344fff30217ab11a90349fb36db117c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

