### PR TITLE
fix(connection-details): label the activity timeframe toggle group for screen readers

### DIFF
--- a/apps/web/src/components/details/connection/connection-activity.tsx
+++ b/apps/web/src/components/details/connection/connection-activity.tsx
@@ -238,7 +238,11 @@ export function ConnectionActivity({ connectionId }: ConnectionActivityProps) {
             {t("details.connectionActivity.activity")}
           </h3>
         </div>
-        <div className="flex items-center gap-0.5 bg-muted rounded-lg p-0.5">
+        <div
+          role="group"
+          aria-label={t("details.connectionActivity.timeframe")}
+          className="flex items-center gap-0.5 bg-muted rounded-lg p-0.5"
+        >
           {TIMEFRAMES.map((tf) => (
             <button
               key={tf.value}

--- a/apps/web/src/i18n/en/details.ts
+++ b/apps/web/src/i18n/en/details.ts
@@ -28,6 +28,7 @@ export const details = {
   "details.connectionActivity.errors": "Errors",
   "details.connectionActivity.noActivityInThisPeriod":
     "No activity in this period",
+  "details.connectionActivity.timeframe": "Timeframe",
   "details.connectionActivity.toolCalls": "Tool calls",
   "details.connectionActivity.topErrors": "Top errors",
   "details.connectionAgentsPanel.usedByAgents": "Used by agents",

--- a/apps/web/src/i18n/pt-br/details.ts
+++ b/apps/web/src/i18n/pt-br/details.ts
@@ -30,6 +30,7 @@ export const details = {
   "details.connectionActivity.errors": "Erros",
   "details.connectionActivity.noActivityInThisPeriod":
     "Nenhuma atividade neste período",
+  "details.connectionActivity.timeframe": "Período",
   "details.connectionActivity.toolCalls": "Chamadas de ferramenta",
   "details.connectionActivity.topErrors": "Principais erros",
   "details.connectionAgentsPanel.usedByAgents": "Usado por agentes",


### PR DESCRIPTION
The 7d/14d/30d timeframe toggle in the connection activity card (`connection-activity.tsx`) is a set of three `aria-pressed` buttons with no group semantics — assistive tech announces three unrelated buttons, not a single labeled control. #6857 (merged today) already fixed each button's own pressed state; this closes the remaining gap by giving the wrapping `div` `role="group"` and an `aria-label` ("Timeframe" / "Período"), following the same a11y pattern used elsewhere in the repo (e.g. #6857, #6448).

Why a maintainer wants it: a screen-reader user currently can't tell the three buttons form one timeframe selector — this is a one-line fix for a real, verifiable a11y regression.

Change: added `details.connectionActivity.timeframe` to `en`/`pt-br` dictionaries, applied `role="group"` + `aria-label` to the toggle container.

To verify: open a connection's details page, inspect the timeframe toggle's accessibility tree (DevTools > Accessibility) and confirm it now reports as a labeled group named "Timeframe".

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (only a pre-existing, unrelated prosemirror version-mismatch error remains, not touching this file), `bunx oxlint` on the three changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Labels the 7d/14d/30d timeframe toggle in the connection activity card so screen readers announce it as a single labeled group instead of three unrelated buttons. Adds the "Timeframe"/"Período" label to the `en` and `pt-br` dictionaries.

<sup>Written for commit 94d95d968faa90b170727e094b8fe92a204bba54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

