### PR TITLE
fix(virtual-mcp): reset add-connection dialog search on reopen

### DIFF
--- a/apps/web/src/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/web/src/views/virtual-mcp/add-connection-dialog.tsx
@@ -92,6 +92,13 @@ export function AddConnectionDialog({
   const [connectingItemId, setConnectingItemId] = useState<string | null>(null);
   const [search, setSearch] = useState(initialSearch);
   const [createOpen, setCreateOpen] = useState(false);
+
+  // Dialog stays mounted across opens — reset the search term each time it opens.
+  const [wasOpen, setWasOpen] = useState(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) setSearch(initialSearch);
+  }
   const { org } = useProjectContext();
   const { data: session } = authClient.useSession();
   const connectionActions = useConnectionActions();


### PR DESCRIPTION
Bug found while auditing the Virtual MCP UI (`apps/web/src/views/virtual-mcp/`) for stale-state handling.

`AddConnectionDialog` is mounted persistently by every caller (`virtual-mcp/index.tsx`, `chat/input.tsx`, `home/native-tiles.tsx`, `sidebar-footer.tsx`) — only the `open` prop toggles. Its `search` state is initialized once via `useState(initialSearch)` and never reset, so it survives across opens/closes of the same dialog instance.

Failure scenario: a user opens "Add connection", types a search term (e.g. "postgres"), doesn't find what they want and closes the dialog, then reopens it later to add a different connection — the search box still shows "postgres", silently filtering out every other connection until they notice and clear it manually.

Fix: track the previous `open` value and reset `search` back to `initialSearch` whenever the dialog transitions from closed to open (the React-recommended "adjust state during render" pattern, since `useEffect` is banned in this repo).

How to verify: open any Add-connection dialog (e.g. from an agent's connections tab), type a search term, close it, reopen it — the search field should be empty (or back to its `initialSearch` default) instead of showing the previous term.

Checks run locally: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (no errors in the touched file), `bunx oxlint apps/web/src/views/virtual-mcp/add-connection-dialog.tsx` (0 warnings/errors). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Add connection dialog now resets its search field to `initialSearch` whenever it reopens. Previously, the dialog kept the previous search term because it remains mounted, which could hide available connections until the user cleared it manually.

<sup>Written for commit aff78d9e8c61049c9752ecf48ae67fa38e3e6567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

