### PR TITLE
feat(jira): start agent runs from Jira status changes, with Jira-side tools

### DIFF
--- a/apps/api/migrations/200-jira-run-trigger.ts
+++ b/apps/api/migrations/200-jira-run-trigger.ts
@@ -1,0 +1,52 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * The Jira integration as a run trigger.
+ *
+ * An issue entering a Jira status that has a rule starts an agent run. The run
+ * is anchored on a board item (`source = 'jira'`) so quota, pull requests,
+ * review and rerun keep working, but that item is not a card the board shows —
+ * the issue's home is Jira, and the item carries no copy of it.
+ *
+ * - `org_jira_column_automations`: the rule per Jira status — row existence is
+ *   the switch, `prompt` null means the agent's own instruction. Keyed by the
+ *   STATUS name, not the column: a Jira column is a bucket of statuses and the
+ *   webhook reports the status.
+ * - `jira_trigger_claims`: one row per (issue, changelog entry) — the fence
+ *   that keeps a redelivered webhook or the safety-net poll from dispatching a
+ *   second paid run for the same transition.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE task_board_items
+      ADD COLUMN IF NOT EXISTS source text
+      CONSTRAINT chk_task_board_items_source CHECK (source IN ('jira'))
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS org_jira_column_automations (
+      organization_id text NOT NULL REFERENCES organization(id) ON DELETE CASCADE,
+      jira_status text NOT NULL,
+      prompt text,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (organization_id, jira_status)
+    )
+  `.execute(db);
+  await sql`
+    CREATE TABLE IF NOT EXISTS jira_trigger_claims (
+      organization_id text NOT NULL REFERENCES organization(id) ON DELETE CASCADE,
+      jira_issue_id text NOT NULL,
+      changelog_id text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (organization_id, jira_issue_id, changelog_id)
+    )
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS jira_trigger_claims`.execute(db);
+  await sql`DROP TABLE IF EXISTS org_jira_column_automations`.execute(db);
+  await sql`ALTER TABLE task_board_items DROP COLUMN IF EXISTS source`.execute(
+    db,
+  );
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -198,6 +198,7 @@ import * as migration196taskboardcolumntrackerstatuses from "./196-task-board-co
 import * as migration197taskboardprompts from "./197-task-board-prompts.ts";
 import * as migration198taskboardexternalurl from "./198-task-board-external-url.ts";
 import * as migration199dropjiramirrorandorgcolumns from "./199-drop-jira-mirror-and-org-columns.ts";
+import * as migration200jirarruntrigger from "./200-jira-run-trigger.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -431,6 +432,7 @@ const migrations: Record<string, Migration> = {
   "198-task-board-external-url": migration198taskboardexternalurl,
   "199-drop-jira-mirror-and-org-columns":
     migration199dropjiramirrorandorgcolumns,
+  "200-jira-run-trigger": migration200jirarruntrigger,
 };
 
 export default migrations;

--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -115,6 +115,12 @@ import { createReportPagesRoutes } from "./routes/report-pages";
 import reportsRoutes from "./routes/reports";
 import { stripeWebhookRoutes } from "./routes/stripe-webhook";
 import { githubWebhookRoutes } from "./routes/github-webhook";
+import { createJiraAttachmentRoutes } from "./routes/jira-attachments";
+import { createJiraWebhookRoutes } from "./routes/jira-webhook";
+import {
+  registerJiraTriggerSweepWorkflow,
+  setJiraTriggerSweepRuntime,
+} from "@/jira/dbos-jira-trigger-sweep";
 import filesRoutes from "./routes/files";
 import { createThreadOutputsRoutes } from "./routes/thread-outputs";
 import { createSelfRoutes } from "./routes/self";
@@ -1392,6 +1398,15 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Optional — 503 without GITHUB_WEBHOOK_SECRET, and pools refresh on their
   // own schedule regardless.
   app.route("/api/_github", githubWebhookRoutes);
+  // Jira: the issue-event intake that starts runs, and the attachment grant
+  // route those runs download through. Both authenticate by capability
+  // (per-org secret, signed token), not by session.
+  const jiraRouteDeps = {
+    db: database.db,
+    encryptionKey: getSettings().encryptionKey,
+  };
+  app.route("/api/_jira", createJiraWebhookRoutes(jiraRouteDeps));
+  app.route("/api/_jira", createJiraAttachmentRoutes(jiraRouteDeps));
 
   // Auth-gated report page + domain-derived metadata. API-only/test apps safely
   // return 404 for the HTML shell when no built client directory is supplied.
@@ -1542,6 +1557,12 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Hourly auto-archive of settled Done cards, one org leg per candidate org.
   setTaskBoardArchiveSweepRuntime({ db: database.db });
+
+  // Every 10 minutes: the Jira transitions the webhook may have missed.
+  setJiraTriggerSweepRuntime({
+    db: database.db,
+    encryptionKey: getSettings().encryptionKey,
+  });
 
   // Every 5 minutes: email what's still unread, then prune the 30-day window.
   setNotificationDigestRuntime({ db: database.db });
@@ -1815,6 +1836,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   registerPublicSetsSyncWorkflow();
   registerOrgRepoSyncWorkflow();
   registerTaskBoardArchiveSweepWorkflow();
+  registerJiraTriggerSweepWorkflow();
   registerNotificationDigestWorkflow();
   registerTaskBoardMergedTagSweepWorkflow();
   registerTaskBoardGithubReadWorkflow();

--- a/apps/api/src/api/routes/jira-attachments.ts
+++ b/apps/api/src/api/routes/jira-attachments.ts
@@ -1,0 +1,56 @@
+/**
+ * GET /api/_jira/attachments/:token — one Jira attachment's bytes, for a run.
+ *
+ * The sandbox never holds the Jira credential (a live third-party token in a
+ * shell, a transcript and a log), so Studio spends it and streams the bytes.
+ * The token is a signed, expiring grant to ONE attachment of ONE org, minted
+ * by `JIRA_ATTACHMENT_DOWNLOAD` for the run that asked; it is the route's
+ * whole authentication, which is why it lives outside session auth next to
+ * the webhook intake. Never log the token.
+ */
+
+import { Hono } from "hono";
+import type { Kysely } from "kysely";
+import { CredentialVault } from "@/encryption/credential-vault";
+import { verifyAttachmentToken } from "@/jira/attachment-token";
+import { JiraClient } from "@/jira/client";
+import { JiraIntegrationStorage } from "@/storage/jira-integrations";
+import type { Database } from "@/storage/types";
+
+export function createJiraAttachmentRoutes(deps: {
+  db: Kysely<Database>;
+  encryptionKey: string;
+}): Hono {
+  const storage = new JiraIntegrationStorage(
+    deps.db,
+    new CredentialVault(deps.encryptionKey),
+  );
+  const app = new Hono();
+  app.get("/attachments/:token", async (c) => {
+    const grant = verifyAttachmentToken(c.req.param("token"));
+    if (!grant) return c.json({ error: "Invalid or expired link" }, 404);
+    const integration = await storage.getByOrg(grant.organizationId);
+    if (!integration) return c.json({ error: "Jira is not connected" }, 404);
+    const client = new JiraClient(
+      integration.siteUrl,
+      integration.email,
+      integration.apiToken,
+    );
+    const upstream = await client.downloadAttachment(grant.attachmentId);
+    if (!upstream.ok || !upstream.body) {
+      return c.json({ error: "Jira refused the download" }, 502);
+    }
+    const headers = new Headers();
+    for (const name of [
+      "content-type",
+      "content-length",
+      "content-disposition",
+    ]) {
+      const value = upstream.headers.get(name);
+      if (value) headers.set(name, value);
+    }
+    headers.set("cache-control", "no-store");
+    return new Response(upstream.body, { status: 200, headers });
+  });
+  return app;
+}

--- a/apps/api/src/api/routes/jira-webhook.ts
+++ b/apps/api/src/api/routes/jira-webhook.ts
@@ -1,0 +1,80 @@
+/**
+ * POST /api/_jira/webhook/:secret — Jira issue-event intake, per org.
+ *
+ * The trigger behind the integration: an `issue_updated` event whose changelog
+ * carries a status change is checked against the org's rules and, when one
+ * matches, starts an agent run on the issue (`jira/trigger.ts`). Everything
+ * else is acknowledged and dropped.
+ *
+ * Jira admin webhooks carry no HMAC signature, so the per-org secret in the
+ * path is the whole authentication; the payload is parsed but never trusted
+ * for anything the trigger does not re-read from Jira with the integration's
+ * own credential. Answers 202 before doing the work: Jira times a hook out in
+ * seconds and the dispatch reads the issue, its comments and a quota row.
+ *
+ * Instance-level (underscore namespace, mounted before the /api/:org
+ * catch-all) and outside session auth, like the GitHub/Stripe intakes.
+ */
+
+import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import type { Kysely } from "kysely";
+import { CredentialVault } from "@/encryption/credential-vault";
+import {
+  parseWebhookTransition,
+  triggerRunForTransition,
+} from "@/jira/trigger";
+import { JiraIntegrationStorage } from "@/storage/jira-integrations";
+import type { Database } from "@/storage/types";
+import { buildOrgContext } from "@/tools/task-board/org-context";
+
+/** The route is unauthenticated until the secret lookup — cap the body. */
+const MAX_BODY_SIZE = 1_048_576; // 1MB
+
+export function createJiraWebhookRoutes(deps: {
+  db: Kysely<Database>;
+  encryptionKey: string;
+}): Hono {
+  const storage = new JiraIntegrationStorage(
+    deps.db,
+    new CredentialVault(deps.encryptionKey),
+  );
+
+  async function run(secret: string, payload: unknown): Promise<void> {
+    const transition = parseWebhookTransition(payload);
+    if (!transition) return;
+    // Re-fetched here rather than trusted from the ack: config may have changed.
+    const integration = await storage.getByWebhookSecret(secret);
+    if (!integration?.enabled) return;
+    const ctx = await buildOrgContext(deps.db, integration.organizationId);
+    if (!ctx) return;
+    const outcome = await triggerRunForTransition(ctx, integration, transition);
+    if (outcome === "started") {
+      console.log(
+        `[jira-webhook] started a run for ${transition.issueKey} entering "${transition.toStatus}"`,
+      );
+    }
+  }
+
+  const app = new Hono();
+  app.post(
+    "/webhook/:secret",
+    bodyLimit({ maxSize: MAX_BODY_SIZE }),
+    async (c) => {
+      const secret = c.req.param("secret");
+      const integration = await storage.getByWebhookSecret(secret);
+      if (!integration) return c.json({ error: "Unknown webhook" }, 404);
+      let payload: unknown;
+      try {
+        payload = await c.req.json();
+      } catch {
+        return c.json({ error: "Body must be JSON" }, 400);
+      }
+      void run(secret, payload).catch((err) => {
+        console.error("[jira-webhook] trigger failed", err);
+      });
+      return c.body(null, 202);
+    },
+  );
+  return app;
+}

--- a/apps/api/src/api/routes/task-run-mcp.ts
+++ b/apps/api/src/api/routes/task-run-mcp.ts
@@ -17,7 +17,7 @@ import { Hono } from "hono";
 import type { StudioContext } from "../../core/studio-context";
 import { managementContextStore, toolSubsetMCP } from "../../tools";
 import {
-  resolveReviewRunToolNames,
+  resolveTaskRunToolNames,
   taskRunContextStore,
 } from "../../tools/task-board/task-run-context";
 import { serveMcpRequest } from "../utils/serve-mcp";
@@ -30,16 +30,16 @@ export const createTaskRunMcpRoutes = () => {
   app.all("/:threadId", async (c) => {
     const ctx = c.get("studioContext");
     const threadId = c.req.param("threadId");
-    // A reviewer's run gets one extra tool (`TASK_BOARD_REVIEW_DECISION`) — the
-    // one it is instructed to finish with. Derived from the run thread itself,
-    // not from a request argument, for the same reason the threadId is in the
-    // path: the per-run key is minted with full access, so anything the caller
-    // could assert it could also forge. The lookup is org-scoped by
-    // `resolveOrgFromPath`, so a foreign thread reads as null → narrow list.
+    // Which surface — worker, reviewer, or Jira — is derived from the run
+    // thread itself, not from a request argument, for the same reason the
+    // threadId is in the path: the per-run key is minted with full access, so
+    // anything the caller could assert it could also forge. The lookup is
+    // org-scoped by `resolveOrgFromPath`, so a foreign thread reads as null →
+    // narrow list.
     const thread = await ctx.storage.threads.get(threadId);
     const server = toolSubsetMCP(
       "mcp-task-run",
-      resolveReviewRunToolNames(thread?.title),
+      resolveTaskRunToolNames(thread),
     );
     const transport = new WebStandardStreamableHTTPServerTransport({
       enableJsonResponse:

--- a/apps/api/src/core/signing-key.ts
+++ b/apps/api/src/core/signing-key.ts
@@ -1,0 +1,27 @@
+/**
+ * The key Studio signs its own short-lived tokens with.
+ *
+ * One key for every HMAC token the server mints and later verifies itself —
+ * reviewer identities, attachment download grants. Derived from the auth
+ * secret so it survives a restart; a random key is the unit-test fallback,
+ * where nothing outlives the process.
+ */
+
+import { randomBytes } from "node:crypto";
+import { getSettings } from "@/settings";
+
+let signingKey: Buffer | null = null;
+
+export function getSigningKey(): Buffer {
+  if (signingKey) return signingKey;
+  let secret: string | undefined;
+  try {
+    const settings = getSettings();
+    secret = settings.studioJwtSecret ?? settings.betterAuthSecret;
+  } catch {
+    // Settings not initialized (e.g. unit tests) — fall back like auth/jwt.ts.
+    secret = undefined;
+  }
+  signingKey = secret ? Buffer.from(secret) : randomBytes(32);
+  return signingKey;
+}

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -6,6 +6,7 @@
   "file-storage/dbos-org-repo-sync.ts": "32c606976916fde2be7abe3084f7388744bdb610c178e9c2a07a8080f764904e",
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",
   "harnesses/decopilot/background-tool-workflow.ts": "1ae73b5a614ae6439942c1e52de52deeb3e18d1bb7e528be820720b592cfe833",
+  "jira/dbos-jira-trigger-sweep.ts": "07108e0a60f298d206c7f11bf36500bde8e61701b42bdab6b5ba9d7e99997eca",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
   "notifications/dbos-digest.ts": "673bc164593266704d2918a0bcaaf838a2480dfb46d1d19c02bdb38c73ecc370",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",

--- a/apps/api/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/index.ts
@@ -65,6 +65,7 @@ import { createClusterResearchJob } from "./cluster-research-job";
 import type { PendingImage } from "@/harnesses/lib/decopilot/built-in-tools/vm-tools/types";
 import { buildPortableBuiltInTools } from "@/harnesses/lib/decopilot/built-in-tools/portable-built-ins";
 import { createThreadTools } from "./thread-tools";
+import { createJiraRunTools } from "./jira-run-tools";
 import { createTaskBoardTools } from "./task-board-tools";
 import type { ModelsConfig } from "@/harnesses/lib/types";
 import type { StudioProvider } from "@/ai-providers/types";
@@ -220,7 +221,19 @@ async function buildAllTools(
   // Task-board built-ins — the Super Agent aggregates no connections, so these
   // are the only way it can read or move cards on the board. Before this it had
   // to `subtask`-delegate to the (now retired) Task Manager agent.
-  Object.assign(tools, createTaskBoardTools(ctx));
+  //
+  // A Jira-triggered run gets the ISSUE's tools instead. Its card is a hidden
+  // anchor nobody reads, so handing it the board tools would have it record its
+  // work where no one looks while the issue stayed untouched. The sandbox
+  // harness makes the same swap at its run-scoped MCP endpoint
+  // (`resolveTaskRunToolNames`); this is the same rule for the Decopilot path,
+  // which an org with no repo to work in takes.
+  Object.assign(
+    tools,
+    (await isJiraRun(ctx, taskId))
+      ? createJiraRunTools(ctx, taskId)
+      : createTaskBoardTools(ctx),
+  );
   // VM file tools — six LLM-visible tools (read/write/edit/grep/glob/bash)
   // always registered when a vmContext is provided. The handle is resolved
   // lazily on the first tool invocation: `ensureSandbox` either reuses
@@ -556,4 +569,24 @@ export function buildBuiltInTools(
     tools.subtask = createSubtaskTool(writer, subtaskParams, ctx);
   }
   return tools;
+}
+
+/**
+ * Whether this run was started by the Jira integration.
+ *
+ * Read off the run thread's own metadata (stamped at dispatch), not off
+ * anything the model or the caller could assert — the same discriminator the
+ * run-scoped MCP endpoint uses. A thread that cannot be read is not a Jira run:
+ * the board tools are the safe default for every other run there is.
+ */
+async function isJiraRun(
+  ctx: StudioContext,
+  threadId: string,
+): Promise<boolean> {
+  try {
+    const thread = await ctx.storage.threads.get(threadId);
+    return thread?.metadata?.source === "jira";
+  } catch {
+    return false;
+  }
 }

--- a/apps/api/src/harnesses/decopilot/built-in-tools/jira-run-tools.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/jira-run-tools.ts
@@ -1,0 +1,62 @@
+/**
+ * Jira built-ins, for a Jira-triggered run that lands on Decopilot.
+ *
+ * The sandbox-hosted harness reaches these over its run-scoped MCP endpoint,
+ * which serves them by thread (`task-run-context.ts`). Decopilot has no such
+ * endpoint — it gets built-ins — so without this a Jira run in an org with no
+ * repo would be handed the TASK BOARD tools instead, and would dutifully
+ * "update the task" on the hidden anchor item nobody reads while the issue
+ * everybody reads went untouched.
+ *
+ * The thread is passed rather than read from request scope: a built-in runs
+ * inside the agent loop, not inside the MCP request the endpoint version has.
+ */
+
+import { tool, zodSchema, type ToolSet } from "ai";
+import type { StudioContext } from "@/core/studio-context";
+import {
+  JIRA_ATTACHMENT_DOWNLOAD,
+  JIRA_COMMENT_ADD,
+  JIRA_ISSUE_GET,
+  JIRA_ISSUE_TRANSITION,
+} from "@/tools/jira/run-tools";
+import { taskRunContextStore } from "@/tools/task-board/task-run-context";
+
+/** Names kept verbatim, as the task-board built-ins are: the run's opening
+ *  message tells the model to call them by these names. */
+export function createJiraRunTools(
+  ctx: StudioContext,
+  threadId: string,
+): ToolSet {
+  // The tools resolve their issue from the run's thread, read from the same
+  // store the MCP endpoint sets. Supplying it here is what lets one
+  // implementation serve both paths.
+  const inRunScope = <T>(run: () => Promise<T>): Promise<T> =>
+    taskRunContextStore.run({ threadId }, run);
+
+  return {
+    JIRA_ISSUE_GET: tool({
+      description: JIRA_ISSUE_GET.description,
+      inputSchema: zodSchema(JIRA_ISSUE_GET.inputSchema),
+      execute: (input) => inRunScope(() => JIRA_ISSUE_GET.execute(input, ctx)),
+    }),
+    JIRA_COMMENT_ADD: tool({
+      description: JIRA_COMMENT_ADD.description,
+      inputSchema: zodSchema(JIRA_COMMENT_ADD.inputSchema),
+      execute: (input) =>
+        inRunScope(() => JIRA_COMMENT_ADD.execute(input, ctx)),
+    }),
+    JIRA_ISSUE_TRANSITION: tool({
+      description: JIRA_ISSUE_TRANSITION.description,
+      inputSchema: zodSchema(JIRA_ISSUE_TRANSITION.inputSchema),
+      execute: (input) =>
+        inRunScope(() => JIRA_ISSUE_TRANSITION.execute(input, ctx)),
+    }),
+    JIRA_ATTACHMENT_DOWNLOAD: tool({
+      description: JIRA_ATTACHMENT_DOWNLOAD.description,
+      inputSchema: zodSchema(JIRA_ATTACHMENT_DOWNLOAD.inputSchema),
+      execute: (input) =>
+        inRunScope(() => JIRA_ATTACHMENT_DOWNLOAD.execute(input, ctx)),
+    }),
+  };
+}

--- a/apps/api/src/jira/attachment-token.test.ts
+++ b/apps/api/src/jira/attachment-token.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { mintAttachmentToken, verifyAttachmentToken } from "./attachment-token";
+
+describe("attachment token", () => {
+  const grant = {
+    organizationId: "org_1",
+    attachmentId: "10042",
+    expiresAt: 2_000_000,
+  };
+
+  it("round-trips a grant while it is live", () => {
+    const token = mintAttachmentToken(grant);
+    expect(verifyAttachmentToken(token, 1_000_000)).toEqual(grant);
+  });
+
+  it("refuses an expired grant", () => {
+    const token = mintAttachmentToken(grant);
+    expect(verifyAttachmentToken(token, 2_000_000)).toBeNull();
+  });
+
+  /** The token is the only authentication on the download route, so a payload
+   *  edit — another attachment, another org, a later expiry — must fail. */
+  it("refuses a token whose payload was edited", () => {
+    const token = mintAttachmentToken(grant);
+    const [, mac] = token.split(".");
+    const edited = Buffer.from(
+      JSON.stringify({ ...grant, attachmentId: "10043" }),
+    ).toString("base64url");
+    expect(verifyAttachmentToken(`${edited}.${mac}`, 1_000_000)).toBeNull();
+  });
+
+  it("refuses garbage", () => {
+    for (const bad of ["", "abc", "abc.def", "not-base64.zz"]) {
+      expect(verifyAttachmentToken(bad, 1_000_000)).toBeNull();
+    }
+  });
+});

--- a/apps/api/src/jira/attachment-token.ts
+++ b/apps/api/src/jira/attachment-token.ts
@@ -1,0 +1,68 @@
+/**
+ * A short-lived grant to download one Jira attachment through Studio.
+ *
+ * The agent's sandbox never holds the Jira credential. `JIRA_ATTACHMENT_DOWNLOAD`
+ * mints one of these, the run `curl`s `/api/_jira/attachments/<token>`, and
+ * the server spends the integration's token on its behalf. The grant is the
+ * whole authentication of that route, so it is bound to the org and the
+ * attachment, expires, and is signed — a guess or an edit fails closed.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { getSigningKey } from "@/core/signing-key";
+
+export interface AttachmentGrant {
+  organizationId: string;
+  attachmentId: string;
+  /** Unix ms. */
+  expiresAt: number;
+}
+
+/** Long enough to run a `curl` inside a step, short enough that a leaked
+ *  transcript is not a durable link to a customer's file. */
+export const ATTACHMENT_GRANT_TTL_MS = 10 * 60 * 1000;
+
+function sign(payload: string): string {
+  return createHmac("sha256", getSigningKey())
+    .update(payload)
+    .digest("base64url");
+}
+
+export function mintAttachmentToken(grant: AttachmentGrant): string {
+  const payload = Buffer.from(JSON.stringify(grant)).toString("base64url");
+  return `${payload}.${sign(payload)}`;
+}
+
+/** The grant a token carries, or null when it is forged, malformed or past
+ *  its expiry. `now` is injectable for the test. */
+export function verifyAttachmentToken(
+  token: string,
+  now: number = Date.now(),
+): AttachmentGrant | null {
+  const dot = token.indexOf(".");
+  if (dot <= 0) return null;
+  const payload = token.slice(0, dot);
+  const mac = Buffer.from(token.slice(dot + 1));
+  const expected = Buffer.from(sign(payload));
+  if (mac.length !== expected.length || !timingSafeEqual(mac, expected)) {
+    return null;
+  }
+  let grant: unknown;
+  try {
+    grant = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (
+    typeof grant !== "object" ||
+    grant === null ||
+    typeof (grant as AttachmentGrant).organizationId !== "string" ||
+    typeof (grant as AttachmentGrant).attachmentId !== "string" ||
+    typeof (grant as AttachmentGrant).expiresAt !== "number"
+  ) {
+    return null;
+  }
+  const typed = grant as AttachmentGrant;
+  if (typed.expiresAt <= now) return null;
+  return typed;
+}

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -12,6 +12,7 @@
  */
 
 import { retry } from "@decocms/shared/std";
+import { getSettings } from "@/settings";
 import { type AdfMedia, markdownToAdf } from "./markdown-adf";
 import {
   collectWikiMentionAccountIds,
@@ -21,6 +22,9 @@ import {
 } from "./wiki-markdown";
 
 const REQUEST_TIMEOUT_MS = 15_000;
+
+/** Attachment bytes can be large; the download gets its own budget. */
+const UPLOAD_TIMEOUT_MS = 60_000;
 
 /** Account ids per `/user/bulk` request. Jira allows 200, but each id spends
  *  ~56 URL bytes, so 200 would build a ~11KB request line — past the 4KB cap
@@ -67,6 +71,20 @@ export interface JiraIssue {
   id: string;
   key: string;
   fields: JiraIssueFields;
+}
+
+export interface JiraAttachment {
+  id: string;
+  filename: string;
+  size: number;
+  mimeType?: string;
+}
+
+/** One changelog entry: what changed on the issue, and when. */
+export interface JiraChangelogHistory {
+  id: string;
+  created: string;
+  items: Array<{ field: string; toString?: string | null; to?: string | null }>;
 }
 
 export interface JiraComment {
@@ -121,17 +139,36 @@ function isRetriableError(error: unknown): boolean {
  * local address, an internal service, a look-alike domain harvesting the
  * token. Self-hosted Data Center would need an explicit allowlist, not a
  * loosening of this.
+ *
+ * The one exception is opt-in and for a stand-in Jira on the developer's own
+ * machine: `JIRA_ALLOW_LOCAL_SITE_URL` admits `http://localhost:<port>` and
+ * `http://127.0.0.1:<port>`, nothing else. Off unless set, so a deployment
+ * that never heard of it behaves exactly as before.
  */
 const JIRA_CLOUD_HOST = /^[a-z0-9][a-z0-9-]*\.atlassian\.net$/;
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1"]);
+
+function localSiteUrlsAllowed(): boolean {
+  try {
+    return getSettings().jiraAllowLocalSiteUrl;
+  } catch {
+    // Settings not initialized (unit tests): the strict rule applies.
+    return false;
+  }
+}
 
 export function normalizeSiteUrl(input: string): string {
   const raw = input.trim().replace(/\/+$/, "");
   const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
-  let hostname: string;
+  let url: URL;
   try {
-    hostname = new URL(withScheme).hostname.toLowerCase();
+    url = new URL(withScheme);
   } catch {
     throw new Error(`Invalid Jira site URL: ${input}`);
+  }
+  const hostname = url.hostname.toLowerCase();
+  if (LOCAL_HOSTS.has(hostname) && localSiteUrlsAllowed()) {
+    return `http://${hostname}${url.port ? `:${url.port}` : ""}`;
   }
   if (!JIRA_CLOUD_HOST.test(hostname)) {
     throw new Error(
@@ -377,18 +414,27 @@ export class JiraClient {
   async searchIssues(params: {
     jql: string;
     nextPageToken?: string;
-  }): Promise<{ issues: JiraIssue[]; nextPageToken: string | null }> {
+    /** Carry each issue's changelog, for a caller that needs its transitions. */
+    expandChangelog?: boolean;
+  }): Promise<{
+    issues: Array<
+      JiraIssue & { changelog?: { histories: JiraChangelogHistory[] } }
+    >;
+    nextPageToken: string | null;
+  }> {
     const query = new URLSearchParams({
       jql: params.jql,
       maxResults: String(SEARCH_PAGE_SIZE),
       fields: ISSUE_FIELDS,
     });
+    if (params.expandChangelog) query.set("expand", "changelog");
     if (params.nextPageToken) query.set("nextPageToken", params.nextPageToken);
     const page = await this.request<{
       issues?: Array<{
         id: string;
         key: string;
         fields: JiraIssueFields & Record<string, unknown>;
+        changelog?: { histories: JiraChangelogHistory[] };
       }>;
       nextPageToken?: string | null;
     }>(`/rest/api/3/search/jql?${query}`);
@@ -396,6 +442,39 @@ export class JiraClient {
       issues: page.issues ?? [],
       nextPageToken: page.nextPageToken ?? null,
     };
+  }
+
+  /** One issue with what a run's opening message shows. */
+  async getIssue(issueId: string): Promise<{
+    id: string;
+    key: string;
+    fields: {
+      summary: string;
+      status: { name: string };
+      description: unknown;
+      attachment?: JiraAttachment[];
+    };
+  }> {
+    return this.request(
+      `/rest/api/3/issue/${encodeURIComponent(issueId)}?fields=summary,status,description,attachment`,
+    );
+  }
+
+  /**
+   * The bytes of one attachment, as the upstream response so a route can
+   * stream them. Jira answers the content URL with a 303 to the media CDN;
+   * `fetch` follows it, and the platform drops the Authorization header on
+   * the cross-origin hop, which the CDN's signed URL does not need.
+   */
+  async downloadAttachment(attachmentId: string): Promise<Response> {
+    return fetch(
+      `${this.baseUrl}/rest/api/3/attachment/content/${encodeURIComponent(attachmentId)}`,
+      {
+        headers: { Authorization: this.authHeader },
+        redirect: "follow",
+        signal: AbortSignal.timeout(UPLOAD_TIMEOUT_MS),
+      },
+    );
   }
 
   /** Transitions available from the issue's CURRENT status — Jira never sets
@@ -486,13 +565,9 @@ export class JiraClient {
   }
 
   /** Attachments on the issue. */
-  async listAttachments(
-    issueId: string,
-  ): Promise<Array<{ id: string; filename: string; size: number }>> {
+  async listAttachments(issueId: string): Promise<JiraAttachment[]> {
     const issue = await this.request<{
-      fields?: {
-        attachment?: Array<{ id: string; filename: string; size: number }>;
-      };
+      fields?: { attachment?: JiraAttachment[] };
     }>(`/rest/api/3/issue/${encodeURIComponent(issueId)}?fields=attachment`);
     return issue.fields?.attachment ?? [];
   }

--- a/apps/api/src/jira/dbos-jira-trigger-sweep.ts
+++ b/apps/api/src/jira/dbos-jira-trigger-sweep.ts
@@ -1,0 +1,171 @@
+/**
+ * Safety net under the Jira webhook: every ten minutes, ask each enabled
+ * integration which issues changed status recently and run the same trigger
+ * the webhook runs. A webhook the tenant never configured, or one Jira dropped,
+ * costs latency instead of a missed run; the per-transition claim makes the
+ * overlap free.
+ *
+ * Same shape as `dbos-archive-sweep.ts`: one pod per tick, the work list read
+ * inside a step, one step per integration that never throws.
+ */
+
+import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
+import type { Kysely } from "kysely";
+import { CredentialVault } from "@/encryption/credential-vault";
+import { JiraIntegrationStorage } from "@/storage/jira-integrations";
+import type { Database } from "@/storage/types";
+import { buildOrgContext } from "@/tools/task-board/org-context";
+import { JiraClient } from "./client";
+import { transitionsFromChangelog, triggerRunForTransition } from "./trigger";
+
+/** Every ten minutes at :07 — off the other sweeps' ticks. */
+const SWEEP_CRONTAB = "7-59/10 * * * *";
+
+/** Wider than the tick so two consecutive sweeps overlap; the claim dedupes. */
+const LOOKBACK_MINUTES = 15;
+
+/** Pages of 100 issues per integration per tick. Past this the tenant has a
+ *  problem this sweep should not paper over. */
+const MAX_PAGES = 5;
+
+export interface JiraTriggerSweepRuntime {
+  db: Kysely<Database>;
+  encryptionKey: string;
+}
+
+let runtime: JiraTriggerSweepRuntime | null = null;
+
+export function setJiraTriggerSweepRuntime(rt: JiraTriggerSweepRuntime): void {
+  runtime = rt;
+}
+
+function requireRuntime(): JiraTriggerSweepRuntime {
+  if (!runtime) {
+    throw new Error(
+      "[jira-trigger] runtime not initialized — setJiraTriggerSweepRuntime() must run before the workflow fires",
+    );
+  }
+  return runtime;
+}
+
+function storage(): JiraIntegrationStorage {
+  const rt = requireRuntime();
+  return new JiraIntegrationStorage(
+    rt.db,
+    new CredentialVault(rt.encryptionKey),
+  );
+}
+
+/** One integration, folded to a result — the step body must never throw. */
+async function sweepOneIntegration(
+  integrationId: string,
+  since: Date,
+): Promise<{ integrationId: string; started: number; error?: string }> {
+  try {
+    const integration = await storage().getById(integrationId);
+    if (!integration?.enabled || !integration.boardId) {
+      return { integrationId, started: 0 };
+    }
+    const ctx = await buildOrgContext(
+      requireRuntime().db,
+      integration.organizationId,
+    );
+    if (!ctx) return { integrationId, started: 0 };
+    const rules = await ctx.storage.jiraIntegrations.listAutomations(
+      integration.organizationId,
+    );
+    if (rules.length === 0) return { integrationId, started: 0 };
+
+    const client = new JiraClient(
+      integration.siteUrl,
+      integration.email,
+      integration.apiToken,
+    );
+    const scope = await client.getBoardScopeJql(integration.boardId);
+    const jql = `(${scope}) AND status CHANGED AFTER "-${LOOKBACK_MINUTES}m"`;
+    let started = 0;
+    let nextPageToken: string | undefined;
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const result = await client.searchIssues({
+        jql,
+        nextPageToken,
+        expandChangelog: true,
+      });
+      for (const issue of result.issues) {
+        const transitions = transitionsFromChangelog(
+          issue,
+          issue.changelog?.histories ?? [],
+          since,
+        );
+        for (const transition of transitions) {
+          const outcome = await triggerRunForTransition(
+            ctx,
+            integration,
+            transition,
+          );
+          if (outcome === "started") started++;
+        }
+      }
+      nextPageToken = result.nextPageToken ?? undefined;
+      if (!nextPageToken) break;
+    }
+    return { integrationId, started };
+  } catch (err) {
+    return {
+      integrationId,
+      started: 0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function jiraTriggerSweepWorkflowFn(
+  scheduledTime: Date,
+  _currentTime: Date,
+): Promise<void> {
+  // Window off the SCHEDULED time, so a replayed tick asks for the same one.
+  const since = new Date(scheduledTime.getTime() - LOOKBACK_MINUTES * 60_000);
+  const ids = await DBOS.runStep(() => storage().listEnabledIds(), {
+    name: "loadJiraIntegrations",
+  });
+  if (ids.length === 0) return;
+  const results = await Promise.all(
+    ids.map((id) =>
+      DBOS.runStep(() => sweepOneIntegration(id, since), {
+        name: `sweepJira:${id}`,
+      }),
+    ),
+  );
+  for (const result of results) {
+    if (result.error) {
+      console.warn(
+        `[jira-trigger] integration ${result.integrationId} failed: ${result.error}`,
+      );
+    } else if (result.started > 0) {
+      console.log(
+        `[jira-trigger] integration ${result.integrationId} started ${result.started} run(s) the webhook missed`,
+      );
+    }
+  }
+}
+
+let registeredWorkflow: typeof jiraTriggerSweepWorkflowFn | null = null;
+
+/**
+ * Must run before DBOS.launch(). Guarded so HMR repeats don't re-register.
+ *
+ * ⚠️ Durable DBOS workflow. Changing its STEP SEQUENCE (add/remove/reorder a
+ * step, or change a step's recorded I/O) requires bumping
+ * DBOS_WORKFLOW_VERSION — see apps/api/src/dbos/workflow-version.ts.
+ */
+export function registerJiraTriggerSweepWorkflow(): void {
+  if (registeredWorkflow) return;
+  registeredWorkflow = DBOS.registerWorkflow(jiraTriggerSweepWorkflowFn, {
+    name: "jiraTriggerSweepWorkflow",
+  });
+  DBOS.registerScheduled(registeredWorkflow, {
+    name: "jiraTriggerSweepWorkflow",
+    crontab: SWEEP_CRONTAB,
+    mode: SchedulerMode.ExactlyOncePerIntervalWhenActive,
+  });
+}

--- a/apps/api/src/jira/issue-prompt.test.ts
+++ b/apps/api/src/jira/issue-prompt.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { type IssueForPrompt, renderIssueForPrompt } from "./issue-prompt";
+
+const base: IssueForPrompt = {
+  key: "EX-12",
+  url: "https://example.atlassian.net/browse/EX-12",
+  summary: "Fix the checkout button",
+  status: "Doing",
+  description: "The button is green.\n\nMake it blue.",
+  comments: [],
+  attachments: [],
+};
+
+describe("renderIssueForPrompt", () => {
+  it("leads with key, summary, status and link", () => {
+    const text = renderIssueForPrompt(base);
+    expect(text.startsWith("# EX-12: Fix the checkout button")).toBe(true);
+    expect(text).toContain("Status: Doing");
+    expect(text).toContain("Link: https://example.atlassian.net/browse/EX-12");
+    expect(text).toContain("Make it blue.");
+  });
+
+  /** The id is what the download tool takes, so it has to be on the page. */
+  it("lists attachments by id and says how to fetch one", () => {
+    const text = renderIssueForPrompt({
+      ...base,
+      attachments: [{ id: "10042", filename: "mock.png", size: 20480 }],
+    });
+    expect(text).toContain("mock.png (20 KB) — attachment id `10042`");
+    expect(text).toContain("JIRA_ATTACHMENT_DOWNLOAD");
+  });
+
+  it("omits the attachment and comment sections when there is nothing", () => {
+    const text = renderIssueForPrompt(base);
+    expect(text).not.toContain("## Attachments");
+    expect(text).not.toContain("## Comments");
+  });
+
+  it("renders comments in order with their author", () => {
+    const text = renderIssueForPrompt({
+      ...base,
+      comments: [
+        { author: "Ana", created: "2026-09-01T10:00:00Z", body: "first" },
+        { author: "Bo", created: "2026-09-01T11:00:00Z", body: "second" },
+      ],
+    });
+    expect(text.indexOf("**Ana**")).toBeLessThan(text.indexOf("**Bo**"));
+  });
+
+  it("truncates a sprawling description rather than dropping it", () => {
+    const text = renderIssueForPrompt({
+      ...base,
+      description: "x".repeat(20_000),
+    });
+    expect(text).toContain("[… truncated]");
+    expect(text.length).toBeLessThan(13_000);
+  });
+});

--- a/apps/api/src/jira/issue-prompt.ts
+++ b/apps/api/src/jira/issue-prompt.ts
@@ -1,0 +1,117 @@
+/**
+ * A Jira issue, rendered for an agent to read.
+ *
+ * The run's opening message and `JIRA_ISSUE_GET` both show the issue this way:
+ * summary, status, description, the comment thread, and the attachments by
+ * id — the id being what `JIRA_ATTACHMENT_DOWNLOAD` takes. Rendered, not
+ * stored: the issue's home is Jira, and the only copy Studio keeps is inside
+ * the run's own transcript.
+ */
+
+import {
+  collectMentionAccountIds,
+  type JiraClient,
+  jiraBodyToText,
+  JiraUserDirectory,
+} from "./client";
+
+export interface IssueForPrompt {
+  key: string;
+  url: string;
+  summary: string;
+  status: string;
+  description: string;
+  comments: Array<{ author: string; created: string; body: string }>;
+  attachments: Array<{ id: string; filename: string; size: number }>;
+}
+
+/** Caps so one sprawling issue cannot crowd out the instruction. */
+const MAX_DESCRIPTION_CHARS = 12_000;
+const MAX_COMMENTS_CHARS = 12_000;
+
+export function issueUrl(siteUrl: string, key: string): string {
+  return `${siteUrl.replace(/\/+$/, "")}/browse/${encodeURIComponent(key)}`;
+}
+
+/** Read everything the prompt shows, resolving mentions to names once. */
+export async function loadIssueForPrompt(
+  client: JiraClient,
+  siteUrl: string,
+  issueId: string,
+): Promise<IssueForPrompt> {
+  const [issue, comments] = await Promise.all([
+    client.getIssue(issueId),
+    client.listComments(issueId),
+  ]);
+  const users = new JiraUserDirectory(client);
+  const names = await users.resolve([
+    ...collectMentionAccountIds(issue.fields.description),
+    ...comments.flatMap((c) => collectMentionAccountIds(c.body)),
+  ]);
+  return {
+    key: issue.key,
+    url: issueUrl(siteUrl, issue.key),
+    summary: issue.fields.summary,
+    status: issue.fields.status.name,
+    description: jiraBodyToText(issue.fields.description, names).trim(),
+    comments: comments.map((c) => ({
+      author: c.author?.displayName ?? "Unknown",
+      created: c.created,
+      body: jiraBodyToText(c.body, names).trim(),
+    })),
+    attachments: (issue.fields.attachment ?? []).map((a) => ({
+      id: a.id,
+      filename: a.filename,
+      size: a.size,
+    })),
+  };
+}
+
+function clip(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}\n\n[… truncated]` : text;
+}
+
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function renderIssueForPrompt(issue: IssueForPrompt): string {
+  const lines: string[] = [
+    `# ${issue.key}: ${issue.summary}`,
+    `Status: ${issue.status}`,
+    `Link: ${issue.url}`,
+    "",
+    "## Description",
+    issue.description
+      ? clip(issue.description, MAX_DESCRIPTION_CHARS)
+      : "_(empty)_",
+  ];
+  if (issue.attachments.length > 0) {
+    lines.push("", "## Attachments");
+    for (const a of issue.attachments) {
+      lines.push(
+        `- ${a.filename} (${humanSize(a.size)}) — attachment id \`${a.id}\``,
+      );
+    }
+    lines.push(
+      "",
+      "Fetch one with `JIRA_ATTACHMENT_DOWNLOAD` and the attachment id; it returns a short-lived URL to `curl` into the sandbox.",
+    );
+  }
+  if (issue.comments.length > 0) {
+    lines.push("", "## Comments");
+    let budget = MAX_COMMENTS_CHARS;
+    for (const c of issue.comments) {
+      const body = clip(c.body, Math.max(0, budget));
+      lines.push(`**${c.author}** (${c.created}):`, body, "");
+      budget -= body.length;
+      if (budget <= 0) {
+        lines.push("[… older comments omitted]");
+        break;
+      }
+    }
+  }
+  return lines.join("\n").trim();
+}

--- a/apps/api/src/jira/trigger.integration.test.ts
+++ b/apps/api/src/jira/trigger.integration.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Real-Postgres coverage for what the Jira trigger leans on in storage.
+ *
+ * The fence is the point: the webhook, its redelivery and the safety-net poll
+ * can all report the same transition, and exactly one of them may dispatch a
+ * paid run. That is a conditional insert on a real unique key, which no
+ * in-memory fake can be trusted to model.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import { CredentialVault } from "../encryption/credential-vault";
+import { JiraIntegrationStorage } from "../storage/jira-integrations";
+import { TaskBoardStorage } from "../storage/task-board";
+
+const ORG = "org_jira_trigger";
+const USER = "user_jira_trigger";
+
+describe("Jira trigger storage (real Postgres)", () => {
+  let database: StudioDatabase;
+  let jira: JiraIntegrationStorage;
+  let taskBoard: TaskBoardStorage;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values({ id: ORG, name: ORG, slug: "org-jira-trigger", createdAt: now })
+      .execute();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"jira-trigger@test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    jira = new JiraIntegrationStorage(
+      database.db,
+      new CredentialVault("0".repeat(64)),
+    );
+    taskBoard = new TaskBoardStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("lets exactly one of several claimers win a transition", async () => {
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => jira.claimTrigger(ORG, "10001", "5001")),
+    );
+    expect(results.filter(Boolean)).toHaveLength(1);
+    // The same issue entering the column again is a NEW transition.
+    expect(await jira.claimTrigger(ORG, "10001", "5002")).toBe(true);
+  });
+
+  it("keeps one anchor per issue, whoever asks first", async () => {
+    const a = await taskBoard.create({
+      organizationId: ORG,
+      title: "EX-1: first",
+      source: "jira",
+      by: USER,
+    });
+    const b = await taskBoard.create({
+      organizationId: ORG,
+      title: "EX-1: second",
+      source: "jira",
+      by: USER,
+    });
+    await jira.createLink({
+      itemId: a.id,
+      organizationId: ORG,
+      jiraIssueId: "20001",
+      jiraIssueKey: "EX-1",
+    });
+    // A racing second link changes nothing rather than throwing.
+    await jira.createLink({
+      itemId: b.id,
+      organizationId: ORG,
+      jiraIssueId: "20001",
+      jiraIssueKey: "EX-1",
+    });
+    expect((await jira.getLinkByIssueId(ORG, "20001"))?.itemId).toBe(a.id);
+    expect((await jira.getLinkByItemId(a.id, ORG))?.jiraIssueKey).toBe("EX-1");
+    expect(await jira.getLinkByItemId(b.id, ORG)).toBeNull();
+  });
+
+  /** The anchor is a run's, not the board's: it must never show up as a card. */
+  it("hides a Jira run's anchor from the board list, but not from getById", async () => {
+    const anchor = await taskBoard.create({
+      organizationId: ORG,
+      title: "EX-2: anchor",
+      source: "jira",
+      by: USER,
+    });
+    const card = await taskBoard.create({
+      organizationId: ORG,
+      title: "a real card",
+      by: USER,
+    });
+    const listed = (await taskBoard.list(ORG)).map((i) => i.id);
+    expect(listed).toContain(card.id);
+    expect(listed).not.toContain(anchor.id);
+    expect((await taskBoard.getById(anchor.id, ORG))?.source).toBe("jira");
+    expect(card.source).toBeNull();
+  });
+
+  it("stores a rule per Jira status, and deleting it is the off switch", async () => {
+    expect(await jira.getAutomation(ORG, "Doing")).toBeNull();
+    await jira.upsertAutomation(ORG, "Doing", null);
+    expect(await jira.getAutomation(ORG, "Doing")).toEqual({
+      jiraStatus: "Doing",
+      prompt: null,
+    });
+    await jira.upsertAutomation(ORG, "Doing", "Fix it");
+    expect((await jira.getAutomation(ORG, "Doing"))?.prompt).toBe("Fix it");
+    await jira.upsertAutomation(ORG, "QA", "Test it");
+    expect((await jira.listAutomations(ORG)).map((a) => a.jiraStatus)).toEqual([
+      "Doing",
+      "QA",
+    ]);
+    expect(await jira.removeAutomation(ORG, "Doing")).toBe(true);
+    expect(await jira.removeAutomation(ORG, "Doing")).toBe(false);
+    expect(await jira.getAutomation(ORG, "Doing")).toBeNull();
+    // Another org's rules are not this org's.
+    expect(await jira.listAutomations("org_other")).toEqual([]);
+  });
+});

--- a/apps/api/src/jira/trigger.test.ts
+++ b/apps/api/src/jira/trigger.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "bun:test";
+import { parseWebhookTransition, transitionsFromChangelog } from "./trigger";
+
+describe("parseWebhookTransition", () => {
+  const updated = (items: Array<{ field: string; toString?: string }>) => ({
+    webhookEvent: "jira:issue_updated",
+    issue: { id: "10001", key: "EX-7" },
+    changelog: { id: "5001", items },
+  });
+
+  it("reads the status an issue landed in, with the transition's identity", () => {
+    expect(
+      parseWebhookTransition(
+        updated([
+          { field: "assignee", toString: "Ana" },
+          { field: "status", toString: "Doing" },
+        ]),
+      ),
+    ).toEqual({
+      issueId: "10001",
+      issueKey: "EX-7",
+      toStatus: "Doing",
+      changelogId: "5001",
+    });
+  });
+
+  /** Jira sends ids as numbers in some payloads and strings in others. */
+  it("accepts numeric ids", () => {
+    const payload = updated([{ field: "status", toString: "Doing" }]);
+    const numeric = {
+      ...payload,
+      issue: { ...payload.issue, id: 10001 },
+      changelog: { ...payload.changelog, id: 5001 },
+    };
+    expect(parseWebhookTransition(numeric)?.changelogId).toBe("5001");
+  });
+
+  it("is null for an update that did not touch the status", () => {
+    expect(
+      parseWebhookTransition(updated([{ field: "summary", toString: "x" }])),
+    ).toBeNull();
+  });
+
+  it("is null for other events and for garbage", () => {
+    expect(
+      parseWebhookTransition({
+        ...updated([]),
+        webhookEvent: "comment_created",
+      }),
+    ).toBeNull();
+    for (const bad of [
+      null,
+      "x",
+      1,
+      {},
+      { webhookEvent: "jira:issue_updated" },
+    ]) {
+      expect(parseWebhookTransition(bad)).toBeNull();
+    }
+  });
+});
+
+describe("transitionsFromChangelog", () => {
+  const issue = { id: "10001", key: "EX-7" };
+  const since = new Date("2026-09-02T10:00:00Z");
+
+  it("keeps only status changes inside the window, oldest first", () => {
+    const out = transitionsFromChangelog(
+      issue,
+      [
+        {
+          id: "3",
+          created: "2026-09-02T10:20:00Z",
+          items: [{ field: "status", toString: "Done" }],
+        },
+        {
+          id: "1",
+          created: "2026-09-02T09:00:00Z",
+          items: [{ field: "status", toString: "Doing" }],
+        },
+        {
+          id: "2",
+          created: "2026-09-02T10:10:00Z",
+          items: [{ field: "priority", toString: "High" }],
+        },
+      ],
+      since,
+    );
+    expect(out.map((t) => t.changelogId)).toEqual(["3"]);
+    expect(out[0]?.toStatus).toBe("Done");
+  });
+
+  it("yields the same shape the webhook does, so both feed one fence", () => {
+    const [t] = transitionsFromChangelog(
+      issue,
+      [
+        {
+          id: "9",
+          created: "2026-09-02T10:01:00Z",
+          items: [{ field: "status", toString: "Doing" }],
+        },
+      ],
+      since,
+    );
+    expect(t).toEqual({
+      issueId: "10001",
+      issueKey: "EX-7",
+      toStatus: "Doing",
+      changelogId: "9",
+    });
+  });
+});

--- a/apps/api/src/jira/trigger.ts
+++ b/apps/api/src/jira/trigger.ts
@@ -1,0 +1,233 @@
+/**
+ * "An issue entered a Jira status that has a rule — run the agent on it."
+ *
+ * The one act behind both the webhook and the safety-net poll. Studio keeps no
+ * copy of the issue: the run is anchored on a hidden board item (so quota,
+ * pull requests and review keep working), the issue's content goes straight
+ * into the run's opening message, and the agent updates the issue itself with
+ * the Jira tools its run is served.
+ *
+ * Idempotency is per TRANSITION, not per issue: `jira_trigger_claims` holds
+ * one row per changelog entry, so a redelivered webhook or the poll finding the
+ * same entry dispatches nothing, while the issue entering the column again
+ * later is a new run. The claim is taken right before dispatch, after the
+ * anchor item exists, so a lost claim never leaves an item with no run.
+ */
+
+import { LANES, SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
+import type { StudioContext } from "@/core/studio-context";
+import type { OrgJiraIntegration, TaskBoardItem } from "@/storage/types";
+import { enqueueSuperAgentForTask } from "@/tools/task-board/enqueue-super-agent";
+import { JiraClient, type JiraChangelogHistory } from "./client";
+import {
+  type IssueForPrompt,
+  issueUrl,
+  loadIssueForPrompt,
+  renderIssueForPrompt,
+} from "./issue-prompt";
+
+export interface IssueTransition {
+  issueId: string;
+  issueKey: string;
+  /** The status NAME the issue landed in — what a rule is keyed by. */
+  toStatus: string;
+  /** Jira's id for this changelog entry: the transition's identity. */
+  changelogId: string;
+}
+
+/**
+ * The status change a Jira webhook payload reports, or null when the event is
+ * not one (a comment, a field edit, an unrelated event type).
+ */
+export function parseWebhookTransition(
+  payload: unknown,
+): IssueTransition | null {
+  if (typeof payload !== "object" || payload === null) return null;
+  const p = payload as {
+    webhookEvent?: unknown;
+    issue?: { id?: unknown; key?: unknown };
+    changelog?: {
+      id?: unknown;
+      items?: Array<{ field?: unknown; toString?: unknown }>;
+    };
+  };
+  if (p.webhookEvent !== "jira:issue_updated") return null;
+  const issueId = p.issue?.id;
+  const issueKey = p.issue?.key;
+  const changelogId = p.changelog?.id;
+  if (
+    (typeof issueId !== "string" && typeof issueId !== "number") ||
+    typeof issueKey !== "string" ||
+    (typeof changelogId !== "string" && typeof changelogId !== "number")
+  ) {
+    return null;
+  }
+  const status = p.changelog?.items?.find((item) => item.field === "status");
+  if (!status || typeof status.toString !== "string") return null;
+  return {
+    issueId: String(issueId),
+    issueKey,
+    toStatus: status.toString,
+    changelogId: String(changelogId),
+  };
+}
+
+/**
+ * Every status change on an issue since `since`, oldest first — what the poll
+ * reads off a search expanded with the changelog. The same shape the webhook
+ * yields, so both feed one fence.
+ */
+export function transitionsFromChangelog(
+  issue: { id: string; key: string },
+  histories: readonly JiraChangelogHistory[],
+  since: Date,
+): IssueTransition[] {
+  const out: IssueTransition[] = [];
+  for (const history of histories) {
+    if (new Date(history.created).getTime() < since.getTime()) continue;
+    const status = history.items.find((item) => item.field === "status");
+    if (!status || typeof status.toString !== "string") continue;
+    out.push({
+      issueId: issue.id,
+      issueKey: issue.key,
+      toStatus: status.toString,
+      changelogId: history.id,
+    });
+  }
+  return out.sort((a, b) => Number(a.changelogId) - Number(b.changelogId));
+}
+
+export type TriggerOutcome = "started" | "no_rule" | "duplicate" | "disabled";
+
+/** What the run is told first when the rule has no prompt of its own. */
+const DEFAULT_JIRA_INSTRUCTION =
+  "A Jira issue was moved into a column you are responsible for. Work the issue.";
+
+/** Appended to every Jira-triggered run: the board tools are absent on
+ *  purpose, and the issue is the thing to keep up to date. */
+const JIRA_RUN_FOOTER = [
+  "This run was started by a Jira issue, not a board card. Keep the ISSUE up to date, not a Studio card:",
+  "- `JIRA_ISSUE_GET` re-reads the issue (description, comments, attachments).",
+  "- `JIRA_COMMENT_ADD` posts a comment on it (markdown). Leave one when you finish, with what you did and any pull request link.",
+  "- `JIRA_ISSUE_TRANSITION` moves it to another status when your work warrants it.",
+  "- `JIRA_ATTACHMENT_DOWNLOAD` fetches an attachment into the sandbox by its id.",
+].join("\n");
+
+function jiraRunTitle(issue: { key: string; summary: string }): string {
+  return `Jira ${issue.key}: ${issue.summary}`;
+}
+
+/**
+ * Dispatch a run for `transition` if the org has a rule for its status and
+ * nothing dispatched this transition already.
+ */
+export async function triggerRunForTransition(
+  ctx: StudioContext,
+  integration: OrgJiraIntegration,
+  transition: IssueTransition,
+): Promise<TriggerOutcome> {
+  if (!integration.enabled) return "disabled";
+  const orgId = integration.organizationId;
+  const rule = await ctx.storage.jiraIntegrations.getAutomation(
+    orgId,
+    transition.toStatus,
+  );
+  if (!rule) return "no_rule";
+
+  const client = new JiraClient(
+    integration.siteUrl,
+    integration.email,
+    integration.apiToken,
+  );
+  const issue = await loadIssueForPrompt(
+    client,
+    integration.siteUrl,
+    transition.issueId,
+  );
+  const item = await ensureAnchorItem(ctx, integration, transition, issue);
+
+  const claimed = await ctx.storage.jiraIntegrations.claimTrigger(
+    orgId,
+    transition.issueId,
+    transition.changelogId,
+  );
+  if (!claimed) return "duplicate";
+
+  const delegated = await ctx.storage.taskBoard.update(
+    item.id,
+    orgId,
+    {
+      assigneeId: SUPER_AGENT_ASSIGNEE_ID,
+      assignedBy: integration.createdBy,
+    },
+    integration.createdBy,
+  );
+  try {
+    await enqueueSuperAgentForTask(ctx, delegated, {
+      instruction: rule.prompt ?? DEFAULT_JIRA_INSTRUCTION,
+      source: {
+        kind: "jira",
+        issueKey: issue.key,
+        title: jiraRunTitle(issue),
+        body: `${renderIssueForPrompt(issue)}\n\n${JIRA_RUN_FOOTER}`,
+      },
+    });
+  } catch (err) {
+    // Nothing dispatched: leave the anchor unowned rather than assigned to an
+    // agent that will never run. The claim stands — the transition is spent,
+    // and the caller's log is the record of why.
+    await ctx.storage.taskBoard
+      .unassignSuperAgent(item.id, orgId, integration.createdBy)
+      .catch(() => {});
+    throw err;
+  }
+  return "started";
+}
+
+/**
+ * The board item a Jira issue's runs hang off. One per issue, created the
+ * first time a rule fires for it and reused after; hidden from the board by
+ * `source`, titled by the issue so the monitoring history reads.
+ */
+async function ensureAnchorItem(
+  ctx: StudioContext,
+  integration: OrgJiraIntegration,
+  transition: IssueTransition,
+  issue: IssueForPrompt,
+): Promise<TaskBoardItem> {
+  const orgId = integration.organizationId;
+  const title = `${issue.key}: ${issue.summary}`;
+  const linked = await ctx.storage.jiraIntegrations.getLinkByIssueId(
+    orgId,
+    transition.issueId,
+  );
+  if (linked) {
+    const existing = await ctx.storage.taskBoard.getById(linked.itemId, orgId);
+    if (existing) {
+      return existing.title === title
+        ? existing
+        : ctx.storage.taskBoard.update(
+            existing.id,
+            orgId,
+            { title },
+            integration.createdBy,
+          );
+    }
+  }
+  const created = await ctx.storage.taskBoard.create({
+    organizationId: orgId,
+    title,
+    status: LANES.progress,
+    source: "jira",
+    externalKey: issue.key,
+    externalUrl: issueUrl(integration.siteUrl, issue.key),
+    by: integration.createdBy,
+  });
+  await ctx.storage.jiraIntegrations.createLink({
+    itemId: created.id,
+    organizationId: orgId,
+    jiraIssueId: transition.issueId,
+    jiraIssueKey: issue.key,
+  });
+  return created;
+}

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -235,6 +235,7 @@ export function resolveConfig(
     ),
     localMode,
     disableRateLimit: toBool(envVars.DISABLE_RATE_LIMIT),
+    jiraAllowLocalSiteUrl: toBool(envVars.JIRA_ALLOW_LOCAL_SITE_URL),
     studioProvisionSecretKey: envVars.STUDIO_PROVISION_SECRET_KEY,
     deploymentAdminEmails: (envVars.DEPLOYMENT_ADMIN_EMAILS ?? "")
       .split(",")

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -34,6 +34,9 @@ export interface Settings {
   studioJwtSecret: string | undefined;
   localMode: boolean;
   disableRateLimit: boolean;
+  /** Admit `http://localhost:<port>` as a Jira site — a stand-in Jira for
+   *  local development and e2e. See `normalizeSiteUrl`. */
+  jiraAllowLocalSiteUrl: boolean;
   studioProvisionSecretKey: string | undefined; // Secret key to call the Deco AI Gateway API to provision keys
   /** Lowercased emails allowed onto the /admin instance dashboard (DEPLOYMENT_ADMIN_EMAILS, CSV). */
   deploymentAdminEmails: string[];

--- a/apps/api/src/storage/jira-integrations.ts
+++ b/apps/api/src/storage/jira-integrations.ts
@@ -2,6 +2,20 @@ import type { Kysely } from "kysely";
 import type { CredentialVault } from "../encryption/credential-vault";
 import type { Database, OrgJiraIntegration } from "./types";
 
+/** The issue a run's anchor item stands for. */
+export interface JiraIssueLink {
+  itemId: string;
+  jiraIssueId: string;
+  jiraIssueKey: string;
+}
+
+/** A rule on a Jira status: row existence is the switch, `prompt` null is the
+ *  agent's own instruction. */
+export interface JiraColumnAutomation {
+  jiraStatus: string;
+  prompt: string | null;
+}
+
 /**
  * Per-org Jira Cloud integration configs (see migration 171). One row per
  * org; the API token is vault-encrypted at rest and decrypted on read — the
@@ -126,4 +140,158 @@ export class JiraIntegrationStorage {
       .executeTakeFirst();
     return row ? this.toEntity(row as Row) : null;
   }
+
+  /**
+   * Ids of every enabled integration — the safety-net poll's work list. Ids,
+   * not entities: a DBOS step's output is persisted, and an entity carries
+   * the decrypted token.
+   */
+  async listEnabledIds(): Promise<string[]> {
+    const rows = await this.db
+      .selectFrom("org_jira_integrations")
+      .select("id")
+      .where("enabled", "=", true)
+      .orderBy("created_at", "asc")
+      .execute();
+    return rows.map((row) => row.id);
+  }
+
+  async getLinkByIssueId(
+    organizationId: string,
+    jiraIssueId: string,
+  ): Promise<JiraIssueLink | null> {
+    const row = await this.db
+      .selectFrom("task_board_item_jira_links")
+      .select(["item_id", "jira_issue_id", "jira_issue_key"])
+      .where("organization_id", "=", organizationId)
+      .where("jira_issue_id", "=", jiraIssueId)
+      .executeTakeFirst();
+    return row ? linkFromRow(row) : null;
+  }
+
+  async getLinkByItemId(
+    itemId: string,
+    organizationId: string,
+  ): Promise<JiraIssueLink | null> {
+    const row = await this.db
+      .selectFrom("task_board_item_jira_links")
+      .select(["item_id", "jira_issue_id", "jira_issue_key"])
+      .where("item_id", "=", itemId)
+      .where("organization_id", "=", organizationId)
+      .executeTakeFirst();
+    return row ? linkFromRow(row) : null;
+  }
+
+  /** Idempotent on the issue: a second caller for the same issue changes
+   *  nothing, so both read the same anchor back. */
+  async createLink(params: {
+    itemId: string;
+    organizationId: string;
+    jiraIssueId: string;
+    jiraIssueKey: string;
+  }): Promise<void> {
+    await this.db
+      .insertInto("task_board_item_jira_links")
+      .values({
+        item_id: params.itemId,
+        organization_id: params.organizationId,
+        jira_issue_id: params.jiraIssueId,
+        jira_issue_key: params.jiraIssueKey,
+      })
+      .onConflict((oc) => oc.doNothing())
+      .execute();
+  }
+
+  /**
+   * Claim one transition for dispatch. Exactly one caller gets `true` per
+   * (issue, changelog entry) — the webhook, its redelivery and the poll can all
+   * see the same entry, and only the winner may start the run.
+   */
+  async claimTrigger(
+    organizationId: string,
+    jiraIssueId: string,
+    changelogId: string,
+  ): Promise<boolean> {
+    const result = await this.db
+      .insertInto("jira_trigger_claims")
+      .values({
+        organization_id: organizationId,
+        jira_issue_id: jiraIssueId,
+        changelog_id: changelogId,
+      })
+      .onConflict((oc) => oc.doNothing())
+      .executeTakeFirst();
+    return (result.numInsertedOrUpdatedRows ?? 0n) > 0n;
+  }
+
+  async listAutomations(
+    organizationId: string,
+  ): Promise<JiraColumnAutomation[]> {
+    const rows = await this.db
+      .selectFrom("org_jira_column_automations")
+      .select(["jira_status", "prompt"])
+      .where("organization_id", "=", organizationId)
+      .orderBy("jira_status", "asc")
+      .execute();
+    return rows.map((r) => ({ jiraStatus: r.jira_status, prompt: r.prompt }));
+  }
+
+  async getAutomation(
+    organizationId: string,
+    jiraStatus: string,
+  ): Promise<JiraColumnAutomation | null> {
+    const row = await this.db
+      .selectFrom("org_jira_column_automations")
+      .select(["jira_status", "prompt"])
+      .where("organization_id", "=", organizationId)
+      .where("jira_status", "=", jiraStatus)
+      .executeTakeFirst();
+    return row ? { jiraStatus: row.jira_status, prompt: row.prompt } : null;
+  }
+
+  async upsertAutomation(
+    organizationId: string,
+    jiraStatus: string,
+    prompt: string | null,
+  ): Promise<JiraColumnAutomation> {
+    await this.db
+      .insertInto("org_jira_column_automations")
+      .values({
+        organization_id: organizationId,
+        jira_status: jiraStatus,
+        prompt,
+      })
+      .onConflict((oc) =>
+        oc
+          .columns(["organization_id", "jira_status"])
+          .doUpdateSet({ prompt, updated_at: new Date() }),
+      )
+      .execute();
+    return { jiraStatus, prompt };
+  }
+
+  /** Deleting IS the off switch. Returns whether there was a rule. */
+  async removeAutomation(
+    organizationId: string,
+    jiraStatus: string,
+  ): Promise<boolean> {
+    const result = await this.db
+      .deleteFrom("org_jira_column_automations")
+      .where("organization_id", "=", organizationId)
+      .where("jira_status", "=", jiraStatus)
+      .executeTakeFirst();
+    return (result.numDeletedRows ?? 0n) > 0n;
+  }
+}
+
+function linkFromRow(row: {
+  item_id: string;
+  jira_issue_id: string;
+  jira_issue_key: string;
+}): JiraIssueLink {
+  return {
+    itemId: row.item_id,
+    jiraIssueId: row.jira_issue_id,
+    jiraIssueKey: row.jira_issue_key,
+  };
 }

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -252,6 +252,9 @@ export class TaskBoardStorage {
       .where("organization_id", "=", organizationId)
       // Dismissed findings are off the board; `getById` still resolves them.
       .where("dismissed_at", "is", null)
+      // So is a Jira run's anchor: the issue lives in Jira, the item only
+      // carries the run.
+      .where("source", "is", null)
       .orderBy("sort_order", "asc")
       .execute();
 
@@ -279,6 +282,8 @@ export class TaskBoardStorage {
       .selectAll()
       .where("organization_id", "=", organizationId)
       .where("dismissed_at", "is", null)
+      // A Jira run's anchor is not a card, so it is not a search result either.
+      .where("source", "is", null)
       .where("title", "ilike", `%${escapeLikePattern(search)}%`)
       .orderBy("updated_at", "desc")
       .limit(limit)
@@ -320,6 +325,9 @@ export class TaskBoardStorage {
     externalKey?: string | null;
     /** Link to the card's issue in the tracker it came from. */
     externalUrl?: string | null;
+    /** `jira` hides the card from the board: it anchors a run, it is not work
+     *  the board shows. */
+    source?: "jira" | null;
     by: string;
   }): Promise<TaskBoardItem> {
     const id = generatePrefixedId("board");
@@ -350,6 +358,7 @@ export class TaskBoardStorage {
           due_date: params.dueDate ?? null,
           external_key: params.externalKey ?? null,
           external_url: params.externalUrl ?? null,
+          source: params.source ?? null,
           sort_order: sql<number>`(
           select coalesce(min(sort_order), 0) - 1
           from task_board_items
@@ -2400,6 +2409,7 @@ export class TaskBoardStorage {
     repo: string | null;
     due_date: string | Date | null;
     external_url?: string | null;
+    source?: "jira" | null;
     sort_order: number;
     key_seq: number;
     retry_attempts?: number;
@@ -2425,6 +2435,7 @@ export class TaskBoardStorage {
           ? row.due_date.toISOString()
           : row.due_date,
       externalUrl: row.external_url ?? null,
+      source: row.source ?? null,
       sortOrder: row.sort_order,
       keySeq: row.key_seq,
       retryAttempts: row.retry_attempts ?? 0,

--- a/apps/api/src/storage/threads.ts
+++ b/apps/api/src/storage/threads.ts
@@ -163,6 +163,8 @@ export class OrgScopedThreadStorage {
       agentId?: string;
       includeArchived?: boolean;
       hasTrigger?: boolean;
+      /** `metadata.source` — e.g. `jira` for runs the Jira integration started. */
+      source?: string;
     },
   ): Promise<{ threads: Thread[]; total: number }> {
     return this.inner.list(this.requireOrg(), createdBy, options);
@@ -719,6 +721,8 @@ export class SqlThreadStorage implements ThreadStoragePort {
       agentId?: string;
       includeArchived?: boolean;
       hasTrigger?: boolean;
+      /** `metadata.source` — e.g. `jira` for runs the Jira integration started. */
+      source?: string;
     },
   ): Promise<{ threads: Thread[]; total: number }> {
     const archived = options?.includeArchived === true;
@@ -766,6 +770,9 @@ export class SqlThreadStorage implements ThreadStoragePort {
     if (options?.status) {
       query = query.where("status", "=", options.status as ThreadStatus);
     }
+    if (options?.source) {
+      query = query.where(sql`metadata->>'source'`, "=", options.source);
+    }
 
     let countQuery = this.db
       .selectFrom("threads")
@@ -810,6 +817,13 @@ export class SqlThreadStorage implements ThreadStoragePort {
         "status",
         "=",
         options.status as ThreadStatus,
+      );
+    }
+    if (options?.source) {
+      countQuery = countQuery.where(
+        sql`metadata->>'source'`,
+        "=",
+        options.source,
       );
     }
 

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1642,6 +1642,10 @@ export interface TaskBoardItemTable {
   /** The card's issue in the tracker it came from (`{site}/browse/{KEY}`), for
    *  a human to open. Written by the Jira pull; null for a card Studio owns.
    *  Deliberately NOT in the description — see migration 198. */
+  /** What created the card, when not a person or an import: `jira` for the
+   *  hidden anchor a Jira-triggered run hangs off. Null for a card the board
+   *  shows. */
+  source: ColumnType<"jira" | null, "jira" | null | undefined, "jira" | null>;
   external_url: ColumnType<
     string | null,
     string | null | undefined,
@@ -1912,6 +1916,9 @@ export interface TaskBoardItem {
   /** Link to that issue in the tracker, for a human to open. Never part of the
    *  description, which is quoted into agent prompts verbatim. */
   externalUrl: string | null;
+  /** `jira` for the hidden anchor of a Jira-triggered run; null for a card the
+   *  board shows. */
+  source: "jira" | null;
   /** Infrastructure retries already spent on this card's runs — the budget
    *  `reactToFailedTaskRun` spends against `MAX_RUN_RETRIES`. */
   retryAttempts: number;
@@ -2066,6 +2073,26 @@ export interface TaskBoardItemJiraLinkTable {
   created_at: ColumnType<Date, Date | string | undefined, never>;
 }
 
+/** A rule the Jira integration runs when an issue enters a status (migration
+ *  200). Row existence is the switch; `prompt` null is the agent's own
+ *  instruction. */
+export interface OrgJiraColumnAutomationTable {
+  organization_id: string;
+  jira_status: string;
+  prompt: string | null;
+  created_at: ColumnType<Date, Date | string | undefined, Date | string>;
+  updated_at: ColumnType<Date, Date | string | undefined, Date | string>;
+}
+
+/** One row per Jira transition a run was dispatched for — the fence between
+ *  a redelivered webhook, the safety-net poll, and a second paid run. */
+export interface JiraTriggerClaimTable {
+  organization_id: string;
+  jira_issue_id: string;
+  changelog_id: string;
+  created_at: ColumnType<Date, Date | string | undefined, never>;
+}
+
 /**
  * Complete database schema
  * All tables exist within the organization scope (database boundary)
@@ -2213,6 +2240,8 @@ export interface Database extends PrivateRegistryDatabase {
   // Jira integration
   org_jira_integrations: OrgJiraIntegrationTable;
   task_board_item_jira_links: TaskBoardItemJiraLinkTable;
+  org_jira_column_automations: OrgJiraColumnAutomationTable;
+  jira_trigger_claims: JiraTriggerClaimTable;
 
   // Follow/inbox for the task board
   notification_subscriptions: NotificationSubscriptionTable;

--- a/apps/api/src/tools/index.ts
+++ b/apps/api/src/tools/index.ts
@@ -230,6 +230,14 @@ export const CORE_TOOLS = [
   JiraTools.JIRA_INTEGRATION_DELETE,
   JiraTools.JIRA_BOARDS_LIST,
   JiraTools.JIRA_BOARD_COLUMNS_LIST,
+  JiraTools.JIRA_AUTOMATION_LIST,
+  JiraTools.JIRA_AUTOMATION_UPSERT,
+  JiraTools.JIRA_AUTOMATION_DELETE,
+  // Served only on a Jira-triggered run's MCP endpoint (task-run-context.ts)
+  JiraTools.JIRA_ISSUE_GET,
+  JiraTools.JIRA_COMMENT_ADD,
+  JiraTools.JIRA_ISSUE_TRANSITION,
+  JiraTools.JIRA_ATTACHMENT_DOWNLOAD,
 
   // Object Storage tools
   ObjectStorageTools.LIST_OBJECTS,

--- a/apps/api/src/tools/jira/automations.ts
+++ b/apps/api/src/tools/jira/automations.ts
@@ -1,0 +1,94 @@
+/**
+ * JIRA_AUTOMATION_* — which Jira statuses start an agent run, and with what
+ * instruction. Keyed by the status NAME: a Jira column is a bucket of statuses
+ * and the webhook reports the status, so that is the thing a rule can be on.
+ * Row existence is the switch, like the board's own column rules.
+ */
+
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth, requireOrganization } from "@/core/studio-context";
+import { MAX_AUTOMATION_PROMPT_LENGTH } from "@/tools/task-board/schema";
+
+const MAX_STATUS_NAME_LENGTH = 200;
+
+const AutomationSchema = z.object({
+  jiraStatus: z.string(),
+  prompt: z.string().nullable(),
+});
+
+export const JIRA_AUTOMATION_LIST = defineTool({
+  name: "JIRA_AUTOMATION_LIST",
+  description:
+    "List the Jira statuses that start an agent run when an issue enters " +
+    "them. A status with no rule is uneventful.",
+  inputSchema: z.object({}),
+  outputSchema: z.object({ automations: z.array(AutomationSchema) }),
+  handler: async (_input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const organization = requireOrganization(ctx);
+    return {
+      automations: await ctx.storage.jiraIntegrations.listAutomations(
+        organization.id,
+      ),
+    };
+  },
+});
+
+export const JIRA_AUTOMATION_UPSERT = defineTool({
+  name: "JIRA_AUTOMATION_UPSERT",
+  description:
+    "Run the agent on every issue that enters a Jira status. Replaces the " +
+    "rule already on that status, if any. Omit `prompt` for the agent's own " +
+    "instruction; give one to say what it should do there. The issue itself " +
+    "is always in the run's message, so the prompt is the instruction, not " +
+    "the whole message.",
+  inputSchema: z.object({
+    jiraStatus: z
+      .string()
+      .min(1)
+      .max(MAX_STATUS_NAME_LENGTH)
+      .describe("A status name of the board — see JIRA_BOARD_COLUMNS_LIST."),
+    prompt: z
+      .string()
+      .max(MAX_AUTOMATION_PROMPT_LENGTH)
+      .nullable()
+      .optional()
+      .describe("What to do with an issue landing here; null for the default."),
+  }),
+  outputSchema: z.object({ automation: AutomationSchema }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const organization = requireOrganization(ctx);
+    const prompt = input.prompt?.trim() ? input.prompt.trim() : null;
+    return {
+      automation: await ctx.storage.jiraIntegrations.upsertAutomation(
+        organization.id,
+        input.jiraStatus.trim(),
+        prompt,
+      ),
+    };
+  },
+});
+
+export const JIRA_AUTOMATION_DELETE = defineTool({
+  name: "JIRA_AUTOMATION_DELETE",
+  description:
+    "Stop running the agent on issues entering a Jira status. Removing the " +
+    "rule IS the off switch.",
+  inputSchema: z.object({ jiraStatus: z.string().min(1) }),
+  outputSchema: z.object({ removed: z.boolean() }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const organization = requireOrganization(ctx);
+    return {
+      removed: await ctx.storage.jiraIntegrations.removeAutomation(
+        organization.id,
+        input.jiraStatus,
+      ),
+    };
+  },
+});

--- a/apps/api/src/tools/jira/index.ts
+++ b/apps/api/src/tools/jira/index.ts
@@ -236,3 +236,15 @@ export const JIRA_BOARD_COLUMNS_LIST = defineTool({
     return { columns: await client.getBoardColumns(input.boardId) };
   },
 });
+
+export {
+  JIRA_AUTOMATION_DELETE,
+  JIRA_AUTOMATION_LIST,
+  JIRA_AUTOMATION_UPSERT,
+} from "./automations";
+export {
+  JIRA_ATTACHMENT_DOWNLOAD,
+  JIRA_COMMENT_ADD,
+  JIRA_ISSUE_GET,
+  JIRA_ISSUE_TRANSITION,
+} from "./run-tools";

--- a/apps/api/src/tools/jira/run-tools.ts
+++ b/apps/api/src/tools/jira/run-tools.ts
@@ -1,0 +1,182 @@
+/**
+ * The Jira tools a Jira-triggered run is served instead of the board tools.
+ *
+ * The run works on an ISSUE, so this is how it reads it, comments on it, moves
+ * it, and fetches its files — all through Studio, with the integration's own
+ * credential, which never reaches the sandbox. Which issue is not an input:
+ * the run's MCP endpoint is keyed by thread (`task-run-context.ts`), and the
+ * thread's anchor item is linked to exactly one issue.
+ */
+
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireOrganization, type StudioContext } from "@/core/studio-context";
+import { getPublicUrl } from "@/core/server-constants";
+import {
+  ATTACHMENT_GRANT_TTL_MS,
+  mintAttachmentToken,
+} from "@/jira/attachment-token";
+import { JiraClient } from "@/jira/client";
+import { loadIssueForPrompt, renderIssueForPrompt } from "@/jira/issue-prompt";
+import { requireTaskRunContext } from "@/tools/task-board/task-run-context";
+import type { OrgJiraIntegration } from "@/storage/types";
+
+const MAX_COMMENT_LENGTH = 50_000;
+
+/** The issue this run is on, with a client to reach it. */
+async function resolveRunIssue(ctx: StudioContext): Promise<{
+  integration: OrgJiraIntegration;
+  client: JiraClient;
+  issueId: string;
+  issueKey: string;
+}> {
+  const { threadId } = requireTaskRunContext();
+  const organization = requireOrganization(ctx);
+  const integration = await ctx.storage.jiraIntegrations.getByOrg(
+    organization.id,
+  );
+  if (!integration) throw new Error("Jira is not connected for this org");
+  for (const itemId of await ctx.storage.taskBoard.linkedTaskIds(
+    threadId,
+    organization.id,
+  )) {
+    const link = await ctx.storage.jiraIntegrations.getLinkByItemId(
+      itemId,
+      organization.id,
+    );
+    if (link) {
+      return {
+        integration,
+        client: new JiraClient(
+          integration.siteUrl,
+          integration.email,
+          integration.apiToken,
+        ),
+        issueId: link.jiraIssueId,
+        issueKey: link.jiraIssueKey,
+      };
+    }
+  }
+  throw new Error("This run is not working on a Jira issue");
+}
+
+export const JIRA_ISSUE_GET = defineTool({
+  name: "JIRA_ISSUE_GET",
+  description:
+    "Re-read the Jira issue this run is working on: summary, status, " +
+    "description, comments, and attachments with the ids " +
+    "JIRA_ATTACHMENT_DOWNLOAD takes.",
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    key: z.string(),
+    url: z.string(),
+    status: z.string(),
+    markdown: z.string(),
+  }),
+  handler: async (_input, ctx) => {
+    await ctx.access.check();
+    const { integration, client, issueId } = await resolveRunIssue(ctx);
+    const issue = await loadIssueForPrompt(
+      client,
+      integration.siteUrl,
+      issueId,
+    );
+    return {
+      key: issue.key,
+      url: issue.url,
+      status: issue.status,
+      markdown: renderIssueForPrompt(issue),
+    };
+  },
+});
+
+export const JIRA_COMMENT_ADD = defineTool({
+  name: "JIRA_COMMENT_ADD",
+  description:
+    "Post a comment on the Jira issue this run is working on. Markdown is " +
+    "rendered as Jira rich text. Leave one when you finish: what you did, " +
+    "and any pull request link.",
+  inputSchema: z.object({
+    body: z.string().min(1).max(MAX_COMMENT_LENGTH),
+  }),
+  outputSchema: z.object({ commentId: z.string() }),
+  handler: async (input, ctx) => {
+    await ctx.access.check();
+    const { client, issueId } = await resolveRunIssue(ctx);
+    const { id } = await client.addComment(issueId, input.body);
+    return { commentId: id };
+  },
+});
+
+export const JIRA_ISSUE_TRANSITION = defineTool({
+  name: "JIRA_ISSUE_TRANSITION",
+  description:
+    "Move the Jira issue this run is working on to another status, by the " +
+    "status name (case-insensitive). Only a status the issue's workflow can " +
+    "reach from where it is; the error names the reachable ones.",
+  inputSchema: z.object({ toStatus: z.string().min(1) }),
+  outputSchema: z.object({ status: z.string() }),
+  handler: async (input, ctx) => {
+    await ctx.access.check();
+    const { client, issueId } = await resolveRunIssue(ctx);
+    const transitions = await client.listTransitions(issueId);
+    const wanted = input.toStatus.trim().toLowerCase();
+    const match = transitions.find(
+      (t) =>
+        t.to.name.toLowerCase() === wanted || t.name.toLowerCase() === wanted,
+    );
+    if (!match) {
+      throw new Error(
+        `The issue cannot move to "${input.toStatus}" from here — reachable: ${
+          transitions.map((t) => t.to.name).join(", ") || "none"
+        }`,
+      );
+    }
+    await client.transitionIssue(issueId, match.id);
+    return { status: match.to.name };
+  },
+});
+
+export const JIRA_ATTACHMENT_DOWNLOAD = defineTool({
+  name: "JIRA_ATTACHMENT_DOWNLOAD",
+  description:
+    "Get a short-lived URL for one attachment of the Jira issue this run is " +
+    "working on, to `curl -L -o <path>` into the sandbox. Attachment ids are " +
+    "listed by JIRA_ISSUE_GET. The URL needs no credential and expires.",
+  inputSchema: z.object({ attachmentId: z.string().min(1) }),
+  outputSchema: z.object({
+    url: z.string(),
+    filename: z.string(),
+    expiresAt: z.string(),
+    command: z.string(),
+  }),
+  handler: async (input, ctx) => {
+    await ctx.access.check();
+    const { integration, client, issueId, issueKey } =
+      await resolveRunIssue(ctx);
+    // Only this issue's attachments: the grant is minted from the run's own
+    // issue, never from an id the model typed for some other issue.
+    const attachment = (await client.listAttachments(issueId)).find(
+      (a) => a.id === input.attachmentId,
+    );
+    if (!attachment) {
+      throw new Error(
+        `${issueKey} has no attachment "${input.attachmentId}" — JIRA_ISSUE_GET lists the ids`,
+      );
+    }
+    const expiresAt = Date.now() + ATTACHMENT_GRANT_TTL_MS;
+    const token = mintAttachmentToken({
+      organizationId: integration.organizationId,
+      attachmentId: attachment.id,
+      expiresAt,
+    });
+    const url = `${getPublicUrl()}/api/_jira/attachments/${token}`;
+    const safeName = attachment.filename.replace(/[^\w.-]+/g, "_");
+    return {
+      url,
+      filename: attachment.filename,
+      expiresAt: new Date(expiresAt).toISOString(),
+      command: `curl -fsSL -o ${JSON.stringify(safeName)} ${JSON.stringify(url)}`,
+    };
+  },
+});

--- a/apps/api/src/tools/jira/run-tools.ts
+++ b/apps/api/src/tools/jira/run-tools.ts
@@ -23,14 +23,24 @@ import type { OrgJiraIntegration } from "@/storage/types";
 
 const MAX_COMMENT_LENGTH = 50_000;
 
-/** The issue this run is on, with a client to reach it. */
-async function resolveRunIssue(ctx: StudioContext): Promise<{
+interface RunIssue {
   integration: OrgJiraIntegration;
   client: JiraClient;
   issueId: string;
   issueKey: string;
-}> {
-  const { threadId } = requireTaskRunContext();
+}
+
+/**
+ * The issue a run is on, with a client to reach it.
+ *
+ * `threadId` is the run's thread. Omitted on the MCP endpoint, where the path
+ * already names it; passed explicitly by the built-in path, which has no
+ * request scope to read it from.
+ */
+async function resolveRunIssue(
+  ctx: StudioContext,
+  threadId = requireTaskRunContext().threadId,
+): Promise<RunIssue> {
   const organization = requireOrganization(ctx);
   const integration = await ctx.storage.jiraIntegrations.getByOrg(
     organization.id,

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -65,7 +65,7 @@ function isThreadRunLive(
  * The Super Agent is told to link the PR and set In Review *while still
  * running* (`claude-code-task-run.ts`), so the card is reviewable long before
  * the run that owns the branch is finished. Title is the discriminator the rest
- * of the board already uses (`resolveReviewRunToolNames`); liveness is
+ * of the board already uses (`resolveTaskRunToolNames`); liveness is
  * {@link isThreadRunLive}, so a dead author's stall window releases the card
  * rather than stranding it.
  */

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -79,6 +79,11 @@ export type SuperAgentPromptOpts = {
   /** A human asked for this run (`TASK_BOARD_ITEM_RERUN`), so the per-task run
    *  cap — which bounds automatic re-dispatch — does not apply to it. */
   userInitiated?: boolean;
+  /** The run works on something outside the board — a Jira issue — and the
+   *  card is only its anchor. `body` replaces the card's description in the
+   *  prompt, `title` names the thread, and the thread is stamped so its tools
+   *  and the monitoring filter can tell it apart. */
+  source?: { kind: "jira"; issueKey: string; title: string; body: string };
 };
 
 /**
@@ -316,6 +321,16 @@ export async function enqueueSuperAgentForTask(
     // no repos imported runs Decopilot exactly as before.
     const choice = await resolveTaskRepoChoice(ctx, task.organizationId);
 
+    // A run on an external issue reads the issue, not the card: the card's
+    // description is empty on purpose, so the prompt gets the rendered issue.
+    const promptTask = opts?.source
+      ? { ...task, description: opts.source.body }
+      : task;
+    const title = opts?.source?.title ?? `Super Agent: ${task.title}`;
+    const runMetadata = opts?.source
+      ? { source: opts.source.kind, jira_issue_key: opts.source.issueKey }
+      : undefined;
+
     // Set here, not per caller, so the automatic hand-back and the manual
     // "Resolve conflict" button land on the same tier.
     const modelClass: ClaudeCodeModelClass | undefined = opts?.resolveConflict
@@ -326,10 +341,11 @@ export async function enqueueSuperAgentForTask(
       harness = "claude-code";
       const repo = "repo" in choice ? choice.repo : null;
       await enqueueAgentRunForTask(ctx, task, {
-        title: `Super Agent: ${task.title}`,
+        title,
+        ...(runMetadata ? { metadata: runMetadata } : {}),
         ...(opts?.runClass ? { runClass: opts.runClass } : {}),
         ...(pinnedRef ? { pinnedRef } : {}),
-        prompt: buildClaudeCodeTaskPrompt(task, repo, {
+        prompt: buildClaudeCodeTaskPrompt(promptTask, repo, {
           ...promptOpts,
           // Names the candidates in the prompt so the run doesn't spend its first
           // step asking what exists.
@@ -342,9 +358,10 @@ export async function enqueueSuperAgentForTask(
       });
     } else {
       await enqueueAgentRunForTask(ctx, task, {
-        title: `Super Agent: ${task.title}`,
+        title,
+        ...(runMetadata ? { metadata: runMetadata } : {}),
         ...(opts?.runClass ? { runClass: opts.runClass } : {}),
-        prompt: buildSuperAgentTaskPrompt(task, promptOpts),
+        prompt: buildSuperAgentTaskPrompt(promptTask, promptOpts),
         temperature: 0.5,
         ...(pinnedRef ? { pinnedRef } : {}),
       });

--- a/apps/api/src/tools/task-board/enqueue-task-run.ts
+++ b/apps/api/src/tools/task-board/enqueue-task-run.ts
@@ -105,6 +105,9 @@ export async function enqueueAgentRunForTask(
      * twice. Omit for a caller with a single trigger.
      */
     fence?: { threadId: string; workflowID: string };
+    /** Extra thread metadata, merged over the run's own — how a Jira-triggered
+     *  run is stamped for its tool surface and the monitoring filter. */
+    metadata?: Record<string, unknown>;
   },
 ): Promise<{ threadId: string; isNew: boolean }> {
   const organizationId = task.organizationId;
@@ -164,6 +167,7 @@ export async function enqueueAgentRunForTask(
   // optimization.
   const metadata = {
     ...(thread.metadata ?? {}),
+    ...(opts.metadata ?? {}),
     // Read back by `resolveSandboxBranch` at provision time (via the thread, so
     // a durable re-dispatch resolves the same pod). See `pinnedRef` above.
     ...(opts.pinnedRef ? { pinnedRef: opts.pinnedRef } : {}),

--- a/apps/api/src/tools/task-board/review-token.ts
+++ b/apps/api/src/tools/task-board/review-token.ts
@@ -7,28 +7,12 @@
  * one agent could forge the "both reviewers approved" auto-merge gate.
  *
  * A signature, not a stored row: the tuple it signs is already derivable at
- * verify time, so there is nothing to persist. Same signing key and compare as
- * `file-storage/share-password.ts`.
+ * verify time, so there is nothing to persist. Signed with `core/signing-key`.
  */
 
-import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
 import type { ReviewerKind } from "@decocms/shared/task-board";
-import { getSettings } from "@/settings";
-
-let signingKey: Buffer | null = null;
-function getSigningKey(): Buffer {
-  if (signingKey) return signingKey;
-  let secret: string | undefined;
-  try {
-    const settings = getSettings();
-    secret = settings.studioJwtSecret ?? settings.betterAuthSecret;
-  } catch {
-    // Settings not initialized (e.g. unit tests) — fall back like auth/jwt.ts.
-    secret = undefined;
-  }
-  signingKey = secret ? Buffer.from(secret) : randomBytes(32);
-  return signingKey;
-}
+import { getSigningKey } from "@/core/signing-key";
 
 /** The `rtok_` prefix is quoted verbatim in reviewer prompts — keep it. */
 export function mintReviewToken(

--- a/apps/api/src/tools/task-board/run-reactions.test.ts
+++ b/apps/api/src/tools/task-board/run-reactions.test.ts
@@ -212,6 +212,7 @@ function makeItem(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
     sortOrder: 0,
     keySeq: 1,
     externalUrl: null,
+    source: null,
     retryAttempts: 0,
     reviewCycleStartedAt: null,
     threads: [],

--- a/apps/api/src/tools/task-board/schema.test.ts
+++ b/apps/api/src/tools/task-board/schema.test.ts
@@ -42,6 +42,7 @@ describe("TaskBoardItemSchema – proxy round-trip validation", () => {
     sortOrder: 0,
     keySeq: 1,
     externalUrl: null,
+    source: null,
     retryAttempts: 0,
     reviewCycleStartedAt: null,
     threads: [],

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -169,6 +169,9 @@ export const TaskBoardItemSchema = z.object({
    *  verbatim into every agent run's prompt, and a URL there is context the run
    *  does not need and used to act on. Null for a card Studio owns. */
   externalUrl: z.string().nullable(),
+  /** `jira` for the hidden anchor of a Jira-triggered run — never in
+   *  `TASK_BOARD_ITEM_LIST`; null for a card the board shows. */
+  source: z.enum(["jira"]).nullable(),
   // Infrastructure retries already spent on this card's runs — the budget
   // `reactToFailedTaskRun` spends against `MAX_RUN_RETRIES`. Present on every
   // `TaskBoardItem` (see storage/types.ts), so it must be modeled here too:

--- a/apps/api/src/tools/task-board/task-run-context.test.ts
+++ b/apps/api/src/tools/task-board/task-run-context.test.ts
@@ -1,5 +1,5 @@
 /**
- * Which task-board tools a run's MCP endpoint serves, by run thread title.
+ * Which tools a run's MCP endpoint serves, by run thread.
  *
  * The bug this encodes: reviewer runs were told to finish by calling
  * `TASK_BOARD_REVIEW_DECISION` and never had it — reviews reached a verdict and
@@ -10,13 +10,14 @@
 import { describe, expect, test } from "bun:test";
 import {
   REVIEW_RUN_TOOL_NAMES,
-  resolveReviewRunToolNames,
+  JIRA_RUN_TOOL_NAMES,
+  resolveTaskRunToolNames,
   TASK_RUN_TOOL_NAMES,
 } from "./task-run-context";
 
-describe("resolveReviewRunToolNames", () => {
+describe("resolveTaskRunToolNames", () => {
   test("a Reviewer run can record its decision", () => {
-    expect(resolveReviewRunToolNames("Reviewer: Add an H1")).toContain(
+    expect(resolveTaskRunToolNames({ title: "Reviewer: Add an H1" })).toContain(
       "TASK_BOARD_REVIEW_DECISION",
     );
   });
@@ -26,23 +27,25 @@ describe("resolveReviewRunToolNames", () => {
   // Review forever.
   for (const legacy of ["QA Agent", "Code Reviewer"]) {
     test(`a ${legacy} run from before the merge still can`, () => {
-      expect(resolveReviewRunToolNames(`${legacy}: Add an H1`)).toContain(
-        "TASK_BOARD_REVIEW_DECISION",
-      );
+      expect(
+        resolveTaskRunToolNames({ title: `${legacy}: Add an H1` }),
+      ).toContain("TASK_BOARD_REVIEW_DECISION");
     });
   }
 
   // The invariant the narrow list exists for: the worker must not be able to
   // approve or bounce its own work.
   test("a Super Agent run cannot record a review decision", () => {
-    expect(resolveReviewRunToolNames("Super Agent: Add an H1")).toEqual(
-      TASK_RUN_TOOL_NAMES,
-    );
+    expect(
+      resolveTaskRunToolNames({ title: "Super Agent: Add an H1" }),
+    ).toEqual(TASK_RUN_TOOL_NAMES);
   });
 
   test("an unknown or missing title falls back to the narrow surface", () => {
     for (const title of [null, undefined, "", "Some chat"]) {
-      expect(resolveReviewRunToolNames(title)).toEqual(TASK_RUN_TOOL_NAMES);
+      expect(resolveTaskRunToolNames({ title: title })).toEqual(
+        TASK_RUN_TOOL_NAMES,
+      );
     }
   });
 
@@ -66,5 +69,27 @@ describe("resolveReviewRunToolNames", () => {
       expect(REVIEW_RUN_TOOL_NAMES).toContain(name);
     }
     expect(REVIEW_RUN_TOOL_NAMES).toHaveLength(TASK_RUN_TOOL_NAMES.length + 1);
+  });
+
+  // The card behind a Jira-triggered run is only its anchor. Serving the board
+  // tools there would let the agent update a card nobody reads instead of the
+  // issue everybody does — so the Jira surface has none of them.
+  test("a Jira-triggered run gets the issue's tools and none of the board's", () => {
+    const names = resolveTaskRunToolNames({
+      title: "Jira EX-12: Fix the checkout button",
+      metadata: { source: "jira" },
+    });
+    expect(names).toEqual(JIRA_RUN_TOOL_NAMES);
+    expect(names).toContain("JIRA_COMMENT_ADD");
+    expect(names.some((n) => n.startsWith("TASK_BOARD_"))).toBe(false);
+  });
+
+  test("the Jira stamp wins over a title that looks like a reviewer's", () => {
+    expect(
+      resolveTaskRunToolNames({
+        title: "Reviewer: EX-12",
+        metadata: { source: "jira" },
+      }),
+    ).toEqual(JIRA_RUN_TOOL_NAMES);
   });
 });

--- a/apps/api/src/tools/task-board/task-run-context.ts
+++ b/apps/api/src/tools/task-board/task-run-context.ts
@@ -10,6 +10,7 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { ToolName } from "@decocms/shared/tools/registry-metadata";
+import type { ThreadMetadata } from "@decocms/shared/entities";
 import {
   isReviewerThreadTitle,
   REVIEWER_KINDS,
@@ -77,18 +78,37 @@ export const REVIEW_RUN_TOOL_NAMES: readonly ToolName[] = [
 ];
 
 /**
- * Which tool surface a task-run MCP session gets, from the run thread's title.
- *
- * The title is how the rest of the board already tells a reviewer thread from a
- * Super Agent one (`isReviewerThreadTitle`, `"Super Agent:"` in
- * `enqueueReviewersOnThreadFinish`) — reusing it keeps one discriminator rather
- * than adding a column. A missing thread falls back to the narrow list.
+ * The surface for a run the Jira integration started: the issue's tools, and
+ * NONE of the board's. The card behind such a run is only its anchor, and a
+ * board tool there would let the agent "update the task" on a card nobody
+ * reads instead of the issue everybody does.
  */
-export function resolveReviewRunToolNames(
-  title: string | null | undefined,
+export const JIRA_RUN_TOOL_NAMES: readonly ToolName[] = [
+  "TASK_ADD_REPO",
+  "JIRA_ISSUE_GET",
+  "JIRA_COMMENT_ADD",
+  "JIRA_ISSUE_TRANSITION",
+  "JIRA_ATTACHMENT_DOWNLOAD",
+];
+
+/**
+ * Which tool surface a task-run MCP session gets, from the run thread.
+ *
+ * A Jira-triggered run is stamped in its metadata at dispatch. A reviewer is
+ * told apart by the title, which is how the rest of the board already tells a
+ * reviewer thread from a Super Agent one (`isReviewerThreadTitle`,
+ * `"Super Agent:"` in `enqueueReviewersOnThreadFinish`). A missing thread
+ * falls back to the narrow list.
+ */
+export function resolveTaskRunToolNames(
+  thread:
+    | { title?: string | null; metadata?: ThreadMetadata | null }
+    | null
+    | undefined,
 ): readonly ToolName[] {
+  if (thread?.metadata?.source === "jira") return JIRA_RUN_TOOL_NAMES;
   const isReviewer = REVIEWER_KINDS.some((kind) =>
-    isReviewerThreadTitle(title, kind),
+    isReviewerThreadTitle(thread?.title, kind),
   );
   return isReviewer ? REVIEW_RUN_TOOL_NAMES : TASK_RUN_TOOL_NAMES;
 }

--- a/apps/api/src/tools/task-board/update.test.ts
+++ b/apps/api/src/tools/task-board/update.test.ts
@@ -32,6 +32,7 @@ function item(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
     sortOrder: 0,
     keySeq: 1,
     externalUrl: null,
+    source: null,
     retryAttempts: 0,
     reviewCycleStartedAt: null,
     threads: [],

--- a/apps/api/src/tools/thread/list.ts
+++ b/apps/api/src/tools/thread/list.ts
@@ -53,6 +53,12 @@ const ThreadListInputSchema = CollectionListInputSchema.extend({
     .string()
     .optional()
     .describe("Filter by agent (connection or virtual MCP) ID"),
+  source: z
+    .string()
+    .optional()
+    .describe(
+      "Filter by what started the run (`metadata.source`), e.g. `jira` for runs the Jira integration dispatched",
+    ),
 });
 
 /**
@@ -107,6 +113,7 @@ export const COLLECTION_THREADS_LIST = defineTool({
           agentId: input.agentId,
           includeArchived: input.where?.hidden,
           hasTrigger: input.where?.has_trigger,
+          source: input.source,
         });
 
     const hasMore = offset + limit < total;

--- a/apps/web/src/hooks/use-jira-integration.ts
+++ b/apps/web/src/hooks/use-jira-integration.ts
@@ -1,7 +1,8 @@
 /**
  * Per-org Jira integration (`JIRA_*` tools) — managed from Settings → Tasks.
- * One integration per org: credentials, the board it watches, and the webhook
- * that tells it when a card moves.
+ * One integration per org: credentials, the board it watches, the webhook
+ * that tells it when an issue moves, and the per-status rules that start an
+ * agent run when an issue enters a status.
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -56,5 +57,63 @@ export function useJiraBoards(connected: boolean) {
     enabled: connected,
     staleTime: 60_000,
     queryFn: async () => (await studio.call("JIRA_BOARDS_LIST", {})).boards,
+  });
+}
+
+export function useJiraBoardColumns(boardId: string | null) {
+  const { org } = useProjectContext();
+  const studio = useStudioTools();
+  return useQuery({
+    queryKey: KEYS.jiraBoardColumns(org.id, boardId),
+    enabled: boardId !== null,
+    staleTime: 60_000,
+    queryFn: async () =>
+      (await studio.call("JIRA_BOARD_COLUMNS_LIST", { boardId: boardId ?? "" }))
+        .columns,
+  });
+}
+
+export type JiraAutomation =
+  StudioToolIO["JIRA_AUTOMATION_LIST"]["output"]["automations"][number];
+
+export function useJiraAutomations() {
+  const { org } = useProjectContext();
+  const studio = useStudioTools();
+  return useQuery({
+    queryKey: KEYS.jiraAutomations(org.id),
+    queryFn: async () =>
+      (await studio.call("JIRA_AUTOMATION_LIST", {})).automations,
+  });
+}
+
+/**
+ * Turn a status rule on, off, or reword it.
+ *
+ * `null` is off: the row is deleted rather than stored empty, so "no rule" has
+ * one representation. An empty prompt is stored as no prompt, which means the
+ * agent runs on its own instruction.
+ */
+export function useSetJiraAutomation() {
+  const { org } = useProjectContext();
+  const studio = useStudioTools();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: {
+      jiraStatus: string;
+      prompt: string | null;
+    }) => {
+      if (input.prompt === null) {
+        await studio.call("JIRA_AUTOMATION_DELETE", {
+          jiraStatus: input.jiraStatus,
+        });
+        return;
+      }
+      await studio.call("JIRA_AUTOMATION_UPSERT", {
+        jiraStatus: input.jiraStatus,
+        prompt: input.prompt.trim() === "" ? undefined : input.prompt,
+      });
+    },
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: KEYS.jiraAutomations(org.id) }),
   });
 }

--- a/apps/web/src/i18n/en/orgs.ts
+++ b/apps/web/src/i18n/en/orgs.ts
@@ -287,5 +287,8 @@ export const orgs = {
   "orgs.threadsFiltersPopover.filterChats": "Filter Chats",
   "orgs.threadsFiltersPopover.filters": "Filters",
   "orgs.threadsFiltersPopover.status": "Status",
+  "orgs.threadsFiltersPopover.source": "Source",
+  "orgs.threadsFiltersPopover.allSources": "All sources",
+  "orgs.threadsFiltersPopover.sourceJira": "Jira",
   "orgs.threadsFiltersPopover.user": "User",
 } as const;

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -51,7 +51,7 @@ export const settings = {
   "settings.jira.createTokenLink": "Create an API token",
   "settings.jira.webhookTitle": "Instant updates (webhook)",
   "settings.jira.webhookDescription":
-    "Optional. Without it, changes made in Jira reach the board on the next 10-minute sync; with it, they arrive in seconds.",
+    "Optional. Without it, an issue entering an automated status is picked up on the next 10-minute check; with it, the run starts within seconds.",
   "settings.jira.webhookCopy": "Copy",
   "settings.jira.webhookCopied": "Webhook URL copied",
   "settings.jira.webhookStep1":
@@ -63,7 +63,18 @@ export const settings = {
   "settings.jira.webhookStep4":
     "Optionally scope it with a JQL filter, e.g. project = <your project key>.",
   "settings.jira.webhookStep5":
-    "Save. Changes made in Jira now show up on the board within seconds.",
+    "Save. An issue entering an automated status now starts its run within seconds.",
+  "settings.jira.automationsLabel": "Run the agent when an issue enters…",
+  "settings.jira.automationsDescription":
+    "When an issue enters one of these statuses, Studio starts an agent run on it. The agent reads the issue and updates it in Jira; nothing is copied to the board.",
+  "settings.jira.addAutomation": "Add automation",
+  "settings.jira.automationOn": "Automation on",
+  "settings.jira.promptPlaceholder": "Review the issue and leave a comment…",
+  "settings.jira.promptHelp":
+    "Leave empty to use the agent's own instruction. The issue's description, comments and attachments are always included.",
+  "settings.jira.removeAriaLabel": "Stop running the agent on {status}",
+  "settings.jira.noColumnsYet": "No columns on this board yet",
+  "settings.jira.columnsFailed": "Could not load this board's columns",
   "settings.syncedRepos.pageDescription":
     "GitHub repositories mirrored into read-only library folders and kept in sync every few minutes. Great for a shared skills repo.",
   "settings.syncedRepos.addRepo": "Add repo",

--- a/apps/web/src/i18n/pt-br/orgs.ts
+++ b/apps/web/src/i18n/pt-br/orgs.ts
@@ -293,5 +293,8 @@ export const orgs = {
   "orgs.threadsFiltersPopover.filterChats": "Filtrar chats",
   "orgs.threadsFiltersPopover.filters": "Filtros",
   "orgs.threadsFiltersPopover.status": "Status",
+  "orgs.threadsFiltersPopover.source": "Origem",
+  "orgs.threadsFiltersPopover.allSources": "Todas as origens",
+  "orgs.threadsFiltersPopover.sourceJira": "Jira",
   "orgs.threadsFiltersPopover.user": "Usuário",
 } satisfies Record<keyof typeof orgsEn, string>;

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -54,7 +54,7 @@ export const settings = {
   "settings.jira.createTokenLink": "Criar um API token",
   "settings.jira.webhookTitle": "Atualizações instantâneas (webhook)",
   "settings.jira.webhookDescription":
-    "Opcional. Sem ele, mudanças feitas no Jira chegam ao quadro na próxima sincronização de 10 minutos; com ele, chegam em segundos.",
+    "Opcional. Sem ele, uma issue que entra num status automatizado é detectada na próxima verificação de 10 minutos; com ele, a run começa em segundos.",
   "settings.jira.webhookCopy": "Copiar",
   "settings.jira.webhookCopied": "URL do webhook copiada",
   "settings.jira.webhookStep1":
@@ -66,7 +66,20 @@ export const settings = {
   "settings.jira.webhookStep4":
     "Opcionalmente restrinja com um filtro JQL, ex.: project = <chave do projeto>.",
   "settings.jira.webhookStep5":
-    "Salve. Mudanças feitas no Jira passam a aparecer no quadro em segundos.",
+    "Salve. Uma issue que entra num status automatizado passa a iniciar sua run em segundos.",
+  "settings.jira.automationsLabel":
+    "Rodar o agente quando uma issue entrar em…",
+  "settings.jira.automationsDescription":
+    "Quando uma issue entra em um destes status, o Studio inicia um run do agente nela. O agente lê a issue e a atualiza no Jira; nada é copiado para o quadro.",
+  "settings.jira.addAutomation": "Adicionar automação",
+  "settings.jira.automationOn": "Automação ativa",
+  "settings.jira.promptPlaceholder": "Revise a issue e deixe um comentário…",
+  "settings.jira.promptHelp":
+    "Deixe vazio para usar a instrução do próprio agente. A descrição, os comentários e os anexos da issue sempre vão junto.",
+  "settings.jira.removeAriaLabel": "Parar de rodar o agente em {status}",
+  "settings.jira.noColumnsYet": "Este board ainda não tem colunas",
+  "settings.jira.columnsFailed":
+    "Não foi possível carregar as colunas do board",
   "settings.syncedRepos.pageDescription":
     "Repositórios do GitHub espelhados em pastas somente leitura da biblioteca, sincronizados a cada poucos minutos. Ótimo para um repo de skills compartilhado.",
   "settings.syncedRepos.addRepo": "Adicionar repo",

--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -37,6 +37,7 @@ function item(id: string, sortOrder: number): TaskBoardItem {
     sortOrder,
     keySeq: 1,
     externalUrl: null,
+    source: null,
     retryAttempts: 0,
     reviewCycleStartedAt: null,
     threads: [],

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -512,6 +512,9 @@ export const KEYS = {
   // Jira integration (Settings → Jira)
   jiraIntegration: (orgId: string) => ["jira-integration", orgId] as const,
   jiraBoards: (orgId: string) => ["jira-boards", orgId] as const,
+  jiraBoardColumns: (orgId: string, boardId: string | null) =>
+    ["jira-board-columns", orgId, boardId] as const,
+  jiraAutomations: (orgId: string) => ["jira-automations", orgId] as const,
   // Cross-volume recent-files feed (Library home). Separate root key so a
   // volume named like the segment can never collide; mutations invalidate it
   // explicitly alongside the volume prefix.

--- a/apps/web/src/routes/orgs/monitoring/index.tsx
+++ b/apps/web/src/routes/orgs/monitoring/index.tsx
@@ -684,11 +684,13 @@ function MonitoringDashboardContent({
   );
   const [threadFilterUserIds, setThreadFilterUserIds] = useState<string[]>([]);
   const [threadFilterStatus, setThreadFilterStatus] = useState("all");
+  const [threadFilterSource, setThreadFilterSource] = useState("all");
 
   const threadActiveFiltersCount =
     (threadFilterAgentIds.length > 0 ? 1 : 0) +
     (threadFilterUserIds.length > 0 ? 1 : 0) +
-    (threadFilterStatus !== "all" ? 1 : 0);
+    (threadFilterStatus !== "all" ? 1 : 0) +
+    (threadFilterSource !== "all" ? 1 : 0);
 
   const memberOptions = getOrgMembers(membersData).map((m) => {
     const label = m.user.name ?? m.user.email ?? m.userId;
@@ -785,6 +787,7 @@ function MonitoringDashboardContent({
                   filterAgentIds={threadFilterAgentIds}
                   filterUserIds={threadFilterUserIds}
                   filterStatus={threadFilterStatus}
+                  filterSource={threadFilterSource}
                   virtualMcpOptions={virtualMcpOptions}
                   memberOptions={memberOptions}
                   activeFiltersCount={threadActiveFiltersCount}
@@ -792,6 +795,7 @@ function MonitoringDashboardContent({
                     filterAgentIds,
                     filterUserIds,
                     filterStatus,
+                    filterSource,
                   }) => {
                     if (filterAgentIds !== undefined)
                       setThreadFilterAgentIds(filterAgentIds);
@@ -799,6 +803,8 @@ function MonitoringDashboardContent({
                       setThreadFilterUserIds(filterUserIds);
                     if (filterStatus !== undefined)
                       setThreadFilterStatus(filterStatus);
+                    if (filterSource !== undefined)
+                      setThreadFilterSource(filterSource);
                   }}
                 />
               )}
@@ -922,6 +928,7 @@ function MonitoringDashboardContent({
           filterAgentIds={threadFilterAgentIds}
           filterUserIds={threadFilterUserIds}
           filterStatus={threadFilterStatus}
+          filterSource={threadFilterSource}
         />
       ) : tab === "audit" ? (
         <AuditTabContent

--- a/apps/web/src/routes/orgs/monitoring/threads-filters-popover.tsx
+++ b/apps/web/src/routes/orgs/monitoring/threads-filters-popover.tsx
@@ -21,6 +21,7 @@ interface ThreadsFiltersPopoverProps {
   filterAgentIds: string[];
   filterUserIds: string[];
   filterStatus: string;
+  filterSource: string;
   virtualMcpOptions: Array<{ value: string; label: string }>;
   memberOptions: Array<{ value: string; label: string }>;
   activeFiltersCount: number;
@@ -28,6 +29,7 @@ interface ThreadsFiltersPopoverProps {
     filterAgentIds?: string[];
     filterUserIds?: string[];
     filterStatus?: string;
+    filterSource?: string;
   }) => void;
 }
 
@@ -35,6 +37,7 @@ export function ThreadsFiltersPopover({
   filterAgentIds,
   filterUserIds,
   filterStatus,
+  filterSource,
   virtualMcpOptions,
   memberOptions,
   activeFiltersCount,
@@ -139,6 +142,30 @@ export function ThreadsFiltersPopover({
                 </SelectContent>
               </Select>
             </div>
+
+            <div>
+              <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+                {t("orgs.threadsFiltersPopover.source")}
+              </label>
+              <Select
+                value={filterSource}
+                onValueChange={(value) =>
+                  onUpdateFilters({ filterSource: value })
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">
+                    {t("orgs.threadsFiltersPopover.allSources")}
+                  </SelectItem>
+                  <SelectItem value="jira">
+                    {t("orgs.threadsFiltersPopover.sourceJira")}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
           </div>
 
           {activeFiltersCount > 0 && (
@@ -151,6 +178,7 @@ export function ThreadsFiltersPopover({
                   filterAgentIds: [],
                   filterUserIds: [],
                   filterStatus: "all",
+                  filterSource: "all",
                 });
                 setOpen(false);
               }}

--- a/apps/web/src/routes/orgs/monitoring/threads.tsx
+++ b/apps/web/src/routes/orgs/monitoring/threads.tsx
@@ -217,6 +217,7 @@ export interface ThreadsTabContentProps {
   filterAgentIds?: string[];
   filterUserIds?: string[];
   filterStatus?: string;
+  filterSource?: string;
 }
 
 const THREADS_PAGE_SIZE = 50;
@@ -232,6 +233,7 @@ export function ThreadsTabContent({
   filterAgentIds,
   filterUserIds,
   filterStatus,
+  filterSource,
 }: ThreadsTabContentProps) {
   const t = useT();
   const startDate = dateRange.startDate.toISOString();
@@ -244,6 +246,7 @@ export function ThreadsTabContent({
     agentIds: filterAgentIds,
     userIds: filterUserIds,
     status: filterStatus,
+    source: filterSource,
   });
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
@@ -267,6 +270,9 @@ export function ThreadsTabContent({
               : {}),
             ...(filterStatus && filterStatus !== "all"
               ? { status: filterStatus }
+              : {}),
+            ...(filterSource && filterSource !== "all"
+              ? { source: filterSource }
               : {}),
           },
         })) as { structuredContent?: unknown };
@@ -368,7 +374,8 @@ export function ThreadsTabContent({
     !!searchQuery ||
     (filterAgentIds?.length ?? 0) > 0 ||
     (filterUserIds?.length ?? 0) > 0 ||
-    !!(filterStatus && filterStatus !== "all");
+    !!(filterStatus && filterStatus !== "all") ||
+    !!(filterSource && filterSource !== "all");
 
   return (
     <div className="flex-1 flex flex-col overflow-auto min-w-0">

--- a/apps/web/src/views/settings/jira.tsx
+++ b/apps/web/src/views/settings/jira.tsx
@@ -1,10 +1,11 @@
 /**
  * Settings → Tasks → "Jira integration" section — connect a Jira Cloud site
- * (email + API token), pick the board Studio watches, and wire the webhook
- * that tells it the moment a card moves.
+ * (email + API token), pick the board Studio watches, choose which statuses
+ * start an agent run, and wire the webhook that tells it the moment an issue
+ * moves.
  */
 
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@decocms/ui/components/button.tsx";
 import { Input } from "@decocms/ui/components/input.tsx";
@@ -12,11 +13,14 @@ import {
   ArrowUpRight,
   Check,
   ChevronSelectorVertical,
+  Plus,
+  Trash01,
 } from "@untitledui/icons";
 import { cn } from "@decocms/ui/lib/utils.ts";
 import { Combobox } from "@decocms/ui/components/combobox.tsx";
 import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
 import { Switch } from "@decocms/ui/components/switch.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -49,8 +53,11 @@ import type { TranslationKey } from "@/i18n/en";
 import {
   type JiraIntegration,
   useDeleteJiraIntegration,
+  useJiraAutomations,
+  useJiraBoardColumns,
   useJiraBoards,
   useJiraIntegration,
+  useSetJiraAutomation,
   useUpsertJiraIntegration,
 } from "@/hooks/use-jira-integration";
 import { TaskSystemPromptSettings } from "./task-system-prompt";
@@ -299,6 +306,153 @@ function BoardRow({ integration }: { integration: JiraIntegration }) {
   );
 }
 
+/**
+ * One card per Jira STATUS on the selected board. A Jira column is a bucket of
+ * statuses, so the card is headed by the column and names the status beneath
+ * it whenever that adds information. Rules are keyed by status name.
+ */
+function AutomationsRow({ boardId }: { boardId: string }) {
+  const t = useT();
+  const columns = useJiraBoardColumns(boardId);
+  const automations = useJiraAutomations();
+
+  let body: ReactNode;
+  if (columns.isPending || automations.isPending) {
+    body = <Skeleton className="h-40 w-full" />;
+  } else if (columns.isError) {
+    body = (
+      <p className="text-xs text-muted-foreground">
+        {t("settings.jira.columnsFailed")}
+      </p>
+    );
+  } else if ((columns.data ?? []).length === 0) {
+    body = (
+      <p className="text-xs text-muted-foreground">
+        {t("settings.jira.noColumnsYet")}
+      </p>
+    );
+  } else {
+    const promptOf = new Map(
+      (automations.data ?? []).map((a) => [a.jiraStatus, a.prompt]),
+    );
+    body = (
+      <div className="flex w-full flex-col gap-3">
+        {(columns.data ?? []).flatMap((column) =>
+          column.statuses.map((status) => (
+            <StatusAutomationCard
+              key={`${column.name}:${status}`}
+              columnName={column.name}
+              status={status}
+              showStatus={status !== column.name || column.statuses.length > 1}
+              hasAutomation={promptOf.has(status)}
+              prompt={promptOf.get(status) ?? null}
+            />
+          )),
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <SettingsCardItem
+      title={t("settings.jira.automationsLabel")}
+      description={t("settings.jira.automationsDescription")}
+    >
+      <div className="mt-3">{body}</div>
+    </SettingsCardItem>
+  );
+}
+
+/** `prompt` null with `hasAutomation` true means the rule runs on the agent's
+ *  own instruction; the status is absent from the automations list when there
+ *  is no rule at all. */
+function StatusAutomationCard({
+  columnName,
+  status,
+  showStatus,
+  hasAutomation,
+  prompt,
+}: {
+  columnName: string;
+  status: string;
+  showStatus: boolean;
+  hasAutomation: boolean;
+  prompt: string | null;
+}) {
+  const t = useT();
+  const setAutomation = useSetJiraAutomation();
+  // A draft, so typing is not a write per keystroke. Re-seeded on change.
+  const [draft, setDraft] = useState(prompt ?? "");
+  const [syncedWith, setSyncedWith] = useState(prompt);
+  if (syncedWith !== prompt) {
+    setSyncedWith(prompt);
+    setDraft(prompt ?? "");
+  }
+
+  const save = (next: string | null) =>
+    setAutomation.mutate(
+      { jiraStatus: status, prompt: next },
+      {
+        onError: (err) =>
+          toast.error(errorMessage(err, t("settings.jira.saveFailed"))),
+      },
+    );
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border p-3">
+      <div className="flex flex-col min-w-0">
+        <span className="truncate text-sm font-medium">{columnName}</span>
+        {showStatus && (
+          <span className="truncate text-xs text-muted-foreground">
+            {status}
+          </span>
+        )}
+      </div>
+
+      {hasAutomation ? (
+        <div className="flex flex-col gap-2 rounded-lg bg-muted/40 p-2.5">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-medium">
+              {t("settings.jira.automationOn")}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label={t("settings.jira.removeAriaLabel", { status })}
+              onClick={() => save(null)}
+            >
+              <Trash01 size={14} />
+            </Button>
+          </div>
+          <Textarea
+            value={draft}
+            rows={2}
+            placeholder={t("settings.jira.promptPlaceholder")}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={() => {
+              if (draft !== (prompt ?? "")) save(draft);
+            }}
+            data-jira-automation-prompt={status}
+          />
+          <p className="text-xs text-muted-foreground">
+            {t("settings.jira.promptHelp")}
+          </p>
+        </div>
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-fit"
+          onClick={() => save("")}
+        >
+          <Plus size={14} />
+          {t("settings.jira.addAutomation")}
+        </Button>
+      )}
+    </div>
+  );
+}
+
 function EnabledRow({ integration }: { integration: JiraIntegration }) {
   const t = useT();
   const upsert = useUpsertJiraIntegration();
@@ -400,6 +554,7 @@ function JiraContent() {
     <SettingsCard>
       <ConnectionRow integration={data} />
       <BoardRow integration={data} />
+      {data.boardId && <AutomationsRow boardId={data.boardId} />}
       <EnabledRow integration={data} />
       <WebhookRow integration={data} />
     </SettingsCard>

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -59,10 +59,13 @@
       // `bun run fixtures/...` command string — knip can't trace a process
       // launch, so without this entry it flags the file as unused.
       // github-stub-server.ts wraps fixtures/github-stub.ts (the in-memory
-      // Git Data stub the decofile-api spec points GITHUB_API_BASE_URL at).
+      // Git Data stub the decofile-api spec points GITHUB_API_BASE_URL at);
+      // jira-stub-server.ts wraps fixtures/jira-stub.ts (the stand-in Jira the
+      // run-trigger spec points an integration's siteUrl at).
       "entry": [
         "fixtures/commerce-upgrade-mock.ts",
-        "fixtures/github-stub-server.ts"
+        "fixtures/github-stub-server.ts",
+        "fixtures/jira-stub-server.ts"
       ]
     },
     "apps/native": {

--- a/packages/e2e/fixtures/jira-stub-server.ts
+++ b/packages/e2e/fixtures/jira-stub-server.ts
@@ -1,0 +1,16 @@
+/**
+ * Standalone entry for the Jira stub (jira-stub.ts).
+ *
+ * Launched as a Playwright `webServer` so the Jira run trigger resolves a real
+ * board, issue and attachment over HTTP without reaching a customer's site.
+ * The integration's `siteUrl` points here; the API is run with
+ * `JIRA_ALLOW_LOCAL_SITE_URL=1`. Follows the github-stub-server.ts pattern.
+ */
+
+import { createJiraStubServer } from "./jira-stub";
+
+const port = Number(process.env.JIRA_STUB_PORT ?? "4103");
+
+createJiraStubServer().listen(port, () => {
+  console.log(`[jira-stub] listening on http://localhost:${port}`);
+});

--- a/packages/e2e/fixtures/jira-stub.ts
+++ b/packages/e2e/fixtures/jira-stub.ts
@@ -1,0 +1,202 @@
+/**
+ * A stand-in Jira Cloud, in memory.
+ *
+ * Enough of the REST surface for the run trigger to work end to end: the
+ * credential check, the board and its columns, one issue with a comment and an
+ * attachment, the transitions that issue can take, and the writes the run's
+ * tools make. State lives per process and is reset by `/__reset`, so a spec can
+ * assert on what the server actually received.
+ *
+ * Studio reaches it because the integration's `siteUrl` points here and the
+ * API runs with `JIRA_ALLOW_LOCAL_SITE_URL=1`; nothing else about the code path
+ * differs from a real site.
+ */
+
+import { createServer, type Server } from "node:http";
+
+/** The issue every spec works with. The spec inlines these values too — a
+ *  black-box test owns the shapes it asserts. */
+const ISSUE_ID = "10001";
+const ISSUE_KEY = "EX-1";
+const ATTACHMENT_ID = "77001";
+const ATTACHMENT_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+const BOARD_ID = "1610";
+
+/** Column name → the status inside it. Deliberately unlike each other: a Jira
+ *  column is a bucket of statuses and the two names routinely differ, which is
+ *  what keying rules by STATUS is for. */
+const COLUMNS: Array<{ name: string; statusId: string; status: string }> = [
+  { name: "Backlog", statusId: "1", status: "Backlog" },
+  { name: "Em Progresso", statusId: "2", status: "Fazendo" },
+  { name: "Code Review", statusId: "3", status: "Code Review" },
+  { name: "QA", statusId: "4", status: "Teste" },
+];
+
+const adf = (text: string) => ({
+  type: "doc",
+  version: 1,
+  content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+});
+
+interface StubState {
+  status: string;
+  comments: Array<{ id: string; body: unknown; created: string }>;
+  transitions: string[];
+}
+
+function freshState(): StubState {
+  return {
+    status: "Backlog",
+    comments: [
+      {
+        id: "c1",
+        body: adf("Please keep the hover state."),
+        created: "2026-09-02T10:00:00.000Z",
+      },
+    ],
+    transitions: [],
+  };
+}
+
+export function createJiraStubServer(): Server {
+  let state = freshState();
+
+  return createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const path = url.pathname;
+    const json = (body: unknown, status = 200) => {
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(JSON.stringify(body));
+    };
+    const body = async (): Promise<Record<string, unknown>> => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(chunk as Buffer);
+      return chunks.length
+        ? (JSON.parse(Buffer.concat(chunks).toString()) as Record<
+            string,
+            unknown
+          >)
+        : {};
+    };
+
+    // Spec-facing control surface, outside Jira's own API shape.
+    if (path === "/health") return json({ ok: true });
+    if (path === "/__reset") {
+      state = freshState();
+      return json({ ok: true });
+    }
+    if (path === "/__state") {
+      return json({
+        status: state.status,
+        transitions: state.transitions,
+        comments: state.comments.length,
+        lastComment: state.comments.at(-1)?.body ?? null,
+      });
+    }
+
+    if (path === "/rest/api/3/myself") {
+      return json({ accountId: "bot", displayName: "Studio Bot" });
+    }
+    if (path === "/rest/agile/1.0/board") {
+      return json({
+        values: [
+          {
+            id: Number(BOARD_ID),
+            name: "DECO",
+            type: "scrum",
+            location: { projectKey: "EX", projectName: "Example" },
+          },
+        ],
+        isLast: true,
+      });
+    }
+    if (path === `/rest/agile/1.0/board/${BOARD_ID}/configuration`) {
+      return json({
+        filter: { id: "500" },
+        columnConfig: {
+          columns: COLUMNS.map((c) => ({
+            name: c.name,
+            statuses: [{ id: c.statusId }],
+          })),
+        },
+      });
+    }
+    if (path === "/rest/api/3/filter/500") {
+      return json({ jql: "project = EX ORDER BY Rank ASC" });
+    }
+    if (path.startsWith("/rest/api/3/status/")) {
+      const id = path.split("/").pop();
+      const column = COLUMNS.find((c) => c.statusId === id);
+      return json({ id, name: column?.status ?? id });
+    }
+    if (path === "/rest/api/3/field") return json([]);
+    if (path === "/rest/api/3/user/bulk") return json({ values: [] });
+    if (path === "/rest/api/3/search/jql") {
+      return json({ issues: [], nextPageToken: null });
+    }
+
+    if (path === `/rest/api/3/issue/${ISSUE_ID}` && req.method === "GET") {
+      return json({
+        id: ISSUE_ID,
+        key: ISSUE_KEY,
+        fields: {
+          summary: "Make the checkout button blue",
+          status: { name: state.status },
+          description: adf(
+            "The checkout button is green. Product wants it blue. See the mock attached.",
+          ),
+          attachment: [
+            {
+              id: ATTACHMENT_ID,
+              filename: "mock.png",
+              size: ATTACHMENT_BYTES.length,
+              mimeType: "image/png",
+            },
+          ],
+        },
+      });
+    }
+    if (path === `/rest/api/3/issue/${ISSUE_ID}/comment`) {
+      if (req.method === "POST") {
+        const posted = await body();
+        const id = `c${state.comments.length + 1}`;
+        state.comments.push({
+          id,
+          body: posted.body,
+          created: new Date().toISOString(),
+        });
+        return json({ id }, 201);
+      }
+      return json({ comments: state.comments, total: state.comments.length });
+    }
+    if (path === `/rest/api/3/issue/${ISSUE_ID}/transitions`) {
+      if (req.method === "POST") {
+        const posted = (await body()) as { transition?: { id?: string } };
+        const target = COLUMNS.find(
+          (c) => c.statusId === posted.transition?.id,
+        );
+        if (target) {
+          state.status = target.status;
+          state.transitions.push(target.status);
+        }
+        res.writeHead(204);
+        return res.end();
+      }
+      // Everything but where it already is, so a spec can move it somewhere.
+      return json({
+        transitions: COLUMNS.filter((c) => c.status !== state.status).map(
+          (c) => ({ id: c.statusId, name: c.status, to: { name: c.status } }),
+        ),
+      });
+    }
+    if (path === `/rest/api/3/attachment/content/${ATTACHMENT_ID}`) {
+      res.writeHead(200, {
+        "content-type": "image/png",
+        "content-disposition": 'attachment; filename="mock.png"',
+      });
+      return res.end(Buffer.from(ATTACHMENT_BYTES));
+    }
+
+    json({ errorMessages: [`not stubbed: ${req.method} ${path}`] }, 404);
+  });
+}

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -20,6 +20,13 @@ const commerceMockKey = "e2e-commerce-key";
 const githubStubPort = process.env.GITHUB_STUB_PORT || "4102";
 const githubStubOrigin = `http://localhost:${githubStubPort}`;
 
