### PR TITLE
fix(jira): don't mark an issue's status/sprint retried before automation runs

### DIFF
--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -740,10 +740,6 @@ async function runSync(
           },
           JIRA_SYNC_ACTOR,
         );
-        await ctx.storage.jiraIntegrations.touchLink(link.itemId, {
-          jiraStatus: jiraStatusName,
-          jiraSprintId: jiraSprint?.id ?? null,
-        });
         if (before && writeStatus && before.status !== status) {
           await ctx.storage.taskBoard.recordActivity({
             taskBoardItemId: link.itemId,
@@ -770,11 +766,10 @@ async function runSync(
           integrationAccountId,
           users,
         );
-        // Last, because this is what marks the issue "fully processed": moving
-        // it before `pullComments` means a failed comment fetch is never
-        // retried — the next run reads the issue as unchanged and those
-        // comments are stranded for good.
+        // Last: writing these any earlier lets a failed automation/comment pull abort the run after retry-detection already moved, stranding both for good.
         await ctx.storage.jiraIntegrations.touchLink(link.itemId, {
+          jiraStatus: jiraStatusName,
+          jiraSprintId: jiraSprint?.id ?? null,
           jiraUpdatedAt: issueUpdated,
         });
         emitTaskBoardUpdated(orgId, item);


### PR DESCRIPTION
`runSync`'s link-exists branch wrote `link.jiraStatus`/`jiraSprintId` right after the board `update`, before `maybeAutoDelegate` and `pullComments` ran. If either threw an unhandled error (e.g. a DB blip in `claimUnassignedForSuperAgent`), the whole issue's processing aborted — but the retry-detection fields were already persisted with the new status.

Failure scenario: the next tick re-reads the same issue (its `jiraUpdatedAt` link field was never touched, so it isn't skipped by `isUnchanged`), but `link.jiraStatus` now already equals the issue's current Jira status, so `statusChangedOnJira` is false and `before.status === item.status`. `triggersColumnAutomation` therefore returns false and `maybeAutoDelegate`/`pullComments` are silently never retried — the card is permanently stuck without its column automation or its Jira comments, with no error surfaced anywhere (`runSync` throwing here just gets folded into `last_sync_error` and never mentions this card again once the run succeeds).

Fix: fold `jiraStatus`/`jiraSprintId` into the same final `touchLink` call as `jiraUpdatedAt`, which already runs after automation and the comment pull — extending the file's own existing "last, because this marks the issue fully processed" reasoning (previously applied only to `jiraUpdatedAt`) to the other two retry-detection fields.

To confirm: read `runSync`'s `if (link)` branch in `apps/api/src/jira/sync.ts` and trace what happens if `maybeAutoDelegate` throws before vs after this change — before, the status write survives and the automation/comment retry is silently lost; after, nothing in the retry-detection state moves until the issue actually finishes.

Verified locally: `bun test apps/api/src/jira/sync.test.ts` (34 pass — these cover the exported pure functions `buildJql`/`isUnchanged`/`rewritesStatus`/`triggersColumnAutomation`/etc.; `runSync` itself needs Postgres and isn't unit-tested per repo convention, so no new test was added for this ordering change), `bunx tsc --noEmit` in `apps/api`, `bunx oxlint` on the changed file. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Jira sync now persists `jiraStatus` and `jiraSprintId` only after automation and comment pulling complete, alongside `jiraUpdatedAt`. Previously, an error in either step could persist the retry markers early, causing the next run to skip the failed automation or comment sync.

- Verified with `bun test apps/api/src/jira/sync.test.ts`, `bunx tsc --noEmit`, and `bunx oxlint`.

<sup>Written for commit 432c8891167fd5ba1ed0afbf5117a21bd2fe7e84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

