### PR TITLE
fix(organization): cap brand context images and metadata JSON size

### DIFF
--- a/packages/shared/src/organization/schema.test.ts
+++ b/packages/shared/src/organization/schema.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it } from "bun:test";
 import {
   autoResolveConflictsEnabled,
+  BrandContextSchema,
   DEFAULT_ON_FLAGS,
   orgFlagEnabled,
 } from "./schema";
+
+function baseBrandContext(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "brand_1",
+    name: "Acme",
+    domain: "acme.com",
+    overview: "An acme company",
+    ...overrides,
+  };
+}
 
 describe("orgFlagEnabled", () => {
   it("default-on flags read as enabled unless stored exactly false", () => {
@@ -66,5 +77,31 @@ describe("orgFlagEnabled", () => {
       orgFlagEnabled({ reviewer_enabled: "true" }, "reviewer_enabled"),
     ).toBe(true);
     expect(orgFlagEnabled({ auto_merge: "true" }, "auto_merge")).toBe(false);
+  });
+});
+
+describe("BrandContextSchema JSON field caps", () => {
+  it("accepts metadata and images within the caps", () => {
+    const result = BrandContextSchema.safeParse(
+      baseBrandContext({
+        metadata: { tone: "playful" },
+        images: [{ url: "https://example.com/a.png" }],
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an oversized metadata blob", () => {
+    const huge = { blob: "x".repeat(300 * 1024) };
+    const result = BrandContextSchema.safeParse(
+      baseBrandContext({ metadata: huge }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects more than 50 images", () => {
+    const images = Array(51).fill({ url: "https://example.com/a.png" });
+    const result = BrandContextSchema.safeParse(baseBrandContext({ images }));
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -282,6 +282,17 @@ export function autoResolveConflictsEnabled(
 }
 
 /**
+ * `images` and `metadata` are caller-supplied JSON blobs with no other size
+ * limit on the write path (BRAND_CONTEXT_CREATE/UPDATE pass this schema
+ * straight through to storage) — an org member with ordinary brand-write
+ * permission could otherwise stash an arbitrarily large payload in a brand
+ * context row. Mirrors the `configuration_state`/`metadata` cap on
+ * `ConnectionEntitySchema`.
+ */
+const MAX_BRAND_JSON_FIELD_BYTES = 256 * 1024;
+const MAX_BRAND_IMAGES = 50;
+
+/**
  * Brand context schema - org-scoped company profile
  */
 export const BrandContextSchema = z.object({
@@ -317,6 +328,7 @@ export const BrandContextSchema = z.object({
     .describe("Semantic color palette"),
   images: z
     .array(z.record(z.string(), z.unknown()))
+    .max(MAX_BRAND_IMAGES)
     .nullable()
     .optional()
     .describe("Brand images"),
@@ -324,6 +336,15 @@ export const BrandContextSchema = z.object({
     .record(z.string(), z.unknown())
     .nullable()
     .optional()
+    .refine(
+      (value) =>
+        value === null ||
+        value === undefined ||
+        JSON.stringify(value).length <= MAX_BRAND_JSON_FIELD_BYTES,
+      {
+        message: `metadata must serialize to at most ${MAX_BRAND_JSON_FIELD_BYTES} bytes`,
+      },
+    )
     .describe(
       "Extra design tokens (typography, components, spacing, layout, tone, etc.)",
     ),


### PR DESCRIPTION
Bug: `BrandContextSchema` (packages/shared/src/organization/schema.ts) has no size limit on `images` (array of arbitrary records) or `metadata` (arbitrary record), and `BRAND_CONTEXT_CREATE`/`BRAND_CONTEXT_UPDATE` pass this schema straight through to storage with no other body-size guard on the write path. An org member with ordinary brand-write permission could stash an arbitrarily large JSON blob in a `brand_context` row. This mirrors the exact gap already fixed on `ConnectionEntitySchema.metadata`/`configuration_state` in #6908 (still open, different file — no overlap).

Fix: cap `images` at 50 entries and `metadata` at 256KB serialized, same bound and pattern used for connections.

Failure scenario before the fix: `BRAND_CONTEXT_UPDATE({ metadata: { blob: 'x'.repeat(10_000_000) } })` parses and persists a ~10MB JSON blob into the org's brand_context row. After the fix, `BrandContextSchema.safeParse` rejects it.

Reviewer check: `bun test packages/shared/src/organization/schema.test.ts` — new cases assert acceptance within caps, rejection of an oversized metadata blob, and rejection of >50 images.

Locally ran: `bun run fmt`, `cd packages/shared && bunx tsc --noEmit`, `cd apps/api && bunx tsc --noEmit` (clean, no brand-context/schema errors), `bun test packages/shared/src/organization/schema.test.ts` (7 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps brand context images to 50 entries and metadata to 256KB, matching the connection schema. Previously, an org member with brand-write permission could store arbitrarily large JSON in a `brand_context` row; now oversized payloads are rejected.

<sup>Written for commit 42b2825f1d4c62335eca22f193226a0005b5471b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

