### PR TITLE
fix(site-editor): align preview controls with content editing

### DIFF
--- a/apps/web/src/components/sandbox/blocks/blocks-panel.tsx
+++ b/apps/web/src/components/sandbox/blocks/blocks-panel.tsx
@@ -77,11 +77,6 @@ export function BlocksPanel({
     : null;
   const decofile = useDecofile(fetchParams, { fetchEnabled: devServerReady });
   const meta = useLiveMeta(fetchParams, { fetchEnabled: devServerReady });
-  // No `frameworkKnownMissing` here on purpose: the sticky bit exists to stop
-  // Preview's page selector flickering on transient read failures.
-  // This panel is already open, and showing the accurate "we couldn't read the
-  // decofile" card for a real failure is more useful than pinning it to the
-  // framework-missing card.
   const state = resolveBlocksTabState({
     lifecyclePhase: sandboxEvents.lifecycle.phase,
     decofile: toBlocksQueryState(decofile),
@@ -90,8 +85,14 @@ export function BlocksPanel({
     fastPreviewActive: useSessionRuntime(virtualMcpId).runtime === "cms",
   });
 
-  if (state.kind === "loading") return <PanelLoading />;
-  if (state.kind === "empty") return <BlocksEmptyState />;
+  const panel = (children: ReactNode) => (
+    <div data-testid="blocks-panel" className="h-full min-h-0 overflow-hidden">
+      {children}
+    </div>
+  );
+
+  if (state.kind === "loading") return panel(<PanelLoading />);
+  if (state.kind === "empty") return panel(<BlocksEmptyState />);
   if (state.kind === "error") {
     const retry = () => {
       if (state.source === "sandbox") {
@@ -100,21 +101,20 @@ export function BlocksPanel({
       }
       void Promise.all([decofile.refetch(), meta.refetch()]);
     };
-    return <BlocksErrorState source={state.source} onRetry={retry} />;
+    return panel(<BlocksErrorState source={state.source} onRetry={retry} />);
   }
 
   // On production the editor stays visible but read-only per widget.
-  const gateReadOnly = (children: ReactNode) => (
-    <div data-testid="blocks-panel" className="h-full min-h-0 overflow-hidden">
+  const gateReadOnly = (children: ReactNode) =>
+    panel(
       <ReadOnlyPane
         readOnly={readOnly}
         virtualMcpId={virtualMcpId}
         className="h-full min-h-0"
       >
         {children}
-      </ReadOnlyPane>
-    </div>
-  );
+      </ReadOnlyPane>,
+    );
 
   // Blocks edits whatever page its sibling Preview canvas is on. The shared
   // workspace target is published by Preview; when Preview hasn't run yet,

--- a/apps/web/src/components/sandbox/preview/cms-controls.test.ts
+++ b/apps/web/src/components/sandbox/preview/cms-controls.test.ts
@@ -2,62 +2,29 @@ import { describe, expect, it } from "bun:test";
 import { showCmsPageSelector } from "./cms-controls";
 
 describe("showCmsPageSelector", () => {
-  it("shows it for a deco site (blocks resolved to content)", () => {
+  it("shows it whenever content editing and the preview toolbar are enabled", () => {
     expect(
       showCmsPageSelector({
         showPreviewToolbar: true,
-        blocksState: { kind: "content" },
+        contentEditingEnabled: true,
       }),
     ).toBe(true);
   });
 
-  it("hides it for a non-deco repo (decofile/meta 404 → framework missing)", () => {
+  it("hides it under the same disabled gate as Content and Blocks", () => {
     expect(
       showCmsPageSelector({
         showPreviewToolbar: true,
-        blocksState: { kind: "empty", reason: "framework-missing" },
+        contentEditingEnabled: false,
       }),
     ).toBe(false);
-  });
-
-  it("keeps it for a deco site whose decofile has no pages yet (Create page stays reachable)", () => {
-    expect(
-      showCmsPageSelector({
-        showPreviewToolbar: true,
-        blocksState: { kind: "empty", reason: "no-content" },
-      }),
-    ).toBe(true);
-  });
-
-  it("hides it while the reads are still in flight", () => {
-    expect(
-      showCmsPageSelector({
-        showPreviewToolbar: true,
-        blocksState: { kind: "loading" },
-      }),
-    ).toBe(false);
-  });
-
-  it("keeps it when a read failed — absence is unproven, so don't revoke", () => {
-    expect(
-      showCmsPageSelector({
-        showPreviewToolbar: true,
-        blocksState: { kind: "error", source: "data" },
-      }),
-    ).toBe(true);
-    expect(
-      showCmsPageSelector({
-        showPreviewToolbar: true,
-        blocksState: { kind: "error", source: "sandbox" },
-      }),
-    ).toBe(true);
   });
 
   it("hides it when the toolbar itself is hidden", () => {
     expect(
       showCmsPageSelector({
         showPreviewToolbar: false,
-        blocksState: { kind: "empty", reason: "no-content" },
+        contentEditingEnabled: true,
       }),
     ).toBe(false);
   });

--- a/apps/web/src/components/sandbox/preview/cms-controls.ts
+++ b/apps/web/src/components/sandbox/preview/cms-controls.ts
@@ -1,49 +1,7 @@
-/**
- * Pure capability gate for the Preview toolbar's CMS page selector.
- *
- * The selector only means anything for a repo that uses the deco framework for
- * sites: it navigates decofile pages/global sections. Studio itself — and any
- * other plain app repo previewed on a coding agent — has no decofile, so
- * rendering it there is misleading (it degrades into showing the raw preview
- * host, e.g. "pedro-je4bq0tm-38bb…"). Those repos get a plain label instead.
- *
- * This does NOT gate the Blocks form. Blocks and the Content panel share the
- * agent's `cms !== "off"` product gate, with Blocks restricted to desktop;
- * their own states explain missing or unreadable content after entry.
- *
- * The question is *framework presence*, NOT "is there content right now". So
- * the gate reads the one state that proves absence — `empty` with reason
- * `framework-missing` (the decofile/meta reads 404'd) — and hides only there. In
- * particular a real deco site with an empty decofile stays `no-content` and keeps
- * its controls, which is how "Create page" (rendered inside the page-selector
- * dropdown) remains reachable for a site that has no pages yet. A data error
- * doesn't revoke the capability either: it means the reads never resolved, so
- * absence is unproven, and the toolbar degrades to its pre-existing behaviour
- * rather than dropping controls out from under a working site. A repo that has
- * already proven absence never reaches that branch: `framework-missing` is
- * sticky per repo+branch, so its later transient read failures stay
- * `framework-missing` instead of flipping to `error`.
- *
- * `loading` hides, so the controls never flash in for a repo that turns out not
- * to be a deco site.
- */
-
-import type { BlocksTabState } from "@/layouts/main-panel-tabs/blocks-tab-state";
-
+/** The page selector uses the exact same product gate as Content and Blocks. */
 export function showCmsPageSelector(input: {
-  /** Toolbar itself is visible (an iframe surface is active). */
   showPreviewToolbar: boolean;
-  blocksState: BlocksTabState;
+  contentEditingEnabled: boolean;
 }): boolean {
-  if (!input.showPreviewToolbar) return false;
-  const state = input.blocksState;
-  switch (state.kind) {
-    case "loading":
-      return false;
-    case "empty":
-      return state.reason !== "framework-missing";
-    case "content":
-    case "error":
-      return true;
-  }
+  return input.showPreviewToolbar && input.contentEditingEnabled;
 }

--- a/apps/web/src/components/sandbox/preview/editing-mode.test.ts
+++ b/apps/web/src/components/sandbox/preview/editing-mode.test.ts
@@ -3,7 +3,7 @@ import {
   defaultPreviewEditingMode,
   isBlocksEditingEnabled,
   resolveEffectivePreviewEditingMode,
-  togglePreviewEditorMode,
+  toggleVisualEditingMode,
 } from "./editing-mode";
 
 describe("isBlocksEditingEnabled", () => {
@@ -20,69 +20,44 @@ describe("isBlocksEditingEnabled", () => {
   });
 });
 
-describe("togglePreviewEditorMode", () => {
-  test("activates an editor from the neutral preview", () => {
-    expect(togglePreviewEditorMode("preview", "visual")).toBe("visual");
-    expect(togglePreviewEditorMode("preview", "blocks")).toBe("blocks");
+describe("toggleVisualEditingMode", () => {
+  test("activates Visual from Preview or Blocks", () => {
+    expect(toggleVisualEditingMode("preview", false)).toBe("visual");
+    expect(toggleVisualEditingMode("blocks", true)).toBe("visual");
   });
 
-  test("turns off the active editor", () => {
-    expect(togglePreviewEditorMode("visual", "visual")).toBe("preview");
-    expect(togglePreviewEditorMode("blocks", "blocks")).toBe("preview");
+  test("returns from Visual to Blocks when content editing is enabled", () => {
+    expect(toggleVisualEditingMode("visual", true)).toBe("blocks");
   });
 
-  test("switches directly between mutually exclusive editors", () => {
-    expect(togglePreviewEditorMode("visual", "blocks")).toBe("blocks");
-    expect(togglePreviewEditorMode("blocks", "visual")).toBe("visual");
+  test("returns from Visual to Preview when Blocks is unavailable", () => {
+    expect(toggleVisualEditingMode("visual", false)).toBe("preview");
   });
 });
 
-/** MOVED from `defaultSurfaceTabId`, inverted: the Site Editor row lands on
- *  Preview for every session now, and what a desktop CMS session gets there is
- *  the blocks editor already open — not the Content view. */
 describe("defaultPreviewEditingMode", () => {
-  test("a desktop CMS session opens on the blocks editor", () => {
+  test("desktop opens Blocks whenever Content is enabled", () => {
     expect(
       defaultPreviewEditingMode({
-        runtime: "cms",
         cmsMode: "on",
         isMobile: false,
       }),
     ).toBe("blocks");
   });
 
-  test("a mobile CMS session opens on the plain preview", () => {
+  test("mobile opens the plain preview", () => {
     expect(
       defaultPreviewEditingMode({
-        runtime: "cms",
         cmsMode: "on",
         isMobile: true,
       }),
     ).toBe("preview");
   });
 
-  test("a sandbox session opens on the plain preview", () => {
-    expect(
-      defaultPreviewEditingMode({
-        runtime: "sandbox",
-        cmsMode: "on",
-        isMobile: false,
-      }),
-    ).toBe("preview");
-  });
-
-  /** `off` is the one thing that overrides the runtime: an agent with no CMS
-   *  has no blocks editor to land in. */
-  test("off keeps even a CMS session on the plain preview", () => {
-    for (const runtime of ["cms", "sandbox"] as const) {
-      expect(
-        defaultPreviewEditingMode({
-          runtime,
-          cmsMode: "off",
-          isMobile: false,
-        }),
-      ).toBe("preview");
-    }
+  test("CMS off opens the plain preview", () => {
+    expect(defaultPreviewEditingMode({ cmsMode: "off", isMobile: false })).toBe(
+      "preview",
+    );
   });
 });
 

--- a/apps/web/src/components/sandbox/preview/editing-mode.ts
+++ b/apps/web/src/components/sandbox/preview/editing-mode.ts
@@ -1,10 +1,7 @@
-import type { ThreadRuntime } from "@decocms/shared/thread/session-runtime";
 import type { CmsMode } from "@decocms/shared/sdk/types";
 import { isContentEditingEnabled } from "@/layouts/main-panel-tabs/content-editing-gate";
 
 export type PreviewEditingMode = "preview" | "visual" | "blocks";
-
-export type PreviewEditorMode = Exclude<PreviewEditingMode, "preview">;
 
 /** Blocks is a desktop editing surface. Content remains available on mobile. */
 export function isBlocksEditingEnabled(input: {
@@ -14,35 +11,29 @@ export function isBlocksEditingEnabled(input: {
   return input.contentEditingEnabled && !input.isMobile;
 }
 
-export function togglePreviewEditorMode(
+/** Leaving Visual returns to the Blocks split whenever that surface is enabled. */
+export function toggleVisualEditingMode(
   current: PreviewEditingMode,
-  requested: PreviewEditorMode,
+  blocksEditingEnabled: boolean,
 ): PreviewEditingMode {
-  return current === requested ? "preview" : requested;
+  if (current !== "visual") return "visual";
+  return blocksEditingEnabled ? "blocks" : "preview";
 }
 
 /**
- * The editing mode a fresh Preview opens in — derived from the SESSION, never
- * from a per-agent auto-open flag.
- *
- * A desktop CMS session has no working tree and nothing to code: editing blocks
- * beside the frame is what the Site Editor IS there, so Preview opens with the
- * blocks editor already split in rather than behind a control the user has to
- * find. Mobile and sandbox sessions open on the plain preview, and `off` — an
- * agent with no CMS at all — keeps every session there.
+ * A fresh Preview follows the same product gate as Content. When content
+ * editing is enabled, Blocks is part of the desktop Site Editor surface rather
+ * than an opt-in toolbar mode. Mobile and `off` keep the plain preview.
  */
 export function defaultPreviewEditingMode(input: {
-  /** THIS session's runtime, read from the thread's own stamp. */
-  runtime: ThreadRuntime;
   /** The agent's CMS mode, already normalised by `resolveCmsMode`. */
   cmsMode: CmsMode;
   isMobile: boolean;
 }): PreviewEditingMode {
-  return input.runtime === "cms" &&
-    isBlocksEditingEnabled({
-      contentEditingEnabled: isContentEditingEnabled(input.cmsMode),
-      isMobile: input.isMobile,
-    })
+  return isBlocksEditingEnabled({
+    contentEditingEnabled: isContentEditingEnabled(input.cmsMode),
+    isMobile: input.isMobile,
+  })
     ? "blocks"
     : "preview";
 }

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -45,14 +45,9 @@ import {
   extractGlobalSections,
   extractPages,
   findPageForPath,
-  hasEditableDecoContent,
   type GlobalSectionEntry,
   type PageEntry,
 } from "@/components/sections-editor/page-list";
-import {
-  resolveBlocksTabState,
-  toBlocksQueryState,
-} from "@/layouts/main-panel-tabs/blocks-tab-state";
 import {
   fillPathTemplate,
   normalizePagePath,
@@ -452,32 +447,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   });
   const decofile = decofileQuery.data;
   const meta = metaQuery.data;
-  // Same readiness classification the CMS panel itself uses. We only auto-open
-  // the CMS once this resolves to "content" (metadata loaded AND there is
-  // editable content) so the panel never opens onto a loading/empty/error card.
-  // Sticky per repo+branch; see `frameworkKnownMissing`.
-  const frameworkMissingKey = `${virtualMcpId}:${branch ?? ""}`;
-  // Remembered across renders as state (not a ref): the classification feeds the
-  // render, so it has to re-run when we learn the framework is absent. Storing
-  // the key rather than a boolean makes a repo/branch switch reset it for free.
-  const [frameworkMissingProvenFor, setFrameworkMissingProvenFor] = useState<
-    string | null
-  >(null);
-  const blocksState = resolveBlocksTabState({
-    lifecyclePhase,
-    decofile: toBlocksQueryState(decofileQuery),
-    meta: toBlocksQueryState(metaQuery),
-    hasEditableContent: hasEditableDecoContent(decofile, meta),
-    fastPreviewActive: fastPreviewEnabled,
-    frameworkKnownMissing: frameworkMissingProvenFor === frameworkMissingKey,
-  });
-  if (
-    blocksState.kind === "empty" &&
-    blocksState.reason === "framework-missing" &&
-    frameworkMissingProvenFor !== frameworkMissingKey
-  ) {
-    setFrameworkMissingProvenFor(frameworkMissingKey);
-  }
   const pages = decofile
     ? extractPages(decofile).sort((a, b) => a.name.localeCompare(b.name))
     : [];
@@ -1395,14 +1364,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const showPreviewToolbar =
     previewSurfaceActive && (daemonReady || display.mode === "production");
 
-  /** The page selector is for a CMS session on a proven deco site. A sandbox
-   *  session previews an arbitrary app with no decofile to navigate, so the
-   *  topbar shows the iframe's domain instead — see the toolbar below.
-   *  `showCmsPageSelector` keeps its veto so the selector never degrades into
-   *  listing a raw preview host. */
-  const pageSelectorVisible =
-    session.runtime === "cms" &&
-    showCmsPageSelector({ showPreviewToolbar, blocksState });
+  /** The page selector shares the exact project-level gate used by Content and
+   *  Blocks. Session runtime and metadata readiness do not change the topbar's
+   *  shape; the selector can expose setup/creation flows while data loads. */
+  const pageSelectorVisible = showCmsPageSelector({
+    showPreviewToolbar,
+    contentEditingEnabled,
+  });
 
   /** Refresh · what-the-frame-is-showing · open-in-new, kept as one block so
    *  desktop can put it in the header's centre slot and mobile in its own. The
@@ -1425,13 +1393,10 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
       </Tooltip>
 
       {/* The topbar always names what the iframe is showing; only HOW differs
-          by runtime. A CMS session gets the page selector — page name, editable
-          `:param` segments, and the dropdown that also hosts "Create page". A
-          sandbox session is previewing an arbitrary app with no decofile to
-          navigate, so it gets the iframe's domain as plain text and nothing to
-          click. `showCmsPageSelector` still has the final say, so a CMS session on a
-          repo that proves it has no deco framework degrades to the label rather
-          than to a selector listing a raw preview host. */}
+          by the shared content-editing gate. Enabled projects get the page
+          selector — page name, editable `:param` segments, and the dropdown
+          that also hosts "Create page". Disabled projects get the iframe's
+          domain as plain text. */}
       {pageSelectorVisible ? (
         <div ref={pagesContainerRef} className="relative min-w-0 w-64 shrink">
           <div className="flex h-7 w-full min-w-0 items-center rounded-md border border-border bg-background transition-colors duration-200 hover:bg-accent">

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -21,7 +21,6 @@ import {
   Globe02,
   LayoutAlt01,
   Plus,
-  PuzzlePiece01,
   Monitor04,
   SearchLg,
   Phone02,
@@ -35,7 +34,6 @@ import {
   TooltipTrigger,
 } from "@decocms/ui/components/tooltip.tsx";
 import { ToolbarIconButton } from "@/components/toolbar-icon-button";
-import { HeaderTabButton } from "@/layouts/main-panel-tabs/header-tab-button";
 import {
   MainPanelHeaderPortal,
   useMainPanelHeaderSlot,
@@ -138,9 +136,8 @@ import {
   defaultPreviewEditingMode,
   isBlocksEditingEnabled,
   resolveEffectivePreviewEditingMode,
-  togglePreviewEditorMode,
+  toggleVisualEditingMode,
   type PreviewEditingMode,
-  type PreviewEditorMode,
 } from "./editing-mode";
 import { isContentEditingEnabled } from "@/layouts/main-panel-tabs/content-editing-gate";
 
@@ -315,13 +312,10 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   });
 
   /** Singular: Visual and Blocks cannot both be active, while device size is
-   *  independent and survives a switch. Which mode it STARTS in is the
-   *  session's — a desktop CMS session opens with Blocks already split in (see
-   *  `defaultPreviewEditingMode`). Derived once at mount: the shell renders
-   *  this only after the thread and project resolve, so the runtime is already
-   *  authoritative and nothing needs re-syncing. */
+   *  independent and survives a switch. Blocks starts open whenever the shared
+   *  Content gate and desktop constraint allow it. */
   const [editingMode, setEditingMode] = useState<PreviewEditingMode>(() =>
-    defaultPreviewEditingMode({ runtime: session.runtime, cmsMode, isMobile }),
+    defaultPreviewEditingMode({ cmsMode, isMobile }),
   );
   const [previewDeviceSize, setPreviewDeviceSize] =
     useState<PreviewDeviceSize>("desktop");
@@ -1202,8 +1196,10 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     if (mode === "blocks") injectCmsEditor();
   };
 
-  const toggleEditingMode = (mode: PreviewEditorMode) => {
-    activateEditingMode(togglePreviewEditorMode(editingMode, mode));
+  const toggleVisualEditing = () => {
+    activateEditingMode(
+      toggleVisualEditingMode(editingMode, blocksEditingEnabled),
+    );
   };
 
   const handleRefresh = () => {
@@ -1739,65 +1735,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     </>
   ) : null;
 
-  // Blocks and Content deliberately share one agent-level product gate. Blocks
-  // adds only its desktop layout constraint. Readiness is rendered inside
-  // BlocksPanel; it never delays or revokes the entry point after a transient
-  // decofile/meta read.
-  const blocksActive = effectiveEditingMode === "blocks";
-  const desktopBlocksToggle = blocksEditingEnabled ? (
-    <HeaderTabButton
-      title={t("sandbox.cmsSettings.title")}
-      tooltip={
-        blocksActive
-          ? t("sandbox.preview.exitEditor")
-          : t("sandbox.preview.editContent")
-      }
-      labelCollapse="sooner"
-      icon={{ kind: "component", Component: PuzzlePiece01 }}
-      active={blocksActive}
-      onClick={() => toggleEditingMode("blocks")}
-      testId="preview-blocks-toggle"
-    />
-  ) : null;
-
-  // Desktop composition (portaled into the panel header's centre slot): the
-  // Blocks action leads, followed by the iframe navigation controls once ready.
-  const urlControls =
-    desktopBlocksToggle || urlGroup ? (
-      <div className="flex min-w-0 items-center gap-0.5">
-        {desktopBlocksToggle}
-        {desktopBlocksToggle && urlGroup && (
-          <div className="mx-0.5 h-5 w-px shrink-0 bg-border" />
-        )}
-        {urlGroup}
-      </div>
-    ) : null;
-
-  /** Compact Blocks ⇄ Preview control for the inline (no header-slot) layout.
-   *  It uses the same gate as the desktop action and Content tab. */
-  const inlineBlocksToggle = blocksEditingEnabled ? (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <ToolbarIconButton
-          onClick={() => toggleEditingMode("blocks")}
-          aria-pressed={blocksActive}
-          aria-label={
-            blocksActive
-              ? t("sandbox.preview.exitEditor")
-              : t("sandbox.preview.editContent")
-          }
-          active={blocksActive}
-          data-testid="preview-blocks-toggle"
-        >
-          <PuzzlePiece01 size={16} />
-        </ToolbarIconButton>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">
-        {blocksActive
-          ? t("sandbox.preview.exitEditor")
-          : t("sandbox.preview.editContent")}
-      </TooltipContent>
-    </Tooltip>
+  // Desktop composition (portaled into the panel header's centre slot).
+  const urlControls = urlGroup ? (
+    <div className="flex min-w-0 items-center gap-0.5">{urlGroup}</div>
   ) : null;
   const canVisualEdit = display.mode === "sandbox";
 
@@ -1836,7 +1776,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             <Tooltip>
               <TooltipTrigger asChild>
                 <ToolbarIconButton
-                  onClick={() => toggleEditingMode("visual")}
+                  onClick={toggleVisualEditing}
                   aria-pressed={effectiveEditingMode === "visual"}
                   aria-label={t("sandbox.preview.visualEditor")}
                   active={effectiveEditingMode === "visual"}
@@ -1903,24 +1843,16 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
         ? urlControls && (
             <MainPanelHeaderPortal>{urlControls}</MainPanelHeaderPortal>
           )
-        : (inlineBlocksToggle || urlGroup) && (
+        : urlGroup && (
             /* Declares the same container as PanelHeader: without a header slot
              (mobile or a standalone desktop surface), the controls render
              inline instead of portaling. Without it their container queries
              would find no container and every label would stay at full width.
 
-             Three zones rather than the desktop's single left-packed group:
-             the view controls sit in the middle, the left carries the compact
-             Blocks toggle on standalone desktop (it remains empty on mobile),
-             and an empty right spacer balances it. The two side zones are
-             `flex-1` (equal basis) while the middle is content-sized,
-             so the page selector centres on the BAR wherever there is slack to
-             divide — giving the middle the flex-1 instead would centre it
-             between the side zones, not on the bar. */
+             Equal empty side zones keep the content-sized URL group centered
+             on the bar wherever there is room. */
             <div className="@container/panel-header relative flex h-12 shrink-0 items-center gap-2 border-b border-border/60 px-3 md:px-4">
-              <div className="flex flex-1 items-center justify-start">
-                {inlineBlocksToggle}
-              </div>
+              <div className="flex-1" />
               <div className="flex min-w-0 shrink items-center justify-center gap-0.5">
                 {urlGroup}
               </div>

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -437,9 +437,7 @@ export const sandbox = {
   "sandbox.preview.deviceDesktop": "Desktop",
   "sandbox.preview.deviceMobile": "Mobile (375px)",
   "sandbox.preview.deviceTablet": "Tablet (768px)",
-  "sandbox.preview.editContent": "Edit content",
   "sandbox.preview.enterToGo": "Enter to go",
-  "sandbox.preview.exitEditor": "Exit editor",
   "sandbox.preview.failedToCreatePage": "Failed to create page",
   "sandbox.preview.globalComponents": "Global components",
   "sandbox.preview.globalLoaders": "Global loaders",
@@ -566,7 +564,7 @@ export const sandbox = {
     "Whether this project offers a CMS.",
   "sandbox.cmsSettings.contentEditing.on": "Enabled",
   "sandbox.cmsSettings.contentEditing.onDescription":
-    "The Site Editor offers Content and desktop Blocks, and a CMS chat opens with Blocks active on desktop.",
+    "The Site Editor offers Content and opens Blocks beside Preview on desktop.",
   "sandbox.cmsSettings.contentEditing.off": "Disabled",
   "sandbox.cmsSettings.contentEditing.offDescription":
     "No Content view or Blocks form in the Site Editor. The site still previews, and the project can still edit content.",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -454,9 +454,7 @@ export const sandbox = {
   "sandbox.preview.deviceDesktop": "Desktop",
   "sandbox.preview.deviceMobile": "Celular (375px)",
   "sandbox.preview.deviceTablet": "Tablet (768px)",
-  "sandbox.preview.editContent": "Editar conteúdo",
   "sandbox.preview.enterToGo": "Enter para ir",
-  "sandbox.preview.exitEditor": "Sair do editor",
   "sandbox.preview.failedToCreatePage": "Falha ao criar página",
   "sandbox.preview.globalComponents": "Componentes globais",
   "sandbox.preview.globalLoaders": "Loaders globais",
@@ -589,7 +587,7 @@ export const sandbox = {
     "Se este projeto oferece um CMS.",
   "sandbox.cmsSettings.contentEditing.on": "Ativado",
   "sandbox.cmsSettings.contentEditing.onDescription":
-    "O Editor do Site oferece Conteúdo e Blocos no desktop, e um chat de CMS abre com o editor de Blocos aberto no desktop.",
+    "O Editor do Site oferece Conteúdo e abre Blocos ao lado do Preview no desktop.",
   "sandbox.cmsSettings.contentEditing.off": "Desativado",
   "sandbox.cmsSettings.contentEditing.offDescription":
     "Sem a visão Conteúdo nem o formulário de Blocos no Editor do Site. O site continua sendo pré-visualizado, e o projeto ainda pode editar o conteúdo.",

--- a/apps/web/src/layouts/agent-shell-layout/panel-header.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/panel-header.tsx
@@ -8,8 +8,8 @@
  *
  * Portal targets live in the main panel header:
  *   - `MainPanelHeaderSlot` — the flexible middle region. Preview fills it with
- *     its Blocks toggle + page controls, so Preview needs no second toolbar
- *     (single top bar in CMS).
+ *     its page controls, so Preview needs no second toolbar (single top bar in
+ *     CMS).
  *
  * When no provider is present (mobile, where the main panel is full-screen and
  * uses the shared header), `useMainPanelHeaderSlot` returns null and consumers
@@ -75,8 +75,7 @@ export function MainPanelHeaderProvider({ children }: { children: ReactNode }) {
 
 /**
  * The centered middle portal target in the main panel header. Preview fills it
- * with its Blocks toggle and page controls so the group sits centered over the
- * page.
+ * with its page controls so the group sits centered over the page.
  */
 export function MainPanelHeaderSlot({ className }: { className?: string }) {
   const ctx = use(MainPanelHeaderContext);

--- a/apps/web/src/layouts/main-panel-tabs/blocks-tab-state.test.ts
+++ b/apps/web/src/layouts/main-panel-tabs/blocks-tab-state.test.ts
@@ -218,8 +218,6 @@ describe("resolveBlocksTabState", () => {
     ).toEqual({ kind: "error", source: "data" });
   });
 
-  // `framework-missing` is sticky, so a wrong call mid-checkout would outlive
-  // the checkout: the tree is between two branches there.
   test("a 404 while checking out is not proof — stays loading", () => {
     expect(
       resolveBlocksTabState(
@@ -229,44 +227,6 @@ describe("resolveBlocksTabState", () => {
         }),
       ),
     ).toEqual({ kind: "loading" });
-  });
-
-  test("a proven-404 repo stays framework-missing through a transient refetch failure", () => {
-    for (const errorStatus of [500, 502, undefined]) {
-      expect(
-        resolveBlocksTabState(
-          input({
-            decofile: { status: "error", hasData: false, errorStatus },
-            frameworkKnownMissing: true,
-          }),
-        ),
-      ).toEqual({ kind: "empty", reason: "framework-missing" });
-    }
-    expect(
-      resolveBlocksTabState(
-        input({
-          lifecyclePhase: "crashed",
-          meta: { status: "error", hasData: false, errorStatus: 500 },
-          frameworkKnownMissing: true,
-        }),
-      ),
-    ).toEqual({ kind: "empty", reason: "framework-missing" });
-  });
-
-  test("frameworkKnownMissing doesn't touch the non-failing paths", () => {
-    expect(
-      resolveBlocksTabState(
-        input({ hasEditableContent: true, frameworkKnownMissing: true }),
-      ),
-    ).toEqual({ kind: "content" });
-    expect(
-      resolveBlocksTabState(
-        input({
-          lifecyclePhase: "clone-failed",
-          frameworkKnownMissing: true,
-        }),
-      ),
-    ).toEqual({ kind: "error", source: "sandbox" });
   });
 
   test("keeps cached editable content during a failed background refetch", () => {
@@ -303,19 +263,6 @@ describe("sandbox-less Fast Preview (fastPreviewActive)", () => {
         }),
       ),
     ).toEqual({ kind: "content" });
-  });
-
-  test("a transient failure stays framework-missing once the 404 was proven", () => {
-    expect(
-      resolveBlocksTabState(
-        input({
-          lifecyclePhase: "idle",
-          decofile: { status: "error", hasData: false, errorStatus: 502 },
-          fastPreviewActive: true,
-          frameworkKnownMissing: true,
-        }),
-      ),
-    ).toEqual({ kind: "empty", reason: "framework-missing" });
   });
 
   test("a failed decofile read is immediately real — no lifecycle recovery is coming", () => {

--- a/apps/web/src/layouts/main-panel-tabs/blocks-tab-state.ts
+++ b/apps/web/src/layouts/main-panel-tabs/blocks-tab-state.ts
@@ -42,19 +42,6 @@ export interface BlocksTabStateInput {
    *  not a sandbox — the lifecycle phase stays "idle" forever and must not
    *  gate the panel. Data readiness alone decides. */
   fastPreviewActive?: boolean;
-  /**
-   * The decofile/meta pair already resolved as `framework-missing` (a real 404)
-   * earlier in this session, for this same repo+branch. "This repo uses the deco
-   * framework" cannot go false→true→false within one checkout, so once proven
-   * absent the classification is sticky: a later *transient* failure of the same
-   * reads (network blip, sandbox-proxy hiccup, dev-server restart caught
-   * mid-cycle, non-404 non-2xx) must not be reclassified as a generic data
-   * error. Without this, every failed refetch flipped the state to `error`,
-   * which `showCmsPageSelector` treats as "capability unproven → keep selector",
-   * flashing the page selector in and out on each retry cycle. Only a remount
-   * or a repo/branch change resets it.
-   */
-  frameworkKnownMissing?: boolean;
 }
 
 export type BlocksTabState =
@@ -108,18 +95,6 @@ function classifyPhase(phase: LifecycleState["phase"]): PhaseClass {
   }
 }
 
-/**
- * A failed decofile/meta read, once it's real. Sticks to `framework-missing`
- * when this repo+branch already proved the 404 (see `frameworkKnownMissing`),
- * so a transient failure of the same reads can't reclassify a non-deco repo
- * back into the generic-error bucket.
- */
-function failedState(input: BlocksTabStateInput): BlocksTabState {
-  return input.frameworkKnownMissing
-    ? { kind: "empty", reason: "framework-missing" }
-    : { kind: "error", source: "data" };
-}
-
 export function resolveBlocksTabState(
   input: BlocksTabStateInput,
 ): BlocksTabState {
@@ -129,7 +104,7 @@ export function resolveBlocksTabState(
     const failed =
       (input.decofile.status === "error" && !input.decofile.hasData) ||
       (input.meta.status === "error" && !input.meta.hasData);
-    if (failed) return failedState(input);
+    if (failed) return { kind: "error", source: "data" };
     if (!input.decofile.hasData || !input.meta.hasData) {
       return { kind: "loading" };
     }
@@ -148,9 +123,7 @@ export function resolveBlocksTabState(
     (input.meta.status === "error" && !input.meta.hasData);
 
   // Mid-checkout the working tree is between two branches, so an absent
-  // `.deco/*` says nothing about the branch being switched TO — and
-  // `framework-missing` is sticky per repo+branch, so a wrong call here would
-  // outlive the checkout that caused it.
+  // `.deco/*` says nothing about the branch being switched TO.
   if (readFailed && input.lifecyclePhase === "checking-out") {
     return { kind: "loading" };
   }
@@ -172,7 +145,7 @@ export function resolveBlocksTabState(
     // server has settled (running/crashed), where the failure is real.
     const devSettled =
       input.lifecyclePhase === "running" || input.lifecyclePhase === "crashed";
-    return devSettled ? failedState(input) : { kind: "loading" };
+    return devSettled ? { kind: "error", source: "data" } : { kind: "loading" };
   }
 
   if (!input.decofile.hasData || !input.meta.hasData) {

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -318,10 +318,9 @@ export function useMainPanelTabs(ctx: {
     parseCodeTabId(rawActiveTab) !== null;
   /** The surface's own landing view is the preview, for every runtime — a URL
    *  that names no view lands there, and `?main=content` is the only thing that
-   *  opens Content. What a desktop CMS session gets on that preview is the
-   *  blocks editor already open (see `defaultPreviewEditingMode`), a mode of the
-   *  view rather than a second address, so nothing here has to second-guess the
-   *  URL. */
+   *  opens Content. On desktop, that preview includes Blocks whenever the same
+   *  product gate exposes Content; it remains a mode of the view rather than a
+   *  second address, so nothing here has to second-guess the URL. */
   const activeTab =
     !panelTabId && !routeDefaultMain && defaultTabHidden
       ? visibleDefaultTabId

--- a/apps/web/src/views/virtual-mcp/content-editing-field.tsx
+++ b/apps/web/src/views/virtual-mcp/content-editing-field.tsx
@@ -23,8 +23,8 @@ import { useT } from "@/i18n/use-t.ts";
 
 /** The CMS mode select (`metadata.ui.layout.cms`) — whether this agent offers
  *  content editing at all. `off` removes the Site Editor's Content view from
- *  the switcher and from what a CMS session opens on. Only meaningful for
- *  agents with a clonable source, which the caller gates on. */
+ *  the switcher and its desktop Blocks panel. Only meaningful for agents with
+ *  a clonable source, which the caller gates on. */
 export interface ContentEditingFieldProps<T extends FieldValues> {
   control: Control<T>;
   /** Settings auto-save on change — persist immediately (blur-equivalent). */

--- a/packages/e2e/tests/org-home-agents.spec.ts
+++ b/packages/e2e/tests/org-home-agents.spec.ts
@@ -56,18 +56,21 @@ test.describe("org home — the agent roster", () => {
     await createAgent(page.request, orgSlug, title);
 
     await page.goto(`/${orgSlug}/home`);
-    await expect(page.getByTestId("main-panel")).toBeVisible({
+    const mainPanel = page.getByTestId("main-panel");
+    await expect(mainPanel).toBeVisible({
       timeout: SHELL_TIMEOUT_MS,
     });
 
-    await expect(page.getByText(title, { exact: true })).toBeVisible({
-      timeout: SHELL_TIMEOUT_MS,
-    });
+    await expect(
+      mainPanel.getByRole("button", { name: title, exact: true }),
+    ).toBeVisible({ timeout: SHELL_TIMEOUT_MS });
 
     /* The backfilled managers are plumbing, not the org's work. If this ever
        fails, the home is rendering the unfiltered list again. */
     for (const manager of ["Agent Manager", "Automation Manager"]) {
-      await expect(page.getByText(manager, { exact: true })).toHaveCount(0);
+      await expect(mainPanel.getByText(manager, { exact: true })).toHaveCount(
+        0,
+      );
     }
   });
 

--- a/packages/e2e/tests/standalone-blocks-panel.spec.ts
+++ b/packages/e2e/tests/standalone-blocks-panel.spec.ts
@@ -50,7 +50,7 @@ async function createClonableAgent(
 test.describe("Blocks preview mode", () => {
   test.setTimeout(90_000);
 
-  test("desktop offers Blocks and Content under the same enabled gate", async ({
+  test("desktop renders Blocks and Content under the same enabled gate", async ({
     authedPage,
   }) => {
     const { page, orgSlug } = authedPage;
@@ -64,7 +64,6 @@ test.describe("Blocks preview mode", () => {
 
     const chat = page.getByTestId("chat-panel");
     const main = page.getByTestId("main-panel");
-    const blocksToggle = page.getByTestId("preview-blocks-toggle");
     const contentTab = page.getByRole("button", {
       name: "Content",
       exact: true,
@@ -72,8 +71,7 @@ test.describe("Blocks preview mode", () => {
 
     await expect(chat).toBeVisible({ timeout: 30_000 });
     await expect(main).toBeVisible();
-    // Both controls are local to the Site Editor surface.
-    await expect(blocksToggle).toHaveCount(0);
+    // Both editing surfaces are local to the Site Editor.
     await expect(contentTab).toHaveCount(0);
     await expect(page.getByTestId("blocks-panel")).toHaveCount(0);
 
@@ -91,10 +89,8 @@ test.describe("Blocks preview mode", () => {
       (url) => url.searchParams.get("virtualmcpid") === agentId,
     );
     await expect(contentTab).toBeVisible();
-    await expect(blocksToggle).toBeVisible();
-    await expect(blocksToggle).toHaveAttribute("aria-label", "CMS");
-    await blocksToggle.click();
-    await expect(blocksToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(page.getByTestId("preview-blocks-toggle")).toHaveCount(0);
+    await expect(page.getByTestId("blocks-panel")).toBeVisible();
     await expect(chat).toBeVisible();
     await expect(main).toBeVisible();
   });


### PR DESCRIPTION
## What is this contribution about?

Aligns the Site Editor preview controls around one project-level content-editing gate:

- Removes the CMS/Blocks toolbar toggle.
- Opens Blocks directly on desktop whenever Content is enabled; CMS-off projects and mobile layouts omit Blocks.
- Shows the center page selector whenever Content is enabled, regardless of session runtime or metadata readiness.
- Uses the plain preview domain only when Content is disabled.
- Removes the obsolete framework-readiness state that previously controlled selector visibility.

The Visual editor toggle returns to the Blocks split when content editing is enabled, so removing the CMS control does not leave Blocks unreachable.

## How did you verify your code works?

- `bun run fmt`
- Focused gate and preview unit tests — 43 passing
- `packages/e2e/tests/standalone-blocks-panel.spec.ts` — 3 passing against isolated real PostgreSQL, covering the absent toggle, automatic desktop Blocks panel, CMS-off behavior, and mobile omission
- `packages/e2e/tests/org-home-agents.spec.ts` scopes roster assertions to the main panel, avoiding duplicate whole-page title matches.
- `bun run --cwd=apps/web check`
- `bun run --cwd=packages/e2e check`
- `bun run lint` — 0 errors
- `bun run --cwd=apps/web build`
- `bun run knip` — no unused-code findings

## Screenshots/Demonstration

The branch is running locally at http://localhost:4000 against https://studio-stg.decocms.com for manual verification.

## How to Test

1. Open a project with Content editing enabled on a desktop viewport.
2. Open Site Editor and confirm Blocks appears beside Preview without a CMS toolbar button.
3. Confirm the centered control is the page selector, including in a sandbox-backed chat or while CMS metadata loads.
4. Disable Content editing and confirm Content and Blocks disappear and the center control becomes the plain domain.
5. Use a mobile viewport and confirm Blocks is not rendered.

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation impact reviewed
- [x] No breaking changes