### PR TITLE
fix(oauth-proxy): echo client metadata in the pre-registered DCR response

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -476,7 +476,11 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
   // answer DCR from the connection's hand-registered client so the authorize
   // and token legs below need no special case.
   if (endpoint === "register" && connection.oauth_config?.clientId) {
+    // The client metadata is echoed back because RFC 7591 §3.2.1 says the
+    // response is the request plus the credentials, and clients validate it.
+    const requested = await c.req.json().catch(() => ({}));
     return c.json({
+      ...(typeof requested === "object" && requested !== null ? requested : {}),
       client_id: connection.oauth_config.clientId,
       ...(connection.oauth_config.clientSecret
         ? { client_secret: connection.oauth_config.clientSecret }

--- a/apps/api/src/api/routes/oauth-proxy.integration.test.ts
+++ b/apps/api/src/api/routes/oauth-proxy.integration.test.ts
@@ -370,11 +370,16 @@ describe("MCP OAuth Proxy E2E", () => {
       const res = await app.request(`/oauth-proxy/${connectionId}/register`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ client_name: "probe", redirect_uris: [] }),
+        body: JSON.stringify({
+          client_name: "probe",
+          redirect_uris: ["https://studio.example/oauth/callback"],
+        }),
       });
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({
+        client_name: "probe",
+        redirect_uris: ["https://studio.example/oauth/callback"],
         client_id: "static-client-id",
         client_secret: "static-client-secret",
         client_secret_expires_at: 0,


### PR DESCRIPTION
Follow-up to #6972 (merged) — that got Figma past the 403; this fixes the next error along.

The MCP SDK validates a DCR response against the full client-information schema (client metadata merged with the issued credentials), so a response carrying only `client_id` / `client_secret` fails:

```
Authentication failed: [ { "expected": "array", "code": "invalid_type", "path": [ "redirect_uris" ], "message": "Invalid input" } ]
```

RFC 7591 §3.2.1 says the registration response is the request plus the credentials, so echo the posted metadata back and overlay the connection's client on top. A non-object or unparseable body degrades to `{}` rather than throwing.

## Testing

- Existing integration test extended: the probe now posts `redirect_uris` and asserts they come back alongside the credentials.
- ⚠️ **Still not run** — needs a live Postgres, which I don't have up. `bun run --cwd=apps/api check` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OAuth proxy's pre-registered DCR response so it includes the client metadata from the request, matching RFC 7591's response shape and satisfying client-side validation like the MCP SDK. The response now echoes the posted body and overlays the connection's client credentials; a non-object or unparseable body degrades to `{}` instead of throwing.

Adds an integration test that posts `redirect_uris` and asserts they come back alongside the credentials.

<sup>Written for commit 562029aeacfd60698f26207673924e5abd6a7a07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

