### PR TITLE
fix(web): keep project rows in the collapsed sidebar rail

### DIFF
--- a/apps/web/src/components/sidebar/nav-row.tsx
+++ b/apps/web/src/components/sidebar/nav-row.tsx
@@ -41,6 +41,8 @@ interface SidebarNavRowProps {
   className?: string;
   /** `data-tour` anchor, for the rows a product tour highlights. */
   dataTour?: string;
+  /** Rows nested under this one, rendered inside its `<li>` after the button. */
+  children?: ReactNode;
 }
 
 export function SidebarNavRow({
@@ -52,6 +54,7 @@ export function SidebarNavRow({
   ariaLabel,
   className,
   dataTour,
+  children,
 }: SidebarNavRowProps) {
   const isCollapsed = useSidebarCollapsed();
   const name = ariaLabel ?? label;
@@ -89,6 +92,7 @@ export function SidebarNavRow({
             {body}
           </Link>
         </SidebarMenuButton>
+        {children}
       </SidebarMenuItem>
     );
   }
@@ -98,6 +102,7 @@ export function SidebarNavRow({
       <SidebarMenuButton {...shared} aria-label={name} onClick={onSelect}>
         {body}
       </SidebarMenuButton>
+      {children}
     </SidebarMenuItem>
   );
 }

--- a/apps/web/src/components/sidebar/projects-section.tsx
+++ b/apps/web/src/components/sidebar/projects-section.tsx
@@ -176,8 +176,8 @@ export function SidebarProjectsSection({
    *  underneath them turns the one place that says where you are into a place
    *  that says where you could be instead. The picker and the way back out are
    *  the controls for leaving; this section is the org's map.
-   *  The rail is icons only, and a nested task row has no icon to be. */
-  if (scopeId || collapsed || projects.length === 0) return null;
+   *  Collapsed keeps the rows at icon width; only the heading and the nested task rows drop, having no icon to be. */
+  if (scopeId || projects.length === 0) return null;
 
   const byProject = tasksNeedingMeByProject(
     projects,
@@ -187,14 +187,16 @@ export function SidebarProjectsSection({
 
   return (
     <div
-      className="flex flex-col gap-1"
+      className={cn("flex flex-col gap-1", collapsed && "pt-3")}
       data-tour={LAYOUT_TOUR_ANCHORS.projects}
     >
-      {/* The gap above is what separates the org's map from the destinations
-          it follows; the one below only sets the heading on its own list. */}
-      <p className="px-2 pt-5 pb-0.5 text-xs font-medium text-muted-foreground/60">
-        {t("sidebar.projects.heading")}
-      </p>
+      {/* The heading carries the gap that separates the org's map from the
+          destinations above it; collapsed, the container carries it instead. */}
+      {!collapsed && (
+        <p className="px-2 pt-5 pb-0.5 text-xs font-medium text-muted-foreground/60">
+          {t("sidebar.projects.heading")}
+        </p>
+      )}
       <SidebarMenu className="gap-1">
         {projects.map((project) => {
           const tasks = byProject.get(project.id) ?? [];
@@ -222,7 +224,7 @@ export function SidebarProjectsSection({
                   onNavigate?.();
                 }}
               />
-              {tasks.length > 0 && (
+              {!collapsed && tasks.length > 0 && (
                 <ul className={cn("flex flex-col")}>
                   {tasks.map((task, index) => (
                     <TaskRow

--- a/apps/web/src/components/sidebar/projects-section.tsx
+++ b/apps/web/src/components/sidebar/projects-section.tsx
@@ -201,31 +201,31 @@ export function SidebarProjectsSection({
         {projects.map((project) => {
           const tasks = byProject.get(project.id) ?? [];
           return (
-            <li key={project.id} className="flex flex-col">
-              <SidebarNavRow
-                icon={
-                  <AgentAvatar
-                    icon={project.icon}
-                    name={project.title}
-                    size="2xs"
-                    className="size-4 shrink-0"
-                  />
-                }
-                label={project.title}
-                isActive={project.id === scopeId}
-                /** A button, not a link: these resolve a SESSION, so the
-                 *  destination id is not knowable at render time — the same
-                 *  reason `ProjectNav`'s rows are buttons. */
-                onSelect={() => {
-                  track("sidebar_project_clicked");
-                  navigateToAgent(project.id, {
-                    panel: landingTabIdFor(project.metadata?.ui?.layout),
-                  });
-                  onNavigate?.();
-                }}
-              />
+            <SidebarNavRow
+              key={project.id}
+              icon={
+                <AgentAvatar
+                  icon={project.icon}
+                  name={project.title}
+                  size="2xs"
+                  className="size-4 shrink-0"
+                />
+              }
+              label={project.title}
+              isActive={project.id === scopeId}
+              /** A button, not a link: these resolve a SESSION, so the
+               *  destination id is not knowable at render time — the same
+               *  reason `ProjectNav`'s rows are buttons. */
+              onSelect={() => {
+                track("sidebar_project_clicked");
+                navigateToAgent(project.id, {
+                  panel: landingTabIdFor(project.metadata?.ui?.layout),
+                });
+                onNavigate?.();
+              }}
+            >
               {!collapsed && tasks.length > 0 && (
-                <ul className={cn("flex flex-col")}>
+                <ul className="flex flex-col">
                   {tasks.map((task, index) => (
                     <TaskRow
                       key={task.id}
@@ -237,7 +237,7 @@ export function SidebarProjectsSection({
                   ))}
                 </ul>
               )}
-            </li>
+            </SidebarNavRow>
           );
         })}
       </SidebarMenu>


### PR DESCRIPTION
## What is this contribution about?

With the sidebar collapsed, the org's projects disappeared from the nav entirely. `SidebarProjectsSection` returned `null` on `collapsed`, so the rail dropped from "the same map, narrower" to "a strictly worse nav" — the only way to reach a project became the picker popover.

The rows now render at icon width. `SidebarNavRow` already handles that state: it hides the label span, shows the project title as a tooltip, and keeps the `aria-label` in both states, so a collapsed project row is a named, reachable button. Only what has no icon to be still drops when collapsed:

- the **"Projects"** heading (it would render as stray text at icon width) — the container picks up `pt-3` so the group still reads as separate from the destinations above it;
- the **nested task rows** (text plus a tree elbow, nothing to draw at 16px).

The task-board query keeps its `enabled: !collapsed` gate, so the rail costs no extra request.

### Tap targets

Making the rows appear surfaced a second bug: they rendered at **16x16** in the rail while every other row is **34x34**.

The collapsed size rule is `w-full!` capped by `max-w-[calc(var(--sidebar-width-icon)-1rem)]`, so the button's width comes from its parent. This section wrapped each row in its own `<li className="flex flex-col">` to hold the nested task list — and under `SidebarMenu`'s collapsed `items-center`, that wrapper shrink-wraps to the icon, leaving `w-full` to resolve to 16px. The same wrapper was also an `<li>` around `SidebarNavRow`'s own `<li>`, which is invalid markup.

`SidebarNavRow` now accepts `children`, rendered inside its `SidebarMenuItem` after the button, so the task list lives in the row's own list item and the wrapper is gone. The button is a direct child of a full-width `SidebarMenuItem` again and sizes exactly like the destination rows. Measured in the browser: every rail button is now 34x34 on a 38px pitch, and `document.querySelectorAll('li > li').length` is 0.

The `scopeId` gate is unchanged: inside a project the sidebar is already about that project, so the org-wide list still hides there, collapsed or not.

## How did you verify your code works?

- `bun test apps/web/src/components/sidebar/` — 82 pass / 0 fail (the section's pure helpers, `needsAttention` and `tasksNeedingMeByProject`, are untouched by this change).
- `bun run fmt`, `bun run lint` (0 errors), `bun run check:ci` (all workspaces exit 0), `bun run knip` (no new findings).
- Ran the app locally (`bun run apps/api/src/cli.ts dev`) against a scratch org seeded with three projects and drove it in the browser:
  - expanded → "Projects" heading + three rows, unchanged;
  - collapsed → three project avatars render below Settings with the new gap;
  - the accessibility tree exposes them as `button "Storefront"` / `button "Checkout API"` / `button "Docs Site"` — named, not bare "button";
  - measured every rail button via `getBoundingClientRect()`: all 34x34, 38px apart, project rows included;
  - `li > li` count is 0;
  - temporarily stubbed two tasks per project to confirm the nested rows and their tree elbows still render correctly inside the row's `<li>` (stub reverted);
  - hovering one shows its title as a tooltip;
  - clicking one from the rail navigates into project scope (`?virtualmcpid=…`), at which point the list correctly hides again.

## Screenshots/Demonstration

Collapsed rail, org scope, three projects — the project icons sit below the Settings gear on the same 38px pitch as the destinations above them, and hovering one shows its title:

```
 GI          <- org
 [|]         <- collapse toggle
 -----
 Home        34x34
 Tasks       34x34
 Library     34x34
 Settings    34x34
              <- gap (was the heading's pt-5)
 (>_)        Docs Site      34x34
 (ıl)        Checkout API   34x34   <- tooltip on hover
 (&+)        Storefront     34x34
```

Screenshots attached in the linked session.

## How to Test

1. Open an org that has at least one project.
2. On the org home (no project scoped), confirm the sidebar shows the **Projects** list.
3. Collapse the sidebar.
4. **Expected:** the project icons stay in the rail, below Settings, separated by a small gap, and are the **same size and spacing** as the Home/Tasks/Library/Settings icons above them. Hovering one shows the project title; clicking one navigates into that project.
5. While scoped to a project, collapse and expand again — the org-wide project list stays hidden in both states (unchanged behavior).

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127daitRsPBp3vNVCyrF5LT
