### PR TITLE
fix(connections): validate registry oauth_config with the real OAuthConfigSchema

### DIFF
--- a/apps/web/src/utils/extract-connection-data.test.ts
+++ b/apps/web/src/utils/extract-connection-data.test.ts
@@ -44,4 +44,51 @@ describe("extractConnectionData", () => {
     expect(data.connection_type).toBe("HTTP");
     expect(data.connection_url).toBe("https://example.com/mcp");
   });
+
+  // Registry oauth_config is untrusted third-party _meta; a non-URL endpoint must not survive.
+  it("drops oauth_config when an endpoint isn't a valid URL", () => {
+    const item: RegistryItem = {
+      ...packageOnlyItem,
+      _meta: {
+        "mcp.studio": {
+          oauth_config: {
+            authorizationEndpoint: "not-a-url",
+            tokenEndpoint: "https://example.com/token",
+            clientId: "client-1",
+            scopes: ["read"],
+            grantType: "authorization_code",
+          },
+        },
+      },
+    };
+
+    const data = extractConnectionData(item, "org-1", "user-1", {
+      remoteIndex: 0,
+    });
+
+    expect(data.oauth_config).toBeNull();
+  });
+
+  it("keeps a well-formed oauth_config", () => {
+    const item: RegistryItem = {
+      ...packageOnlyItem,
+      _meta: {
+        "mcp.studio": {
+          oauth_config: {
+            authorizationEndpoint: "https://example.com/authorize",
+            tokenEndpoint: "https://example.com/token",
+            clientId: "client-1",
+            scopes: ["read"],
+            grantType: "authorization_code",
+          },
+        },
+      },
+    };
+
+    const data = extractConnectionData(item, "org-1", "user-1", {
+      remoteIndex: 0,
+    });
+
+    expect(data.oauth_config).toMatchObject({ clientId: "client-1" });
+  });
 });

--- a/apps/web/src/utils/extract-connection-data.ts
+++ b/apps/web/src/utils/extract-connection-data.ts
@@ -3,7 +3,7 @@
  * Shared between store server detail and inline installation flows.
  */
 
-import type { OAuthConfig } from "@decocms/shared/sdk/types";
+import { type OAuthConfig, OAuthConfigSchema } from "@decocms/shared/sdk/types";
 import type { RegistryItem, MCPRegistryServer } from "@/components/store/types";
 import { getStudioMcpMetadata } from "@decocms/shared/registry/metadata";
 import { getGitHubAvatarUrl } from "@/utils/github.ts";
@@ -90,20 +90,12 @@ export function extractConnectionData(
   const icon =
     server?.icons?.[0]?.src || getGitHubAvatarUrl(server?.repository) || null;
 
-  const rawOauthConfig = studioMeta?.oauth_config as
-    | Record<string, unknown>
-    | null
-    | undefined;
-  const oauthConfig: OAuthConfig | null =
-    rawOauthConfig &&
-    typeof rawOauthConfig.authorizationEndpoint === "string" &&
-    typeof rawOauthConfig.tokenEndpoint === "string" &&
-    typeof rawOauthConfig.clientId === "string" &&
-    Array.isArray(rawOauthConfig.scopes) &&
-    (rawOauthConfig.grantType === "authorization_code" ||
-      rawOauthConfig.grantType === "client_credentials")
-      ? (rawOauthConfig as unknown as OAuthConfig)
-      : null;
+  const oauthConfigResult = OAuthConfigSchema.safeParse(
+    studioMeta?.oauth_config,
+  );
+  const oauthConfig: OAuthConfig | null = oauthConfigResult.success
+    ? oauthConfigResult.data
+    : null;
 
   const configState = studioMeta?.configuration_state as
     | Record<string, unknown>

--- a/packages/shared/src/sdk/types/connection.ts
+++ b/packages/shared/src/sdk/types/connection.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 /**
  * OAuth configuration schema for downstream MCP
  */
-const OAuthConfigSchema = z.object({
+export const OAuthConfigSchema = z.object({
   authorizationEndpoint: z.string().url(),
   tokenEndpoint: z.string().url(),
   introspectionEndpoint: z.string().url().optional(),

--- a/packages/shared/src/sdk/types/index.ts
+++ b/packages/shared/src/sdk/types/index.ts
@@ -2,6 +2,7 @@ export {
   ConnectionEntitySchema,
   ConnectionCreateDataSchema,
   ConnectionUpdateDataSchema,
+  OAuthConfigSchema,
   isStdioParameters,
   parseVirtualUrl,
   buildVirtualUrl,


### PR DESCRIPTION
**Source:** a validation gap found while auditing the shared SDK connection types (`packages/shared/src/sdk/types/connection.ts`) for the per-user-OAuth focus area.

**What's wrong:** `extractConnectionData` (`apps/web/src/utils/extract-connection-data.ts`) reads `oauth_config` off a registry item's `_meta` — data supplied by a third-party MCP server, i.e. untrusted input — and hand-rolled its own field checks (`typeof x === "string"`, `Array.isArray`, enum equality) instead of using the connection SDK's own `OAuthConfigSchema`. Notably it never checked that `authorizationEndpoint`/`tokenEndpoint` were valid URLs (the schema requires `.url()`), then cast the loosely-checked object straight to `OAuthConfig` with `as unknown as OAuthConfig`.

**Failure scenario:** a malicious or malformed registry entry with `oauth_config.authorizationEndpoint: "not-a-url"` passed the hand-rolled check (it's a string) and would have been carried into the connection payload sent to `CONNECTION_CREATE` as a real OAuth endpoint, relying entirely on server-side re-validation to catch it.

**Fix:** replace the hand-rolled checks with `OAuthConfigSchema.safeParse(...)`, the single source of truth already used server-side — dedupes the validation logic and closes the URL gap client-side too. Exported `OAuthConfigSchema` from `@decocms/shared/sdk/types` (previously only the inferred type was exported). Added two regression tests: a non-URL endpoint now yields `oauth_config: null`, and a well-formed config still passes through.

**Verify:** `bun test apps/web/src/utils/extract-connection-data.test.ts` (4 pass).

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` in `apps/web` and `packages/shared` (only pre-existing, unrelated prosemirror-version errors elsewhere in `apps/web`), `bunx oxlint` on all 4 touched files (0 warnings/errors), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates registry `oauth_config` against the shared `OAuthConfigSchema` instead of hand-rolled checks, so malformed endpoints from third-party registry entries no longer reach the connection payload.

- Replaces manual field checks in `extractConnectionData` with `OAuthConfigSchema.safeParse`; a non-URL endpoint now yields `oauth_config: null` instead of being cast to `OAuthConfig` and sent to `CONNECTION_CREATE`.
- Exports `OAuthConfigSchema` from `@decocms/shared/sdk/types` (previously only the inferred type was exported).
- Adds two regression tests: one for a non-URL endpoint being dropped, one for a well-formed config passing through.

<sup>Written for commit 30ef1181511754d8f7004a6c7904995258f48e67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

