### PR TITLE
fix(task-board): don't block fetchOrPlaceholder when the PR cache has no KV

### DIFF
--- a/apps/api/src/tools/task-board/pr-cache.test.ts
+++ b/apps/api/src/tools/task-board/pr-cache.test.ts
@@ -106,6 +106,42 @@ describe("JetStreamKVPrCache", () => {
   });
 });
 
+describe("fetchOrPlaceholder without KV (NATS down / not yet ready)", () => {
+  test("returns the placeholder instead of blocking on fetchLive", async () => {
+    const clock = { now: 0 };
+    const cache = new JetStreamKVPrCache(
+      PR_CARDS_CACHE,
+      { getJetStream: () => null },
+      () => clock.now,
+    );
+    // No init() call — this.kv stays null, like a pod not yet connected to NATS.
+    let resolveFetch: (() => void) | undefined;
+    const fetchLive = () =>
+      new Promise<{ n: number }>((resolve) => {
+        resolveFetch = () => resolve({ n: 1 });
+      });
+
+    const first = await cache.fetchOrPlaceholder({
+      namespace: "org_1",
+      key: "task_1",
+      fetchLive,
+      placeholder: { n: 0 },
+    });
+    expect(first).toEqual({ value: { n: 0 }, live: false });
+
+    resolveFetch?.();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const second = await cache.fetchOrPlaceholder({
+      namespace: "org_1",
+      key: "task_1",
+      fetchLive: () => Promise.reject(new Error("should not refetch yet")),
+      placeholder: { n: 0 },
+    });
+    expect(second).toEqual({ value: { n: 1 }, live: true });
+  });
+});
+
 describe("PR card cache config", () => {
   test("a card that was rendered once never blocks on GitHub again", () => {
     // The card cache exists because the read cache could not make a page

--- a/apps/api/src/tools/task-board/pr-cache.ts
+++ b/apps/api/src/tools/task-board/pr-cache.ts
@@ -106,6 +106,17 @@ export class JetStreamKVPrCache {
   private readonly revalidating = new Set<string>();
   /** Used whenever KV is unavailable — development, or NATS not yet ready. */
   private readonly fallback: InMemoryMcpReadCache;
+  /**
+   * Backs {@link fetchOrPlaceholder} whenever KV is unavailable. `fallback`
+   * (above) can't serve that method: it has no notion of "return a placeholder
+   * without blocking", so without this a NATS outage silently turned
+   * `fetchOrPlaceholder`'s documented never-blocks guarantee into a synchronous
+   * `fetchLive()` — exactly the GitHub round-trip the card cache exists to
+   * remove from the request path. Capped so a sustained outage can't grow it
+   * unbounded.
+   */
+  private readonly placeholderFallback = new Map<string, StoredRead>();
+  private static readonly MAX_PLACEHOLDER_FALLBACK_ENTRIES = 1000;
 
   constructor(
     private readonly config: PrCacheConfig,
@@ -220,12 +231,6 @@ export class JetStreamKVPrCache {
   }): Promise<{ value: T; live: boolean }> {
     const { namespace, key: rawKey, fetchLive, placeholder } = params;
     const { cache, revalidateAfterMs, maxStaleMs } = this.config;
-    if (!this.kv) {
-      // No KV to hand a background result to, so there is nothing to come back
-      // for — blocking once beats never enriching at all.
-      return { value: await fetchLive(), live: true };
-    }
-
     const key = this.storageKey(namespace, rawKey);
     const stored = await this.read(key);
     const age = stored
@@ -260,6 +265,7 @@ export class JetStreamKVPrCache {
   }
 
   private async read(key: string): Promise<StoredRead | null> {
+    if (!this.kv) return this.placeholderFallback.get(key) ?? null;
     try {
       const entry = await this.kv?.get(key);
       if (!entry?.value?.length) return null;
@@ -275,6 +281,18 @@ export class JetStreamKVPrCache {
     value: unknown,
     cache: string,
   ): Promise<void> {
+    if (!this.kv) {
+      // Evict the oldest entry (insertion order) once past the cap.
+      if (
+        this.placeholderFallback.size >=
+        JetStreamKVPrCache.MAX_PLACEHOLDER_FALLBACK_ENTRIES
+      ) {
+        const oldest = this.placeholderFallback.keys().next().value;
+        if (oldest !== undefined) this.placeholderFallback.delete(oldest);
+      }
+      this.placeholderFallback.set(key, { storedAt: this.now(), value });
+      return;
+    }
     try {
       await this.kv?.put(
         key,


### PR DESCRIPTION
Follows #6966, which added the KV-backed PR card cache and its `fetchOrPlaceholder` method: on a hit it returns the stored card, and on a miss it's documented to "NEVER block" — return a placeholder immediately and enrich in the background.

That guarantee only held when `this.kv` was set. When it's `null` — NATS down, or a pod that hasn't finished connecting yet, both states the same file's `fetch()` method already treats as routine and falls back for — `fetchOrPlaceholder` instead did `return { value: await fetchLive(), live: true }`: a synchronous GitHub round-trip on the task dialog's poll path, which is precisely the wait this cache was built (in the same PR, per its own comments: "922 misses to 81 hits in an hour") to remove.

**Failure scenario:** NATS is unreachable (a rolling deploy, a brief outage, or just a pod that started before NATS did) and a user opens a task's PR dialog. Every poll now blocks on a live GitHub call instead of painting instantly from the placeholder + background refresh the rest of the class already implements for exactly this case.

**Fix:** give `fetchOrPlaceholder` the same non-blocking placeholder semantics as the KV path, backed by a small capped in-memory Map (`placeholderFallback`, 1000 entries, insertion-order eviction) instead of hitting KV. `read`/`write` now branch on `this.kv` once, so both cache methods share the same shape.

**Regression test** added in `pr-cache.test.ts`: constructs a `JetStreamKVPrCache` without calling `init()` (kv stays null) and asserts the first `fetchOrPlaceholder` call returns the placeholder immediately (doesn't await the pending `fetchLive`), and that once that fetch resolves, the next call serves the cached value without re-fetching.

Reviewer check: `bun test apps/api/src/tools/task-board/pr-cache.test.ts`.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above (10 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `fetchOrPlaceholder` in the PR card cache so it never blocks on a live GitHub call when KV is unavailable (e.g., NATS down or pod starting).

- Previously, when KV was `null`, it awaited `fetchLive` on every poll, causing a synchronous GitHub round-trip.
- Now it returns a placeholder immediately and enriches in the background, backed by a capped in-memory map (1000 entries, insertion-order eviction).
- Added a regression test to `pr-cache.test.ts` covering the no-KV path.

<sup>Written for commit 405ea876bd5ebd38e6641bfd84c106b42796433c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

