### PR TITLE
fix(extract-connection-data): fall back to HTTP for an unrecognized remote type

### DIFF
--- a/apps/web/src/utils/extract-connection-data.test.ts
+++ b/apps/web/src/utils/extract-connection-data.test.ts
@@ -69,6 +69,23 @@ describe("extractConnectionData", () => {
     expect(data.oauth_config).toBeNull();
   });
 
+  // An unrecognized remote type must not mint an invalid connection_type enum value.
+  it("falls back to HTTP for an unrecognized remote type", () => {
+    const item: RegistryItem = {
+      ...packageOnlyItem,
+      server: {
+        ...packageOnlyItem.server,
+        remotes: [{ type: "graphql", url: "https://example.com/mcp" }],
+      },
+    };
+
+    const data = extractConnectionData(item, "org-1", "user-1", {
+      remoteIndex: 0,
+    });
+
+    expect(data.connection_type).toBe("HTTP");
+  });
+
   it("keeps a well-formed oauth_config", () => {
     const item: RegistryItem = {
       ...packageOnlyItem,

--- a/apps/web/src/utils/extract-connection-data.ts
+++ b/apps/web/src/utils/extract-connection-data.ts
@@ -158,10 +158,9 @@ export function extractConnectionData(
       ...(Object.keys(envVars).length > 0 && { envVars }),
     };
   } else if (selectedRemote) {
-    connectionType = (getConnectionTypeLabel(selectedRemote.type) || "HTTP") as
-      | "HTTP"
-      | "SSE"
-      | "Websocket";
+    // An unrecognized remote type uppercases to a bogus label — fall back to HTTP rather than mint an invalid connection_type.
+    const label = getConnectionTypeLabel(selectedRemote.type);
+    connectionType = label === "SSE" || label === "Websocket" ? label : "HTTP";
     connectionUrl = selectedRemote.url || "";
   } else {
     // Fallback


### PR DESCRIPTION
A bug found while auditing `extract-connection-data.ts` for the "connection & thread utility helpers" focus area.

`getConnectionTypeLabel` (registry-utils.ts) uppercases any `remote.type` it doesn't recognize (e.g. a future "graphql" or "grpc" MCP transport) and returns it verbatim. `extractConnectionData` then force-cast that arbitrary string into the `"HTTP" | "SSE" | "Websocket"` union with an `as`-cast, without checking it's actually one of those values.

`connection_type` is a strict zod enum (`ConnectionEntitySchema`, packages/shared/src/sdk/types/connection.ts) downstream. So installing a store item whose remote advertises an unrecognized type would silently mint an invalid `connection_type` (e.g. `"GRAPHQL"`) that fails schema validation at connection creation, instead of degrading gracefully to a working HTTP connection the way a package-only fallback already does elsewhere in this function.

Fix: only pass through the label when it's actually `"SSE"` or `"Websocket"`; otherwise fall back to `"HTTP"`. Added a regression test (`extract-connection-data.test.ts`) covering an unrecognized remote type.

To confirm: `bun test apps/web/src/utils/extract-connection-data.test.ts`.

Locally ran: `bun test apps/web/src/utils/extract-connection-data.test.ts` (5 pass), `bunx oxlint` on both touched files (0 errors/warnings), `bun run fmt` (no changes needed). Skipped the full `apps/web` typecheck — it fails on a pre-existing, unrelated prosemirror version-mismatch error in `mention-suggestion.tsx`; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `extract-connection-data` so a registry item with an unrecognized remote type falls back to an HTTP connection instead of minting an invalid `connection_type`. Previously, the uppercased label (e.g. `"GRAPHQL"`) was force-cast into the `"HTTP" | "SSE" | "Websocket"` union and would fail strict zod validation when the connection was created.

- Falls back to `"HTTP"` unless the label is `"SSE"` or `"Websocket"`.
- Adds a regression test covering an unrecognized remote type.

<sup>Written for commit 8efe3d29cb8eb9c29b792b59559a5868a3ce5e0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

