### PR TITLE
fix(sandbox-daemon): don't panic on Classify(nil, nil)

### DIFF
--- a/packages/sandbox/daemon-go/internal/config/classify.go
+++ b/packages/sandbox/daemon-go/internal/config/classify.go
@@ -44,6 +44,13 @@ type Transition struct {
 // runtime-change > pm-change > port-change > env-change >
 // git-credential-refresh > no-op.
 func Classify(before, after *TenantConfig) Transition {
+	// Every other nil-config case here goes through a nil-safe accessor
+	// method; the after==nil, before==nil path is the one that reaches a
+	// bare field access (after.Env below), so normalize it up front instead
+	// of leaving that one arm to panic on a caller that passes nil.
+	if after == nil {
+		after = &TenantConfig{}
+	}
 	beforeHasUrl := before.HasCloneUrl()
 	afterHasUrl := after.HasCloneUrl()
 	beforeUrl := before.CloneUrl()

--- a/packages/sandbox/daemon-go/internal/config/classify_test.go
+++ b/packages/sandbox/daemon-go/internal/config/classify_test.go
@@ -152,6 +152,17 @@ func TestClassify(t *testing.T) {
 	}
 }
 
+// Classify is exported and every other nil-config combination goes through a
+// nil-safe accessor; nil-before/nil-after used to reach a bare `after.Env`
+// field access and panic instead of returning no-op like nil/&TenantConfig{}
+// does.
+func TestClassifyNilAfterDoesNotPanic(t *testing.T) {
+	got := Classify(nil, nil)
+	if got.Kind != KindNoOp {
+		t.Fatalf("Classify(nil, nil) = %q, want %q", got.Kind, KindNoOp)
+	}
+}
+
 func TestClassifyEnvDiffKeys(t *testing.T) {
 	before := withEnv(&TenantConfig{}, map[string]string{"A": "1", "B": "2"})
 	after := withEnv(&TenantConfig{}, map[string]string{"A": "changed", "C": "3"})


### PR DESCRIPTION
Bug found while auditing `packages/sandbox/daemon-go/internal/config` for malformed-input handling in `Classify`.

`Classify(before, after *TenantConfig)` handles a nil `before` via nil-safe accessor methods (`HasCloneUrl()`, `Branch()`, etc. all check `c == nil` first) everywhere except one arm: when `before == nil` and no meaningful field is present, it calls `diffEnv(nil, after.Env)` — a bare struct-field access on `after`. If `after` is also nil, that's a nil-pointer dereference panic, not a graceful no-op like the otherwise-symmetric `Classify(nil, &TenantConfig{})` case (which the existing test suite already covers and returns `KindNoOp` for).

`Classify` is exported from the `config` package and its only current caller (`Store.apply` in `store.go`) always passes a non-nil `after` (the result of `DeepMerge`, which never returns nil), so this isn't reachable in production today — but it's a real crash-on-misuse footgun in an exported API, and the fix is a one-line normalization plus a regression test.

**Fix:** normalize `after` to `&TenantConfig{}` at the top of `Classify` when nil, matching how `before` is already handled — `Classify(nil, nil)` now returns `KindNoOp`, consistent with `Classify(nil, &TenantConfig{})`.

**Reviewer check:** `cd packages/sandbox/daemon-go && go test ./internal/config/...`

**Verified locally:** `gofmt -l`, `go vet ./internal/config/...`, `go test ./internal/config/...` (all pass). Full CI covers the rest of the daemon.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `Classify(nil, nil)` in `packages/sandbox/daemon-go/internal/config` from panicking on a nil-pointer dereference to returning `KindNoOp`, matching the existing behavior for `Classify(nil, &TenantConfig{})`. The bug wasn't reachable from the current caller (`Store.apply` always passes a non-nil `after`), but it was a crash-on-misuse footgun in an exported API.

<sup>Written for commit fa2888dcb1fb619904b3006907f3857cbed169ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

