### PR TITLE
fix(sandbox): give each daemon-client retry attempt its own abort timeout

### DIFF
--- a/packages/sandbox/server/daemon-client.test.ts
+++ b/packages/sandbox/server/daemon-client.test.ts
@@ -114,6 +114,27 @@ describe("malformed 2xx bodies", () => {
   });
 });
 
+describe("retry timeout budget", () => {
+  it("gives each retry attempt its own AbortSignal instead of reusing an already-fired one", async () => {
+    let attempts = 0;
+    const { calls } = installFetch(() => {
+      attempts++;
+      if (attempts === 1) {
+        throw new DOMException("The operation timed out.", "AbortError");
+      }
+      return new Response(
+        JSON.stringify({ bootId: "b", transition: "t", config: {} }),
+        { status: 200 },
+      );
+    });
+    await postConfig("http://daemon:9000", "tok", { env: {} } as never);
+    expect(calls.length).toBe(2);
+    // A shared signal here would make the retry fail instantly instead.
+    expect(calls[0]!.init.signal).not.toBe(calls[1]!.init.signal);
+    expect(calls[1]!.init.signal?.aborted).toBe(false);
+  });
+});
+
 describe("proxyDaemonRequest", () => {
   it("injects Authorization: Bearer <token> header", async () => {
     const { calls } = installFetch(() => new Response("", { status: 204 }));

--- a/packages/sandbox/server/daemon-client.ts
+++ b/packages/sandbox/server/daemon-client.ts
@@ -53,11 +53,18 @@ function isTransientError(err: unknown): boolean {
  * a daemon that sends headers and then stalls rejects the `.text()`, and a
  * `.text()` awaited outside this try is exactly the unlabelled DOMException
  * again. Every caller wants the body anyway.
+ *
+ * `timeoutMs` is applied via a *fresh* `AbortSignal.timeout()` on every
+ * attempt — not one built once by the caller and reused. A signal that has
+ * already fired stays fired, so reusing it across retries would make every
+ * attempt after the first one that times out fail instantly with the same
+ * stale AbortError instead of getting its own timeout window.
  */
 async function daemonRequest(
   url: string,
-  init: RequestInit,
+  init: Omit<RequestInit, "signal">,
   endpoint: string,
+  timeoutMs: number,
 ): Promise<{ status: number; ok: boolean; body: string }> {
   try {
     const retryOpts: RetryOptions = {
@@ -70,7 +77,10 @@ async function daemonRequest(
     };
 
     return await retry(async () => {
-      const res = await fetch(url, init);
+      const res = await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
       return { status: res.status, ok: res.ok, body: await res.text() };
     }, retryOpts);
   } catch (err) {
@@ -209,9 +219,9 @@ async function configRequest(
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(wire),
-      signal: AbortSignal.timeout(opts?.timeoutMs ?? CONFIG_TIMEOUT_MS),
     },
     "/_sandbox/config",
+    opts?.timeoutMs ?? CONFIG_TIMEOUT_MS,
   );
   if (!res.ok) {
     throw new ConfigRequestError(res.status, res.body);
@@ -235,9 +245,9 @@ export async function postSetupStep(
     {
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(CONFIG_TIMEOUT_MS),
     },
     `/_sandbox/setup/${step}`,
+    CONFIG_TIMEOUT_MS,
   );
   if (!res.ok) {
     throw new Error(
@@ -267,9 +277,9 @@ export async function postOrgFsConfig(
         Authorization: `Bearer ${token}`,
       },
       body: configJson,
-      signal: AbortSignal.timeout(CONFIG_TIMEOUT_MS),
     },
     "/_sandbox/orgfs-config",
+    CONFIG_TIMEOUT_MS,
   );
   if (!res.ok) {
     throw new Error(


### PR DESCRIPTION
**Source**: bug found reading `packages/sandbox/server/daemon-client.ts` — follows the retry logic added in #6861.

**Why a maintainer wants this**: `daemonRequest`'s retry loop calls `fetch(url, init)` repeatedly reusing the *same* `init` object, whose `signal` was a single `AbortSignal.timeout(...)` built once by the caller before the first attempt. `AbortSignal.timeout()` fires once and stays aborted forever, so once attempt 1 times out, every retry reuses that already-fired signal and fails instantly with `AbortError` — never getting the fresh timeout window it needs. `isTransientError` treats `AbortError` as retriable specifically for the cold-start-clone-then-30s-timeout case the surrounding comments describe, so this silently burns the whole retry budget doing nothing useful in exactly that scenario.

**Failure scenario**: a config POST to a cold-booting sandbox exceeds `CONFIG_TIMEOUT_MS` (30s) on the first attempt. Retry attempts 2 and 3 receive the identical, already-aborted signal and fail in the same tick instead of getting their own 30s window, so the retry logic added in #6861 provides no benefit for the case it was built for.

**Fix + regression test**: build a fresh `AbortSignal.timeout(timeoutMs)` inside the retried closure on every attempt, instead of once outside it. Added a test in `daemon-client.test.ts` that fails an AbortError on attempt 1 and asserts attempt 2 gets a distinct, non-aborted signal.

**To verify**: `bun test packages/sandbox/server/daemon-client.test.ts`

**Checks run locally**: `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit`, `bun test packages/sandbox/server/daemon-client.test.ts` (25 pass), `bunx oxlint packages/sandbox/server/daemon-client.ts packages/sandbox/server/daemon-client.test.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries in `daemonRequest` now create a fresh abort timeout for each attempt, so a timed-out first request no longer causes later retries to fail immediately with the same aborted signal.

- Applies to config, setup, and orgfs-config daemon requests.
- Adds regression coverage confirming retries receive distinct, active signals.

<sup>Written for commit 0f91d3a5000886b4c17791cb4dad3c170bb798e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

