### PR TITLE
fix(agents): resume last branch when entering a repo-backed agent

### DIFF
--- a/apps/web/src/components/header/shell-breadcrumb.tsx
+++ b/apps/web/src/components/header/shell-breadcrumb.tsx
@@ -24,14 +24,16 @@ import {
   getWellKnownDecopilotVirtualMCP,
   useProjectContext,
   useVirtualMCP,
+  useVirtualMCPs,
 } from "@/sdk";
+import { getActiveGithubRepo } from "@/lib/github-repo";
 import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
 import { AgentAvatar } from "@/components/agent-icon";
 import { OrgIcon, OrgSwitcherPopover } from "@/components/header/org-switcher";
 import { AgentScopePicker } from "@/components/sidebar/agents-section";
 import { useThreads } from "@/components/chat/store/hooks";
 import { usePanelActions } from "@/layouts/shell-layout";
-import { findReusableNewChat } from "@/lib/reusable-new-chat";
+import { findAgentEntryThread } from "@/lib/reusable-new-chat";
 import { useProjectDefaultRuntime } from "@/sdk/project-default-runtime";
 import { authClient } from "@/lib/auth-client.ts";
 import { usePendingInvitations } from "@/hooks/use-pending-invitations";
@@ -179,6 +181,7 @@ export function AgentSwitcherCrumb({
 } = {}) {
   const { org } = useProjectContext();
   const { threads } = useThreads();
+  const allAgents = useVirtualMCPs();
   const { data: session } = authClient.useSession();
   const { setTaskId, createNewTask } = usePanelActions();
   const projectDefaultRuntime = useProjectDefaultRuntime();
@@ -196,11 +199,13 @@ export function AgentSwitcherCrumb({
   // Decopilot id.
   const handlePickAgent = (id: string | null) => {
     const targetId = id ?? decopilotId;
-    const existing = findReusableNewChat(
+    const target = (allAgents ?? []).find((a) => a.id === targetId);
+    const existing = findAgentEntryThread(
       threads,
       targetId,
       session?.user?.id,
       projectDefaultRuntime(targetId),
+      !!(target && getActiveGithubRepo(target)),
     );
     if (existing) {
       setTaskId(existing.id, targetId);

--- a/apps/web/src/hooks/use-navigate-to-agent.ts
+++ b/apps/web/src/hooks/use-navigate-to-agent.ts
@@ -16,7 +16,8 @@ import { appendAgentToPersonalOrder } from "@/components/sidebar/task-groups/sta
 import { useBumpSidebarOrderRevision } from "@/components/sidebar/sidebar-agent-groups-context";
 import { useOptionalThreadManager } from "@/components/chat/store/hooks";
 import type { Task } from "@/components/chat/task/types";
-import { findReusableNewChat } from "@/lib/reusable-new-chat";
+import { findAgentEntryThread } from "@/lib/reusable-new-chat";
+import { getActiveGithubRepo } from "@/lib/github-repo";
 import { defaultThreadRuntime } from "@decocms/shared/thread/session-runtime";
 
 const NO_THREADS: Task[] = [];
@@ -60,15 +61,15 @@ export function useNavigateToAgent() {
       serverPinnedIds,
     );
     bumpOrderRevision();
-    // Focus the agent's existing empty chat if it has one; otherwise a fresh id
-    // (the route loader's ensure-fallback creates the thread on landing).
+    // Resume the last branch (repo-backed) or the empty chat, else a fresh id.
     const target = (allAgents ?? []).find((a) => a.id === virtualMcpId);
     const taskId =
-      findReusableNewChat(
+      findAgentEntryThread(
         threads,
         virtualMcpId,
         session?.user?.id,
         target ? defaultThreadRuntime(target.metadata) : undefined,
+        !!(target && getActiveGithubRepo(target)),
       )?.id ?? crypto.randomUUID();
     const view = options?.panel ? panelLocationForTab(options.panel) : null;
     navigate({

--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -49,7 +49,7 @@ import { agentHasClonableSource } from "@/lib/agent-capabilities";
 import { generateBranchName } from "@decocms/shared/branch-name";
 import { defaultThreadRuntime } from "@decocms/shared/thread/session-runtime";
 import { useThreadManager } from "@/components/chat/store/hooks";
-import { findReusableNewChat } from "@/lib/reusable-new-chat";
+import { findAgentEntryThread } from "@/lib/reusable-new-chat";
 import { Navigate, useNavigate, useParams } from "@tanstack/react-router";
 import { useIsSandboxStartPending } from "@/components/sandbox/hooks/use-sandbox-start";
 import { useStatusSounds } from "../../hooks/use-status-sounds";
@@ -635,13 +635,14 @@ function AgentInsetProvider() {
    * Super Agent (no repo) keeps its lazy threadless composer.
    */
   if (routeThreadId === null && hasActiveGithubRepo) {
-    // Focus the user's idle empty chat for this agent, else mint one — as useNavigateToAgent does.
+    // Resume the last branch for this repo-backed agent, else its empty chat, else mint one.
     const threadId =
-      findReusableNewChat(
+      findAgentEntryThread(
         threads,
         virtualMcpId,
         session?.user?.id,
         defaultThreadRuntime(entity.metadata),
+        hasActiveGithubRepo,
       )?.id ?? generatedThreadId;
     return (
       <Navigate

--- a/apps/web/src/lib/find-last-thread-for-agent.ts
+++ b/apps/web/src/lib/find-last-thread-for-agent.ts
@@ -1,29 +1,20 @@
 import type { Task } from "@/components/chat/task/types";
+import { threadRuntimeMatches } from "@/lib/thread-runtime-match";
+import type { ThreadRuntime } from "@decocms/shared/thread/session-runtime";
 
-/**
- * The current user's most-recently-updated non-archived thread with `agentId`,
- * or null when they have none. Scans an already-loaded thread list (the
- * ThreadManager's org-wide "Mine" page, ordered `updated_at` desc) — used by
- * the sidebar agent rows to resume the last conversation instead of always
- * landing on an empty composer.
- *
- * `created_by === userId` scopes the match to the current user — the list is
- * org-wide (it carries teammates' threads for the activity view), so without it
- * we'd resume a teammate's read-only thread. `!hidden` skips archived threads.
- * Returns null when nothing matches, so callers fall back to the empty-composer
- * behavior. Unlike `findReusableNewChat` this intentionally does NOT gate on
- * `title`/`harness_id`: we want the last *real* conversation, empty or not.
- */
+/** Current user's most-recently-updated non-archived thread for `agentId` (optionally runtime-matched), or null — the last *real* thread, empty or not. */
 export function findLastThreadForAgent(
   threads: Task[],
   agentId: string,
   userId: string | undefined,
+  expectedRuntime?: ThreadRuntime,
 ): Task | null {
   let best: Task | null = null;
   for (const t of threads) {
     if (t.virtual_mcp_id !== agentId) continue;
     if (t.created_by !== userId) continue;
     if (t.hidden) continue;
+    if (!threadRuntimeMatches(t, expectedRuntime)) continue;
     if (!best || t.updated_at > best.updated_at) best = t;
   }
   return best;

--- a/apps/web/src/lib/reusable-new-chat.test.ts
+++ b/apps/web/src/lib/reusable-new-chat.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { Task } from "@/components/chat/task/types";
-import { findReusableNewChat } from "./reusable-new-chat";
+import { findAgentEntryThread, findReusableNewChat } from "./reusable-new-chat";
 
 const USER = "user-1";
 
@@ -115,5 +115,71 @@ describe("findReusableNewChat", () => {
         "sandbox",
       );
     });
+  });
+});
+
+describe("findAgentEntryThread", () => {
+  const empty = task({
+    id: "empty",
+    title: "New chat",
+    updated_at: "2026-01-01T00:00:00Z",
+  });
+  const lastReal = task({
+    id: "last",
+    title: "Fix the login bug",
+    harness_id: "claude-code",
+    branch: "tavano-newbranch",
+    updated_at: "2026-02-01T00:00:00Z",
+  });
+
+  // Inverts the old always-reuse-empty behavior that stranded repo-backed agents on the empty chat's stale branch.
+  it("resumes the most-recent real thread (last branch) for a repo-backed agent", () => {
+    expect(
+      findAgentEntryThread([empty, lastReal], "agent-1", USER, undefined, true)
+        ?.id,
+    ).toBe("last");
+  });
+
+  it("keeps reusing the empty chat for a branchless agent", () => {
+    expect(
+      findAgentEntryThread([empty, lastReal], "agent-1", USER, undefined, false)
+        ?.id,
+    ).toBe("empty");
+  });
+
+  it("falls back to the empty chat when a repo-backed agent has no real thread", () => {
+    expect(
+      findAgentEntryThread([empty], "agent-1", USER, undefined, true)?.id,
+    ).toBe("empty");
+  });
+
+  it("returns undefined when nothing matches (caller mints a fresh id)", () => {
+    expect(
+      findAgentEntryThread([], "agent-1", USER, undefined, true),
+    ).toBeUndefined();
+  });
+
+  it("never resumes a thread of the other runtime for a repo-backed agent", () => {
+    const cmsReal = task({
+      id: "cms-real",
+      title: "Edit copy",
+      harness_id: "decopilot",
+      metadata: { runtime: "cms" },
+      updated_at: "2026-03-01T00:00:00Z",
+    });
+    const sandboxEmpty = task({
+      id: "sandbox-empty",
+      metadata: { runtime: "sandbox" },
+      updated_at: "2026-01-01T00:00:00Z",
+    });
+    expect(
+      findAgentEntryThread(
+        [cmsReal, sandboxEmpty],
+        "agent-1",
+        USER,
+        "sandbox",
+        true,
+      )?.id,
+    ).toBe("sandbox-empty");
   });
 });

--- a/apps/web/src/lib/reusable-new-chat.ts
+++ b/apps/web/src/lib/reusable-new-chat.ts
@@ -1,5 +1,6 @@
 import type { Task } from "@/components/chat/task/types";
-import { parseThreadRuntime } from "@decocms/shared/thread/session-runtime";
+import { findLastThreadForAgent } from "@/lib/find-last-thread-for-agent";
+import { threadRuntimeMatches } from "@/lib/thread-runtime-match";
 import type { ThreadRuntime } from "@decocms/shared/thread/session-runtime";
 
 /**
@@ -36,25 +37,23 @@ export function findReusableNewChat(
       t.created_by === userId &&
       t.title === "New chat" &&
       !t.harness_id &&
-      runtimeMatches(t, expectedRuntime),
+      threadRuntimeMatches(t, expectedRuntime),
   );
 }
 
-/**
- * A thread's runtime is immutable, so an empty chat stamped with the OTHER
- * runtime is not reusable — focusing it would silently drop the user into a
- * coding session (or a CMS one) they didn't ask for.
- *
- * An unstamped row always matches: it predates the stamp and resolves to the
- * project default by definition. `undefined` — the caller couldn't resolve the
- * project — keeps the pre-existing unfiltered behavior rather than guessing.
- */
-function runtimeMatches(thread: Task, expected: ThreadRuntime | undefined) {
-  if (!expected) return true;
-  // A `/watch` synthetic carries no metadata, so its absent stamp is "not
-  // loaded", not "unstamped" — trusting it would reuse a CMS chat for a coding
-  // session (or the reverse) on nothing more than a race with the feed.
-  if (thread.partial) return false;
-  const stamp = parseThreadRuntime(thread.metadata?.runtime);
-  return stamp === null || stamp === expected;
+/** Thread to land on when *entering* an agent: a `hasBranch` agent resumes its last real thread (last branch worked on); else reuse the empty chat, then `undefined` (caller mints a fresh id). */
+export function findAgentEntryThread(
+  threads: Task[],
+  agentId: string,
+  userId: string | undefined,
+  expectedRuntime: ThreadRuntime | undefined,
+  hasBranch: boolean,
+): Task | undefined {
+  if (hasBranch) {
+    return (
+      findLastThreadForAgent(threads, agentId, userId, expectedRuntime) ??
+      findReusableNewChat(threads, agentId, userId, expectedRuntime)
+    );
+  }
+  return findReusableNewChat(threads, agentId, userId, expectedRuntime);
 }

--- a/apps/web/src/lib/thread-runtime-match.ts
+++ b/apps/web/src/lib/thread-runtime-match.ts
@@ -1,0 +1,28 @@
+import type { Task } from "@/components/chat/task/types";
+import { parseThreadRuntime } from "@decocms/shared/thread/session-runtime";
+import type { ThreadRuntime } from "@decocms/shared/thread/session-runtime";
+
+/**
+ * Whether a thread is reusable for a session of `expected` runtime.
+ *
+ * A thread's runtime is immutable, so an empty chat stamped with the OTHER
+ * runtime is not reusable — focusing it would silently drop the user into a
+ * coding session (or a CMS one) they didn't ask for.
+ *
+ * An unstamped row always matches: it predates the stamp and resolves to the
+ * project default by definition. `undefined` — the caller couldn't resolve the
+ * project — keeps the pre-existing unfiltered behavior rather than guessing.
+ *
+ * A `partial` (`/watch` synthetic) thread carries no metadata, so its absent
+ * stamp is "not loaded", not "unstamped" — never reuse it, to avoid crossing
+ * runtimes on a race with the feed.
+ */
+export function threadRuntimeMatches(
+  thread: Task,
+  expected: ThreadRuntime | undefined,
+) {
+  if (!expected) return true;
+  if (thread.partial) return false;
+  const stamp = parseThreadRuntime(thread.metadata?.runtime);
+  return stamp === null || stamp === expected;
+}


### PR DESCRIPTION
## Summary

Entering a repo-backed agent kept landing the user on a **stale branch**. The entry points (`useNavigateToAgent`, the URL-has-no-`?thread=` redirect, and the breadcrumb agent picker) used `findReusableNewChat`, which re-focuses the same empty **"New chat"** thread every time. That thread's `branch` is minted once at creation (`generateBranchName` → e.g. `tavano-rdhxlysm`) and never changes, so re-entering always resurfaced the old branch — even after the user created and worked on a newer one in another thread.

## Fix

New `findAgentEntryThread(threads, agentId, userId, runtime, hasBranch)`:
- **repo-backed agent** (`hasBranch`, via `getActiveGithubRepo`) → resume the most-recently-updated real thread (its branch = the last branch worked on), runtime-matched — same heuristic the sidebar rows already use.
- **branchless agent** (Super Agent) → keep the original reuse-empty-chat behavior (avoids piling up duplicate empty threads).
- Falls back to the empty chat, then `undefined` (caller mints a fresh id).

The explicit **"+ New chat"** button (`use-threads-panel`) is intentionally left on `findReusableNewChat` — clicking it should start fresh, not resume.

### Draft & Releases mode
Covered by the same path, no separate branch-selection needed. The gate is repo presence (independent of `draftsMode`), and drafts mode still keys on the per-thread `branch` — a "release" is only a name+color overlay in `vm.metadata.releases`. The drafts picker reads `value={currentBranch}`, so it reflects the resumed branch automatically.

## Files
- `lib/thread-runtime-match.ts` (new) — extracted `threadRuntimeMatches` (breaks the import cycle between the two resolvers).
- `lib/reusable-new-chat.ts` — `findAgentEntryThread`.
- `lib/find-last-thread-for-agent.ts` — now accepts an optional `expectedRuntime` and skips threads of the other runtime.
- Entry points: `hooks/use-navigate-to-agent.ts`, `layouts/agent-shell-layout/index.tsx`, `components/header/shell-breadcrumb.tsx`.

## Testing
- `bun test` on both resolver suites: 27 pass. Added `findAgentEntryThread` cases (resume last real thread, branchless fallback, empty-only fallback, none→undefined, cross-runtime skip) — inverting the old always-reuse-empty expectation.
- `bun run --cwd=apps/web check` clean; `bun run fmt` / `lint` clean (no new warnings).

## Behavior note
Re-entering a repo-backed agent now **resumes the last conversation/branch** instead of always opening an empty composer (Conductor/Cursor-style). Start fresh via "+ New chat".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes entering a repo-backed agent so it resumes the last real conversation (its branch) instead of always re-focusing the same empty "New chat" thread, which was stuck on the branch minted at creation. Start fresh via the "+ New chat" button.

- New `findAgentEntryThread` drives all three entry points (navigate, URL-without-thread redirect, breadcrumb picker) and falls back to the empty chat, then a fresh thread id.
- Branchless agents (Super Agent) keep the reuse-empty-chat behavior so duplicate empty threads don't pile up.
- Runtime matching moved into `threadRuntimeMatches` to break an import cycle between the two resolvers.
- Applies to Draft & Releases mode since the gate is repo presence; the drafts picker reads the resumed branch automatically.

<sup>Written for commit d4aa527344bc1a6392af92bb0f5ee05b3c25bdcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

