### PR TITLE
fix(organization): cap free-text string length in settings-update collections

### DIFF
--- a/apps/api/src/tools/organization/settings-update.test.ts
+++ b/apps/api/src/tools/organization/settings-update.test.ts
@@ -135,6 +135,48 @@ describe("ORGANIZATION_SETTINGS_UPDATE", () => {
     ).toBe(false);
   });
 
+  it("rejects an oversized string in a sidebar item, enabled_plugins entry, blockedMcps entry, registries key, or default_home_agents id", () => {
+    const longString = "x".repeat(501);
+
+    expect(
+      ORGANIZATION_SETTINGS_UPDATE.inputSchema.safeParse({
+        organizationId: "org-a",
+        sidebar_items: [{ title: longString, url: "/x", icon: "star" }],
+      }).success,
+    ).toBe(false);
+
+    expect(
+      ORGANIZATION_SETTINGS_UPDATE.inputSchema.safeParse({
+        organizationId: "org-a",
+        enabled_plugins: [longString],
+      }).success,
+    ).toBe(false);
+
+    expect(
+      ORGANIZATION_SETTINGS_UPDATE.inputSchema.safeParse({
+        organizationId: "org-a",
+        registry_config: { registries: {}, blockedMcps: [longString] },
+      }).success,
+    ).toBe(false);
+
+    expect(
+      ORGANIZATION_SETTINGS_UPDATE.inputSchema.safeParse({
+        organizationId: "org-a",
+        registry_config: {
+          registries: { [longString]: { enabled: true } },
+          blockedMcps: [],
+        },
+      }).success,
+    ).toBe(false);
+
+    expect(
+      ORGANIZATION_SETTINGS_UPDATE.inputSchema.safeParse({
+        organizationId: "org-a",
+        default_home_agents: { ids: [longString] },
+      }).success,
+    ).toBe(false);
+  });
+
   it("rejects an oversized registries record on registry_config", () => {
     // Regression: registries was the one sibling collection left uncapped.
     const registries = Object.fromEntries(

--- a/apps/api/src/tools/organization/settings-update.ts
+++ b/apps/api/src/tools/organization/settings-update.ts
@@ -15,6 +15,7 @@ const MAX_BLOCKED_MCPS = 500;
 const MAX_DEFAULT_HOME_AGENTS = 100;
 const MAX_ENABLED_PLUGINS = 200;
 const MAX_REGISTRIES = 200;
+const MAX_STRING_LENGTH = 500;
 
 export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
   name: "ORGANIZATION_SETTINGS_UPDATE",
@@ -30,18 +31,28 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
   inputSchema: z.object({
     organizationId: z.string(),
     sidebar_items: z.array(SidebarItemSchema).max(MAX_SIDEBAR_ITEMS).optional(),
-    enabled_plugins: z.array(z.string()).max(MAX_ENABLED_PLUGINS).optional(),
+    enabled_plugins: z
+      .array(z.string().max(MAX_STRING_LENGTH))
+      .max(MAX_ENABLED_PLUGINS)
+      .optional(),
     registry_config: RegistryConfigSchema.extend({
       registries: z
-        .record(z.string(), z.object({ enabled: z.boolean() }))
+        .record(
+          z.string().max(MAX_STRING_LENGTH),
+          z.object({ enabled: z.boolean() }),
+        )
         .refine((r) => Object.keys(r).length <= MAX_REGISTRIES, {
           message: `registries must have at most ${MAX_REGISTRIES} entries`,
         }),
-      blockedMcps: z.array(z.string()).max(MAX_BLOCKED_MCPS),
+      blockedMcps: z
+        .array(z.string().max(MAX_STRING_LENGTH))
+        .max(MAX_BLOCKED_MCPS),
     }).optional(),
     simple_mode: SimpleModeConfigSchema.optional(),
     default_home_agents: DefaultHomeAgentsConfigSchema.extend({
-      ids: z.array(z.string()).max(MAX_DEFAULT_HOME_AGENTS),
+      ids: z
+        .array(z.string().max(MAX_STRING_LENGTH))
+        .max(MAX_DEFAULT_HOME_AGENTS),
     }).optional(),
     // .strict() here (not on the shared OrgFlagsSchema) so a mistyped flag
     // name is rejected instead of silently stripped and merged as `{}` —

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -7,13 +7,16 @@
 
 import { z } from "zod";
 
+// Bounds a single free-text field below, independent of the array/record size caps.
+const MAX_SETTINGS_STRING_LENGTH = 500;
+
 /**
  * Sidebar item schema - matches SidebarItem interface from storage/types.ts
  */
 export const SidebarItemSchema = z.object({
-  title: z.string(),
-  url: z.string(),
-  icon: z.string(),
+  title: z.string().max(MAX_SETTINGS_STRING_LENGTH),
+  url: z.string().max(MAX_SETTINGS_STRING_LENGTH),
+  icon: z.string().max(MAX_SETTINGS_STRING_LENGTH),
 });
 
 export type SidebarItem = z.infer<typeof SidebarItemSchema>;
@@ -26,12 +29,15 @@ export type SidebarItem = z.infer<typeof SidebarItemSchema>;
  */
 export const RegistryConfigSchema = z.object({
   registries: z
-    .record(z.string(), z.object({ enabled: z.boolean() }))
+    .record(
+      z.string().max(MAX_SETTINGS_STRING_LENGTH),
+      z.object({ enabled: z.boolean() }),
+    )
     .describe(
       "Per-registry enabled/disabled state. Key is connection ID. Absent registries are treated as enabled.",
     ),
   blockedMcps: z
-    .array(z.string())
+    .array(z.string().max(MAX_SETTINGS_STRING_LENGTH))
     .describe("List of MCP app_name or app_id values to hide from the store."),
 });
 
@@ -102,7 +108,7 @@ export type UserModelPreferences = z.infer<typeof UserModelPreferencesSchema>;
  */
 export const DefaultHomeAgentsConfigSchema = z.object({
   ids: z
-    .array(z.string())
+    .array(z.string().max(MAX_SETTINGS_STRING_LENGTH))
     .describe(
       "Ordered list of custom virtual MCP agent ids to show on the home view.",
     ),


### PR DESCRIPTION
Follows the array/record size-cap series on this tool (#6904, #6930, #6934): those bounded how many sidebar items, plugins, blocked MCPs, registries, and default home agent ids a client can send, but left every individual string inside those collections unbounded — a single sidebar item's `title`/`url`/`icon`, a `blockedMcps` entry, a `registries` key, an `enabled_plugins` entry, or a `default_home_agents.ids` entry could still be an arbitrarily long string written straight into the `organization_settings` jsonb columns.

A maintainer wants this because it closes the same DoS-shaped gap the prior three PRs targeted, just on the string-length axis instead of array-length: one 50-item sidebar array can otherwise still smuggle megabytes into a single row.

Adds a `MAX_SETTINGS_STRING_LENGTH`/`MAX_STRING_LENGTH` (500 chars) cap to: `SidebarItemSchema`'s `title`/`url`/`icon` and `DefaultHomeAgentsConfigSchema.ids` in the shared `packages/shared/src/organization/schema.ts` source of truth, plus the `registry_config.registries` keys, `registry_config.blockedMcps`, and `enabled_plugins` entries in `ORGANIZATION_SETTINGS_UPDATE`'s input schema (these three are re-declared via `.extend()` in the update tool, so the shared-schema cap alone doesn't reach them). Pure additive validation — any existing value under 500 chars round-trips unchanged.

Regression test: `settings-update.test.ts` now asserts a 501-char string in each of the five spots is rejected by `safeParse`.

Reviewer check: `bun test apps/api/src/tools/organization/settings-update.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in `apps/api` and `packages/shared` (both clean), the targeted test file above (8/8 pass), and `bunx oxlint` on the three touched files (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps free-text strings in organization settings collections at 500 characters, closing the same DoS gap the earlier array/record size caps left open.

- Applies to sidebar item `title`/`url`/`icon`, `enabled_plugins` entries, `blockedMcps` entries, `registries` keys, and `default_home_agents.ids`.
- Values under 500 characters round-trip unchanged, so no migration is needed.
- Adds regression tests covering a 501-character string in each of the five spots.

<sup>Written for commit 3eb92e759a75323e8ad6b97b11908b5e420758d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

