### PR TITLE
feat(task-board): back the PR read cache with JetStream KV

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -146,6 +146,10 @@ import {
   setSkillCatalogCache,
   type SkillCatalogCache,
 } from "../file-storage/skill-catalog-cache";
+import {
+  JetStreamKVPrReadCache,
+  setPrReadCache,
+} from "../tools/task-board/pr-read-cache";
 import { isMcpCacheEnabled } from "../mcp-clients/mcp-read-cache";
 import {
   startMcpCacheInvalidation,
@@ -985,6 +989,7 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   let mcpListCache: McpListCache | null;
   let skillCatalogCache: SkillCatalogCache | null;
+  let prReadCache: JetStreamKVPrReadCache | null;
   let connectionCircuitStore: ConnectionCircuitStore;
   // Model lists are public, low-stakes metadata cached per-replica with a TTL —
   // no NATS needed, so this is shared across the test and production branches.
@@ -1010,6 +1015,9 @@ export async function createApp(options: CreateAppOptions = {}) {
     // Without NATS every read rebuilds the catalog — the behavior before the
     // cache existed.
     skillCatalogCache = null;
+    // Null here means `getPrReadCache()` serves its inert instance — the
+    // per-pod in-memory SWR cache, which is what this path had before.
+    prReadCache = null;
     connectionCircuitStore = new NoopConnectionCircuitStore();
     cancelBroadcast = {
       start: async () => {},
@@ -1086,6 +1094,12 @@ export async function createApp(options: CreateAppOptions = {}) {
     scc.init().catch(() => {});
     skillCatalogCache = scc;
 
+    const prc = new JetStreamKVPrReadCache({
+      getJetStream: () => natsProvider!.getJetStream(),
+    });
+    prc.init().catch(() => {});
+    prReadCache = prc;
+
     const ccs = new JetStreamKVConnectionCircuitStore({
       getJetStream: () => natsProvider!.getJetStream(),
     });
@@ -1115,6 +1129,9 @@ export async function createApp(options: CreateAppOptions = {}) {
       scc.init().catch((err: unknown) => {
         console.error("[SkillCatalogCache] Deferred init failed:", err);
       });
+      prc.init().catch((err: unknown) => {
+        console.error("[PrReadCache] Deferred init failed:", err);
+      });
       ccs.init().catch((err: unknown) => {
         console.error("[ConnectionCircuitStore] Deferred init failed:", err);
       });
@@ -1138,6 +1155,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Set tool list cache after cleanup to avoid previous cleanup nulling the new cache
   setMcpListCache(mcpListCache);
   setSkillCatalogCache(skillCatalogCache);
+  setPrReadCache(prReadCache);
   setConnectionCircuitStore(connectionCircuitStore);
 
   const threadStorage = new SqlThreadStorage(database.db);
@@ -1221,12 +1239,14 @@ export async function createApp(options: CreateAppOptions = {}) {
     streamBuffer.teardown();
     mcpListCache?.teardown();
     skillCatalogCache?.teardown();
+    prReadCache?.teardown();
     modelListCache.teardown();
     providerKeyCache.teardown();
     teardownMcpCacheInvalidation();
     connectionCircuitStore.teardown();
     setMcpListCache(null);
     setSkillCatalogCache(null);
+    setPrReadCache(null);
     setConnectionCircuitStore(null);
   };
 

--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -240,7 +240,10 @@ export async function mergeLinkedPr(
       const attempt = await attemptMerge(client, pr, mergeMethod);
       if (attempt.kind === "merged") {
         // Drop the polled read cache so the next poll sees `merged` → Done.
-        invalidatePrReads(conn.id);
+        // Awaited: the UI refetches as soon as this responds, and the KV delete
+        // is a round-trip — firing it and returning races the very poll it is
+        // meant to fix.
+        await invalidatePrReads(conn.id);
         return { merged: true };
       }
       // A 429 says nothing about the method; re-asking IS the burst — stop.

--- a/apps/api/src/tools/task-board/pr-read-cache.test.ts
+++ b/apps/api/src/tools/task-board/pr-read-cache.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import type { KV } from "@nats-io/kv";
+import { JetStreamKVPrReadCache } from "./pr-read-cache";
+
+/** Minimal in-process stand-in for the KV bucket: only what the cache calls. */
+function fakeKv(): KV {
+  const store = new Map<string, Uint8Array>();
+  return {
+    get: async (key: string) => {
+      const value = store.get(key);
+      return value ? { value, operation: "PUT" } : null;
+    },
+    put: async (key: string, value: Uint8Array) => {
+      store.set(key, value);
+      return 1;
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    keys: async (filter: string) => {
+      const prefix = filter.replace(/\.\*$/, ".");
+      return [...store.keys()].filter((k) => k.startsWith(prefix));
+    },
+  } as unknown as KV;
+}
+
+async function cacheAt(clock: { now: number }) {
+  const cache = new JetStreamKVPrReadCache(
+    { getJetStream: () => null },
+    () => clock.now,
+  );
+  await cache.init(fakeKv());
+  return cache;
+}
+
+describe("JetStreamKVPrReadCache", () => {
+  test("serves the stored read, then revalidates in the background once stale", async () => {
+    const clock = { now: 0 };
+    const cache = await cacheAt(clock);
+    let calls = 0;
+    const pending: Promise<void>[] = [];
+    const read = () =>
+      cache.fetch({
+        connectionId: "conn_1",
+        name: "pull_request_read",
+        args: { number: 7 },
+        fetchLive: async () => ({ n: ++calls }),
+        onRevalidation: (p) => pending.push(p),
+      });
+
+    expect(await read()).toEqual({ n: 1 });
+    // Fresh: served from KV, no second GitHub call.
+    clock.now = 10_000;
+    expect(await read()).toEqual({ n: 1 });
+    expect(calls).toBe(1);
+
+    // Stale: the OLD value is returned immediately while one refresh runs.
+    clock.now = 60_000;
+    expect(await read()).toEqual({ n: 1 });
+    expect(pending).toHaveLength(1);
+    await Promise.all(pending);
+    expect(calls).toBe(2);
+    expect(await read()).toEqual({ n: 2 });
+  });
+
+  test("keeps serving the stored read when a revalidation fails", async () => {
+    const clock = { now: 0 };
+    const cache = await cacheAt(clock);
+    const pending: Promise<void>[] = [];
+    let fail = false;
+    const read = () =>
+      cache.fetch({
+        connectionId: "conn_1",
+        name: "pull_request_read",
+        args: { number: 7 },
+        fetchLive: async () => {
+          if (fail) throw new Error("too many requests");
+          return { ok: true };
+        },
+        onRevalidation: (p) => pending.push(p),
+      });
+
+    await read();
+    fail = true;
+    clock.now = 60_000;
+    expect(await read()).toEqual({ ok: true });
+    await Promise.all(pending);
+    expect(await read()).toEqual({ ok: true });
+  });
+
+  test("invalidate drops the connection's reads", async () => {
+    const clock = { now: 0 };
+    const cache = await cacheAt(clock);
+    let calls = 0;
+    const read = () =>
+      cache.fetch({
+        connectionId: "conn_1",
+        name: "pull_request_read",
+        args: { number: 7 },
+        fetchLive: async () => ({ n: ++calls }),
+        onRevalidation: () => {},
+      });
+
+    await read();
+    await cache.invalidate("conn_1");
+    await read();
+    expect(calls).toBe(2);
+  });
+});

--- a/apps/api/src/tools/task-board/pr-read-cache.ts
+++ b/apps/api/src/tools/task-board/pr-read-cache.ts
@@ -1,0 +1,216 @@
+/**
+ * Cross-pod stale-while-revalidate cache for the GitHub PR reads behind a task
+ * board card, over NATS JetStream KV.
+ *
+ * This is the upgrade path the per-pod `InMemoryMcpReadCache` in `prs-get.ts`
+ * left open: that one worked, but each replica warmed its own copy, so a cold
+ * pod (and every pod after a deploy) still blocked the task dialog on a live
+ * GitHub round-trip, and N replicas cost N fetches per window against the same
+ * secondary rate limit the cache exists to dodge. KV makes one fetch serve every
+ * replica, and survives a restart.
+ *
+ * Semantics match the in-memory cache it replaces: a hit returns immediately;
+ * past `revalidateAfterMs` the stored value is served while ONE background
+ * fetch refreshes it; past `maxStaleMs` the caller blocks on a live fetch. The
+ * single-flight guard is per-pod, so a stampede across replicas can still cost
+ * one fetch per replica — bounded, and far below the per-viewer fetch it
+ * replaces.
+ *
+ * Best-effort throughout: no NATS, a cold bucket, an oversized value or a decode
+ * failure all fall back to the in-memory cache, which is also what development
+ * (no NATS) runs on. Mirrors {@link ../../mcp-clients/mcp-list-cache.ts}.
+ */
+
+import { createHash } from "node:crypto";
+import { type JetStreamClient, StorageType } from "@nats-io/jetstream";
+import { Kvm, type KV } from "@nats-io/kv";
+import { InMemoryMcpReadCache } from "../../mcp-clients/mcp-read-cache";
+import { jsonCodec } from "../../nats/json-codec";
+import { meter } from "../../observability";
+
+const cacheCounter = meter.createCounter("pr_read_cache.fetches", {
+  description: "Task board PR read cache outcomes (hit, stale, miss, error)",
+  unit: "{fetches}",
+});
+
+const KV_BUCKET = "DECOCMS_PR_READS";
+
+/** Just under the dialog's 60s poll, so a poll refreshes rather than blocks. */
+const REVALIDATE_AFTER_MS = 55_000;
+/** How long a rate-limit window may be papered over with the last good read. */
+const MAX_STALE_MS = 30 * 60_000;
+const MAX_VALUE_BYTES = 512 * 1024;
+
+const FALLBACK_ENTRY = {
+  revalidateAfterMs: REVALIDATE_AFTER_MS,
+  maxStaleMs: MAX_STALE_MS,
+  maxValueBytes: MAX_VALUE_BYTES,
+} as const;
+
+interface StoredRead {
+  storedAt: number;
+  value: unknown;
+}
+
+export interface PrReadCacheFetch {
+  connectionId: string;
+  name: string;
+  args: Record<string, unknown>;
+  /** MUST reject (not return) on error, so a failure is never stored. */
+  fetchLive: () => Promise<unknown>;
+  /** Receives the background revalidation so the caller can keep its MCP client
+   *  open until it settles. */
+  onRevalidation: (promise: Promise<void>) => void;
+}
+
+export class JetStreamKVPrReadCache {
+  private kv: KV | null = null;
+  private readonly codec = jsonCodec<StoredRead>();
+  /** Keys with an in-flight background revalidation on THIS pod. */
+  private readonly revalidating = new Set<string>();
+  /** Used whenever KV is unavailable — development, or NATS not yet ready. */
+  private readonly fallback = new InMemoryMcpReadCache({
+    "tools/call": FALLBACK_ENTRY,
+    "resources/read": FALLBACK_ENTRY,
+    "prompts/get": FALLBACK_ENTRY,
+  });
+
+  constructor(
+    private readonly options: { getJetStream: () => JetStreamClient | null },
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  /** @param kv Test seam: use this bucket instead of opening the real one. */
+  async init(kv?: KV): Promise<void> {
+    if (kv) {
+      this.kv = kv;
+      return;
+    }
+    const js = this.options.getJetStream();
+    if (!js) return; // NATS not ready — fall back until re-init
+    this.kv = await new Kvm(js).create(KV_BUCKET, {
+      storage: StorageType.Memory,
+      ttl: MAX_STALE_MS,
+      maxValueSize: MAX_VALUE_BYTES,
+    });
+  }
+
+  /**
+   * KV keys allow only `[-/_=.a-zA-Z0-9]`, and the tool arguments carry braces
+   * and quotes — so the call is hashed. The connection id stays a readable
+   * prefix because `invalidate` deletes by subject filter on it.
+   */
+  private key(connectionId: string, name: string, args: unknown): string {
+    const digest = createHash("sha256")
+      .update(JSON.stringify({ name, args }))
+      .digest("hex")
+      .slice(0, 32);
+    return `${connectionId}.${digest}`;
+  }
+
+  async fetch(params: PrReadCacheFetch): Promise<unknown> {
+    const { connectionId, name, args, fetchLive, onRevalidation } = params;
+    if (!this.kv) {
+      return this.fallback.fetch({
+        type: "tools/call",
+        connectionId,
+        // The GitHub installation is the connection's, not the caller's, so
+        // every org member reading the same PR shares one entry.
+        scope: { kind: "org" },
+        params: { name, arguments: args },
+        fetchLive,
+        onRevalidation,
+      });
+    }
+
+    const key = this.key(connectionId, name, args);
+    const stored = await this.read(key);
+    const age = stored
+      ? this.now() - stored.storedAt
+      : Number.POSITIVE_INFINITY;
+
+    if (!stored || age > MAX_STALE_MS) {
+      cacheCounter.add(1, { outcome: "miss" });
+      const value = await fetchLive();
+      await this.write(key, value);
+      return value;
+    }
+
+    if (age > REVALIDATE_AFTER_MS && !this.revalidating.has(key)) {
+      cacheCounter.add(1, { outcome: "stale" });
+      this.revalidating.add(key);
+      onRevalidation(
+        fetchLive()
+          .then((value) => this.write(key, value))
+          .catch(() => {
+            // Best-effort: keep serving the stored value until MAX_STALE_MS.
+            cacheCounter.add(1, { outcome: "error" });
+          })
+          .finally(() => this.revalidating.delete(key)),
+      );
+    } else {
+      cacheCounter.add(1, { outcome: "hit" });
+    }
+
+    return stored.value;
+  }
+
+  private async read(key: string): Promise<StoredRead | null> {
+    try {
+      const entry = await this.kv?.get(key);
+      if (!entry?.value?.length) return null;
+      if (entry.operation === "DEL" || entry.operation === "PURGE") return null;
+      return this.codec.decode(entry.value);
+    } catch {
+      return null; // a decode/read failure is a miss
+    }
+  }
+
+  private async write(key: string, value: unknown): Promise<void> {
+    try {
+      await this.kv?.put(
+        key,
+        this.codec.encode({ storedAt: this.now(), value }),
+      );
+    } catch {
+      // Oversized or NATS hiccup — best-effort, the next read refetches.
+    }
+  }
+
+  /** Drop this connection's cached PR reads (its config, auth or PR state
+   *  changed — see `invalidatePrReads`). */
+  async invalidate(connectionId: string): Promise<void> {
+    this.fallback.invalidate(connectionId);
+    if (!this.kv) return;
+    try {
+      const keys = await this.kv.keys(`${connectionId}.*`);
+      for await (const key of keys) {
+        await this.kv.delete(key).catch(() => {});
+      }
+    } catch {
+      // best-effort: the TTL is the backstop.
+    }
+  }
+
+  teardown(): void {
+    this.kv = null;
+  }
+}
+
+// Module-level active cache — set once at app startup, like the other KV caches.
+let activeCache: JetStreamKVPrReadCache | null = null;
+
+export function setPrReadCache(cache: JetStreamKVPrReadCache | null): void {
+  activeCache = cache;
+}
+
+/**
+ * Never null: without NATS (development, or a deployment with the cache off)
+ * this is an instance whose KV never initializes, which is exactly the per-pod
+ * in-memory cache this file replaced. Call sites don't branch.
+ */
+const INERT_CACHE = new JetStreamKVPrReadCache({ getJetStream: () => null });
+
+export function getPrReadCache(): JetStreamKVPrReadCache {
+  return activeCache ?? INERT_CACHE;
+}

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -12,7 +12,6 @@ import {
   SUPER_AGENT_ASSIGNEE_ID,
 } from "@decocms/shared/task-board";
 import { retry, RetryError } from "@decocms/shared/std";
-import { InMemoryMcpReadCache } from "@/mcp-clients/mcp-read-cache";
 import { TaskBoardItemPrSchema } from "./schema";
 import { cardWorkLanded } from "./archive-merged";
 import { recordTaskActivity } from "./activity";
@@ -44,52 +43,16 @@ export function isRateLimitError(err: unknown): boolean {
 }
 
 /**
- * Stale-while-revalidate cache for the PR reads on the POLLED paths — the task
- * dialog's 60s refresh and the review sweeper — which is where the GitHub 429s
- * came from. Each poll costs four `pull_request_read` calls per PR plus one
- * `GET_CHECK_RUN` per failing check, uncached: `clientFromConnection` (what this
- * file uses) bypasses the proxy's read cache entirely, so every viewer, every
- * poll, every replica hit GitHub live.
- *
- * SWR is what keeps the UI alive: past `revalidateAfterMs` a poll is served from
- * the entry it already has while ONE background call refreshes it (single-flight
- * — concurrent viewers of the same PR collapse into one), and a failed refresh
- * keeps serving the previous value until `maxStaleMs`. So a rate-limit window
- * shows the last known PR state instead of blanking the card to all-nulls.
- *
- * `maxStaleMs` is deliberately much longer than the poll: it only matters while
- * GitHub is refusing us, and half an hour of "the state as of when GitHub last
- * answered" beats an empty card that loses its checks, preview and ship button.
- *
- * Its own instance, not the shared `getMcpReadCache()`: that one is tuned for
- * proxied tool calls (30s/5min) and is settings-gated off in development, and
- * this path wants a longer stale window and to work the same everywhere.
- *
- * ponytail: per-pod, so N replicas still cost N fetches per window. Move it to
- * NATS KV if that's still too many.
- */
-const PR_READ_CACHE_ENTRY = {
-  /** Just under the dialog's 60s poll, so a poll refreshes rather than blocks. */
-  revalidateAfterMs: 55_000,
-  /** How long a rate-limit window may be papered over with the last good read. */
-  maxStaleMs: 30 * 60_000,
-  maxValueBytes: 512 * 1024,
-} as const;
-const prReadCache = new InMemoryMcpReadCache({
-  "tools/call": PR_READ_CACHE_ENTRY,
-  "resources/read": PR_READ_CACHE_ENTRY,
-  "prompts/get": PR_READ_CACHE_ENTRY,
-});
-
-/**
  * Drop this connection's cached PR reads. Call it after WRITING to GitHub
  * through the connection (a merge), so the next poll sees the new state instead
  * of serving the pre-merge one for the rest of the revalidate window — the card
  * only moves to Done once a poll observes `merged`, and a minute of "did my ship
  * button work?" is exactly the confusion this cache must not introduce.
  */
-export function invalidatePrReads(connectionId: string): void {
-  prReadCache.invalidate(connectionId);
+import { getPrReadCache } from "./pr-read-cache";
+
+export function invalidatePrReads(connectionId: string): Promise<void> {
+  return getPrReadCache().invalidate(connectionId);
 }
 
 /** `owner/repo#number`, for log lines. */
@@ -113,13 +76,10 @@ async function cachedPrRead(
   pending: Promise<void>[],
 ): Promise<Record<string, unknown> | null> {
   try {
-    const raw = await prReadCache.fetch({
-      type: "tools/call",
+    const raw = await getPrReadCache().fetch({
       connectionId,
-      // The GitHub installation is the connection's, not the caller's, so every
-      // org member reading the same PR shares one entry.
-      scope: { kind: "org" },
-      params: { name, arguments: args },
+      name,
+      args,
       fetchLive: () =>
         retry(
           async () => {


### PR DESCRIPTION
## Summary

The GitHub PR reads behind a task board card were cached per pod (`InMemoryMcpReadCache` in `prs-get.ts`). That worked, but every replica warmed its own copy — so a cold pod, and every pod after a deploy, still blocked the task dialog on a live GitHub round-trip, and N replicas cost N fetches per window against the very secondary rate limit the cache exists to dodge.

This promotes it to NATS JetStream KV — the upgrade path the existing `ponytail:` comment named. One fetch now serves every replica, and the entry survives a restart.

## What changed

- New `apps/api/src/tools/task-board/pr-read-cache.ts` — `JetStreamKVPrReadCache`, mirroring `JetStreamKVMcpListCache` / `JetStreamKVSkillCatalogCache`. Bucket `DECOCMS_PR_READS`, memory storage, TTL as the backstop.
- Semantics are **unchanged**: 55s revalidate / 30min max stale, single-flight background refresh, stale served through a rate-limit window.
- `invalidatePrReads` (called after a merge) now clears the cache on **every** pod instead of only the merging one — so it's `await`ed before the tool responds, since the UI refetches as soon as the merge returns.
- Without NATS (development, `disableNats`) the cache falls back to the same in-memory SWR cache it replaced, so local behavior is identical.

## Testing

- `apps/api/src/tools/task-board/pr-read-cache.test.ts` — 3 tests against an in-process fake KV, with an injected clock: serve-then-revalidate-once-stale, keep serving the stored read when a revalidation fails (the rate-limit case), and `invalidate` drops the connection's reads.
- `bun run --cwd=apps/api check`, `bun run lint`, `knip` clean.
- The 10 `*.integration.test.ts` failures in `apps/api/src/tools/task-board/` need Postgres and fail on `main` too.

## Affected areas

Task board PR card / task dialog (`TASK_BOARD_ITEM_PRS_GET`), and the merge path's cache invalidation. No UI change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the task board PR read cache from per-pod in-memory to NATS JetStream KV, so one GitHub fetch serves every replica and survives restarts instead of each pod warming its own copy.

- Cache invalidation after a merge now clears the cache on every pod and is awaited before the tool responds.
- Without NATS (development), the cache falls back to the same in-memory SWR cache it replaces, so local behavior is unchanged.
- Staleness semantics are unchanged: 55s revalidate / 30min max stale with single-flight background refresh.

<sup>Written for commit 6c24171823b179e7a2c2d2ab4903e923cef3fea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

