### PR TITLE
fix(connections): clear the OAuth refresh backoff entry on connection delete

### DIFF
--- a/apps/api/src/tools/connection/delete.test.ts
+++ b/apps/api/src/tools/connection/delete.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, mock } from "bun:test";
 import { WellKnownOrgMCPId } from "@decocms/shared/sdk";
-import { COLLECTION_CONNECTIONS_DELETE } from "./delete";
+
+const mockClearRefreshBackoff = mock((_connectionId?: string) => {});
+mock.module("../../oauth/token-refresh", () => ({
+  clearRefreshBackoff: mockClearRefreshBackoff,
+}));
+
+const { COLLECTION_CONNECTIONS_DELETE } = await import("./delete");
 
 function makeCtx(options: {
   referencedByThread: boolean;
@@ -79,6 +85,16 @@ describe("COLLECTION_CONNECTIONS_DELETE", () => {
 
     expect(result.item.id).toBe("conn_repo");
     expect(deleteConnection).toHaveBeenCalledWith("conn_repo");
+  });
+
+  it("clears the token-refresh backoff entry on delete", async () => {
+    // Regression: the backoff map has no TTL and would leak this connectionId forever otherwise.
+    mockClearRefreshBackoff.mockClear();
+    const { ctx } = makeCtx({ referencedByThread: false });
+
+    await COLLECTION_CONNECTIONS_DELETE.handler({ id: "conn_repo" }, ctx);
+
+    expect(mockClearRefreshBackoff).toHaveBeenCalledWith("conn_repo");
   });
 
   it("revokes the connection's trigger callback token on delete", async () => {

--- a/apps/api/src/tools/connection/delete.ts
+++ b/apps/api/src/tools/connection/delete.ts
@@ -18,6 +18,7 @@ import {
 } from "../../core/studio-context";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
 import { invalidateConnectionCaches } from "../../mcp-clients/mcp-cache-invalidation";
+import { clearRefreshBackoff } from "../../oauth/token-refresh";
 import { isDevAssetsConnection, usesLocalObjectStorage } from "./dev-assets";
 import { ConnectionEntitySchema } from "./schema";
 
@@ -132,6 +133,9 @@ export const COLLECTION_CONNECTIONS_DELETE = defineTool({
 
     // Delete connection
     await ctx.storage.connections.delete(input.id);
+
+    // token-refresh's backoff map has no TTL and would leak this connectionId forever otherwise.
+    clearRefreshBackoff(input.id);
 
     // trigger_callback_tokens.connection_id has no FK either — same class of orphan.
     await ctx.storage.triggerCallbackTokens.deleteByConnection(


### PR DESCRIPTION
**Source:** bug found while auditing the OAuth token-refresh lifecycle (`apps/api/src/oauth/token-refresh.ts`).

**Payoff:** `token-refresh.ts` keeps a module-level `refreshBackoff` Map, keyed by `connectionId`, with no TTL — it's meant to suppress hammering a down token endpoint after a transient refresh failure (see the comment above `refreshBackoff`). But nothing ever cleared it when the connection itself is deleted, so any connection that ever hit a transient OAuth refresh failure leaves a permanent entry in that Map for the life of the process (connection ids are never reused). This is the same class of leak `mcp-list-cache`'s revalidation throttle had (fixed by clearing it in `invalidateConnectionCaches` on connection delete) — this fix applies the same pattern to `token-refresh.ts`'s backoff map, which that fix didn't cover since it's a separate module.

**Failure scenario:** a connection's token endpoint blips (5xx/network error), `refreshAndStore` arms a backoff entry for its `connectionId`, the connection is later deleted — the entry is never removed, so it sits in memory forever. High-churn orgs (short-lived per-repo/sandbox connections hitting a flaky upstream) accumulate these indefinitely between process restarts.

**Fix:** call `clearRefreshBackoff(input.id)` in `COLLECTION_CONNECTIONS_DELETE`'s handler right after the connection row is deleted, alongside the other per-connection cleanup already done there (trigger callback tokens, cache invalidation).

**Regression test:** `apps/api/src/tools/connection/delete.test.ts` — mocks `../../oauth/token-refresh` and asserts `clearRefreshBackoff` is called with the deleted connection's id.

**To confirm:** `bun test apps/api/src/tools/connection/delete.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a memory leak where OAuth refresh backoff entries for deleted connections stayed in memory for the life of the process.

- `token-refresh.ts` keeps a module-level `refreshBackoff` map keyed by `connectionId` with no TTL; deleting a connection never removed its entry.
- The connection delete handler now calls `clearRefreshBackoff` right after the row is deleted, matching the existing cache-invalidation cleanup.
- Adds a regression test asserting the deleted connection's id is passed to `clearRefreshBackoff`.

<sup>Written for commit d72f2392145f7950de7dcb4e220ba533565ffe63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

