### PR TITLE
refactor(mcp-clients): dedupe the HTTP/Websocket/SSE outbound transport setup

### DIFF
--- a/apps/api/src/mcp-clients/outbound/index.ts
+++ b/apps/api/src/mcp-clients/outbound/index.ts
@@ -93,11 +93,20 @@ export async function createOutboundClient(
     }
 
     case "HTTP":
-    case "Websocket": {
+    case "Websocket":
+    case "SSE": {
       if (!connection.connection_url) {
         throw new Error(`${connection.connection_type} connection missing URL`);
       }
       const connectionUrl = connection.connection_url;
+      const makeBaseTransport =
+        connection.connection_type === "SSE"
+          ? (url: URL, headers: Record<string, string>) =>
+              new SSEClientTransport(url, { requestInit: { headers } })
+          : (url: URL, headers: Record<string, string>) =>
+              new StreamableHTTPClientTransport(url, {
+                requestInit: { headers },
+              });
 
       // Deferred: only builds headers (DB lookup + JWT issuance) on a cache miss.
       return ctx.getOrCreateClient(async () => {
@@ -108,45 +117,9 @@ export async function createOutboundClient(
           Object.assign(headers, httpParams.headers);
         }
 
-        let transport: Transport = new StreamableHTTPClientTransport(
+        let transport: Transport = makeBaseTransport(
           new URL(connectionUrl),
-          { requestInit: { headers } },
-        );
-
-        // Compose with auth and monitoring transports
-        transport = composeTransport(
-          transport,
-          (t) => new AuthTransport(t, { ctx, connection, superUser }),
-          (t) =>
-            new MonitoringTransport(t, {
-              ctx,
-              connectionId,
-              virtualMcpId,
-            }),
-        );
-
-        return transport;
-      }, connectionId);
-    }
-
-    case "SSE": {
-      if (!connection.connection_url) {
-        throw new Error("SSE connection missing URL");
-      }
-      const connectionUrl = connection.connection_url;
-
-      // Deferred: only builds headers (DB lookup + JWT issuance) on a cache miss.
-      return ctx.getOrCreateClient(async () => {
-        const headers = await buildRequestHeaders(connection, ctx, superUser);
-
-        const httpParams = connection.connection_headers;
-        if (httpParams && "headers" in httpParams) {
-          Object.assign(headers, httpParams.headers);
-        }
-
-        let transport: Transport = new SSEClientTransport(
-          new URL(connectionUrl),
-          { requestInit: { headers } },
+          headers,
         );
 
         // Compose with auth and monitoring transports


### PR DESCRIPTION
Source: code reduction (C1) found auditing `apps/api/src/mcp-clients/**` for this tick's focus area (MCP client core).

The `HTTP`/`Websocket` and `SSE` cases in `createOutboundClient` (`apps/api/src/mcp-clients/outbound/index.ts`) were byte-for-byte identical except for which SDK transport class they instantiated (`StreamableHTTPClientTransport` vs `SSEClientTransport`). Collapsed the three switch cases into one, factoring the transport constructor into a small `makeBaseTransport` closure selected once per call; header-building, `composeTransport` wiring, and the `ctx.getOrCreateClient` call are now written once instead of twice.

Net: -39 / +12 lines. Behavior-preserving — same headers, same `AuthTransport`/`MonitoringTransport` composition, same pooling key, just no longer duplicated per transport kind; verified by reading the diff line-by-line (no branch logic changed, only where the two copies converge).

How to verify: `cd apps/api && bunx tsc --noEmit` (green) and `bunx oxlint apps/api/src/mcp-clients/outbound/index.ts` (0 warnings/errors). No existing unit test targets this file directly (it's exercised via connection-level integration tests), so this PR carries no test — it's a pure structural dedup with no behavior change.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint` on the touched file. Full CI (including integration/e2e) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the HTTP/Websocket/SSE outbound transport setup in the MCP client outbound layer. Behavior is unchanged; the three transport types now share one implementation, reducing code size and risk of drift.

<sup>Written for commit 57636bf153b44344ed9369e6f35d5baab25e4cc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

