### PR TITLE
fix(task-board): show the passing-checks score on a collapsed failing footer

### DIFF
--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -161,6 +161,7 @@ export const taskBoard = {
   "taskBoard.taskDialog.prChecksPassing": "Checks passing",
   "taskBoard.taskDialog.prChecksPending": "Checks pending",
   "taskBoard.taskDialog.prChecksLabel": "Checks",
+  "taskBoard.taskDialog.prChecksScore": "{passed}/{total} successful checks",
   "taskBoard.taskDialog.prStateClosed": "Closed",
   "taskBoard.taskDialog.prStateDraft": "Draft",
   "taskBoard.taskDialog.prStateMerged": "Merged",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -169,6 +169,8 @@ export const taskBoard = {
   "taskBoard.taskDialog.prChecksPassing": "Verificações passaram",
   "taskBoard.taskDialog.prChecksPending": "Verificações pendentes",
   "taskBoard.taskDialog.prChecksLabel": "Verificações",
+  "taskBoard.taskDialog.prChecksScore":
+    "{passed}/{total} verificações com sucesso",
   "taskBoard.taskDialog.prStateClosed": "Fechado",
   "taskBoard.taskDialog.prStateDraft": "Rascunho",
   "taskBoard.taskDialog.prStateMerged": "Mesclado",

--- a/apps/web/src/layouts/task-board/pr-card-actions.test.ts
+++ b/apps/web/src/layouts/task-board/pr-card-actions.test.ts
@@ -5,8 +5,12 @@
  * button whose merge would 405. The card must offer "Resolve conflict" there
  * instead.
  */
-import { describe, expect, it } from "bun:test";
-import { prCardActions } from "./pr-card-actions";
+import { describe, expect, it, test } from "bun:test";
+import {
+  collapsedChecksScore,
+  isSuccessfulCheck,
+  prCardActions,
+} from "./pr-card-actions";
 import type { TaskBoardItemPr } from "./config";
 
 function pr(overrides: Partial<TaskBoardItemPr> = {}): TaskBoardItemPr {
@@ -82,5 +86,58 @@ describe("prCardActions", () => {
     );
     expect(a.showResolveConflict).toBe(true);
     expect(a.showShip).toBe(false);
+  });
+});
+
+describe("collapsedChecksScore", () => {
+  const check = (
+    name: string,
+    conclusion: string | null,
+    status = "completed",
+  ) => ({ name, status, conclusion }) as TaskBoardItemPr["checks"][number];
+
+  const mixed = [
+    check("copilot", "success"),
+    check("Build", "success"),
+    check("Cypress", "failure"),
+    check("Gates", "failure"),
+  ];
+
+  test("collapsed and failing: counts the green checks, not the red ones", () => {
+    expect(collapsedChecksScore("failing", mixed, false)).toEqual({
+      passed: 2,
+      total: 4,
+    });
+  });
+
+  test("expanded: no score, so the red failing header comes back", () => {
+    expect(collapsedChecksScore("failing", mixed, true)).toBeNull();
+  });
+
+  test("not failing: no score", () => {
+    expect(collapsedChecksScore("passing", mixed, false)).toBeNull();
+    expect(collapsedChecksScore("pending", mixed, false)).toBeNull();
+    expect(collapsedChecksScore(null, mixed, false)).toBeNull();
+  });
+
+  test("failing with no check rows to count: no score", () => {
+    expect(collapsedChecksScore("failing", [], false)).toBeNull();
+  });
+
+  test("a still-running check is not counted as passed", () => {
+    const running = [
+      check("Build", "success"),
+      check("E2E", null, "in_progress"),
+    ];
+    expect(collapsedChecksScore("failing", running, false)).toEqual({
+      passed: 1,
+      total: 2,
+    });
+  });
+
+  test("neutral and skipped count as successful, matching their green icon", () => {
+    expect(isSuccessfulCheck(check("a", "neutral"))).toBe(true);
+    expect(isSuccessfulCheck(check("a", "skipped"))).toBe(true);
+    expect(isSuccessfulCheck(check("a", "timed_out"))).toBe(false);
   });
 });

--- a/apps/web/src/layouts/task-board/pr-card-actions.ts
+++ b/apps/web/src/layouts/task-board/pr-card-actions.ts
@@ -32,3 +32,38 @@ export function prCardActions(
     showResolveConflict: reviewsReady && isOpen && hasConflict,
   };
 }
