### PR TITLE
fix(task-board): stop run-reactions writing Studio's literal lane names to the activity log

### DIFF
--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -454,8 +454,8 @@ export async function reactToFailedTaskRun(
             action: "status_changed",
             actorId: null,
             data: {
-              from: "in_progress",
-              to: "in_progress",
+              from: lanes.progress,
+              to: lanes.progress,
               retry: attempts + 1,
               of: budget,
               reason: failure.errorText ?? failure.kind,
@@ -477,8 +477,8 @@ export async function reactToFailedTaskRun(
           action: "status_changed",
           actorId: null,
           data: {
-            from: "in_progress",
-            to: "todo",
+            from: lanes.progress,
+            to: lanes.queue,
             reason: failure.errorText ?? failure.kind,
             retriesSpent: attempts,
           },
@@ -586,7 +586,7 @@ export async function parkReviewedCardForHuman(
         taskBoardItemId: item.id,
         action: "status_changed",
         actorId: null,
-        data: { from: item.status, to: "in_review" },
+        data: { from: item.status, to: lanes.review },
       })
       .catch(() => {});
     emitTaskBoardUpdated(item.organizationId, parked);


### PR DESCRIPTION
Follows #6849/#6862/#6873 — the same "hardcoded lane literal instead of the board's own lanes" bug class, this time in `run-reactions.ts`.

Three `status_changed` activity writes hardcoded Studio's own lane names (`"in_progress"`, `"todo"`, `"in_review"`) instead of reading them off the resolved `BoardLanes`:
- `reactToFailedTaskRun`'s retry-scheduled entry (`from`/`to: "in_progress"`)
- `reactToFailedTaskRun`'s return-to-todo entry (`from: "in_progress", to: "todo"`)
- `parkReviewedCardForHuman`'s park entry (`to: "in_review"`)

On an org-owned board (`org_board_columns`), a card's real progress/queue/review column can be named something other than Studio's literal — so the card's `status` is written correctly (via `lanes.progress`/`lanes.queue`/`lanes.review`, already dynamic) but the activity-log entry describing that same write lied about which columns it moved from/to. That's exactly the discrepancy a reviewer would see on the task's timeline in the UI.

Fix: use the already-in-scope `lanes` (`BoardLanes`) values instead of the literals, matching the pattern the rest of the file already uses (e.g. `advanceTaskBoardForRun`'s `data: { from: current.status, to: status }`).

Behavior-preserving for every org on Studio's canonical board — `lanes.progress === "in_progress"`, `lanes.queue === "todo"`, `lanes.review === "in_review"` there (see `STUDIO_LANES` in `board-handler.ts`), so the written data is byte-identical. Only an org-owned board's timeline changes, and only to become accurate.

Reviewer: `bun test apps/api/src/tools/task-board/run-reactions.test.ts` (21 pass, no test asserted the old literals).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bun test apps/api/src/tools/task-board/run-reactions.test.ts`, `bunx oxlint apps/api/src/tools/task-board/run-reactions.ts` — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `run-reactions.ts` activity-log writes to use the board's actual lane values instead of Studio's hardcoded `"in_progress"`, `"todo"`, and `"in_review"` literals. On org-owned boards with custom lane names, the timeline previously showed incorrect from/to columns; now it matches the real status change. Boards using Studio's default lanes see no behavioral change.

<sup>Written for commit e686b779b99e9163ec5b387c41acc988622910cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

