### PR TITLE
fix(preview): expose the page selector's open/closed state to screen readers

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1490,6 +1490,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
               className="flex h-full shrink-0 items-center pl-1 pr-2"
               onClick={() => setPagesOpen((prev) => !prev)}
               aria-label={t("sandbox.preview.choosePage")}
+              aria-expanded={pagesOpen}
             >
               <ChevronDown
                 size={12}


### PR DESCRIPTION
**Source:** a11y gap found while auditing `apps/web/src/components/sandbox/preview/preview.tsx` (sandbox preview components focus area) — the recent site-editor toolbar rework (#6943/#6946/#6947) touched this file without adding it.

**Payoff:** the chevron button that opens/closes the CMS page-selector popover (page name + `:param` inputs + "Create page") had `aria-label` but no `aria-expanded`, so a screen-reader user got no indication the control is a disclosure toggle or which state it's in — the same gap this repo has fixed repeatedly for other toggles (#6884, #6895, #6902, #6903).

**Fix:** add `aria-expanded={pagesOpen}` to the toggle button, mirroring the existing pattern in `page-template-select.tsx` and other disclosure buttons in the codebase.

**Verify:** open Preview on a deco-framework repo, inspect the page-selector chevron button in devtools — `aria-expanded` should flip between `false`/`true` as the popover opens/closes.

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (zero errors touching this file — the one pre-existing error is an unrelated prosemirror version-hoisting conflict in `mention-suggestion.tsx`), `bunx oxlint apps/web/src/components/sandbox/preview/preview.tsx` (0 warnings/errors). No test added — a one-line ARIA attribute on an existing toggle isn't independently testable logic; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `aria-expanded` to the page-selector chevron button so screen readers announce whether the popover is open or closed. Previously the button only had an `aria-label`, giving no indication that it toggles a disclosure.

<sup>Written for commit 2647dcf2999bc6288458ff87157792d633d50665. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

