### PR TITLE
fix(agents-list): debounce the server-side agent search term

### DIFF
--- a/apps/web/src/routes/agents-list.tsx
+++ b/apps/web/src/routes/agents-list.tsx
@@ -34,12 +34,14 @@ import { toast } from "sonner";
 import { GitHubRepoPicker } from "@/components/github-repo-picker.tsx";
 import { track } from "@/lib/posthog-client";
 import { useT } from "@/i18n/use-t.ts";
+import { useDebouncedValue } from "@/hooks/use-debounced-value.ts";
 
 export default function AgentsListPage() {
   const t = useT();
   const { org } = useProjectContext();
   const [search, setSearch] = useState("");
-  const agents = useVirtualMCPs({ searchTerm: search });
+  const searchTerm = useDebouncedValue(search, 300);
+  const agents = useVirtualMCPs({ searchTerm });
   const actions = useVirtualMCPActions();
   const { createVirtualMCP, isCreating } = useCreateVirtualMCP({
     navigateOnCreate: true,


### PR DESCRIPTION
Follows #6882, which moved the agents-list search from client-side filtering to a server-side `searchTerm` on `useVirtualMCPs`. That hook backs onto a `useSuspenseQuery`, so every keystroke now fires a fresh MCP tool call and re-suspends the list (a loading flash on each character) instead of the previous instant client-side filter.

The repo already has an established fix for exactly this shape — `useDebouncedValue` (see `apps/web/src/layouts/library/index.tsx`, which debounces its search input at 300ms before using it as a server `searchTerm`). This PR applies the same pattern here: the `SearchInput` stays bound to the raw `search` state (so typing feels instant), while `useVirtualMCPs` receives a 300ms-debounced value.

Failure scenario: type a 5-character query into the agents list search box — without debouncing, that's 5 round-trips to the MCP list tool and 5 Suspense flashes instead of 1 request after the user pauses.

How to verify: `apps/web/src/routes/agents-list.tsx` — open the Agents list and type into the search box; the list should update once, ~300ms after typing stops, with no flicker per keystroke.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web workspace — clean except one pre-existing, unrelated prosemirror-version-mismatch error in mention-suggestion.tsx), `bunx oxlint apps/web/src/routes/agents-list.tsx` (0 warnings/errors). No unit test exists for this route (it's a thin container component wiring existing hooks), so nothing to target with `bun test`; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the agents list search so typing no longer fires a server request or shows a Suspense flash on every keystroke. The input still feels instant, and `useVirtualMCPs` now gets a 300ms-debounced search term, so the list updates once after the user pauses.

<sup>Written for commit 99e5f88fbcb661c12a907456f61ee7127a57fcf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

