### PR TITLE
fix(branch-picker): expose the selected version/release to screen readers

### DIFF
--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -415,6 +415,7 @@ function VersionRow({
     <button
       type="button"
       disabled={disabled}
+      aria-pressed={selected}
       onClick={onSelect}
       className={cn(
         "flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left text-sm transition-colors",
@@ -463,6 +464,7 @@ function ReleaseRow({
         <TooltipTrigger asChild>
           <button
             type="button"
+            aria-pressed={selected}
             onClick={onSelect}
             className="flex min-w-0 flex-1 items-center gap-2.5 px-2 py-2 text-left text-sm"
           >


### PR DESCRIPTION
**Source:** own finding while auditing `branch-picker.tsx`/`start-draft-cta.tsx` for a11y/focus/double-click gaps per this tick's focus area, following the recent hardening in #6864/#6866/#6867.

**Why:** `VersionRow` and `ReleaseRow` (the rows in the version/release popover) only indicate the currently-selected version visually, via a `bg-accent` background on the row. A screen-reader user gets no signal for which version is currently active — the same class of gap the a11y lane has fixed repeatedly (aria-pressed/aria-current for toggle/selection state, e.g. #4903, #6448, #6831).

**Fix:** add `aria-pressed={selected}` to the two select buttons (`VersionRow`, `ReleaseRow`). Pure additive attribute, no behavior/logic change.

**To confirm:** open the branch/version picker in the chat header, tab to a row with a screen reader (or inspect the accessibility tree) — the selected row now reports `pressed`.

**Verified locally:** `bun run fmt` (clean), `bunx oxlint apps/web/src/components/thread/github/branch-picker.tsx` (0 warnings/errors). `bunx tsc --noEmit` in `apps/web` shows one pre-existing, unrelated error in `mention-suggestion.tsx` (prosemirror-model duplicate-version type mismatch) not touched by this diff. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `aria-pressed={selected}` to the version and release row buttons in the branch picker so screen readers can tell which version or release is selected. Previously the selected row was only indicated visually via a background color, leaving screen reader users without that state. This is a pure additive attribute with no behavior change.

<sup>Written for commit afac5e62ccb67857e9b73c0b24a350a3af25986c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