+// The Jira run trigger reads a board, an issue and an attachment from the
+// tenant's Jira site. jira-run-trigger.spec.ts points an integration at a local
+// stub (jira-stub-server.ts, started as a webServer below) instead of a real
+// site; JIRA_ALLOW_LOCAL_SITE_URL lets the server accept that `siteUrl`, which
+// it otherwise restricts to *.atlassian.net.
+const jiraStubPort = process.env.JIRA_STUB_PORT || "4103";
+
 // e2e exercises production-like behavior; the MCP read/list cache is on in prod
 // but defaults off under NODE_ENV=development (which the API `dev` script sets),
 // so opt it back in here. Without this, cache-dependent specs (e.g. proxy
@@ -49,7 +56,7 @@ const githubStubOrigin = `http://localhost:${githubStubPort}`;
 // the config isn't a spec module).
 const vaultServiceToken = "e2e-vault-service-token";
 
-const apiServerCommand = `MCP_CACHE_ENABLED=true VAULT_SERVICE_TOKEN=${vaultServiceToken} REPORTS_INTERNAL_API_URL=${commerceMockOrigin} REPORTS_INTERNAL_API_KEY=${commerceMockKey} GITHUB_API_BASE_URL=${githubStubOrigin} BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} RUN_IDLE_TIMEOUT_MS=120000 DEPLOYMENT_ADMIN_EMAILS=deployment-admin@e2e.local,deployment-admin-2@e2e.local bun run dev`;
+const apiServerCommand = `MCP_CACHE_ENABLED=true VAULT_SERVICE_TOKEN=${vaultServiceToken} REPORTS_INTERNAL_API_URL=${commerceMockOrigin} REPORTS_INTERNAL_API_KEY=${commerceMockKey} GITHUB_API_BASE_URL=${githubStubOrigin} JIRA_ALLOW_LOCAL_SITE_URL=1 BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} RUN_IDLE_TIMEOUT_MS=120000 DEPLOYMENT_ADMIN_EMAILS=deployment-admin@e2e.local,deployment-admin-2@e2e.local bun run dev`;
 // CI serves the PRODUCTION build via `vite preview` (same Node proxy as dev —
 // see apps/web/vite.config.ts): the suite's charter is production-like
 // behavior, and the dev server's on-demand transform inflated browser-heavy
