### PR TITLE
fix(sandbox): retry a transient 502/503/504 from the daemon, not just network failures

### DIFF
--- a/packages/sandbox/server/daemon-client.test.ts
+++ b/packages/sandbox/server/daemon-client.test.ts
@@ -158,6 +158,37 @@ describe("Bun-style connection errors", () => {
   });
 });
 
+describe("transient HTTP status retries", () => {
+  it("retries a 503 and returns the eventual success", async () => {
+    let attempts = 0;
+    const { calls } = installFetch(() => {
+      attempts++;
+      if (attempts === 1) return new Response("unavailable", { status: 503 });
+      return new Response(
+        JSON.stringify({ bootId: "b", transition: "t", config: {} }),
+        { status: 200 },
+      );
+    });
+    await postConfig("http://daemon:9000", "tok", { env: {} } as never);
+    expect(calls.length).toBe(2);
+  });
+
+  it("surfaces the last 503 as a ConfigRequestError once retries are exhausted", async () => {
+    installFetch(() => new Response("still unavailable", { status: 503 }));
+    await expect(
+      postConfig("http://daemon:9000", "tok", { env: {} } as never),
+    ).rejects.toThrow("/_sandbox/config returned 503");
+  });
+
+  it("does not retry a plain 500", async () => {
+    const { calls } = installFetch(() => new Response("boom", { status: 500 }));
+    await expect(
+      postConfig("http://daemon:9000", "tok", { env: {} } as never),
+    ).rejects.toThrow("/_sandbox/config returned 500");
+    expect(calls.length).toBe(1);
+  });
+});
+
 describe("proxyDaemonRequest", () => {
   it("injects Authorization: Bearer <token> header", async () => {
     const { calls } = installFetch(() => new Response("", { status: 204 }));

--- a/packages/sandbox/server/daemon-client.ts
+++ b/packages/sandbox/server/daemon-client.ts
@@ -5,7 +5,7 @@
 
 import type { ConfigPatch, TenantConfig } from "../daemon-protocol";
 import { sleep } from "../shared";
-import { retry, type RetryOptions } from "@decocms/shared/std";
+import { retry, RetryError, type RetryOptions } from "@decocms/shared/std";
 
 export type { ConfigPatch };
 
@@ -47,7 +47,27 @@ function isTransientError(err: unknown): boolean {
   if (err instanceof DOMException && err.name === "AbortError") {
     return true;
   }
+  if (err instanceof TransientStatusError) {
+    return true;
+  }
   return false;
+}
+
+/** HTTP statuses the daemon can return while restarting/behind a proxy that
+ * are worth one more attempt, same as a network-level connection failure.
+ * Deliberately excludes 500 (an application bug, not infra hiccup). */
+const TRANSIENT_STATUSES = new Set([502, 503, 504]);
+
+/** Marks a non-2xx response as retriable so it flows through the same retry
+ * path as a thrown network error, instead of returning immediately as a
+ * "successful" (but failed) response. */
+class TransientStatusError extends Error {
+  constructor(
+    readonly status: number,
+    readonly responseBody: string,
+  ) {
+    super(`transient status ${status}`);
+  }
 }
 
 /**
@@ -95,9 +115,18 @@ async function daemonRequest(
         ...init,
         signal: AbortSignal.timeout(timeoutMs),
       });
-      return { status: res.status, ok: res.ok, body: await res.text() };
+      const body = await res.text();
+      if (TRANSIENT_STATUSES.has(res.status)) {
+        throw new TransientStatusError(res.status, body);
+      }
+      return { status: res.status, ok: res.ok, body };
     }, retryOpts);
   } catch (err) {
+    // Unwrap RetryError's cause: a transient status is a real response.
+    const cause = err instanceof RetryError ? err.cause : err;
+    if (cause instanceof TransientStatusError) {
+      return { status: cause.status, ok: false, body: cause.responseBody };
+    }
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(
       `[SANDBOX_UNREACHABLE] sandbox daemon ${endpoint} request failed: ${message}`,


### PR DESCRIPTION
Bug found while auditing `packages/sandbox/server/daemon-client.ts` (brittle-retry-logic focus area) — not tied to a specific issue.

**The gap:** `daemonRequest`'s retry wrapper (`retry()` from `@decocms/shared/std`) only retries when `fetch` itself throws (network error, timeout). A non-2xx *response* — including 502/503/504, which a daemon pod restarting behind its NetworkPolicy/proxy can legitimately return — was returned immediately with zero retries. Every other transient-HTTP-failure client already hardened in this repo (jira/github clients, per the repo's own convention) retries transient 5xx before giving up; this daemon client didn't, so a single restart blip during `postConfig`/`postSetupStep`/`postOrgFsConfig` surfaced as a hard failure instead of self-healing on the next attempt like a network blip already does.

**The fix:** classify 502/503/504 as retriable by routing them through the same retry path as a thrown error (`TransientStatusError`), while excluding 500 (an application bug, not an infra hiccup — still fails fast). On exhaustion, unwraps `RetryError.cause` so callers still get their normal typed error (`ConfigRequestError`, etc.) instead of a misleading `[SANDBOX_UNREACHABLE]`.

**Regression test:** `packages/sandbox/server/daemon-client.test.ts` — added 3 cases: retries a 503 then succeeds, surfaces the last 503 as `ConfigRequestError` once retries are exhausted, and confirms a plain 500 is NOT retried (single attempt).

**Reviewer command:** `bun test packages/sandbox/server/daemon-client.test.ts`

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` (packages/sandbox), the targeted test file (29/29 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `daemonRequest` so transient 502/503/504 responses from the sandbox daemon are retried, matching how thrown network errors are already retried. Previously these statuses were returned immediately, so a daemon restarting behind its proxy surfaced as a hard failure instead of self-healing.

**Bug Fixes**
- 500 is deliberately not retried because it indicates an application bug, not an infrastructure hiccup.
- After retries are exhausted, callers still get the normal typed error (`ConfigRequestError`) instead of `[SANDBOX_UNREACHABLE]`.
- Adds regression tests covering retry success, exhausted retries, and no retry on 500.

<sup>Written for commit cc2a38162e0a5fcfcd7ea3b7bec3f87fc4897d34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

