### PR TITLE
fix(connections): guard against orphaning an automation's event trigger on delete

### DIFF
--- a/apps/api/src/storage/automations.ts
+++ b/apps/api/src/storage/automations.ts
@@ -94,6 +94,9 @@ export interface AutomationsStorage {
     eventType: string,
     organizationId: string,
   ): Promise<(AutomationTrigger & { automation: Automation })[]>;
+  listActiveByEventTriggerConnectionId(
+    connectionId: string,
+  ): Promise<Pick<Automation, "id" | "name">[]>;
   // Includes inactive automations: reconciler pauses (not deletes) their schedules.
   findAllCronTriggers(): Promise<
     (AutomationTrigger & { automation: Automation })[]
@@ -539,6 +542,29 @@ class KyselyAutomationsStorage implements AutomationsStorage {
       ...triggerFromDbRow(row),
       automation: automationFromAliasedRow(row),
     }));
+  }
+
+  /**
+   * Active automations with an event trigger bound to this connection.
+   *
+   * `automation_triggers.connection_id` has no FK — deleting the connection
+   * would silently strand the trigger (it just stops matching forever).
+   * Callers tearing down a connection must check this first.
+   */
+  async listActiveByEventTriggerConnectionId(
+    connectionId: string,
+  ): Promise<Pick<Automation, "id" | "name">[]> {
+    const rows = await this.db
+      .selectFrom("automation_triggers as t")
+      .innerJoin("automations as a", "a.id", "t.automation_id")
+      .select(["a.id", "a.name"])
+      .where("t.type", "=", "event")
+      .where("t.connection_id", "=", connectionId)
+      .where("a.active", "=", true)
+      .distinct()
+      .execute();
+
+    return rows;
   }
 
   async findAllCronTriggers(): Promise<

--- a/apps/api/src/tools/connection/delete.test.ts
+++ b/apps/api/src/tools/connection/delete.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, mock } from "bun:test";
 import { COLLECTION_CONNECTIONS_DELETE } from "./delete";
 
-function makeCtx(options: { referencedByThread: boolean }) {
+function makeCtx(options: {
+  referencedByThread: boolean;
+  referencingAutomations?: { id: string; name: string }[];
+}) {
   const connection = {
     id: "conn_repo",
     organization_id: "org_123",
@@ -9,6 +12,7 @@ function makeCtx(options: { referencedByThread: boolean }) {
   };
   const deleteConnection = mock(async () => {});
   const isReferencedByThread = mock(async () => options.referencedByThread);
+  const deactivateAutomation = mock(async () => {});
   const ctx = {
     auth: { user: { id: "user_123" } },
     organization: { id: "org_123" },
@@ -20,10 +24,16 @@ function makeCtx(options: { referencedByThread: boolean }) {
         isReferencedByThread,
       },
       virtualMcps: { listByConnectionId: mock(async () => []) },
+      automations: {
+        listActiveByEventTriggerConnectionId: mock(
+          async () => options.referencingAutomations ?? [],
+        ),
+        deactivateAutomation,
+      },
       organizationSettings: { get: mock(async () => null) },
     },
   } as unknown as Parameters<typeof COLLECTION_CONNECTIONS_DELETE.handler>[1];
-  return { ctx, deleteConnection, isReferencedByThread };
+  return { ctx, deleteConnection, isReferencedByThread, deactivateAutomation };
 }
 
 describe("COLLECTION_CONNECTIONS_DELETE", () => {
@@ -47,6 +57,36 @@ describe("COLLECTION_CONNECTIONS_DELETE", () => {
     );
 
     expect(result.item.id).toBe("conn_repo");
+    expect(deleteConnection).toHaveBeenCalledWith("conn_repo");
+  });
+
+  it("refuses to delete a connection with an active automation event trigger", async () => {
+    // Regression: automation_triggers.connection_id has no FK and would strand silently.
+    const { ctx, deleteConnection } = makeCtx({
+      referencedByThread: false,
+      referencingAutomations: [{ id: "auto_1", name: "Notify on PR" }],
+    });
+
+    await expect(
+      COLLECTION_CONNECTIONS_DELETE.handler({ id: "conn_repo" }, ctx),
+    ).rejects.toThrow(/CONNECTION_IN_USE_BY_AUTOMATION/);
+
+    expect(deleteConnection).not.toHaveBeenCalled();
+  });
+
+  it("force-deletes a connection by deactivating its referencing automations", async () => {
+    const { ctx, deleteConnection, deactivateAutomation } = makeCtx({
+      referencedByThread: false,
+      referencingAutomations: [{ id: "auto_1", name: "Notify on PR" }],
+    });
+
+    const result = await COLLECTION_CONNECTIONS_DELETE.handler(
+      { id: "conn_repo", force: true },
+      ctx,
+    );
+
+    expect(result.item.id).toBe("conn_repo");
+    expect(deactivateAutomation).toHaveBeenCalledWith("auto_1");
     expect(deleteConnection).toHaveBeenCalledWith("conn_repo");
   });
 });

