### PR TITLE
fix(oauth): reject a private-network tokenEndpoint on downstream token save

### DIFF
--- a/apps/api/src/api/routes/downstream-token.integration.test.ts
+++ b/apps/api/src/api/routes/downstream-token.integration.test.ts
@@ -86,6 +86,21 @@ describe("Downstream Token Routes", () => {
     expect(body.error).toBe("tokenEndpoint must be an http(s) URL");
   });
 
+  it("rejects tokenEndpoint targeting a private network", async () => {
+    const res = await app.request("/connections/conn_1/oauth-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        accessToken: "at",
+        tokenEndpoint: "http://169.254.169.254/latest/meta-data",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("tokenEndpoint must not target a private network");
+  });
+
   it("accepts http(s) tokenEndpoint", async () => {
     const res = await app.request("/connections/conn_1/oauth-token", {
       method: "POST",

--- a/apps/api/src/api/routes/downstream-token.ts
+++ b/apps/api/src/api/routes/downstream-token.ts
@@ -9,6 +9,7 @@ import { Hono } from "hono";
 import type { StudioContext } from "../../core/studio-context";
 import { canRefresh } from "../../oauth/token-refresh";
 import { resolveOriginTokenEndpoint } from "../../oauth/resolve-token-endpoint";
+import { isPrivateUrl } from "../../tools/registry/discover-tools";
 import {
   DownstreamTokenStorage,
   type DownstreamTokenData,
@@ -77,6 +78,14 @@ export const createDownstreamTokenRoutes = () => {
 
       if (url.protocol !== "http:" && url.protocol !== "https:") {
         return c.json({ error: "tokenEndpoint must be an http(s) URL" }, 400);
+      }
+
+      // Same SSRF guard applied to origin-controlled endpoint URLs elsewhere (oauth-proxy.ts).
+      if (isPrivateUrl(body.tokenEndpoint)) {
+        return c.json(
+          { error: "tokenEndpoint must not target a private network" },
+          400,
+        );
       }
     }
 


### PR DESCRIPTION
The `POST /connections/:connectionId/oauth-token` route (`downstream-token.ts`) validates a user-supplied `tokenEndpoint` for a valid http(s) URL, but not for whether it targets a private/internal network — unlike every other origin-controlled OAuth endpoint URL in this codebase (`oauth-proxy.ts`'s `assertOriginEndpointIsSafe`, `resolve-token-endpoint.ts`), which all reject via `isPrivateUrl`.

**Failure scenario:** an org member (or a caller who can reach this endpoint with a stolen session) saves a token with `tokenEndpoint: "http://169.254.169.254/latest/meta-data"` (or any RFC1918/loopback address). That value is persisted verbatim and later used by `refreshAccessToken` (`oauth/refresh-access-token.ts`) as the target of a server-side POST carrying the connection's `client_id`/`client_secret`/`refresh_token` in the body — a classic SSRF into the API server's own network, triggered automatically on every background token refresh.

**Fix:** apply the same `isPrivateUrl` guard already used elsewhere in this file's own trust boundary (server-side origin metadata fetches) to this user-supplied value too, rejecting it with a 400 before it's ever persisted.

Added a regression test to `downstream-token.integration.test.ts` covering the new 400 for a `169.254.169.254` tokenEndpoint (same file/pattern as the existing invalid-URL and non-http(s) tests).

**To verify:** `cd apps/api && bunx tsc --noEmit` (clean) and `bunx oxlint apps/api/src/api/routes/downstream-token.ts apps/api/src/api/routes/downstream-token.integration.test.ts` (0 warnings/errors) — both run locally. The new/existing integration test needs real Postgres, which isn't available in this environment; a reviewer can confirm with `bun test apps/api/src/api/routes/downstream-token.integration.test.ts` against the repo's Postgres. Full CI validates the rest.

Note: `apps/api/src/api/routes/downstream-token.ts` also has open PR #6023 in flight (per-user OAuth), but that diff only touches the upsert/delete/get calls further down in the same handlers — this change is confined to the untouched `tokenEndpoint` validation block above them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects private-network `tokenEndpoint` values on the downstream OAuth token save route, closing an SSRF vector. The route previously accepted any http(s) URL, so a value like `http://169.254.169.254/latest/meta-data` was persisted and later used by server-side token refresh requests; it now returns 400 before saving, matching the private-network guard used for other OAuth endpoint URLs.

- Adds a regression test for a `169.254.169.254` token endpoint.

<sup>Written for commit 283c8e10075536c8c9885ffb737e6b5bf44bb49f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

