### PR TITLE
fix(thread): surface a toast when start-draft creation fails

### DIFF
--- a/apps/web/src/components/thread/github/start-draft-cta.tsx
+++ b/apps/web/src/components/thread/github/start-draft-cta.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { ArrowRight, Lock01 } from "@untitledui/icons";
+import { toast } from "sonner";
 import { cn } from "@decocms/ui/lib/utils.ts";
 import { useT } from "@/i18n/use-t.ts";
 import { useCreateDraft } from "./use-version-gate";
@@ -27,6 +28,8 @@ export function StartDraftCta({
     setPending(true);
     try {
       await createDraft();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
     } finally {
       setPending(false);
     }
@@ -36,6 +39,7 @@ export function StartDraftCta({
     <button
       type="button"
       disabled={pending}
+      aria-busy={pending}
       onClick={() => void handleClick()}
       className={cn(
         "group flex items-center gap-3 rounded-2xl border border-border bg-background/60 px-4 py-3.5 text-left shadow-sm backdrop-blur-sm transition-colors hover:bg-background/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-60",


### PR DESCRIPTION
**Bug**: `StartDraftCta.handleClick` (`apps/web/src/components/thread/github/start-draft-cta.tsx`) calls `await createDraft()` in a bare `try/finally` — if `createDraft()` rejects (e.g. the release-mint or thread-repoint network call in `useCreateDraft` fails), the error is swallowed as an unhandled promise rejection. The button just quietly re-enables with zero user feedback, so a user has no idea their click to start a draft failed.

**Fix**: catch the error and `toast.error(...)`, matching the exact pattern already used by sibling actions in the same directory (`cms-header-actions.tsx`, `publish-dialog.tsx`, `use-cms-publish-actions.ts`) for the same class of mutation failure. Also added `aria-busy={pending}` on the button so screen readers get a signal while the draft is being created (it already gets `disabled`, but no busy-state announcement).

**Why a maintainer wants this**: this is the only mutation-triggering action in `thread/github/` that doesn't surface its own failure — a quiet regression once `useCreateDraft`'s network calls started actually being able to fail here.

**Verify**: click "start a new draft" while `createRelease` is mocked/forced to reject and confirm a toast now appears (previously: silent). Reviewer command: `cd apps/web && bunx tsc --noEmit` (clean for this file; one pre-existing unrelated prosemirror version-mismatch error in `mention-suggestion.tsx` is untouched by this diff).

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/web workspace — no new errors), `bunx oxlint apps/web/src/components/thread/github/start-draft-cta.tsx` (0 warnings/errors). No existing test covers this file; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a toast when starting a draft fails, so users no longer get a silent failure — previously the button just re-enabled with no feedback.

- Adds `aria-busy` to the button so screen readers announce the pending state while the draft is being created.

<sup>Written for commit 6031019559a9f0e892146fdca3bdf034a0886653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

