### PR TITLE
feat(oauth-proxy): serve DCR from a connection's pre-registered client

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -472,6 +472,20 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
     return c.json({ error: "Connection not found" }, 404);
   }
 
+  // Some providers advertise a `registration_endpoint` and then 403 it (Figma):
+  // answer DCR from the connection's hand-registered client so the authorize
+  // and token legs below need no special case.
+  if (endpoint === "register" && connection.oauth_config?.clientId) {
+    return c.json({
+      client_id: connection.oauth_config.clientId,
+      ...(connection.oauth_config.clientSecret
+        ? { client_secret: connection.oauth_config.clientSecret }
+        : {}),
+      // 0 = never expires; an expiry would send the client back through /register.
+      client_secret_expires_at: 0,
+    });
+  }
+
   // Get origin auth server - tries Protected Resource Metadata first, then falls back to origin root
   const resourceRes = await fetchProtectedResourceMetadata(
     connection.connection_url,

--- a/apps/api/src/api/routes/oauth-proxy.integration.test.ts
+++ b/apps/api/src/api/routes/oauth-proxy.integration.test.ts
@@ -338,6 +338,50 @@ describe("MCP OAuth Proxy E2E", () => {
     }
   });
 
+  // Pre-registered OAuth clients — for providers that 403 their own DCR.
+  describe("Register Endpoint", () => {
+    test("returns the connection's pre-registered client instead of proxying DCR", async () => {
+      const connectionId = "conn_preregistered_oauth";
+      await database.db
+        .insertInto("connections")
+        .values({
+          id: connectionId,
+          organization_id: "org_test",
+          created_by: "test_user",
+          title: "Pre-registered OAuth",
+          connection_type: "HTTP",
+          // Unreachable on purpose: a short-circuit that still dials would fail.
+          connection_url: "https://mcp.invalid.example/mcp",
+          oauth_config: JSON.stringify({
+            authorizationEndpoint: "https://auth.example/authorize",
+            tokenEndpoint: "https://auth.example/token",
+            clientId: "static-client-id",
+            clientSecret: "static-client-secret",
+            scopes: ["mcp:connect"],
+            grantType: "authorization_code",
+          }),
+          status: "active",
+          pinned: false,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .execute();
+
+      const res = await app.request(`/oauth-proxy/${connectionId}/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_name: "probe", redirect_uris: [] }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        client_id: "static-client-id",
+        client_secret: "static-client-secret",
+        client_secret_expires_at: 0,
+      });
+    });
+  });
+
   // ===========================================================================
   // Servers without OAuth support - should return 401 without WWW-Authenticate
   // ===========================================================================


### PR DESCRIPTION
## Summary

Figma's remote MCP server advertises `registration_endpoint: https://api.figma.com/v1/oauth/mcp/register` and then answers it with a bare `403 Forbidden` (verified with a direct curl, no Studio in the path). Every MCP client does the spec-mandated DCR call, gets a non-JSON 403, and dies before it ever has a `client_id` — which surfaces in the UI as `Authentication failed: HTTP 403: ... "Forbidden" is not valid JSON`.

The way in is an app registered by hand in the provider's console. `connections.oauth_config` already has `clientId` / `clientSecret` / endpoints / scopes — and nothing has ever read it.

So: when a connection carries `oauth_config.clientId`, the proxy answers `POST /oauth-proxy/:id/register` itself with an RFC 7591 response instead of forwarding it. The client believes it registered; the authorize and token legs below are untouched, so there is no per-provider branch anywhere. Fixes every provider that refuses open DCR, not just Figma.

14 lines in `app.ts`. No behavior change for connections without `oauth_config` (the overwhelming majority) — the branch is skipped and DCR proxies as before.

## Testing

- New integration test in `oauth-proxy.integration.test.ts`: a connection with `oauth_config` pointed at a deliberately **unreachable** origin, asserting `/register` returns the stored client — a short-circuit that still dialled upstream would fail rather than quietly pass.
- ⚠️ **I could not run the suite** — it needs a live Postgres and I had none up locally. `bun run --cwd=apps/api check` passes. Please confirm CI green before merging.
- Not yet exercised end-to-end against Figma: that needs the client credentials stored on a real connection.

## Follow-up (not in this PR)

`oauth_config` is **not** vault-encrypted — only `connection_token`, `configuration_state`, and STDIO `envVars` are. A client secret stored there sits in the row in the clear. Worth fixing before this is used widely.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Answers `POST /oauth-proxy/:id/register` from the connection's pre-registered `oauth_config` client when providers like Figma advertise a registration endpoint and respond with a bare 403, so MCP clients get a valid RFC 7591 response instead of dying before obtaining a `client_id`. Connections without `oauth_config.clientId` are unchanged — the register call proxies upstream as before.

- The authorize and token legs are untouched; no per-provider branch is added.
- The new integration test points at an unreachable origin so a short-circuit that still dials upstream fails rather than passing silently.
- The suite needs a live Postgres and was not run locally; only `bun run --cwd=apps/api check` was verified.
- `oauth_config` is not vault-encrypted, so a client secret stored there sits in the clear in the row.

<sup>Written for commit d93bcb885bd50cc27a6e661e4c2cf9017c14e2fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

