### PR TITLE
fix(virtual-mcp): cap connections array and per-connection selected-item arrays

### DIFF
--- a/packages/shared/src/sdk/types/virtual-mcp.test.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.test.ts
@@ -258,6 +258,28 @@ test("VirtualMCPCreateDataSchema rejects more than 20 kickstart prompts", () => 
   expect(result.success).toBe(false);
 });
 
+test("VirtualMCPCreateDataSchema rejects more than 200 connections", () => {
+  const result = VirtualMCPCreateDataSchema.safeParse({
+    title: "Agent",
+    connections: Array.from({ length: 201 }, (_, i) => ({
+      connection_id: `conn-${i}`,
+    })),
+  });
+  expect(result.success).toBe(false);
+});
+
+test("VirtualMCPUpdateDataSchema rejects more than 500 selected_tools on a connection", () => {
+  const result = VirtualMCPUpdateDataSchema.safeParse({
+    connections: [
+      {
+        connection_id: "conn-1",
+        selected_tools: Array.from({ length: 501 }, (_, i) => `tool-${i}`),
+      },
+    ],
+  });
+  expect(result.success).toBe(false);
+});
+
 test("VirtualMCPUpdateDataSchema rejects a description over 500 chars", () => {
   const result = VirtualMCPUpdateDataSchema.safeParse({
     description: "a".repeat(501),

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -34,15 +34,45 @@ const VirtualMCPConnectionSchema = z.object({
 
 export type VirtualMCPConnection = z.infer<typeof VirtualMCPConnectionSchema>;
 
+/** Cap on how many tool/resource/prompt names a single connection can select
+ *  on write — an unbounded array here is attacker-controlled payload size on
+ *  a mutation input, not a real agent config (no connection realistically
+ *  exposes more than a few hundred tools). */
+const SELECTED_ITEMS_MAX = 500;
+
+/** Cap on how many connections a single virtual MCP can list on write — same
+ *  rationale as {@link SELECTED_ITEMS_MAX}: no real agent config connects to
+ *  hundreds of MCPs. */
+const CONNECTIONS_MAX = 200;
+
 /**
  * Virtual MCP connection schema for input (Create/Update) - fields can be optional
  */
 const VirtualMCPConnectionInputSchema = VirtualMCPConnectionSchema.extend({
-  selected_tools: VirtualMCPConnectionSchema.shape.selected_tools.optional(),
-  selected_resources:
-    VirtualMCPConnectionSchema.shape.selected_resources.optional(),
-  selected_prompts:
-    VirtualMCPConnectionSchema.shape.selected_prompts.optional(),
+  selected_tools: z
+    .array(z.string())
+    .max(SELECTED_ITEMS_MAX)
+    .nullable()
+    .optional()
+    .describe(
+      "Selected tool names. null = all tools included, array = only these tools included",
+    ),
+  selected_resources: z
+    .array(z.string())
+    .max(SELECTED_ITEMS_MAX)
+    .nullable()
+    .optional()
+    .describe(
+      "Selected resource URIs or patterns. Supports * and ** wildcards for pattern matching. null = all resources included, array = only these resources included",
+    ),
+  selected_prompts: z
+    .array(z.string())
+    .max(SELECTED_ITEMS_MAX)
+    .nullable()
+    .optional()
+    .describe(
+      "Selected prompt names. null = all prompts included, array = only these prompts included",
+    ),
 });
 
 /**
@@ -899,6 +929,7 @@ export const VirtualMCPCreateDataSchema = z.object({
     .describe("Additional metadata including MCP server instructions"),
   connections: z
     .array(VirtualMCPConnectionInputSchema)
+    .max(CONNECTIONS_MAX)
     .describe(
       "Connections to include/exclude (can be empty for exclusion mode)",
     ),
@@ -944,6 +975,7 @@ export const VirtualMCPUpdateDataSchema = z.object({
     .describe("Additional metadata including MCP server instructions"),
   connections: z
     .array(VirtualMCPConnectionInputSchema)
+    .max(CONNECTIONS_MAX)
     .optional()
     .describe("New connections (replaces existing)"),
   prompts: z


### PR DESCRIPTION
Follows the same hardening pass as #6921/#6916/#6914/#6904/#6908 (cap attacker-controlled array/JSON size on a mutation input) — this repo's virtual-mcp schema had already capped title/description/kickstart-prompts but left the `connections` array on `VirtualMCPCreateDataSchema`/`VirtualMCPUpdateDataSchema`, and each connection's `selected_tools`/`selected_resources`/`selected_prompts` arrays, completely unbounded.

**Payoff**: `COLLECTION_VIRTUAL_MCP_CREATE`/`UPDATE` is a tool any org member can call with an arbitrary JSON body. Without a cap, a client (buggy or malicious) can submit a connections array or a selected-tool-names array with an unbounded number of entries, inflating the stored `connections.metadata`/config JSON without limit — same DoS shape the prior wave of PRs fixed for other fields on this same schema.

**Fix**: added `CONNECTIONS_MAX = 200` on the `connections` array (create + update) and `SELECTED_ITEMS_MAX = 500` on each connection's `selected_tools`/`selected_resources`/`selected_prompts` arrays in `VirtualMCPConnectionInputSchema` (the input-only schema — the read/entity schema for stored data is untouched, so existing rows still parse). Bounds are generous: no real agent config realistically connects to hundreds of MCPs or selects hundreds of tools per connection.

**Regression test**: `packages/shared/src/sdk/types/virtual-mcp.test.ts` — a reviewer can run `bun test packages/shared/src/sdk/types/virtual-mcp.test.ts` to see the two new tests (`rejects more than 200 connections`, `rejects more than 500 selected_tools`) fail against the old schema and pass now.

Verified locally: `bun run fmt`, `bunx tsc --noEmit` (packages/shared), the targeted test file (38 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds caps to the virtual MCP create/update schema so `connections` and per-connection selected item arrays can't grow without bound. Old behavior accepted any number of entries; new behavior rejects more than 200 connections and more than 500 selected items per connection. Existing stored rows still parse because only the input schema is capped.

- Adds regression tests for both limits in `packages/shared/src/sdk/types/virtual-mcp.test.ts`.

<sup>Written for commit 4f8036916d72110232b9565acdfd0c9ccb4c74a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

