### PR TITLE
fix(agent-shell-layout): restore visible chat label on panel toggle

### DIFF
--- a/apps/web/src/layouts/agent-shell-layout/toggle-buttons.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/toggle-buttons.tsx
@@ -1,18 +1,22 @@
-import { AlignLeft01, AlignRight01, LayoutRight } from "@untitledui/icons";
+import { LayoutRight, MessageCircle01 } from "@untitledui/icons";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@decocms/ui/components/tooltip.tsx";
-import { ToolbarIconButton } from "@/components/toolbar-icon-button";
+import {
+  panelButtonChrome,
+  ToolbarIconButton,
+} from "@/components/toolbar-icon-button";
 import { track } from "@/lib/posthog-client";
 import { useT } from "@/i18n/use-t";
 
 /**
- * A panel collapse control — the pair of chevron-into-bar buttons that bracket
- * the workspace: the left one lives at the start of the MAIN header and
- * hides/shows the chat, the right one lives at the end of the CHAT header and
- * hides/shows the main panel.
+ * A panel collapse control bracketing the workspace: the left one lives at
+ * the start of the MAIN header and hides/shows the chat (chat-bubble icon),
+ * the right one lives at the end of the CHAT header and hides/shows the main
+ * panel (chevron-into-bar icon).
  *
  * Deliberately a plain icon button, not a HeaderTabButton: these are chrome for
  * the panel itself, not one of its views, so they never take the tab's active
@@ -38,24 +42,42 @@ export function PanelCollapseToggle({
     : side === "left"
       ? t("agentShellLayout.toggleButtons.showChat")
       : t("agentShellLayout.toggleButtons.showPanel");
-  const Icon =
-    side === "right" ? LayoutRight : open ? AlignLeft01 : AlignRight01;
+  const onClick = () => {
+    track("agent_toolbar_toggled", {
+      button: side === "left" ? "chat" : "main",
+      next_state: open ? "closed" : "open",
+    });
+    onToggle();
+  };
+
+  // The chat toggle spells out its label; the main-panel toggle stays icon-only.
+  if (side === "left") {
+    return (
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onClick}
+        className={cn(
+          "flex h-10 md:h-7 shrink-0 items-center gap-1.5 rounded-md px-2 text-sm disabled:opacity-40",
+          panelButtonChrome(),
+        )}
+      >
+        <MessageCircle01 size={16} />
+        {label}
+      </button>
+    );
+  }
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <ToolbarIconButton
           aria-label={label}
           disabled={disabled}
-          onClick={() => {
-            track("agent_toolbar_toggled", {
-              button: side === "left" ? "chat" : "main",
-              next_state: open ? "closed" : "open",
-            });
-            onToggle();
-          }}
+          onClick={onClick}
           className="size-7 rounded-md disabled:opacity-40"
         >
-          <Icon size={16} />
+          <LayoutRight size={16} />
         </ToolbarIconButton>
       </TooltipTrigger>
       <TooltipContent side="bottom">{label}</TooltipContent>


### PR DESCRIPTION
## What is this contribution about?
The left-side panel toggle (which opens/closes the chat side panel) had been reduced to a bare chevron icon during the top-bar redesign, with no visible text — devs reported it wasn't obvious it toggled the chat. This restores a chat-bubble icon and a visible "Show chat"/"Hide chat" text label on that toggle. The main-panel toggle on the right stays icon-only, unchanged.

## How did you verify your code works?
Ran `bun run fmt`, `bun run --cwd=apps/web check` (tsc --noEmit, passes), and `bun run lint` (no issues in the changed file). No automated test coverage exists for this component; UI change was reviewed by reading the rendered JSX/classes for both the `side="left"` and `side="right"` code paths.

## Screenshots/Demonstration
_Not captured in this session — reviewer should pull the branch and check the toggle at the start of the main panel header._

## How to Test
1. Open Studio and navigate to any workspace with the chat side panel.
2. Look at the start of the main panel's header.
3. Expected outcome: the toggle now shows a chat-bubble icon plus a "Hide chat" (or "Show chat" when collapsed) text label, instead of a bare chevron.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores a visible label on the chat side-panel toggle so it's clear the button opens and closes the chat. The left toggle now shows a chat-bubble icon and "Show chat"/"Hide chat" text instead of a bare chevron; the right main-panel toggle stays icon-only with its tooltip.

<sup>Written for commit 473ea01220285c7c25f1010850611364577d2993. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