@@ -117,6 +124,16 @@ export default defineConfig({
       // imports).
       command: `GITHUB_STUB_PORT=${githubStubPort} bun run fixtures/github-stub-server.ts`,
       url: `${githubStubOrigin}/health`,
+      reuseExistingServer: true,
+      timeout: 30_000,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    {
+      // Stand-in Jira for the run trigger. Started before the studio server so
+      // an integration can point at it. Standalone process (no app imports).
+      command: `JIRA_STUB_PORT=${jiraStubPort} bun run fixtures/jira-stub-server.ts`,
+      url: `http://localhost:${jiraStubPort}/health`,
       reuseExistingServer: true,
       timeout: 30_000,
       stdout: "pipe",

--- a/packages/e2e/tests/jira-run-trigger.spec.ts
+++ b/packages/e2e/tests/jira-run-trigger.spec.ts
@@ -1,0 +1,283 @@
+/**
+ * The Jira integration as a run trigger, end to end over HTTP.
+ *
+ * An issue entering a Jira status that has a rule starts an agent run on that
+ * issue. Studio keeps no copy of the issue: the run hangs off a hidden anchor
+ * item, and the agent works the issue through the Jira tools its run is served.
+ *
+ * The tenant's Jira is a local stub (`fixtures/jira-stub.ts`), pointed at by
+ * the integration's `siteUrl`; every other part of the path is the real one —
+ * the credential check, the board read, the webhook route, the dispatch fence.
+ *
+ * What this cannot cover here: the agent run itself needs a model provider, so
+ * the dispatch is asserted by its OUTCOME on the anchor (see the un-delegate
+ * test) rather than by a completed run.
+ */
+
+import { expect, test } from "../fixtures/test";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { connectDevDb } from "../fixtures/db";
+import type { APIRequestContext } from "@playwright/test";
+import type { Client } from "pg";
+
+const JIRA_STUB_ORIGIN = `http://localhost:${process.env.JIRA_STUB_PORT ?? "4103"}`;
+
+// The stub's fixture data, inlined: a black-box test owns the shapes it asserts.
+const BOARD_ID = "1610";
+const ISSUE_ID = "10001";
+const ISSUE_KEY = "EX-1";
+const ISSUE_SUMMARY = "Make the checkout button blue";
+/** The status inside the "Em Progresso" column — a Jira column is a bucket of
+ *  statuses, and a rule is keyed by the STATUS the webhook reports. */
+const AUTOMATED_STATUS = "Fazendo";
+
+interface Integration {
+  id: string;
+  webhookSecret: string;
+  boardId: string | null;
+  enabled: boolean;
+}
+
+/** A `jira:issue_updated` payload, as Jira sends one. */
+function statusChange(changelogId: string, toStatus = AUTOMATED_STATUS) {
+  return {
+    webhookEvent: "jira:issue_updated",
+    issue: { id: ISSUE_ID, key: ISSUE_KEY },
+    changelog: {
+      id: changelogId,
+      items: [
+        { field: "assignee", toString: "Ana" },
+        { field: "status", fromString: "Backlog", toString: toStatus },
+      ],
+    },
+  };
+}
+
+async function connectIntegration(
+  api: APIRequestContext,
+  orgSlug: string,
+): Promise<Integration> {
+  const { integration } = await callSelfMcpTool<{ integration: Integration }>(
+    api,
+    orgSlug,
+    "JIRA_INTEGRATION_UPSERT",
+    {
+      siteUrl: JIRA_STUB_ORIGIN,
+      email: "bot@example.test",
+      apiToken: "stub-token",
+      boardId: BOARD_ID,
+      boardName: "DECO",
+      enabled: true,
+    },
+  );
+  return integration;
+}
+
+test.describe("Jira run trigger", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db.end();
+  });
+
+  /** Every DB assertion is scoped to the test's own org. */
+  const orgIdOf = async (orgSlug: string): Promise<string> => {
+    const { rows } = await db.query<{ id: string }>(
+      "select id from organization where slug = $1",
+      [orgSlug],
+    );
+    expect(rows).toHaveLength(1);
+    return rows[0].id;
+  };
+
+  test("connects to the site, and reads its board's columns by status", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+
+    const integration = await connectIntegration(api, orgSlug);
+    expect(integration.enabled).toBe(true);
+    expect(integration.boardId).toBe(BOARD_ID);
+    // The secret is the webhook's whole authentication, so it has to come back.
+    expect(integration.webhookSecret).toBeTruthy();
+
+    const { boards } = await callSelfMcpTool<{
+      boards: Array<{ id: number; name: string }>;
+    }>(api, orgSlug, "JIRA_BOARDS_LIST", {});
+    expect(boards.map((b) => b.name)).toContain("DECO");
+
+    const { columns } = await callSelfMcpTool<{
+      columns: Array<{ name: string; statuses: string[] }>;
+    }>(api, orgSlug, "JIRA_BOARD_COLUMNS_LIST", { boardId: BOARD_ID });
+    // Column name and status name differ, which is why rules key on the status.
+    expect(columns).toContainEqual({
+      name: "Em Progresso",
+      statuses: [AUTOMATED_STATUS],
+    });
+  });
+
+  test("a rule exists only while its row does", async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+    await connectIntegration(api, orgSlug);
+    const list = () =>
+      callSelfMcpTool<{
+        automations: Array<{ jiraStatus: string; prompt: string | null }>;
+      }>(api, orgSlug, "JIRA_AUTOMATION_LIST", {});
+
+    expect((await list()).automations).toEqual([]);
+    await callSelfMcpTool(api, orgSlug, "JIRA_AUTOMATION_UPSERT", {
+      jiraStatus: AUTOMATED_STATUS,
+    });
+    expect((await list()).automations).toEqual([
+      { jiraStatus: AUTOMATED_STATUS, prompt: null },
+    ]);
+
+    await callSelfMcpTool(api, orgSlug, "JIRA_AUTOMATION_UPSERT", {
+      jiraStatus: AUTOMATED_STATUS,
+      prompt: "Implement it and open a pull request.",
+    });
+    expect((await list()).automations[0].prompt).toBe(
+      "Implement it and open a pull request.",
+    );
+
+    const { removed } = await callSelfMcpTool<{ removed: boolean }>(
+      api,
+      orgSlug,
+      "JIRA_AUTOMATION_DELETE",
+      { jiraStatus: AUTOMATED_STATUS },
+    );
+    expect(removed).toBe(true);
+    expect((await list()).automations).toEqual([]);
+  });
+
+  test("an issue entering an automated status is claimed exactly once", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+    const orgId = await orgIdOf(orgSlug);
+
+    const integration = await connectIntegration(api, orgSlug);
+    await callSelfMcpTool(api, orgSlug, "JIRA_AUTOMATION_UPSERT", {
+      jiraStatus: AUTOMATED_STATUS,
+      prompt: "Implement it and open a pull request.",
+    });
+
+    const hook = (payload: unknown) =>
+      api.post(`/api/_jira/webhook/${integration.webhookSecret}`, {
+        data: payload,
+      });
+
+    // Answered before the work: Jira times a hook out in seconds.
+    expect((await hook(statusChange("9001"))).status()).toBe(202);
+    await expect
+      .poll(async () => (await anchors(db, orgId)).length, { timeout: 20_000 })
+      .toBe(1);
+
+    // A redelivery of the SAME transition must not buy a second run.
+    expect((await hook(statusChange("9001"))).status()).toBe(202);
+    // An update that did not touch the status is not a transition at all.
+    expect(
+      (
+        await hook({
+          webhookEvent: "jira:issue_updated",
+          issue: { id: ISSUE_ID, key: ISSUE_KEY },
+          changelog: { id: "9002", items: [{ field: "summary" }] },
+        })
+      ).status(),
+    ).toBe(202);
+    // A status with no rule is uneventful.
+    expect((await hook(statusChange("9003", "Teste"))).status()).toBe(202);
+    await page.waitForTimeout(3_000);
+
+    const [anchor] = await anchors(db, orgId);
+    expect(anchor.title).toBe(`${ISSUE_KEY}: ${ISSUE_SUMMARY}`);
+    // Read off the issue, so the trigger really went to the site.
+    expect(anchor.external_url).toBe(`${JIRA_STUB_ORIGIN}/browse/${ISSUE_KEY}`);
+    expect(anchor.external_key).toBe(ISSUE_KEY);
+
+    const claims = await db.query(
+      "select changelog_id from jira_trigger_claims where organization_id = $1",
+      [orgId],
+    );
+    expect(claims.rows.map((r) => r.changelog_id)).toEqual(["9001"]);
+
+    const links = await db.query(
+      "select jira_issue_key from task_board_item_jira_links where organization_id = $1",
+      [orgId],
+    );
+    expect(links.rows).toEqual([{ jira_issue_key: ISSUE_KEY }]);
+
+    // The anchor carries a run; it is not work the board shows.
+    const { items } = await callSelfMcpTool<{ items: Array<{ id: string }> }>(
+      api,
+      orgSlug,
+      "TASK_BOARD_ITEM_LIST",
+      {},
+    );
+    expect(items.map((i) => i.id)).not.toContain(anchor.id);
+
+    // No model provider in this org, so the dispatch fails — and a failed
+    // dispatch must leave the anchor unowned rather than assigned to an agent
+    // that will never run.
+    expect(anchor.assignee_id).toBeNull();
+  });
+
+  test("an unknown webhook secret is refused", async ({ authedPage }) => {
+    const { page } = authedPage;
+    const res = await page
+      .context()
+      .request.post("/api/_jira/webhook/not-a-real-secret", {
+        data: statusChange("9100"),
+      });
+    expect(res.status()).toBe(404);
+  });
+
+  /** The download route's only authentication is the signed grant its tool
+   *  mints, so anything else must fail closed. */
+  test("the attachment route refuses a token it did not mint", async ({
+    authedPage,
+  }) => {
+    const request = authedPage.page.context().request;
+    for (const token of [
+      "garbage",
+      "abc.def",
+      Buffer.from(
+        JSON.stringify({
+          organizationId: "org_someone_else",
+          attachmentId: "77001",
+          expiresAt: Date.now() + 60_000,
+        }),
+      ).toString("base64url") + ".forged",
+    ]) {
+      const res = await request.get(`/api/_jira/attachments/${token}`);
+      expect(res.status()).toBe(404);
+    }
+  });
+});
+
+/** The org's Jira run anchors — hidden items, so they are read from the DB. */
+async function anchors(
+  db: Client,
+  organizationId: string,
+): Promise<
+  Array<{
+    id: string;
+    title: string;
+    assignee_id: string | null;
+    external_key: string | null;
+    external_url: string | null;
+  }>
+> {
+  const { rows } = await db.query(
+    "select id, title, assignee_id, external_key, external_url from task_board_items where organization_id = $1 and source = 'jira'",
+    [organizationId],
+  );
+  return rows;
+}

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -173,6 +173,9 @@ export interface TaskBoardItem {
   /** Link to that issue in the tracker, for a human to open. Never folded into
    *  `description`, which agent prompts quote verbatim. */
   externalUrl: string | null;
+  /** `jira` for the hidden anchor of a Jira-triggered run; null for a card the
+   *  board shows. */
+  source: "jira" | null;
   /** Infrastructure retries already spent on this card's runs — the budget
    *  `reactToFailedTaskRun` spends against `MAX_RUN_RETRIES`. */
   retryAttempts: number;

--- a/packages/shared/src/thread/schema.ts
+++ b/packages/shared/src/thread/schema.ts
@@ -62,6 +62,16 @@ const ThreadMetadataSchema = z
       .describe(
         "Session runtime, stamped once at creation and immutable afterwards: 'cms' is a sandbox-less content session, 'sandbox' a coding session with a pod. Absent only on threads created before the stamp existed.",
       ),
+    source: z
+      .enum(["jira"])
+      .optional()
+      .describe(
+        "What started the run: 'jira' for a run the Jira integration dispatched when an issue entered an automated status. Absent for a person's thread.",
+      ),
+    jira_issue_key: z
+      .string()
+      .optional()
+      .describe("The Jira issue a 'jira' run works on, e.g. EX-12."),
   })
   .catchall(z.unknown());
 

