### PR TITLE
fix(org-switcher): give the create-organization icon button an accessible name

### DIFF
--- a/apps/web/src/components/header/org-switcher.tsx
+++ b/apps/web/src/components/header/org-switcher.tsx
@@ -232,7 +232,12 @@ function OrganizationsPanel({
           placeholder={t("header.orgSwitcher.searchOrganizations")}
           className="flex-1 min-w-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground/60"
         />
-        <button type="button" onClick={onCreateOrg} className={iconBtnClass}>
+        <button
+          type="button"
+          onClick={onCreateOrg}
+          aria-label={t("header.orgSwitcher.createOrganization")}
+          className={iconBtnClass}
+        >
           <Plus size={16} />
         </button>
       </div>

--- a/apps/web/src/i18n/en/header.ts
+++ b/apps/web/src/i18n/en/header.ts
@@ -1,5 +1,6 @@
 export const header = {
   "header.orgSwitcher.accept": "Accept",
+  "header.orgSwitcher.createOrganization": "Create organization",
   "header.orgSwitcher.declineInvitationTo": "Decline invitation to {name}",
   "header.orgSwitcher.failedToAcceptInvitation": "Failed to accept invitation",
   "header.orgSwitcher.failedToDeclineInvitation":

--- a/apps/web/src/i18n/pt-br/header.ts
+++ b/apps/web/src/i18n/pt-br/header.ts
@@ -2,6 +2,7 @@ import type { header as headerEn } from "../en/header.ts";
 
 export const header = {
   "header.orgSwitcher.accept": "Aceitar",
+  "header.orgSwitcher.createOrganization": "Criar organização",
   "header.orgSwitcher.declineInvitationTo": "Recusar convite para {name}",
   "header.orgSwitcher.failedToAcceptInvitation": "Falha ao aceitar convite",
   "header.orgSwitcher.failedToDeclineInvitation": "Falha ao recusar convite",


### PR DESCRIPTION
The org switcher popover (`apps/web/src/components/header/org-switcher.tsx`, used by both the sidebar-footer account popover and the toolbar org breadcrumb) renders a `+` button that opens the create-organization dialog. It has no `aria-label`, no visible text, and no `title` — only a `Plus` icon glyph — so a screen reader announces it as an unlabeled `button`, and there's no accessible way for AT users to know it creates an organization.

Fix: add `header.orgSwitcher.createOrganization` ("Create organization" / "Criar organização") to the en/pt-br header dictionaries and wire it as the button's `aria-label`, matching the existing pattern used by every other icon-only control in the same file (e.g. the invitation-decline `XClose` button already has one).

How to verify: `cd apps/web && bunx tsc --noEmit` (clean on the touched files) and inspect the accessible name of the `+` button in the org switcher popover (org icon in the sidebar header or toolbar breadcrumb → click to open → the `+` icon button top-right of the search bar) — it now reads "Create organization" instead of being unlabeled.

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (no new errors — the one pre-existing prosemirror version-mismatch error is unrelated to these files), `bunx oxlint` on the three touched files (0 warnings/errors). No unit test added — this is a static aria-label fix with no branching logic to exercise; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives the create-organization button in the org switcher an accessible name so screen readers announce it as "Create organization" instead of an unlabeled button. Adds the label to the en and pt-br header dictionaries.

<sup>Written for commit 8ab36f05342d1b158e4ee39f0173ad7c0d4e8263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

