### PR TITLE
fix(organization): cap free-text field length on ModelSlotSchema

### DIFF
--- a/packages/shared/src/organization/schema.test.ts
+++ b/packages/shared/src/organization/schema.test.ts
@@ -3,6 +3,7 @@ import {
   autoResolveConflictsEnabled,
   BrandContextSchema,
   DEFAULT_ON_FLAGS,
+  ModelSlotSchema,
   orgFlagEnabled,
 } from "./schema";
 
@@ -103,5 +104,35 @@ describe("BrandContextSchema JSON field caps", () => {
     const images = Array(51).fill({ url: "https://example.com/a.png" });
     const result = BrandContextSchema.safeParse(baseBrandContext({ images }));
     expect(result.success).toBe(false);
+  });
+});
+
+describe("ModelSlotSchema", () => {
+  it("accepts a normal model slot", () => {
+    expect(
+      ModelSlotSchema.safeParse({
+        keyId: "key_1",
+        modelId: "claude-sonnet-5",
+        title: "Sonnet 5",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects an oversized keyId, modelId, or title", () => {
+    // Regression: #6961 capped every sibling free-text field but left these three unbounded.
+    const longString = "x".repeat(501);
+    expect(
+      ModelSlotSchema.safeParse({ keyId: longString, modelId: "m" }).success,
+    ).toBe(false);
+    expect(
+      ModelSlotSchema.safeParse({ keyId: "k", modelId: longString }).success,
+    ).toBe(false);
+    expect(
+      ModelSlotSchema.safeParse({
+        keyId: "k",
+        modelId: "m",
+        title: longString,
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -43,11 +43,11 @@ export const RegistryConfigSchema = z.object({
 
 export type RegistryConfig = z.infer<typeof RegistryConfigSchema>;
 
-const ModelSlotSchema = z
+export const ModelSlotSchema = z
   .object({
-    keyId: z.string(),
-    modelId: z.string(),
-    title: z.string().optional(),
+    keyId: z.string().max(MAX_SETTINGS_STRING_LENGTH),
+    modelId: z.string().max(MAX_SETTINGS_STRING_LENGTH),
+    title: z.string().max(MAX_SETTINGS_STRING_LENGTH).optional(),
   })
   .nullable();
 


### PR DESCRIPTION
Follows #6961, which capped every client-controlled string/collection on `ORGANIZATION_SETTINGS_UPDATE`'s schemas (sidebar_items, enabled_plugins, registries, blockedMcps, default_home_agents ids) with a shared `MAX_SETTINGS_STRING_LENGTH` — but left `ModelSlotSchema`'s `keyId`/`modelId`/`title` (used by `SimpleModeConfigSchema.tiers` and `UserModelPreferencesSchema.tiers`, both accepted by `ORGANIZATION_SETTINGS_UPDATE` and the per-user model-preferences tool) as unbounded strings.

Why it matters: an org admin (or any authenticated user for their own preferences) could persist an arbitrarily large string into `organization_settings`/user prefs via these fields, same unbounded-payload-size gap #6961 closed for the sibling fields in the same schema file.

Change: reuses the existing `MAX_SETTINGS_STRING_LENGTH` constant to cap `keyId`, `modelId`, and `title` on `ModelSlotSchema`, and exports the schema so it's directly testable. Added a regression test in `schema.test.ts` asserting an oversized value on any of the three fields is rejected.

To confirm: `bun test packages/shared/src/organization/schema.test.ts`.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in `packages/shared` and `apps/api`, `bunx oxlint` on both changed files, and the targeted test file above — all green. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the existing `MAX_SETTINGS_STRING_LENGTH` cap to `keyId`, `modelId`, and `title` in `ModelSlotSchema`. These fields were previously unbounded, allowing arbitrarily large strings to be persisted via organization settings or user model preferences. The schema is now exported for testing, and a regression test asserts oversized values are rejected.

<sup>Written for commit 9cb4138a1ae7ee42a1bcbbf08b7e572e70028031. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

