### PR TITLE
fix(monitor): bound the custom date range on the CDN/audience analytics routes

### DIFF
--- a/apps/api/src/api/routes/monitor.test.ts
+++ b/apps/api/src/api/routes/monitor.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { resolveWindow } from "./monitor";
+
+describe("resolveWindow custom range", () => {
+  test("accepts a same-day custom range", () => {
+    const w = resolveWindow("custom", "2026-01-01", "2026-01-01");
+    expect(w).toEqual({
+      since: "2026-01-01",
+      until: "2026-01-01",
+      granularity: "hourly",
+      days: 1,
+    });
+  });
+
+  test("accepts a custom range up to the 1y cap", () => {
+    const w = resolveWindow("custom", "2025-01-01", "2026-01-01");
+    expect(w).not.toBeNull();
+    expect(w?.granularity).toBe("daily");
+  });
+
+  test("rejects a custom range past the cap (unbounded warehouse scan)", () => {
+    expect(resolveWindow("custom", "2000-01-01", "2026-01-01")).toBeNull();
+  });
+
+  test("rejects a reversed since/until", () => {
+    expect(resolveWindow("custom", "2026-01-10", "2026-01-01")).toBeNull();
+  });
+
+  test("rejects a malformed date", () => {
+    expect(resolveWindow("custom", "not-a-date", "2026-01-01")).toBeNull();
+  });
+
+  test("resolves a preset unaffected by the custom-range changes", () => {
+    const w = resolveWindow("7d", undefined, undefined);
+    expect(w?.days).toBe(7);
+    expect(w?.granularity).toBe("daily");
+  });
+});

--- a/apps/api/src/api/routes/monitor.ts
+++ b/apps/api/src/api/routes/monitor.ts
@@ -113,12 +113,19 @@ function windowDates(
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
+/** Longest preset span (`1y`) — a `custom` range past this would let an
+ *  authenticated user (for any site they own) run an arbitrarily large scan
+ *  against the shared ClickHouse warehouse on every request. */
+const MAX_CUSTOM_RANGE_DAYS = 366;
+
 /**
  * Resolve a range selection to a concrete window. `custom` reads validated
  * `since`/`until` (YYYY-MM-DD); otherwise a preset from RANGE_TO_WINDOW. Returns
- * null for an unknown preset or a malformed custom range so the caller 400s.
+ * null for an unknown preset, a malformed custom range, a reversed
+ * since/until, or a custom span past `MAX_CUSTOM_RANGE_DAYS` — so the caller
+ * 400s instead of running an unbounded query.
  */
-function resolveWindow(
+export function resolveWindow(
   range: string,
   sinceQ: string | undefined,
   untilQ: string | undefined,
@@ -137,10 +144,11 @@ function resolveWindow(
     ) {
       return null;
     }
-    const days = Math.max(
-      1,
-      Math.round((Date.parse(untilQ) - Date.parse(sinceQ)) / 86400000),
-    );
+    const sinceMs = Date.parse(sinceQ);
+    const untilMs = Date.parse(untilQ);
+    if (untilMs < sinceMs) return null;
+    const days = Math.max(1, Math.round((untilMs - sinceMs) / 86400000));
+    if (days > MAX_CUSTOM_RANGE_DAYS) return null;
     return {
       since: sinceQ,
       until: untilQ,


### PR DESCRIPTION
**Source:** bug found while hardening `apps/api/src/api/routes/monitor.ts` (the org-scoped CDN/audience analytics routes) — not tied to an issue.

**Why a maintainer wants this:** `resolveWindow`'s `range=custom` branch validated only that `since`/`until` were well-formed dates; it never bounded the span or rejected a reversed range. Any authenticated user, for any site their org owns, could set `since=2000-01-01&until=2026-01-01` (or further back) on `GET /:org/monitor/:site/cdn/data` (or `/audience/data`) and repeatedly trigger an unbounded full-history aggregation against the shared stats-lake ClickHouse warehouse — the same warehouse other orgs' Monitor tabs and Infra Billing read from. This is the exact "cap query-length/aggregation on an attacker-controlled arg" gap the repo has repeatedly hardened elsewhere.

**Failure scenario:** a normal org member opens Monitor, network-tabs the request, and replays it with `range=custom&since=1970-01-01&until=2026-01-01` — the ClickHouse query now scans decades of `fact_usage_daily_view`/`fact_usage_hourly_view` instead of the intended bounded window, on every call.

**Fix:** cap the custom range at `MAX_CUSTOM_RANGE_DAYS = 366` (the longest preset, `1y`, plus a day of slack) and reject `until < since`; both now resolve to `null`, which the existing call sites already turn into a 400 ("unknown range"). `resolveWindow` is exported so the pure logic (no ClickHouse, no StudioContext) is unit-testable per the trust-boundary test gate — untrusted query params driving a query against a resource shared across all tenants.

**Reviewer check:** `cd apps/api && bun test src/api/routes/monitor.test.ts` — 6 cases covering same-day, at-cap, over-cap, reversed, malformed, and an unaffected preset.

**Local verification:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/api/routes/monitor.test.ts`, `bunx oxlint` on both touched files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the custom date range on the CDN/audience analytics routes so `range=custom` can no longer trigger an unbounded scan of the shared ClickHouse warehouse. Previously only the date format was validated; now spans past 366 days and reversed `since`/`until` both resolve to `null`, which the existing call sites turn into a 400.

- Exports `resolveWindow` so the pure logic is unit-testable without ClickHouse or StudioContext.
- Adds 6 unit tests covering same-day, at-cap, over-cap, reversed, malformed, and preset ranges.

<sup>Written for commit b2ca47e6768e3c1dbb3892ea649493b3dfb836bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

