### PR TITLE
fix(task-board): resolve the conflict auto-resolve gate from the board's own lanes

### DIFF
--- a/apps/api/src/tools/task-board/conflict-reaction.test.ts
+++ b/apps/api/src/tools/task-board/conflict-reaction.test.ts
@@ -6,7 +6,11 @@
  */
 import { describe, expect, it } from "bun:test";
 import type { ReviewCycleActivity } from "@decocms/shared/task-board";
-import { conflictResolutionCapReached } from "./conflict-reaction";
+import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
+import {
+  conflictResolutionCapReached,
+  isConflictResolutionCandidate,
+} from "./conflict-reaction";
 
 const at = "2026-08-03T00:00:00.000Z";
 const resolution = (): ReviewCycleActivity => ({
@@ -53,6 +57,53 @@ describe("conflictResolutionCapReached", () => {
         resolution(),
         other(),
       ]),
+    ).toBe(false);
+  });
+});
+
+describe("isConflictResolutionCandidate", () => {
+  const item = { status: "in_review", assigneeId: SUPER_AGENT_ASSIGNEE_ID };
+
+  it("is true for an In Review Super Agent task with a detected conflict", () => {
+    expect(isConflictResolutionCandidate(item, "in_review", true)).toBe(true);
+  });
+
+  it("matches an org-owned board's own review column name, not Studio's literal", () => {
+    const orgItem = {
+      status: "col-review",
+      assigneeId: SUPER_AGENT_ASSIGNEE_ID,
+    };
+    expect(isConflictResolutionCandidate(orgItem, "col-review", true)).toBe(
+      true,
+    );
+    // The literal Studio uses is meaningless once the board renamed its column.
+    expect(isConflictResolutionCandidate(orgItem, "in_review", true)).toBe(
+      false,
+    );
+  });
+
+  it("is false for a human-owned task", () => {
+    expect(
+      isConflictResolutionCandidate(
+        { status: "in_review", assigneeId: "user-1" },
+        "in_review",
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("is false without a confirmed conflict", () => {
+    expect(isConflictResolutionCandidate(item, "in_review", null)).toBe(false);
+    expect(isConflictResolutionCandidate(item, "in_review", false)).toBe(false);
+  });
+
+  it("is false once the task moved on", () => {
+    expect(
+      isConflictResolutionCandidate(
+        { status: "in_progress", assigneeId: SUPER_AGENT_ASSIGNEE_ID },
+        "in_review",
+        true,
+      ),
     ).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/conflict-reaction.ts
+++ b/apps/api/src/tools/task-board/conflict-reaction.ts
@@ -21,6 +21,23 @@ import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
  */
 const MAX_AUTO_CONFLICT_RESOLUTIONS = 3;
 
+/** True when this task is a candidate for auto conflict-resolution: an In
+ *  Review task delegated to the Super Agent with a detected conflict. `reviewLane`
+ *  is this board's own In Review column, not Studio's literal `"in_review"` — an
+ *  org-owned board (`org_board_columns`) names it something else. Pure, so the
+ *  org-lane case is unit-tested without a database. */
+export function isConflictResolutionCandidate(
+  item: { status: string; assigneeId: string | null },
+  reviewLane: string | null,
+  conflict: boolean | null,
+): boolean {
+  return (
+    item.status === reviewLane &&
+    item.assigneeId === SUPER_AGENT_ASSIGNEE_ID &&
+    conflict === true
+  );
+}
+
 /** True once a task has hit its all-time cap of auto conflict-resolution
  *  dispatches — counted from the `merge_conflict_resolution` activity entries,
  *  which persist across review cycles (so the cap doesn't reset when the task
@@ -69,12 +86,10 @@ export async function reactToApprovedPrConflict(
   item: TaskBoardItem,
   opts: { pr: { number: number; url: string }; conflict: boolean | null },
 ): Promise<boolean> {
-  // Only an In Review task delegated to the Super Agent is a candidate — a
-  // human-owned review never gets an automatic run, and a task already moved on
-  // (In Progress, Done) must not be bounced.
-  if (item.status !== "in_review") return false;
-  if (item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID) return false;
-  if (opts.conflict !== true) return false;
+  const lanes = await boardLanes(ctx, orgId);
+  if (!isConflictResolutionCandidate(item, lanes.review, opts.conflict)) {
+    return false;
+  }
 
   const settings = await ctx.storage.organizationSettings.get(orgId);
   const flags = settings?.flags ?? {};
@@ -111,7 +126,6 @@ export async function reactToApprovedPrConflict(
   // for the single winner only, so the activity log (which feeds the cap count)
   // stays accurate. No `status_changed` entry — mirrors the request_changes
   // bounce; the review cycle resets only when the run advances back to In Review.
-  const lanes = await boardLanes(ctx, orgId);
   // The fence moves the card between these two, and the failure path moves it
   // back. Narrowing here is what lets the revert below write a string rather
   // than an "undefined means leave it alone" that would strand the card.

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -1210,10 +1210,11 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
     // poll. Gated on assignee === Super Agent so it never fires for a human's
     // manual review; `enqueueEnabledReviewers` is itself idempotent per reviewer
     // per review cycle, so re-polling won't spawn duplicate reviewer runs.
+    const reviewLane = (await boardLanes(ctx, organizationId)).review;
     const openPr = prs.find((p) => p.state === "open" && !p.merged);
     if (
       item &&
-      inReviewPhase(item, (await boardLanes(ctx, organizationId)).review) &&
+      inReviewPhase(item, reviewLane) &&
       item.assigneeId === SUPER_AGENT_ASSIGNEE_ID &&
       prReadyForReview(prs)
     ) {
@@ -1238,7 +1239,7 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
       : null;
     if (
       item &&
-      item.status === "in_review" &&
+      item.status === reviewLane &&
       item.assigneeId === SUPER_AGENT_ASSIGNEE_ID &&
       openPr &&
       openPrConflict === true


### PR DESCRIPTION
Same bug class as #6849 and #6854 ("advanceToReviewIfInProgress" and the failed-run reaction both hardcoded a Studio lane literal instead of reading the org board's own column), found in the conflict auto-resolve path this time.

`TASK_BOARD_ITEM_PRS_GET`'s conflict auto-resolve trigger compared `item.status === "in_review"`, and `reactToApprovedPrConflict`'s own entry gate compared `item.status !== "in_review"` — both against the literal Studio uses, even though `reactToApprovedPrConflict` already fetches `boardLanes(ctx, orgId)` a few lines later and uses `lanes.review`/`lanes.progress` everywhere else in the same function. On an org-owned board (`org_board_columns`) whose In Review column is named anything else, both comparisons never match: an approved PR that develops a merge conflict with its base branch is never auto-handed back to the Super Agent to resolve — it just sits there, silently, forever.

Fix: hoist the `boardLanes` fetch in both files and compare against `lanes.review` instead of the literal. In `conflict-reaction.ts` the guard is also pulled out into a small pure `isConflictResolutionCandidate` helper, matching the file's existing "Pure — unit-tested" pattern, so the org-lane case is covered without a database.

No behavior change for Studio's own board: `STUDIO_LANES.review` is still the literal `"in_review"`, so `lanes.review` resolves to the same value there.

To confirm: `bun test apps/api/src/tools/task-board/conflict-reaction.test.ts` (9 pass, including the new org-lane cases), plus `cd apps/api && bunx tsc --noEmit` and `bunx oxlint` on the three changed files, all clean locally. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the conflict auto-resolve gate so it checks the board's own In Review column instead of Studio's hardcoded `"in_review"` literal. On org-owned boards with a renamed In Review column, approved PRs with merge conflicts were never auto-handed back to the Super Agent; they now are.

- Extracts the entry gate in `conflict-reaction.ts` into a pure `isConflictResolutionCandidate` helper, unit-tested for the org-lane case.
- No behavior change for Studio's own board, where the review lane still resolves to `"in_review"`.

<sup>Written for commit 8a757e01d83a5adcc661589b847d0113a058dd1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

