### PR TITLE
fix(preview): resend CMS section labels after an in-place render swap

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1082,16 +1082,26 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           });
       } else if (e.data?.type === "cms-editor::render-start") {
         beginNavigation();
-      } else if (
-        e.data?.type === "cms-editor::render-end" ||
-        e.data?.type === "cms-editor::render-error"
-      ) {
+      } else if (e.data?.type === "cms-editor::render-end") {
+        endNavigation();
+        // The in-place swap keeps stale label/kind/key data; resend it.
+        const win = previewIframeRef.current?.contentWindow;
+        win?.postMessage(
+          {
+            type: "cms-editor::set-labels",
+            labels: cmsSectionLabels,
+            kinds: cmsSectionKinds,
+            keys: cmsSectionKeys,
+          },
+          allowedOrigin,
+        );
+      } else if (e.data?.type === "cms-editor::render-error") {
         endNavigation();
       }
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, [editorBridgeOrigin]);
+  }, [editorBridgeOrigin, cmsSectionLabels, cmsSectionKinds, cmsSectionKeys]);
 
   // Target origin is pinned to the preview site itself: with "*" the parent
   // would still hand the editor script and page-structure metadata to


### PR DESCRIPTION
Bug found by reading `preview.tsx`'s `cms-editor::render-end` handler and `cms-editor-script.ts`'s `renderInPlace`.

When Fast Preview's in-place render is active (editing a page while the daemon frame stays pinned), an edit that adds/removes/reorders sections triggers `renderInPlace`, which replaces the entire `document.documentElement.innerHTML` but keeps the injected script instance — and its module-level `sectionLabels`/`sectionKinds`/`sectionCandidates` arrays — alive across the swap. Those arrays were only ever (re)sent from `preview.tsx`'s real iframe `onLoad` handler and on mode activation, never after an in-place swap, so post-swap hover badges/labels/kind-colors in the CMS overlay go stale (wrong label, wrong kind color, wrong candidate key) whenever the swap changed the section layout.

Fix: the parent already listens for `cms-editor::render-end` (to clear the navigation indicator) — resend `cms-editor::set-labels` with the current label/kind/key arrays from that same handler, so the overlay picks up the post-swap layout immediately.

Failure scenario: open a page in Blocks/visual mode with in-place rendering active, add or reorder a section, then hover a section in the preview — the hover badge shows a stale label/kind for the old layout until the next full page load.

How to verify: `cd apps/web && bunx tsc --noEmit` (green, no new errors) and `bunx oxlint apps/web/src/components/sandbox/preview/preview.tsx` (0 warnings/errors). This is UI hover-label sync, not a trust boundary, so no new unit test — the logic isn't mockable without violating the unit-test tier rules (no DOM/postMessage mocks); it's better proven manually or via e2e.

Diff: +15/-5, one file, one concern.

Ran locally: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bunx oxlint` on the changed file. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale CMS section labels after an in-place render swap in Fast Preview. When editing a page with in-place rendering active, adding, removing, or reordering sections triggered a full HTML replacement without updating the overlay's label/kind/key data, so hover badges showed the old layout. Now the parent resends the current label, kind, and key arrays on `cms-editor::render-end`, so the overlay updates immediately after the swap.

<sup>Written for commit 36fa3600329fe7d627170e33a957de97ca8d1869. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

