### PR TITLE
fix(organization): cap enabled_plugins array size on settings update

### DIFF
--- a/apps/api/src/tools/organization/settings-update.test.ts
+++ b/apps/api/src/tools/organization/settings-update.test.ts
@@ -103,13 +103,20 @@ describe("ORGANIZATION_SETTINGS_UPDATE", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects oversized sidebar_items, blockedMcps, and default_home_agents.ids", () => {
+  it("rejects oversized sidebar_items, blockedMcps, default_home_agents.ids, and enabled_plugins", () => {
     const item = { title: "x", url: "/x", icon: "star" };
 
     expect(
       ORGANIZATION_SETTINGS_UPDATE.inputSchema.safeParse({
         organizationId: "org-a",
         sidebar_items: Array(51).fill(item),
+      }).success,
+    ).toBe(false);
+
+    expect(
+      ORGANIZATION_SETTINGS_UPDATE.inputSchema.safeParse({
+        organizationId: "org-a",
+        enabled_plugins: Array(201).fill("plugin"),
       }).success,
     ).toBe(false);
 

--- a/apps/api/src/tools/organization/settings-update.ts
+++ b/apps/api/src/tools/organization/settings-update.ts
@@ -13,6 +13,7 @@ import {
 const MAX_SIDEBAR_ITEMS = 50;
 const MAX_BLOCKED_MCPS = 500;
 const MAX_DEFAULT_HOME_AGENTS = 100;
+const MAX_ENABLED_PLUGINS = 200;
 
 export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
   name: "ORGANIZATION_SETTINGS_UPDATE",
@@ -28,7 +29,7 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
   inputSchema: z.object({
     organizationId: z.string(),
     sidebar_items: z.array(SidebarItemSchema).max(MAX_SIDEBAR_ITEMS).optional(),
-    enabled_plugins: z.array(z.string()).optional(),
+    enabled_plugins: z.array(z.string()).max(MAX_ENABLED_PLUGINS).optional(),
     registry_config: RegistryConfigSchema.extend({
       blockedMcps: z.array(z.string()).max(MAX_BLOCKED_MCPS),
     }).optional(),


### PR DESCRIPTION
Follows #6904, which capped `sidebar_items`, `registry_config.blockedMcps`, and `default_home_agents.ids` on `ORGANIZATION_SETTINGS_UPDATE` — the same tool's `enabled_plugins` array was left uncapped, a same-class unbounded-array-into-a-jsonb-column gap in the identical input schema.

A maintainer wants this because an unbounded client-supplied array feeding a JSON column is exactly the resource-bound gap the sibling fields in this same file were just hardened against — leaving one field out defeats the point of the pass.

Failure scenario: a caller passes an arbitrarily large `enabled_plugins` array and it's stored as-is in `organization_settings.enabled_plugins` (jsonb), with no upper bound — same shape as the already-fixed `sidebar_items`/`blockedMcps`/`default_home_agents.ids` cases. Fix caps it at 200 (in line with the existing `MAX_*` constants in the file) and extends the existing `rejects oversized sidebar_items, blockedMcps, and default_home_agents.ids` test to cover it.

Reviewer check: `bun test apps/api/src/tools/organization/settings-update.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `enabled_plugins` at 200 items during organization settings updates. Previously, callers could store arbitrarily large arrays in the `organization_settings` JSON column.

- Adds validation coverage for oversized `enabled_plugins` input alongside the existing array limits.

<sup>Written for commit 0193c98bc5cc380c4e9e63146c3eab326860ed13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

