### PR TITLE
feat(billing): grant configurable AI gateway signup credit to new orgs

### DIFF
--- a/apps/api/src/auth/index.ts
+++ b/apps/api/src/auth/index.ts
@@ -41,6 +41,7 @@ import { createEmailOtpConfig } from "./email-otp";
 import { createEmailSender, findEmailProvider } from "./email-providers";
 import { emailButton, emailParagraph, emailTemplate } from "./email-template";
 import { createMagicLinkConfig } from "./magic-link";
+import { readInitialCreditCents } from "./initial-credit";
 import { seedOrgDb } from "./org";
 import { hoistOrgLogo } from "./hoist-org-logo";
 import { identifyAuthenticatedUser } from "./posthog-identify";
@@ -240,7 +241,9 @@ const plugins = [
   organization({
     organizationCreation: {
       afterCreate: async (data) => {
-        await seedOrgDb(data.organization.id, data.member.userId);
+        await seedOrgDb(data.organization.id, data.member.userId, {
+          signupGrantCents: readInitialCreditCents(data.organization.metadata),
+        });
       },
     },
     organizationHooks: {

--- a/apps/api/src/auth/initial-credit.test.ts
+++ b/apps/api/src/auth/initial-credit.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { readInitialCreditCents } from "./initial-credit";
+
+describe("readInitialCreditCents", () => {
+  it("reads a valid amount from an object", () => {
+    expect(readInitialCreditCents({ initialCreditCents: 2500 })).toBe(2500);
+  });
+
+  it("reads a valid amount from a JSON string (as Better Auth may pass it)", () => {
+    expect(
+      readInitialCreditCents(JSON.stringify({ initialCreditCents: 1000 })),
+    ).toBe(1000);
+  });
+
+  it("accepts 0 (explicit no-grant)", () => {
+    expect(readInitialCreditCents({ initialCreditCents: 0 })).toBe(0);
+  });
+
+  it("preserves other metadata keys without interfering", () => {
+    expect(
+      readInitialCreditCents({ description: "x", initialCreditCents: 500 }),
+    ).toBe(500);
+  });
+
+  it("falls back to undefined for non-object / missing / malformed input", () => {
+    for (const input of [
+      undefined,
+      null,
+      "",
+      "not json",
+      42,
+      [],
+      { other: 1 },
+    ]) {
+      expect(readInitialCreditCents(input)).toBeUndefined();
+    }
+  });
+
+  it("rejects out-of-range or non-integer amounts", () => {
+    for (const value of [
+      -1,
+      1.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      100_001,
+    ]) {
+      expect(
+        readInitialCreditCents({ initialCreditCents: value }),
+      ).toBeUndefined();
+    }
+  });
+
+  it("accepts exactly the cap", () => {
+    expect(readInitialCreditCents({ initialCreditCents: 100_000 })).toBe(
+      100_000,
+    );
+  });
+});

--- a/apps/api/src/auth/initial-credit.ts
+++ b/apps/api/src/auth/initial-credit.ts
@@ -1,0 +1,30 @@
+import { MAX_SIGNUP_GRANT_CENTS } from "@/billing/gateway-admin";
+
+/**
+ * Extract a control-plane-supplied initial AI-credit override (in cents) from
+ * an org's Better Auth metadata, which reaches the afterCreate hook as either
+ * an object or a raw JSON string. Returns undefined for anything that isn't a
+ * finite non-negative integer within the cap, so a malformed value falls back
+ * to the deployment default rather than granting a garbage amount.
+ */
+export function readInitialCreditCents(metadata: unknown): number | undefined {
+  let bag: unknown = metadata;
+  if (typeof bag === "string") {
+    try {
+      bag = JSON.parse(bag);
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof bag !== "object" || bag === null) return undefined;
+  const value = (bag as Record<string, unknown>).initialCreditCents;
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value < 0 ||
+    value > MAX_SIGNUP_GRANT_CENTS
+  ) {
+    return undefined;
+  }
+  return value;
+}

--- a/apps/api/src/auth/org.ts
+++ b/apps/api/src/auth/org.ts
@@ -4,6 +4,10 @@ import {
   getWellKnownSelfConnection,
 } from "@decocms/shared/sdk";
 import { decoAiGatewayAdapter } from "@/ai-providers/adapters/deco-ai-gateway";
+import {
+  gatewayAdminConfigured,
+  grantGatewaySignupCredit,
+} from "@/billing/gateway-admin";
 import { getBaseUrl } from "@/core/server-constants";
 import { getDb } from "@/database";
 import { CredentialVault } from "@/encryption/credential-vault";
@@ -187,6 +191,18 @@ export async function seedOrgDb(organizationId: string, createdBy: string) {
         });
       } catch (err) {
         console.error("Failed to auto-provision Deco AI Gateway key:", err);
+      }
+    }
+
+    // Idempotent at the gateway per `signup-credit:<orgId>`; fail-soft.
+    if (settings.signupGrantCents > 0 && gatewayAdminConfigured()) {
+      try {
+        await grantGatewaySignupCredit({
+          organizationId,
+          amountCents: settings.signupGrantCents,
+        });
+      } catch (err) {
+        console.error("Failed to grant signup AI credit:", err);
       }
     }
   } catch (err) {

--- a/apps/api/src/auth/org.ts
+++ b/apps/api/src/auth/org.ts
@@ -90,8 +90,16 @@ function getDefaultOrgMcps(organizationId: string): MCPCreationSpec[] {
  * Create default MCP connections for a new organization
  * This is deferred to run after the Better Auth request completes
  * to avoid deadlocks when issuing tokens
+ *
+ * `opts.signupGrantCents` overrides the deployment-default AI-credit grant for
+ * this org (the control-plane passes it per-org at creation); omitted → the
+ * `signupGrantCents` setting applies.
  */
-export async function seedOrgDb(organizationId: string, createdBy: string) {
+export async function seedOrgDb(
+  organizationId: string,
+  createdBy: string,
+  opts?: { signupGrantCents?: number },
+) {
   try {
     const database = getDb();
     const settings = getSettings();
@@ -195,11 +203,13 @@ export async function seedOrgDb(organizationId: string, createdBy: string) {
     }
 
     // Idempotent at the gateway per `signup-credit:<orgId>`; fail-soft.
-    if (settings.signupGrantCents > 0 && gatewayAdminConfigured()) {
+    const signupGrantCents =
+      opts?.signupGrantCents ?? settings.signupGrantCents;
+    if (signupGrantCents > 0 && gatewayAdminConfigured()) {
       try {
         await grantGatewaySignupCredit({
           organizationId,
-          amountCents: settings.signupGrantCents,
+          amountCents: signupGrantCents,
         });
       } catch (err) {
         console.error("Failed to grant signup AI credit:", err);

--- a/apps/api/src/billing/gateway-admin.ts
+++ b/apps/api/src/billing/gateway-admin.ts
@@ -34,6 +34,38 @@ async function postGatewayAdmin(
 }
 
 /**
+ * Grant the one-time signup credit to a new org's gateway ledger. Idempotent
+ * at the gateway per referenceId (unique ledger index): the deterministic
+ * `signup-credit:<orgId>` reference collapses any replay — a re-run of
+ * seedOrgDb, a retry — to a no-op, so the org is credited exactly once without
+ * Studio holding any local "already granted" state.
+ *
+ * Fail-soft is the CALLER's job: org creation must never fail on a grant error
+ * (see seedOrgDb), mirroring the auto-provision path.
+ */
+export async function grantGatewaySignupCredit(input: {
+  organizationId: string;
+  amountCents: number;
+}): Promise<void> {
+  if (!gatewayAdminConfigured()) {
+    // Config was removed mid-flight; throw so the fail-soft caller logs it.
+    throw new Error(
+      "gateway admin not configured — cannot grant signup credit",
+    );
+  }
+  await postGatewayAdmin(
+    "/api/admin/credits",
+    {
+      orgId: input.organizationId,
+      amountCents: input.amountCents,
+      description: "Studio signup credit",
+      referenceId: `signup-credit:${input.organizationId}`,
+    },
+    "gateway signup credit grant",
+  );
+}
+
+/**
  * Credit purchased AI credits to the org's gateway ledger. The top-up webhook
  * THROWS on failure and lets Stripe's redelivery be the retry queue — the
  * gateway referenceId dedupe makes every replay a no-op.

--- a/apps/api/src/billing/gateway-admin.ts
+++ b/apps/api/src/billing/gateway-admin.ts
@@ -5,6 +5,10 @@
 
 import { getSettings } from "../settings";
 
+/** Fat-finger cap on any signup/initial-credit grant ($1,000). Keep in sync
+ *  with the DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS cap in resolve-config.ts. */
+export const MAX_SIGNUP_GRANT_CENTS = 100_000;
+
 /** Whether this deployment can reach the gateway admin API at all
  *  (self-hosted deployments can't). */
 export function gatewayAdminConfigured(): boolean {

--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -499,15 +499,15 @@ describe("resolveConfig topup fee percent", () => {
 });
 
 describe("resolveConfig signup grant cents", () => {
-  it("defaults to 2500 ($25)", () => {
-    expect(resolveConfig(flags, {}).settings.signupGrantCents).toBe(2500);
+  it("defaults to 2300 (nets ~$25 with the gateway's $2)", () => {
+    expect(resolveConfig(flags, {}).settings.signupGrantCents).toBe(2300);
   });
 
   it("honors an override", () => {
     expect(
-      resolveConfig(flags, { DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS: "2300" })
+      resolveConfig(flags, { DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS: "5000" })
         .settings.signupGrantCents,
-    ).toBe(2300);
+    ).toBe(5000);
   });
 
   it("allows 0 to disable the signup grant", () => {

--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -498,6 +498,40 @@ describe("resolveConfig topup fee percent", () => {
   });
 });
 
+describe("resolveConfig signup grant cents", () => {
+  it("defaults to 2500 ($25)", () => {
+    expect(resolveConfig(flags, {}).settings.signupGrantCents).toBe(2500);
+  });
+
+  it("honors an override", () => {
+    expect(
+      resolveConfig(flags, { DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS: "2300" })
+        .settings.signupGrantCents,
+    ).toBe(2300);
+  });
+
+  it("allows 0 to disable the signup grant", () => {
+    expect(
+      resolveConfig(flags, { DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS: "0" }).settings
+        .signupGrantCents,
+    ).toBe(0);
+  });
+
+  it("rejects a non-numeric value at boot (fail-fast, not a silent default)", () => {
+    expect(() =>
+      resolveConfig(flags, { DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS: "lots" }),
+    ).toThrow(
+      "DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS must be a non-negative integer",
+    );
+  });
+
+  it("rejects a value above the $1,000 fat-finger cap", () => {
+    expect(() =>
+      resolveConfig(flags, { DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS: "250000" }),
+    ).toThrow("DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS must be at most 100000");
+  });
+});
+
 describe("resolveConfig decopilot max concurrent subagents", () => {
   it("defaults to 4", () => {
     expect(

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -261,6 +261,13 @@ export function resolveConfig(
     aiGatewayEnabled: toBool(envVars.DECO_AI_GATEWAY_ENABLED),
     aiGatewayUrl: envVars.DECO_AI_GATEWAY_URL || "https://ai-site.deco.site",
     aiGatewayAdminToken: envVars.DECO_AI_GATEWAY_ADMIN_TOKEN,
+    // Capped at $1,000 (fat-finger guard); 0 disables the signup grant.
+    signupGrantCents: toNonNegativeIntegerOrDefault(
+      "DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS",
+      envVars.DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS,
+      2500,
+      100_000,
+    ),
     stripeWebhookSecret: envVars.STRIPE_WEBHOOK_SECRET,
     stripeSecretKey: envVars.STRIPE_SECRET_KEY,
     stripeOrgPriceId: envVars.STRIPE_ORG_PRICE_ID,

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -261,11 +261,11 @@ export function resolveConfig(
     aiGatewayEnabled: toBool(envVars.DECO_AI_GATEWAY_ENABLED),
     aiGatewayUrl: envVars.DECO_AI_GATEWAY_URL || "https://ai-site.deco.site",
     aiGatewayAdminToken: envVars.DECO_AI_GATEWAY_ADMIN_TOKEN,
-    // Capped at $1,000 (fat-finger guard); 0 disables the signup grant.
+    // Default 2300 nets ~$25 with the gateway's $2; cap $1,000; 0 disables.
     signupGrantCents: toNonNegativeIntegerOrDefault(
       "DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS",
       envVars.DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS,
-      2500,
+      2300,
       100_000,
     ),
     stripeWebhookSecret: envVars.STRIPE_WEBHOOK_SECRET,

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -75,6 +75,11 @@ export interface Settings {
   /** Bearer for the gateway's /api/admin/* (top-up credits). Absent → the
    *  top-up tool falls back to the gateway's own checkout. */
   aiGatewayAdminToken: string | undefined;
+  /** One-time AI credit granted to every new org on signup, in cents (default
+   *  2500 = $25). 0 disables the grant. Only applied when the gateway admin is
+   *  configured (hosted deployments); self-hosted deployments can't reach the
+   *  admin API and skip it. */
+  signupGrantCents: number;
 
   // Stripe (per-org subscription + AI-credit top-ups). Absent → webhook
   // 503s, no checkout.

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -76,9 +76,10 @@ export interface Settings {
    *  top-up tool falls back to the gateway's own checkout. */
   aiGatewayAdminToken: string | undefined;
   /** One-time AI credit granted to every new org on signup, in cents (default
-   *  2500 = $25). 0 disables the grant. Only applied when the gateway admin is
-   *  configured (hosted deployments); self-hosted deployments can't reach the
-   *  admin API and skip it. */
+   *  2300, which nets ~$25 with the gateway's own $2 provision credit). A
+   *  per-org override may be passed at creation (see readInitialCreditCents).
+   *  0 disables the grant. Only applied when the gateway admin is configured
+   *  (hosted deployments); self-hosted can't reach the admin API and skip it. */
   signupGrantCents: number;
 
   // Stripe (per-org subscription + AI-credit top-ups). Absent → webhook

--- a/apps/api/src/tools/organization/create.ts
+++ b/apps/api/src/tools/organization/create.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
 import { getUserId, requireAuth } from "../../core/studio-context";
 import { isReservedOrganizationSlug } from "@decocms/shared/organization-slugs";
+import { MAX_SIGNUP_GRANT_CENTS } from "../../billing/gateway-admin";
 
 export const ORGANIZATION_CREATE = defineTool({
   name: "ORGANIZATION_CREATE" as const,
@@ -32,6 +33,15 @@ export const ORGANIZATION_CREATE = defineTool({
       ),
     name: z.string().min(1).max(255),
     description: z.string().optional(),
+    initialCreditCents: z
+      .number()
+      .int()
+      .min(0)
+      .max(MAX_SIGNUP_GRANT_CENTS)
+      .optional()
+      .describe(
+        "Initial Deco AI Gateway credit to grant this org, in cents (e.g. 2500 = $25). Overrides the deployment default; omit to use it. 0 grants nothing.",
+      ),
   }),
 
   outputSchema: z.object({
@@ -57,13 +67,16 @@ export const ORGANIZATION_CREATE = defineTool({
       throw new Error("User ID required to create organization");
     }
 
-    // Create organization via bound auth client
+    // initialCreditCents rides in metadata for the afterCreate seed hook.
+    const metadata: Record<string, unknown> = {};
+    if (input.description) metadata.description = input.description;
+    if (input.initialCreditCents !== undefined) {
+      metadata.initialCreditCents = input.initialCreditCents;
+    }
     const result = await ctx.boundAuth.organization.create({
       name: input.name,
       slug: input.slug,
-      metadata: input.description
-        ? { description: input.description }
-        : undefined,
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
       userId, // Server-side creation
     });
 

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -7,7 +7,12 @@
  */
 export interface StudioToolIO {
   ORGANIZATION_CREATE: {
-    input: { slug: string; name: string; description?: string | undefined };
+    input: {
+      slug: string;
+      name: string;
+      description?: string | undefined;
+      initialCreditCents?: number | undefined;
+    };
     output: {
       id: string;
       name: string;


### PR DESCRIPTION
## Summary

Every new org is granted a one-time **Deco AI Gateway credit** on creation, netting **~$25** with the gateway's existing $2 provision credit. The amount is a deployment default and can be **overridden per-org by the control plane** at org creation.

### How the credit is granted
- The gateway's `provisionKey` only mints a key (+ a small $2 auto-grant); balance is separate. The server-to-server grant is `POST /api/admin/credits` (already used by the Stripe top-up webhook), **idempotent per `referenceId`**.
- New `grantGatewaySignupCredit` (`billing/gateway-admin.ts`) uses `referenceId = signup-credit:<orgId>` → a re-run of `seedOrgDb` or any retry is a no-op at the gateway, so **no local "already granted" state** is needed.
- Called **fail-soft** from `seedOrgDb` (own try/catch, only logs) — a grant error never fails org creation, mirroring the AI-key auto-provision path. Independent of the provision block.

### Configurability
- **Deployment default**: `DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS` (default **2300** = nets ~$25; `0` disables; capped at $1,000 via `MAX_SIGNUP_GRANT_CENTS`).
- **Per-org override (control plane)**: `ORGANIZATION_CREATE` accepts optional `initialCreditCents`. It rides in org metadata; the `afterCreate` seed hook (the canonical creation boundary, covering the MCP tool **and** direct Better Auth calls) reads it via `readInitialCreditCents`, a defensive parser that handles metadata as object or JSON string and ignores out-of-range/garbage (→ falls back to the default).

### Scope
Applies to every org **only when the gateway admin is configured** (`gatewayAdminConfigured()` = `aiGatewayEnabled && aiGatewayAdminToken`) — hosted deployments. Self-hosted can't reach the admin API and skip it.

## Testing
- `resolve-config.test.ts`: default/override/0/non-numeric/cap for the new setting.
- `initial-credit.test.ts`: object vs JSON-string metadata, 0, out-of-range/garbage, cap boundary.
- `bun run check` (all workspaces) and `bun run lint` pass; `bun run fmt` applied; `generate:tool-contracts` re-run (tool-io.ts).
- The one failing test locally (`billing-checkout.integration.test.ts`) is a pre-existing Postgres-dependent integration test (no local DB), untouched by this PR.

## Caveats
- **Stacks on the gateway's own $2**: I can't suppress the gateway (ai-site) auto-grant from Studio, so the default is 2300 to net ~$25. Change the env if the gateway's behavior changes.
- **`/api/admin/credits` contract** (field names, `referenceId` dedupe) is inferred from the existing `creditGatewayTopUp` consumer — the ai-site gateway repo isn't in this workspace. Worth a confirm from the gateway side before relying on exact idempotency semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grants new organizations a one-time Deco AI Gateway credit on creation, replacing the previous no-credit behavior. The amount is configurable via deployment default and per-org override.

**Configuration**
- `DECO_AI_GATEWAY_SIGNUP_GRANT_CENTS` sets the default (2300 cents, 0 disables, capped at $1,000).
- `ORGANIZATION_CREATE` accepts optional `initialCreditCents` to override per org.

**Notes**
- Grant is idempotent at the gateway via `referenceId = signup-credit:<orgId>`, so retries never double-grant.
- Fail-soft: a grant error is logged but never fails org creation.
- Only applies when the gateway admin is configured (hosted); self-hosted deployments skip it.
- Default is 2300 cents because the gateway's own $2 provision credit can't be suppressed; the admin API contract is inferred from the existing top-up consumer.

<sup>Written for commit 20c81de09beae491171533876ef32d3209b1d2ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

