### PR TITLE
fix(decopilot): quote a bare carriage return in csvField

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/csv.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/csv.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { csvField } from "./csv";
+
+describe("csvField", () => {
+  it("passes plain fields through untouched", () => {
+    expect(csvField("plain")).toBe("plain");
+    expect(csvField(null)).toBe("");
+    expect(csvField(undefined)).toBe("");
+    expect(csvField("")).toBe("");
+  });
+
+  it("quotes fields containing a comma, quote, semicolon, or newline", () => {
+    expect(csvField("a,b")).toBe('"a,b"');
+    expect(csvField('say "hi"')).toBe('"say ""hi"""');
+    expect(csvField("a;b")).toBe('"a;b"');
+    expect(csvField("a\nb")).toBe('"a\nb"');
+  });
+
+  it("quotes a bare carriage return", () => {
+    expect(csvField("a\rb")).toBe('"a\rb"');
+  });
+});

--- a/apps/api/src/harnesses/lib/decopilot/csv.ts
+++ b/apps/api/src/harnesses/lib/decopilot/csv.ts
@@ -9,6 +9,7 @@ export function csvField(s: string | null | undefined): string {
     s.includes(",") ||
     s.includes('"') ||
     s.includes("\n") ||
+    s.includes("\r") ||
     s.includes(";")
   ) {
     return `"${s.replaceAll('"', '""')}"`;


### PR DESCRIPTION
Bug found while auditing `apps/api/src/harnesses/lib/decopilot/` utilities.

`csvField` (used by the `<available-skills>`, `<available-prompts>`, `<available-agents>`, and connections CSV blocks in the decopilot system prompt) only quoted a field containing `\n`, but not a bare `\r`. A skill/agent/prompt description with a stray `\r` (e.g. Windows-style text, or `\r` with no following `\n`) would be emitted unquoted, letting it act as a line terminator for many CSV consumers and misalign the CSV rows the model reads.

Failure scenario: any org-controlled skill/agent description containing a bare `\r` corrupts the CSV table's row structure in the system prompt fed to the model.

Fix: also check for `\r` in the quoting condition (matches RFC-4180, which requires quoting on CR as well as LF). Added `csv.test.ts` with a regression case for a bare `\r`; the prior test suite (comma/quote/semicolon/newline) still passes.

Reviewer check: `cd apps/api && bun test src/harnesses/lib/decopilot/csv.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `csvField` to quote fields containing a bare carriage return (`\r`) in addition to newlines, so CSV rows in the decopilot system prompt no longer misalign when descriptions contain Windows-style text.

**Bug Fixes**
- Adds regression tests covering plain fields, comma/quote/semicolon/newline quoting, and bare `\r`.

<sup>Written for commit 81622c9f15a0753fcca2ed9c71a0a061018b26ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

