### PR TITLE
perf(task-board): paint PR cards instantly, drop the MCP handshake from warm reads

### DIFF
--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -66,9 +66,61 @@ const prLabel = (pr: TaskBoardItemPrRef) =>
  * `callTool` RESOLVES (doesn't reject) on an upstream MCP error, so an `isError`
  * result is rethrown here — otherwise the cache would happily store GitHub's
  * "too many requests" as the PR's state and serve it for half an hour.
+ *
+ * Takes a `getClient` THUNK, not a client. The cache only calls `fetchLive` on a
+ * miss or a background revalidation, so on a warm card the client is never
+ * built — and building one is not free: the per-request pool bakes a fresh
+ * Studio token, which costs a `downstream_tokens` read plus an eager MCP
+ * `initialize` handshake (~80-120ms) before any tool call can go out. Handed a
+ * ready client instead, every poll paid that round-trip to then answer entirely
+ * from cache.
  */
+type GetPrClient = () => Promise<
+  Awaited<ReturnType<typeof clientFromConnection>>
+>;
+
+/**
+ * A GitHub MCP client for `conn`, opened AT MOST ONCE and only if a read
+ * actually misses the SWR cache.
+ *
+ * Opening one is not free: the per-request pool bakes a fresh Studio token, so
+ * it costs a `downstream_tokens` read plus an eager MCP `initialize` handshake
+ * (~80-120ms) before any tool call can go out. Every read below is cached, so a
+ * warm card would otherwise pay that round-trip only to answer from cache.
+ *
+ * `closeWhenIdle` closes once the cache's background revalidations settle — and
+ * does nothing at all when nothing was ever opened.
+ */
+function lazyPrClient(
+  conn: ConnectionEntity,
+  ctx: StudioContext,
+): { get: GetPrClient; closeWhenIdle: (pending: Promise<void>[]) => void } {
+  type PrClient = Awaited<ReturnType<typeof clientFromConnection>>;
+  let client: PrClient | null = null;
+  let promise: Promise<PrClient> | null = null;
+  return {
+    get: () => {
+      promise ??= clientFromConnection(conn, ctx, true).then((c) => {
+        client = c;
+        return c;
+      });
+      return promise;
+    },
+    // Do NOT await this — the whole point of serving a stale value is to return
+    // without waiting on GitHub. Closing eagerly (which this did) killed every
+    // revalidation the moment it started, so a cached entry could never
+    // refresh: a PR read before its deploy comment existed showed no preview
+    // and no checks until the entry aged out half an hour later.
+    closeWhenIdle: (pending) => {
+      void Promise.allSettled(pending).then(() =>
+        client?.close().catch(() => {}),
+      );
+    },
+  };
+}
+
 async function cachedPrRead(
-  client: Awaited<ReturnType<typeof clientFromConnection>>,
+  getClient: GetPrClient,
   connectionId: string,
   name: string,
   args: Record<string, unknown>,
@@ -83,7 +135,7 @@ async function cachedPrRead(
       fetchLive: () =>
         retry(
           async () => {
-            const result = await client.callTool(
+            const result = await (await getClient()).callTool(
               { name, arguments: args },
               undefined,
               {
@@ -110,8 +162,8 @@ async function cachedPrRead(
             isRetriable: (err) => !isRateLimitError(err),
           },
         ),
-      // A background revalidation runs on `client` AFTER this call returns the
-      // stale value — so the caller must keep the client open until it settles.
+      // A background revalidation calls `getClient` AFTER this returns the stale
+      // value — so the caller must keep the client open until it settles.
       onRevalidation: (promise) => pending.push(promise),
     });
     return toolResultJson(raw);
@@ -563,14 +615,14 @@ function isFailingRun(r: RawCheckRun): boolean {
 /** Fetch a check-run's output markdown via the github MCP `GET_CHECK_RUN` tool
  *  (the list tool omits `output`). Best-effort: null on any failure. */
 async function fetchCheckRunSummary(
-  client: Awaited<ReturnType<typeof clientFromConnection>>,
+  getClient: GetPrClient,
   connectionId: string,
   pr: TaskBoardItemPrRef,
   checkRunId: number,
   pending: Promise<void>[],
 ): Promise<string | null> {
   const obj = await cachedPrRead(
-    client,
+    getClient,
     connectionId,
     "GET_CHECK_RUN",
     { owner: pr.repoOwner, repo: pr.repoName, checkRunId },
@@ -714,7 +766,7 @@ export async function fetchPrConflict(
  *  differ in which they post to), merged into one checks summary, plus the deco
  *  deploy preview URL. Best-effort: any failure yields nulls. */
 async function fetchPrStatusExtras(
-  client: Awaited<ReturnType<typeof clientFromConnection>>,
+  getClient: GetPrClient,
   connectionId: string,
   pr: TaskBoardItemPrRef,
   pending: Promise<void>[],
@@ -726,7 +778,7 @@ async function fetchPrStatusExtras(
 }> {
   const read = (method: "get_status" | "get_check_runs" | "get_comments") =>
     cachedPrRead(
-      client,
+      getClient,
       connectionId,
       "pull_request_read",
       {
@@ -766,7 +818,7 @@ async function fetchPrStatusExtras(
     if (headSha) {
       previewUrl = extractPreviewUrlFromDeployment(
         await cachedPrRead(
-          client,
+          getClient,
           connectionId,
           "GET_PREVIEW_DEPLOYMENT",
           { owner: pr.repoOwner, repo: pr.repoName, sha: headSha },
@@ -788,7 +840,7 @@ async function fetchPrStatusExtras(
         summary:
           isFailingRun(r) && r.id != null
             ? await fetchCheckRunSummary(
-                client,
+                getClient,
                 connectionId,
                 pr,
                 r.id,
@@ -881,8 +933,8 @@ async function fetchPrLiveState(
     name: pr.repoName,
   });
   if (!conn) return NO_LIVE_STATE;
-  const client = await clientFromConnection(conn, ctx, true);
-  // Background revalidations started by the read cache below run on `client`,
+  const { get: getClient, closeWhenIdle } = lazyPrClient(conn, ctx);
+  // Background revalidations started by the read cache below run on the client,
   // so it may not be closed until they settle — see the `finally`.
   const pending: Promise<void>[] = [];
   try {
@@ -892,7 +944,7 @@ async function fetchPrLiveState(
     // wastes the extras, but that's rare here and best-effort.
     // One `get`, shared: it populates the PR fields and feeds the deployment preview its head sha (stable, unlike the flakier `get_status`).
     const prGet = cachedPrRead(
-      client,
+      getClient,
       conn.id,
       "pull_request_read",
       {
@@ -906,7 +958,7 @@ async function fetchPrLiveState(
     );
     const [obj, extras] = await Promise.all([
       prGet,
-      fetchPrStatusExtras(client, conn.id, pr, pending, prGet),
+      fetchPrStatusExtras(getClient, conn.id, pr, pending, prGet),
     ]);
     if (!obj) return NO_LIVE_STATE;
     const rawState = obj.state;
@@ -928,13 +980,7 @@ async function fetchPrLiveState(
   } catch {
     return NO_LIVE_STATE;
   } finally {
-    // Close only once the background revalidations are done, and do NOT await
-    // that here — the whole point of serving a stale value is to return without
-    // waiting on GitHub. Closing eagerly (which this did) killed every
-    // revalidation the moment it started, so a cached entry could never
-    // refresh: a PR read before its deploy comment existed showed no preview
-    // and no checks until the entry aged out half an hour later.
-    void Promise.allSettled(pending).then(() => client.close().catch(() => {}));
+    closeWhenIdle(pending);
   }
 }
 
@@ -959,11 +1005,11 @@ async function fetchPrGet(
     name: pr.repoName,
   });
   if (!conn) return null;
-  const client = await clientFromConnection(conn, ctx, true);
+  const { get: getClient, closeWhenIdle } = lazyPrClient(conn, ctx);
   const pending: Promise<void>[] = [];
   try {
     return await cachedPrRead(
-      client,
+      getClient,
       conn.id,
       "pull_request_read",
       {
@@ -978,7 +1024,7 @@ async function fetchPrGet(
   } catch {
     return null;
   } finally {
-    void Promise.allSettled(pending).then(() => client.close().catch(() => {}));
+    closeWhenIdle(pending);
   }
 }
 

--- a/apps/web/index.css
+++ b/apps/web/index.css
@@ -113,6 +113,32 @@
 }
 
 @layer utilities {
+  /* A card whose contents are cached and being revalidated in the background:
+     its border breathes instead of the whole card blanking to a skeleton.
+     Inset so it needs no border on the element (see `todo-cb-pulse`). */
+  .revalidating-ring {
+    animation: revalidating-ring-pulse 1.6s ease-in-out infinite;
+  }
+
+  @keyframes revalidating-ring-pulse {
+    0%,
+    100% {
+      box-shadow: inset 0 0 0 1px var(--color-border);
+    }
+    50% {
+      box-shadow: inset 0 0 0 1.5px var(--color-ring);
+    }
+  }
+
+  /* Motion is the whole signal here, so with it suppressed keep a static ring
+     rather than dropping the "still loading" cue entirely. */
+  @media (prefers-reduced-motion: reduce) {
+    .revalidating-ring {
+      animation: none;
+      box-shadow: inset 0 0 0 1px var(--color-ring);
+    }
+  }
+
   .shimmer {
     background-image: linear-gradient(
       90deg,

--- a/apps/web/src/hooks/use-task-board-item-prs.ts
+++ b/apps/web/src/hooks/use-task-board-item-prs.ts
@@ -1,7 +1,12 @@
 import { useProjectContext } from "@/sdk";
+import type { TaskBoardItemPr } from "@/layouts/task-board/config";
 import { useQuery } from "@tanstack/react-query";
 import { KEYS } from "@/lib/query-keys";
 import { useStudioTools } from "@/lib/studio-tools";
+import {
+  readCachedTaskPrs,
+  writeCachedTaskPrs,
+} from "@/lib/task-board-prs-cache";
 
 /** Poll interval for a task's PRs while the dialog is open. The tool fetches
  *  live GitHub state — PR/checks status and the checks→QA hand-off it drives —
@@ -25,11 +30,26 @@ export function useTaskBoardItemPrs(itemId: string | undefined) {
     queryKey: KEYS.taskBoardItemPrs(locator, itemId ?? ""),
     enabled: !!itemId,
     refetchInterval: PRS_POLL_INTERVAL_MS,
-    queryFn: async () =>
-      (
-        await studio.call("TASK_BOARD_ITEM_PRS_GET", {
-          taskBoardItemId: itemId!,
-        })
-      ).prs,
+    // Seeded from localStorage so a cold page load paints the last known cards
+    // instead of a skeleton. `initialDataUpdatedAt` carries the real age, so
+    // React Query treats the seed as already stale and refetches on mount — the
+    // card shows a breathing border while it does (`isFetching` in PrCard).
+    // Both are FUNCTIONS: React Query only calls them when the key has no
+    // cached data, so the parse doesn't run on every render.
+    initialData: () =>
+      itemId
+        ? ((readCachedTaskPrs(locator, itemId)?.data as
+            | TaskBoardItemPr[]
+            | undefined) ?? undefined)
+        : undefined,
+    initialDataUpdatedAt: () =>
+      itemId ? readCachedTaskPrs(locator, itemId)?.updatedAt : undefined,
+    queryFn: async () => {
+      const { prs } = await studio.call("TASK_BOARD_ITEM_PRS_GET", {
+        taskBoardItemId: itemId!,
+      });
+      writeCachedTaskPrs(locator, itemId!, prs);
+      return prs;
+    },
   });
 }

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -1809,6 +1809,7 @@ function PreviewButton({ url }: { url: string }) {
  */
 function PrCard({
   pr,
+  revalidating,
   previewThread,
   reviewsReady,
   shipPending,
@@ -1818,6 +1819,8 @@ function PrCard({
   onOpenPreview,
 }: {
   pr: TaskBoardItemPr;
+  /** A live GitHub read is in flight behind the values shown. */
+  revalidating: boolean;
   previewThread?: TaskBoardItemThread;
   /** Task-level: In Review + every enabled reviewer approved. */
   reviewsReady: boolean;
@@ -1851,7 +1854,15 @@ function PrCard({
     : checksState;
 
   return (
-    <div className="flex flex-col gap-3 rounded-xl bg-card p-3 card-shadow">
+    <div
+      className={cn(
+        "flex flex-col gap-3 rounded-xl bg-card p-3 card-shadow",
+        // Cards are seeded from localStorage, so what's on screen may be a
+        // minute (or a day) old. The breathing border says "these numbers are
+        // being checked" without blanking the card back to a skeleton.
+        revalidating && "revalidating-ring",
+      )}
+    >
       <div className="flex items-center gap-3">
         <GitHubIcon className="size-4 shrink-0 text-foreground" />
         <span className="min-w-0 flex-1 truncate text-sm text-foreground">
@@ -2039,7 +2050,11 @@ function LinksSection({
   onOpenPreview?: (thread: TaskBoardItemThread) => void;
 }) {
   const t = useT();
-  const { data: prs, isLoading: prsLoading } = useTaskBoardItemPrs(item.id);
+  const {
+    data: prs,
+    isLoading: prsLoading,
+    isFetching: prsFetching,
+  } = useTaskBoardItemPrs(item.id);
   const { data: activity } = useTaskBoardActivity(item.id);
   const reviewerOn = useReviewerEnabled();
   const promote = usePromoteToProduction(item.id);
@@ -2099,6 +2114,7 @@ function LinksSection({
             <PrCard
               key={pr.url}
               pr={pr}
+              revalidating={prsFetching}
               previewThread={previewThread}
               reviewsReady={reviewsReady}
               shipPending={promote.isPending}

--- a/apps/web/src/lib/localstorage-keys.ts
+++ b/apps/web/src/lib/localstorage-keys.ts
@@ -22,6 +22,8 @@ export const LOCALSTORAGE_KEYS = {
     `studio:chat:threadIntent:${locator}:${taskId}`,
   chatDraft: (locator: ProjectLocator | string, taskKey: string) =>
     `studio:chat:draft:${locator}:${taskKey}`,
+  /** One entry per locator holding that org's recently-viewed task PR cards. */
+  taskBoardPrs: (locator: ProjectLocator) => `studio:task-board-prs:${locator}`,
   sidePanelWidth: () => `studio:side-panel:width`,
   sidebarOpen: () => `studio:sidebar-open`,
   preferences: () => `studio:user:preferences`,

--- a/apps/web/src/lib/task-board-prs-cache.test.ts
+++ b/apps/web/src/lib/task-board-prs-cache.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import type { ProjectLocator } from "@/sdk";
+
+// The module early-returns on `typeof window === "undefined"`. Bun's runtime has
+// no DOM, so stub a minimal window (with a localStorage) before importing it,
+// and clean up after — leaving a fake `window` on globalThis breaks other tests
+// that check `typeof window` and then dereference real DOM properties.
+const windowStubbedHere = typeof globalThis.window === "undefined";
+if (windowStubbedHere) {
+  (globalThis as unknown as { window: object }).window = {};
+}
+
+let store: Record<string, string> = {};
+(globalThis.window as { localStorage?: unknown }).localStorage = {
+  getItem: (k: string) => (k in store ? store[k] : null),
+  setItem: (k: string, v: string) => {
+    store[k] = v;
+  },
+  removeItem: (k: string) => {
+    delete store[k];
+  },
+};
+
+const { readCachedTaskPrs, writeCachedTaskPrs } = await import(
+  "./task-board-prs-cache"
+);
+
+afterAll(() => {
+  if (windowStubbedHere) {
+    delete (globalThis as unknown as { window?: object }).window;
+  }
+});
+
+const loc = "org/proj" as unknown as ProjectLocator;
+const prs = [{ number: 1, title: "Fix it" }];
+
+describe("task board PR localStorage cache", () => {
+  beforeEach(() => {
+    store = {};
+  });
+
+  test("round-trips a task's cards", () => {
+    writeCachedTaskPrs(loc, "task-1", prs);
+    expect(readCachedTaskPrs(loc, "task-1")?.data).toEqual(prs);
+  });
+
+  test("a task that was never written is a miss", () => {
+    writeCachedTaskPrs(loc, "task-1", prs);
+    expect(readCachedTaskPrs(loc, "task-2")).toBeNull();
+  });
+
+  test("an entry older than the max age is a miss, not stale data", () => {
+    writeCachedTaskPrs(loc, "task-1", prs);
+    const key = Object.keys(store)[0]!;
+    const parsed = JSON.parse(store[key]!);
+    parsed["task-1"].updatedAt = Date.now() - 25 * 60 * 60 * 1000;
+    store[key] = JSON.stringify(parsed);
+    expect(readCachedTaskPrs(loc, "task-1")).toBeNull();
+  });
+
+  test("keeps the store bounded, evicting the least recently written", () => {
+    for (let i = 0; i < 45; i++) writeCachedTaskPrs(loc, `task-${i}`, prs);
+    const key = Object.keys(store)[0]!;
+    const parsed = JSON.parse(store[key]!) as Record<string, unknown>;
+    expect(Object.keys(parsed).length).toBeLessThanOrEqual(40);
+    // The newest survives; the oldest is gone.
+    expect(readCachedTaskPrs(loc, "task-44")).not.toBeNull();
+    expect(readCachedTaskPrs(loc, "task-0")).toBeNull();
+  });
+
+  test("corrupt storage reads as a miss instead of throwing", () => {
+    store["studio:task-board-prs:org/proj"] = "{not json";
+    expect(readCachedTaskPrs(loc, "task-1")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/task-board-prs-cache.ts
+++ b/apps/web/src/lib/task-board-prs-cache.ts
@@ -1,0 +1,87 @@
+/**
+ * localStorage cache for a task's PR cards.
+ *
+ * The card's data comes from a live GitHub read, and the server can only make
+ * that fast, not instant. On a cold page load React Query has nothing, so
+ * opening a task painted `PrCardSkeleton` and the Links section reflowed once
+ * the read landed — every single time.
+ *
+ * Seeding the query from here paints the last known card immediately and
+ * revalidates in the background (the card shows a breathing border while it
+ * does). Non-secret org metadata only — PR titles, numbers, check names, the
+ * preview URL — the same class as the connection list `query-persist.ts`
+ * already persists.
+ *
+ * Its own capped store rather than the bootstrap `dehydrate` blob: that one is
+ * parsed synchronously before React mounts, and every task a user ever opened
+ * has no business on the boot path.
+ */
+
+import { LOCALSTORAGE_KEYS } from "./localstorage-keys";
+import type { ProjectLocator } from "@/sdk";
+
+/** Stale entries are still SERVED (they revalidate immediately); past this they
+ *  are dropped, so a task nobody has opened in a day stops taking up room. */
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/** Cap on tasks cached per org. Bounds growth for someone who opens hundreds of
+ *  cards over a week; the least-recently-written go first. */
+const MAX_CACHED_TASKS = 40;
+
+type Entry = { data: unknown; updatedAt: number };
+type Store = Record<string, Entry>;
+
+function read(locator: ProjectLocator): Store {
+  try {
+    const raw = window.localStorage.getItem(
+      LOCALSTORAGE_KEYS.taskBoardPrs(locator),
+    );
+    return raw ? (JSON.parse(raw) as Store) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Drop expired entries, then keep the `MAX_CACHED_TASKS` most recent. Without
+ *  it the map only ever grows. */
+function prune(store: Store): Store {
+  const now = Date.now();
+  const fresh = Object.entries(store).filter(
+    ([, e]) => now - e.updatedAt <= MAX_AGE_MS,
+  );
+  fresh.sort(([, a], [, b]) => a.updatedAt - b.updatedAt);
+  while (fresh.length > MAX_CACHED_TASKS) fresh.shift();
+  return Object.fromEntries(fresh);
+}
+
+/** The cached cards for a task, or null on a miss/expiry. */
+export function readCachedTaskPrs(
+  locator: ProjectLocator,
+  itemId: string,
+): Entry | null {
+  if (typeof window === "undefined") return null;
+  const entry = read(locator)[itemId];
+  if (!entry || Date.now() - entry.updatedAt > MAX_AGE_MS) return null;
+  return entry;
+}
+
+/** Store a task's cards. Best-effort: a quota failure must never break a read. */
+export function writeCachedTaskPrs(
+  locator: ProjectLocator,
+  itemId: string,
+  data: unknown,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    const store = read(locator);
+    store[itemId] = { data, updatedAt: Date.now() };
+    // Prune AFTER inserting: pruning first lets the store settle one entry
+    // above the cap forever, since the new write always lands on top of it.
+    window.localStorage.setItem(
+      LOCALSTORAGE_KEYS.taskBoardPrs(locator),
+      JSON.stringify(prune(store)),
+    );
+  } catch {
+    // Quota / serialization failure — the query just runs cold next time.
+  }
+}


### PR DESCRIPTION
## Why the Links section sat on a skeleton

Two separate causes — one per side.

**Server: every poll opened an MCP client before consulting the cache.**

`fetchPrLiveState` called `clientFromConnection` up front and handed the ready client to `cachedPrRead`. Opening one is not free: the client pool is **per-request** by design (HTTP transports bake Studio token headers at creation time, so they can't be reused across requests — `client-pool.ts:6-9`), so each call costs a `downstream_tokens` read plus an **eager MCP `initialize` handshake** — the codebase's own estimate is ~80-120ms (`lazy-client.ts:6-8`). A card whose reads all hit the SWR cache paid that round-trip purely to then answer from memory.

**Client: the query was cold on every page load.**

`useTaskBoardItemPrs` had no seed, so `loadingPrs` was true on first mount and the section painted `PrCardSkeleton` and reflowed when the read landed — even for a task opened thirty seconds earlier.

For completeness, what is *already* fast and was not the problem: the four GitHub reads per PR run concurrently (`Promise.all`), the check-run summaries are parallel and only fetched for failing runs, and the reads themselves are SWR-cached in JetStream KV since #6952.

## What changed

**`cachedPrRead` takes a client thunk, not a client.** The cache only invokes `fetchLive` on a miss or a background revalidation, so on a warm card no client is ever built — no token read, no handshake. `lazyPrClient(conn, ctx)` memoizes the open and its `closeWhenIdle` is a no-op when nothing was opened. Applied to `fetchPrGet` too, which the archive/review sweeps run once per candidate PR.

**localStorage seed for the cards.** `apps/web/src/lib/task-board-prs-cache.ts` — its own capped store (24h TTL, 40 tasks per org, LRU by write time), not the bootstrap `dehydrate` blob, which is parsed synchronously before React mounts and has no business carrying every task a user ever opened. Fed to the query via `initialData` / `initialDataUpdatedAt` **as functions**, so React Query only reads storage on a cache miss rather than every render, and the real age makes the seed stale so it refetches on mount. Contents are non-secret org metadata (PR titles, numbers, check names, preview URL) — the same class as the connection list `query-persist.ts` already persists.

**Revalidation indicator.** While the refetch is in flight the card's border breathes (`revalidating-ring` in `index.css`, an inset `box-shadow` pulse following the existing `todo-cb-pulse` pattern) instead of the card blanking back to a skeleton. Under `prefers-reduced-motion: reduce` it degrades to a static ring rather than dropping the cue, since the motion *is* the signal.

## Testing

- `apps/web/src/lib/task-board-prs-cache.test.ts` — 5 tests: round-trip, miss, TTL expiry reads as a miss (not as stale data), the cap evicts least-recently-written, corrupt storage reads as a miss instead of throwing. The cap test caught a real off-by-one — pruning *before* the insert let the store settle one entry above the cap forever; it prunes after now.
- `bun run --cwd=apps/api check`, `bun run --cwd=apps/web check`, `bun run lint`, `knip` clean. #6952's `pr-read-cache` tests still pass.

## Known, not addressed here

With two PRs linked to one task, both `fetchPrLiveState` calls share the same pooled client and each closes it in its `finally` — so one finishing can close the client the other is still using. Pre-existing, and this change makes it *less* likely to bite (far fewer clients get opened at all), but it is still there.

## Screenshots

Not captured — the states need a task with a linked PR and a warm/cold cache to contrast. The visible change is: cards appear immediately with a pulsing border instead of a skeleton block.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes task board PR cards paint instantly instead of showing a skeleton, and drops the MCP handshake from warm reads. Previously every poll opened a client before consulting the cache; now a warm card never builds one.

**Server**
- `cachedPrRead` now takes a client thunk, so a warm cache hit opens no MCP client — no `downstream_tokens` read, no ~80–120ms `initialize` handshake.
- `fetchPrGet` gets the same lazy treatment via `lazyPrClient`, which memoizes the open and no-ops `closeWhenIdle` when nothing was opened.

**Client**
- `useTaskBoardItemPrs` seeds from a new capped localStorage store (24h TTL, 40 tasks per org, LRU eviction), so a cold page load paints the last known cards instead of a skeleton.
- The seed carries its real age, so React Query treats it as stale and refetches on mount.
- While that refetch runs, the card shows a breathing border (static ring under `prefers-reduced-motion`) instead of blanking back to a skeleton.

The known race where two PRs on one task share a client and one closes it mid-use is pre-existing; this change makes it less likely to bite.

<sup>Written for commit f455928aa8cffb0b22a571e47284f541905c220e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

