### PR TITLE
fix(create-agent-dropdown): translate the hardcoded "Beta" badge

### DIFF
--- a/apps/web/src/components/create-agent-dropdown.tsx
+++ b/apps/web/src/components/create-agent-dropdown.tsx
@@ -41,7 +41,7 @@ export function CreateAgentDropdownContent({
         {t("common.createAgentDropdown.importFromGitHub")}
         {showBetaBadge && (
           <span className="ml-auto text-[10px] font-medium text-muted-foreground bg-muted rounded px-1 py-0.5">
-            Beta
+            {t("common.createAgentDropdown.beta")}
           </span>
         )}
       </DropdownMenuItem>

--- a/apps/web/src/i18n/en/common.ts
+++ b/apps/web/src/i18n/en/common.ts
@@ -283,6 +283,7 @@ export const common = {
   "common.createAgentDropdown.createFromScratch": "Create from scratch",
   "common.createAgentDropdown.importFromGitHub": "Import from GitHub",
   "common.createAgentDropdown.importFromDeco": "Import from deco.cx",
+  "common.createAgentDropdown.beta": "Beta",
   "common.mainPanelTabs.overview": "Overview",
   "common.mainPanelTabs.preview": "Preview",
   "common.mainPanelTabs.code": "Code",

--- a/apps/web/src/i18n/pt-br/common.ts
+++ b/apps/web/src/i18n/pt-br/common.ts
@@ -293,6 +293,7 @@ export const common = {
   "common.createAgentDropdown.createFromScratch": "Criar do zero",
   "common.createAgentDropdown.importFromGitHub": "Importar do GitHub",
   "common.createAgentDropdown.importFromDeco": "Importar do deco.cx",
+  "common.createAgentDropdown.beta": "Beta",
   "common.mainPanelTabs.overview": "Visão Geral",
   "common.mainPanelTabs.preview": "Visualização",
   "common.mainPanelTabs.code": "Código",


### PR DESCRIPTION
**Source**: bug found auditing `apps/web/src/components/create-agent-dropdown.tsx` (my assigned focus area this tick).

**What**: `CreateAgentDropdownContent`'s GitHub-import beta badge rendered a literal `Beta` string instead of routing through `t()`. Per this repo's i18n rule (`apps/web/src` must never hardcode user-facing strings), this silently stayed English even when the app is switched to pt-br, unlike every sibling label in the same dropdown (`createFromScratch`, `importFromGitHub`, `importFromDeco`), which already go through `t()`.

**Fix**: added `common.createAgentDropdown.beta` to both `en/common.ts` and `pt-br/common.ts` (kept as "Beta" in pt-br too, a standard loanword in pt-br product UI), and swapped the JSX literal for `t("common.createAgentDropdown.beta")`.

**How to verify**: `bunx tsc --noEmit` in `apps/web` (clean for the touched files; the only pre-existing failure is an unrelated prosemirror version-mismatch error in `mention-suggestion.tsx`), plus a visual check that switching language to pt-br still shows the badge.

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/web), `bunx oxlint` on the 3 touched files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the create agent dropdown's beta badge so it translates to pt-br instead of staying hardcoded as "Beta".

- Adds the `common.createAgentDropdown.beta` key to both the English and pt-br dictionaries.
- Swaps the literal `Beta` JSX string for `t("common.createAgentDropdown.beta")` in `create-agent-dropdown.tsx`.

<sup>Written for commit 4303fd8dce67830c4c5f5f7e546536e3b2b72e1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

