### PR TITLE
fix(cms-tour): restore a visible keyboard focus ring on the tour's footer buttons

### DIFF
--- a/apps/web/src/components/cms-tour/cms-tour.css
+++ b/apps/web/src/components/cms-tour/cms-tour.css
@@ -83,6 +83,16 @@
   text-shadow: none;
 }
 
+/* `all: unset` above (needed to reset driver.js's own inline button styles)
+   drops the browser's default focus outline with nothing replacing it, so
+   tabbing to Next/Back/Skip left no visible focus indicator. Match the
+   app's Button focus ring (--ring) instead of relying on driver.js's :focus
+   background tint, which our background-color overrides below also erase. */
+.cms-tour-popover .driver-popover-footer-btn:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
 /* Primary action — Next / Done. */
 .cms-tour-popover .driver-popover-next-btn {
   background-color: var(--primary);


### PR DESCRIPTION
The CMS onboarding tour (`apps/web/src/components/cms-tour/`) is a keyboard-navigable dialog by nature (Next/Back/Skip via Tab, driver.js also binds arrow keys/Escape), so its buttons need a visible `:focus-visible` indicator — a core accessibility requirement for any keyboard-operable control, which this focus area's brief calls out explicitly.

**Bug:** `.driver-popover-footer-btn` in `cms-tour.css` uses `all: unset` to reset driver.js's inline button styles, which also strips the browser's default focus outline. driver.js's own base CSS falls back to a `:focus{background-color:#f7f7f7}` tint, but our per-button overrides (`.driver-popover-next-btn`, `.driver-popover-prev-btn`, `.cms-tour-skip`) set an unconditional `background-color` with no `:focus` rule of their own, and being loaded after driver.css with equal selector specificity, they win the cascade — so tabbing to Next / Back / Skip during the tour shows **no visible focus indicator at all**. A sighted keyboard user tabbing through the tour can't tell which button is about to activate on Enter.

**Fix:** add one `:focus-visible` rule using the app's own `--ring` design-system token (the same token `packages/ui`'s `Button` component uses for its focus ring), scoped under `.cms-tour-popover` like every other rule in this file.

**How to verify:** open a code agent's live preview, trigger the tour (⋯ menu → "Visual tour", or clear `cmsTourSeen:<userId>` from localStorage and reload), then press Tab — the Next/Back/Skip buttons now show a 2px outline in the `--ring` color instead of no visual change.

Checks run locally: `bun run fmt` (clean), `bunx oxlint apps/web/src/components/cms-tour/cms-tour.css` (n/a — CSS, not lintable by oxlint; no JS/TS touched so no typecheck needed). This is a pure CSS fix with no logic change, so there's nothing to unit-test; full CI will still run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores a visible keyboard focus ring for the CMS tour’s Next, Back, and Skip buttons, which previously lost the browser outline because of the button reset styles.

- Uses the app’s `--ring` token with a 2px outline and offset for `:focus-visible`.
- Applies the fix only within the CMS tour popover.

<sup>Written for commit 27d54e96e98e206cfa3da8ced6e1aec8d9e7a454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

