### PR TITLE
refactor(sidebar): remove dead orderRevision state from SidebarAgentGroupsContext

### DIFF
--- a/apps/web/src/components/sidebar/agents-section.tsx
+++ b/apps/web/src/components/sidebar/agents-section.tsx
@@ -53,10 +53,7 @@ import {
   agentHasClonableSource,
   getDevAgentIds,
 } from "@/lib/agent-capabilities";
-import {
-  useSidebarAgentGroupsEmpty,
-  useBumpSidebarOrderRevision,
-} from "./sidebar-agent-groups-context";
+import { useSidebarAgentGroupsEmpty } from "./sidebar-agent-groups-context";
 import { useT } from "@/i18n/use-t.ts";
 
 function CollectionSearchWrapper({
@@ -389,7 +386,6 @@ function PinAgentPopoverContent({
   const allAgents = useVirtualMCPs({ searchTerm: deferredSearch || undefined });
   const agents = allAgents ?? [];
   const { org } = useProjectContext();
-  const bumpOrderRevision = useBumpSidebarOrderRevision();
 
   const navigateToNewTask = useNavigateToNewTaskWithBranchCarry(org.slug);
 
@@ -440,7 +436,6 @@ function PinAgentPopoverContent({
       setSearch("");
       return;
     }
-    bumpOrderRevision();
     onClose();
     setSearch("");
     navigateToNewTask(agent.id);

--- a/apps/web/src/components/sidebar/sidebar-agent-groups-context.tsx
+++ b/apps/web/src/components/sidebar/sidebar-agent-groups-context.tsx
@@ -3,8 +3,6 @@ import { createContext, useContext, useState, type ReactNode } from "react";
 interface SidebarAgentGroupsContextValue {
   empty: boolean;
   setEmpty: (next: boolean) => void;
-  orderRevision: number;
-  bumpOrderRevision: () => void;
 }
 
 const SidebarAgentGroupsContext =
@@ -16,13 +14,9 @@ export function SidebarAgentGroupsProvider({
   children: ReactNode;
 }) {
   const [empty, setEmpty] = useState(false);
-  const [orderRevision, setOrderRevision] = useState(0);
-  const bumpOrderRevision = () => setOrderRevision((n) => n + 1);
 
   return (
-    <SidebarAgentGroupsContext.Provider
-      value={{ empty, setEmpty, orderRevision, bumpOrderRevision }}
-    >
+    <SidebarAgentGroupsContext.Provider value={{ empty, setEmpty }}>
       {children}
     </SidebarAgentGroupsContext.Provider>
   );
@@ -30,8 +24,4 @@ export function SidebarAgentGroupsProvider({
 
 export function useSidebarAgentGroupsEmpty(): boolean {
   return useContext(SidebarAgentGroupsContext)?.empty ?? false;
-}
-
-export function useBumpSidebarOrderRevision(): () => void {
-  return useContext(SidebarAgentGroupsContext)?.bumpOrderRevision ?? (() => {});
 }

--- a/apps/web/src/hooks/use-navigate-to-agent.ts
+++ b/apps/web/src/hooks/use-navigate-to-agent.ts
@@ -15,7 +15,6 @@ import {
 import { useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { authClient } from "@/lib/auth-client";
-import { useBumpSidebarOrderRevision } from "@/components/sidebar/sidebar-agent-groups-context";
 import { useOptionalThreadManager } from "@/components/chat/store/hooks";
 import type { Task } from "@/components/chat/task/types";
 import { findAgentEntryThread } from "@/lib/reusable-new-chat";
@@ -50,7 +49,6 @@ export function useNavigateToAgent() {
    *  not a wrong answer; it means "ask again on click". */
   const cachedAgents = useVirtualMCPsNonBlocking();
   const { data: session } = authClient.useSession();
-  const bumpOrderRevision = useBumpSidebarOrderRevision();
   /** The open-thread list is read at CLICK time, off the store. Subscribing
    *  re-rendered every sidebar row for a value nothing renders, and the
    *  snapshot a click needs is the one at the click. */
@@ -62,7 +60,6 @@ export function useNavigateToAgent() {
     options: NavigateToAgentOptions | undefined,
     wantedRuntime: ThreadRuntime | undefined,
   ) => {
-    bumpOrderRevision();
     /** Resume the agent's ENTRY thread — its last branch for a repo-backed
      *  agent, otherwise its empty chat — and mint a fresh id only when there is
      *  none. `wantedRuntime` narrows which empty chat qualifies, so "open the
@@ -112,7 +109,6 @@ export function useNavigateToAgent() {
   };
 
   return (virtualMcpId: string, options?: NavigateToAgentOptions) => {
-    bumpOrderRevision();
     // Both of these answer without awaiting, in the click's own task.
     const cached = cachedAgents.find((a) => a.id === virtualMcpId);
     if (options?.runtime) {


### PR DESCRIPTION
Source: reactive bug-hunt over the files touched by #6801 ("one sidebar, one picker, one scope"), specifically `agents-section.tsx` and `use-navigate-to-agent.ts` from my area's file hints.

`SidebarAgentGroupsContext` carried an `orderRevision` counter plus a `bumpOrderRevision()` setter, called from `agents-section.tsx`'s `handleSelect` and twice per navigation from `use-navigate-to-agent.ts` (once in the outer callback, once again inside `go()`). `rg -rn "orderRevision" apps/web/src` confirms the counter's *value* is never read anywhere outside the context file itself — no consumer subscribes to it, no derived list sorts by it. Bumping it only forces a re-render of the context's consumers, which then render the exact same `empty` value they already had, so every one of these calls was a pure no-op with no visible effect, on every single agent-navigation click.

Why a maintainer wants this: it's dead machinery masquerading as an active MRU/reorder mechanism — it reads like it does something (three call sites, plausible-looking comments) but has never had a consumer since it was introduced. Removing it deletes three no-op re-renders per navigation and the confusing surface area, with zero behavior change.

Net: -21 / +2 lines. Confirmed behavior-preserving: `orderRevision`'s value has zero readers repo-wide (single `rg` grep), and `empty`/`setEmpty` (the two fields anything actually reads) are untouched.

To confirm: `rg -n "orderRevision" apps/web/src` (no hits) and a manual click through the agent switcher / sidebar agent list still navigates and highlights the right agent.

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean on the touched files; one pre-existing, unrelated prosemirror version-mismatch error elsewhere), `bunx oxlint` on the 3 changed files (0 warnings/errors). No test needed — this is a pure dead-code removal with a `rg` zero-references proof, not new logic. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the dead `orderRevision` state from `SidebarAgentGroupsContext` and its call sites in `agents-section.tsx` and `use-navigate-to-agent.ts`. The counter was bumped on every agent navigation but never read anywhere in the app, so each call only forced a no-op re-render. Behavior is unchanged; this only deletes the misleading machinery and three wasted renders per navigation.

<sup>Written for commit 4829c0d635392d6b1764bf84847b51e19b47647b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

