### PR TITLE
fix(virtual-mcp): cap enabled_plugins array size on agent create/update

### DIFF
--- a/packages/shared/src/sdk/types/virtual-mcp.test.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.test.ts
@@ -287,6 +287,26 @@ test("VirtualMCPUpdateDataSchema rejects a description over 500 chars", () => {
   expect(result.success).toBe(false);
 });
 
+test("VirtualMCPCreateDataSchema rejects more than 200 enabled_plugins", () => {
+  const result = VirtualMCPCreateDataSchema.safeParse({
+    title: "Agent",
+    connections: [],
+    metadata: {
+      enabled_plugins: Array.from({ length: 201 }, (_, i) => `plugin-${i}`),
+    },
+  });
+  expect(result.success).toBe(false);
+});
+
+test("VirtualMCPUpdateDataSchema rejects more than 200 enabled_plugins", () => {
+  const result = VirtualMCPUpdateDataSchema.safeParse({
+    metadata: {
+      enabled_plugins: Array.from({ length: 201 }, (_, i) => `plugin-${i}`),
+    },
+  });
+  expect(result.success).toBe(false);
+});
+
 test("SandboxRecord.startedWith is optional with nullable packageManager/port/path", () => {
   const a = SandboxRecordSchema.parse({ sandboxHandle: "v", previewUrl: null });
   expect(a.startedWith).toBeUndefined();

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -45,6 +45,13 @@ const SELECTED_ITEMS_MAX = 500;
  *  hundreds of MCPs. */
 const CONNECTIONS_MAX = 200;
 
+/** Cap on how many plugin IDs `metadata.enabled_plugins` can carry on write —
+ *  same rationale as the sibling cap on organization_settings.enabled_plugins
+ *  (apps/api/src/tools/organization/settings-update.ts): the plugin registry
+ *  is a small, finite set, so an unbounded array here is attacker-controlled
+ *  payload size, not a real agent config. */
+const ENABLED_PLUGINS_MAX = 200;
+
 /**
  * Virtual MCP connection schema for input (Create/Update) - fields can be optional
  */
@@ -914,6 +921,14 @@ export const VirtualMCPCreateDataSchema = z.object({
   pinned: z.boolean().optional().default(false).describe("Pin to sidebar"),
   metadata: z
     .object(VirtualMcpMetadataFields)
+    .extend({
+      enabled_plugins: z
+        .array(z.string())
+        .max(ENABLED_PLUGINS_MAX)
+        .nullable()
+        .optional()
+        .describe("List of enabled plugin IDs"),
+    })
     .loose()
     .superRefine((metadata, ctx) => {
       if ("sandboxMap" in metadata) {
@@ -960,6 +975,14 @@ export const VirtualMCPUpdateDataSchema = z.object({
   pinned: z.boolean().optional().describe("Pin/unpin from sidebar"),
   metadata: z
     .object(VirtualMcpMetadataFields)
+    .extend({
+      enabled_plugins: z
+        .array(z.string())
+        .max(ENABLED_PLUGINS_MAX)
+        .nullable()
+        .optional()
+        .describe("List of enabled plugin IDs"),
+    })
     .loose()
     .superRefine((metadata, ctx) => {
       if ("sandboxMap" in metadata) {


### PR DESCRIPTION
Same class of gap as #6930 (organization_settings.enabled_plugins) and #6931 (virtual-mcp connections/selected-item arrays), both merged the same day: an unbounded array on a mutation input is attacker-controlled payload size, not a real agent config — the plugin registry is a small, finite set.

`VirtualMCPCreateDataSchema`/`VirtualMCPUpdateDataSchema`'s `metadata.enabled_plugins` (packages/shared/src/sdk/types/virtual-mcp.ts, the tool-input schemas behind `VIRTUAL_CREATE`/`VIRTUAL_UPDATE`) had no cap, unlike its org-settings sibling (`MAX_ENABLED_PLUGINS = 200` in apps/api/src/tools/organization/settings-update.ts). A caller could pass an arbitrarily large array into a virtual MCP's metadata JSON blob.

Added the same 200-item cap, applied only on the two write schemas (via `.extend()`), leaving the read-side `VirtualMCPEntitySchema` uncapped so a pre-existing over-cap row still parses on read — the same treatment `CONNECTIONS_MAX`/`SELECTED_ITEMS_MAX` already get in this file.

Reviewer check: `bun test packages/shared/src/sdk/types/virtual-mcp.test.ts` (two new tests: create/update both reject 201 enabled_plugins entries).

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (packages/shared), `bunx oxlint` on both changed files, targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the `enabled_plugins` array in virtual MCP create/update inputs at 200 entries, so callers can no longer send unbounded payloads. Previously the field had no cap, unlike its org-settings sibling.

- Applies the cap only to `VirtualMCPCreateDataSchema` and `VirtualMCPUpdateDataSchema`; the read-side `VirtualMCPEntitySchema` stays uncapped so existing over-cap rows still parse.
- Adds two tests verifying both write schemas reject 201 plugins.

<sup>Written for commit fd65b1e1e6b6be55328d2fba7af214f414b642cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

