### PR TITLE
fix(organization): cap registries record size on settings update

### DIFF
--- a/apps/api/src/tools/organization/settings-update.test.ts
+++ b/apps/api/src/tools/organization/settings-update.test.ts
@@ -134,4 +134,18 @@ describe("ORGANIZATION_SETTINGS_UPDATE", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("rejects an oversized registries record on registry_config", () => {
+    // Regression: registries was the one sibling collection left uncapped.
+    const registries = Object.fromEntries(
+      Array.from({ length: 201 }, (_, i) => [`conn-${i}`, { enabled: true }]),
+    );
+
+    expect(
+      ORGANIZATION_SETTINGS_UPDATE.inputSchema.safeParse({
+        organizationId: "org-a",
+        registry_config: { registries, blockedMcps: [] },
+      }).success,
+    ).toBe(false);
+  });
 });

--- a/apps/api/src/tools/organization/settings-update.ts
+++ b/apps/api/src/tools/organization/settings-update.ts
@@ -14,6 +14,7 @@ const MAX_SIDEBAR_ITEMS = 50;
 const MAX_BLOCKED_MCPS = 500;
 const MAX_DEFAULT_HOME_AGENTS = 100;
 const MAX_ENABLED_PLUGINS = 200;
+const MAX_REGISTRIES = 200;
 
 export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
   name: "ORGANIZATION_SETTINGS_UPDATE",
@@ -31,6 +32,11 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
     sidebar_items: z.array(SidebarItemSchema).max(MAX_SIDEBAR_ITEMS).optional(),
     enabled_plugins: z.array(z.string()).max(MAX_ENABLED_PLUGINS).optional(),
     registry_config: RegistryConfigSchema.extend({
+      registries: z
+        .record(z.string(), z.object({ enabled: z.boolean() }))
+        .refine((r) => Object.keys(r).length <= MAX_REGISTRIES, {
+          message: `registries must have at most ${MAX_REGISTRIES} entries`,
+        }),
       blockedMcps: z.array(z.string()).max(MAX_BLOCKED_MCPS),
     }).optional(),
     simple_mode: SimpleModeConfigSchema.optional(),


### PR DESCRIPTION
Follows #6930 and #6931 (same-day, same file: `enabled_plugins` and `virtual-mcp` connections arrays were capped) — the `registry_config.registries` record on `ORGANIZATION_SETTINGS_UPDATE` was the one sibling collection left uncapped. `sidebar_items`, `enabled_plugins`, `blockedMcps`, and `default_home_agents.ids` all got a `.max(...)`, but `registries` is a `z.record(string, {enabled: boolean})` keyed by client-supplied connection ids with no bound on key count, so a caller can still balloon the stored settings row with an arbitrarily large registries map.

Fix: cap `registries` at 200 entries (same order of magnitude as the other caps here) via a `.refine` on key count, since `z.record` has no built-in `.max`.

Failure scenario: `ORGANIZATION_SETTINGS_UPDATE` with `registry_config.registries` containing thousands of keys previously validated and got upserted into the JSON column unbounded.

Reviewer check: `bun test apps/api/src/tools/organization/settings-update.test.ts` — includes a new regression test asserting 201 registries entries are rejected.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the `registries` record in `registry_config` on `ORGANIZATION_SETTINGS_UPDATE` at 200 entries so callers can no longer store an arbitrarily large map in the settings row. Previously this was the only sibling collection without a size limit; oversized requests now fail validation. Adds a regression test for the new limit.

<sup>Written for commit 8f312448fecd802f47d49f46ee968d12e34287b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

