### PR TITLE
fix(docs): repair broken org-filesystem anchor link in architecture guide

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/architecture.mdx
@@ -108,7 +108,7 @@ This distinction matters for reasoning about the system:
 | File & object-storage (`/api/:org/files/*`, presigned GET/PUT, uploads, `/api/:org/fs/*`) | ✅ serving clients | ✅ agent tools read/write files & mint presigned URLs |
 | Worker-only over HTTP | — | none — tool calls are in-process |
 
-File and object-storage routes are the genuine "called by both" surface, and they are backed by an S3-compatible **Object Store**. The `/api/:org/fs/*` routes also back the [org-filesystem mount](#org-filesystem-org-fs) inside sandboxes.
+File and object-storage routes are the genuine "called by both" surface, and they are backed by an S3-compatible **Object Store**. The `/api/:org/fs/*` routes also back the [org-filesystem mount](#org-filesystem) inside sandboxes.
 
 ## Sandboxes
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/architecture.mdx
@@ -108,7 +108,7 @@ Essa distinção importa para raciocinar sobre o sistema:
 | File & object-storage (`/api/:org/files/*`, GET/PUT presigned, uploads, `/api/:org/fs/*`) | ✅ servindo clients | ✅ tools de agent leem/escrevem arquivos e geram presigned URLs |
 | Apenas worker via HTTP | — | nenhuma — as chamadas de tool são in-process |
 
-As rotas de file e object-storage são a verdadeira superfície "chamada por ambos", e são respaldadas por um **Object Store** compatível com S3. As rotas `/api/:org/fs/*` também dão suporte ao [mount do org-filesystem](#org-filesystem-org-fs) dentro das sandboxes.
+As rotas de file e object-storage são a verdadeira superfície "chamada por ambos", e são respaldadas por um **Object Store** compatível com S3. As rotas `/api/:org/fs/*` também dão suporte ao [mount do org-filesystem](#org-filesystem) dentro das sandboxes.
 
 ## Sandboxes
 


### PR DESCRIPTION
Fixes broken internal anchor links in the architecture documentation.

The heading "### Org filesystem (org-fs)" generates anchor `#org-filesystem`, but links were incorrectly referencing `#org-filesystem-org-fs`. Fixed in both EN and PT-BR versions.

Verification:
- `bun run fmt` ✓ (no changes needed)
- `bunx oxlint` ✓ (no errors)
- All remaining anchor links verified to be valid
- No behavior changes, purely documentation link correction

Diff: -2/+2 (two anchor link fixes)

Run `grep -r '](#' apps/docs/client/src/content/deco-studio` to verify all anchor links are valid.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken internal anchor links in the architecture docs so the org-filesystem mount link now resolves correctly in both EN and PT-BR versions.

The heading "Org filesystem (org-fs)" generates the anchor `#org-filesystem`, but the links pointed to `#org-filesystem-org-fs`, which doesn't exist.

<sup>Written for commit 0d0d1b893dabd99e3c047aabe93c61d0bb44f292. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

