### PR TITLE
feat(home): list projects above the feed, capped at 6 with "See all"

### DIFF
--- a/apps/web/src/components/org-home/project-feed.tsx
+++ b/apps/web/src/components/org-home/project-feed.tsx
@@ -353,14 +353,10 @@ export function useOrgTasksSuspense(): TaskBoardItem[] {
 export function ProjectFeed({
   projects,
   tasks,
-  action,
   showFilter = true,
 }: {
   projects: VirtualMCPEntity[];
   tasks: TaskBoardItem[];
-  /** The page's own control for this section — today, "Import from GitHub".
-   *  Passed in rather than imported so the feed owns no creation path. */
-  action?: ReactNode;
   /** Off inside a project: the list is already one project, so a filter whose
    *  only option is the thing you are looking at is a control that cannot do
    *  anything. */
@@ -402,16 +398,13 @@ export function ProjectFeed({
         >
           {t("home.projectFeed.heading")}
         </h2>
-        <div className="flex items-center gap-2">
-          {showFilter && (
-            <ProjectFilter
-              index={index}
-              value={bucketId}
-              onChange={setBucketId}
-            />
-          )}
-          {action}
-        </div>
+        {showFilter && (
+          <ProjectFilter
+            index={index}
+            value={bucketId}
+            onChange={setBucketId}
+          />
+        )}
       </div>
       {entries.length === 0 ? (
         <p className="rounded-xl border border-dashed border-border p-12 text-center text-sm text-muted-foreground">

--- a/apps/web/src/components/org-home/project-roster.tsx
+++ b/apps/web/src/components/org-home/project-roster.tsx
@@ -1,0 +1,97 @@
+/**
+ * The org home's project list — the projects a person made, most recent first,
+ * above the feed.
+ *
+ * The roster is what the home is FOR: it gets you into a project. It sits above
+ * the feed because "where do I go" comes before "what happened", and it is the
+ * one place on the home that is always there — the feed hides itself when the
+ * board is empty, but a project you can open is never nothing to show.
+ *
+ * It shows the SIX most recent and defers the rest to "See all" — the home is a
+ * launchpad, not the full roster, which lives at Settings › Agents. Each project
+ * is just its mark and its name — no card, no description, no footer. The home
+ * is a way IN; the lighter the row, the faster the eye finds the one it wants.
+ */
+
+import type { ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { AgentAvatar } from "@/components/agent-icon";
+import { useNavigateToAgent } from "@/hooks/use-navigate-to-agent";
+import { landingTabIdFor } from "@/layouts/main-panel-tabs/tab-id";
+import { useProjectContext } from "@/sdk";
+import { track } from "@/lib/posthog-client";
+import { useT } from "@/i18n/use-t.ts";
+
+/** Projects the home shows before it defers to Settings › Agents. */
+const MAX_PROJECTS = 6;
+
+function ProjectRosterItem({ project }: { project: VirtualMCPEntity }) {
+  const navigateToAgent = useNavigateToAgent();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        track("org_home_project_clicked");
+        navigateToAgent(project.id, {
+          panel: landingTabIdFor(project.metadata?.ui?.layout),
+        });
+      }}
+      className="flex min-w-0 items-center gap-3 rounded-lg p-2 text-left transition-colors hover:bg-accent/60"
+    >
+      <AgentAvatar icon={project.icon} name={project.title} size="sm+" />
+      <span className="truncate text-sm font-medium text-foreground">
+        {project.title}
+      </span>
+    </button>
+  );
+}
+
+export function ProjectRoster({
+  projects,
+  action,
+}: {
+  projects: VirtualMCPEntity[];
+  /** The section's own control — today, "Import from GitHub". Passed in rather
+   *  than imported so the roster owns no creation path. */
+  action?: ReactNode;
+}) {
+  const t = useT();
+  const { org } = useProjectContext();
+  /** Most recent first, then capped — the home leads with what you touched last
+   *  and hands the tail to "See all". */
+  const recent = [...projects]
+    .sort((a, b) => (b.updated_at ?? "").localeCompare(a.updated_at ?? ""))
+    .slice(0, MAX_PROJECTS);
+  const hasMore = projects.length > MAX_PROJECTS;
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-medium text-foreground">
+          {t("home.projects.heading")}
+        </h2>
+        {action}
+      </div>
+      {/* `@container`, so the grid answers to this reading column's width rather
+          than the viewport — the home caps at 720px, where two columns fit. */}
+      <div className="@container">
+        <div className="grid grid-cols-1 gap-1 @lg:grid-cols-2">
+          {recent.map((project) => (
+            <ProjectRosterItem key={project.id} project={project} />
+          ))}
+        </div>
+      </div>
+      {hasMore && (
+        <div>
+          <Button asChild variant="ghost" size="sm">
+            <Link to="/$org/settings/agents" params={{ org: org.slug }}>
+              {t("home.projects.seeAll")}
+            </Link>
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/i18n/en/home.ts
+++ b/apps/web/src/i18n/en/home.ts
@@ -10,6 +10,8 @@ export const home = {
   "home.orgHome.greetingAfternoonBare": "Good afternoon!",
   "home.orgHome.greetingEveningBare": "Good evening!",
   "home.orgHome.searchPlaceholder": "Search projects, chats and tasks\u2026",
+  "home.projects.heading": "Projects",
+  "home.projects.seeAll": "See all",
   "home.projectFeed.heading": "Feed",
   "home.newTask.placeholder": "What needs doing in this project?",
   "home.newTask.submit": "Create task",

--- a/apps/web/src/i18n/pt-br/home.ts
+++ b/apps/web/src/i18n/pt-br/home.ts
@@ -12,6 +12,8 @@ export const home = {
   "home.orgHome.greetingAfternoonBare": "Boa tarde!",
   "home.orgHome.greetingEveningBare": "Boa noite!",
   "home.orgHome.searchPlaceholder": "Buscar projetos, chats e tarefas\u2026",
+  "home.projects.heading": "Projetos",
+  "home.projects.seeAll": "Ver todos",
   "home.projectFeed.heading": "Feed",
   "home.newTask.placeholder": "O que precisa ser feito neste projeto?",
   "home.newTask.submit": "Criar tarefa",

--- a/apps/web/src/layouts/main-panel-tabs/org-agents-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/org-agents-tab.tsx
@@ -20,9 +20,12 @@ import { GitHubIcon } from "@/components/icons/github-icon";
 import { ConnectPill } from "@/components/org-home/connect-pill";
 import { firstName, greetingSlot } from "@/components/org-home/greeting";
 import {
+  buildFeed,
   ProjectFeed,
   useOrgTasksSuspense,
 } from "@/components/org-home/project-feed";
+import { ProjectRoster } from "@/components/org-home/project-roster";
+import { buildProjectIndex } from "@/lib/project-index";
 import { useCapability } from "@/hooks/use-capability";
 import { scopableProjects } from "@/hooks/use-project-scope";
 import { authClient } from "@/lib/auth-client";
@@ -146,12 +149,22 @@ function OrgHomeBody({
     );
   }
 
+  /** The feed hides itself when the board has nothing to show — an org with
+   *  projects but no cards yet lands on its roster, not on an empty panel
+   *  captioned "nothing here yet". Measured on the UNFILTERED feed so that
+   *  narrowing to a project with no cards keeps the section (and its filter, to
+   *  get back out) rather than making the whole thing vanish under you. */
+  const hasActivity =
+    buildFeed(buildProjectIndex(agents), tasks, null).length > 0;
+
   return (
-    <ProjectFeed
-      projects={agents}
-      tasks={tasks}
-      action={canManageAgents && importButton("org_home")}
-    />
+    <div className="flex flex-col gap-12">
+      <ProjectRoster
+        projects={agents}
+        action={canManageAgents && importButton("org_home")}
+      />
+      {hasActivity && <ProjectFeed projects={agents} tasks={tasks} />}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

The org home (Início) now leads with a **project roster above the feed**, so the first thing you land on is a way *in* to a project.

- **Projects list, above the feed** — a new `ProjectRoster` renders each project as just its mark + name (no card, background, description or footer), a slightly larger icon (`sm+`).
- **Capped at 6, most recent first** — sorted by `updated_at` desc, sliced to 6.
- **"See all"** — shown only when there are more than 6 projects; links to Settings › Agents (`/$org/settings/agents`), the full list with search.
- **Feed hides when empty** — an org with projects but no attributable cards lands on its roster, not on an empty "nothing here yet" panel. Measured on the *unfiltered* feed, so narrowing to a project with no cards keeps the section (and its filter) rather than making it vanish.
- **"Import from GitHub" moved to the roster header** so it stays reachable even when the feed is gone (the `action` prop was removed from `ProjectFeed`).

The sidebar was **not** touched — it still lists all projects.

## Testing

- `bun run --cwd=apps/web check` ✅
- `bun run lint` ✅ (no new warnings)
- `bun run fmt` ✅
- `bun test apps/web/src/components/org-home/` ✅ (15 pass)

## Screenshots

_Roster with the 6 most-recent projects above the feed; "See all" appears past 6._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a project roster above the org home feed so the first thing you land on is a way into a project. The feed previously led the page; now the six most recently updated projects appear first, each as its mark and name, with a "See all" link to Settings › Agents when there are more than six.

**Behavior changes**
- The feed now hides when the unfiltered board has no cards, so an org with projects but no activity lands on its roster instead of an empty panel.
- "Import from GitHub" moved to the roster header and stays reachable when the feed is hidden.

<sup>Written for commit 3a0bee1faed14a73bb4578070880ccc8061dfbcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

