### PR TITLE
refactor(preview): remove duplicated JSDoc block on reloadIframeOrFallback

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -263,11 +263,6 @@ function pageMatchScore(name: string, path: string, q: string): number {
  * Reload the iframe in place; falls back to reassigning `src` when the
  * iframe's live location is cross-origin (sandbox preview domain) and
  * `.reload()` throws.
-
-/**
- * Reload the iframe in place; falls back to reassigning `src` when the
- * iframe's live location is cross-origin (sandbox preview domain) and
- * `.reload()` throws.
  */
 function reloadIframeOrFallback(
   iframe: HTMLIFrameElement,


### PR DESCRIPTION
Source: dead-code reduction (C1) found while auditing `apps/web/src/components/sandbox/preview/preview.tsx` for this tick's sandbox-preview-cleanup focus area.

`reloadIframeOrFallback`'s doc comment was duplicated: an orphaned, unterminated copy of the JSDoc (missing its closing `*/`) sat directly above the real one, so the block that actually attaches to the function is the second copy — the first is pure dead text with no closing tag. Net line delta: -5/+0, comment-only, no behavior change.

Reviewer check: `git diff` on the file — the removed lines are a verbatim duplicate of the four lines immediately following them.

Local checks run: `bun run fmt` (clean), `bunx oxlint apps/web/src/components/sandbox/preview/preview.tsx` (0 warnings/errors). No type or test changes since this is a comment-only edit; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a duplicated, unterminated JSDoc block above `reloadIframeOrFallback` in `apps/web/src/components/sandbox/preview/preview.tsx`. Comment-only change, no behavior impact.

<sup>Written for commit 853205acbd01abd27713b4360393fb3348f6744c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

