### PR TITLE
fix(branch-picker): surface a toast when a release write fails

### DIFF
--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -53,6 +53,7 @@ import { generateBranchName } from "@decocms/shared/branch-name";
 import type { Release } from "@decocms/shared/sdk/types";
 import type { SandboxMap } from "@/sdk";
 import { useT } from "@/i18n/use-t.ts";
+import { toast } from "sonner";
 import { decodeHtmlEntities } from "./decode-html-entities.ts";
 import { matchesBranchSearch, useBranches } from "./use-branches";
 import { useOpenPrs } from "./use-pr-data.ts";
@@ -142,15 +143,22 @@ export function BranchPicker({
     setOpen(false);
   };
 
+  // A failed release write reverts the row silently otherwise — surface it.
+  const reportReleaseError = (err: unknown) => {
+    toast.error(
+      err instanceof Error ? err.message : t("thread.branchPicker.saveError"),
+    );
+  };
+
   // Advanced: adopt an existing branch/PR head as a named draft, then switch.
   const adoptBranch = (branch: string, name: string) => {
     if (!releases.some((r) => r.branch === branch)) {
-      void createRelease({
+      createRelease({
         branch,
         name: name.trim() || branch,
         color: nextReleaseColor(releases.length),
         createdAt: new Date().toISOString(),
-      });
+      }).catch(reportReleaseError);
     }
     onChange(branch);
     setAdvanced(false);
@@ -159,7 +167,7 @@ export function BranchPicker({
 
   const create = () => {
     const branch = generateBranchName(userLabel);
-    void createRelease({
+    createRelease({
       branch,
       name: nextDraftName(
         releases,
@@ -167,7 +175,7 @@ export function BranchPicker({
       ),
       color: nextReleaseColor(releases.length),
       createdAt: new Date().toISOString(),
-    });
+    }).catch(reportReleaseError);
     (onCreateBranch ?? onChange)(branch);
     setOpen(false);
   };
@@ -185,7 +193,7 @@ export function BranchPicker({
 
   const saveRename = (branch: string) => {
     const next = editName.trim();
-    if (next) void renameRelease(branch, next);
+    if (next) renameRelease(branch, next).catch(reportReleaseError);
     setEditing(null);
     setEditName("");
   };
@@ -197,7 +205,7 @@ export function BranchPicker({
     // Land on production before the deleted draft vanishes from the list.
     if (r.branch === value && baseBranch) pick(baseBranch);
     else setOpen(false);
-    void deleteRelease(r.branch);
+    deleteRelease(r.branch).catch(reportReleaseError);
   };
 
   const popover = (

--- a/apps/web/src/i18n/en/thread.ts
+++ b/apps/web/src/i18n/en/thread.ts
@@ -20,6 +20,7 @@ export const thread = {
   "thread.branchPicker.newVersion": "New draft",
   "thread.branchPicker.rename": "Rename",
   "thread.branchPicker.save": "Save",
+  "thread.branchPicker.saveError": "Couldn't save the version. Try again.",
   "thread.branchPicker.selectVersion": "Select a version",
   "thread.branchPicker.newChatHint":
     "This chat's branch is fixed. Picking or creating a branch opens a new chat on it.",

--- a/apps/web/src/i18n/pt-br/thread.ts
+++ b/apps/web/src/i18n/pt-br/thread.ts
@@ -22,6 +22,8 @@ export const thread = {
   "thread.branchPicker.newVersion": "Novo Rascunho",
   "thread.branchPicker.rename": "Renomear",
   "thread.branchPicker.save": "Salvar",
+  "thread.branchPicker.saveError":
+    "Não foi possível salvar a versão. Tente novamente.",
   "thread.branchPicker.selectVersion": "Selecione uma versão",
   "thread.branchPicker.newChatHint":
     "A branch deste chat é fixa. Escolher ou criar uma branch abre um chat novo nela.",


### PR DESCRIPTION
**Bug, found while hardening `branch-picker.tsx` (4-churn file this tick, see #6884/#6910/#6928).**

`create`, `adoptBranch`, `saveRename`, and `confirmDelete` all fire their release mutation (`createRelease`/`renameRelease`/`deleteRelease`, all backed by `useReleases`' `write()`) with `void`, discarding the returned promise. `write()` already reverts the optimistic cache on failure (it calls `invalidateQueries` in its `.catch` before rethrowing) but nothing downstream ever looks at that rejection, so a failed rename/delete/create/adopt just silently snaps back to the prior state with zero user feedback — no toast, no console signal a user would ever see. Every sibling GitHub-panel action (`cms-header-actions.tsx`, `publish-dialog.tsx`, `start-draft-cta.tsx`) already surfaces its own mutation failures with `toast.error`; the branch picker was the one holdout.

Failure scenario: creating/renaming/deleting a release calls `VIRTUAL_MCP_UPDATE` under the hood — a permission error, a network blip, or a stale-write conflict rejects that call. The row the user just renamed (or the draft they just tried to discard) quietly reappears/reverts with no indication anything went wrong; the user has no way to know whether to retry.

Fix: catch the rejection at each of the four call sites and show `toast.error(err.message ?? t("thread.branchPicker.saveError"))`, matching the pattern used elsewhere in the same directory. Added the one new i18n key (en + pt-br).

To verify: open the branch picker, rename or delete a draft while the network is offline (or throttle `VIRTUAL_MCP_UPDATE` to fail) — a toast now appears instead of a silent revert.

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (green on the touched files; the one pre-existing prosemirror-model version-mismatch error in `mention-suggestion.tsx` is unrelated, same noise noted in #6910), `bunx oxlint` on the three changed files (0 warnings/errors). No new test: this is UI error-surfacing, not a trust-boundary/security/data-loss path, so it doesn't clear the standalone-test gate. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces a toast when a release write fails in the branch picker. Previously, failed create, adopt, rename, and delete operations silently reverted to the prior state with no user feedback; now each call site catches the rejection and shows the error message via `toast.error`, matching the pattern used by sibling GitHub-panel actions.

- Adds the `thread.branchPicker.saveError` i18n key in English and Brazilian Portuguese.

<sup>Written for commit 412fd0a263f0a19aa94c51c55bd2897e539dd000. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

