### PR TITLE
fix(sandbox): drain daemon health response body on non-2xx status

### DIFF
--- a/packages/sandbox/server/daemon-client.ts
+++ b/packages/sandbox/server/daemon-client.ts
@@ -114,7 +114,15 @@ export async function probeDaemonHealth(
     const res = await fetch(`${daemonUrl}/health`, {
       signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
     });
-    if (!res.ok) return null;
+    if (!res.ok) {
+      // Drain the body to ensure connection cleanup even on non-2xx responses.
+      try {
+        await res.text();
+      } catch {
+        // Ignore drain errors; connection cleanup is best-effort.
+      }
+      return null;
+    }
     const body = (await res.json()) as Partial<DaemonHealth>;
     if (
       typeof body === "object" &&


### PR DESCRIPTION
## Source
Sandbox daemon client lifecycle issue in `probeDaemonHealth()`.

## Payoff
Prevents connection leaks when the daemon health probe receives non-2xx responses by draining the response body before returning, following the established pattern in the codebase for discarded HTTP responses.

## Failure scenario
When `probeDaemonHealth()` receives a non-200 response (e.g., 500, 503), it returns null without consuming the response body. This leaves the connection in an undrained state, potentially leaking file descriptors or connection slots during repeated health probes—particularly problematic in `waitForDaemonReady()` which polls the health endpoint in a loop.

## Verification
- `bun test packages/sandbox/server/daemon-client.test.ts` — 24 tests pass
- `cd packages/sandbox && bunx tsc --noEmit` — no type errors
- `bunx oxlint packages/sandbox/server/daemon-client.ts` — 0 warnings, 0 errors

## Notes
The fix drains the response body in a try-catch to ensure cleanup is best-effort, mirroring the pattern used elsewhere in the codebase when handling discarded HTTP responses (e.g., "drain a discarded 401 body before retrying").

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`probeDaemonHealth()` now drains the response body before returning `null` for non-2xx responses. This prevents connection leaks during repeated health checks while keeping drain failures best-effort.

<sup>Written for commit 5a16749d0b0fa0b60c678149ef88d26eadb012fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

