### PR TITLE
refactor(org-home): drop the redundant TranslationKey cast in NewTaskComposer

### DIFF
--- a/apps/web/src/components/org-home/new-task-composer.tsx
+++ b/apps/web/src/components/org-home/new-task-composer.tsx
@@ -34,7 +34,6 @@ import {
 import { track } from "@/lib/posthog-client";
 import { toast } from "sonner";
 import { useT } from "@/i18n/use-t.ts";
-import type { TranslationKey } from "@/i18n/use-t.ts";
 import type { ComponentType, ReactNode } from "react";
 
 /** One attribute pill: a glyph, the value or its unset name, a menu. */
@@ -262,7 +261,7 @@ export function NewTaskComposer() {
               key={value}
               icon={PRIORITY_CONFIG[value].icon}
               iconClassName={PRIORITY_CONFIG[value].iconClassName}
-              label={t(PRIORITY_CONFIG[value].labelKey as TranslationKey)}
+              label={t(PRIORITY_CONFIG[value].labelKey)}
               selected={priority === value}
               onSelect={() => setPriority(priority === value ? null : value)}
             />


### PR DESCRIPTION
Follows #6801 (the org-home redesign that introduced `NewTaskComposer`).

`PRIORITY_CONFIG[value].labelKey` is already typed as `TranslationKey` in `apps/web/src/layouts/task-board/config.tsx` (`Record<TaskBoardItemPriority, { labelKey: TranslationKey; ... }>`), so the `as TranslationKey` cast on it in the priority-pill options was dead weight — the type pill immediately below it, reading `TASK_TYPE_CONFIG[value].labelKey` (identically typed), needs no such cast. A stray cast like this is exactly the kind of thing that silently swallows a real type error if `labelKey`'s type is ever narrowed or `PRIORITY_CONFIG`'s shape changes; removing it keeps that a compile-time error again.

Dropped the cast and its now-unused `TranslationKey` import.

To confirm: `cd apps/web && bunx tsc --noEmit` (no errors reference `new-task-composer.tsx`; the file typechecks with the cast removed, proving the cast was never load-bearing).

Locally ran `bun run fmt`, `bunx tsc --noEmit` (apps/web workspace — one pre-existing, unrelated prosemirror version-mismatch error in `mention-suggestion.tsx`, present before this change), and `bunx oxlint apps/web/src/components/org-home/new-task-composer.tsx` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the redundant `as TranslationKey` cast on `PRIORITY_CONFIG[value].labelKey` in `NewTaskComposer`'s priority pill, since `PRIORITY_CONFIG` already types `labelKey` as `TranslationKey`. Dropping the cast keeps a future change to `labelKey`'s type a compile-time error instead of a silent one; also removes the now-unused `TranslationKey` import.

<sup>Written for commit 530052cbe49ab776acf879ce7cf1af903d34c3c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