--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -193,6 +193,13 @@ const ALL_TOOL_NAMES = [
   "JIRA_INTEGRATION_DELETE",
   "JIRA_BOARDS_LIST",
   "JIRA_BOARD_COLUMNS_LIST",
+  "JIRA_AUTOMATION_LIST",
+  "JIRA_AUTOMATION_UPSERT",
+  "JIRA_AUTOMATION_DELETE",
+  "JIRA_ISSUE_GET",
+  "JIRA_COMMENT_ADD",
+  "JIRA_ISSUE_TRANSITION",
+  "JIRA_ATTACHMENT_DOWNLOAD",
 
   // Object Storage tools
   "LIST_OBJECTS",
@@ -892,7 +899,7 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
   },
   {
     name: "JIRA_INTEGRATION_GET",
-    description: "Get the org's Jira integration config and last sync status",
+    description: "Get the org's Jira integration config",
     category: "Jira",
   },
   {
@@ -913,6 +920,42 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
   {
     name: "JIRA_BOARD_COLUMNS_LIST",
     description: "List a Jira board's columns and statuses for the mapping",
+    category: "Jira",
+  },
+  {
+    name: "JIRA_AUTOMATION_LIST",
+    description: "List which Jira statuses start an agent run",
+    category: "Jira",
+  },
+  {
+    name: "JIRA_AUTOMATION_UPSERT",
+    description: "Run the agent on issues entering a Jira status",
+    category: "Jira",
+  },
+  {
+    name: "JIRA_AUTOMATION_DELETE",
+    description: "Stop running the agent on issues entering a Jira status",
+    category: "Jira",
+  },
+  {
+    name: "JIRA_ISSUE_GET",
+    description: "Re-read the Jira issue a run is working on",
+    category: "Jira",
+  },
+  {
+    name: "JIRA_COMMENT_ADD",
+    description: "Comment on the Jira issue a run is working on",
+    category: "Jira",
+  },
+  {
+    name: "JIRA_ISSUE_TRANSITION",
+    description: "Move the Jira issue a run is working on to another status",
+    category: "Jira",
+  },
+  {
+    name: "JIRA_ATTACHMENT_DOWNLOAD",
+    description:
+      "Get a short-lived download URL for an attachment of the run's Jira issue",
     category: "Jira",
   },
   {
@@ -1478,6 +1521,9 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "JIRA_INTEGRATION_DELETE",
       "JIRA_BOARDS_LIST",
       "JIRA_BOARD_COLUMNS_LIST",
+      "JIRA_AUTOMATION_LIST",
+      "JIRA_AUTOMATION_UPSERT",
+      "JIRA_AUTOMATION_DELETE",
     ],
   },
   {

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -379,6 +379,7 @@ export interface StudioToolIO {
         sortOrder: number;
         keySeq: number | null;
         externalUrl: string | null;
+        source: "jira" | null;
         retryAttempts: number;
         reviewCycleStartedAt: string | null;
         threads: {
@@ -447,6 +448,7 @@ export interface StudioToolIO {
         sortOrder: number;
         keySeq: number | null;
         externalUrl: string | null;
+        source: "jira" | null;
         retryAttempts: number;
         reviewCycleStartedAt: string | null;
         threads: {
@@ -541,6 +543,7 @@ export interface StudioToolIO {
         sortOrder: number;
         keySeq: number | null;
         externalUrl: string | null;
+        source: "jira" | null;
         retryAttempts: number;
         reviewCycleStartedAt: string | null;
         threads: {
@@ -3887,6 +3890,8 @@ export interface StudioToolIO {
                 | undefined;
               read_only?: boolean | undefined;
               runtime?: "cms" | "sandbox" | undefined;
+              source?: "jira" | undefined;
+              jira_issue_key?: string | undefined;
             }
           | undefined;
         run_config?: Record<string, unknown> | null | undefined;
@@ -3919,6 +3924,7 @@ export interface StudioToolIO {
       status?: string | undefined;
       userId?: string | undefined;
       agentId?: string | undefined;
+      source?: string | undefined;
     };
     output: {
       items: {
@@ -3954,6 +3960,8 @@ export interface StudioToolIO {
                 | undefined;
               read_only?: boolean | undefined;
               runtime?: "cms" | "sandbox" | undefined;
+              source?: "jira" | undefined;
+              jira_issue_key?: string | undefined;
             }
           | undefined;
         run_config?: Record<string, unknown> | null | undefined;
@@ -3998,6 +4006,8 @@ export interface StudioToolIO {
                 | undefined;
               read_only?: boolean | undefined;
               runtime?: "cms" | "sandbox" | undefined;
+              source?: "jira" | undefined;
+              jira_issue_key?: string | undefined;
             }
           | undefined;
         run_config?: Record<string, unknown> | null | undefined;
@@ -4030,6 +4040,8 @@ export interface StudioToolIO {
                 | undefined;
               read_only?: boolean | undefined;
               runtime?: "cms" | "sandbox" | undefined;
+              source?: "jira" | undefined;
+              jira_issue_key?: string | undefined;
             }
           | undefined;
         branch?: string | null | undefined;
@@ -4070,6 +4082,8 @@ export interface StudioToolIO {
                 | undefined;
               read_only?: boolean | undefined;
               runtime?: "cms" | "sandbox" | undefined;
+              source?: "jira" | undefined;
+              jira_issue_key?: string | undefined;
             }
           | undefined;
         run_config?: Record<string, unknown> | null | undefined;
@@ -4112,6 +4126,8 @@ export interface StudioToolIO {
                 | undefined;
               read_only?: boolean | undefined;
               runtime?: "cms" | "sandbox" | undefined;
+              source?: "jira" | undefined;
+              jira_issue_key?: string | undefined;
             }
           | undefined;
         run_config?: Record<string, unknown> | null | undefined;
@@ -5119,6 +5135,36 @@ export interface StudioToolIO {
   JIRA_BOARD_COLUMNS_LIST: {
     input: { boardId: string };
     output: { columns: { name: string; statuses: string[] }[] };
+  };
+  JIRA_AUTOMATION_LIST: {
+    input: { [x: string]: never };
+    output: { automations: { jiraStatus: string; prompt: string | null }[] };
+  };
+  JIRA_AUTOMATION_UPSERT: {
+    input: { jiraStatus: string; prompt?: string | null | undefined };
+    output: { automation: { jiraStatus: string; prompt: string | null } };
+  };
+  JIRA_AUTOMATION_DELETE: {
+    input: { jiraStatus: string };
+    output: { removed: boolean };
+  };
+  JIRA_ISSUE_GET: {
+    input: { [x: string]: never };
+    output: { key: string; url: string; status: string; markdown: string };
+  };
+  JIRA_COMMENT_ADD: { input: { body: string }; output: { commentId: string } };
+  JIRA_ISSUE_TRANSITION: {
+    input: { toStatus: string };
+    output: { status: string };
+  };
+  JIRA_ATTACHMENT_DOWNLOAD: {
+    input: { attachmentId: string };
+    output: {
+      url: string;
+      filename: string;
+      expiresAt: string;
+      command: string;
+    };
   };
   LIST_OBJECTS: {
     input: {


### PR DESCRIPTION
Stacked on #6888 (base: `refactor/jira-trigger-1-remove-mirror`). Merge that one first.

## Summary

The Jira integration becomes a **run trigger**. When an issue enters a Jira status that has a rule, Studio starts a Super Agent run on it. Nothing is copied to the board; the agent reads the issue and updates it in Jira.

**Trigger**
- `POST /api/_jira/webhook/:secret` now parses `jira:issue_updated` and reacts to the changelog's status item (`jira/trigger.ts`). Answers 202 before the work.
- `jiraTriggerSweepWorkflow` (DBOS, every 10 min, 15-min lookback) re-reads recent transitions off a changelog-expanded search — the safety net when the tenant never configured the webhook or Jira dropped one.
- `jira_trigger_claims` holds one row per (issue, changelog entry): the webhook, its redelivery and the sweep can all see the same transition and exactly one may dispatch. Verified on real Postgres with five concurrent claimers.

**Run anchor.** A hidden board item (`task_board_items.source = 'jira'`, excluded from `TASK_BOARD_ITEM_LIST`) per issue, linked through the reduced `task_board_item_jira_links`. Quota, PRs, review cycle and rerun keep working unchanged. The issue's content is rendered into the run's opening message (`jira/issue-prompt.ts`), never persisted. If dispatch fails the anchor is un-delegated rather than left assigned to an agent that will never run.

**Run tools.** The run's MCP endpoint (`/api/:org/mcp/task-run/:threadId`) serves `JIRA_ISSUE_GET`, `JIRA_COMMENT_ADD`, `JIRA_ISSUE_TRANSITION`, `JIRA_ATTACHMENT_DOWNLOAD` and `TASK_ADD_REPO` — and none of the board tools — when the thread is stamped `metadata.source = "jira"`. The download tool mints a signed, 10-minute grant bound to (org, attachment); `GET /api/_jira/attachments/:token` streams the bytes with the integration's credential. The sandbox never holds a Jira token.

**Rules.** `org_jira_column_automations`, keyed by Jira **status name** (a column is a bucket of statuses; the webhook reports the status). Tools `JIRA_AUTOMATION_LIST/UPSERT/DELETE`. Row existence is the switch; `prompt` null is the agent's own instruction.

**UI.** Settings → Board → Jira: one card per status of the chosen board with "Add automation" → prompt textarea → trash to remove. Monitoring → Threads: a **Source** filter (`COLLECTION_THREADS_LIST` gained `source`). Threads are titled `Jira <KEY>: <summary>`.

**Dev seam.** `JIRA_ALLOW_LOCAL_SITE_URL=1` admits `http://localhost:<port>` as a Jira site so a stand-in Jira can drive local/e2e testing. Off unless set; production behaviour unchanged.

## Testing

- `bun run check`, `bun run lint`, `bun run fmt`, `knip`: clean. `DBOS_WORKFLOW_VERSION` unchanged (a new workflow is recovery-compatible); snapshot re-baselined.
- Unit: webhook payload parsing, changelog → transitions, issue rendering, grant token mint/verify/expiry/tamper, run-context tool surface by thread metadata.
- Real Postgres: claim fence under concurrency, one anchor per issue, anchor hidden from the board list, rules CRUD; the surrounding `tools/task-board` + `storage/task-board*` suites (1262 pass).
- **e2e (`packages/e2e/tests/jira-run-trigger.spec.ts`, 5 tests, green locally):** a stand-in Jira runs as a Playwright `webServer` and an integration points at it (`JIRA_ALLOW_LOCAL_SITE_URL=1`); everything else is the real path. Connect + credential check, board and column read by STATUS, rule CRUD, then the webhook: one transition → exactly one anchor + link + claim; a redelivery, a non-status update and an unruled status add nothing; the anchor never appears in `TASK_BOARD_ITEM_LIST`; an unknown secret 404s; the attachment route rejects a token it did not mint.
- **Also driven by hand in a browser** against the same kind of stub: the run's MCP endpoint served exactly the five Jira tools and no board tool, `JIRA_ISSUE_GET` rendered description + comment + attachment id, `JIRA_COMMENT_ADD` posted ADF, `JIRA_ISSUE_TRANSITION` matched case-insensitively and listed the reachable statuses on a bad one, and `JIRA_ATTACHMENT_DOWNLOAD` minted a URL that streamed the bytes.

### What is still not covered, and why

The agent run itself. It needs a model provider, and this machine has no key (and no Docker daemon, so no sandbox pod either). The e2e asserts the dispatch by its **outcome**: with no provider the dispatch throws, and the spec pins that the anchor is left **unassigned** rather than delegated to a run that never starts. A run that actually completes — and the reviewer/PR path behind it — is unproven here and wants a staging org with a provider.

### Found while testing

A Jira-triggered run in an org with **no repo** does not take the sandbox harness, so it never reaches the run-scoped MCP endpoint that serves the Jira tools — it went to Decopilot and got the **task board** built-ins. It would have "updated the task" on the hidden anchor nobody reads while the issue went untouched. Decopilot now makes the same swap the endpoint does, off the run thread's own `metadata.source`. This was the second commit; it is why the PR grew past the trigger itself.

## Follow-ups
- The redelivery path re-reads the issue before discovering the claim is taken; a cheap pre-check would save one Jira round-trip.
- The e2e cannot dispatch a run (no provider); worth extending once a staging org with a model is available to the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Jira no longer mirrors issues into the board. When an issue enters a configured Jira status, Studio starts an agent run against Jira, while a hidden anchor preserves quota, pull request, review, and rerun support.

**Triggering**
- The webhook starts runs immediately, and a 10-minute DBOS sweep catches missed or unconfigured webhooks.
- A per-transition claim prevents redeliveries and the sweep from creating more than one paid run.
- Settings now configures rules by Jira status name, with Jira runs available as a Monitoring → Threads source filter.

**Run access**
- The issue, comments, and attachment IDs appear in the opening message but are not stored as board content.
- Jira-triggered runs expose Jira issue, comment, transition, and attachment tools instead of board tools, on the sandbox MCP endpoint and in Decopilot built-ins alike.
- Attachment downloads use signed 10-minute grants, so the sandbox never receives a Jira token.
- An e2e suite drives the flow against a stand-in Jira, enabled with `JIRA_ALLOW_LOCAL_SITE_URL=1`; the mirror-removal refactor must land first.

<sup>Written for commit 4cf17f147d5e3726b65702d24f77e8ece3c426f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

