### PR TITLE
fix(docs): repair broken #org-filesystem anchor in architecture.mdx

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/architecture.mdx
@@ -108,7 +108,7 @@ This distinction matters for reasoning about the system:
 | File & object-storage (`/api/:org/files/*`, presigned GET/PUT, uploads, `/api/:org/fs/*`) | ✅ serving clients | ✅ agent tools read/write files & mint presigned URLs |
 | Worker-only over HTTP | — | none — tool calls are in-process |
 
-File and object-storage routes are the genuine "called by both" surface, and they are backed by an S3-compatible **Object Store**. The `/api/:org/fs/*` routes also back the [org-filesystem mount](#org-filesystem) inside sandboxes.
+File and object-storage routes are the genuine "called by both" surface, and they are backed by an S3-compatible **Object Store**. The `/api/:org/fs/*` routes also back the [org-filesystem mount](#org-filesystem-org-fs) inside sandboxes.
 
 ## Sandboxes
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/architecture.mdx
@@ -108,7 +108,7 @@ Essa distinção importa para raciocinar sobre o sistema:
 | File & object-storage (`/api/:org/files/*`, GET/PUT presigned, uploads, `/api/:org/fs/*`) | ✅ servindo clients | ✅ tools de agent leem/escrevem arquivos e geram presigned URLs |
 | Apenas worker via HTTP | — | nenhuma — as chamadas de tool são in-process |
 
-As rotas de file e object-storage são a verdadeira superfície "chamada por ambos", e são respaldadas por um **Object Store** compatível com S3. As rotas `/api/:org/fs/*` também dão suporte ao [mount do org-filesystem](#org-filesystem) dentro das sandboxes.
+As rotas de file e object-storage são a verdadeira superfície "chamada por ambos", e são respaldadas por um **Object Store** compatível com S3. As rotas `/api/:org/fs/*` também dão suporte ao [mount do org-filesystem](#org-filesystem-org-fs) dentro das sandboxes.
 
 ## Sandboxes
 


### PR DESCRIPTION
Source: repo-wide docs health scan (broken links/anchors) over `apps/docs/client/src/content/deco-studio/**/*.mdx`.

Both the en and pt-br `studio/architecture.mdx` link to `[org-filesystem mount](#org-filesystem)`, but the actual heading is `### Org filesystem (org-fs)`, which Astro/rehype slugifies to `org-filesystem-org-fs`. The link currently 404s (scrolls to nothing / triggers Astro's broken-anchor warning) in both locales.

Fix: point both links at the real slug, `#org-filesystem-org-fs`.

How I found and verified it: wrote a one-off script that extracts every markdown heading in each `.mdx` file, slugifies it the same way rehype-slug does (lowercase, strip non-alphanumerics, hyphenate), and checks every same-file `](#anchor)` link against that set, plus every cross-file `path#anchor` link against the target file's heading set. This was the only broken anchor found across all 70 mdx files (en+pt-br); I also checked for missing front-matter, missing pt-br/en pairs, byte-identical (untranslated) locale pairs, broken relative/absolute internal links, and stale version-number references — all clean.

Reviewer check: search `apps/docs/client/src/content/deco-studio/{en,pt-br}/studio/architecture.mdx` for `org-filesystem` and confirm both links now match the `### Org filesystem (org-fs)` heading's slug.

Locally: `bun run fmt` (no changes needed, pure content diff, no code/types touched).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken #org-filesystem anchors in the en and pt-br `studio/architecture.mdx` so they point to the correct heading slug, `#org-filesystem-org-fs`, eliminating Astro's broken-anchor warnings.

<sup>Written for commit 8b3874248ec4f49add5e6f001923258fe7286722. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

