### PR TITLE
perf(task-board): delete PR cache keys concurrently on invalidate

### DIFF
--- a/apps/api/src/tools/task-board/pr-cache.test.ts
+++ b/apps/api/src/tools/task-board/pr-cache.test.ts
@@ -104,6 +104,30 @@ describe("JetStreamKVPrCache", () => {
     await read();
     expect(calls).toBe(2);
   });
+
+  test("invalidate drops every key under the namespace, not just the first", async () => {
+    const clock = { now: 0 };
+    const cache = await cacheAt(clock);
+    let calls = 0;
+    const read = (number: number) =>
+      cache.fetch({
+        namespace: "conn_1",
+        key: JSON.stringify({ name: "pull_request_read", number }),
+        fetchLive: async () => ({ n: ++calls }),
+        onRevalidation: () => {},
+      });
+
+    await read(1);
+    await read(2);
+    await read(3);
+    expect(calls).toBe(3);
+
+    await cache.invalidate("conn_1");
+    await read(1);
+    await read(2);
+    await read(3);
+    expect(calls).toBe(6);
+  });
 });
 
 describe("PR card cache config", () => {

--- a/apps/api/src/tools/task-board/pr-cache.ts
+++ b/apps/api/src/tools/task-board/pr-cache.ts
@@ -295,10 +295,13 @@ export class JetStreamKVPrCache {
     this.fallback.invalidate(namespace);
     if (!this.kv) return;
     try {
-      const keys = await this.kv.keys(`${namespace}.*`);
-      for await (const key of keys) {
-        await this.kv.delete(key).catch(() => {});
+      const kv = this.kv;
+      const keys: string[] = [];
+      for await (const key of await kv.keys(`${namespace}.*`)) {
+        keys.push(key);
       }
+      // Independent deletes — run concurrently, not one round-trip at a time.
+      await Promise.all(keys.map((key) => kv.delete(key).catch(() => {})));
     } catch {
       // best-effort: the TTL is the backstop.
     }


### PR DESCRIPTION
**Source**: reduction/optimization found while hunting the mcp-tool-latency-profiling focus area (relates to #2995 "DB latency amplifies significantly across MCP tool calls") — read `pr-cache.ts` (added by #6966, the JetStream KV cache fronting task-board PR reads/cards).

**The problem**: `JetStreamKVPrCache.invalidate(namespace)` lists every KV key under a namespace, then deletes them one at a time in a `for await` loop — each `kv.delete()` is its own NATS round-trip, awaited sequentially. `invalidatePrCards(organizationId)` and `invalidatePrReadsForConnection(connectionId)` are both awaited synchronously from task-board tool handlers (e.g. `TASK_BOARD_ITEM_PR_LINK`, merge-pr) right before they return. An org or connection with many cached PR entries pays N sequential round-trips inline on that tool call — the busier the board, the slower every PR-link/merge call gets, which is exactly the tool-call latency amplification pattern #2995 describes.

**The fix**: collect the matched keys, then `Promise.all` the deletes. They're independent, unrelated keys with no ordering requirement, and the existing per-key `.catch(() => {})` (best-effort, TTL is the backstop) is preserved — behavior is unchanged, just concurrent instead of serial.

**Verify**: `cd apps/api && bun test src/tools/task-board/pr-cache.test.ts` — added a test asserting `invalidate` still drops every key under a namespace (not just the first), which would have caught an incorrect early-return/short-circuit in a naive rewrite.

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up task-board PR cache invalidation by deleting matched keys concurrently instead of one at a time, cutting the serial NATS round-trips that slow PR-link and merge tool calls on busy boards (the latency pattern in #2995). Behavior is unchanged — deletes are independent and best-effort with TTL as the backstop.

- Switches `invalidate()` from a sequential `for await` loop to `Promise.all` over collected keys.
- Adds a test asserting all keys under a namespace are dropped, not just the first.

<sup>Written for commit 254a341fc06dbb089103dfed2ee1449c8d58b518. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

