### PR TITLE
feat(sections-editor): read-only edit popover with "new draft" CTA

### DIFF
--- a/apps/web/src/components/sandbox/blocks/blocks-panel.tsx
+++ b/apps/web/src/components/sandbox/blocks/blocks-panel.tsx
@@ -106,7 +106,11 @@ export function BlocksPanel({
   // On production the editor stays visible but read-only per widget.
   const gateReadOnly = (children: ReactNode) => (
     <div data-testid="blocks-panel" className="h-full min-h-0 overflow-hidden">
-      <ReadOnlyPane readOnly={readOnly} className="h-full min-h-0">
+      <ReadOnlyPane
+        readOnly={readOnly}
+        virtualMcpId={virtualMcpId}
+        className="h-full min-h-0"
+      >
         {children}
       </ReadOnlyPane>
     </div>

--- a/apps/web/src/components/sandbox/content/content-browser.tsx
+++ b/apps/web/src/components/sandbox/content/content-browser.tsx
@@ -1183,7 +1183,11 @@ function ContentBrowserReady({
             }
           />
         )}
-      <ReadOnlyPane readOnly={readOnly} className="flex-1 min-w-0">
+      <ReadOnlyPane
+        readOnly={readOnly}
+        virtualMcpId={virtualMcpId}
+        className="flex-1 min-w-0"
+      >
         {activeCollection === "loaders" || activeCollection === "actions" ? (
           <RunnableBlocksBrowser
             orgSlug={orgSlug}

--- a/apps/web/src/components/sections-editor/fields/read-only-context.ts
+++ b/apps/web/src/components/sections-editor/fields/read-only-context.ts
@@ -13,3 +13,16 @@ export const ReadOnlyProvider = ReadOnlyContext.Provider;
 export function useIsReadOnly(): boolean {
   return useContext(ReadOnlyContext);
 }
+
+/**
+ * The agent whose production a read-only pane is showing — so a blocked field
+ * can offer "start a new draft" without threading the id through every field
+ * prop. `null` outside a {@link ReadOnlyProvider} that supplied one.
+ */
+const ReadOnlyVirtualMcpContext = createContext<string | null>(null);
+
+export const ReadOnlyVirtualMcpProvider = ReadOnlyVirtualMcpContext.Provider;
+
+export function useReadOnlyVirtualMcpId(): string | null {
+  return useContext(ReadOnlyVirtualMcpContext);
+}

--- a/apps/web/src/components/sections-editor/fields/read-only-pane.tsx
+++ b/apps/web/src/components/sections-editor/fields/read-only-pane.tsx
@@ -1,54 +1,113 @@
 import type { ReactNode } from "react";
+import { Plus } from "@untitledui/icons";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@decocms/ui/components/tooltip.tsx";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@decocms/ui/components/popover.tsx";
+import { useCreateDraft } from "@/components/thread/github/use-version-gate";
 import { useT } from "@/i18n/use-t.ts";
-import { ReadOnlyProvider } from "./read-only-context";
+import {
+  ReadOnlyProvider,
+  ReadOnlyVirtualMcpProvider,
+  useReadOnlyVirtualMcpId,
+} from "./read-only-context";
 
 /**
  * Drop-in replacement for a panel's wrapper `<div>` that also publishes the
  * read-only state to every descendant form widget via {@link ReadOnlyProvider}.
  * Swapping `<div className=…>` → `<ReadOnlyPane className=… readOnly=…>` keeps
  * the children at the same nesting depth (no reindent) and adds no layout box
- * beyond the div — the provider is DOM-transparent.
+ * beyond the div — the provider is DOM-transparent. `virtualMcpId` lets a
+ * blocked control offer "start a new draft" (see {@link ReadOnlyEditPopover}).
  */
 export function ReadOnlyPane({
   readOnly,
+  virtualMcpId,
   className,
   children,
 }: {
   readOnly: boolean;
+  virtualMcpId: string;
   className?: string;
   children: ReactNode;
 }) {
   return (
     <div className={className}>
-      <ReadOnlyProvider value={readOnly}>{children}</ReadOnlyProvider>
+      <ReadOnlyVirtualMcpProvider value={virtualMcpId}>
+        <ReadOnlyProvider value={readOnly}>{children}</ReadOnlyProvider>
+      </ReadOnlyVirtualMcpProvider>
     </div>
+  );
+}
+
+/**
+ * "Start a new draft" action shown inside the read-only popover. Kept in its own
+ * component so {@link useCreateDraft} only runs when the popover is open (Radix
+ * mounts content on demand) rather than once per blocked control.
+ */
+function StartDraftButton({ virtualMcpId }: { virtualMcpId: string }) {
+  const t = useT();
+  const createDraft = useCreateDraft(virtualMcpId);
+  return (
+    <button
+      type="button"
+      onClick={() => void createDraft()}
+      className="inline-flex items-center gap-1.5 self-start rounded-md bg-background px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-background/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-foreground"
+    >
+      <Plus size={14} className="shrink-0" />
+      {t("thread.branchPicker.newVersion")}
+    </button>
+  );
+}
+
+/**
+ * The tooltip-styled popover body shown when an edit is blocked on production:
+ * a "production is read-only" line plus a "start a new draft" button. Rendered
+ * inside a {@link Popover} — either the trigger form ({@link ReadOnlyEditPopover})
+ * or a controlled/anchored one (e.g. a blocked drag gesture).
+ */
+export function ReadOnlyEditPopoverContent() {
+  const t = useT();
+  const virtualMcpId = useReadOnlyVirtualMcpId();
+  return (
+    <PopoverContent
+      align="center"
+      className="flex w-fit max-w-[260px] flex-col gap-2.5 border-transparent bg-foreground p-3 text-background"
+    >
+      <p className="text-xs text-balance">
+        {t("sectionsEditor.readOnlyFieldTooltip")}
+      </p>
+      {virtualMcpId ? <StartDraftButton virtualMcpId={virtualMcpId} /> : null}
+    </PopoverContent>
+  );
+}
+
+/**
+ * Wraps any control whose action is blocked on production so clicking it opens
+ * the read-only popover instead. `children` is the clickable trigger.
+ */
+export function ReadOnlyEditPopover({ children }: { children: ReactNode }) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <ReadOnlyEditPopoverContent />
+    </Popover>
   );
 }
 
 /**
  * Wraps a single leaf value widget as read-only: a real (layout-preserving) box
  * so the form's `space-y` still applies, dimmed for a distinct look, made inert
- * so nothing edits, with a transparent overlay that captures hover to surface a
- * "production is read-only" tooltip.
+ * so nothing edits, with a transparent overlay that opens the read-only popover.
  */
 export function ReadOnlyFieldWrap({ children }: { children: ReactNode }) {
-  const t = useT();
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div className="relative opacity-70">
-          <div inert>{children}</div>
-          <div className="absolute inset-0 cursor-not-allowed" />
-        </div>
-      </TooltipTrigger>
-      <TooltipContent className="max-w-[240px]">
-        {t("sectionsEditor.readOnlyFieldTooltip")}
-      </TooltipContent>
-    </Tooltip>
+    <ReadOnlyEditPopover>
+      <div className="relative opacity-70">
+        <div inert>{children}</div>
+        <div className="absolute inset-0 cursor-pointer" />
+      </div>
+    </ReadOnlyEditPopover>
   );
 }

--- a/apps/web/src/components/sections-editor/section-list.tsx
+++ b/apps/web/src/components/sections-editor/section-list.tsx
@@ -1,9 +1,18 @@
-import { useRef, useState } from "react";
+import {
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { createPortal } from "react-dom";
 import { SORTABLE_DROP_ANIMATION } from "@/lib/dnd-drop-animation.ts";
 import { cn } from "@decocms/ui/lib/utils.ts";
 import { useT } from "@/i18n/use-t.ts";
 import { useIsReadOnly } from "./fields/read-only-context";
+import {
+  ReadOnlyEditPopover,
+  ReadOnlyEditPopoverContent,
+} from "./fields/read-only-pane";
+import { Popover, PopoverAnchor } from "@decocms/ui/components/popover.tsx";
 import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Copy01,
@@ -264,15 +273,48 @@ function SortableSectionItem({
 
   const enableMakeReusable = canMakeSectionReusable(section);
 
+  // Read-only: detect a drag-to-reorder attempt and surface the popover instead.
+  const dragPressRef = useRef<{ x: number; y: number } | null>(null);
+  const suppressSelectRef = useRef(false);
+  const [dragBlockAt, setDragBlockAt] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+  const readOnlyDragProps = readOnly
+    ? {
+        onPointerDown: (e: ReactPointerEvent) => {
+          suppressSelectRef.current = false;
+          dragPressRef.current = { x: e.clientX, y: e.clientY };
+        },
+        onPointerMove: (e: ReactPointerEvent) => {
+          const start = dragPressRef.current;
+          if (!start) return;
+          if (Math.hypot(e.clientX - start.x, e.clientY - start.y) > 8) {
+            dragPressRef.current = null;
+            suppressSelectRef.current = true;
+            setDragBlockAt({ x: e.clientX, y: e.clientY });
+          }
+        },
+        onPointerUp: () => {
+          dragPressRef.current = null;
+        },
+      }
+    : { ...attributes, ...listeners };
+
   return (
     <div
       ref={setNodeRef}
       style={style}
-      {...(readOnly ? {} : attributes)}
-      {...(readOnly ? {} : listeners)}
+      {...readOnlyDragProps}
       role="button"
       tabIndex={0}
-      onClick={onSelect}
+      onClick={() => {
+        if (suppressSelectRef.current) {
+          suppressSelectRef.current = false;
+          return;
+        }
+        onSelect();
+      }}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
@@ -327,13 +369,12 @@ function SortableSectionItem({
         </Tooltip>
       )}
 
-      <Tooltip>
-        <TooltipTrigger asChild>
+      {readOnly ? (
+        <ReadOnlyEditPopover>
           <Button
             type="button"
             variant="ghost"
             size="icon"
-            disabled={readOnly}
             aria-label={
               isHidden
                 ? t("sectionsEditor.sectionList.showSection")
@@ -342,10 +383,7 @@ function SortableSectionItem({
             className={cn(
               actionButtonVisibilityClass(reserveActionButtonSpace, isHidden),
             )}
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleHidden();
-            }}
+            onClick={(e) => e.stopPropagation()}
             onPointerDown={(e) => e.stopPropagation()}
           >
             {isHidden ? (
@@ -354,89 +392,152 @@ function SortableSectionItem({
               <Eye className="h-3.5 w-3.5" />
             )}
           </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {isHidden
-            ? t("sectionsEditor.sectionList.showSection")
-            : t("sectionsEditor.sectionList.hideSection")}
-        </TooltipContent>
-      </Tooltip>
+        </ReadOnlyEditPopover>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={
+                isHidden
+                  ? t("sectionsEditor.sectionList.showSection")
+                  : t("sectionsEditor.sectionList.hideSection")
+              }
+              className={cn(
+                actionButtonVisibilityClass(reserveActionButtonSpace, isHidden),
+              )}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleHidden();
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              {isHidden ? (
+                <EyeOff className="h-3.5 w-3.5" />
+              ) : (
+                <Eye className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {isHidden
+              ? t("sectionsEditor.sectionList.showSection")
+              : t("sectionsEditor.sectionList.hideSection")}
+          </TooltipContent>
+        </Tooltip>
+      )}
 
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
+      {readOnly ? (
+        <ReadOnlyEditPopover>
           <Button
             type="button"
             variant="ghost"
             size="icon"
-            disabled={readOnly}
             aria-label={t("sectionsEditor.sectionList.sectionActionsMenu")}
             className={cn(
               actionButtonVisibilityClass(reserveActionButtonSpace, false),
-              "data-[state=open]:ml-0 data-[state=open]:w-7 data-[state=open]:opacity-100 data-[state=open]:[transition:opacity_150ms_ease-out,width_0ms,margin-left_0ms]",
             )}
             onClick={(e) => e.stopPropagation()}
             onPointerDown={(e) => e.stopPropagation()}
           >
             <DotsHorizontal className="h-3.5 w-3.5" />
           </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-44">
-          <DropdownMenuItem
-            onClick={(e) => {
-              e.stopPropagation();
-              onDuplicate();
-            }}
-          >
-            <Copy01 className="h-4 w-4" />
-            {t("sectionsEditor.sectionList.duplicateMenuItem")}
-          </DropdownMenuItem>
-          {enableAddVariant && (
-            <DropdownMenuItem
-              className={VARIANT_MENU_ITEM_CLASS}
-              onClick={(e) => {
-                e.stopPropagation();
-                onAddVariant();
-              }}
+        </ReadOnlyEditPopover>
+      ) : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={t("sectionsEditor.sectionList.sectionActionsMenu")}
+              className={cn(
+                actionButtonVisibilityClass(reserveActionButtonSpace, false),
+                "data-[state=open]:ml-0 data-[state=open]:w-7 data-[state=open]:opacity-100 data-[state=open]:[transition:opacity_150ms_ease-out,width_0ms,margin-left_0ms]",
+              )}
+              onClick={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
             >
-              <Flag01 className="h-4 w-4" />
-              {t("sectionsEditor.sectionList.addVariantMenuItem")}
-            </DropdownMenuItem>
-          )}
-          {enableMakeReusable && (
-            <DropdownMenuItem
-              className={GLOBAL_SECTION_MENU_ITEM_CLASS}
-              onClick={(e) => {
-                e.stopPropagation();
-                onMakeReusable();
-              }}
-            >
-              <LayoutAlt01 className="h-4 w-4" />
-              {t("sectionsEditor.sectionList.makeReusableMenuItem")}
-            </DropdownMenuItem>
-          )}
-          {section.isSavedBlock === true && !section.isMultivariate && (
+              <DotsHorizontal className="h-3.5 w-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-44">
             <DropdownMenuItem
               onClick={(e) => {
                 e.stopPropagation();
-                onDetach();
+                onDuplicate();
               }}
             >
-              <LayoutAlt01 className="h-4 w-4" />
-              {t("sectionsEditor.sectionList.detachMenuItem")}
+              <Copy01 className="h-4 w-4" />
+              {t("sectionsEditor.sectionList.duplicateMenuItem")}
             </DropdownMenuItem>
-          )}
-          <DropdownMenuItem
-            className="text-destructive focus:text-destructive"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete();
-            }}
-          >
-            <Trash01 className="h-4 w-4" />
-            {t("sectionsEditor.sectionList.deleteMenuItem")}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+            {enableAddVariant && (
+              <DropdownMenuItem
+                className={VARIANT_MENU_ITEM_CLASS}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onAddVariant();
+                }}
+              >
+                <Flag01 className="h-4 w-4" />
+                {t("sectionsEditor.sectionList.addVariantMenuItem")}
+              </DropdownMenuItem>
+            )}
+            {enableMakeReusable && (
+              <DropdownMenuItem
+                className={GLOBAL_SECTION_MENU_ITEM_CLASS}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onMakeReusable();
+                }}
+              >
+                <LayoutAlt01 className="h-4 w-4" />
+                {t("sectionsEditor.sectionList.makeReusableMenuItem")}
+              </DropdownMenuItem>
+            )}
+            {section.isSavedBlock === true && !section.isMultivariate && (
+              <DropdownMenuItem
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDetach();
+                }}
+              >
+                <LayoutAlt01 className="h-4 w-4" />
+                {t("sectionsEditor.sectionList.detachMenuItem")}
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+            >
+              <Trash01 className="h-4 w-4" />
+              {t("sectionsEditor.sectionList.deleteMenuItem")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+
+      {readOnly && (
+        <Popover
+          open={dragBlockAt !== null}
+          onOpenChange={(open) => {
+            if (!open) setDragBlockAt(null);
+          }}
+        >
+          <PopoverAnchor asChild>
+            <div
+              className="pointer-events-none fixed"
+              style={{ left: dragBlockAt?.x ?? 0, top: dragBlockAt?.y ?? 0 }}
+            />
+          </PopoverAnchor>
+          <ReadOnlyEditPopoverContent />
+        </Popover>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -55,7 +55,12 @@ import { TOUR_ANCHORS } from "@/components/cms-tour/anchors";
 import { decodeHtmlEntities } from "./decode-html-entities.ts";
 import { matchesBranchSearch, useBranches } from "./use-branches";
 import { useOpenPrs } from "./use-pr-data.ts";
-import { nextReleaseColor, releaseDotClass, useReleases } from "./use-releases";
+import {
+  nextDraftName,
+  nextReleaseColor,
+  releaseDotClass,
+  useReleases,
+} from "./use-releases";
 
 interface Props {
   virtualMcpId: string;
@@ -151,23 +156,14 @@ export function BranchPicker({
     setOpen(false);
   };
 
-  // One above the highest existing "Rascunho N" — renamed releases don't count.
-  const nextDraftName = () => {
-    const base = t("thread.branchPicker.defaultVersionName");
-    const prefix = `${base} `;
-    const max = releases.reduce((m, r) => {
-      if (!r.name.startsWith(prefix)) return m;
-      const n = Number(r.name.slice(prefix.length));
-      return Number.isInteger(n) && n > m ? n : m;
-    }, 0);
-    return `${base} ${max + 1}`;
-  };
-
   const create = () => {
     const branch = generateBranchName(userLabel);
     void createRelease({
       branch,
-      name: nextDraftName(),
+      name: nextDraftName(
+        releases,
+        t("thread.branchPicker.defaultVersionName"),
+      ),
       color: nextReleaseColor(releases.length),
       createdAt: new Date().toISOString(),
     });

--- a/apps/web/src/components/thread/github/use-releases.ts
+++ b/apps/web/src/components/thread/github/use-releases.ts
@@ -14,6 +14,22 @@ export function nextReleaseColor(count: number): string {
   return RELEASE_COLORS[count % RELEASE_COLORS.length]!;
 }
 
+/**
+ * Next auto name for an unnamed draft: one above the highest existing
+ * "`{base}` N" (e.g. "Rascunho 3" → "Rascunho 4"), starting at "`{base}` 1".
+ * Renamed releases don't count. Shared so the branch picker and the "start a
+ * new draft" CTAs number drafts identically.
+ */
+export function nextDraftName(releases: Release[], base: string): string {
+  const prefix = `${base} `;
+  const max = releases.reduce((m, r) => {
+    if (!r.name.startsWith(prefix)) return m;
+    const n = Number(r.name.slice(prefix.length));
+    return Number.isInteger(n) && n > m ? n : m;
+  }, 0);
+  return `${base} ${max + 1}`;
+}
+
 const DOT_CLASS: Record<string, string> = {
   orange: "bg-orange-500",
   violet: "bg-violet-500",

--- a/apps/web/src/components/thread/github/use-version-gate.ts
+++ b/apps/web/src/components/thread/github/use-version-gate.ts
@@ -9,7 +9,7 @@ import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
 import { useT } from "@/i18n/use-t.ts";
 import { useOptionalChatTask } from "@/components/chat/context";
 import { usePrByBranch } from "./use-pr-data.ts";
-import { nextReleaseColor, useReleases } from "./use-releases";
+import { nextDraftName, nextReleaseColor, useReleases } from "./use-releases";
 
 /**
  * The project's production branch — the PR base of the current branch, or "main"
@@ -72,7 +72,9 @@ export function useCreateDraft(virtualMcpId: string) {
     const branch = generateBranchName(userLabel);
     await createRelease({
       branch,
-      name: name?.trim() || t("thread.branchPicker.defaultVersionName"),
+      name:
+        name?.trim() ||
+        nextDraftName(releases, t("thread.branchPicker.defaultVersionName")),
       color: nextReleaseColor(releases.length),
       createdAt: new Date().toISOString(),
     });


### PR DESCRIPTION
## Summary

On production (read-only) the CMS stays navigable but every edit is blocked. This swaps the passive hover tooltip for an actionable path forward and makes it consistent across the editor.

- **Fields**: the hover tooltip on production-locked leaf fields becomes a tooltip-styled **popover** (click to open) that shows the "production is read-only" message **and** a **New draft** button, which creates a draft and moves editing onto it (`useCreateDraft`).
- **Section list**: the same popover now appears on the blocked mutation controls too —
  - **Hide/show** button (was disabled)
  - **Actions "…" menu** (was disabled)
  - **Drag-to-reorder** — a drag attempt (press + 8px move, matching the editor's sensor) surfaces the popover at the pointer instead of doing nothing. A plain click still selects the section to view it.
- **Draft auto-naming unified**: previously the picker created `Draft 1` while the CTA/popover created a plain `Draft`. Extracted `nextDraftName(releases, base)` into `use-releases.ts` so every entry point numbers unnamed drafts from **`Draft 1`**.

Implementation notes:
- `ReadOnlyPane` now carries `virtualMcpId` via a small context (`ReadOnlyVirtualMcpProvider`) so a blocked control can offer "start a new draft" without threading the id through every field prop.
- The popover body (`ReadOnlyEditPopoverContent`) is shared between the trigger form (`ReadOnlyEditPopover`) and the controlled/anchored drag-gesture popover; `useCreateDraft` only runs when a popover is open (Radix mounts content on demand), not once per read-only field.

## Testing

- `bun run check` ✅
- `bun run lint` ✅ (0 errors)
- `bun run fmt` ✅
- Interaction (click/drag → popover) is E2E-tier; no automated test added yet. Happy to add a Playwright spec in `packages/e2e` covering "on production, clicking hide / attempting drag opens the popover with New draft".

## Screenshots

_Popover replaces the old tooltip; includes the New draft button._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the read-only hover tooltip in the sections editor with a popover that offers a New draft button, so production users have a clear next step instead of a blocked edit. The same popover now also appears on the section list's disabled hide, actions, and drag-to-reorder controls, and draft auto-naming is unified so both the branch picker and the new CTA number unnamed drafts from `Draft 1`.

**Notes**
- A plain click on a section still selects it; only an actual drag attempt opens the popover.

<sup>Written for commit 10420890fa6cf1c579bf78fc653c4863b72d9ec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

