### PR TITLE
feat(git): author sandbox commits as the real publisher, not the bot

### DIFF
--- a/packages/sandbox/daemon-go/internal/gitx/coauthor.go
+++ b/packages/sandbox/daemon-go/internal/gitx/coauthor.go
@@ -37,6 +37,30 @@ func stripCoAuthorTrailers(message string) string {
 	return strings.TrimRight(strings.Join(kept, "\n"), " \t\r\n")
 }
 
+// CommitAttribution decides how a commit is attributed to the operator (the
+// human who triggered it — the thread owner / publisher). Git's committer stays
+// the configured bot identity; only the Author changes.
+//
+//   - operator has a valid name AND email → they become the git Author via
+//     `--author`, and the now-redundant Co-authored-by trailer is dropped
+//     (a commit authored by X should not also list X as a co-author).
+//   - otherwise → we cannot form a valid `--author`, so we fall back to the
+//     Co-authored-by trailer so attribution is never lost.
+//
+// Returns the (possibly rewritten) commit message and the extra `git commit`
+// args to splice in before `-m` (empty when there is no valid author).
+func CommitAttribution(message string, operator *CoAuthorIdentity) (msg string, authorArgs []string) {
+	var normalized *CoAuthorIdentity
+	if operator != nil {
+		normalized = NormalizeCoAuthorIdentity(operator.UserName, operator.UserEmail)
+	}
+	if normalized != nil && normalized.UserEmail != "" {
+		author := normalized.UserName + " <" + normalized.UserEmail + ">"
+		return stripCoAuthorTrailers(message), []string{"--author", author}
+	}
+	return AppendCoAuthorTrailer(message, operator), nil
+}
+
 func AppendCoAuthorTrailer(message string, operator *CoAuthorIdentity) string {
 	if operator == nil {
 		return message

--- a/packages/sandbox/daemon-go/internal/gitx/coauthor_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/coauthor_test.go
@@ -1,0 +1,51 @@
+package gitx
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCommitAttributionMakesOperatorTheAuthor(t *testing.T) {
+	msg, args := CommitAttribution("Update from sandbox", &CoAuthorIdentity{
+		UserName:  "Jane Doe",
+		UserEmail: "jane@example.com",
+	})
+	if msg != "Update from sandbox" {
+		t.Fatalf("message = %q, want unchanged", msg)
+	}
+	want := []string{"--author", "Jane Doe <jane@example.com>"}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("authorArgs = %v, want %v", args, want)
+	}
+}
+
+func TestCommitAttributionDropsRedundantTrailer(t *testing.T) {
+	// A client-supplied trailer must not survive once the same person is the author.
+	msg, args := CommitAttribution(
+		"Publish\n\nCo-authored-by: Jane Doe <jane@example.com>",
+		&CoAuthorIdentity{UserName: "Jane Doe", UserEmail: "jane@example.com"},
+	)
+	if msg != "Publish" {
+		t.Fatalf("message = %q, want trailer stripped", msg)
+	}
+	if len(args) != 2 {
+		t.Fatalf("authorArgs = %v, want --author set", args)
+	}
+}
+
+func TestCommitAttributionFallsBackToTrailerWithoutEmail(t *testing.T) {
+	msg, args := CommitAttribution("Update", &CoAuthorIdentity{UserName: "Jane Doe"})
+	if args != nil {
+		t.Fatalf("authorArgs = %v, want nil (no valid author)", args)
+	}
+	if msg != "Update\n\nCo-authored-by: Jane Doe" {
+		t.Fatalf("message = %q, want co-author trailer fallback", msg)
+	}
+}
+
+func TestCommitAttributionNoOperator(t *testing.T) {
+	msg, args := CommitAttribution("Update", nil)
+	if args != nil || msg != "Update" {
+		t.Fatalf("CommitAttribution(nil) = (%q, %v), want (\"Update\", nil)", msg, args)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/gitx/publish.go
+++ b/packages/sandbox/daemon-go/internal/gitx/publish.go
@@ -317,7 +317,7 @@ func Publish(deps PublishDeps, message string) error {
 		if deps.GetOperator != nil {
 			operator = deps.GetOperator()
 		}
-		commitMsg := AppendCoAuthorTrailer(msg, operator)
+		commitMsg, authorArgs := CommitAttribution(msg, operator)
 		env := map[string]string{
 			"GIT_CEILING_DIRECTORIES": repoDir,
 			"GIT_OPTIONAL_LOCKS":      "0",
@@ -325,7 +325,9 @@ func Publish(deps PublishDeps, message string) error {
 		for k, v := range skipHooksEnv {
 			env[k] = v
 		}
-		args := []string{"-c", "core.hooksPath=" + getEmptyHooksDir(), "commit", "--no-verify", "-m", commitMsg}
+		args := []string{"-c", "core.hooksPath=" + getEmptyHooksDir(), "commit", "--no-verify"}
+		args = append(args, authorArgs...)
+		args = append(args, "-m", commitMsg)
 		if _, err := Run(args, RunOpts{Cwd: repoDir, Env: env}); err != nil {
 			return err
 		}

--- a/packages/sandbox/daemon-go/internal/gitx/publish_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/publish_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -80,6 +81,41 @@ func TestInstallSandboxHooksWritesTheBranchList(t *testing.T) {
 			t.Fatal("feature branch was refused as protected")
 		}
 		// Any other error is expected — this repo has no `origin` to push to.
+	}
+}
+
+// The published commit must be authored by the operator (the human publisher),
+// while the committer stays the configured bot identity.
+func TestPublishAuthorsCommitAsOperator(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature/x")
+	if err := os.WriteFile(filepath.Join(repo, "f.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// No origin: Publish commits, then fails at push. The commit is what we assert.
+	_ = Publish(PublishDeps{
+		RepoDir: repo,
+		GetOperator: func() *CoAuthorIdentity {
+			return &CoAuthorIdentity{UserName: "Jane Doe", UserEmail: "jane@example.com"}
+		},
+	}, "Publish content")
+
+	show := func(format string) string {
+		cmd := exec.Command("git", "log", "-1", "--pretty="+format)
+		cmd.Dir = repo
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("git log: %v", err)
+		}
+		return string(out)
+	}
+	if got := show("%an <%ae>"); got != "Jane Doe <jane@example.com>\n" {
+		t.Fatalf("author = %q, want the operator", got)
+	}
+	if got := show("%cn <%ce>"); got != "t <t@example.com>\n" {
+		t.Fatalf("committer = %q, want the configured bot identity", got)
+	}
+	if body := show("%B"); strings.Contains(body, "Co-authored-by:") {
+		t.Fatalf("commit body still has a co-author trailer: %q", body)
 	}
 }
 

--- a/packages/sandbox/daemon-go/internal/gitx/rebase.go
+++ b/packages/sandbox/daemon-go/internal/gitx/rebase.go
@@ -77,10 +77,10 @@ func commitBeforeRebase(repoDir string, operator *CoAuthorIdentity) error {
 	if _, err := rebaseRun(repoDir, []string{"add", "."}); err != nil {
 		return err
 	}
-	args := []string{
-		"-c", "core.hooksPath=" + getEmptyHooksDir(),
-		"commit", "--no-verify", "-m", AppendCoAuthorTrailer("Before rebase", operator),
-	}
+	commitMsg, authorArgs := CommitAttribution("Before rebase", operator)
+	args := []string{"-c", "core.hooksPath=" + getEmptyHooksDir(), "commit", "--no-verify"}
+	args = append(args, authorArgs...)
+	args = append(args, "-m", commitMsg)
 	_, err := rebaseRun(repoDir, args, skipHooksEnv)
 	return err
 }


### PR DESCRIPTION
## Problema

Os commits git do daemon do sandbox eram **autorados E committados pelo bot** (a identidade do git config setada por `ConfigureGitIdentity`), e a pessoa responsável pela thread/publish aparecia só como `Co-authored-by:` no corpo. Isso quebra auditoria de commits/compliance e integrações de release-tracking (ex: DX) que dependem do campo **Author** para identificar quem publicou.

Exemplo do estado atual:
```
Author:    Deco Studio <studio@deco.cx>
Committer: Deco Studio <studio@deco.cx>
chore(daemon): sync all local changes to remote on shutdown
Co-authored-by: Wilgnne Khawan Barbosa Alencar <wilgnne.alencar@stone.com.br>
```

## Solução (padrão Admin v1)

**Author = a pessoa responsável (dona da thread / quem publica), Committer = o bot do Studio.**

- Novo helper `CommitAttribution`: quando o operator tem **nome + email válidos**, ele vira o git author (`git commit --author`) e o trailer `Co-authored-by:` redundante é removido; sem email válido → cai no trailer, pra atribuição nunca sumir. O committer continua a identidade do git config (o bot).
- Aplicado nos caminhos de commit de **publish** e **rebase** do daemon.

## Fora de escopo (de propósito)

O caminho de publish sandbox-less (decofile / GitHub Git Data API) **não** foi alterado. O `POST /git/commits` do GitHub preenche o `committer` a partir do `author` quando o `committer` é omitido — então atribuir esse caminho corretamente exige setar um committer explícito (a identidade do app-bot) e preservar a verificação ("Verified") do commit. Isso fica para uma PR separada.

## Nota sobre "parou de marcar"

A marcação (co-author) some inteira quando o operator não tem um `name` de exibição — `normalizeCoAuthorIdentity` exige nome (só email não basta). Esta PR melhora o caso comum (a pessoa vira Author de verdade), mas o mesmo requisito de nome permanece. Cobrir contas sem nome (derivar um nome do local-part do email) fica como follow-up de produto.

## Testes

- Go `gitx` (suíte completa) ✅
- Novos testes: `CommitAttribution` (unit) + end-to-end em `publish_test.go` afirmando Author=pessoa / Committer=bot / sem trailer.

> Lembrete: o daemon Go roda como binário no sandbox, então a mudança só vale nos pods após a imagem do sandbox ser buildada/deployada com este commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)