### PR TITLE
fix(storage): set updated_by on virtual MCP create and remove duplicate comment

### DIFF
--- a/apps/api/src/storage/virtual.ts
+++ b/apps/api/src/storage/virtual.ts
@@ -5,9 +5,6 @@
  * Virtual MCPs are stored as connections with connection_type = 'VIRTUAL'.
  * The aggregations (which child connections are included) are stored in
  * the connection_aggregations table.
- *
- * The aggregations (which child connections are included) are stored in
- * the connection_aggregations table.
  */
 
 import type { Kysely } from "kysely";
@@ -76,6 +73,7 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
           id,
           organization_id: organizationId,
           created_by: userId,
+          updated_by: userId,
           title: data.title,
           description: data.description ?? null,
           icon: data.icon ?? null,


### PR DESCRIPTION
## Summary

Virtual MCP storage hygiene cleanup: fixes missing `updated_by` field on creation and removes duplicate comment.

## Changes

1. **Set `updated_by` on virtual MCP creation** — When creating a virtual MCP, the `updated_by` field was left NULL in the database. For consistency with other collection entities and the update pattern already established in the codebase (line 352), `updated_by` is now set to the creator's userId on creation, matching `created_by`. This ensures the audit trail is complete from the first record.

2. **Remove duplicate comment** — The header comment in virtual.ts had the same line repeated twice ("The aggregations... are stored in the connection_aggregations table."). Removed the redundancy.

## Verification

- `bun run fmt` ✓ (no changes needed)
- `bunx tsc --noEmit` in apps/api ✓ (no type errors)
- `bunx oxlint src/storage/virtual.ts` ✓ (no lint errors)

## Line delta

-3 / +1 (net -2, duplicate comment removed and updated_by field added)

## Command to verify

```bash
cd apps/api && bunx tsc --noEmit && bunx oxlint src/storage/virtual.ts
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets `updated_by` to the creator’s user ID when creating virtual MCPs instead of leaving it `NULL`, providing a complete audit trail from creation. Also removes a duplicate header comment.

<sup>Written for commit 48a6885932cae9af0f8f4c7ee0aa927cb02dd8a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

