### PR TITLE
fix(commerce-diagnostic): don't get stuck loading when gate 2 fails to open

### DIFF
--- a/apps/web/src/hooks/commerce-diagnostic-status.test.ts
+++ b/apps/web/src/hooks/commerce-diagnostic-status.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { deriveCommerceReportBannerStatus } from "./commerce-diagnostic-status";
+import {
+  deriveCommerceReportBannerStatus,
+  isCommerceDiagnosticLoading,
+} from "./commerce-diagnostic-status";
 
 describe("deriveCommerceReportBannerStatus", () => {
   test("no diagnostic hides the banner", () => {
@@ -63,5 +66,63 @@ describe("deriveCommerceReportBannerStatus", () => {
         locked: false,
       }),
     ).toBe("generating");
+  });
+});
+
+describe("isCommerceDiagnosticLoading", () => {
+  test("loading while gate 1 (the connection lookup) is in flight", () => {
+    expect(
+      isCommerceDiagnosticLoading({
+        connectionQueryPending: true,
+        hasConnection: false,
+        cdClientFailed: false,
+        diagnosticQueryPending: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("not loading once gate 1 resolves with no CD connection", () => {
+    expect(
+      isCommerceDiagnosticLoading({
+        connectionQueryPending: false,
+        hasConnection: false,
+        cdClientFailed: false,
+        diagnosticQueryPending: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("loading while the diagnostic read (gate 2) is in flight", () => {
+    expect(
+      isCommerceDiagnosticLoading({
+        connectionQueryPending: false,
+        hasConnection: true,
+        cdClientFailed: false,
+        diagnosticQueryPending: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("not loading once the diagnostic read resolves", () => {
+    expect(
+      isCommerceDiagnosticLoading({
+        connectionQueryPending: false,
+        hasConnection: true,
+        cdClientFailed: false,
+        diagnosticQueryPending: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("a failed gate-2 client open resolves to not-loading, not stuck forever", () => {
+    // regression: a disabled query never leaves "pending" on its own
+    expect(
+      isCommerceDiagnosticLoading({
+        connectionQueryPending: false,
+        hasConnection: true,
+        cdClientFailed: true,
+        diagnosticQueryPending: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/hooks/commerce-diagnostic-status.ts
+++ b/apps/web/src/hooks/commerce-diagnostic-status.ts
@@ -35,3 +35,35 @@ export function deriveCommerceReportBannerStatus(
   if (diagnostic.scanned_at) return "ready";
   return "none";
 }
+
+export interface CommerceDiagnosticLoadingState {
+  /** Gate 1 (the CD connection lookup) hasn't resolved yet. */
+  connectionQueryPending: boolean;
+  /** Gate 1 resolved and found a CD connection. */
+  hasConnection: boolean;
+  /**
+   * Opening the CD MCP client (gate 2) failed permanently — e.g. the
+   * connection was revoked or the network is down. With no client, the
+   * diagnostic read never runs and would otherwise sit at its initial
+   * "pending" state forever.
+   */
+  cdClientFailed: boolean;
+  /** The diagnostic read (gate 2's query) hasn't resolved yet. */
+  diagnosticQueryPending: boolean;
+}
+
+/**
+ * Whether {@link useCommerceDiagnostic} should still report `isLoading`. A
+ * failed gate-2 client open must resolve to "not loading" (diagnostic: null)
+ * rather than leave callers stuck on a loading state that can never clear —
+ * the diagnostic query stays disabled, and never fetching, once its client
+ * dependency has errored out.
+ */
+export function isCommerceDiagnosticLoading(
+  state: CommerceDiagnosticLoadingState,
+): boolean {
+  if (state.connectionQueryPending) return true;
+  if (!state.hasConnection) return false;
+  if (state.cdClientFailed) return false;
+  return state.diagnosticQueryPending;
+}

--- a/apps/web/src/hooks/use-commerce-diagnostic.ts
+++ b/apps/web/src/hooks/use-commerce-diagnostic.ts
@@ -26,6 +26,7 @@ import { unwrapToolResult } from "@/routes/commerce-onboarding/companions-core";
 import {
   type CommerceDiagnosticRunState,
   deriveCommerceReportBannerStatus,
+  isCommerceDiagnosticLoading,
 } from "./commerce-diagnostic-status";
 
 /** Poll cadence while a run is live; a run takes minutes, not seconds. */
@@ -62,7 +63,8 @@ export interface UseCommerceDiagnosticResult {
    * True while we still can't tell whether a report exists — either gate 1 is in
    * flight, or it found the connection and the diagnostic read is in flight. It
    * goes false (with a null diagnostic) as soon as gate 1 says the org has no CD
-   * connection, so "no report" is distinguishable from "not known yet".
+   * connection, or gate 2 fails to open a client, so "no report" is
+   * distinguishable from "not known yet".
    */
   isLoading: boolean;
   /** The org's Commerce Discovery site, as claimed on the connection. */
@@ -105,7 +107,7 @@ export function useCommerceDiagnostic(): UseCommerceDiagnosticResult {
   const connectionItem = connectionQuery.data?.item ?? null;
 
   // Gate 2: only orgs that passed gate 1 open a client to the CD MCP.
-  const { data: cdClient } = useQuery({
+  const { data: cdClient, isError: cdClientIsError } = useQuery({
     ...mcpClientQueryOptions({
       connectionId,
       orgId: org.id,
@@ -141,9 +143,12 @@ export function useCommerceDiagnostic(): UseCommerceDiagnosticResult {
   return {
     diagnostic: diagnosticQuery.data ?? null,
     isSuccess: diagnosticQuery.isSuccess,
-    isLoading:
-      connectionQuery.isPending ||
-      (!!connectionItem && diagnosticQuery.isPending),
+    isLoading: isCommerceDiagnosticLoading({
+      connectionQueryPending: connectionQuery.isPending,
+      hasConnection: !!connectionItem,
+      cdClientFailed: cdClientIsError,
+      diagnosticQueryPending: diagnosticQuery.isPending,
+    }),
     siteUrl: typeof siteUrl === "string" && siteUrl ? siteUrl : null,
     host: hostFromSiteUrl(siteUrl),
     connectionId,


### PR DESCRIPTION
Bug found while auditing `use-commerce-diagnostic.ts` (fresh hook, little test coverage per this tick's focus area).

If the Commerce Discovery MCP client (gate 2 — `mcpClientQueryOptions`) fails to connect (a revoked connection, a network blip), react-query puts that query into an error state after its retries, so `cdClient` stays `undefined`. The diagnostic read query (gate 2's own read) stays `enabled: false` forever because it depends on `cdClient` — and a disabled react-query query never leaves its initial `pending` status, since it never runs. `isLoading` was computed only from `connectionQuery.isPending` and `diagnosticQuery.isPending`, so it never noticed the failure and stayed `true` forever. Both the home report banner and the task-board paywall banner (the two consumers of this hook) would be stuck showing a loading skeleton instead of falling back to "no report".

Fix: pull the truth table for `isLoading` out into a pure, unit-tested `isCommerceDiagnosticLoading()` in `commerce-diagnostic-status.ts`, and feed it the gate-2 query's `isError` flag so a failed client open now resolves to `isLoading: false` / `diagnostic: null`.

Reviewer check: `bun test apps/web/src/hooks/commerce-diagnostic-status.test.ts` — includes a regression test for the failed-gate-2 case (`cdClientFailed: true` while `diagnosticQueryPending: true` now resolves to not-loading, whereas before this fix the equivalent inline expression would have stayed stuck at loading).

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in `apps/web` (the one remaining error is a pre-existing prosemirror dual-version type clash, unrelated to this change), the targeted test above, and `bunx oxlint` on the three changed files. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the commerce diagnostic hook getting stuck in a loading state when the Commerce Discovery MCP client (gate 2) fails to open, so consumers now fall back to "no report" instead of showing a loading skeleton forever.

**Bug Fixes**
- Extracts the `isLoading` truth table into a pure, unit-tested `isCommerceDiagnosticLoading()` helper.
- Feeds the gate-2 query's `isError` state into the helper so a failed client open resolves to `isLoading: false` with a `null` diagnostic.
- Adds a regression test covering the failed gate-2 case.

<sup>Written for commit 7affb8435fd54cdb5a7d5bdb509d1c929d9d1bf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

