### PR TITLE
fix(agents-list): search server-side instead of over the first fetched page

### DIFF
--- a/apps/web/src/routes/agents-list.tsx
+++ b/apps/web/src/routes/agents-list.tsx
@@ -38,9 +38,9 @@ import { useT } from "@/i18n/use-t.ts";
 export default function AgentsListPage() {
   const t = useT();
   const { org } = useProjectContext();
-  const agents = useVirtualMCPs();
-  const actions = useVirtualMCPActions();
   const [search, setSearch] = useState("");
+  const agents = useVirtualMCPs({ searchTerm: search });
+  const actions = useVirtualMCPActions();
   const { createVirtualMCP, isCreating } = useCreateVirtualMCP({
     navigateOnCreate: true,
   });
@@ -53,15 +53,8 @@ export default function AgentsListPage() {
   const { granted: canManageAgents } = useCapability("agents:manage");
   const showDecoImport = useIsDecoStaff();
 
-  const lowerSearch = search.toLowerCase();
-
-  // Filter out org-admin and apply search
-  const filteredAgents = agents.filter(
-    (s) =>
-      s.id !== org.id &&
-      (s.title.toLowerCase().includes(lowerSearch) ||
-        s.description?.toLowerCase().includes(lowerSearch)),
-  );
+  // Search is server-side via searchTerm; only the org-admin exclusion stays here.
+  const filteredAgents = agents.filter((s) => s.id !== org.id);
 
   const { data: lastUsedMap } = useVirtualMCPsLastUsed(
     filteredAgents.map((a) => a.id),


### PR DESCRIPTION
**Bug**: `useVirtualMCPs()` on the Agents list page (`apps/web/src/routes/agents-list.tsx`) is called with no options, so `useCollectionList` defaults `pageSize` to 100 and fetches only the first 100 agents (offset 0). The page then ran its search box's title/description match as a client-side `.filter()` over that already-capped array. In any org with more than 100 agents, searching for one past the first page silently renders the "no agents found" empty state even though the agent exists.

**Fix**: `useVirtualMCPs` already forwards its options straight into `useCollectionList`, which turns a `searchTerm` into a server-side `where: contains` clause over `title`/`description` (the same pattern `useConnections`/`connections.tsx` already uses). Pass the search box's value through as `searchTerm` so the query itself scopes matches across the whole org, and drop the now-redundant client-side title/description filter — only the org-admin (`s.id !== org.id`) exclusion stays local, since it isn't a search concern.

**Reviewer check**: `cd apps/web && bunx tsc --noEmit` (only a pre-existing, unrelated prosemirror version-mismatch error remains, untouched by this diff) and `bunx oxlint apps/web/src/routes/agents-list.tsx` (0 errors/warnings).

**Verification**: ran the two commands above locally, both clean on this file. No existing test covers this route's search behavior to invert, and the bug only reproduces with >100 agents in a real org (needs live data), so no test rides along — this is a pure logic fix, not a coverage gap.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, the Agents list filtered searches client-side over only the first 100 agents, so matches beyond that page appeared missing. It now passes the search term to the server, allowing title and description matches across the organization while keeping the org-admin exclusion local.

<sup>Written for commit 8dd38a6519cdfbe397357e83de5338504a6efb19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

