### PR TITLE
refactor(web): drop the unneeded id_token record-cast in mcp-oauth

### DIFF
--- a/apps/web/src/sdk/lib/mcp-oauth.ts
+++ b/apps/web/src/sdk/lib/mcp-oauth.ts
@@ -575,7 +575,6 @@ export async function authenticateMcp(params: {
 
     if (result === "REDIRECT") {
       const fullResult = await oauthCompletePromise;
-      const rawTokens = fullResult.tokens as unknown as Record<string, unknown>;
       return {
         token: fullResult.tokens.access_token,
         tokenInfo: {
@@ -587,8 +586,7 @@ export async function authenticateMcp(params: {
           clientSecret: fullResult.clientSecret,
           tokenEndpoint: fullResult.tokenEndpoint,
           userinfoEndpoint: fullResult.userinfoEndpoint,
-          idToken:
-            typeof rawTokens.id_token === "string" ? rawTokens.id_token : null,
+          idToken: fullResult.tokens.id_token ?? null,
         },
         error: null,
       };
@@ -597,7 +595,6 @@ export async function authenticateMcp(params: {
     // If we got here without redirect, check for tokens
     const tokens = provider.tokens();
     const clientInfo = provider.clientInformation();
-    const rawTokens = tokens as unknown as Record<string, unknown> | null;
     return {
       token: tokens?.access_token || null,
       tokenInfo: tokens
@@ -613,10 +610,7 @@ export async function authenticateMcp(params: {
                 : null,
             tokenEndpoint: null, // Would need to be passed through
             userinfoEndpoint: null,
-            idToken:
-              rawTokens && typeof rawTokens.id_token === "string"
-                ? rawTokens.id_token
-                : null,
+            idToken: tokens.id_token ?? null,
           }
         : null,
       error: null,


### PR DESCRIPTION
Follows an audit of the MCP OAuth client (`apps/web/src/sdk/lib/mcp-oauth.ts`).

`authenticateMcp` read `id_token` off the SDK's `OAuthTokens` result by casting it `as unknown as Record<string, unknown>` and then checking `typeof rawTokens.id_token === "string"`, as if `id_token` were an untyped extra field. It isn't: `@modelcontextprotocol/sdk`'s `OAuthTokensSchema` already declares `id_token: z.ZodOptional<z.ZodString>`, so `OAuthTokens.id_token` is a real, typed `string | undefined` field. The double-cast was dead workaround code for a value already reachable with the real type (`tokens.id_token ?? null`).

This is behavior-preserving — same runtime value, just read through its actual type instead of an unnecessary cast — and removes a real cast/dead-code pattern (checklist item 9: don't `as`-cast to read a field that's already typed). Net: -8/+2 lines, two `Record<string, unknown>` casts and their guards deleted.

How to verify: `bunx tsc --noEmit` in `apps/web` (no new errors — the one pre-existing prosemirror version-mismatch error is unrelated), `bun test apps/web/src/sdk/lib/mcp-oauth.test.ts` and `bun test apps/web/src/lib/mcp-oauth.test.ts` (both green), `bunx oxlint apps/web/src/sdk/lib/mcp-oauth.ts` (0 warnings/errors).

Locally ran: `bun run fmt`, targeted `tsc --noEmit`, both test files, and per-file oxlint. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unnecessary `as unknown as Record<string, unknown>` casts in `apps/web/src/sdk/lib/mcp-oauth.ts` when reading `id_token`. The field is already typed as `string | undefined` in the SDK's `OAuthTokens` schema, so we now read it directly with `tokens.id_token ?? null`. No behavior change.

<sup>Written for commit 0a586509aa34cabc7cc4763d4782928a423b2f08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

