### PR TITLE
fix(virtual-mcp): cap metadata.sidebarViews array size on write

### DIFF
--- a/packages/shared/src/sdk/types/virtual-mcp.test.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.test.ts
@@ -329,6 +329,19 @@ describe("metadata.sidebarViews", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("caps the array at 10 entries", () => {
+    expect(
+      VirtualMCPUpdateDataSchema.safeParse({
+        metadata: { sidebarViews: [...sidebarViews] },
+      }).success,
+    ).toBe(true);
+    expect(
+      VirtualMCPUpdateDataSchema.safeParse({
+        metadata: { sidebarViews: [...sidebarViews, "overview"] },
+      }).success,
+    ).toBe(false);
+  });
 });
 
 test("metadata.runtime is typed and round-trips through parse", () => {

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -867,6 +867,7 @@ const VirtualMcpMetadataFields = {
     .describe("UI customization settings"),
   sidebarViews: z
     .array(VirtualMcpSidebarViewSchema)
+    .max(10)
     .nullable()
     .optional()
     .describe(


### PR DESCRIPTION
Follows #6957, which added `.max()` caps to every array field on `VirtualMcpMetadataFields`/`VirtualMCPCreateDataSchema`/`VirtualMCPUpdateDataSchema` — but missed the top-level, actively-written `metadata.sidebarViews` (added in #6938, configurable project sidebar views). The deprecated, read-only-fallback `layout.sidebarViews` sibling a few lines above (line 228-230 in this file) already carries `.max(10)`; this field, which is the one new writes actually use, had no cap at all.

`VirtualMcpSidebarViewSchema` is a 10-value enum, so a legitimate list never exceeds 10 entries — an unbounded array here is attacker-controlled payload size on a mutation input (VIRTUAL_MCP_CREATE / VIRTUAL_MCP_UPDATE), not a real agent config, matching the exact pattern #6957 fixed everywhere else in this file.

Fix: add the same `.max(10)` cap used by the sibling deprecated field.

Failure scenario without the fix: a client can POST `metadata.sidebarViews` with an arbitrarily long array (e.g. thousands of repeated `"overview"` entries) and it validates and persists, bloating the stored JSON metadata column with no bound.

Regression test added: `caps the array at 10 entries` in `virtual-mcp.test.ts`, asserting all-10-values passes and 11 values fails.

Reviewer check: `bun test packages/shared/src/sdk/types/virtual-mcp.test.ts`

Locally verified: `bun run fmt`, `cd packages/shared && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `metadata.sidebarViews` at 10 entries so clients can no longer persist unbounded arrays on `VIRTUAL_MCP_CREATE` / `VIRTUAL_MCP_UPDATE` writes.

- Matches the existing `.max(10)` cap on the deprecated `layout.sidebarViews` field.
- Adds a regression test asserting 10 values pass and 11 fail.

<sup>Written for commit 02c279118d2aca10fcd05f9dadc10f6ffd65828f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

