### PR TITLE
refactor(shared): derive SandboxMapOwnerKind from its Zod schema

### DIFF
--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -399,10 +399,10 @@ const GithubRepoSchema = z.object({
 
 export type GithubRepo = z.infer<typeof GithubRepoSchema>;
 
-/** The app surfaces that can own a sandbox-map entry. */
-type SandboxMapOwnerKind = "agent-sandbox" | "local-api";
-
 const SandboxMapOwnerKindSchema = z.enum(["agent-sandbox", "local-api"]);
+
+/** The app surfaces that can own a sandbox-map entry. */
+type SandboxMapOwnerKind = z.infer<typeof SandboxMapOwnerKindSchema>;
 /**
  * A single sandbox record in the per-(user, branch, kind) sandbox map — the
  * provider-issued handle plus the preview URL the UI renders.


### PR DESCRIPTION
**Source:** a compile-time-safety gap found while auditing `packages/shared/src/sdk/types/virtual-mcp.ts` (virtual-MCP SDK types focus area) — not tied to an issue.

**Payoff:** `SandboxMapOwnerKind` (`"agent-sandbox" | "local-api"`) was hand-duplicated as a separate type literal right next to `SandboxMapOwnerKindSchema`, which is meant to be its single source of truth. Adding a third owner kind to the schema (or renaming one) would silently leave the type stale — `parseBranchMap`'s `Partial<Record<SandboxMapOwnerKind, SandboxRecord>>` return type and the `sandboxMap[userId][branch]` shape it documents would quietly stop matching what the schema actually validates, with no compile error to catch it.

**Fix:** derive the type from the schema instead: `type SandboxMapOwnerKind = z.infer<typeof SandboxMapOwnerKindSchema>`. Behavior-preserving — same two literal values, now with one source instead of two.

**Verify:** `cd packages/shared && bunx tsc --noEmit` (green).

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` in `packages/shared`, `bunx oxlint packages/shared/src/sdk/types/virtual-mcp.ts` (0 warnings/errors). No behavior-affecting test needed — pure type-level change. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives `SandboxMapOwnerKind` from its Zod schema so the type can't drift out of sync with the schema's allowed values.

Previously, the type was a hand-written literal union sitting next to `SandboxMapOwnerKindSchema`. If the schema gained a third owner kind, the type would silently become stale and `parseBranchMap`'s return type would stop matching what the schema validates. Now the schema is the single source of truth via `z.infer`, with no behavior change.

<sup>Written for commit 18b7a75dc0591413511712d12dbb58ccf96e11a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

