### PR TITLE
fix(task-board): retire a drag override when its card leaves the list

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -1899,9 +1899,11 @@ function Lanes({
   if (overrides.size > 0 && !activeId) {
     const settled = [...overrides].filter(([id, placement]) => {
       const server = items.find((item) => item.id === id);
+      // A card gone from `items` (deleted, archived, filtered out) never matches again.
       return (
-        server?.status === placement.status &&
-        server.sortOrder === placement.sortOrder
+        !server ||
+        (server.status === placement.status &&
+          server.sortOrder === placement.sortOrder)
       );
     });
     if (settled.length > 0) {


### PR DESCRIPTION
**Bug.** `Lanes`' render-time override-retirement loop (apps/web/src/layouts/task-board/index.tsx) only removes a card's drag-placement override from the `overrides` Map once the server's copy of that card reports the same status/sortOrder. If the card instead *leaves* `items` (the already filter-narrowed `visibleItems` — deleted, archived, or filtered out by an assignee/project change while the drop's optimistic patch hadn't landed yet), `items.find(...)` returns `undefined`, the equality check can never pass, and the override sits in the Map forever. Each such drop leaks one entry for the rest of the session.

**Why it matters:** on a long-lived board session with routine drags + filter changes, this Map only grows — a real (if slow) memory leak in a component that stays mounted for the life of the tab.

**Fix:** treat a card missing from `items` as settled too (nothing left to preview/bridge for it), so its override is dropped in the same retirement pass.

**How to verify:** `bunx tsc --noEmit` in apps/web (clean) and `bunx oxlint apps/web/src/layouts/task-board/index.tsx` (0 warnings/errors) — both run locally. No behavior change for the normal settle path (still requires status+sortOrder match when the card is present); full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a memory leak in the task board where drag placement overrides stayed in the `overrides` Map forever after a card left the visible list (deleted, archived, or filtered out). The retirement pass now treats a missing card as settled, so its override is dropped in the same pass. No behavior change for visible cards; they still require status and sort order to match.

<sup>Written for commit bde103543bfd2e2296c5fc7f1d04c8c4d98b580a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

