### PR TITLE
fix(task-board): reap never-started threads from the board's own In Progress lane

### DIFF
--- a/apps/api/src/tools/task-board/stall-recovery.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.ts
@@ -196,13 +196,14 @@ export async function recoverStalledTasks(
 ): Promise<void> {
   const organizationId = ctx.organization?.id;
   if (!organizationId) return;
+  const lanes = await boardLanes(ctx, organizationId);
 
   for (const item of items) {
     // First clear any never-started thread blocking this card's gate below.
     // Skipped for a card that isn't parked In Progress: In Review / Done cards
     // are not waiting on a run, and a card a human is actively working has no
     // stuck agent thread to reap.
-    if (item.status === "in_progress") {
+    if (item.status === lanes.progress) {
       try {
         const reaped = await failNeverStartedThreads(ctx, item);
         // `item.threads` is now stale for this card — the statuses the gate
@@ -247,7 +248,7 @@ export async function recoverStalledTasks(
           thread.threadId,
           organizationId,
           ctx.storage.organizationBilling,
-          await boardLanes(ctx, organizationId),
+          lanes,
         );
       } else {
         await nudgeThread(ctx, item, row);


### PR DESCRIPTION
Same bug class as #6849/#6854/#6873: the board-open stall-recovery sweep (`recoverStalledTasks` in `stall-recovery.ts`) gated its never-started-thread reap on the literal `"in_progress"` instead of the board's own `lanes.progress` column — which the same function already fetches a few lines later for the advance path.

On an org-owned board (`org_board_columns`) whose In Progress column is named anything else, a run that never reached `RUN_STARTED` is invisible to the in-memory idle reaper (per the file's own docs) and, with this gate never matching, is now also never reaped here. Since `shouldAdvanceToReview` requires every thread terminal, one such never-started thread freezes that card's advance gate forever on such a board.

Fix: hoist the `boardLanes` fetch once per call (this also dedupes the redundant per-item fetch used later for the advance path) and compare `item.status` against `lanes.progress` instead of the literal.

No new test: the gate is now a trivial single-line comparison against an already-tested `boardLanes` accessor, and `recoverStalledTasks` itself needs a live `StudioContext`/Postgres to exercise — no unit-testable surface changed.

To confirm: `bun test apps/api/src/tools/task-board/stall-recovery.test.ts` (still 20 pass — untouched by this change).

Locally verified: `bun test apps/api/src/tools/task-board/stall-recovery.test.ts` (20 pass), `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/tools/task-board/stall-recovery.ts` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the board-open stall-recovery sweep so never-started threads are reaped from the board's own In Progress lane (`lanes.progress`) instead of the hardcoded `"in_progress"`. On org-owned boards with a differently named column, such threads previously never got reaped and froze the card's advance gate.

Also hoists the `boardLanes` fetch to once per call, removing a redundant per-item fetch on the advance path.

<sup>Written for commit 828afbcf040c4159a9cef6173a5d6b0364b364ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

