### PR TITLE
fix(reports): bound Commerce Discovery HTTP calls with a request timeout

### DIFF
--- a/apps/api/src/tools/reports/auth-client.ts
+++ b/apps/api/src/tools/reports/auth-client.ts
@@ -5,6 +5,14 @@ import type { Settings } from "../../settings";
 
 const DEFAULT_INTERNAL_API_URL = new URL(COMMERCE_DISCOVERY_MCP_URL).origin;
 
+/**
+ * None of these calls carried a timeout — a hung Commerce Discovery request
+ * (dead connection, stalled upstream) would block the calling tool call
+ * indefinitely. 15s matches the jira client's REQUEST_TIMEOUT_MS for the same
+ * kind of external-service call.
+ */
+const REQUEST_TIMEOUT_MS = 15_000;
+
 const UpgradeResponseSchema = z.object({
   token: z.string().min(1),
 });
@@ -239,6 +247,7 @@ export async function fetchCommerceDiscoveryAuth(
       ...(input.email ? { email: input.email } : {}),
       ...(input.reportUrl ? { report_url: input.reportUrl } : {}),
     }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
 
   if (!response.ok) {
@@ -301,6 +310,7 @@ export async function bindCommerceDiscoveryResource(
       provider: input.provider,
       resource_id: input.resourceId,
     }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
 
   if (response.status === 409) {
@@ -376,6 +386,7 @@ export async function triggerCommerceDiscoveryRun(
       org_id: input.orgId,
       ...(input.githubRepo ? { github_repo: input.githubRepo } : {}),
     }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
 
   if (response.status === 409) {
@@ -429,6 +440,7 @@ export async function fetchCommerceDiscoveryConnectionStatus(
   const response = await fetchImpl(url, {
     method: "GET",
     headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
 
   if (response.status === 404 || response.status === 409) {


### PR DESCRIPTION
Bounded fix in apps/api/src/tools/reports/ (reports tooling robustness area).

None of the 4 outbound fetch calls in `auth-client.ts` (`/upgrade`, `/bindings`, `/run`, `/connections/status` — Commerce Discovery's internal API) carried a timeout. A hung or slow-draining connection to that external service would block the calling MCP tool call (COMMERCE_DISCOVERY_SETUP/BIND/RUN/CONNECTION_STATUS) indefinitely, tying up the request until the client itself gives up.

Adds `signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)` (15s) to all 4 calls — a native platform feature, no new dependency. 15s matches `REQUEST_TIMEOUT_MS` already used for the same class of external HTTP call in `apps/api/src/jira/client.ts`, so it's consistent with the repo's existing convention (see 'External HTTP client resilience' lane in bot memory — 'bound the fetch with a timeout').

Behavior-preserving on the happy path (fast responses are unaffected); on timeout, `fetchImpl`'s promise now rejects with an AbortError instead of hanging, which callers already handle as an unexpected throw (same as any other network failure — no new try/catch needed here).

How to verify: `bun test apps/api/src/tools/reports/auth-client.test.ts` (26 tests, all mock `fetchImpl` and ignore the extra `signal` field, so no behavior change in tests) and `cd apps/api && bunx tsc --noEmit`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/tools/reports/auth-client.test.ts` (26 pass), `bunx oxlint apps/api/src/tools/reports/auth-client.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 15-second timeout to the four Commerce Discovery HTTP calls in `apps/api/src/tools/reports/auth-client.ts` so a hung connection no longer blocks the calling MCP tool call indefinitely. On timeout, the fetch rejects with an AbortError that callers already handle like any other network failure; fast responses are unaffected.

<sup>Written for commit 2f39ea2660ef20bdbde90ddb17353f1660b23b25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

