### PR TITLE
fix(organization): cap the serialized size of BrandContextSchema's images array

### DIFF
--- a/packages/shared/src/organization/schema.test.ts
+++ b/packages/shared/src/organization/schema.test.ts
@@ -106,6 +106,13 @@ describe("BrandContextSchema JSON field caps", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects an oversized images blob within the count cap", () => {
+    // Unlike metadata, images had a count cap but no byte cap.
+    const images = [{ blob: "x".repeat(300 * 1024) }];
+    const result = BrandContextSchema.safeParse(baseBrandContext({ images }));
+    expect(result.success).toBe(false);
+  });
+
   it("rejects an oversized overview, name, domain, or logo URL", () => {
     expect(
       BrandContextSchema.safeParse(

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -383,6 +383,15 @@ export const BrandContextSchema = z.object({
     .max(MAX_BRAND_IMAGES)
     .nullable()
     .optional()
+    .refine(
+      (value) =>
+        value === null ||
+        value === undefined ||
+        JSON.stringify(value).length <= MAX_BRAND_JSON_FIELD_BYTES,
+      {
+        message: `images must serialize to at most ${MAX_BRAND_JSON_FIELD_BYTES} bytes`,
+      },
+    )
     .describe("Brand images"),
   metadata: z
     .record(z.string(), z.unknown())


### PR DESCRIPTION
Follows #6967/#6969, which capped every other free-text field on `ModelSlotSchema` and `BrandContextSchema` but missed one sibling of `metadata` on the same schema.

`BrandContextSchema.images` had a count cap (`max(50)`) but, unlike `metadata` right below it, no byte-size cap on the serialized array — an org member with ordinary brand-write permission could stash one arbitrarily large blob inside any of the 50 allowed image entries, the exact gap `metadata`'s `MAX_BRAND_JSON_FIELD_BYTES` refine already closes for its own field.

Fix: add the same `JSON.stringify(...).length <= MAX_BRAND_JSON_FIELD_BYTES` refine to `images`, reusing the existing constant.

Failure scenario before this fix: `BRAND_CONTEXT_CREATE`/`BRAND_CONTEXT_UPDATE` would accept `images: [{ blob: "x".repeat(300 * 1024) }]` (well under the 50-item cap) and write it straight to storage unbounded.

Regression test: `packages/shared/src/organization/schema.test.ts` — "rejects an oversized images blob within the count cap".

Reviewer check: `cd packages/shared && bun test src/organization/schema.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (packages/shared), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the serialized size of `BrandContextSchema.images` so oversized image blobs are rejected instead of stored unbounded.

Previously `images` only had a 50-item count cap, so a single entry could hold an arbitrarily large blob. The field now uses the same `MAX_BRAND_JSON_FIELD_BYTES` refine as `metadata`, so `BRAND_CONTEXT_CREATE` and `BRAND_CONTEXT_UPDATE` reject arrays that serialize past the byte limit.

This is a behavior change for org members who stored image blobs over the byte cap; those writes now fail validation.

<sup>Written for commit fcd1b608adde135a9be165136038c0e971136c8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

