### PR TITLE
fix(task-board): retry a failed PR client open, not just a failed call

### DIFF
--- a/apps/api/src/tools/task-board/prs-get.test.ts
+++ b/apps/api/src/tools/task-board/prs-get.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { lazyOnce } from "./prs-get";
+
+describe("lazyOnce", () => {
+  it("shares one in-flight attempt across concurrent callers", async () => {
+    let calls = 0;
+    const { get } = lazyOnce(async () => {
+      calls++;
+      return "ok";
+    });
+    const [a, b] = await Promise.all([get(), get()]);
+    expect(a).toBe("ok");
+    expect(b).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  it("clears the memo on failure so the next get() retries open()", async () => {
+    let calls = 0;
+    const { get } = lazyOnce(async () => {
+      calls++;
+      if (calls === 1) throw new Error("transient");
+      return "ok";
+    });
+    await expect(get()).rejects.toThrow("transient");
+    expect(await get()).toBe("ok");
+    expect(calls).toBe(2);
+  });
+
+  it("never re-opens once a get() succeeds", async () => {
+    let calls = 0;
+    const { get, current } = lazyOnce(async () => {
+      calls++;
+      return calls;
+    });
+    expect(await get()).toBe(1);
+    expect(await get()).toBe(1);
+    expect(calls).toBe(1);
+    expect(current()).toBe(1);
+  });
+});

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -80,6 +80,38 @@ type GetPrClient = () => Promise<
 >;
 
 /**
+ * Memoizes `open`'s in-flight/resolved promise so concurrent callers share one
+ * attempt — but clears the memo on failure, so the NEXT `get()` actually
+ * retries `open()` instead of replaying the same rejection forever. Without
+ * this, `retry()`'s attempts around a `get()` call are hollow once the first
+ * attempt fails: each "retry" just re-awaits the already-rejected promise, so
+ * a transient failure never gets a real second try. Exported for the unit
+ * test.
+ */
+export function lazyOnce<T>(open: () => Promise<T>): {
+  get: () => Promise<T>;
+  current: () => T | null;
+} {
+  let value: T | null = null;
+  let promise: Promise<T> | null = null;
+  return {
+    get: () => {
+      promise ??= open()
+        .then((v) => {
+          value = v;
+          return v;
+        })
+        .catch((err) => {
+          promise = null;
+          throw err;
+        });
+      return promise;
+    },
+    current: () => value,
+  };
+}
+
+/**
  * A GitHub MCP client for `conn`, opened AT MOST ONCE and only if a read
  * actually misses the SWR cache.
  *
@@ -95,17 +127,11 @@ function lazyPrClient(
   conn: ConnectionEntity,
   ctx: StudioContext,
 ): { get: GetPrClient; closeWhenIdle: (pending: Promise<void>[]) => void } {
-  type PrClient = Awaited<ReturnType<typeof clientFromConnection>>;
-  let client: PrClient | null = null;
-  let promise: Promise<PrClient> | null = null;
+  const { get, current } = lazyOnce(() =>
+    clientFromConnection(conn, ctx, true),
+  );
   return {
-    get: () => {
-      promise ??= clientFromConnection(conn, ctx, true).then((c) => {
-        client = c;
-        return c;
-      });
-      return promise;
-    },
+    get,
     // Do NOT await this — the whole point of serving a stale value is to return
     // without waiting on GitHub. Closing eagerly (which this did) killed every
     // revalidation the moment it started, so a cached entry could never
@@ -113,7 +139,9 @@ function lazyPrClient(
     // and no checks until the entry aged out half an hour later.
     closeWhenIdle: (pending) => {
       void Promise.allSettled(pending).then(() =>
-        client?.close().catch(() => {}),
+        current()
+          ?.close()
+          .catch(() => {}),
       );
     },
   };


### PR DESCRIPTION
Follows #6958 (lazy PR client for warm-card reads).

`lazyPrClient`'s `get()` memoized `clientFromConnection`'s promise indefinitely — including on rejection. Once opening the client failed once, every later `get()` call within that fetch — including each of `retry()`'s 3 attempts wrapped around a `callTool`, and the parallel `pull_request_read` + extras calls — replayed the same cached rejection instead of actually retrying the open. A transient token/handshake failure permanently poisons the rest of that `fetchPrLiveState`/`fetchPrGet` invocation: `retry()`'s backoff still elapses, but each "attempt" fails instantly on the stale rejection, so a card silently falls back to `NO_LIVE_STATE` (or a stale cached value) instead of getting the real second chance `retry()` is there to provide.

Extracted the memoize logic into a small generic `lazyOnce()` (exported for the test) that behaves identically on the success path — one open shared by concurrent callers — but clears its memo on failure so the next `get()` actually reopens.

Failure scenario: a transient error opening the GitHub MCP client (e.g. a momentary `downstream_tokens` read failure) now causes every subsequent read for that PR fetch to fail immediately too, even though `retry()` was supposed to give it up to 3 tries.

Regression test: `apps/api/src/tools/task-board/prs-get.test.ts` — asserts `lazyOnce` shares one in-flight attempt, clears its memo and retries `open()` after a failure, and never re-opens once a `get()` has succeeded.

Reviewer check: `bun test apps/api/src/tools/task-board/prs-get.test.ts`.

Checked locally: `bun run fmt`, `apps/api` `tsc --noEmit`, the targeted test file above, `oxlint` on both changed files. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where a failed GitHub MCP client open was memoized forever, so retry attempts were hollow and a transient token/handshake failure would silently return `NO_LIVE_STATE` instead of giving `retry()` a real second chance.

**Bug Fixes**
- Extracted the memoization into a generic `lazyOnce()` helper, behavior-preserving on the success path (one open shared by concurrent callers).
- Added a regression test in `apps/api/src/tools/task-board/prs-get.test.ts` covering retry after failure, shared in-flight attempts, and no re-open after success.

<sup>Written for commit 18a53eb7a5f178cbedf7396002cc482b8880b0c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

