### PR TITLE
fix(decopilot): cap the enable_tool tools array

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/enable-tool.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/enable-tool.test.ts
@@ -31,6 +31,11 @@ describe("EnableToolInputSchema", () => {
     );
   });
 
+  test("rejects an oversized tools array", () => {
+    const tools = Array.from({ length: 201 }, (_, i) => `tool_${i}`);
+    expect(EnableToolInputSchema.safeParse({ tools }).success).toBe(false);
+  });
+
   test("rejects a connections input field", () => {
     const parsed = EnableToolInputSchema.safeParse({
       tools: ["a"],

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/enable-tool.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/enable-tool.ts
@@ -8,10 +8,15 @@
 import { tool } from "ai";
 import { z } from "zod";
 
+/** Well above any realistic tool catalog (mcp-tools.ts's comment cites 100s of
+ *  tools total); just bounds a runaway/malformed call. */
+const MAX_TOOLS_PER_CALL = 200;
+
 export const EnableToolInputSchema = z.object({
   tools: z
     .array(z.string())
     .min(1)
+    .max(MAX_TOOLS_PER_CALL)
     .describe(
       "Tool ids to enable, taken verbatim from <available-connections>.",
     ),


### PR DESCRIPTION
Follows the same "cap an attacker/model-controlled array input" pattern already applied to `enable-tool.ts`'s sibling built-in tool, `update-interests.ts` (which caps its `interests` array at 10). `enable-tool.ts`'s `EnableToolInputSchema.tools` had `min(1)` but no upper bound, so a runaway or malformed model tool-call could pass an arbitrarily large array through `createEnableToolTool`'s per-item loop.

Why a maintainer wants it: bounds an unbounded per-tool-call array the same way every other decopilot built-in tool in this directory already does, closing a validation gap before it needs a bigger fix.

Fix: added `.max(200)` to the schema (well above any realistic tool catalog size per the comment in `mcp-tools.ts`). Added a test asserting a 201-item array now fails schema validation.

Reviewer check: `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/enable-tool.test.ts`

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the `tools` array in the `enable_tool` input schema at 200, matching the pattern used by other built-in tools. Previously the array had no upper bound, so a malformed or runaway model call could pass an arbitrarily large array; now those calls fail schema validation. Adds a test covering the new limit.

<sup>Written for commit b4580ac9f37eb07d6d240055468af3eedc5ef4e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

