### PR TITLE
fix(docs): translate chat placeholder text to Portuguese

### DIFF
--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/concepts.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/concepts.mdx
@@ -24,7 +24,7 @@ O Studio usa um pequeno conjunto de conceitos que se constroem uns sobre os outr
 
 ### Home e a sidebar
 
-Quando você abre o Studio, cai na **tela inicial**: um único campo de chat — _"What's on your mind?"_ — alimentado pelo **Decopilot**, o assistente nativo do Studio, além de um grid customizável de atalhos para seus agents. É só começar a digitar para iniciar; a conversa que você começa fica salva em **Decopilot** na sidebar.
+Quando você abre o Studio, cai na **tela inicial**: um único campo de chat — _"O que você precisa?"_ — alimentado pelo **Decopilot**, o assistente nativo do Studio, além de um grid customizável de atalhos para seus agents. É só começar a digitar para iniciar; a conversa que você começa fica salva em **Decopilot** na sidebar.
 
 A sidebar fixa à esquerda é a mesma em qualquer lugar que você vá:
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/quickstart.mdx
@@ -41,7 +41,7 @@ Quando quiser usar suas próprias keys (Anthropic, Google, OpenRouter, etc.) ou 
 
 ## Comece a conversar (Decopilot)
 
-Você não precisa construir nada para começar. A tela inicial é um composer de chat — _"What's on your mind?"_ — alimentado pelo **Decopilot**, o assistente embutido do Studio. Digite um pedido e ele põe mãos à obra, usando quaisquer tools que você tenha conectado. Cada conversa fica salva em **Decopilot**, na sidebar à esquerda.
+Você não precisa construir nada para começar. A tela inicial é um composer de chat — _"O que você precisa?"_ — alimentado pelo **Decopilot**, o assistente embutido do Studio. Digite um pedido e ele põe mãos à obra, usando quaisquer tools que você tenha conectado. Cada conversa fica salva em **Decopilot**, na sidebar à esquerda.
 
 Quando estiver pronto para criar um worker focado e reutilizável, crie um agent dedicado.
 


### PR DESCRIPTION
## Summary
Translate the untranslated English phrase "What's on your mind?" to Portuguese in two documentation files (`concepts.mdx` and `quickstart.mdx`). This phrase appears as a quoted placeholder text describing the home chat input in the deco Studio UI.

## Changes
- `apps/docs/client/src/content/deco-studio/pt-br/studio/concepts.mdx`: Translate "What's on your mind?" → "O que você precisa?"
- `apps/docs/client/src/content/deco-studio/pt-br/studio/quickstart.mdx`: Translate "What's on your mind?" → "O que você precisa?"

## Verification
Manual verification confirmed both phrases have been translated and no other untranslated instances remain in the Portuguese documentation corpus. No tests required for documentation housekeeping.

## Why
Keeps the Portuguese documentation consistent with the translation standard; the phrase was an i18n sync gap in the living documentation corpus.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translates the untranslated English chat placeholder "What's on your mind?" to "O que você precisa?" in the Portuguese deco Studio docs. Updates both `concepts.mdx` and `quickstart.mdx` so the UI text matches the translation standard, with no other untranslated instances remaining.

<sup>Written for commit f4e622c2289ee598ee806a26a993205bd72997db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

