### PR TITLE
fix(admin): require an audit actor before releasing an org site slug

### DIFF
--- a/apps/api/src/api/routes/admin.ts
+++ b/apps/api/src/api/routes/admin.ts
@@ -618,14 +618,19 @@ export function createAdminRoutes(): Hono<Env> {
     if (!org) {
       return c.json({ error: "Organization not found" }, 404);
     }
+
+    const { actorId: effectiveActorId, impersonatedBy } =
+      await getAuditActor(c);
+    const actorId = impersonatedBy ?? effectiveActorId;
+    if (!actorId) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
     const released = await new OrgSiteStorage(db).releaseSite(slug, orgId);
     if (!released) {
       return c.json({ error: "Site not found for this organization" }, 404);
     }
 
-    const { actorId: effectiveActorId, impersonatedBy } =
-      await getAuditActor(c);
-    const actorId = impersonatedBy ?? effectiveActorId;
     auditAdminAction("org_site_release", {
       actor_user_id: actorId,
       ...(impersonatedBy ? { impersonated_user_id: effectiveActorId } : {}),


### PR DESCRIPTION
Bug found while auditing `apps/api/src/storage/org-sites.ts` and its admin route (`apps/api/src/api/routes/admin.ts`), per this tick's org-sites storage focus area.

The `DELETE /orgs/:orgId/sites/:slug` route (org site slug release, a destructive, security-sensitive action — it frees a slug for another org to reclaim) performed `releaseSite(...)` and only *afterward* resolved the audit actor via `getAuditActor(c)`, with no check that an actor was actually present. The sibling `POST /orgs/:orgId/sites` route (claim/reassign) already resolves the actor *first* and returns 401 if missing, before doing anything destructive. The DELETE route lacked that guard, so if `getAuditActor` ever returned no actor id (e.g. a session lookup edge case), the release would still go through and get audited with `actor_user_id: undefined` — an accountability gap on an irreversible, tenant-ownership-changing action.

Fix: move the actor resolution above the `releaseSite` call and return 401 when there's no actor, matching the existing POST-route pattern exactly.

Net effect: same behavior for the normal (authenticated) path; closes the theoretical hole where a missing actor could still perform+audit the release.

How to confirm: `cd apps/api && bunx tsc --noEmit` (clean); `bunx oxlint apps/api/src/api/routes/admin.ts` (0 warnings/errors). No unit test added — this route is only covered end-to-end (`packages/e2e/tests/deployment-admin.spec.ts`, "sites: claim, list, release"), which needs Docker/Postgres not available in this environment; the existing e2e still exercises the authenticated happy path unchanged. Full CI runs that suite.

Checks run locally: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bunx oxlint` on the changed file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the org site slug release route so it resolves the audit actor before releasing the slug and returns 401 when no actor is present, matching the POST claim route. Previously the release happened first and could be audited with `actor_user_id: undefined` if the actor lookup failed, leaving an accountability gap on this irreversible, tenant-ownership-changing action.

<sup>Written for commit 253c5020926fbd7a20c6db88681c6859c3831267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

