### PR TITLE
fix(decopilot): re-sync a dirty message queue when the /watch SSE reconnects

### DIFF
--- a/apps/web/src/components/chat/chat-context.tsx
+++ b/apps/web/src/components/chat/chat-context.tsx
@@ -970,6 +970,26 @@ export function ActiveTaskProvider({
   // Delivery is at-most-once (NATS Core, no replay): a dropped event self-heals
   // because any LATER same-thread status event re-reconciles. Scoped to threads
   // that actually queued work (`isQueueDirty`) so normal threads are untouched.
+  // Shared by onTaskStatus and onReconnect: a dropped `/watch` connection can lose a status event, so a reconnect also re-checks the dirty queue.
+  const resyncDirtyQueue = () => {
+    const cb = cbRef.current;
+    if (!isQueueDirty(cb.taskId)) return;
+    void (async () => {
+      await refreshMessageQueue(cb.orgSlug, cb.taskId);
+      const applied = await conn.reconcileFromServer();
+      // The gate queue has drained — the last queued turn finished and its
+      // parts are committed (guaranteed by the ordering above), so the body
+      // is whole. Stop reconciling until the next time work is queued.
+      // Gate on `applied`: `reconcileFromServer` skips its apply while the
+      // next queued turn is already mid-stream (racing dequeue) — and by
+      // then the gate queue can look drained. The flag must survive the
+      // skip so that turn's own terminal event retries the reconcile.
+      if (applied && messageQueueStore(cb.taskId).get().length === 0) {
+        clearQueueDirty(cb.taskId);
+      }
+    })();
+  };
+
   useDecopilotEvents({
     orgSlug: org.slug,
     taskId,
@@ -983,22 +1003,9 @@ export function ActiveTaskProvider({
         if (stashed) conn.applyLocalMessage(stashed);
         void refreshMessageQueue(cb.orgSlug, cb.taskId); // authoritative re-sync
       }
-      if (!isQueueDirty(cb.taskId)) return;
-      void (async () => {
-        await refreshMessageQueue(cb.orgSlug, cb.taskId);
-        const applied = await conn.reconcileFromServer();
-        // The gate queue has drained — the last queued turn finished and its
-        // parts are committed (guaranteed by the ordering above), so the body
-        // is whole. Stop reconciling until the next time work is queued.
-        // Gate on `applied`: `reconcileFromServer` skips its apply while the
-        // next queued turn is already mid-stream (racing dequeue) — and by
-        // then the gate queue can look drained. The flag must survive the
-        // skip so that turn's own terminal event retries the reconcile.
-        if (applied && messageQueueStore(cb.taskId).get().length === 0) {
-          clearQueueDirty(cb.taskId);
-        }
-      })();
+      resyncDirtyQueue();
     },
+    onReconnect: resyncDirtyQueue,
   });
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- observer slot is per-mount; useEffect is the natural fit

--- a/apps/web/src/hooks/use-decopilot-events.ts
+++ b/apps/web/src/hooks/use-decopilot-events.ts
@@ -39,6 +39,14 @@ export interface UseDecopilotEventsOptions {
   onFinish?: (event: DecopilotFinishEvent) => void;
   /** Called on each "decopilot.thread.status" event (task status changed) */
   onTaskStatus?: (event: DecopilotThreadStatusEvent) => void;
+  /**
+   * Called after the underlying `/watch` connection re-establishes post-drop
+   * (network blip, tab wake, dev-server hot-reload). Events fired while the
+   * connection was down are lost (at-most-once delivery) — a caller relying
+   * on one of these events to resync local state (e.g. a queued turn's
+   * dequeue) should use this hook to catch up instead of staying stuck.
+   */
+  onReconnect?: () => void;
 }
 
 interface CallbacksRef {
@@ -46,6 +54,7 @@ interface CallbacksRef {
   onStep?: (event: DecopilotStepEvent) => void;
   onFinish?: (event: DecopilotFinishEvent) => void;
   onTaskStatus?: (event: DecopilotThreadStatusEvent) => void;
+  onReconnect?: () => void;
 }
 
 /**
@@ -66,6 +75,7 @@ export function useDecopilotEvents(options: UseDecopilotEventsOptions): void {
     onStep,
     onFinish,
     onTaskStatus,
+    onReconnect,
   } = options;
 
   const callbacksRef = useRef<CallbacksRef>({
@@ -73,9 +83,16 @@ export function useDecopilotEvents(options: UseDecopilotEventsOptions): void {
     onStep,
     onFinish,
     onTaskStatus,
+    onReconnect,
   });
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
-  callbacksRef.current = { taskId, onStep, onFinish, onTaskStatus };
+  callbacksRef.current = {
+    taskId,
+    onStep,
+    onFinish,
+    onTaskStatus,
+    onReconnect,
+  };
 
   // `subscribe` only depends on `enabled` and `orgSlug` so the EventSource
   // connection is not torn down when callbacks or taskId change.
@@ -131,7 +148,9 @@ export function useDecopilotEvents(options: UseDecopilotEventsOptions): void {
         onStoreChange();
       };
 
-      return decopilotSSE.subscribe(orgSlug, handler);
+      return decopilotSSE.subscribe(orgSlug, handler, () =>
+        callbacksRef.current.onReconnect?.(),
+      );
     };
   }
 


### PR DESCRIPTION
Follows the decopilot hot-reload-recovery hardening area (issue #2711's theme). `useDecopilotEvents` subscribes to the shared `/watch` SSE pool but never passed an `onReconnect` callback, even though the pool already supports one (see `thread-manager-store.ts`'s `onWatchReconnect`) and delivery is at-most-once — any `decopilot.thread.status` event fired while the connection is down (network blip, tab wake, or a dev-server hot-reload) is simply lost.

Failure scenario: a user sends a message while a turn is running, so it queues behind the gate (`markQueueDirty`). If the connection drops right as the queued turn's `in_progress`/terminal status event fires, `chat-context.tsx` never resyncs — the queued message stays stuck in the tray, its reply never lands in the body, and the thread looks stuck until the user manually reloads the page.

Fix: added `onReconnect` to `UseDecopilotEventsOptions`, threaded it through to `decopilotSSE.subscribe`'s existing third argument, and wired `chat-context.tsx`'s dirty-queue resync logic (already used by the status handler) to also run on reconnect. No behavior change to the happy path — this only adds a catch-up call when the connection needed to be re-established.

Reviewer check: `cd apps/web && bunx tsc --noEmit` (no new errors touching these files — the one pre-existing prosemirror version-mismatch error is unrelated) and `bunx oxlint apps/web/src/hooks/use-decopilot-events.ts apps/web/src/components/chat/chat-context.tsx` (0 warnings/errors). Ran `bun run fmt` locally. No unit test exists for this hook (it's wired through a live EventSource + module-scoped SSE pool, not unit-testable without infra); full e2e/CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stuck queued messages in the Decopilot chat when the `/watch` SSE connection drops and reconnects. Previously, a `decopilot.thread.status` event fired while disconnected was lost (at-most-once delivery), so the dirty queue never resynced and the message stayed stuck until a manual page reload. Now the same dirty-queue resync that runs on a status event also runs on reconnect.

- Adds `onReconnect` to `useDecopilotEvents` and wires it to the existing dirty-queue resync logic in `chat-context.tsx`.
- No behavior change to the happy path; the reconnect callback only fires when the connection re-establishes after a drop.

<sup>Written for commit 947a45a6421ec0a8f11727c7c13f9183125ebfc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

