### PR TITLE
fix(oauth-proxy): cap the register endpoint's body size

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -104,6 +104,7 @@ import {
   createWellKnownAuthServerRoutes,
   fetchAuthorizationServerMetadata,
   fetchProtectedResourceMetadata,
+  oauthProxyBodyLimit,
   protectedResourceMetadataHandler,
 } from "./routes/oauth-proxy";
 import openaiCompatRoutes from "./routes/openai-compat";
@@ -1530,6 +1531,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // canonical mount lives under `/api/:org/oauth-proxy/...` (registered via
   // `createOrgScopedApi` below) and gets cross-org enforcement for free.
   app.use("/oauth-proxy/:connectionId/*", logDeprecatedRoute);
+  app.use("/oauth-proxy/:connectionId/*", oauthProxyBodyLimit);
   app.all("/oauth-proxy/:connectionId/*", oauthProxyHandler);
 
   // Better-Auth-served Protected Resource Metadata for the gateway-style MCP

--- a/apps/api/src/api/routes/oauth-proxy.integration.test.ts
+++ b/apps/api/src/api/routes/oauth-proxy.integration.test.ts
@@ -385,6 +385,40 @@ describe("MCP OAuth Proxy E2E", () => {
         client_secret_expires_at: 0,
       });
     });
+
+    test("rejects an oversized register body with 413 before parsing it", async () => {
+      const connectionId = "conn_oversized_register_body";
+      await database.db
+        .insertInto("connections")
+        .values({
+          id: connectionId,
+          organization_id: "org_test",
+          created_by: "test_user",
+          title: "Oversized register body",
+          connection_type: "HTTP",
+          connection_url: "https://mcp.invalid.example/mcp",
+          oauth_config: JSON.stringify({
+            authorizationEndpoint: "https://auth.example/authorize",
+            tokenEndpoint: "https://auth.example/token",
+            clientId: "static-client-id",
+            scopes: ["mcp:connect"],
+            grantType: "authorization_code",
+          }),
+          status: "active",
+          pinned: false,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .execute();
+
+      const res = await app.request(`/oauth-proxy/${connectionId}/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ padding: "x".repeat(2 * 1024 * 1024) }),
+      });
+
+      expect(res.status).toBe(413);
+    });
   });
 
   // ===========================================================================

--- a/apps/api/src/api/routes/oauth-proxy.ts
+++ b/apps/api/src/api/routes/oauth-proxy.ts
@@ -13,6 +13,7 @@
  */
 
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import { oAuthProtectedResourceMetadata } from "better-auth/plugins";
 import { ContextFactory } from "../../core/context-factory";
 import type { StudioContext } from "../../core/studio-context";
@@ -41,6 +42,17 @@ import {
 type Variables = {
   studioContext: StudioContext;
 };
+
+/**
+ * The DCR-echo branch of `oauthProxyHandler` (app.ts) reads the request body
+ * as JSON before any auth check — this route is unauthenticated by design.
+ * Cap it like the other unauthenticated body-reading routes (jira-webhook,
+ * trigger-callback) so an attacker can't force large-body parses.
+ */
+export const oauthProxyBodyLimit = bodyLimit({
+  maxSize: 1_048_576, // 1MB
+  onError: (c) => c.json({ error: "Payload too large" }, 413),
+});
 
 type HonoEnv = { Variables: Variables };
 

--- a/apps/api/src/api/routes/org-scoped.ts
+++ b/apps/api/src/api/routes/org-scoped.ts
@@ -21,7 +21,10 @@ import { createDownstreamTokenRoutes } from "./downstream-token";
 import { createFileUploadRoutes } from "./file-uploads";
 import { createKVRoutes } from "./kv";
 import { createOrgFsRoutes } from "./org-fs";
-import { createOrgScopedWellKnownProtectedResourceRoutes } from "./oauth-proxy";
+import {
+  createOrgScopedWellKnownProtectedResourceRoutes,
+  oauthProxyBodyLimit,
+} from "./oauth-proxy";
 import { createSsoRoutes } from "./org-sso";
 import { createProxyRoutes } from "./proxy";
 import { createSelfRoutes } from "./self";
@@ -169,6 +172,7 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   // OAuth proxy under the org-scoped prefix; resolveOrgFromPath has run, so
   // the handler can enforce cross-org access (connection.organization_id
   // must match the resolved org).
+  app.use("/oauth-proxy/:connectionId/*", oauthProxyBodyLimit);
   app.all("/oauth-proxy/:connectionId/*", deps.oauthProxyHandler);
 
   // SSE events: GET /watch streams.


### PR DESCRIPTION
Follows #6972/#6973 (serve DCR from a connection's pre-registered client, then echo the requester's metadata back). That new branch of `oauthProxyHandler` calls `c.req.json()` on the unauthenticated `/oauth-proxy/:connectionId/register` route — before any auth or ownership check — with no cap on the body it parses.

Every other unauthenticated/webhook-style body-reading route in this repo (jira-webhook, trigger-callback, github-webhook, stripe-webhook, kv, sandbox-proxy, org-fs) already wraps its parse in hono's `bodyLimit` middleware; this new route didn't get one, so anyone who knows (or brute-forces) a `connectionId` can force repeated large-body JSON parses with no auth.

**Fix**: added a shared `oauthProxyBodyLimit` (1MB cap, 413 on overflow) exported from `oauth-proxy.ts` and mounted on both the legacy `/oauth-proxy/:connectionId/*` and canonical `/api/:org/oauth-proxy/:connectionId/*` routes, matching the existing pattern.

**Regression test**: `oauth-proxy.integration.test.ts` — "rejects an oversized register body with 413 before parsing it", posting a >1MB JSON body to `/register` and asserting a 413.

**To verify**: `bun test apps/api/src/api/routes/oauth-proxy.integration.test.ts` (needs a real Postgres — CI has one; this sandbox doesn't, so I verified via `bunx tsc --noEmit` (clean) and `bunx oxlint` on the 4 changed files (0 warnings/errors) instead).

Locally ran: `bun run fmt`, `apps/api` `bunx tsc --noEmit`, `bunx oxlint` on the changed files. Full CI (including this integration test against real Postgres) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the request body size on the oauth-proxy register endpoint so unauthenticated callers can't force large JSON parses. The route now rejects bodies over 1MB with a 413, matching the pattern used by other unauthenticated body-reading routes. The limit applies to both the legacy `/oauth-proxy/:connectionId/*` and canonical `/api/:org/oauth-proxy/:connectionId/*` routes. Adds a regression test for the 413 response.

<sup>Written for commit 44fde03399575f38abe4aba46bc5b5cda8da7226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

