### PR TITLE
fix(decopilot): rewrite MCP schema property keys Anthropic rejects

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/mcp-tools.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/mcp-tools.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { hasLlmSafeInputSchema } from "./mcp-tools";
+
+describe("hasLlmSafeInputSchema", () => {
+  it("accepts safe keys and schemas without properties", () => {
+    expect(hasLlmSafeInputSchema({ type: "object" })).toBe(true);
+    expect(
+      hasLlmSafeInputSchema({ properties: { "a.b-c_1": {}, x: {} } }),
+    ).toBe(true);
+  });
+
+  it("rejects invalid characters, empty keys and keys over 64 chars", () => {
+    expect(
+      hasLlmSafeInputSchema({ properties: { "site/sections/A.tsx": {} } }),
+    ).toBe(false);
+    expect(hasLlmSafeInputSchema({ properties: { "": {} } })).toBe(false);
+    expect(
+      hasLlmSafeInputSchema({ properties: { [`k${"x".repeat(64)}`]: {} } }),
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/harnesses/lib/decopilot/mcp-tools.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/mcp-tools.test.ts
@@ -1,21 +1,43 @@
 import { describe, expect, it } from "bun:test";
-import { hasLlmSafeInputSchema } from "./mcp-tools";
+import { llmSafeInputSchema } from "./mcp-tools";
 
-describe("hasLlmSafeInputSchema", () => {
-  it("accepts safe keys and schemas without properties", () => {
-    expect(hasLlmSafeInputSchema({ type: "object" })).toBe(true);
-    expect(
-      hasLlmSafeInputSchema({ properties: { "a.b-c_1": {}, x: {} } }),
-    ).toBe(true);
+describe("llmSafeInputSchema", () => {
+  it("passes safe schemas through untouched", () => {
+    const schema = { type: "object", properties: { "a.b-c_1": {}, x: {} } };
+    const result = llmSafeInputSchema(schema);
+    expect(result.schema).toBe(schema);
+    expect(result.keyMap.size).toBe(0);
+    expect(llmSafeInputSchema({ type: "object" }).schema).toEqual({
+      type: "object",
+    });
   });
 
-  it("rejects invalid characters, empty keys and keys over 64 chars", () => {
-    expect(
-      hasLlmSafeInputSchema({ properties: { "site/sections/A.tsx": {} } }),
-    ).toBe(false);
-    expect(hasLlmSafeInputSchema({ properties: { "": {} } })).toBe(false);
-    expect(
-      hasLlmSafeInputSchema({ properties: { [`k${"x".repeat(64)}`]: {} } }),
-    ).toBe(false);
+  it("renames unsafe keys, keeps required in sync and maps back", () => {
+    const long = `k${"x".repeat(70)}`;
+    const { schema, keyMap } = llmSafeInputSchema({
+      type: "object",
+      properties: { "site/sections/A.tsx": { type: "string" }, [long]: {} },
+      required: ["site/sections/A.tsx"],
+    });
+    const keys = Object.keys(
+      (schema as { properties: Record<string, unknown> }).properties,
+    );
+    expect(keys).toEqual(["site_sections_A.tsx", long.slice(0, 64)]);
+    expect((schema as { required: string[] }).required).toEqual([
+      "site_sections_A.tsx",
+    ]);
+    expect(keyMap.get("site_sections_A.tsx")).toBe("site/sections/A.tsx");
+    expect(keyMap.get(long.slice(0, 64))).toBe(long);
+  });
+
+  it("does not collide with an existing safe key", () => {
+    const { schema, keyMap } = llmSafeInputSchema({
+      properties: { a_b: {}, "a/b": {} },
+    });
+    const keys = Object.keys(
+      (schema as { properties: Record<string, unknown> }).properties,
+    );
+    expect(keys).toEqual(["a_b", "a_b_2"]);
+    expect(keyMap.get("a_b_2")).toBe("a/b");
   });
 });

--- a/apps/api/src/harnesses/lib/decopilot/mcp-tools.ts
+++ b/apps/api/src/harnesses/lib/decopilot/mcp-tools.ts
@@ -34,14 +34,77 @@ export function toolNeedsApproval(
 
 /** Anthropic rejects the WHOLE request (400) if any tool's
  *  `input_schema.properties` has a key outside this pattern, so one bad MCP
- *  tool kills every run. Drop that tool instead of the run. */
+ *  tool kills every run. Rename those keys for the model and map them back on
+ *  call. Only top-level keys are validated upstream, so only those are touched.
+ */
 const LLM_SAFE_PROPERTY_KEY = /^[a-zA-Z0-9_.-]{1,64}$/;
 
-export function hasLlmSafeInputSchema(inputSchema: unknown): boolean {
+function sanitizePropertyKey(key: string): string {
+  const safe = key.replace(/[^a-zA-Z0-9_.-]/g, "_").slice(0, 64);
+  return safe.length > 0 ? safe : "_";
+}
+
+/** Schema with LLM-safe top-level property keys, plus safeKey -> originalKey
+ *  for the renamed ones (empty when nothing needed renaming). */
+export function llmSafeInputSchema(inputSchema: unknown): {
+  schema: unknown;
+  keyMap: Map<string, string>;
+} {
+  const keyMap = new Map<string, string>();
   const properties = (inputSchema as { properties?: unknown } | null)
     ?.properties;
-  if (properties == null || typeof properties !== "object") return true;
-  return Object.keys(properties).every((k) => LLM_SAFE_PROPERTY_KEY.test(k));
+  if (properties == null || typeof properties !== "object") {
+    return { schema: inputSchema, keyMap };
+  }
+  const keys = Object.keys(properties);
+  if (keys.every((k) => LLM_SAFE_PROPERTY_KEY.test(k))) {
+    return { schema: inputSchema, keyMap };
+  }
+
+  const used = new Set(keys.filter((k) => LLM_SAFE_PROPERTY_KEY.test(k)));
+  const rename = new Map<string, string>();
+  for (const key of keys) {
+    if (LLM_SAFE_PROPERTY_KEY.test(key)) continue;
+    let safe = sanitizePropertyKey(key);
+    if (used.has(safe)) {
+      const base = safe.slice(0, 60);
+      let i = 2;
+      while (used.has(`${base}_${i}`)) i++;
+      safe = `${base}_${i}`;
+    }
+    used.add(safe);
+    rename.set(key, safe);
+    keyMap.set(safe, key);
+  }
+
+  const source = properties as Record<string, unknown>;
+  const renamedProperties: Record<string, unknown> = {};
+  for (const key of keys) {
+    renamedProperties[rename.get(key) ?? key] = source[key];
+  }
+  const original = inputSchema as Record<string, unknown>;
+  const schema: Record<string, unknown> = {
+    ...original,
+    properties: renamedProperties,
+  };
+  if (Array.isArray(original.required)) {
+    schema.required = original.required.map((k) =>
+      typeof k === "string" ? (rename.get(k) ?? k) : k,
+    );
+  }
+  return { schema, keyMap };
+}
+
+function restoreOriginalKeys(
+  input: Record<string, unknown>,
+  keyMap: Map<string, string>,
+): Record<string, unknown> {
+  if (keyMap.size === 0) return input;
+  const restored: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    restored[keyMap.get(key) ?? key] = value;
+  }
+  return restored;
 }
 
 export function sanitizeToolName(name: string): string {
@@ -208,28 +271,22 @@ export async function toolsFromMCP(
 }> {
   const truncate = !options.disableOutputTruncation;
   const list = await client.listTools();
-  const visibleTools = list.tools
-    .filter((t) => (options.isToolVisible ?? defaultToolVisibility)(t))
-    .filter((t) => {
-      if (hasLlmSafeInputSchema(t.inputSchema)) return true;
-      console.warn(
-        "skipping MCP tool with LLM-unsafe input schema property keys",
-        { tool: t.name },
-      );
-      return false;
-    });
+  const visibleTools = list.tools.filter((t) =>
+    (options.isToolVisible ?? defaultToolVisibility)(t),
+  );
 
   const nameMap = buildShortNameMap(visibleTools);
   const toolEntries = visibleTools.map((t) => {
     const { name, title, description, inputSchema, annotations, _meta } = t;
     const safeName = nameMap.get(name)!;
+    const { schema: safeInputSchema, keyMap } = llmSafeInputSchema(inputSchema);
 
     return [
       safeName,
       tool<Record<string, unknown>, CallToolResult>({
         title: title ?? name,
         description,
-        inputSchema: jsonSchema(inputSchema as JSONSchema7),
+        inputSchema: jsonSchema(safeInputSchema as JSONSchema7),
         outputSchema: undefined,
         needsApproval:
           toolNeedsApproval(toolApprovalLevel, annotations?.readOnlyHint, {
@@ -240,9 +297,13 @@ export async function toolsFromMCP(
           let isError = false;
           let outputBytes: number | undefined;
           try {
+            const namedInput = restoreOriginalKeys(
+              input as Record<string, unknown>,
+              keyMap,
+            );
             const resolvedInput = options.resolveArgs
-              ? await options.resolveArgs(input as Record<string, unknown>)
-              : (input as Record<string, unknown>);
+              ? await options.resolveArgs(namedInput)
+              : namedInput;
             const result = await client.callTool(
               {
                 name: t.name,

--- a/apps/api/src/harnesses/lib/decopilot/mcp-tools.ts
+++ b/apps/api/src/harnesses/lib/decopilot/mcp-tools.ts
@@ -32,6 +32,18 @@ export function toolNeedsApproval(
   return readOnlyHint !== true;
 }
 
+/** Anthropic rejects the WHOLE request (400) if any tool's
+ *  `input_schema.properties` has a key outside this pattern, so one bad MCP
+ *  tool kills every run. Drop that tool instead of the run. */
+const LLM_SAFE_PROPERTY_KEY = /^[a-zA-Z0-9_.-]{1,64}$/;
+
+export function hasLlmSafeInputSchema(inputSchema: unknown): boolean {
+  const properties = (inputSchema as { properties?: unknown } | null)
+    ?.properties;
+  if (properties == null || typeof properties !== "object") return true;
+  return Object.keys(properties).every((k) => LLM_SAFE_PROPERTY_KEY.test(k));
+}
+
 export function sanitizeToolName(name: string): string {
   let safe = name.replace(/[^a-zA-Z0-9_.\-:]/g, "_");
   if (safe.length === 0 || !/^[a-zA-Z_]/.test(safe)) {
@@ -196,9 +208,16 @@ export async function toolsFromMCP(
 }> {
   const truncate = !options.disableOutputTruncation;
   const list = await client.listTools();
-  const visibleTools = list.tools.filter((t) =>
-    (options.isToolVisible ?? defaultToolVisibility)(t),
-  );
+  const visibleTools = list.tools
+    .filter((t) => (options.isToolVisible ?? defaultToolVisibility)(t))
+    .filter((t) => {
+      if (hasLlmSafeInputSchema(t.inputSchema)) return true;
+      console.warn(
+        "skipping MCP tool with LLM-unsafe input schema property keys",
+        { tool: t.name },
+      );
+      return false;
+    });
 
   const nameMap = buildShortNameMap(visibleTools);
   const toolEntries = visibleTools.map((t) => {


### PR DESCRIPTION
## Problem

Runs on montecarlo (MONT-46) failed with:

```
API Error: 400 tools.675.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}$'
```

Tool *names* are sanitized (`buildShortNameMap`), but JSON Schema property keys are passed through verbatim. Anthropic validates them and rejects the **entire** request — so a single malformed MCP tool (out of ~675) makes every run in that org unrunnable, retry after retry.

## Fix

`llmSafeInputSchema` renames the offending top-level property keys (invalid chars → `_`, truncated to 64, deduped against the keys already present), keeps `required` in sync, and returns a `safeKey -> originalKey` map. `execute` maps the model's arguments back to the original names before `client.callTool`, so the tool stays usable instead of disappearing.

Only top-level keys are rewritten — that is what the upstream 400 validates (`custom.input_schema.properties`).

## Testing

`bun test ./apps/api/src/harnesses/lib/decopilot/mcp-tools.test.ts` — pass-through for safe schemas, rename + `required` sync + reverse map, collision with an existing safe key. `bun run --cwd=apps/api check` clean.