### PR TITLE
fix(web): show the sandbox terminal only on the Site Editor

### DIFF
--- a/apps/web/src/layouts/main-panel-tabs/tab-id.ts
+++ b/apps/web/src/layouts/main-panel-tabs/tab-id.ts
@@ -209,8 +209,7 @@ export const GATED_CONTROL_PLANE_TABS = new Set<string>([
 
 // Agent-independent overlays (Tasks `board`, Library `files`, the commerce
 // report's `connect-sources`, the empty `reports`) take over the panel and aren't
-// sandbox-backed views. Shared by the drawer-visibility check and the
-// in-panel-app navigate allowlist so the two stay in sync.
+// sandbox-backed views. Also the in-panel-app navigate allowlist.
 export const OVERLAY_TABS = new Set([
   "board",
   "files",

--- a/apps/web/src/layouts/main-panel-tabs/terminal-drawer-gate.test.ts
+++ b/apps/web/src/layouts/main-panel-tabs/terminal-drawer-gate.test.ts
@@ -10,14 +10,19 @@ function input(
   return {
     hasClonableSource: true,
     fastPreviewActive: false,
-    mainTab: null,
+    mainTab: "site-editor",
     ...overrides,
   };
 }
 
 describe("shouldShowTerminalDrawer", () => {
-  test("shows for a sandbox session on a clonable agent", () => {
+  test("shows on the Site Editor for a sandbox session on a clonable agent", () => {
     expect(shouldShowTerminalDrawer(input())).toBe(true);
+  });
+
+  // `/site-editor?main=content` is the same route as the preview.
+  test("shows on the Site Editor's Content sub-view", () => {
+    expect(shouldShowTerminalDrawer(input({ mainTab: "content" }))).toBe(true);
   });
 
   // Callers only reach this gate with visibility already on.
@@ -33,17 +38,27 @@ describe("shouldShowTerminalDrawer", () => {
     );
   });
 
-  test("hides under an overlay tab", () => {
-    expect(shouldShowTerminalDrawer(input({ mainTab: "board" }))).toBe(false);
-    expect(shouldShowTerminalDrawer(input({ mainTab: "files" }))).toBe(false);
-    expect(
-      shouldShowTerminalDrawer(input({ mainTab: "connect-sources" })),
-    ).toBe(false);
-    expect(shouldShowTerminalDrawer(input({ mainTab: "reports" }))).toBe(false);
+  test("hides under every view that is not the Site Editor", () => {
+    for (const mainTab of [
+      "overview",
+      "settings",
+      "git",
+      "code",
+      "code:src%2Fapp.tsx",
+      "assets",
+      "automations",
+      "hosting",
+      "board",
+      "files",
+      "connect-sources",
+      "reports",
+      "discover",
+    ]) {
+      expect(shouldShowTerminalDrawer(input({ mainTab }))).toBe(false);
+    }
   });
 
-  test("shows under a non-overlay tab", () => {
-    expect(shouldShowTerminalDrawer(input({ mainTab: "preview" }))).toBe(true);
-    expect(shouldShowTerminalDrawer(input({ mainTab: "code" }))).toBe(true);
+  test("hides when the panel names no view", () => {
+    expect(shouldShowTerminalDrawer(input({ mainTab: null }))).toBe(false);
   });
 });

--- a/apps/web/src/layouts/main-panel-tabs/terminal-drawer-gate.ts
+++ b/apps/web/src/layouts/main-panel-tabs/terminal-drawer-gate.ts
@@ -9,11 +9,14 @@
  * "starting" (the `computePreviewState` fallback for "no previewUrl") next to a
  * Stop button for something that will never boot.
  *
- * Sandbox sessions get it unconditionally: there is no show/hide toggle, so this
- * gate is the only thing standing between a session and its terminal.
+ * Which views get it is an allowlist, so a new view opts in.
  */
 
-import { OVERLAY_TABS } from "./tab-id";
+/** The Site Editor surface: the preview, and `?main=content` on that segment. */
+const SITE_EDITOR_TABS: ReadonlySet<string> = new Set([
+  "site-editor",
+  "content",
+]);
 
 export interface TerminalDrawerGateInput {
   /** The agent (or the thread, via `load_repo`) has a repo to clone. */
@@ -34,6 +37,7 @@ export function shouldShowTerminalDrawer(
   return (
     input.hasClonableSource &&
     !input.fastPreviewActive &&
-    !(input.mainTab !== null && OVERLAY_TABS.has(input.mainTab))
+    input.mainTab !== null &&
+    SITE_EDITOR_TABS.has(input.mainTab)
   );
 }

--- a/packages/e2e/tests/sandbox-drawer-site-editor.spec.ts
+++ b/packages/e2e/tests/sandbox-drawer-site-editor.spec.ts
@@ -1,13 +1,9 @@
-/**
- * E2E: the sandbox PreviewDrawer renders below every main-panel tab on
- * cloneable agents — not just the preview tab. See spec at
- * docs/superpowers/specs/2026-06-03-sandbox-drawer-everywhere-design.md.
- */
+/** E2E: the sandbox PreviewDrawer renders on the Site Editor and nowhere else. */
 import { expect, test } from "../fixtures/test";
 import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
 
-test.describe("sandbox drawer is available on every main-panel tab", () => {
-  test("drawer toolbar renders on Settings and Preview tabs", async ({
+test.describe("sandbox drawer is scoped to the Site Editor", () => {
+  test("drawer toolbar renders on the Site Editor and not on Settings", async ({
     authedPage,
   }) => {
     const { page, orgSlug } = authedPage;
@@ -30,7 +26,7 @@ test.describe("sandbox drawer is available on every main-panel tab", () => {
       "COLLECTION_VIRTUAL_MCP_CREATE",
       {
         data: {
-          title: "drawer-everywhere e2e",
+          title: "drawer site-editor e2e",
           description: "cloneable",
           status: "active",
           pinned: false,
@@ -60,19 +56,19 @@ test.describe("sandbox drawer is available on every main-panel tab", () => {
     // we deliberately don't try to start the sandbox.
     const sandboxToolbarTab = page.getByRole("button", { name: /^sandbox$/i });
 
-    /** Settings is the most common non-preview tab, so landing the drawer there
-     *  proves it was hoisted out of PreviewContent. The legacy `?main=` URL is
-     *  translated on entry, which this pins too. */
-    await page.goto(
-      `/${orgSlug}/${thread.item.id}?virtualmcpid=${agent.item.id}&main=settings`,
-    );
-    await expect(sandboxToolbarTab).toBeVisible({ timeout: 15_000 });
-
-    // Switch to the preview tab via URL — the drawer was already visible
-    // here before the refactor, so this is the regression-prevention half.
+    /** The legacy `?main=preview` is translated to `site-editor` on entry. */
     await page.goto(
       `/${orgSlug}/${thread.item.id}?virtualmcpid=${agent.item.id}&main=preview`,
     );
     await expect(sandboxToolbarTab).toBeVisible({ timeout: 15_000 });
+
+    /** Wait on the settings body, so the absence below is a painted panel. */
+    await page.goto(
+      `/${orgSlug}/${thread.item.id}?virtualmcpid=${agent.item.id}&main=settings`,
+    );
+    await expect(page.getByPlaceholder("Project name")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(sandboxToolbarTab).toHaveCount(0);
   });
 });

--- a/packages/e2e/tests/tab-error-boundary-recovery.spec.ts
+++ b/packages/e2e/tests/tab-error-boundary-recovery.spec.ts
@@ -4,8 +4,6 @@
  * MainPanelContent) so the new tab renders normally. The sandbox drawer
  * stays interactive throughout — it's a sibling of the boundary.
  *
- * See spec at docs/superpowers/specs/2026-06-03-sandbox-drawer-everywhere-design.md.
- *
  * Trigger: dev-only `window.__forceTabError = <activeTab>` hook in
  * apps/web/src/layouts/main-panel-tabs/index.tsx's TabBody.
  */
@@ -15,7 +13,7 @@ import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
 
 test.describe("tab error boundary recovers on tab switch", () => {
   // Helper: create a clonable agent + thread + return their ids. Mirrors the
-  // setup used in sandbox-drawer-everywhere.spec.ts so the drawer assertion
+  // setup used in sandbox-drawer-site-editor.spec.ts so the drawer assertion
   // in scenario B is meaningful (agentHasClonableSource must be true).
   async function setup({ page, orgSlug }: { page: Page; orgSlug: string }) {
     const api = page.context().request;
@@ -100,13 +98,15 @@ test.describe("tab error boundary recovers on tab switch", () => {
     const { page, orgSlug } = authedPage;
     const { agentId, threadId } = await setup({ page, orgSlug });
 
+    /** The Site Editor is the one tab the drawer renders under, so it is the
+     *  only one whose crash can prove the drawer outlives a dead tab body. */
     await page.addInitScript(() => {
       (window as unknown as { __forceTabError?: string }).__forceTabError =
-        "settings";
+        "site-editor";
     });
 
     await page.goto(
-      `/${orgSlug}/${threadId}?virtualmcpid=${agentId}&main=settings`,
+      `/${orgSlug}/${threadId}?virtualmcpid=${agentId}&main=preview`,
     );
 
     // Error UI is visible inside the boundary.


### PR DESCRIPTION
## Summary

With a project selected, the bottom sandbox terminal drawer (the `sandbox` strip with Start/Stop and the setup/script log tabs) followed the user around the whole main panel. It gated on a **denylist** of four overlay tabs (`board`, `files`, `connect-sources`, `reports`), so it still rendered under Home, Settings, Code, Assets, Git, Automations and Hosting — and under a panel naming no view at all (`mainTab: null`) — even though it is a window onto the pod serving the *preview*.

This flips `shouldShowTerminalDrawer` to an **allowlist** of the Site Editor surface:

```ts
const SITE_EDITOR_TABS = new Set(["site-editor", "content"]);

input.hasClonableSource &&
  !input.fastPreviewActive &&
  input.mainTab !== null &&
  SITE_EDITOR_TABS.has(input.mainTab)
```

- `content` is in the set because `/site-editor?main=content` is the **same route** — `tabIdForPanel` gives it its own tab id but it shares the segment, so excluding it would make the strip flicker away when toggling Preview ↔ Content inside the Site Editor.
- `preview` is not, because ids reaching this gate already went through `normalizePanelSegment` (`preview` → `site-editor`).
- A new view now has to opt in rather than inherit the drawer.

The other two conditions — clonable source, and not a Fast Preview session — are unchanged.

## Testing

- `terminal-drawer-gate.test.ts`: the two tests encoding the denylist were **inverted**, not appended to. "hides under an overlay tab" / "shows under a non-overlay tab" became "hides under every view that is not the Site Editor" (sweeping `overview`, `settings`, `git`, `code`, `code:<path>`, `assets`, `automations`, `hosting` plus the four old overlays), with new cases for the Content sub-view and for `mainTab: null`. 6 pass.
- `bun run fmt`, `bun run lint` (0 errors) and `bun run --cwd=apps/web check` all clean.

## Affected areas

`apps/web` main panel only — one gate, one render site (`MainPanelWithDrawer` → `PreviewDrawerHost`). Also drops a stale line in `tab-id.ts` claiming `OVERLAY_TABS` is shared with the drawer-visibility check; its remaining consumers are `panel-route.ts` and `project-app-navigate.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKSc8f7PAhCpXVN8Qs6gL3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox terminal drawer so it appears only on the Site Editor instead of following the user to every panel view.

- The drawer previously gated on a denylist of four overlay tabs; it now uses an allowlist of `site-editor` and `content`, and hides when the panel names no view.
- `content` is included because `/site-editor?main=content` is the same route, avoiding a flicker when toggling between preview and content.
- The `hasClonableSource` and `fastPreviewActive` conditions are unchanged, and a new view must opt in to show the drawer.
- E2E specs were updated to match: the drawer renders on the Site Editor, is absent on Settings, and the error-boundary recovery test now crashes the Site Editor instead of Settings.

<sup>Written for commit e87866888e7fbcc0b6d75bf7186bb530c68f1a46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

