### PR TITLE
fix(organization): don't clobber existing org metadata on description update

### DIFF
--- a/apps/api/src/tools/organization/update.test.ts
+++ b/apps/api/src/tools/organization/update.test.ts
@@ -10,11 +10,14 @@ function makeCtx() {
       createdAt: new Date("2026-01-01T00:00:00Z"),
     }),
   );
+  const get = mock(async () => ({
+    metadata: { archived: true, archivedAt: "2026-01-01T00:00:00Z" },
+  }));
   return {
     auth: { user: { id: "user-1" } },
     access: { check: mock(async () => {}) },
     organization: { id: "org-1", slug: "acme", name: "Acme" },
-    boundAuth: { organization: { update } },
+    boundAuth: { organization: { update, get } },
     update,
   } as unknown as Parameters<typeof ORGANIZATION_UPDATE.handler>[1] & {
     update: typeof update;
@@ -29,7 +32,13 @@ describe("ORGANIZATION_UPDATE", () => {
 
     expect(ctx.update).toHaveBeenCalledWith({
       organizationId: "org-1",
-      data: { metadata: { description: "" } },
+      data: {
+        metadata: {
+          archived: true,
+          archivedAt: "2026-01-01T00:00:00Z",
+          description: "",
+        },
+      },
     });
   });
 
@@ -43,8 +52,28 @@ describe("ORGANIZATION_UPDATE", () => {
 
     expect(ctx.update).toHaveBeenCalledWith({
       organizationId: "org-1",
-      data: { metadata: { description: "hello" } },
+      data: {
+        metadata: {
+          archived: true,
+          archivedAt: "2026-01-01T00:00:00Z",
+          description: "hello",
+        },
+      },
     });
+  });
+
+  it("preserves unrelated metadata keys instead of dropping them", async () => {
+    const ctx = makeCtx();
+
+    await ORGANIZATION_UPDATE.handler(
+      { id: "org-1", description: "hello" },
+      ctx,
+    );
+
+    const call = ctx.update.mock.calls[0]?.[0] as {
+      data: { metadata: Record<string, unknown> };
+    };
+    expect(call.data.metadata.archived).toBe(true);
   });
 
   it("rejects updating an organization other than the authenticated one", async () => {

--- a/apps/api/src/tools/organization/update.ts
+++ b/apps/api/src/tools/organization/update.ts
@@ -52,9 +52,14 @@ export const ORGANIZATION_UPDATE = defineTool({
     // and renaming would silently invalidate every saved URL.
     const updateData: Record<string, unknown> = {};
     if (input.name) updateData.name = input.name;
-    // !== undefined, not truthy: "" clears the description and must persist.
-    if (input.description !== undefined)
-      updateData.metadata = { description: input.description };
+    // Merge into existing metadata: organization.update replaces it wholesale (see delete.ts).
+    if (input.description !== undefined) {
+      const existing = await ctx.boundAuth.organization.get(input.id);
+      updateData.metadata = {
+        ...existing?.metadata,
+        description: input.description,
+      };
+    }
 
     // Update organization via Better Auth
     const result = await ctx.boundAuth.organization.update({


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/tools/organization/*` for the role/permission focus area.

**Payoff:** `ORGANIZATION_UPDATE` wrote `updateData.metadata = { description }` directly, which Better Auth's `organization.update` persists *wholesale* (it replaces the column, it doesn't merge). `ORGANIZATION_DELETE` already works around this exact behavior by reading the existing org and spreading its metadata before adding the archive flags (see the comment there: "organization.update replaces it wholesale"). `ORGANIZATION_UPDATE` never got the same treatment, so any call that only sets/changes `description` silently wipes every other key stored under `organization.metadata` — including `archived`/`archivedAt` if a soft-delete flag were ever present alongside a later rename, and any future metadata key added by other code paths.

**Fix:** `ORGANIZATION_UPDATE` now fetches the existing org via `ctx.boundAuth.organization.get` and spreads its `metadata` before overlaying `description`, matching `delete.ts`'s existing pattern.

**Regression test:** `update.test.ts` now stubs `organization.get` to return metadata with an unrelated `archived: true` key, and asserts a description-only update still emits it in the write payload (previously it would have been dropped). The two existing tests were updated to reflect the merge (inverted from asserting the old wholesale-replace payload).

**Verify:** `bun test apps/api/src/tools/organization/update.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ORGANIZATION_UPDATE` so updating only the description no longer wipes other keys stored in `organization.metadata`. Previously the tool replaced the entire metadata column; now it merges into the existing metadata, matching the pattern already used by `ORGANIZATION_DELETE`.

**Bug Fixes**
- Preserves unrelated metadata keys (like `archived`/`archivedAt`) when a description-only update is made.
- Adds a regression test asserting unrelated metadata survives the update.

<sup>Written for commit 9e39c9b3366ccecd6582533b0bacce83c571a4e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

