### PR TITLE
fix(agents-section): stop nesting a button inside the breadcrumb agent-picker trigger

### DIFF
--- a/apps/web/src/components/sidebar/agents-section.tsx
+++ b/apps/web/src/components/sidebar/agents-section.tsx
@@ -1,4 +1,11 @@
-import { Suspense, useState, type ReactElement, type ReactNode } from "react";
+import {
+  Suspense,
+  cloneElement,
+  useState,
+  type MouseEvent,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import { ToolbarIconButton } from "@/components/toolbar-icon-button";
 import { cn } from "@decocms/ui/lib/utils.ts";
 import {
@@ -499,7 +506,7 @@ function PinAgentPopover({
 }: {
   compact?: boolean;
   /** Custom trigger (e.g. the breadcrumb agent crumb); defaults to the "+" btn. */
-  trigger?: ReactElement;
+  trigger?: ReactElement<{ onClick?: (event: MouseEvent) => void }>;
   /** Scope-picker mode: set the sidebar agent filter instead of opening a task. */
   onSelectAgent?: (id: string | null) => void;
   selectedAgentId?: string | null;
@@ -555,13 +562,13 @@ function PinAgentPopover({
       {isMobile ? (
         <>
           {trigger ? (
-            <button
-              type="button"
-              onClick={() => setOpen(true)}
-              className="contents"
-            >
-              {trigger}
-            </button>
+            // trigger is always a <button> — merge onto it, don't wrap it in another one.
+            cloneElement(trigger, {
+              onClick: (event: MouseEvent) => {
+                trigger.props.onClick?.(event);
+                setOpen(true);
+              },
+            })
           ) : compact ? (
             wrapEmptyHint(
               <MobileCompactButton


### PR DESCRIPTION
Found while auditing `apps/web/src/components/header/shell-breadcrumb.tsx` for a11y issues (the header breadcrumb focus area) — the actual defect lives one level down, in the shared picker that backs the breadcrumb's agent-switcher trigger.

`AgentSwitcherCrumb` (shell-breadcrumb.tsx) passes its own `<button>` as a custom `trigger` to `AgentScopePicker`/`PinAgentPopover` (agents-section.tsx). This `trigger` prop is only ever used from the breadcrumb — nowhere else in the codebase passes a custom trigger to this component. On mobile, `PinAgentPopover` wrapped that trigger in *another* `<button onClick={() => setOpen(true)}>`, producing a literal `<button><button>...</button></button>` in the live DOM (React builds the tree via `createElement`/`appendChild`, so this isn't auto-corrected the way raw HTML parsing would). Nested interactive controls are invalid HTML and a WCAG 4.1.2 violation — screen readers can announce the outer control ambiguously or skip it, and it's exactly the class of markup that trips up AT navigation on the mobile agent-picker breadcrumb.

Fix: use `cloneElement` to merge the `setOpen(true)` handler onto the trigger's own `onClick`, instead of wrapping it in a second `<button>`. No behavior change for the default (non-custom-trigger) mobile buttons, which are untouched.

Failure scenario: open the app on a narrow viewport, tap the agent name in the topbar breadcrumb — a screen reader encounters two nested button roles for one control instead of one.

To confirm: `cd apps/web && bunx tsc --noEmit` (green, aside from a pre-existing unrelated prosemirror version-skew error in mention-suggestion.tsx) and `bunx oxlint apps/web/src/components/sidebar/agents-section.tsx` (0 warnings/errors). No existing test file covers this component's markup shape; full CI validates the rest.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web), `bunx oxlint` on the changed file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mobile agent-picker breadcrumb rendering a `<button>` inside another `<button>`, which is invalid HTML and violates WCAG 4.1.2. The picker now merges its open handler onto the breadcrumb trigger's existing `onClick` instead of wrapping it in a second button, so assistive tech sees one control; the default mobile trigger is unchanged.

<sup>Written for commit 22b673338fe2502f7f7d27dc33c2d505dde7c756. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

