### PR TITLE
fix(virtual-mcp): cap a literal runtime env var's value length

### DIFF
--- a/packages/shared/src/sdk/types/virtual-mcp.test.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.test.ts
@@ -566,6 +566,32 @@ test("VirtualMCPUpdateDataSchema rejects more than 100 runtime env vars", () => 
   expect(result.success).toBe(false);
 });
 
+test("VirtualMCPUpdateDataSchema rejects a literal runtime env value over 8192 chars", () => {
+  const result = VirtualMCPUpdateDataSchema.safeParse({
+    metadata: {
+      runtime: {
+        env: [
+          { key: "TOKEN", kind: "literal" as const, value: "a".repeat(8193) },
+        ],
+      },
+    },
+  });
+  expect(result.success).toBe(false);
+});
+
+test("VirtualMCPUpdateDataSchema accepts a literal runtime env value at the 8192 char boundary", () => {
+  const result = VirtualMCPUpdateDataSchema.safeParse({
+    metadata: {
+      runtime: {
+        env: [
+          { key: "TOKEN", kind: "literal" as const, value: "a".repeat(8192) },
+        ],
+      },
+    },
+  });
+  expect(result.success).toBe(true);
+});
+
 test("SandboxRecord.startedWith is optional with nullable packageManager/port/path", () => {
   const a = SandboxRecordSchema.parse({ sandboxHandle: "v", previewUrl: null });
   expect(a.startedWith).toBeUndefined();

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -79,6 +79,12 @@ const RUNTIME_ENV_MAX = 100;
 /** Cap on git submodule credentials per sandbox. */
 const SUBMODULE_CREDENTIALS_MAX = 50;
 
+/** Cap on a single literal env var's value length — an unbounded string here
+ *  is attacker-controlled payload size on a mutation input (posted verbatim
+ *  to the sandbox daemon on every SANDBOX_START), not a real env value. 8KB
+ *  comfortably covers legitimate values (JSON config, certs, tokens). */
+const RUNTIME_ENV_LITERAL_VALUE_MAX = 8192;
+
 /**
  * Virtual MCP connection schema for input (Create/Update) - fields can be optional
  */
@@ -407,7 +413,7 @@ const RuntimeEnvEntrySchema = z.discriminatedUnion("kind", [
   z.object({
     key: envVarKey,
     kind: z.literal("literal"),
-    value: z.string(),
+    value: z.string().max(RUNTIME_ENV_LITERAL_VALUE_MAX),
   }),
   z.object({
     key: envVarKey,


### PR DESCRIPTION
Reduction/hardening found while auditing `packages/shared/src/sdk/types/virtual-mcp.ts` (this tick's focus area).

**The gap**: `metadata.runtime.env[].value` (a literal env var's value, in `RuntimeEnvEntrySchema`) was a bare `z.string()` with no length cap, on `VirtualMCPCreateDataSchema`/`VirtualMCPUpdateDataSchema` — a mutation input a caller controls directly. Every sibling array in this same file (`selected_tools`, `subAgents`, `knowledge`, `submoduleCredentials`, etc.) already carries an explicit `.max()` write-time cap with a comment about attacker-controlled payload size; this one scalar string field was the odd one out. Per the file's own docs, this value is resolved and "posted to `/_sandbox/config`" on every `SANDBOX_START`, so an unbounded value is unnecessary payload bloat on a hot path with no legitimate use case (real env values don't need to be multi-megabyte).

**Fix**: cap it at 8192 chars (`RUNTIME_ENV_LITERAL_VALUE_MAX`), matching the repo's existing string-length-cap convention (`MAX_SETTINGS_STRING_LENGTH = 500` in `packages/shared/src/organization/schema.ts`; other caps in the codebase range 160–50000 depending on the field's legitimate use). 8KB comfortably covers real env values (JSON config blobs, certs, tokens) while bounding the payload.

**Failure scenario prevented**: a caller of `VirtualMCPCreateDataSchema`/`VirtualMCPUpdateDataSchema` could previously set an arbitrarily large `runtime.env[].value` (e.g. megabytes), which would be persisted in the agent's metadata and re-sent on every sandbox start.

**Verification**:
- Added two regression tests: reject a 8193-char value, accept the 8192-char boundary.
- `bun test packages/shared/src/sdk/types/virtual-mcp.test.ts` — 54 pass, 0 fail.
- `cd packages/shared && bunx tsc --noEmit` — clean.
- `bunx oxlint packages/shared/src/sdk/types/virtual-mcp.ts packages/shared/src/sdk/types/virtual-mcp.test.ts` — 0 warnings/errors.
- `bun run fmt` — clean.

CI runs the full suite; these are the targeted checks for this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the length of literal runtime env var values in Virtual MCP create/update inputs to 8192 characters. Previously, `metadata.runtime.env[].value` accepted strings of any length, letting a caller control an oversized payload that gets persisted in the agent's metadata and posted to the sandbox daemon on every sandbox start. Values over 8192 characters are now rejected; the boundary test verifies the cap.

<sup>Written for commit f788452e8467f07b883ecaba5dc18c1fd40c5097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

