### PR TITLE
fix(connection-details): use the real total-calls count in the activity KPI

### DIFF
--- a/apps/web/src/components/details/connection/connection-activity.tsx
+++ b/apps/web/src/components/details/connection/connection-activity.tsx
@@ -68,7 +68,12 @@ function ActivityChart({ connectionId, orgId, timeframe }: ActivityChartProps) {
     staleTime: 5 * 60 * 1000,
   });
 
-  const stats = calculateStats(data?.logs ?? [], dateRange);
+  const stats = calculateStats(
+    data?.logs ?? [],
+    dateRange,
+    undefined,
+    data?.total,
+  );
   const chartData = stats.data;
   const hasData = stats.totalCalls > 0;
   const topErrors = computeTopErrors(data?.logs ?? []);


### PR DESCRIPTION
The Connection Activity widget (`apps/web/src/components/details/connection/connection-activity.tsx`) fetches at most 2000 monitoring logs (`limit: 2000, offset: 0`) but the `MONITORING_LOGS_LIST` response also returns a `total` field backed by a `count(*) OVER()` window query that is independent of the `LIMIT`/`OFFSET` (`apps/api/src/storage/monitoring-sql.ts:520-526`). `calculateStats` already has an `overrideTotalCalls` parameter meant for exactly this, but the caller never passed it, so `totalCalls` silently fell back to `logs.length` — for any connection making more than 2000 tool calls in the selected window, the "Tool calls" KPI understated the real volume with no indication it was a sample.

Fix: pass `data?.total` as `overrideTotalCalls` so the displayed count matches the real total the backend already computed.

Failure scenario: a busy connection with 5,000 calls in the last 14 days shows "2,000" tool calls instead of "5,000" — a maintainer investigating a connection's health sees an undercount with no error message or warning.

How to verify: `cd apps/web && bunx tsc --noEmit` (green, unrelated to my change — confirmed no hits on connection-activity.tsx) and `bunx oxlint apps/web/src/components/details/connection/connection-activity.tsx` (0 warnings/errors). No unit test exists for this file (it's a hook-driven component, not pure logic); the bucketed chart data itself is untouched — only the summary KPI's source value changed. Full CI covers the rest.

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in apps/web, `bunx oxlint` on the changed file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Connection Activity “Tool calls” KPI now uses the backend’s total log count instead of the fetched log count, so connections with more than 2,000 calls no longer show an understated total.

- The activity chart and error calculations remain unchanged.

<sup>Written for commit 2ab4b5b12b27467045d5c67a3e3ad59e574570a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

