### PR TITLE
fix(task-board): invalidate the PR card cache wherever a PR gets linked

### DIFF
--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -18,6 +18,7 @@ import { reactToSuperAgentDelegation } from "./enqueue-super-agent";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { extractPrFromText } from "./pr-extract";
+import { invalidatePrCards } from "./prs-get";
 import { rejectsUngatedDeliveryLane } from "./update";
 
 export const TASK_BOARD_ITEM_CREATE = defineTool({
@@ -144,6 +145,10 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
         repoOwner: pr.owner,
         repoName: pr.repo,
         connectionId: null,
+      });
+      // Drop the cached card so a viewer's next poll shows the new PR, not a stale "no PR" placeholder.
+      await invalidatePrCards(organizationId).catch((err) => {
+        console.error("[task-board] PR card cache invalidation failed", err);
       });
     }
 

--- a/apps/api/src/tools/task-board/pr-link.ts
+++ b/apps/api/src/tools/task-board/pr-link.ts
@@ -25,6 +25,7 @@ import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { requireAuth, requireOrganization } from "@/core/studio-context";
 import { extractPrFromText } from "./pr-extract";
+import { invalidatePrCards } from "./prs-get";
 import { resolveRunTaskTargets } from "./run-reactions";
 import { requireTaskRunContext } from "./task-run-context";
 
@@ -100,6 +101,13 @@ export const TASK_BOARD_ITEM_PR_LINK = defineTool({
         taskBoardItemId,
         organizationId,
       );
+    }
+
+    // Drop the cached card so a viewer's next poll shows the new PR, not a stale "no PR" placeholder.
+    if (taskBoardItemIds.length > 0) {
+      await invalidatePrCards(organizationId).catch((err) => {
+        console.error("[task-board] PR card cache invalidation failed", err);
+      });
     }
 
     return { url: pr.url, prNumber: pr.number, taskBoardItemIds };

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -22,6 +22,7 @@ import { resolveTier } from "@/core/resolve-tier";
 import type { TaskBoardStorage } from "@/storage/task-board";
 import type { TaskBoardItem } from "@/storage/types";
 import { extractPrFromValue, type ExtractedPr } from "./pr-extract";
+import { invalidatePrCards } from "./prs-get";
 import { resolveRunTaskTargets, emitTaskBoardUpdated } from "./run-reactions";
 
 // Cap on cards sent to the LLM prompt, so a large backlog doesn't inflate cost per PR-open.
@@ -195,6 +196,10 @@ export async function applyBoardDecision(
   if (!item) return null;
 
   await linkPr(item.id);
+  // Drop the cached card so a viewer's next poll shows the new PR, not a stale "no PR" placeholder.
+  await invalidatePrCards(orgId).catch((err) => {
+    console.error("[task-board] PR card cache invalidation failed", err);
+  });
   await storage.linkThread(item.id, threadId, orgId);
   if (decision.comment?.trim()) {
     await storage.createComment({

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -32,6 +32,7 @@ import type { OrganizationBillingStorage } from "@/storage/organization-billing"
 import { TERMINAL_THREAD_STATUSES } from "@/storage/task-board";
 import type { StudioContext } from "@/core/studio-context";
 import { extractPrFromValue } from "./pr-extract";
+import { invalidatePrCards } from "./prs-get";
 import { retryBudgetFor } from "./transient-failure";
 import { exponentialBackoffWithJitter } from "@decocms/shared/std";
 import { sseHub } from "@/event-bus/sse-hub";
@@ -258,6 +259,8 @@ export async function capturePrForRun(
         connectionId: connectionId ?? null,
       });
     }
+    // Drop the cached cards so a viewer's next poll shows the new PR, not a stale "no PR" placeholder.
+    if (targets.length > 0) await invalidatePrCards(orgId);
   } catch (err) {
     console.error("[task-board] PR capture failed", err);
   }

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -22,6 +22,7 @@ import { taskRunContextStore } from "./task-run-context";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { runColumnAutomation } from "./run-column-automation";
 import { extractPrFromText } from "./pr-extract";
+import { invalidatePrCards } from "./prs-get";
 import {
   ensureTaskExecutionAllowed,
   isReportsTask,
@@ -417,6 +418,10 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
         repoOwner: pr.owner,
         repoName: pr.repo,
         connectionId: null,
+      });
+      // Drop the cached card so a viewer's next poll shows the new PR, not a stale "no PR" placeholder.
+      await invalidatePrCards(organizationId).catch((err) => {
+        console.error("[task-board] PR card cache invalidation failed", err);
       });
     }
 


### PR DESCRIPTION
Follows #6966 (the PR-card KV cache) — a hardening gap in the same feature, in the same focus area as this tick's cache-followup hunt.

#6966 made `mergeLinkedPr` invalidate the org's PR card cache after a merge, specifically so a viewer polling the task dialog doesn't keep seeing a stale pre-merge card for the rest of the cache's revalidate window (up to 30s, plus the dialog's own 60s poll interval — up to ~90s of "did my button work?" confusion). The exact same staleness exists at the OTHER end of a PR's life: every place a PR gets LINKED to a task (`TASK_BOARD_ITEM_PR_LINK`, `TASK_BOARD_ITEM_CREATE`/`_UPDATE`'s inline PR field, `capturePrForRun`'s bash-output scan, and the native `pr_opened` board-decision reaction) writes the link to storage but leaves the org's cached card as-is — so a task dialog already open when the agent's PR lands can keep showing "no PR" for up to a full extra 60s poll cycle instead of picking it up on the next one.

Fix: call the same `invalidatePrCards(orgId)` (exported by `prs-get.ts`) at each of those five link sites, mirroring the exact pattern `mergeLinkedPr` already established. Best-effort (`.catch` + log) everywhere except `capturePrForRun`, which is already wrapped in one outer try/catch.

How to confirm: `bunx tsc --noEmit` in `apps/api` (clean — also confirms no issue from the new `run-reactions.ts` → `prs-get.ts` → `run-reactions.ts` import cycle; both exports are hoisted function declarations), and the existing unit suites for the touched files pass unchanged (no test needed for this fix itself — it's a one-line call to an existing, already-tested `invalidate()`).

Commands run locally: `bun test apps/api/src/tools/task-board/pr-cache.test.ts apps/api/src/tools/task-board/prs-get.test.ts apps/api/src/tools/task-board/run-reactions.test.ts apps/api/src/tools/task-board/update.test.ts` (all pass), `bunx tsc --noEmit` in `apps/api` (clean), `bunx oxlint` on each touched file (0 warnings/errors), `bun run fmt`. Full CI validates the rest (including the Postgres-backed `pr-open-board-reaction.integration.test.ts`, not runnable here).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale PR cards in the task dialog when a PR gets linked to a task. Previously only `mergeLinkedPr` invalidated the cache, so viewers could keep seeing a stale "no PR" card for up to ~90s after a PR was linked. Now every place that links a PR — the inline PR field on create/update, the PR-link tool, the bash-output scan, and the `pr_opened` board decision — invalidates the org's PR card cache the same way. Invalidation is best-effort and failures are logged.

<sup>Written for commit fdbb09a0cb031fa2b405227230a2af5983c58d2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

