### PR TITLE
fix(sections-editor): validate an existing page's path before saving it

### DIFF
--- a/apps/web/src/components/sections-editor/sections-editor-panels.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor-panels.tsx
@@ -25,6 +25,7 @@ import { useIsReadOnly } from "./fields/read-only-context";
 import { SeoFormFields } from "./seo-form-fields";
 import { parsePageVariants, type PageVariant } from "./page-variants";
 import { formatMatcher } from "./format-matcher";
+import { validatePagePath } from "./page-path-utils";
 import { useT } from "@/i18n/use-t.ts";
 
 /**
@@ -237,6 +238,7 @@ export function PageHeaderInputs({
   const [pendingPath, setPendingPath] = useState<string | null>(null);
   // Set on Escape so the ensuing blur doesn't re-prompt.
   const skipCommitRef = useRef(false);
+  const [pathError, setPathError] = useState<string | null>(null);
 
   // Reset local state when navigating to a different page
   if (prevKey !== pageKey) {
@@ -244,6 +246,7 @@ export function PageHeaderInputs({
     setName(initialName);
     setPath(initialPath);
     setPendingPath(null);
+    setPathError(null);
   }
 
   const commitPath = () => {
@@ -255,8 +258,17 @@ export function PageHeaderInputs({
     if (trimmed === initialPath.trim()) {
       // No real change — normalize the displayed value and move on.
       setPath(initialPath);
+      setPathError(null);
       return;
     }
+    // Same validation the create-page flow already runs (page-path-utils).
+    const error = validatePagePath(trimmed);
+    if (error) {
+      setPathError(error);
+      setPath(initialPath);
+      return;
+    }
+    setPathError(null);
     setPendingPath(trimmed);
   };
 
@@ -291,7 +303,10 @@ export function PageHeaderInputs({
         type="text"
         value={path}
         readOnly={readOnly}
-        onChange={(e) => setPath(e.target.value)}
+        onChange={(e) => {
+          setPath(e.target.value);
+          setPathError(null);
+        }}
         onBlur={commitPath}
         onKeyDown={(e) => {
           if (e.key === "Enter") {
@@ -301,12 +316,14 @@ export function PageHeaderInputs({
             e.preventDefault();
             skipCommitRef.current = true;
             setPath(initialPath);
+            setPathError(null);
             e.currentTarget.blur();
           }
         }}
         className="w-full bg-transparent text-xs text-muted-foreground truncate outline-none border-none p-0 focus:ring-0 placeholder:text-muted-foreground"
         placeholder={t("sectionsEditor.sectionsEditorPanels.pathPlaceholder")}
       />
+      {pathError && <p className="text-xs text-destructive">{pathError}</p>}
       <AlertDialog
         open={pendingPath !== null}
         onOpenChange={(next) => {


### PR DESCRIPTION
**Bug**: the page-rename path input in `PageHeaderInputs` (`sections-editor-panels.tsx`) commits whatever the user types straight to the decofile on blur, with no validation. `CreatePageModal` already runs the identical input through `validatePagePath` (`page-path-utils.ts`) at page-creation time — but that same guard was never wired into the edit flow, so an existing page's path could be rewritten to an empty string, a path missing the leading `/`, a protocol-relative `//path`, or one containing a `..` segment, all of which the create flow already rejects.

**Why a maintainer wants this**: the path drives route matching/preview URL resolution for the page, so an invalid value silently corrupts that page's routing until someone notices and manually fixes the decofile. This closes the same validation gap on the edit path that the create path already has.

**Fix**: `commitPath` now runs the trimmed value through the existing `validatePagePath` before opening the rename-confirmation dialog. An invalid value surfaces an inline error message (same style/wording as `CreatePageModal`) and reverts the input to the last-saved path instead of prompting to save the bad value.

**Verify**: open a page in the Sections Editor, edit the path field to something like `not-a-path` (no leading slash) or clear it entirely, and blur — the input should show a validation error and revert rather than opening the "change path" confirmation dialog. A valid path (e.g. `/foo`) still shows the existing confirm-and-save flow.

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` in `apps/web` (pre-existing unrelated prosemirror version-mismatch error only, nothing in the touched file), `bunx oxlint apps/web/src/components/sections-editor/sections-editor-panels.tsx` (0 warnings/errors). No component test harness exists for this file (no `.test.tsx` in `sections-editor/`), so this relies on the targeted checks above plus CI's e2e suite; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates page path edits in the Sections Editor before saving. Previously, the path input committed whatever the user typed on blur; invalid paths (empty, missing leading `/`, protocol-relative, or containing `..` segments) were written straight to the decofile, silently breaking page routing. Now those paths show an inline error and revert to the last saved value instead of being saved.

- Reuses the same `validatePagePath` check the page-creation flow already runs.
- Valid paths still open the rename confirmation dialog as before.

<sup>Written for commit d27f3032c9a541f593d9d20a8429b0aff225a239. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