--- a/apps/api/src/tools/connection/delete.ts
+++ b/apps/api/src/tools/connection/delete.ts
@@ -97,6 +97,28 @@ export const COLLECTION_CONNECTIONS_DELETE = defineTool({
       throw new Error(JSON.stringify({ code: "CONNECTION_IN_USE_BY_THREAD" }));
     }
 
+    // An automation's event trigger connection_id has no FK, so it would strand silently.
+    const referencingAutomations =
+      await ctx.storage.automations.listActiveByEventTriggerConnectionId(
+        input.id,
+      );
+    if (referencingAutomations.length > 0) {
+      if (input.force) {
+        await Promise.all(
+          referencingAutomations.map((automation) =>
+            ctx.storage.automations.deactivateAutomation(automation.id),
+          ),
+        );
+      } else {
+        throw new Error(
+          JSON.stringify({
+            code: "CONNECTION_IN_USE_BY_AUTOMATION",
+            automationNames: referencingAutomations.map((a) => a.name),
+          }),
+        );
+      }
+    }
+
     // Delete connection
     await ctx.storage.connections.delete(input.id);
 


### PR DESCRIPTION
`automation_triggers.connection_id` (used for event-type triggers) has no FK constraint at all — unlike Virtual MCP references (FK RESTRICT, already guarded) or thread repo pins (guarded by the just-merged #6865). Deleting a connection that an active automation's event trigger points to silently strands that trigger: it just stops matching forever, with no error surfaced anywhere.

This mirrors the exact pattern #6865 just added for thread pins, extended to automations.

**Failure scenario:** an org wires an event-triggered automation to connection A, then deletes connection A from a different flow (e.g. cleaning up unused connections). The automation looks active in the UI but silently never fires again — no error, no signal.

**Fix:** `COLLECTION_CONNECTIONS_DELETE` now checks `automations.listActiveByEventTriggerConnectionId` before deleting:
- Without `force`: throws `CONNECTION_IN_USE_BY_AUTOMATION` with the referencing automation names (same shape as the existing `CONNECTION_IN_USE` check for Virtual MCPs).
- With `force`: deactivates the referencing automations before deleting the connection.

Added `AutomationsStorage.listActiveByEventTriggerConnectionId`.

**Regression tests** (`delete.test.ts`): blocks deletion when an active automation references the connection; force-deletes by deactivating the automation.

Reviewer check: `bun test apps/api/src/tools/connection/delete.test.ts`

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), targeted test file (4 pass), `bunx oxlint` on all three touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents deleting a connection that an active automation's event trigger depends on, which previously silently stranded the trigger and stopped the automation from firing. Now deletion without `force` errors with `CONNECTION_IN_USE_BY_AUTOMATION`, and with `force` it deactivates the referencing automations first.

<sup>Written for commit 9a5f62130ee84b72a8ba712f9766dc79c8422398. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

