### PR TITLE
fix(agents): drafts-mode entry lands on a named version or production, never an unnamed draft

### DIFF
--- a/apps/web/src/components/header/shell-breadcrumb.tsx
+++ b/apps/web/src/components/header/shell-breadcrumb.tsx
@@ -24,6 +24,10 @@ import {
   useVirtualMCPs,
 } from "@/sdk";
 import { getActiveGithubRepo } from "@/lib/github-repo";
+import {
+  draftsModeEnabled,
+  useBaseBranch,
+} from "@/components/thread/github/use-version-gate";
 import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
 import { AgentAvatar } from "@/components/agent-icon";
 import { AgentScopePicker } from "@/components/sidebar/agents-section";
@@ -113,6 +117,8 @@ export function AgentSwitcherCrumb({
   const { data: session } = authClient.useSession();
   const { setTaskId, createNewTask } = usePanelActions();
   const projectDefaultRuntime = useProjectDefaultRuntime();
+  /** Cold-entry base ("main"): no current branch to resolve a PR base from. */
+  const baseBranch = useBaseBranch(undefined, null);
 
   const decopilot = getWellKnownDecopilotVirtualMCP(org.id);
   const decopilotId = decopilot.id;
@@ -128,17 +134,26 @@ export function AgentSwitcherCrumb({
   const handlePickAgent = (id: string | null) => {
     const targetId = id ?? decopilotId;
     const target = (allAgents ?? []).find((a) => a.id === targetId);
+    const isDraftsMode = draftsModeEnabled(target);
     const existing = findAgentEntryThread(
       threads,
       targetId,
       session?.user?.id,
       projectDefaultRuntime(targetId),
       !!(target && getActiveGithubRepo(target)),
+      {
+        knownBranches: new Set<string>([
+          baseBranch,
+          ...(target?.metadata?.releases ?? []).map((r) => r.branch),
+        ]),
+        draftsMode: isDraftsMode,
+      },
     );
     if (existing) {
       setTaskId(existing.id, targetId);
     } else {
-      void createNewTask(targetId);
+      // Drafts mode mints a fresh thread on production, never an unnamed draft.
+      void createNewTask(targetId, isDraftsMode ? baseBranch : undefined);
     }
     onNavigate?.();
   };

--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -190,6 +190,26 @@ export function BranchPicker({
     setEditName("");
   };
 
+  // Naming the current unlisted branch adopts it as a release (a named version).
+  const saveUnlistedName = () => {
+    const next = editName.trim();
+    if (next && value) {
+      void createRelease({
+        branch: value,
+        name: next,
+        color: nextReleaseColor(releases.length),
+        createdAt: new Date().toISOString(),
+      });
+    }
+    setEditing(null);
+    setEditName("");
+  };
+
+  const cancelRename = () => {
+    setEditing(null);
+    setEditName("");
+  };
+
   const confirmDelete = () => {
     const r = pendingDelete;
     setPendingDelete(null);
@@ -291,43 +311,48 @@ export function BranchPicker({
               {(unlisted || releases.length > 0) && (
                 <div className="my-1 border-t" />
               )}
-              {unlisted && (
-                <VersionRow
-                  dot={releaseDotClass("orange")}
-                  label={t("thread.branchPicker.defaultVersionName")}
-                  branch={value}
-                  selected
-                  onSelect={() => value && pick(value)}
-                />
-              )}
+              {unlisted &&
+                value &&
+                (editing === value ? (
+                  <RenameInput
+                    value={editName}
+                    onChange={setEditName}
+                    onSave={saveUnlistedName}
+                    onCancel={cancelRename}
+                  />
+                ) : (
+                  <ReleaseRow
+                    dot={releaseDotClass("orange")}
+                    label={t("thread.branchPicker.defaultVersionName")}
+                    branch={value}
+                    selected
+                    onSelect={() => pick(value)}
+                    onRename={() => {
+                      setEditing(value);
+                      setEditName(
+                        nextDraftName(
+                          releases,
+                          t("thread.branchPicker.defaultVersionName"),
+                        ),
+                      );
+                    }}
+                  />
+                ))}
               {releases.map((r) =>
                 editing === r.branch ? (
-                  <div key={r.branch} className="flex items-center gap-1.5 p-1">
-                    <input
-                      // biome-ignore lint/a11y/noAutofocus: opened by an explicit click
-                      autoFocus
-                      aria-label={t("thread.branchPicker.rename")}
-                      value={editName}
-                      onChange={(e) => setEditName(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") void saveRename(r.branch);
-                        if (e.key === "Escape") {
-                          // Don't let Escape also close the popover behind it.
-                          e.preventDefault();
-                          e.stopPropagation();
-                          setEditing(null);
-                        }
-                      }}
-                      className="h-8 flex-1 rounded-md border bg-transparent px-2 text-sm outline-none focus:ring-1 focus:ring-ring"
-                    />
-                    <Button size="sm" onClick={() => void saveRename(r.branch)}>
-                      {t("thread.branchPicker.save")}
-                    </Button>
-                  </div>
+                  <RenameInput
+                    key={r.branch}
+                    value={editName}
+                    onChange={setEditName}
+                    onSave={() => saveRename(r.branch)}
+                    onCancel={cancelRename}
+                  />
                 ) : (
                   <ReleaseRow
                     key={r.branch}
-                    release={r}
+                    dot={releaseDotClass(r.color)}
+                    label={r.name}
+                    branch={r.branch}
                     selected={r.branch === value}
                     onSelect={() => pick(r.branch)}
                     onRename={() => startRename(r)}
@@ -440,19 +465,63 @@ function VersionRow({
   );
 }
 
-/** A named release row: click to switch, with a ⋯ menu to rename or discard. */
+/** Inline name editor shared by rename (a release) and adopt (an unlisted branch). */
+function RenameInput({
+  value,
+  onChange,
+  onSave,
+  onCancel,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  const t = useT();
+  return (
+    <div className="flex items-center gap-1.5 p-1">
+      <input
+        // biome-ignore lint/a11y/noAutofocus: opened by an explicit click
+        autoFocus
+        aria-label={t("thread.branchPicker.rename")}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") onSave();
+          if (e.key === "Escape") {
+            // Don't let Escape also close the popover behind it.
+            e.preventDefault();
+            e.stopPropagation();
+            onCancel();
+          }
+        }}
+        className="h-8 flex-1 rounded-md border bg-transparent px-2 text-sm outline-none focus:ring-1 focus:ring-ring"
+      />
+      <Button size="sm" onClick={onSave}>
+        {t("thread.branchPicker.save")}
+      </Button>
+    </div>
+  );
+}
+
+/** A version row: click to switch, with a ⋯ menu to rename (always) and discard
+ *  (only a stored release — an unlisted branch has nothing to discard). */
 function ReleaseRow({
-  release,
+  dot,
+  label,
+  branch,
   selected,
   onSelect,
   onRename,
   onDelete,
 }: {
-  release: Release;
+  dot: string;
+  label: string;
+  branch: string;
   selected: boolean;
   onSelect: () => void;
   onRename: () => void;
-  onDelete: () => void;
+  onDelete?: () => void;
 }) {
   const t = useT();
   return (
@@ -470,17 +539,12 @@ function ReleaseRow({
             onClick={onSelect}
             className="flex min-w-0 flex-1 items-center gap-2.5 px-2 py-2 text-left text-sm"
           >
-            <span
-              className={cn(
-                "h-2 w-2 shrink-0 rounded-full",
-                releaseDotClass(release.color),
-              )}
-            />
-            <span className="flex-1 truncate">{release.name}</span>
+            <span className={cn("h-2 w-2 shrink-0 rounded-full", dot)} />
+            <span className="flex-1 truncate">{label}</span>
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom" className="font-mono text-xs">
-          {t("thread.branchPicker.branchTooltip", { branch: release.branch })}
+          {t("thread.branchPicker.branchTooltip", { branch })}
         </TooltipContent>
       </Tooltip>
       <DropdownMenu>
@@ -499,13 +563,15 @@ function ReleaseRow({
             <Edit01 className="h-4 w-4" />
             {t("thread.branchPicker.rename")}
           </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={onDelete}
-            className="text-destructive focus:text-destructive"
-          >
-            <Trash01 className="h-4 w-4" />
-            {t("thread.branchPicker.delete")}
-          </DropdownMenuItem>
+          {onDelete && (
+            <DropdownMenuItem
+              onSelect={onDelete}
+              className="text-destructive focus:text-destructive"
+            >
+              <Trash01 className="h-4 w-4" />
+              {t("thread.branchPicker.delete")}
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/apps/web/src/hooks/use-ensure-task.ts
+++ b/apps/web/src/hooks/use-ensure-task.ts
@@ -44,7 +44,14 @@ type State =
   | { status: "ready"; task: Task | null }
   | { status: "error"; error: Error };
 
-export function useEnsureTask(id: string | null, virtualMcpId: string): State {
+export function useEnsureTask(
+  id: string | null,
+  virtualMcpId: string,
+  /** Branch to stamp when this hook has to CREATE the row (drafts mode lands a
+   *  fresh entry thread on production instead of an auto-minted unnamed draft).
+   *  Ignored for existing rows and overridden by an explicit parked intent. */
+  defaultBranch?: string,
+): State {
   const manager = useThreadManager();
   const { locator } = useProjectContext();
   const threads = useSyncExternalStore(
@@ -104,6 +111,8 @@ export function useEnsureTask(id: string | null, virtualMcpId: string): State {
       manager.create({
         id: taskId,
         virtual_mcp_id: virtualMcpId,
+        // Default branch first so an explicit parked intent still wins below.
+        ...(defaultBranch ? { branch: defaultBranch } : {}),
         // What the failed create asked for; the runtime it stamps is permanent.
         ...claimThreadIntent(sessionStorage, locator, taskId),
       }),

--- a/apps/web/src/hooks/use-navigate-to-agent.ts
+++ b/apps/web/src/hooks/use-navigate-to-agent.ts
@@ -20,6 +20,10 @@ import type { Task } from "@/components/chat/task/types";
 import { findAgentEntryThread } from "@/lib/reusable-new-chat";
 import { getActiveGithubRepo } from "@/lib/github-repo";
 import {
+  draftsModeEnabled,
+  useBaseBranch,
+} from "@/components/thread/github/use-version-gate";
+import {
   defaultThreadRuntime,
   type ThreadRuntime,
 } from "@decocms/shared/thread/session-runtime";
@@ -53,6 +57,8 @@ export function useNavigateToAgent() {
    *  re-rendered every sidebar row for a value nothing renders, and the
    *  snapshot a click needs is the one at the click. */
   const manager = useOptionalThreadManager();
+  /** Cold-entry base ("main"): no current branch to resolve a PR base from. */
+  const baseBranch = useBaseBranch(undefined, null);
 
   /** The navigation proper, once the wanted runtime is known. */
   const go = (
@@ -72,6 +78,13 @@ export function useNavigateToAgent() {
       wantedRuntime ??
         (target ? defaultThreadRuntime(target.metadata) : undefined),
       !!(target && getActiveGithubRepo(target)),
+      {
+        knownBranches: new Set<string>([
+          baseBranch,
+          ...(target?.metadata?.releases ?? []).map((r) => r.branch),
+        ]),
+        draftsMode: draftsModeEnabled(target),
+      },
     );
     const taskId = entry?.id ?? crypto.randomUUID();
     /** Park the runtime for the create the route loader will run. Only for a

--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -62,6 +62,10 @@ import {
 } from "@/hooks/use-layout-state";
 import { useRefreshViewedThreadMetadata } from "@/hooks/use-refresh-viewed-thread-metadata";
 import { getActiveGithubRepo } from "@/lib/github-repo";
+import {
+  draftsModeEnabled,
+  useBaseBranch,
+} from "@/components/thread/github/use-version-gate";
 import { useT } from "@/i18n/use-t.ts";
 import { Toolbar } from "./toolbar";
 import { WorkspacePanelGroup } from "./workspace-panel-group";
@@ -572,12 +576,33 @@ function AgentInsetProvider() {
     threadManager.threads.subscribe,
     threadManager.threads.get,
   );
+  const threadsStatus = useSyncExternalStore(
+    threadManager.threadsStatus.subscribe,
+    threadManager.threadsStatus.get,
+  );
+
+  // Fetch entity (Suspense-based — resolved before render)
+  const entity = useVirtualMCP(virtualMcpId);
+
+  const hasActiveGithubRepo = !!(entity && getActiveGithubRepo(entity));
+  const isDraftsMode = draftsModeEnabled(entity);
+  // Production + named releases: the versions entry can restore to (see findAgentEntryThread).
+  const baseBranch = useBaseBranch(entity, null);
+  const namedVersionBranches = new Set<string>([
+    baseBranch,
+    ...(entity?.metadata?.releases ?? []).map((r) => r.branch),
+  ]);
 
   // Ensure the thread row exists for this URL before rendering the chat. On
   // 404 the hook fires COLLECTION_THREADS_CREATE (idempotent) and surfaces a
   // "Creating task…" state until the row is persisted. Without this the
   // chat renders with branch=null because the thread never existed.
-  const ensureState = useEnsureTask(routeThreadId, virtualMcpId);
+  const ensureState = useEnsureTask(
+    routeThreadId,
+    virtualMcpId,
+    // Drafts mode: a freshly minted thread lands on production, never an unnamed draft.
+    isDraftsMode ? baseBranch : undefined,
+  );
 
   // Read-only teammate threads: pull the current metadata (githubRepo /
   // sandboxMap bound by load_repo after the panel snapshot) so the preview
@@ -587,9 +612,6 @@ function AgentInsetProvider() {
     ensureState.status === "ready" ? ensureState.task : null,
   );
 
-  // Fetch entity (Suspense-based — resolved before render)
-  const entity = useVirtualMCP(virtualMcpId);
-
   const layoutMetadata = entity?.metadata?.ui?.layout ?? null;
   const entityMetadata = layoutMetadata
     ? {
@@ -598,7 +620,6 @@ function AgentInsetProvider() {
       }
     : null;
 
-  const hasActiveGithubRepo = !!(entity && getActiveGithubRepo(entity));
   const layout = useWorkspaceLayoutState(entityMetadata, {
     virtualMcpId,
     isAgentRoute: true,
@@ -624,6 +645,21 @@ function AgentInsetProvider() {
    * Super Agent (no repo) keeps its lazy threadless composer.
    */
   if (routeThreadId === null && hasActiveGithubRepo) {
+    // Wait for the first thread page: resolving against an empty list would mint a fresh production thread and drop the user off their version.
+    if (threadsStatus.kind === "loading") {
+      return (
+        <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex h-full items-center justify-center bg-background card-shadow rounded-[0.75rem] text-sm text-muted-foreground"
+          >
+            <Spinner className="size-4 mr-2" />
+            {t("agentShellLayout.agentShellLayout.creatingTask")}
+          </div>
+        </div>
+      );
+    }
     // Resume the last branch for this repo-backed agent, else its empty chat, else mint one.
     const threadId =
       findAgentEntryThread(
@@ -632,6 +668,7 @@ function AgentInsetProvider() {
         session?.user?.id,
         defaultThreadRuntime(entity.metadata),
         hasActiveGithubRepo,
+        { knownBranches: namedVersionBranches, draftsMode: isDraftsMode },
       )?.id ?? generatedThreadId;
     return (
       <Navigate

--- a/apps/web/src/lib/find-last-thread-for-agent.ts
+++ b/apps/web/src/lib/find-last-thread-for-agent.ts
@@ -2,12 +2,21 @@ import type { Task } from "@/components/chat/task/types";
 import { threadRuntimeMatches } from "@/lib/thread-runtime-match";
 import type { ThreadRuntime } from "@decocms/shared/thread/session-runtime";
 
-/** Current user's most-recently-updated non-archived thread for `agentId` (optionally runtime-matched), or null — the last *real* thread, empty or not. */
+/**
+ * Current user's most-recently-updated non-archived thread for `agentId`
+ * (optionally runtime-matched), or null — the last *real* thread, empty or not.
+ *
+ * When `onlyBranches` is given, only threads whose `branch` is in that set are
+ * considered. Entry uses this to prefer the last thread on a *named* version (a
+ * release, or production) so re-entry restores the version the user was editing
+ * instead of an unnamed auto-minted draft.
+ */
 export function findLastThreadForAgent(
   threads: Task[],
   agentId: string,
   userId: string | undefined,
   expectedRuntime?: ThreadRuntime,
+  onlyBranches?: ReadonlySet<string>,
 ): Task | null {
   let best: Task | null = null;
   for (const t of threads) {
@@ -15,6 +24,7 @@ export function findLastThreadForAgent(
     if (t.created_by !== userId) continue;
     if (t.hidden) continue;
     if (!threadRuntimeMatches(t, expectedRuntime)) continue;
+    if (onlyBranches && (!t.branch || !onlyBranches.has(t.branch))) continue;
     if (!best || t.updated_at > best.updated_at) best = t;
   }
   return best;

--- a/apps/web/src/lib/reusable-new-chat.test.ts
+++ b/apps/web/src/lib/reusable-new-chat.test.ts
@@ -159,6 +159,81 @@ describe("findAgentEntryThread", () => {
     ).toBeUndefined();
   });
 
+  const onRelease = task({
+    id: "release",
+    title: "Edit hero",
+    harness_id: "claude-code",
+    branch: "tavano-teste",
+    updated_at: "2026-02-01T00:00:00Z",
+  });
+  const newerUnnamedDraft = task({
+    id: "draft",
+    title: "Scratch",
+    harness_id: "claude-code",
+    branch: "tavano-unnamed",
+    updated_at: "2026-03-01T00:00:00Z",
+  });
+  const known = new Set(["main", "tavano-teste"]);
+
+  // Guards against re-entry landing on a newer unnamed draft (phantom "Rascunho") instead of the named release being edited.
+  it("prefers the last thread on a named version over a newer unnamed draft", () => {
+    expect(
+      findAgentEntryThread(
+        [onRelease, newerUnnamedDraft],
+        "agent-1",
+        USER,
+        undefined,
+        true,
+        { knownBranches: known },
+      )?.id,
+    ).toBe("release");
+  });
+
+  it("falls back to the raw last thread when none sits on a named version", () => {
+    expect(
+      findAgentEntryThread(
+        [newerUnnamedDraft],
+        "agent-1",
+        USER,
+        undefined,
+        true,
+        {
+          knownBranches: known,
+        },
+      )?.id,
+    ).toBe("draft");
+  });
+
+  // Drafts mode: an unnamed draft is never editable, so it is never auto-resumed.
+  it("drafts mode resumes the named version, ignoring a newer unnamed draft", () => {
+    expect(
+      findAgentEntryThread(
+        [onRelease, newerUnnamedDraft],
+        "agent-1",
+        USER,
+        undefined,
+        true,
+        { knownBranches: known, draftsMode: true },
+      )?.id,
+    ).toBe("release");
+  });
+
+  it("drafts mode returns undefined when nothing sits on a named version (caller mints on production)", () => {
+    expect(
+      findAgentEntryThread(
+        [newerUnnamedDraft],
+        "agent-1",
+        USER,
+        undefined,
+        true,
+        {
+          knownBranches: known,
+          draftsMode: true,
+        },
+      ),
+    ).toBeUndefined();
+  });
+
   it("never resumes a thread of the other runtime for a repo-backed agent", () => {
     const cmsReal = task({
       id: "cms-real",

--- a/apps/web/src/lib/reusable-new-chat.ts
+++ b/apps/web/src/lib/reusable-new-chat.ts
@@ -41,19 +41,56 @@ export function findReusableNewChat(
   );
 }
 
-/** Thread to land on when *entering* an agent: a `hasBranch` agent resumes its last real thread (last branch worked on); else reuse the empty chat, then `undefined` (caller mints a fresh id). */
+export interface AgentEntryOpts {
+  /** Production ∪ named-release branches — the versions a thread can resume to. */
+  knownBranches?: ReadonlySet<string>;
+  /** Drafts mode never resumes an unnamed draft: a named version or production, else nothing (caller mints a fresh production thread). */
+  draftsMode?: boolean;
+}
+
+/**
+ * Thread to land on when *entering* an agent.
+ *
+ * A `hasBranch` agent's thread branch is only a *named version* (a release or
+ * production) if it was promoted — a fresh thread mints an unnamed auto-generated
+ * branch the drafts picker can only render as a "Rascunho". So we first prefer
+ * the last thread on one of `knownBranches`, restoring the version the user was
+ * editing.
+ *
+ * In `draftsMode` an unnamed draft is never editable: if no thread sits on a
+ * named version we return `undefined` so the caller mints a fresh thread on
+ * production. Otherwise (legacy branch/PR mode) we fall back to the raw last
+ * thread, then the empty chat, then `undefined`.
+ *
+ * A branchless agent (Super Agent) keeps reusing the empty chat, so re-entry
+ * doesn't pile up duplicate empty threads.
+ */
 export function findAgentEntryThread(
   threads: Task[],
   agentId: string,
   userId: string | undefined,
   expectedRuntime: ThreadRuntime | undefined,
   hasBranch: boolean,
+  opts?: AgentEntryOpts,
 ): Task | undefined {
-  if (hasBranch) {
-    return (
-      findLastThreadForAgent(threads, agentId, userId, expectedRuntime) ??
-      findReusableNewChat(threads, agentId, userId, expectedRuntime)
-    );
+  if (!hasBranch) {
+    return findReusableNewChat(threads, agentId, userId, expectedRuntime);
   }
-  return findReusableNewChat(threads, agentId, userId, expectedRuntime);
+  const known = opts?.knownBranches;
+  const onNamedVersion =
+    known && known.size > 0
+      ? (findLastThreadForAgent(
+          threads,
+          agentId,
+          userId,
+          expectedRuntime,
+          known,
+        ) ?? undefined)
+      : undefined;
+  if (opts?.draftsMode) return onNamedVersion;
+  return (
+    onNamedVersion ??
+    findLastThreadForAgent(threads, agentId, userId, expectedRuntime) ??
+    findReusableNewChat(threads, agentId, userId, expectedRuntime)
+  );
 }


### PR DESCRIPTION
## Summary

Entering or refreshing a repo-backed **drafts-mode** agent could strand the user on an auto-minted **unnamed branch** that the drafts picker can only render as a non-manageable "Rascunho" — including the reported case: create "Rascunho 2", refresh a URL with no `?thread=`, and land back on Produção (or a phantom draft).

Root causes were three, layered:

1. **Entry resumed the wrong thread.** `findAgentEntryThread` resumed the most-recently-updated thread regardless of its branch, so an auto-minted unnamed branch (server-minted at thread creation) surfaced as "Rascunho".
2. **A cold refresh raced the thread list.** The threadless-URL redirect resolved the entry thread against an **empty** `threads` store (not loaded yet) → found nothing → minted a fresh production thread. This is why the refresh "reset to Produção".
3. **New threads defaulted to an unnamed branch.** The server mints `generateBranchName` when create isn't given a branch, so a fresh drafts session opened on an editable unnamed draft.

## Fix

- **Entry prefers a named version.** `findAgentEntryThread` takes `{ knownBranches, draftsMode }` and resumes the last thread on a named version (a release **or** production). In **drafts mode** an unnamed draft is *never* auto-resumed — if none qualifies it returns `undefined` so the caller mints a fresh **production** thread. Legacy (non-drafts) and branchless (Super Agent) behavior is unchanged.
- **Redirect waits for the thread list.** The layout gates the threadless-URL redirect on `threadsStatus.kind !== "loading"` (a brief spinner), so a cold refresh resolves against the loaded list and correctly resumes the last named version (e.g. "Rascunho 2").
- **Fresh drafts thread lands on production.** `useEnsureTask` accepts a `defaultBranch`; the layout and the breadcrumb pass the base branch in drafts mode, so a minted thread is stamped with production instead of an auto-minted branch (this also keeps `shouldAdoptBranch` from firing).
- **The unlisted "Rascunho" row is renameable.** It now renders as a `ReleaseRow` with a ⋯ → Rename that **adopts** the branch as a named release — remediation for legacy/edge unnamed branches ("name it to make it editable").

Applied consistently across all three entry points: the layout redirect, `useNavigateToAgent`, and the breadcrumb agent picker.

### Product decisions (confirmed with the author)
- An unnamed draft is never editable; when there's nothing named to resume, entry goes to **Produção**.
- Cold-entry base is assumed to be **`main`** (the app-wide `useBaseBranch` fallback — there's no current branch to resolve a PR base from).

### Known follow-ups (out of scope)
- `shouldAdoptBranch` (repo attached *after* a thread was created) can still mint an unnamed branch in that edge case; the renameable row covers remediation.
- Base assumed as `main` breaks repos whose default branch isn't `main` and lack a `main` branch — the real fix is fetching the repo default branch (would also improve `useBaseBranch`).
- A separate toggle "flash / click-again" when enabling the flag is being tracked separately.

## Testing

- `bun test apps/web/src/lib/reusable-new-chat.test.ts` — 23 pass, incl. new cases: prefer named version over a newer unnamed draft; drafts mode resumes the named version and returns `undefined` (mint on production) when none qualifies.
- `bun run --cwd=apps/web check` clean; `bun run fmt` / `lint` clean (no new warnings on touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes repo-backed drafts-mode agents landing users on an unnamed auto-minted "Rascunho" branch when entering or refreshing. Entry now prefers the last thread on a named version (a release or production); in drafts mode it never resumes or mints an unnamed draft, and when nothing named qualifies it mints a fresh production thread instead.

**Bug Fixes**
- The threadless-URL redirect now waits for the thread list to load before resolving, so a cold refresh no longer mints a spurious production thread against an empty list.
- Fresh drafts-mode threads are stamped with the base branch at create time instead of an auto-minted branch.
- The unlisted "Rascunho" row is now renameable, adopting the branch as a named release for legacy unnamed branches.
- Applied consistently across all three entry points: the layout redirect, `useNavigateToAgent`, and the breadcrumb agent picker.

**Notes**
- In drafts mode, an unnamed draft is never editable; entry goes to Produção when nothing named exists to resume.
- Cold-entry base is assumed to be `main`; repos with a different default branch and no `main` are a known follow-up.
- The `shouldAdoptBranch` edge (repo attached after thread creation) can still mint an unnamed branch; the renameable row covers remediation.

<sup>Written for commit 0d351f5981000138f43fdf7522b441012b8a0c41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

