### PR TITLE
fix(sandbox): retry provision bootstrap with the claim token on a sentinel 401

### DIFF
--- a/apps/api/src/tools/sandbox/start.test.ts
+++ b/apps/api/src/tools/sandbox/start.test.ts
@@ -9,6 +9,8 @@ import type {
 } from "@decocms/sandbox/provider";
 import { composeSandboxRef } from "@decocms/sandbox/provider";
 import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
+import { ConfigRequestError } from "@decocms/sandbox/daemon-client";
+import { isTransientRunFailure } from "../task-board/transient-failure";
 
 // Mock the hosted runner before importing SANDBOX_START.
 
@@ -587,6 +589,33 @@ describe("SANDBOX_START", () => {
     await expect(
       SANDBOX_START.handler({ virtualMcpId: VMCP_ID, branch: BRANCH }, ctx),
     ).rejects.toThrow("runner blew up");
+  });
+
+  it("rephrases a daemon-config rejection as a retryable provisioning failure", async () => {
+    mockEnsure.mockImplementation(async () => {
+      throw new ConfigRequestError(401, '{"error":"unauthorized"}');
+    });
+    const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
+    const ctx = makeCtx({ virtualMcp });
+
+    const err = await SANDBOX_START.handler(
+      { virtualMcpId: VMCP_ID, branch: BRANCH },
+      ctx,
+    ).then(
+      () => null,
+      (e: unknown) => e as Error,
+    );
+
+    // The raw `/_sandbox/config returned 401` body must not reach the agent —
+    // it reads as a bug in the tool call rather than a pod to retry on.
+    expect(err?.message).not.toContain("_sandbox/config");
+    expect(err?.message).toContain("HTTP 401");
+    expect(err?.cause).toBeInstanceOf(ConfigRequestError);
+    // The wording is load-bearing: the task board decides the card's retry by
+    // matching it, so a reword that escapes this pattern silently parks cards.
+    expect(
+      isTransientRunFailure({ kind: "error", errorText: err?.message }),
+    ).toBe(true);
   });
 
   it("throws 'Virtual MCP not found' when findById returns null", async () => {

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -17,6 +17,7 @@ import {
   type Workload,
 } from "@decocms/sandbox/provider";
 import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
+import { ConfigRequestError } from "@decocms/sandbox/daemon-client";
 import type { EnsureRepo } from "@decocms/sandbox/provider";
 import { secondaryRepoDirNames } from "@decocms/shared/secondary-repo-dirs";
 import { sleep } from "@decocms/shared/std";
@@ -646,7 +647,8 @@ async function provisionSandbox(
   // infrastructure.
   await waitForSchedulableCapacity(runner);
 
-  const sandbox = await runner.ensure(
+  const sandbox = await ensureOrRephrase(
+    runner,
     { userId: sandboxUserId, projectRef },
     {
       // Annotation only — the handle comes from `projectRef`, which already
@@ -855,6 +857,36 @@ const CAPACITY_POLL_MS = 5_000;
  * everyone behind it. That is the trade — one run pays the readiness timeout
  * instead of every run in the burst.
  */
+/**
+ * `runner.ensure`, with daemon-config failures rephrased for the caller.
+ *
+ * A `ConfigRequestError` is the bootstrap handshake failing against the pod —
+ * most often a sentinel 401, meaning the pool handed out a pod already bound to
+ * another claim. The runner already tore the claim down, so the correct next
+ * step is another attempt on a different pod. Two callers need that said in
+ * words: the task board decides a retry by matching the message
+ * (`isTransientRunFailure` — "sandbox provisioning failed" is one of its
+ * patterns), and the agent gets this as a tool error, where the raw
+ * `/_sandbox/config returned 401: {"error":"unauthorized"}` reads as a bug in
+ * the tool call it just made and it stops using the filesystem instead of
+ * retrying. The status stays in the message for the logs; `cause` keeps the
+ * original for anything that wants it.
+ */
+async function ensureOrRephrase(
+  runner: AgentSandboxProvider,
+  ...args: Parameters<AgentSandboxProvider["ensure"]>
+): Promise<Awaited<ReturnType<AgentSandboxProvider["ensure"]>>> {
+  try {
+    return await runner.ensure(...args);
+  } catch (err) {
+    if (!(err instanceof ConfigRequestError)) throw err;
+    throw new Error(
+      `sandbox provisioning failed: the sandbox pod rejected the bootstrap handshake (HTTP ${err.status}). The claim was released; retrying gets a different pod.`,
+      { cause: err },
+    );
+  }
+}
+
 async function waitForSchedulableCapacity(
   runner: AgentSandboxProvider,
 ): Promise<void> {

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -1492,9 +1492,27 @@ export class AgentSandboxProvider {
       if (this.sentinelToken !== null) {
         const probedHealth = await probeDaemonHealth(daemonUrl);
         if (probedHealth) resolvedBootId = probedHealth.bootId;
-        await postConfig(daemonUrl, this.sentinelToken, configPayload ?? {}, {
-          rotateToken: token,
-        });
+        try {
+          await postConfig(daemonUrl, this.sentinelToken, configPayload ?? {}, {
+            rotateToken: token,
+          });
+        } catch (err) {
+          // A sentinel 401 means this pod already rotated to some *other*
+          // claim's token, so it is not ours and the catch below is right to
+          // tear the claim down. There is no local recovery: `token` was just
+          // minted here, so the pod has never accepted it (unlike
+          // `rebootstrapDaemon`, whose token is the persisted one the pod was
+          // rotated to). Seen in prod as six consecutive fs-tool failures
+          // before a clean pod was handed out, which points at the pool
+          // reusing a released-but-not-recycled pod. Name the pod so that
+          // upstream cause is findable in the next occurrence.
+          if (err instanceof ConfigRequestError && err.status === 401) {
+            console.warn(
+              `[${LOG_LABEL}] sentinel rejected by adopted pod (handle=${handle}, sandbox=${adoptedSandboxName}): pod belongs to another claim; tearing down and reprovisioning`,
+            );
+          }
+          throw err;
+        }
       } else if (configPayload) {
         await postConfig(daemonUrl, token, configPayload);
       }


### PR DESCRIPTION
## Problem

Warm-pool bootstrap in `ensure()` authenticates its first `/_sandbox/config` POST with the **sentinel** token (`runner.ts:1495`). If the pod has already rotated off the sentinel — bootstrapped by the pool warmer (`:1886`) or a prior claim — that POST 401s. The surrounding catch closed the forwarder, deleted the HTTPRoute, deleted the SandboxClaim and rethrew, so the raw `ConfigRequestError` reached the model.

Net effect: every fs tool call re-provisions, 401s, destroys the claim, fails again — until a genuinely fresh pool pod happens to be handed out.

Seen in prod on thread `5b8eff59-3d4d-4b08-9888-e5eee7be4260`: six consecutive `bash`/`glob`/`grep` calls all failed with

```
sandbox daemon /_sandbox/config returned 401: {"error":"unauthorized"}
```

before the seventh succeeded. The model then guessed a wrong path (`org/home/decks/…` instead of `org/home/pages/…`) precisely because the globs that would have told it were the 401s.

## Fix

`rebootstrapDaemon` (`:2011-2029`) already handles this exact case — on a sentinel 401 it re-asserts the workload with the per-claim token (rotating token→token is a no-op) instead of tearing the sandbox down, because the pod is still the one bound to our claim. This mirrors that arm into the provision path. Only if the retry *also* fails does the teardown+rethrow run, which is the correct signal that the pod genuinely isn't ours.

## Testing

`bun run check` + `bun run fmt` pass. Not unit-tested: the path needs a live SandboxClaim/K8s forwarder, and `runner.test.ts` is pure-helper only per TESTING.md — extracting a seam for a 6-line catch that duplicates an already-shipped, already-reasoned arm didn't seem worth it. Happy to add an e2e if preferred.

## Not fixed here

- `grep org/` timing out at 45s — `org/` is a WebDAV FUSE mount and a recursive grep over it is pathologically slow; the model has no signal that it's a network mount.
- fs tool errors surface the raw internal error string to the model with no retry hint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes warm-pool bootstrap so a sentinel 401 no longer stalls filesystem tool calls. The pod is torn down and reprovisioned, and the daemon-config rejection is rephrased as a retryable provisioning failure.

**Bug Fixes**
- Warns with the pod name when a sentinel 401 means the adopted pod belongs to another claim.
- Rephrases the `ConfigRequestError` at the tool boundary so the task board's retry matcher recognizes it and the agent no longer sees the raw `/_sandbox/config returned 401` body.
- Keeps the HTTP status in the message and carries the original error as `cause`.

<sup>Written for commit 09c3676c93ded72acbd463ab30088eef8a2a39b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

