### PR TITLE
fix(organization): cap sidebar_items, blockedMcps, and default_home_agents.ids on settings update

### DIFF
--- a/apps/api/src/tools/organization/settings-update.test.ts
+++ b/apps/api/src/tools/organization/settings-update.test.ts
@@ -133,4 +133,29 @@ describe("ORGANIZATION_SETTINGS_UPDATE", () => {
 
     expect(result.success).toBe(false);
   });
+
+  it("rejects oversized sidebar_items, blockedMcps, and default_home_agents.ids", () => {
+    const item = { title: "x", url: "/x", icon: "star" };
+
+    expect(
+      ORGANIZATION_SETTINGS_UPDATE.inputSchema.safeParse({
+        organizationId: "org-a",
+        sidebar_items: Array(51).fill(item),
+      }).success,
+    ).toBe(false);
+
+    expect(
+      ORGANIZATION_SETTINGS_UPDATE.inputSchema.safeParse({
+        organizationId: "org-a",
+        registry_config: { registries: {}, blockedMcps: Array(501).fill("x") },
+      }).success,
+    ).toBe(false);
+
+    expect(
+      ORGANIZATION_SETTINGS_UPDATE.inputSchema.safeParse({
+        organizationId: "org-a",
+        default_home_agents: { ids: Array(101).fill("vmcp") },
+      }).success,
+    ).toBe(false);
+  });
 });

--- a/apps/api/src/tools/organization/settings-update.ts
+++ b/apps/api/src/tools/organization/settings-update.ts
@@ -9,6 +9,11 @@ import {
   OrgFlagsSchema,
 } from "@decocms/shared/organization/schema";
 
+// Bounds on client-controlled collection sizes not enforced by the shared schema.
+const MAX_SIDEBAR_ITEMS = 50;
+const MAX_BLOCKED_MCPS = 500;
+const MAX_DEFAULT_HOME_AGENTS = 100;
+
 export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
   name: "ORGANIZATION_SETTINGS_UPDATE",
   description:
@@ -22,11 +27,15 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
   },
   inputSchema: z.object({
     organizationId: z.string(),
-    sidebar_items: z.array(SidebarItemSchema).optional(),
+    sidebar_items: z.array(SidebarItemSchema).max(MAX_SIDEBAR_ITEMS).optional(),
     enabled_plugins: z.array(z.string()).optional(),
-    registry_config: RegistryConfigSchema.optional(),
+    registry_config: RegistryConfigSchema.extend({
+      blockedMcps: z.array(z.string()).max(MAX_BLOCKED_MCPS),
+    }).optional(),
     simple_mode: SimpleModeConfigSchema.optional(),
-    default_home_agents: DefaultHomeAgentsConfigSchema.optional(),
+    default_home_agents: DefaultHomeAgentsConfigSchema.extend({
+      ids: z.array(z.string()).max(MAX_DEFAULT_HOME_AGENTS),
+    }).optional(),
     // .strict() here (not on the shared OrgFlagsSchema) so a mistyped flag
     // name is rejected instead of silently stripped and merged as `{}` —
     // that no-op was indistinguishable from a successful update.


### PR DESCRIPTION
**Source**: bug found while hardening `apps/api/src/tools/organization/settings-get.ts` / `settings-update.ts` (this tick's assigned focus area).

**Why**: `ORGANIZATION_SETTINGS_UPDATE`'s inputSchema reuses the shared org-settings Zod schemas as-is, and none of them bound the size of `sidebar_items`, `registry_config.blockedMcps`, or `default_home_agents.ids`. Any principal holding the `ORGANIZATION_SETTINGS_UPDATE` permission could write an arbitrarily large array into the `organization_settings` jsonb columns, bloating that row and the `ORGANIZATION_SETTINGS_GET` response that every member's client fetches on every page load — this matches the repo's established "cap an attacker-controlled array on a tool input" pattern (#6570, #6591, #6693, #6731, #6749, #6757).

**Fix**: added `.max()` caps (sidebar_items: 50, blockedMcps: 500, default_home_agents.ids: 100) directly on the update tool's own inputSchema via local `.extend()`/`.max()`, rather than on the shared schema — so `ORGANIZATION_SETTINGS_GET`'s output schema stays permissive for any org that already has a larger stored value (a shared-schema cap would risk breaking GET for those orgs). Added a regression test asserting each field rejects one over its cap.

**Verify**: `bun test apps/api/src/tools/organization/settings-update.test.ts`

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`ORGANIZATION_SETTINGS_UPDATE` now rejects oversized `sidebar_items`, `registry_config.blockedMcps`, and `default_home_agents.ids` instead of accepting unbounded arrays. This limits organization-settings row and response growth while leaving existing larger stored values readable through `ORGANIZATION_SETTINGS_GET`.

**Bug Fixes**

- Enforces limits of 50, 500, and 100 items respectively, with regression coverage for each limit.

<sup>Written for commit 10f1b3940f85259f70c21c932bcde6f8250f9573. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

