### PR TITLE
fix(web): extend splash fill animation to five seconds

### DIFF
--- a/apps/web/src/components/splash-screen.css
+++ b/apps/web/src/components/splash-screen.css
@@ -40,7 +40,7 @@
 }
 
 .deco-splash__liquid-rise {
-  animation: deco-splash-liquid-rise 1.1s linear forwards;
+  animation: deco-splash-liquid-rise 5s linear forwards;
 }
 
 .deco-splash__wave-track {
@@ -72,18 +72,17 @@
 }
 
 /* Decelerating rise that reaches full coverage of the mark right at the end of
- * the animation, 1.1s, and no sooner. -54px is the smallest translateY that
+ * the 5s animation, and no sooner. -54px is the smallest translateY that
  * still guarantees full coverage across the whole wave cycle: the crest
  * oscillates ±5 around its center, so covering the mark's highest point
  * (the arrow tip, local y ~13) even at the crest's shallowest phase (local
  * y 63) needs translateY <= 13 - 63 = -50, plus a small margin for curve
  * imprecision. Overshooting further than that (the old -64px target) just
  * left the tail of the animation sitting fully filled with nothing left to
- * animate. A splash that unmounts fast (a warm boot) must not catch the
- * liquid mid-rise, so this completes well inside any real boot's fastest
- * case. Once full, `deco-splash__wave-track`'s own infinite animation keeps
- * the crest moving, so a slow boot reads as "topped up and idling", not
- * stuck. `linear` between stops so the curve is the curve, not re-eased. */
+ * animate. A warm boot may unmount while the liquid is still rising. Once
+ * full, `deco-splash__wave-track`'s own infinite animation keeps the crest
+ * moving, so a slow boot reads as "topped up and idling", not stuck. `linear`
+ * between stops so the curve is the curve, not re-eased. */
 @keyframes deco-splash-liquid-rise {
   0% {
     transform: translateY(55px);


### PR DESCRIPTION
## Summary

- extend the splash logo liquid-fill animation from 1.1 seconds to 5 seconds
- update the animation rationale to match warm-boot behavior

## Verification

- formatted the changed CSS with Biome
- `git diff --check`
- no automated test added for this timing-only CSS change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the splash screen liquid-fill animation from 1.1 seconds to 5 seconds so it lasts longer and aligns with warm-boot behavior. Also updates the animation rationale comment to match the new timing.

<sup>Written for commit 8407c25a95313c143869d6932ab475b65ba17b1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

