### PR TITLE
fix(connection): cap metadata and configuration_state JSON size

### DIFF
--- a/packages/shared/src/sdk/types/connection.test.ts
+++ b/packages/shared/src/sdk/types/connection.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import {
+  ConnectionCreateDataSchema,
+  ConnectionEntitySchema,
+} from "./connection";
+
+function baseEntity(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "conn_1",
+    title: "Test connection",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    created_by: "user_1",
+    organization_id: "org_1",
+    description: null,
+    icon: null,
+    app_name: null,
+    app_id: null,
+    connection_type: "HTTP" as const,
+    connection_url: "https://example.com",
+    connection_token: null,
+    connection_headers: null,
+    oauth_config: null,
+    configuration_state: null,
+    configuration_scopes: null,
+    metadata: null,
+    tools: null,
+    bindings: null,
+    status: "active" as const,
+    ...overrides,
+  };
+}
+
+describe("ConnectionEntitySchema JSON field caps", () => {
+  it("accepts metadata/configuration_state within the size cap", () => {
+    const result = ConnectionEntitySchema.safeParse(
+      baseEntity({ metadata: { foo: "bar" }, configuration_state: { a: 1 } }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an oversized metadata blob", () => {
+    const huge = { blob: "x".repeat(300 * 1024) };
+    const result = ConnectionEntitySchema.safeParse(
+      baseEntity({ metadata: huge }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an oversized configuration_state blob", () => {
+    const huge = { blob: "x".repeat(300 * 1024) };
+    const result = ConnectionEntitySchema.safeParse(
+      baseEntity({ configuration_state: huge }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("still rejects an oversized metadata blob on the create schema", () => {
+    const huge = { blob: "x".repeat(300 * 1024) };
+    const result = ConnectionCreateDataSchema.safeParse({
+      title: "Test",
+      connection_type: "HTTP",
+      metadata: huge,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/sdk/types/connection.ts
+++ b/packages/shared/src/sdk/types/connection.ts
@@ -68,6 +68,30 @@ const StdioConnectionParametersSchema = z.object({
     .describe("Environment variables (encrypted in storage)"),
 });
 
+/**
+ * `metadata` and `configuration_state` are caller-supplied JSON blobs with no
+ * other size limit on the write path (no MCP-endpoint body-size middleware
+ * bounds them) — an org member with ordinary connection-write permission
+ * could otherwise stash an arbitrarily large object in a connection row.
+ * `configuration_state` is also embedded whole in the JWT sent to downstream
+ * MCP servers on every call, so an oversized value bloats every outbound
+ * request, not just storage.
+ */
+const MAX_JSON_FIELD_BYTES = 256 * 1024;
+
+function boundedJsonRecord(fieldName: string) {
+  return z
+    .record(z.string(), z.unknown())
+    .nullable()
+    .refine(
+      (value) =>
+        value === null || JSON.stringify(value).length <= MAX_JSON_FIELD_BYTES,
+      {
+        message: `${fieldName} must serialize to at most ${MAX_JSON_FIELD_BYTES} bytes`,
+      },
+    );
+}
+
 export type HttpConnectionParameters = z.infer<
   typeof HttpConnectionParametersSchema
 >;
@@ -131,20 +155,18 @@ export const ConnectionEntitySchema = z.object({
   oauth_config: OAuthConfigSchema.nullable().describe("OAuth configuration"),
 
   // New configuration fields (snake_case)
-  configuration_state: z
-    .record(z.string(), z.unknown())
-    .nullable()
-    .describe("Configuration state (decrypted)"),
+  configuration_state: boundedJsonRecord("configuration_state").describe(
+    "Configuration state (decrypted)",
+  ),
   configuration_scopes: z
     .array(z.string())
     .nullable()
     .optional()
     .describe("Configuration scopes"),
 
-  metadata: z
-    .record(z.string(), z.unknown())
-    .nullable()
-    .describe("Additional metadata (includes repository info)"),
+  metadata: boundedJsonRecord("metadata").describe(
+    "Additional metadata (includes repository info)",
+  ),
   tools: z
     .array(ToolDefinitionSchema)
     .nullable()


### PR DESCRIPTION
**Source:** bounded reduction/hardening in the shared connection SDK types (this tick's focus area: SDK connection type definitions, supporting #5661). No open PR touches `packages/shared/src/sdk/types/connection.ts`.

**Why a maintainer wants this:** `ConnectionEntitySchema.metadata` and `.configuration_state` are caller-supplied JSON blobs typed as bare `z.record(z.string(), z.unknown())` with no size bound. `ConnectionCreateDataSchema`/`ConnectionUpdateDataSchema` both derive from this schema via `.omit()`/`.partial()`, so the gap applies to `COLLECTION_CONNECTIONS_CREATE`/`_UPDATE` too. There is no body-size middleware in front of the generic MCP tool-call route, so any org member with ordinary connection-write permission could stash an arbitrarily large object in a connection row today. `configuration_state` is also embedded whole in the JWT Studio mints for every downstream MCP call (see the comment in `update.ts`: "must never be null/undefined to ensure it's always included in the JWT token"), so an oversized value doesn't just bloat storage — it bloats every outbound request to that connection. This matches the repo's established pattern of capping attacker/user-controlled input size on a tool input (see `#6749`, `#6757`, `#6853` in the commit history).

**Fix:** added a `boundedJsonRecord()` helper enforcing a 256KB serialized-size cap, applied to both `metadata` and `configuration_state` on `ConnectionEntitySchema`. Behavior-preserving for every value under the cap; only oversized payloads (previously accepted) now fail Zod validation with a clear message.

**Regression test:** `packages/shared/src/sdk/types/connection.test.ts` — asserts in-bounds values still parse, an oversized `metadata`/`configuration_state` value is rejected on the entity schema, and the rejection still holds through `ConnectionCreateDataSchema`'s `.omit()`/`.partial()` derivation.

**To verify:** `bun test packages/shared/src/sdk/types/connection.test.ts`

**Locally ran:** `bun run fmt`, `cd packages/shared && bunx tsc --noEmit`, `cd apps/api && bunx tsc --noEmit` (both clean), `bunx oxlint` on the two touched files (0 warnings/errors), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`metadata` and `configuration_state` on connection schemas were unbounded JSON blobs, so any caller with connection-write permission could store arbitrarily large values and bloat every downstream MCP JWT. They're now capped at 256KB serialized size; oversized payloads fail Zod validation, while values under the cap behave exactly as before.

**Bug Fixes**
- Applies the cap through a shared `boundedJsonRecord()` helper on `ConnectionEntitySchema`; create and update schemas inherit it automatically.
- Adds regression tests for accepted in-bounds values and rejected oversized `metadata` and `configuration_state`.

<sup>Written for commit 63c05bc076b7f4b375184275dbd8b6d9e3de75c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

