### PR TITLE
fix(organization): cap free-text string length on BrandContextSchema

### DIFF
--- a/packages/shared/src/organization/schema.test.ts
+++ b/packages/shared/src/organization/schema.test.ts
@@ -104,4 +104,38 @@ describe("BrandContextSchema JSON field caps", () => {
     const result = BrandContextSchema.safeParse(baseBrandContext({ images }));
     expect(result.success).toBe(false);
   });
+
+  it("rejects an oversized overview, name, domain, or logo URL", () => {
+    expect(
+      BrandContextSchema.safeParse(
+        baseBrandContext({ overview: "x".repeat(5001) }),
+      ).success,
+    ).toBe(false);
+    expect(
+      BrandContextSchema.safeParse(baseBrandContext({ name: "x".repeat(501) }))
+        .success,
+    ).toBe(false);
+    expect(
+      BrandContextSchema.safeParse(
+        baseBrandContext({ domain: "x".repeat(501) }),
+      ).success,
+    ).toBe(false);
+    expect(
+      BrandContextSchema.safeParse(baseBrandContext({ logo: "x".repeat(501) }))
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects an oversized font family or color value", () => {
+    expect(
+      BrandContextSchema.safeParse(
+        baseBrandContext({ fonts: { heading: "x".repeat(501) } }),
+      ).success,
+    ).toBe(false);
+    expect(
+      BrandContextSchema.safeParse(
+        baseBrandContext({ colors: { primary: "x".repeat(501) } }),
+      ).success,
+    ).toBe(false);
+  });
 });

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -291,35 +291,87 @@ export function autoResolveConflictsEnabled(
  */
 const MAX_BRAND_JSON_FIELD_BYTES = 256 * 1024;
 const MAX_BRAND_IMAGES = 50;
+const MAX_BRAND_STRING_LENGTH = 500;
+const MAX_BRAND_OVERVIEW_LENGTH = 5000;
 
 /**
  * Brand context schema - org-scoped company profile
  */
 export const BrandContextSchema = z.object({
   id: z.string().describe("Brand context ID"),
-  name: z.string().describe("Company name"),
-  domain: z.string().describe("Company domain (e.g. example.com)"),
-  overview: z.string().describe("Company overview / description"),
-  logo: z.string().nullable().optional().describe("Logo URL"),
-  favicon: z.string().nullable().optional().describe("Favicon URL"),
-  ogImage: z.string().nullable().optional().describe("OG image URL"),
+  name: z.string().max(MAX_BRAND_STRING_LENGTH).describe("Company name"),
+  domain: z
+    .string()
+    .max(MAX_BRAND_STRING_LENGTH)
+    .describe("Company domain (e.g. example.com)"),
+  overview: z
+    .string()
+    .max(MAX_BRAND_OVERVIEW_LENGTH)
+    .describe("Company overview / description"),
+  logo: z
+    .string()
+    .max(MAX_BRAND_STRING_LENGTH)
+    .nullable()
+    .optional()
+    .describe("Logo URL"),
+  favicon: z
+    .string()
+    .max(MAX_BRAND_STRING_LENGTH)
+    .nullable()
+    .optional()
+    .describe("Favicon URL"),
+  ogImage: z
+    .string()
+    .max(MAX_BRAND_STRING_LENGTH)
+    .nullable()
+    .optional()
+    .describe("OG image URL"),
   fonts: z
     .object({
-      heading: z.string().optional().describe("Font family for headings"),
-      body: z.string().optional().describe("Font family for body text"),
-      code: z.string().optional().describe("Font family for code / monospace"),
+      heading: z
+        .string()
+        .max(MAX_BRAND_STRING_LENGTH)
+        .optional()
+        .describe("Font family for headings"),
+      body: z
+        .string()
+        .max(MAX_BRAND_STRING_LENGTH)
+        .optional()
+        .describe("Font family for body text"),
+      code: z
+        .string()
+        .max(MAX_BRAND_STRING_LENGTH)
+        .optional()
+        .describe("Font family for code / monospace"),
     })
     .nullable()
     .optional()
     .describe("Font families by semantic role"),
   colors: z
     .object({
-      primary: z.string().optional().describe("Primary brand color (hex)"),
-      secondary: z.string().optional().describe("Secondary brand color (hex)"),
-      accent: z.string().optional().describe("Accent / highlight color (hex)"),
-      background: z.string().optional().describe("Background color (hex)"),
+      primary: z
+        .string()
+        .max(MAX_BRAND_STRING_LENGTH)
+        .optional()
+        .describe("Primary brand color (hex)"),
+      secondary: z
+        .string()
+        .max(MAX_BRAND_STRING_LENGTH)
+        .optional()
+        .describe("Secondary brand color (hex)"),
+      accent: z
+        .string()
+        .max(MAX_BRAND_STRING_LENGTH)
+        .optional()
+        .describe("Accent / highlight color (hex)"),
+      background: z
+        .string()
+        .max(MAX_BRAND_STRING_LENGTH)
+        .optional()
+        .describe("Background color (hex)"),
       foreground: z
         .string()
+        .max(MAX_BRAND_STRING_LENGTH)
         .optional()
         .describe("Foreground / text color (hex)"),
     })


### PR DESCRIPTION
Follows the #6904/#6930/#6934/#6961/#6967 wave that capped every other uncapped client-controlled collection/string in the org-settings surface (sidebar_items, enabled_plugins, registries, blockedMcps, default_home_agents.ids, ModelSlotSchema). BrandContextSchema's own free-text fields — `name`, `domain`, `overview`, `logo`/`favicon`/`ogImage` URLs, and the `fonts`/`colors` sub-field strings — were the one sibling left with no `.max()`, even though `images` and `metadata` on the same schema already have caps (`MAX_BRAND_IMAGES`, `MAX_BRAND_JSON_FIELD_BYTES`).

Why it matters: `BRAND_CONTEXT_UPDATE`/`BRAND_CONTEXT_CREATE` (apps/api/src/tools/organization/brand-context-update.ts) and the Firecrawl-driven `BRAND_CONTEXT_EXTRACT` all write through this one schema, so any caller (or a compromised/malfunctioning extraction result) could stash an arbitrarily large `overview` or `logo` URL string into the `brand_context` JSON column with no server-side bound — same class of gap the prior PRs in this wave fixed elsewhere.

Fix: added `.max()` caps — 500 chars on name/domain/logo/favicon/ogImage/font-family/color values (matching `MAX_SETTINGS_STRING_LENGTH` used elsewhere in this file), 5000 on the longer free-text `overview` field. Pure validation tightening; the inferred TypeScript types are unchanged (`z.string().max(n)` still infers `string`), so no caller needed updating.

Regression tests added in `packages/shared/src/organization/schema.test.ts` (same describe block as the existing images/metadata cap tests) assert each new cap rejects an oversized value.

Reviewer check: `bun test packages/shared/src/organization/schema.test.ts`

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in packages/shared, `bunx oxlint` on both changed files, and the targeted test file above (9 pass). Full CI covers the apps/api typecheck against the consuming brand-context tools.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps all previously unbounded free-text strings in `BrandContextSchema` so brand context can no longer bloat the `brand_context` JSON column.

**Bug Fixes**
- Limits `name`, `domain`, logo/favicon/ogImage URLs, and font/color values to 500 characters, and `overview` to 5000.
- Rejects oversized values during validation; no TypeScript type changes, so no callers need updates.

<sup>Written for commit 9cbb9a4bbb082606abf64965d5f9953ccf334ad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

