### PR TITLE
refactor(virtual-mcp): add array size caps to base SDK type definitions

### DIFF
--- a/packages/shared/src/sdk/types/virtual-mcp.test.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.test.ts
@@ -453,6 +453,106 @@ test("VirtualMCPUpdateDataSchema rejects more than 200 enabled_plugins", () => {
   expect(result.success).toBe(false);
 });
 
+test("VirtualMCPEntitySchema rejects more than 200 enabled_plugins on read", () => {
+  const result = VirtualMCPEntitySchema.safeParse({
+    id: "x",
+    title: "x",
+    description: null,
+    icon: null,
+    created_at: "t",
+    updated_at: "t",
+    created_by: "u",
+    organization_id: "o",
+    status: "active",
+    pinned: false,
+    metadata: {
+      instructions: null,
+      enabled_plugins: Array.from({ length: 201 }, (_, i) => `plugin-${i}`),
+    },
+    connections: [],
+  });
+  expect(result.success).toBe(false);
+});
+
+test("VirtualMCPEntitySchema rejects more than 200 subAgents", () => {
+  const result = VirtualMCPEntitySchema.safeParse({
+    id: "x",
+    title: "x",
+    description: null,
+    icon: null,
+    created_at: "t",
+    updated_at: "t",
+    created_by: "u",
+    organization_id: "o",
+    status: "active",
+    pinned: false,
+    metadata: {
+      instructions: null,
+      subAgents: Array.from({ length: 201 }, (_, i) => `agent-${i}`),
+    },
+    connections: [],
+  });
+  expect(result.success).toBe(false);
+});
+
+test("VirtualMCPEntitySchema rejects more than 50 releases", () => {
+  const result = VirtualMCPEntitySchema.safeParse({
+    id: "x",
+    title: "x",
+    description: null,
+    icon: null,
+    created_at: "t",
+    updated_at: "t",
+    created_by: "u",
+    organization_id: "o",
+    status: "active",
+    pinned: false,
+    metadata: {
+      instructions: null,
+      releases: Array.from({ length: 51 }, (_, i) => ({
+        branch: `release-${i}`,
+        name: `Release ${i}`,
+        color: "#000000",
+      })),
+    },
+    connections: [],
+  });
+  expect(result.success).toBe(false);
+});
+
+test("VirtualMCPCreateDataSchema rejects more than 100 knowledge files", () => {
+  const result = VirtualMCPCreateDataSchema.safeParse({
+    title: "Agent",
+    connections: [],
+    metadata: {
+      knowledge: Array.from({ length: 101 }, (_, i) => ({
+        id: `file-${i}`,
+        name: `Doc ${i}`,
+        volume: "lib",
+        path: `/doc${i}.md`,
+        url: `https://example.com/doc${i}.md`,
+        addedAt: new Date().toISOString(),
+      })),
+    },
+  });
+  expect(result.success).toBe(false);
+});
+
+test("VirtualMCPUpdateDataSchema rejects more than 100 runtime env vars", () => {
+  const result = VirtualMCPUpdateDataSchema.safeParse({
+    metadata: {
+      runtime: {
+        env: Array.from({ length: 101 }, (_, i) => ({
+          key: `VAR_${i}`,
+          kind: "literal" as const,
+          value: `value${i}`,
+        })),
+      },
+    },
+  });
+  expect(result.success).toBe(false);
+});
+
 test("SandboxRecord.startedWith is optional with nullable packageManager/port/path", () => {
   const a = SandboxRecordSchema.parse({ sandboxHandle: "v", previewUrl: null });
   expect(a.startedWith).toBeUndefined();

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -52,6 +52,33 @@ const CONNECTIONS_MAX = 200;
  *  payload size, not a real agent config. */
 const ENABLED_PLUGINS_MAX = 200;
 
+/** Cap on how many sub-agent IDs this agent can delegate to. */
+const SUBAGENTS_MAX = 200;
+
+/** Cap on home tiles per agent. */
+const HOME_TILES_MAX = 20;
+
+/** Cap on home prompts (icebreakers) per agent. */
+const HOME_PROMPTS_MAX = 50;
+
+/** Cap on pinned tool views per agent. */
+const PINNED_VIEWS_MAX = 100;
+
+/** Cap on UI layout tabs per agent. */
+const TABS_MAX = 20;
+
+/** Cap on knowledge files attached to an agent. */
+const KNOWLEDGE_MAX = 100;
+
+/** Cap on releases (named branches) per agent. */
+const RELEASES_MAX = 50;
+
+/** Cap on runtime env vars injected per sandbox. */
+const RUNTIME_ENV_MAX = 100;
+
+/** Cap on git submodule credentials per sandbox. */
+const SUBMODULE_CREDENTIALS_MAX = 50;
+
 /**
  * Virtual MCP connection schema for input (Create/Update) - fields can be optional
  */
@@ -200,12 +227,13 @@ export const VirtualMcpUILayoutSchema = z.object({
    *  top-level metadata field. */
   sidebarViews: z
     .array(VirtualMcpSidebarViewSchema)
+    .max(10)
     .nullable()
     .optional()
     .describe(
       "Deprecated layout-scoped sidebar selections. Read only as a fallback when metadata.sidebarViews is absent.",
     ),
-  tabs: z.array(VirtualMcpUILayoutTabSchema).optional(),
+  tabs: z.array(VirtualMcpUILayoutTabSchema).max(TABS_MAX).optional(),
 });
 
 export type VirtualMcpUILayout = z.infer<typeof VirtualMcpUILayoutSchema>;
@@ -305,7 +333,11 @@ const VirtualMcpUISchema = z.object({
   bannerColor: z.string().nullable().optional(),
   icon: z.string().nullable().optional(),
   themeColor: z.string().nullable().optional(),
-  pinnedViews: z.array(VirtualMcpPinnedViewSchema).nullable().optional(),
+  pinnedViews: z
+    .array(VirtualMcpPinnedViewSchema)
+    .max(PINNED_VIEWS_MAX)
+    .nullable()
+    .optional(),
   layout: VirtualMcpUILayoutSchema.nullable().optional(),
   /**
    * Legacy single-tile slot. Still honored by the home-next-actions
@@ -319,7 +351,11 @@ const VirtualMcpUISchema = z.object({
    * the org home board, rendered via MCPAppRenderer against the
    * resource's owning connection.
    */
-  homeTiles: z.array(VirtualMcpHomeTileSchema).nullable().optional(),
+  homeTiles: z
+    .array(VirtualMcpHomeTileSchema)
+    .max(HOME_TILES_MAX)
+    .nullable()
+    .optional(),
   /**
    * Curated list of prompt names to surface on the home board. When
    * absent / null, the BE falls back to listing every prompt the
@@ -327,7 +363,7 @@ const VirtualMcpUISchema = z.object({
    * array means "no prompts" — useful for an agent that only wants to
    * surface its UI tiles.
    */
-  homePrompts: z.array(z.string()).nullable().optional(),
+  homePrompts: z.array(z.string()).max(HOME_PROMPTS_MAX).nullable().optional(),
 });
 
 export type VirtualMcpUI = z.infer<typeof VirtualMcpUISchema>;
@@ -441,6 +477,7 @@ const RuntimeMetadataSchema = z.object({
     ),
   env: z
     .array(RuntimeEnvEntrySchema)
+    .max(RUNTIME_ENV_MAX)
     .nullable()
     .optional()
     .describe(
@@ -448,6 +485,7 @@ const RuntimeMetadataSchema = z.object({
     ),
   submoduleCredentials: z
     .array(SubmoduleCredentialSchema)
+    .max(SUBMODULE_CREDENTIALS_MAX)
     .nullable()
     .optional()
     .describe(
@@ -675,6 +713,7 @@ export type KnowledgeFile = z.infer<typeof KnowledgeFileSchema>;
  */
 const knowledgeMetadataField = z
   .array(KnowledgeFileSchema)
+  .max(KNOWLEDGE_MAX)
   .nullable()
   .optional()
   .describe(
@@ -776,6 +815,7 @@ export type Release = z.infer<typeof ReleaseSchema>;
 
 const releasesMetadataField = z
   .array(ReleaseSchema)
+  .max(RELEASES_MAX)
   .nullable()
   .optional()
   .describe(
@@ -803,11 +843,13 @@ const VirtualMcpMetadataFields = {
     .describe("Instructions also used as system prompt"),
   enabled_plugins: z
     .array(z.string())
+    .max(ENABLED_PLUGINS_MAX)
     .nullable()
     .optional()
     .describe("List of enabled plugin IDs"),
   subAgents: z
     .array(z.string())
+    .max(SUBAGENTS_MAX)
     .nullable()
     .optional()
     .describe(


### PR DESCRIPTION
Adds `.max()` constraints to all array fields in the virtual-MCP type schemas, ensuring reads from the database validate against the same size constraints as writes.

## Changes
Array size caps added to base schema definitions:
- `enabled_plugins`: max 200 (consistent with create/update)
- `subAgents`: max 200 (finite set, prevent DoS)
- `sidebarViews`: max 10 (exact enum size)
- `knowledge`: max 100 (reference docs limit)
- `releases`: max 50 (version management)
- `tabs`: max 20 (UI navigation)
- `pinnedViews`: max 100 (pinned tools)
- `homeTiles`: max 20 (home board tiles)
- `homePrompts`: max 50 (icebreakers)
- `env`: max 100 (runtime vars)
- `submoduleCredentials`: max 50 (git hosts)

## Verification
Run: `bun test packages/shared/src/sdk/types/virtual-mcp.test.ts`
All 51 tests pass. TypeScript check: no errors. Lint: 0 warnings, 0 errors.

This follows the pattern from #6935 (cap enabled_plugins) and #6931 (cap connections), completing the set of array size validations to prevent unbounded attacker-controlled payloads in MCP tool contracts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.max()` size caps to all array fields in the virtual-MCP base SDK schemas so reads from the database validate against the same size constraints as writes, preventing unbounded attacker-controlled payloads in MCP tool contracts.

- Caps apply to `enabled_plugins` (200), `subAgents` (200), `sidebarViews` (10), `knowledge` (100), `releases` (50), `tabs` (20), `pinnedViews` (100), `homeTiles` (20), `homePrompts` (50), `env` (100), and `submoduleCredentials` (50).
- Existing records with arrays over the caps will now fail schema validation on read; verify no current data exceeds these limits.
- Verification: `bun test packages/shared/src/sdk/types/virtual-mcp.test.ts` passes (51 tests), TypeScript and lint are clean.

<sup>Written for commit aa9fd0ed0bdcdc58980a41a799c6703f7665b7f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

