### PR TITLE
fix(connections): surface a clear error deleting the dev-assets connection

### DIFF
--- a/apps/api/src/tools/connection/delete.test.ts
+++ b/apps/api/src/tools/connection/delete.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import { WellKnownOrgMCPId } from "@decocms/shared/sdk";
 import { COLLECTION_CONNECTIONS_DELETE } from "./delete";
 
 function makeCtx(options: { referencedByThread: boolean }) {
@@ -27,6 +28,18 @@ function makeCtx(options: { referencedByThread: boolean }) {
 }
 
 describe("COLLECTION_CONNECTIONS_DELETE", () => {
+  it("refuses to delete the synthetic dev-assets connection with a clear error", async () => {
+    // Regression: findById() can't see it, so this used to say "not found".
+    const { ctx, deleteConnection } = makeCtx({ referencedByThread: false });
+    const devAssetsId = WellKnownOrgMCPId.DEV_ASSETS("org_123");
+
+    await expect(
+      COLLECTION_CONNECTIONS_DELETE.handler({ id: devAssetsId }, ctx),
+    ).rejects.toThrow(/fixed system connection/);
+
+    expect(deleteConnection).not.toHaveBeenCalled();
+  });
+
   it("refuses to delete a connection a thread is pinned to as its repo", async () => {
     // Regression: deleting it would strand the thread's sandbox permanently.
     const { ctx, deleteConnection } = makeCtx({ referencedByThread: true });

--- a/apps/api/src/tools/connection/delete.ts
+++ b/apps/api/src/tools/connection/delete.ts
@@ -18,6 +18,7 @@ import {
 } from "../../core/studio-context";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
 import { invalidateConnectionCaches } from "../../mcp-clients/mcp-cache-invalidation";
+import { isDevAssetsConnection, usesLocalObjectStorage } from "./dev-assets";
 import { ConnectionEntitySchema } from "./schema";
 
 const ConnectionDeleteInputSchema = CollectionDeleteInputSchema.extend({
@@ -52,6 +53,16 @@ export const COLLECTION_CONNECTIONS_DELETE = defineTool({
 
     // Check authorization
     await ctx.access.check();
+
+    // The dev-assets connection is synthetic; findById() below can't see it.
+    if (
+      usesLocalObjectStorage() &&
+      isDevAssetsConnection(input.id, organization.id)
+    ) {
+      throw new Error(
+        "This connection is a fixed system connection and cannot be deleted",
+      );
+    }
 
     // Fetch connection before deleting to return the entity
     const connection = await ctx.storage.connections.findById(input.id);


### PR DESCRIPTION
**Source:** bug found while hardening `apps/api/src/tools/connection/delete.ts` (this tick's focus area).

**Payoff:** a user (or automation) that tries to delete the dev-assets pseudo-connection gets a correct, actionable error instead of a misleading "Connection not found".

**Bug:** the tool's `metadata?.isFixed === true` guard, added specifically to block deleting the dev-assets connection, only runs after `ctx.storage.connections.findById(input.id)` returns a row. But the dev-assets connection is synthetic (`apps/api/src/tools/connection/dev-assets.ts`) and is never persisted to the `connections` table — `COLLECTION_CONNECTIONS_GET` already special-cases it for exactly this reason. So `findById` always returns `null` for its id, and the delete handler throws `Connection not found: <id>` before the isFixed check is ever reached — that branch is dead code for its stated purpose.

**Fix:** mirror the same `isDevAssetsConnection` + `usesLocalObjectStorage` check that `get.ts` already uses, before calling `findById`, and fail with the intended "cannot be deleted" message. Added a regression test asserting the specific error message and that `connections.delete` is never called.

**Verify:** `bun test apps/api/src/tools/connection/delete.test.ts`

**Checked locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deleting the synthetic dev-assets connection so it returns a clear "fixed system connection" error instead of a misleading "Connection not found". The guard now runs before the lookup, since the dev-assets connection is never persisted. Adds a regression test covering the error message and that no delete is performed.

<sup>Written for commit 87bb81620464a0731f97732616b9aa0e8851ad07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

