### PR TITLE
fix(connections): revoke a connection's trigger callback token on delete

### DIFF
--- a/apps/api/src/tools/connection/delete.test.ts
+++ b/apps/api/src/tools/connection/delete.test.ts
@@ -14,6 +14,7 @@ function makeCtx(options: {
   const deleteConnection = mock(async () => {});
   const isReferencedByThread = mock(async () => options.referencedByThread);
   const deactivateAutomation = mock(async () => {});
+  const deleteTokenByConnection = mock(async () => {});
   const ctx = {
     auth: { user: { id: "user_123" } },
     organization: { id: "org_123" },
@@ -32,9 +33,16 @@ function makeCtx(options: {
         deactivateAutomation,
       },
       organizationSettings: { get: mock(async () => null) },
+      triggerCallbackTokens: { deleteByConnection: deleteTokenByConnection },
     },
   } as unknown as Parameters<typeof COLLECTION_CONNECTIONS_DELETE.handler>[1];
-  return { ctx, deleteConnection, isReferencedByThread, deactivateAutomation };
+  return {
+    ctx,
+    deleteConnection,
+    isReferencedByThread,
+    deactivateAutomation,
+    deleteTokenByConnection,
+  };
 }
 
 describe("COLLECTION_CONNECTIONS_DELETE", () => {
@@ -71,6 +79,20 @@ describe("COLLECTION_CONNECTIONS_DELETE", () => {
 
     expect(result.item.id).toBe("conn_repo");
     expect(deleteConnection).toHaveBeenCalledWith("conn_repo");
+  });
+
+  it("revokes the connection's trigger callback token on delete", async () => {
+    // Regression: trigger_callback_tokens.connection_id has no FK and stayed valid forever.
+    const { ctx, deleteTokenByConnection } = makeCtx({
+      referencedByThread: false,
+    });
+
+    await COLLECTION_CONNECTIONS_DELETE.handler({ id: "conn_repo" }, ctx);
+
+    expect(deleteTokenByConnection).toHaveBeenCalledWith(
+      "conn_repo",
+      "org_123",
+    );
   });
 
   it("refuses to delete a connection with an active automation event trigger", async () => {

--- a/apps/api/src/tools/connection/delete.ts
+++ b/apps/api/src/tools/connection/delete.ts
@@ -133,6 +133,12 @@ export const COLLECTION_CONNECTIONS_DELETE = defineTool({
     // Delete connection
     await ctx.storage.connections.delete(input.id);
 
+    // trigger_callback_tokens.connection_id has no FK either — same class of orphan.
+    await ctx.storage.triggerCallbackTokens.deleteByConnection(
+      input.id,
+      organization.id,
+    );
+
     // Cleanup registry_config references to the deleted connection
     const orgSettings = await ctx.storage.organizationSettings.get(
       organization.id,


### PR DESCRIPTION
**Source:** bug found while auditing connection delete for orphaned resources on FK-less connection_id columns — same class as the automation event-trigger orphan fixed in #6894.

**Payoff:** `trigger_callback_tokens.connection_id` has no foreign key to `connections`. `COLLECTION_CONNECTIONS_DELETE` already cleans up virtual-MCP references, pinned threads, and active automation event triggers, but never touched this table, so a connection's callback token hash stayed valid forever after the connection was deleted.

**Failure scenario:** an org creates a trigger (`TRIGGER_CONFIGURE`), which mints a callback token for the connection, then deletes the connection. Any caller who still has the old Bearer token can `POST /api/:org/trigger-callback` and gets a `202` back forever — `validateToken` only checks the token hash, not whether the connection still exists. The regression test `revokes the connection's trigger callback token on delete` in `delete.test.ts` asserts `storage.triggerCallbackTokens.deleteByConnection` is called with the connection and org id.

**Reviewer command:** `cd apps/api && bun test src/tools/connection/delete.test.ts`

**Local checks run:** `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deleting a connection now revokes its trigger callback token, so stale Bearer tokens can no longer keep getting a 202 from the trigger-callback endpoint.

- Adds cleanup of `trigger_callback_tokens` to connection deletion.
- Adds a regression test asserting the token is deleted with the connection and org id.

<sup>Written for commit f5fb5da72f5634eb73a0897bcae5e748543aff74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

