### PR TITLE
fix(reports): retry a transient 5xx on the connection-status GET

### DIFF
--- a/apps/api/src/tools/reports/auth-client.test.ts
+++ b/apps/api/src/tools/reports/auth-client.test.ts
@@ -592,4 +592,59 @@ describe("fetchCommerceDiscoveryConnectionStatus", () => {
     );
     expect(out).toEqual({ providers: {}, claimed: false });
   });
+
+  test("retries a transient 503 and succeeds once the upstream recovers", async () => {
+    let calls = 0;
+    const out = await fetchCommerceDiscoveryConnectionStatus(
+      { siteUrl: "https://example.com", orgId: "org_123" },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async () => {
+          calls += 1;
+          if (calls < 3) {
+            return new Response("upstream unavailable", { status: 503 });
+          }
+          return Response.json({ providers: {} });
+        },
+      },
+    );
+    expect(calls).toBe(3);
+    expect(out).toEqual({ providers: {}, claimed: true });
+  });
+
+  test("gives up after exhausting retries on a persistent 503, surfacing the status", async () => {
+    let calls = 0;
+    await expect(
+      fetchCommerceDiscoveryConnectionStatus(
+        { siteUrl: "https://example.com", orgId: "org_123" },
+        {
+          baseUrl: "https://commerce.example.test",
+          apiKey: "master-key",
+          fetchImpl: async () => {
+            calls += 1;
+            return new Response("upstream unavailable", { status: 503 });
+          },
+        },
+      ),
+    ).rejects.toThrow("Commerce Discovery auth failed with status 503.");
+    expect(calls).toBe(3);
+  });
+
+  test("does not retry a 404 (not a transient failure)", async () => {
+    let calls = 0;
+    const out = await fetchCommerceDiscoveryConnectionStatus(
+      { siteUrl: "https://example.com", orgId: "org_123" },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async () => {
+          calls += 1;
+          return Response.json({ error: "not_found" }, { status: 404 });
+        },
+      },
+    );
+    expect(calls).toBe(1);
+    expect(out).toEqual({ providers: {}, claimed: false });
+  });
 });

--- a/apps/api/src/tools/reports/auth-client.ts
+++ b/apps/api/src/tools/reports/auth-client.ts
@@ -1,4 +1,5 @@
 import { COMMERCE_DISCOVERY_MCP_URL } from "@decocms/shared/sdk";
+import { retry, RetryError } from "@decocms/shared/std";
 import { z } from "zod";
 import { getSettings } from "../../settings";
 import type { Settings } from "../../settings";
@@ -398,6 +399,55 @@ export async function triggerCommerceDiscoveryRun(
   return { triggered: true };
 }
 
+/** A transient (5xx / 429) status from a status-check GET, carrying the
+ *  message already built from the response body so a retry exhaustion still
+ *  surfaces something actionable instead of a generic "retries exceeded". */
+class TransientStatusResponseError extends Error {}
+
+/**
+ * A GET is always safe to retry — unlike the /upgrade, /bindings, and /run
+ * POSTs above (each idempotent only because the callee de-dupes on its own
+ * side, not because a retry can't double an effect), this call has no side
+ * effect at all. So a single flaky 5xx from Commerce Discovery no longer
+ * fails the whole "Conectado" status read.
+ */
+async function fetchStatusWithRetry(
+  fetchImpl: FetchImpl,
+  url: string,
+  apiKey: string,
+): Promise<Response> {
+  try {
+    return await retry(
+      async () => {
+        const response = await fetchImpl(url, {
+          method: "GET",
+          headers: { Authorization: `Bearer ${apiKey}` },
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        });
+        if (response.status >= 500 || response.status === 429) {
+          throw new TransientStatusResponseError(
+            await responseErrorMessage(response),
+          );
+        }
+        return response;
+      },
+      {
+        maxAttempts: 3,
+        minTimeout: 200,
+        maxTimeout: 2000,
+        multiplier: 2,
+        jitter: 1,
+        isRetriable: (error) => error instanceof TransientStatusResponseError,
+      },
+    );
+  } catch (error) {
+    if (error instanceof RetryError && error.cause instanceof Error) {
+      throw error.cause;
+    }
+    throw error;
+  }
+}
+
 const ConnectionStatusSchema = z.object({
   providers: z.record(
     z.string(),
@@ -437,11 +487,7 @@ export async function fetchCommerceDiscoveryConnectionStatus(
     domain,
   )}/connections/status?org_id=${encodeURIComponent(input.orgId)}`;
 
-  const response = await fetchImpl(url, {
-    method: "GET",
-    headers: { Authorization: `Bearer ${apiKey}` },
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  });
+  const response = await fetchStatusWithRetry(fetchImpl, url, apiKey);
 
   if (response.status === 404 || response.status === 409) {
     return { providers: {}, claimed: false };


### PR DESCRIPTION
**Source:** hardening in `apps/api/src/tools/reports/auth-client.ts` (reports-tool-hardening focus area). Not tied to an issue — found by comparing this file's HTTP resilience to the repo's own established pattern in `apps/api/src/jira/client.ts` (retry-on-5xx/429, no-retry-on-4xx), which the reports client didn't have at all.

**Why a maintainer wants it:** `fetchCommerceDiscoveryConnectionStatus` (the GET behind the org's "Conectado" status card) had zero retry logic. A single flaky 503/429 from Commerce Discovery — a real external service — failed the whole status read for the user, even though a GET has no side effect and is always safe to retry. The other three calls in this file (`/upgrade`, `/bindings`, `/run` — all POSTs) are deliberately left untouched: they're only idempotent because the callee de-dupes server-side, so blindly retrying them on a lost response risks a double effect, which is out of scope for this PR.

**Failure scenario:** Commerce Discovery returns a transient 503 (deploy blip, brief overload) while a user opens their connections tab → the whole providers list throws instead of showing what's actually connected, even though retrying a few hundred ms later would have succeeded.

**Fix:** wraps the status GET in the repo's canonical `@decocms/shared/std` `retry()`, using the exact backoff shape and `isRetriable` structure already proven in `apps/api/src/jira/client.ts` (retry 5xx/429, fail fast on 4xx). Added 3 new tests: retries-then-succeeds on a transient 503, gives up and surfaces the real status after exhausting attempts, and confirms a 404 is NOT retried (it's a legitimate soft "not claimed" state, not a transient failure).

**To verify:** `bun test apps/api/src/tools/reports/auth-client.test.ts` (29 pass, including the 3 new ones).

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above, and `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient 5xx/429 responses on the Commerce Discovery connection-status GET so a single flaky upstream error no longer fails the whole status read. Previously this GET had no retry logic, unlike the repo's jira client.

**Bug Fixes**

- Uses `retry()` from `@decocms/shared/std` with the same backoff shape as the jira client (3 attempts, 200ms–2s with jitter).
- Retries 5xx and 429; fails fast on 4xx, and 404/409 still resolve to the soft "not claimed" state.
- POSTs (`/upgrade`, `/bindings`, `/run`) are left unchanged because retrying them risks double effects.

<sup>Written for commit df0e2ae86d5eeb30e485ef2a45ba3a1a8a24681c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

