### PR TITLE
fix(sandbox): retry Bun's plain-Error connection failures in daemon-client

### DIFF
--- a/packages/sandbox/server/daemon-client.test.ts
+++ b/packages/sandbox/server/daemon-client.test.ts
@@ -135,6 +135,29 @@ describe("retry timeout budget", () => {
   });
 });
 
+describe("Bun-style connection errors", () => {
+  it("retries a Bun fetch connection-refused error (plain Error + .code, not TypeError)", async () => {
+    let attempts = 0;
+    const { calls } = installFetch(() => {
+      attempts++;
+      if (attempts === 1) {
+        // Bun's actual shape for a refused/cold-start connection: plain Error + .code.
+        const err = new Error(
+          "Unable to connect. Is the computer able to access the url?",
+        ) as Error & { code: string };
+        err.code = "ConnectionRefused";
+        throw err;
+      }
+      return new Response(
+        JSON.stringify({ bootId: "b", transition: "t", config: {} }),
+        { status: 200 },
+      );
+    });
+    await postConfig("http://daemon:9000", "tok", { env: {} } as never);
+    expect(calls.length).toBe(2);
+  });
+});
+
 describe("proxyDaemonRequest", () => {
   it("injects Authorization: Bearer <token> header", async () => {
     const { calls } = installFetch(() => new Response("", { status: 204 }));

--- a/packages/sandbox/server/daemon-client.ts
+++ b/packages/sandbox/server/daemon-client.ts
@@ -23,10 +23,24 @@ export class ConfigRequestError extends Error {
 }
 
 /** Returns true if an error is transient and should be retried. Distinguishes
- * network/timeout failures (retriable) from other errors (permanent). */
+ * network/timeout failures (retriable) from other errors (permanent).
+ *
+ * Node/undici's fetch throws these as `TypeError`. Bun's fetch — the actual
+ * runtime this server runs on — throws a plain `Error` with a `.code` (e.g.
+ * `"ConnectionRefused"`, `"ConnectionClosed"`) instead: a cold sandbox pod
+ * that isn't accepting connections yet is exactly this, so without the
+ * `.code` check the daemon's single most common transient failure never
+ * actually retried. */
 function isTransientError(err: unknown): boolean {
   // Network errors (DNS, connection refused, etc.) are transient
   if (err instanceof TypeError) {
+    return true;
+  }
+  if (
+    err instanceof Error &&
+    !(err instanceof DOMException) &&
+    typeof (err as { code?: unknown }).code === "string"
+  ) {
     return true;
   }
   // AbortError from timeout is transient


### PR DESCRIPTION
This is a bug fix found while auditing `packages/sandbox/server/daemon-client.ts`'s retry/backoff logic (this repo's focus for sandbox daemon-client robustness).

**The bug**: `daemonRequest`'s `isTransientError` only treats `err instanceof TypeError` (and timeout `AbortError`) as retriable. That's Node/undici's shape for a network failure. This server actually runs on Bun (`apps/api` ships and starts via `bun run ./dist/server/server.js`), and Bun's fetch throws a **plain `Error`** with a `.code` property (e.g. `"ConnectionRefused"`) for a refused connection or DNS failure — verified locally:
```
$ bun run -e 'await fetch("http://127.0.0.1:1")'
// Error: Unable to connect. Is the computer able to access the url? { code: "ConnectionRefused" }
```
That error is not a `TypeError`, so it silently fell through `isTransientError` and never retried — meaning the single most common transient failure this retry logic exists for (a sandbox pod's daemon not yet accepting connections during a cold start) got zero retries instead of the intended 3-attempt exponential backoff, surfacing as an immediate `[SANDBOX_UNREACHABLE]` error to the caller.

**Fix**: also treat a plain `Error` (not `DOMException`) carrying a string `.code` as transient — this only executes inside the `retry()` callback, whose body is exclusively `fetch()` + `res.text()`, so nothing but a network/transport failure can reach it.

**Regression test**: `daemon-client.test.ts` — "retries a Bun fetch connection-refused error (plain Error + .code, not TypeError)": mocks `fetch` to throw Bun's actual connection-refused shape on the first call and succeed on the second, asserting `postConfig` retries and succeeds instead of throwing immediately. This test fails against the old `isTransientError` (0 retries) and passes with the fix.

**To verify**: `bun test packages/sandbox/server/daemon-client.test.ts` (26/26 pass, including the new case).

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` (packages/sandbox), `bun test packages/sandbox/server/daemon-client.test.ts`, `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries now recognize Bun fetch connection failures as transient when they are plain `Error` objects with a string `code`. Previously, only `TypeError` and timeout errors were retried, so cold-start sandbox connections failed immediately instead of using the configured retry backoff.

**Bug Fixes**

- Adds a regression test covering a Bun-style connection-refused error that succeeds on the second attempt.

<sup>Written for commit 432cf7fc0bd474210a56392447a8f4fb9fdce766. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

