### PR TITLE
fix(mcp-proxy): don't crash on a null/malformed downstream tool result

### DIFF
--- a/apps/api/src/api/routes/proxy-monitoring.test.ts
+++ b/apps/api/src/api/routes/proxy-monitoring.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "bun:test";
 import type { StudioContext } from "../../core/studio-context";
-import { createProxyMonitoringMiddleware } from "./proxy-monitoring";
+import {
+  createProxyMonitoringMiddleware,
+  extractCallToolErrorMessage,
+} from "./proxy-monitoring";
 
 function createMockSpan() {
   const attrs: Record<string, unknown> = {};
@@ -133,5 +136,21 @@ describe("proxy monitoring middleware", () => {
 
     expect(spans.length).toBe(1);
     expect(spans[0]!._isEnded()).toBe(true);
+  });
+});
+
+describe("extractCallToolErrorMessage", () => {
+  it("returns undefined for a malformed downstream result instead of throwing", () => {
+    expect(extractCallToolErrorMessage(null as any)).toBeUndefined();
+    expect(extractCallToolErrorMessage(undefined as any)).toBeUndefined();
+    expect(extractCallToolErrorMessage("nope" as any)).toBeUndefined();
+  });
+
+  it("extracts the text content when isError is set", () => {
+    const result = {
+      isError: true,
+      content: [{ type: "text", text: "boom" }],
+    } as any;
+    expect(extractCallToolErrorMessage(result)).toBe("boom");
   });
 });

--- a/apps/api/src/api/routes/proxy-monitoring.ts
+++ b/apps/api/src/api/routes/proxy-monitoring.ts
@@ -17,7 +17,10 @@ type CallToolMiddleware = (
 export function extractCallToolErrorMessage(
   result: CallToolResult,
 ): string | undefined {
-  if (!result.isError) return undefined;
+  // A non-conformant downstream MCP server can send a null/missing result.
+  if (!result || typeof result !== "object" || !result.isError) {
+    return undefined;
+  }
   const content = (result as unknown as { content?: unknown }).content;
   if (!Array.isArray(content)) return undefined;
 


### PR DESCRIPTION
Follows the outbound MCP client hardening lane (mcp-clients/outbound/transports/monitoring.ts).

**Bug:** `extractCallToolErrorMessage` (apps/api/src/api/routes/proxy-monitoring.ts) is called with the raw `response.result` cast to `CallToolResult` from a downstream MCP server's JSON-RPC response — untrusted, arbitrary-server input. If a non-conformant server sends `result: null` (or omits `result`), `if (!result.isError)` throws a TypeError reading `.isError` off `null`/`undefined`.

**Why it matters:** the call site in `apps/api/src/mcp-clients/outbound/transports/monitoring.ts` (`onResponseEnd`) invokes this unconditionally on every tool-call response, synchronously inside the transport's `onmessage` handler — there's no surrounding try/catch (see `WrapperTransport.start()` in packages/mcp-utils/src/compose-transport.ts). One malformed response from any downstream MCP server crashes that response-handling path instead of just failing the one tool call.

**Fix:** guard against non-object/null/undefined `result` before reading `.isError`, returning `undefined` (no error message extracted) same as any other non-error result.

**Regression test:** apps/api/src/api/routes/proxy-monitoring.test.ts — new `extractCallToolErrorMessage` describe block asserts `null`/`undefined`/non-object input returns `undefined` instead of throwing, plus the existing happy-path extraction.

Reviewer check: `bun test apps/api/src/api/routes/proxy-monitoring.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files (all clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `extractCallToolErrorMessage` crashing on null or malformed downstream tool results. A non-conformant MCP server sending `result: null` previously threw a TypeError and broke the whole response-handling path; now it returns `undefined` like any other non-error result. Added regression tests covering null, undefined, and non-object inputs.

<sup>Written for commit 9a8471f8cb04044c36cddb476f4c08a1aae5b8e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

