### PR TITLE
fix(web): re-entering a project resumes your last draft/chat, not production/new

### DIFF
--- a/apps/web/src/hooks/use-navigate-to-agent.ts
+++ b/apps/web/src/hooks/use-navigate-to-agent.ts
@@ -71,30 +71,48 @@ export function useNavigateToAgent() {
      *  none. `wantedRuntime` narrows which empty chat qualifies, so "open the
      *  CMS" cannot resume a sandbox session. */
     const target = (cachedAgents ?? []).find((a) => a.id === virtualMcpId);
-    const entry = findAgentEntryThread(
-      manager?.threads.get() ?? NO_THREADS,
-      virtualMcpId,
-      session?.user?.id,
-      wantedRuntime ??
-        (target ? defaultThreadRuntime(target.metadata) : undefined),
-      !!(target && getActiveGithubRepo(target)),
-      {
-        knownBranches: new Set<string>([
-          baseBranch,
-          ...(target?.metadata?.releases ?? []).map((r) => r.branch),
-        ]),
-        draftsMode: draftsModeEnabled(target),
-      },
-    );
-    const taskId = entry?.id ?? crypto.randomUUID();
+    const hasBranch = !!(target && getActiveGithubRepo(target));
+    /** An agent's entry thread (its last branch/version for a repo editor, its
+     *  last conversation for a plain chat) can only be resolved from the TARGET
+     *  project's thread list. The manager here is keyed on `${org}::${locator}`,
+     *  so at a cross-project surface (org home, another project's sidebar) it is
+     *  a different-scoped instance that can't see this agent's threads. Resolving
+     *  against it always misses and mints a fresh id — a new chat/production
+     *  thread every visit. So we omit `thread` from the URL and let the shell's
+     *  loading-guarded resolver (agent-shell-layout), which runs in the project's
+     *  own scope, own it. We keep resolving here only when a specific runtime was
+     *  requested: that path parks a runtime intent the shell resolver can't read. */
+    const delegateEntryToShell = !options?.runtime;
+    const entry = delegateEntryToShell
+      ? undefined
+      : findAgentEntryThread(
+          manager?.threads.get() ?? NO_THREADS,
+          virtualMcpId,
+          session?.user?.id,
+          wantedRuntime ??
+            (target ? defaultThreadRuntime(target.metadata) : undefined),
+          hasBranch,
+          {
+            knownBranches: new Set<string>([
+              baseBranch,
+              ...(target?.metadata?.releases ?? []).map((r) => r.branch),
+            ]),
+            draftsMode: draftsModeEnabled(target),
+          },
+        );
+    const taskId = delegateEntryToShell
+      ? undefined
+      : (entry?.id ?? crypto.randomUUID());
     /** Park the runtime for the create the route loader will run. Only for a
      *  fresh id — a resumed thread is already stamped, and re-parking would
-     *  leave an unclaimed key behind. */
-    if (!entry && options?.runtime) {
+     *  leave an unclaimed key behind. `taskId` is undefined when delegating. */
+    if (taskId && !entry && options?.runtime) {
       writeThreadIntent(sessionStorage, locator, taskId, {
         runtime: options.runtime,
       });
     }
+    /** No `taskId` → omit `thread` and let the shell resolver add it. */
+    const threadSearch = taskId ? { thread: taskId } : {};
     const view = options?.panel ? panelLocationForTab(options.panel) : null;
     /**
      * An agent that names no view goes to Home, never to a bare `/agents` with
@@ -106,7 +124,7 @@ export function useNavigateToAgent() {
       navigate({
         to: DESTINATION_ROUTE.home,
         params: { org: org.slug },
-        search: { virtualmcpid: virtualMcpId, thread: taskId },
+        search: { virtualmcpid: virtualMcpId, ...threadSearch },
       });
       return;
     }
@@ -116,7 +134,7 @@ export function useNavigateToAgent() {
       search: {
         ...view.payload,
         virtualmcpid: virtualMcpId,
-        thread: taskId,
+        ...threadSearch,
       },
     });
   };

--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -82,7 +82,11 @@ import { useEnsureTask } from "@/hooks/use-ensure-task";
 import { MainPanelBoundary } from "@/layouts/main-panel-boundary";
 import { LegacyMainRedirect } from "@/layouts/legacy-main-redirect";
 import { LegacyThreadRedirect } from "@/layouts/legacy-thread-redirect";
-import { useRouteThreadId, useRouteVirtualMcpId } from "@/layouts/thread-route";
+import {
+  useRouteAgentId,
+  useRouteThreadId,
+  useRouteVirtualMcpId,
+} from "@/layouts/thread-route";
 import { OrgFilePreviewMount } from "./org-file-preview";
 import { OrgFileOpenProvider } from "@/components/chat/org-file-open-context";
 import { BlocksPreviewWorkspaceProvider } from "@/components/sandbox/blocks/blocks-preview-workspace-context";
@@ -565,6 +569,10 @@ function AgentInsetProvider() {
   const routeThreadId = useRouteThreadId();
   /** The agent is the `{-$project}` segment on a destination, `?virtualmcpid=` on the legacy route. */
   const virtualMcpId = useRouteVirtualMcpId();
+  /** Truthy only when the route names a SCOPED agent; `undefined` at org level
+   *  (where `virtualMcpId` falls back to the Super Agent). Gates the threadless
+   *  entry-thread resolver so the org home keeps its fresh composer. */
+  const routeAgentId = useRouteAgentId();
   /** A stable thread id to mint when a repo-backed editor arrives with none and
    *  the user has no idle empty chat to reuse, so a re-render before the URL
    *  catches up reuses it instead of looping through fresh ones. Generated once
@@ -639,13 +647,9 @@ function AgentInsetProvider() {
     return () => document.removeEventListener("keydown", handler);
   }, []);
 
-  /**
-   * A repo-backed editor's branch is a thread field, so it must run on a thread;
-   * mint one into `?thread=` before mounting when the URL names none (#6667). The
-   * Super Agent (no repo) keeps its lazy threadless composer.
-   */
-  if (routeThreadId === null && hasActiveGithubRepo) {
-    // Wait for the first thread page: resolving against an empty list would mint a fresh production thread and drop the user off their version.
+  // Resolve a scoped agent's entry thread HERE, in project scope once loaded — useNavigateToAgent's cross-project manager can't see these threads (#6667); repo agents mint one if none resolves, branchless fall through to the lazy composer, org home (no routeAgentId) stays fresh.
+  if (routeThreadId === null && routeAgentId && entity) {
+    // Wait for the first thread page: resolving against an empty list would mint a fresh thread and drop the user off their last version/conversation.
     if (threadsStatus.kind === "loading") {
       return (
         <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
@@ -660,26 +664,29 @@ function AgentInsetProvider() {
         </div>
       );
     }
-    // Resume the last branch for this repo-backed agent, else its empty chat, else mint one.
-    const threadId =
-      findAgentEntryThread(
-        threads,
-        virtualMcpId,
-        session?.user?.id,
-        defaultThreadRuntime(entity.metadata),
-        hasActiveGithubRepo,
-        { knownBranches: namedVersionBranches, draftsMode: isDraftsMode },
-      )?.id ?? generatedThreadId;
-    return (
-      <Navigate
-        to="."
-        replace
-        search={(prev: Record<string, unknown>) => ({
-          ...prev,
-          thread: threadId,
-        })}
-      />
+    // Resume the last version/conversation for this agent; a repo editor mints a fresh thread when none resolves, a branchless agent falls through to its lazy composer.
+    const entry = findAgentEntryThread(
+      threads,
+      virtualMcpId,
+      session?.user?.id,
+      defaultThreadRuntime(entity.metadata),
+      hasActiveGithubRepo,
+      { knownBranches: namedVersionBranches, draftsMode: isDraftsMode },
     );
+    const threadId =
+      entry?.id ?? (hasActiveGithubRepo ? generatedThreadId : null);
+    if (threadId) {
+      return (
+        <Navigate
+          to="."
+          replace
+          search={(prev: Record<string, unknown>) => ({
+            ...prev,
+            thread: threadId,
+          })}
+        />
+      );
+    }
   }
 
   const chatVirtualMcpId = virtualMcpId;

--- a/apps/web/src/lib/reusable-new-chat.test.ts
+++ b/apps/web/src/lib/reusable-new-chat.test.ts
@@ -140,11 +140,24 @@ describe("findAgentEntryThread", () => {
     ).toBe("last");
   });
 
-  it("keeps reusing the empty chat for a branchless agent", () => {
+  // Inverts the old always-reuse-empty behavior: re-entry now lands you back on your last conversation.
+  it("resumes the most-recent real thread for a branchless agent", () => {
     expect(
       findAgentEntryThread([empty, lastReal], "agent-1", USER, undefined, false)
         ?.id,
+    ).toBe("last");
+  });
+
+  it("reuses the empty chat for a branchless agent with no real thread", () => {
+    expect(
+      findAgentEntryThread([empty], "agent-1", USER, undefined, false)?.id,
     ).toBe("empty");
+  });
+
+  it("returns undefined for a branchless agent with no thread at all", () => {
+    expect(
+      findAgentEntryThread([], "agent-1", USER, undefined, false),
+    ).toBeUndefined();
   });
 
   it("falls back to the empty chat when a repo-backed agent has no real thread", () => {

--- a/apps/web/src/lib/reusable-new-chat.ts
+++ b/apps/web/src/lib/reusable-new-chat.ts
@@ -62,8 +62,7 @@ export interface AgentEntryOpts {
  * production. Otherwise (legacy branch/PR mode) we fall back to the raw last
  * thread, then the empty chat, then `undefined`.
  *
- * A branchless agent (Super Agent) keeps reusing the empty chat, so re-entry
- * doesn't pile up duplicate empty threads.
+ * A branchless agent resumes its last thread (empty or not), never piling up empty chats.
  */
 export function findAgentEntryThread(
   threads: Task[],
@@ -74,7 +73,10 @@ export function findAgentEntryThread(
   opts?: AgentEntryOpts,
 ): Task | undefined {
   if (!hasBranch) {
-    return findReusableNewChat(threads, agentId, userId, expectedRuntime);
+    return (
+      findLastThreadForAgent(threads, agentId, userId, expectedRuntime) ??
+      undefined
+    );
   }
   const known = opts?.knownBranches;
   const onNamedVersion =


### PR DESCRIPTION
## Summary

Entering a project from the org home (or another project's sidebar) always landed on **Production** for repo-backed editors and a **brand-new empty chat** for plain agents — never the draft/conversation you left. Re-entering minted a different thread id every single time.

**Root cause:** the entry thread was resolved *at click time* in `useNavigateToAgent`, reading the current surface's thread manager. That manager is keyed on `${org}::${locator}`, so at a cross-project surface (org home, another project's sidebar) it's a **different-scoped instance** whose thread list can't see the target project's threads. `findAgentEntryThread` always missed → `crypto.randomUUID()` → a fresh production/empty thread every visit.

## Changes

- **`use-navigate-to-agent.ts`** — for scoped agents (unless a specific `runtime` is requested), omit `thread` from the URL and let the shell's resolver own it, instead of freezing a wrong-scope-resolved id.
- **`agent-shell-layout/index.tsx`** — broadened the threadless entry-thread resolver from repo-only (`hasActiveGithubRepo`) to any scoped agent (`routeThreadId === null && routeAgentId && entity`). It runs in the project's own scope and waits for `threadsStatus` to leave `loading`. Repo agents mint a thread when none resolves; branchless fall through to the lazy composer. The org-level Super Agent home (`routeAgentId` undefined) is excluded, so it keeps its fresh ChatGPT-style composer.
- **`reusable-new-chat.ts`** — branchless entry now resumes the last thread (`findLastThreadForAgent`, empty or not) instead of only reusing an empty chat. Re-entry lands you back on your last conversation; an empty chat is reused (never piled up) when it's the only/most-recent thread.
- **`reusable-new-chat.test.ts`** — inverted the test asserting the old always-reuse-empty behavior; added coverage for "reuse empty when no real thread" and "undefined when none".

**"New chat" is unaffected** — `createNewTask` mints an explicit id and navigates with it, so `routeThreadId` isn't null and the resolver is skipped.

## Testing

- `bun run --cwd=apps/web check` ✓ · `bun run fmt` ✓ · `oxlint` (changed files) ✓
- Route/thread/entry unit tests: **68 pass, 0 fail**

## Follow-up

No e2e added yet — the unit tests cover the resolver logic, but the end-to-end navigation flow (home → open draft → back → click project → reopens draft) would live in `packages/e2e`. Happy to add it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes project re-entry so returning to a project resumes your last draft or chat instead of landing on Production or a new empty chat.

- Entry threads are now resolved in the target project's shell after its thread list loads, not from the current surface's thread manager at click time.
- Branchless agents resume their most recent thread; an empty chat is reused only when it's the only thread.
- Explicit "New chat" still creates a fresh thread, and the org-level agent home keeps its fresh composer.

<sup>Written for commit dabfb33795a48b892c3f50f4ea98c708a50dffdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

