### PR TITLE
fix(virtual-mcp): cap description length and kickstart prompts array size

### DIFF
--- a/packages/shared/src/sdk/types/virtual-mcp.test.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.test.ts
@@ -218,6 +218,34 @@ test("VirtualMCPUpdateDataSchema accepts metadata.runtime", () => {
   expect(parsed.metadata?.runtime?.port).toBeNull();
 });
 
+test("VirtualMCPCreateDataSchema rejects a description over 500 chars", () => {
+  const result = VirtualMCPCreateDataSchema.safeParse({
+    title: "Agent",
+    description: "a".repeat(501),
+    connections: [],
+  });
+  expect(result.success).toBe(false);
+});
+
+test("VirtualMCPCreateDataSchema rejects more than 20 kickstart prompts", () => {
+  const result = VirtualMCPCreateDataSchema.safeParse({
+    title: "Agent",
+    connections: [],
+    prompts: Array.from({ length: 21 }, (_, i) => ({
+      title: `Prompt ${i}`,
+      text: "hi",
+    })),
+  });
+  expect(result.success).toBe(false);
+});
+
+test("VirtualMCPUpdateDataSchema rejects a description over 500 chars", () => {
+  const result = VirtualMCPUpdateDataSchema.safeParse({
+    description: "a".repeat(501),
+  });
+  expect(result.success).toBe(false);
+});
+
 test("SandboxRecord.startedWith is optional with nullable packageManager/port/path", () => {
   const a = SandboxRecordSchema.parse({ sandboxHandle: "v", previewUrl: null });
   expect(a.startedWith).toBeUndefined();

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -870,6 +870,7 @@ export const VirtualMCPCreateDataSchema = z.object({
   title: z.string().min(1).max(255).describe("Name for the virtual MCP"),
   description: z
     .string()
+    .max(500)
     .nullable()
     .optional()
     .describe("Optional description"),
@@ -902,6 +903,7 @@ export const VirtualMCPCreateDataSchema = z.object({
     ),
   prompts: z
     .array(AgentKickstartPromptSchema)
+    .max(20)
     .optional()
     .describe(
       "Optional kickstart prompts to seed on the agent. Each becomes a clickable conversation starter (icebreaker) on the agent. Author them from the agent's role and the tools it will have so they're coherent and immediately useful.",
@@ -917,6 +919,7 @@ export const VirtualMCPUpdateDataSchema = z.object({
   title: z.string().min(1).max(255).optional().describe("New name"),
   description: z
     .string()
+    .max(500)
     .nullable()
     .optional()
     .describe("New description (null to clear)"),
@@ -944,6 +947,7 @@ export const VirtualMCPUpdateDataSchema = z.object({
     .describe("New connections (replaces existing)"),
   prompts: z
     .array(AgentKickstartPromptSchema)
+    .max(20)
     .optional()
     .describe(
       "Replace the agent's kickstart prompts with this full set. Omit to leave them unchanged; pass an empty array to remove all. Each becomes a clickable conversation starter (icebreaker).",


### PR DESCRIPTION
**Source:** a bounded gap in the virtual MCP entity schema, in the same DoS-bound category as #6904/#6908/#6911/#6916 (which just capped `AgentKickstartPromptSchema.text` at 4000 chars on this same schema).

**Payoff:** `VirtualMCPCreateDataSchema`/`VirtualMCPUpdateDataSchema` capped `title` at 255 chars but left `description` completely unbounded, and left the `prompts` array (kickstart icebreakers) with no size limit at all — any org member could persist an arbitrarily large description or hundreds of kickstart prompts on a virtual MCP row, all serialized into the connection's `metadata`/columns on every read.

**Fix:** `description` capped at 500 chars (matches the existing convention on `secrets`/`file-configs` description fields), `prompts` capped at 20 entries (a generous ceiling for onboarding icebreakers — no legitimate agent needs more).

**Verify:** `bun test packages/shared/src/sdk/types/virtual-mcp.test.ts` — added 3 tests: rejects a >500-char description on create and update, rejects a 21-entry prompts array on create.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (packages/shared, clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file (34/34 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the `description` length and `prompts` array size on the virtual MCP create and update schemas, preventing unbounded payloads that could be used for denial of service.

- `description` is now limited to 500 characters (matching other description fields).
- `prompts` is now limited to 20 entries (a generous ceiling for icebreakers).
- Existing payloads exceeding these limits will now fail validation.

<sup>Written for commit cd3b5bc884c925e194d8fb0f3dbeafbb32d6d91b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

