### PR TITLE
fix(virtual-mcp): cap kickstart prompt text length

### DIFF
--- a/packages/shared/src/sdk/types/virtual-mcp.test.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, test } from "bun:test";
 import {
+  AgentKickstartPromptSchema,
   SandboxMapSchema,
   VirtualMCPEntitySchema,
   VirtualMCPCreateDataSchema,
@@ -11,6 +12,24 @@ import {
   resolveCmsMode,
   withCmsMode,
 } from "./virtual-mcp";
+
+describe("AgentKickstartPromptSchema", () => {
+  it("rejects a text longer than 4000 chars", () => {
+    const result = AgentKickstartPromptSchema.safeParse({
+      title: "Say hi",
+      text: "a".repeat(4001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a text at the 4000 char boundary", () => {
+    const result = AgentKickstartPromptSchema.safeParse({
+      title: "Say hi",
+      text: "a".repeat(4000),
+    });
+    expect(result.success).toBe(true);
+  });
+});
 
 describe("withCmsMode", () => {
   it("writes the mode and drops the boolean it supersedes", () => {

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -841,6 +841,7 @@ export const AgentKickstartPromptSchema = z.object({
   text: z
     .string()
     .min(1)
+    .max(4000)
     .describe("The message sent to the agent when the prompt is clicked"),
 });
 


### PR DESCRIPTION
**Source**: found while auditing `packages/shared/src/sdk/types/virtual-mcp.ts` (this tick's focus area) for validation gaps in the Virtual MCP SDK types.

**Why**: `AgentKickstartPromptSchema` is the input shape for the `prompts` field on `COLLECTION_VIRTUAL_MCP_CREATE`/`COLLECTION_VIRTUAL_MCP_UPDATE` — a tool-input trust boundary. `title` (max 120) and `description` (max 280) are already bounded, but `text` — the actual message sent to the agent when the prompt is clicked, and the field an attacker/careless caller is most likely to abuse — had no upper bound at all. This is the same 'cap comment/title/desc length on tool input' gap this repo has fixed repeatedly elsewhere (#6570, #6591, #6693, #6731, #6749, #6757, #6904, #6908, #6911).

Separately, the seeding path (`apps/api/src/file-storage/agent-prompts.ts`) already caps the *array* to `MAX_PROMPTS = 20`, so this PR only closes the missing per-field string cap — one concern.

**Failure scenario**: an MCP client could pass an arbitrarily large `text` string for a kickstart prompt; each prompt is persisted as its own JSON file in org-fs and served back as a native MCP prompt on the agent's gateway (icebreaker/home/`/` mentions), so an unbounded string bloats every read of that surface.

**Fix**: added `.max(4000)` to `AgentKickstartPromptSchema.text` (same schema, single field), matching the existing bound pattern on sibling fields in this schema.

**Regression test**: `packages/shared/src/sdk/types/virtual-mcp.test.ts` — new `AgentKickstartPromptSchema` describe block asserts a 4001-char text is rejected and a 4000-char text is accepted.

**To verify**: `bun test packages/shared/src/sdk/types/virtual-mcp.test.ts`

**Checks run locally**: `bun run fmt`, `cd packages/shared && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all green. Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps kickstart prompt `text` at 4000 characters in `AgentKickstartPromptSchema`, matching the existing bounds on `title` and `description`. Previously `text` had no upper bound, letting MCP clients pass arbitrarily large strings that bloat every read of the prompt surface.

- Added regression tests asserting a 4001-char `text` is rejected and a 4000-char `text` is accepted.

<sup>Written for commit 32db3090da9812b033917e52d2accb9a9b82b55c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

