### PR TITLE
fix(projects): align main view with sidebar settings

### DIFF
--- a/apps/web/src/layouts/main-panel-tabs/project-sidebar-views.test.ts
+++ b/apps/web/src/layouts/main-panel-tabs/project-sidebar-views.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_PROJECT_SIDEBAR_VIEWS,
   PROJECT_SIDEBAR_VIEW_IDS,
   availableProjectSidebarViews,
+  defaultMainViewAfterSidebarToggle,
   effectiveProjectSidebarViews,
   isProjectNativeViewId,
   isProjectSidebarViewId,
@@ -165,6 +166,32 @@ describe("project sidebar views", () => {
       "board",
       "site-editor",
     ]);
+  });
+
+  test("falls back to Settings when the disabled sidebar view owns the main view", () => {
+    expect(
+      defaultMainViewAfterSidebarToggle({ type: "assets" }, "assets", false),
+    ).toEqual({ type: "settings" });
+
+    for (const type of ["site-editor", "preview", "content", "code"]) {
+      expect(
+        defaultMainViewAfterSidebarToggle({ type }, "site-editor", false),
+      ).toEqual({ type: "settings" });
+    }
+  });
+
+  test("preserves the main view when enabling a row or disabling another row", () => {
+    const defaultMainView = { type: "ext-apps", id: "assets" };
+
+    expect(
+      defaultMainViewAfterSidebarToggle(defaultMainView, "assets", false),
+    ).toBe(defaultMainView);
+    expect(
+      defaultMainViewAfterSidebarToggle({ type: "reports" }, "reports", true),
+    ).toEqual({ type: "reports" });
+    expect(
+      defaultMainViewAfterSidebarToggle(null, "reports", false),
+    ).toBeNull();
   });
 
   test("prefers canonical sidebar views, including explicit null and empty", () => {

--- a/apps/web/src/layouts/main-panel-tabs/project-sidebar-views.ts
+++ b/apps/web/src/layouts/main-panel-tabs/project-sidebar-views.ts
@@ -60,6 +60,12 @@ export interface ProjectSidebarViewsMetadata {
   } | null;
 }
 
+interface ProjectDefaultMainView {
+  type: string;
+  id?: string;
+  toolName?: string;
+}
+
 /** Resolve the entity whose capabilities govern a main-panel project view.
  *
  * Destination routes such as Tasks and Reports keep the org Super Agent as
@@ -167,6 +173,24 @@ export function selectedProjectSidebarViews(
   return PROJECT_SIDEBAR_VIEW_IDS.filter(
     (viewId) => presence[viewId] && selected.has(viewId),
   );
+}
+
+/** Keep the landing view aligned with the sidebar rows that can reach it.
+ * Preview, Content and Code are all entry points into the Site Editor row. */
+export function defaultMainViewAfterSidebarToggle(
+  defaultMainView: ProjectDefaultMainView | null | undefined,
+  viewId: ProjectSidebarViewId,
+  enabled: boolean,
+): ProjectDefaultMainView | null | undefined {
+  if (enabled || !defaultMainView) return defaultMainView;
+
+  const defaultViewId =
+    defaultMainView.type === "preview" ||
+    defaultMainView.type === "content" ||
+    defaultMainView.type === "code"
+      ? "site-editor"
+      : defaultMainView.type;
+  return defaultViewId === viewId ? { type: "settings" } : defaultMainView;
 }
 
 export function availableProjectSidebarViews(

--- a/apps/web/src/views/virtual-mcp/layout-tab-content.tsx
+++ b/apps/web/src/views/virtual-mcp/layout-tab-content.tsx
@@ -46,9 +46,11 @@ import type { VirtualMcpFormReturn } from "./types";
 import { useProjectNativeViewPresence } from "@/layouts/main-panel-tabs/use-project-native-view-presence";
 import {
   availableProjectSidebarViews,
+  defaultMainViewAfterSidebarToggle,
   effectiveProjectSidebarViews,
   projectSidebarViewPresence,
   resolveProjectSidebarViews,
+  selectedProjectSidebarViews,
   toggleProjectSidebarView,
   type ProjectSidebarViewId,
 } from "@/layouts/main-panel-tabs/project-sidebar-views";
@@ -295,7 +297,8 @@ export function LayoutTabContent({
     if (validPinned.length !== pinnedViews.length) {
       writePinned(validPinned);
 
-      // If the default view was an ext-app that got removed, reset to chat
+      // If the default view was an ext-app that got removed, use the permanent
+      // Settings view instead.
       if (
         currentDefaultMain?.type === "ext-apps" &&
         !validPinned.some(
@@ -304,7 +307,7 @@ export function LayoutTabContent({
             pv.toolName === currentDefaultMain.toolName,
         )
       ) {
-        writeLayout({ defaultMainView: null });
+        writeLayout({ defaultMainView: { type: "settings" } });
       }
     }
   }
@@ -318,10 +321,10 @@ export function LayoutTabContent({
         (v) => !(v.connectionId === connectionId && v.toolName === toolName),
       );
       writePinned(nextPinned);
-      // If the unpinned view was the default, reset to chat
+      // If the unpinned view was the default, use the permanent Settings view.
       const unpinnedKey = `ext-apps:${connectionId}:${toolName}`;
       if (defaultMainView === unpinnedKey) {
-        writeLayout({ defaultMainView: null });
+        writeLayout({ defaultMainView: { type: "settings" } });
       }
     } else {
       const toolTitle = connectionsData
@@ -393,6 +396,14 @@ export function LayoutTabContent({
     });
     form.setValue("metadata.sidebarViewsVersion", 1, { shouldDirty: true });
     optimisticSidebarViews.stage(nextSidebarViews, sidebarViews);
+    const nextDefaultMain = defaultMainViewAfterSidebarToggle(
+      currentDefaultMain,
+      viewId,
+      enabled,
+    );
+    if (nextDefaultMain !== currentDefaultMain) {
+      writeLayout({ defaultMainView: nextDefaultMain });
+    }
     // The parent form subscription coalesces rapid adjacent switch changes and
     // flushes the latest value on unmount. Starting a full metadata write for
     // every click would let out-of-order responses revert the newest choice.
@@ -406,8 +417,16 @@ export function LayoutTabContent({
   // either a Start Website template or a connected GitHub repo — matching
   // the gating in `use-main-panel-tabs.ts`.
   const hasClonableSource = agentHasClonableSource(virtualMcp?.metadata);
-  const availableSidebarViews = availableProjectSidebarViews(
-    projectSidebarViewPresence(hasClonableSource, nativeViews.presence),
+  const sidebarViewPresence = projectSidebarViewPresence(
+    hasClonableSource,
+    nativeViews.presence,
+  );
+  const availableSidebarViews =
+    availableProjectSidebarViews(sidebarViewPresence);
+  const enabledSidebarViews = selectedProjectSidebarViews(
+    sidebarViews,
+    sidebarViewPresence,
+    1,
   );
   const sidebarViewLabels: Record<ProjectSidebarViewId, string> = {
     overview: t("sidebar.navDestinations.home"),
@@ -429,7 +448,7 @@ export function LayoutTabContent({
    * never an agent's view), then the project rows, then Settings last.
    */
   const defaultMainOptions: { value: string; label: string }[] = [];
-  for (const viewId of availableSidebarViews) {
+  for (const viewId of enabledSidebarViews) {
     // Pinned app rows sit before Automations in the actual sidebar, so append
     // that final project row after the pinned-view loop below.
     if (viewId === "automations") continue;
@@ -444,7 +463,7 @@ export function LayoutTabContent({
       label: pv.label || pv.toolName,
     });
   }
-  if (availableSidebarViews.includes("automations")) {
+  if (enabledSidebarViews.includes("automations")) {
     defaultMainOptions.push({
       value: "automations",
       label: sidebarViewLabels.automations,


### PR DESCRIPTION
## Summary

- only offer enabled project sidebar views in the Main view selector
- fall back to Settings when the selected sidebar or pinned app view is disabled
- cover standard and Site Editor-compatible default view values

## Testing

- `bun test apps/web/src/layouts/main-panel-tabs` (210 passed)
- `bun run check`
- `bun run lint`
- `bun run fmt:check`
- `bun run knip`
- full `bun test` attempted; local integration suites require PostgreSQL and a built daemon, while the native signing setup timeout reproduces unchanged on `main`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Main view selector now only offers enabled sidebar views, and disabling the view that owns the current default main view falls back to Settings instead of leaving an unreachable default.

- Preview, Content, and Code all count as the Site Editor row when checking the default.
- Removing a pinned external app that was the default also resets to Settings instead of clearing the default.

<sup>Written for commit f08ae681124f64cd8f5c8ff91e18a7afc827a65b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