+
+/** A check the footer draws green: finished, and not a failure. Shared with
+ *  `checkRunStyle` so the collapsed score can never disagree with the icons
+ *  the expanded list shows. */
+export function isSuccessfulCheck(
+  check: TaskBoardItemPr["checks"][number],
+): boolean {
+  if (check.status !== "completed") return false;
+  const c = check.conclusion;
+  return c === "success" || c === "neutral" || c === "skipped";
+}
+
+/**
+ * The score a COLLAPSED checks footer shows in place of "Checks failing".
+ *
+ * A red "Checks failing" reads as "the whole build is broken" even when one of
+ * seven checks failed — which is the common case, and the one people act on. So
+ * the closed header reports how many passed, in warning. `null` means keep the
+ * normal header: the checks aren't failing, the footer is open (the user is
+ * looking AT the failures, and red is how they find them), or there are no
+ * check rows to count.
+ */
+export function collapsedChecksScore(
+  checksStatus: TaskBoardItemPr["checksStatus"],
+  checks: TaskBoardItemPr["checks"],
+  checksOpen: boolean,
+): { passed: number; total: number } | null {
+  if (checksStatus !== "failing" || checksOpen || checks.length === 0) {
+    return null;
+  }
+  return {
+    passed: checks.filter(isSuccessfulCheck).length,
+    total: checks.length,
+  };
+}

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -105,7 +105,11 @@ import {
   type TaskBoardItemThread,
 } from "./config";
 import { summarizeTaskCost } from "./task-cost";
-import { prCardActions } from "./pr-card-actions";
+import {
+  collapsedChecksScore,
+  isSuccessfulCheck,
+  prCardActions,
+} from "./pr-card-actions";
 import { toast } from "sonner";
 import { useTaskBoardItemPrs } from "@/hooks/use-task-board-item-prs";
 import {
@@ -1729,7 +1733,7 @@ function checkRunStyle(check: TaskBoardItemPr["checks"][number]): {
   if (c && FAILED_CHECK_CONCLUSIONS.has(c)) {
     return { icon: AlertCircle, className: "text-destructive", spin: false };
   }
-  if (c === "success" || c === "neutral" || c === "skipped") {
+  if (isSuccessfulCheck(check)) {
     return { icon: CheckCircle, className: "text-success", spin: false };
   }
   return { icon: HelpCircle, className: "text-muted-foreground", spin: false };
@@ -1763,7 +1767,7 @@ function PrCard({
   const t = useT();
   const [checksOpen, setChecksOpen] = useState(false);
   const style = prStateStyle(pr, t);
-  const checksHeader = prChecksStyle(pr.checksStatus, t);
+  const checksState = prChecksStyle(pr.checksStatus, t);
   const { isOpen, hasConflict, showShip, showResolveConflict } = prCardActions(
     pr,
     reviewsReady,
@@ -1772,8 +1776,16 @@ function PrCard({
     !!previewThread || !!pr.previewUrl || showShip || showResolveConflict;
   // Null-safe: react-query cache from before `checks` shipped can lack it.
   const checks = pr.checks ?? [];
-  const hasChecksFooter = checks.length > 0 || checksHeader != null;
+  const hasChecksFooter = checks.length > 0 || checksState != null;
   const expandable = checks.length > 0;
+  const score = collapsedChecksScore(pr.checksStatus, checks, checksOpen);
+  const checksHeader = score
+    ? {
+        label: t("taskBoard.taskDialog.prChecksScore", score),
+        className: "text-warning",
+        icon: AlertCircle,
+      }
+    : checksState;
 
   return (
     <div className="flex flex-col gap-3 rounded-xl bg-card p-3 card-shadow">


### PR DESCRIPTION
## Summary

A PR card with one failing check out of seven shows a red **"Checks failing"** header, which reads as "the whole build is broken". The collapsed footer now reports the score instead — **"4/7 successful checks"** in warning (orange), not destructive red.

Only the **collapsed** state changes. Expanding restores the red "Checks failing" header and the per-check red icons: at that point the user is looking *at* the failures, and colour is how they find them.

## What changed

- `collapsedChecksScore(checksStatus, checks, checksOpen)` in `pr-card-actions.ts` — the existing home for the card's pure gating logic. Returns `null` (keep the normal header) when the checks aren't failing, the footer is open, or there are no check rows to count.
- `isSuccessfulCheck` is extracted and **shared with `checkRunStyle`**, so the collapsed score can never disagree with the icons the expanded list draws. A still-running check counts as neither passed nor failed; `neutral` and `skipped` count as passed, matching their green icon.
- New i18n key `taskBoard.taskDialog.prChecksScore` in en + pt-br.

## Testing

- 6 new tests in `pr-card-actions.test.ts` covering each gate and the counting rules (13 pass in that file).
- `bun run --cwd=apps/web check`, `bun run lint`, `knip` clean.

## Screenshots

Not captured — reproducing it needs a PR with a partially-failing check suite. The change is a label swap plus `text-destructive` → `text-warning` on the collapsed header only; the expanded list is untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the collapsed checks footer on a PR card so a partially failing suite reports "4/7 successful checks" in warning orange instead of a red "Checks failing" header that reads as a fully broken build. Expanding the footer still shows the red failing header and per-check red icons.

- `collapsedChecksScore` returns the score only when checks are failing, the footer is collapsed, and there are check rows to count; otherwise it returns `null` and the header stays as-is.
- `isSuccessfulCheck` is extracted and shared with the expanded list's icon styling, so the score can never disagree with what the icons show; running checks count as neither passed nor failed, while `neutral` and `skipped` count as passed.
- Added the `taskBoard.taskDialog.prChecksScore` i18n key to en and pt-br, and 6 tests covering the gating and counting rules.

<sup>Written for commit 708aefaa84aa69c85ac4d82b33a387076f86cbd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

