### PR TITLE
fix(mcp-oauth): drop unsafe client_secret cast in token persistence

### DIFF
--- a/apps/web/src/sdk/lib/mcp-oauth.ts
+++ b/apps/web/src/sdk/lib/mcp-oauth.ts
@@ -471,10 +471,7 @@ export async function authenticateMcp(params: {
             resolve({
               tokens,
               clientId: clientInfo.client_id ?? null,
-              clientSecret:
-                "client_secret" in clientInfo
-                  ? (clientInfo.client_secret as string)
-                  : null,
+              clientSecret: clientInfo.client_secret ?? null,
               tokenEndpoint: authServerMetadata?.token_endpoint ?? null,
               userinfoEndpoint:
                 (authServerMetadata?.userinfo_endpoint as
@@ -604,10 +601,7 @@ export async function authenticateMcp(params: {
             expiresIn: tokens.expires_in ?? null,
             scope: tokens.scope ?? null,
             clientId: clientInfo?.client_id ?? null,
-            clientSecret:
-              clientInfo && "client_secret" in clientInfo
-                ? (clientInfo.client_secret as string)
-                : null,
+            clientSecret: clientInfo?.client_secret ?? null,
             tokenEndpoint: null, // Would need to be passed through
             userinfoEndpoint: null,
             idToken: tokens.id_token ?? null,


### PR DESCRIPTION
**Source:** bug found while hardening `apps/web/src/sdk/lib/mcp-oauth.ts` (this tick's assigned focus area: MCP OAuth token flow hardening).

**The bug:** in both places `authenticateMcp` builds the `OAuthTokenInfo` to persist, `clientSecret` was derived as:
```ts
"client_secret" in clientInfo ? (clientInfo.client_secret as string) : null
```
The SDK's `OAuthClientInformation` type already declares `client_secret` as an optional `string` (`z.ZodOptional<z.ZodString>`), so the `in` check plus `as string` cast was both redundant *and* unsound: if the key is present on the object but its value is `undefined` (a shape Zod's `.optional()` explicitly allows), the `in` check passes and the code casts `undefined` to `string`, leaving `tokenInfo.clientSecret` as a bare `undefined` instead of the `string | null` the type promises. That `undefined` then flows into `authenticateAndPersistOAuth`'s `JSON.stringify(...)` body sent to `/oauth-token`, silently dropping the key instead of sending an explicit `null`.

**Fix:** read the already-typed optional field directly with `?? null` — no cast needed, and it now correctly normalizes `undefined` to `null`.

**Why a maintainer wants this:** removes an unsafe `as string` cast the compiler can no longer catch a real mismatch through, and closes a rare case where a DCR client with an explicitly-undefined `client_secret` key would silently violate the `OAuthTokenInfo.clientSecret: string | null` contract.

**Command to confirm:** `cd apps/web && bunx tsc --noEmit` (clean for this file) and `bun test apps/web/src/sdk/lib/mcp-oauth.test.ts` (1 pass, unchanged).

**Checked locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/web workspace — no new errors, pre-existing unrelated prosemirror-version mismatch untouched), `bun test apps/web/src/sdk/lib/mcp-oauth.test.ts` (passes), `bunx oxlint apps/web/src/sdk/lib/mcp-oauth.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
MCP OAuth token persistence now reads the optional `client_secret` directly and normalizes `undefined` to `null` in both `authenticateMcp` paths, removing the unsafe string cast. This preserves the `string | null` contract and prevents an explicitly undefined secret from being silently omitted from the token request.

<sup>Written for commit c613a75188a6c3420469e3419ef68c47fe9c54c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

