### PR TITLE
fix(connection-details): use the real error total in the activity KPI

### DIFF
--- a/apps/web/src/components/details/connection/connection-activity.tsx
+++ b/apps/web/src/components/details/connection/connection-activity.tsx
@@ -68,11 +68,28 @@ function ActivityChart({ connectionId, orgId, timeframe }: ActivityChartProps) {
     staleTime: 5 * 60 * 1000,
   });
 
+  // Real error total from the backend's own count, same fix as data?.total above.
+  const { data: errorData } = useSuspenseQuery({
+    queryKey: KEYS.connectionActivityErrors(connectionId, timeframe, orgId),
+    queryFn: async () => {
+      return (await studio.call("MONITORING_LOGS_LIST", {
+        startDate: dateRange.startDate.toISOString(),
+        endDate: dateRange.endDate.toISOString(),
+        connectionId,
+        isError: true,
+        limit: 1,
+        offset: 0,
+      })) as BaseMonitoringLogsResponse;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
   const stats = calculateStats(
     data?.logs ?? [],
     dateRange,
     undefined,
     data?.total,
+    errorData?.total,
   );
   const chartData = stats.data;
   const hasData = stats.totalCalls > 0;

--- a/apps/web/src/components/monitoring/monitoring-stats-row.tsx
+++ b/apps/web/src/components/monitoring/monitoring-stats-row.tsx
@@ -163,9 +163,11 @@ export function calculateStats(
   dateRange: DateRange,
   bucketCount?: number,
   overrideTotalCalls?: number,
+  overrideTotalErrors?: number,
 ): MonitoringStatsData {
   const totalCalls = overrideTotalCalls ?? logs.length;
-  const totalErrors = logs.filter((log) => log.isError).length;
+  const totalErrors =
+    overrideTotalErrors ?? logs.filter((log) => log.isError).length;
   const durations = logs.map((log) => log.durationMs);
   const avgDurationMs =
     durations.length > 0

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -159,6 +159,19 @@ export const KEYS = {
     timeframe: string,
     orgId: string,
   ) => ["monitoring", "activity", connectionId, timeframe, orgId] as const,
+  connectionActivityErrors: (
+    connectionId: string,
+    timeframe: string,
+    orgId: string,
+  ) =>
+    [
+      "monitoring",
+      "activity",
+      "errors",
+      connectionId,
+      timeframe,
+      orgId,
+    ] as const,
 
   isMCPAuthenticated: (url: string, token: string | null) =>
     ["is-mcp-authenticated", url, token] as const,


### PR DESCRIPTION
The Tool calls KPI was fixed in #6881 to read `data.total` (the backend's `count(*) OVER()` window, independent of the 2000-row LIMIT), but `totalErrors` was left computed from `logs.filter(isError)` — i.e. only the fetched 2000-row page. For a connection with more than 2000 calls in the window, the Errors KPI and the derived error-rate percentage silently undercount (or overcount, depending on where in the window the errors landed) instead of matching the real total.

Fix: fetch the real error total the same way — a second `MONITORING_LOGS_LIST` call filtered by `isError=true` with `limit=1`, reading its own `total` (same `count(*) OVER()` window), and pass it through `calculateStats`' new `overrideTotalErrors` param.

Failure scenario: a connection with 5,000 calls and 300 errors in the last 14 days, only 2,000 of which are in the most recent page — if none of those 300 errors fall in the first 2000 rows, the widget shows 0 errors / 0% error rate instead of 300 / 6%.

To verify: `cd apps/web && bunx tsc --noEmit` (green — the one pre-existing prosemirror-model version-mismatch error in `mention-suggestion.tsx` is unrelated to this change) and `bunx oxlint` on the three changed files (0 warnings/errors). No unit test added: this is a hook-driven component wired to `useSuspenseQuery`, same rationale as #6881; `calculateStats` itself is untouched logic-wise (an added optional param that defaults to the old behavior).

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in apps/web, `bunx oxlint` on the three changed files. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the activity KPI's error count to use the backend's real total, so the error count and rate no longer undercount when more than 2000 calls fall in the window.

**Bug Fixes**
- Adds a separate request for the error total, filtered by `isError=true`, and passes it through to `calculateStats` as an override.
- The new parameter defaults to the old behavior when not provided.

<sup>Written for commit 834e5b434fe632b406434416a7b6ed94a82eb34b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

