### PR TITLE
feat(branch-picker): prefix branch tooltip with "branch:"

### DIFF
--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -412,6 +412,7 @@ function VersionRow({
   disabled?: boolean;
   onSelect: () => void;
 }) {
+  const t = useT();
   const row = (
     <button
       type="button"
@@ -433,7 +434,7 @@ function VersionRow({
     <Tooltip>
       <TooltipTrigger asChild>{row}</TooltipTrigger>
       <TooltipContent side="bottom" className="font-mono text-xs">
-        {branch}
+        {t("thread.branchPicker.branchTooltip", { branch })}
       </TooltipContent>
     </Tooltip>
   );
@@ -479,7 +480,7 @@ function ReleaseRow({
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom" className="font-mono text-xs">
-          {release.branch}
+          {t("thread.branchPicker.branchTooltip", { branch: release.branch })}
         </TooltipContent>
       </Tooltip>
       <DropdownMenu>

--- a/apps/web/src/i18n/en/thread.ts
+++ b/apps/web/src/i18n/en/thread.ts
@@ -1,5 +1,6 @@
 export const thread = {
   "thread.branchPicker.allLoaded": "All loaded",
+  "thread.branchPicker.branchTooltip": "branch: {branch}",
   "thread.branchPicker.branchesTab": "Branches",
   "thread.branchPicker.couldntLoadBranches":
     "Couldn't load branches from GitHub. You can still pick from your branches.",

--- a/apps/web/src/i18n/pt-br/thread.ts
+++ b/apps/web/src/i18n/pt-br/thread.ts
@@ -2,6 +2,7 @@ import type { thread as threadEn } from "../en/thread.ts";
 
 export const thread = {
   "thread.branchPicker.allLoaded": "Todas carregadas",
+  "thread.branchPicker.branchTooltip": "branch: {branch}",
   "thread.branchPicker.branchesTab": "Branches",
   "thread.branchPicker.couldntLoadBranches":
     "Não foi possível carregar branches do GitHub. Você ainda pode escolher entre suas branches.",


### PR DESCRIPTION
## Summary
The version/branch picker in the Studio editor showed just the bare git branch name (e.g. `main`) on hover. This changes the tooltip to `branch: main` so it's clearer what the value is.

Applies to both tooltips in the active drafts-mode picker:
- `VersionRow` (Production / Draft rows)
- `ReleaseRow` (named draft rows)

## Changes
- `apps/web/src/components/thread/github/branch-picker.tsx` — route both tooltips through i18n; added `useT()` to `VersionRow`.
- `apps/web/src/i18n/en/thread.ts` + `apps/web/src/i18n/pt-br/thread.ts` — new key `thread.branchPicker.branchTooltip: "branch: {branch}"` (the `branch:` prefix stays untranslated; the name is interpolated).

## Testing
- `bun run fmt` — clean
- `bun run --cwd=apps/web check` — passes

Note: the deprecated `branch-picker-legacy.tsx` was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefixes branch picker tooltips with "branch:" so hovering a version or release row shows `branch: main` instead of just `main`.

- Routes both tooltips in `VersionRow` and `ReleaseRow` through i18n using the new `thread.branchPicker.branchTooltip` key.
- Adds the key to English and Brazilian Portuguese translations; the `branch:` prefix stays untranslated while the branch name is interpolated.
- Leaves the deprecated `branch-picker-legacy.tsx` untouched.

<sup>Written for commit 2e5ab25ac856e4c584ff4316854384b57aae1ede. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

