### PR TITLE
fix(task-board): sweep a settled delivery-lane card into the archive, not just Done

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -789,7 +789,8 @@ export class TaskBoardStorage {
     const rows = await this.db
       .selectFrom("task_board_items as i")
       .select(["i.id", "i.organization_id as organizationId"])
-      .where("i.status", "=", "done")
+      // Not just Done — a delivery-lane org's shipped cards never reach it.
+      .where("i.status", "in", TAGGABLE_MERGED_STATUSES)
       .where("i.dismissed_at", "is", null)
       .where("i.updated_at", "<", settledBefore)
       .where((eb) =>

--- a/apps/api/src/tools/task-board/archive-merged.integration.test.ts
+++ b/apps/api/src/tools/task-board/archive-merged.integration.test.ts
@@ -118,8 +118,8 @@ describe("auto-archive sweep", () => {
     ]);
   });
 
-  // The delivery lanes sit BEFORE Done, so a card parked in one is still in flight.
-  it("never sweeps a card resting in a delivery lane", async () => {
+  // A shipped delivery-lane card never reaches literal `done` — see `shippedLane`.
+  it("sweeps a settled card resting in a delivery lane, same as Done", async () => {
     const settled = new Date(Date.now() - 3 * DAY_MS);
     const lanes = ["approved", "merged", "post_deploy_validation"] as const;
     const parked = await Promise.all(
@@ -131,16 +131,15 @@ describe("auto-archive sweep", () => {
       200,
     );
     const ids = candidates.map((c) => c.id);
-    for (const id of parked) expect(ids).not.toContain(id);
+    for (const id of parked) expect(ids).toContain(id);
 
-    // And the write path refuses too, even when handed the id directly.
     const swept = await archiveMergedForOrg(ctx, ORG, parked, async () => ({
       state: "closed" as const,
       merged: true,
     }));
-    expect(swept.archived).toBe(0);
-    for (const [i, id] of parked.entries()) {
-      expect((await taskBoard.getById(id, ORG))?.status).toBe(lanes[i]);
+    expect(swept.archived).toBe(lanes.length);
+    for (const id of parked) {
+      expect((await taskBoard.getById(id, ORG))?.status).toBe("archived");
     }
   });
 

--- a/apps/api/src/tools/task-board/archive-merged.ts
+++ b/apps/api/src/tools/task-board/archive-merged.ts
@@ -19,6 +19,7 @@ import { LANES } from "@decocms/shared/task-board";
 import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItemPrRef } from "@/storage/types";
 import { recordTaskActivity } from "./activity";
+import { isTaggableMergedStatus } from "./lanes";
 import { fetchPrLanding } from "./prs-get";
 import { emitTaskBoardUpdated } from "./run-reactions";
 
@@ -90,9 +91,9 @@ function repoLanded(prs: PrLanding[]): boolean {
 /**
  * Archive one candidate if its PRs are all merged. Returns whether it moved.
  *
- * Re-reads the card inside the org's context and re-checks `status === "done"`:
- * the sweep's work list is a snapshot, and a card someone dragged out of Done
- * (or another replica already archived) in the meantime must not be moved.
+ * Re-reads the card inside the org's context and re-checks it is still a
+ * shipped status: the sweep's work list is a snapshot, and a card someone
+ * dragged backward (or another replica already archived) must not be moved.
  */
 async function archiveIfMerged(
   ctx: StudioContext,
@@ -101,7 +102,7 @@ async function archiveIfMerged(
   prLanding: PrLandingReader,
 ): Promise<boolean> {
   const item = await ctx.storage.taskBoard.getById(itemId, organizationId);
-  if (!item || item.status !== "done") return false;
+  if (!item || !isTaggableMergedStatus(item.status)) return false;
 
   const prs = await ctx.storage.taskBoard.listPrs(itemId, organizationId);
   const landings = await Promise.all(
@@ -124,7 +125,11 @@ async function archiveIfMerged(
     taskBoardItemId: itemId,
     action: "status_changed",
     actorId: null,
-    data: { from: "done", to: archived, reason: "merged_pr_auto_archive" },
+    data: {
+      from: item.status,
+      to: archived,
+      reason: "merged_pr_auto_archive",
+    },
   });
   emitTaskBoardUpdated(organizationId, updated);
   return true;


### PR DESCRIPTION
**What**: The auto-archive sweep (`archive-merged.ts` / `listItemsAwaitingArchive`) still gated on the literal status `"done"`, but `shippedLane()` sends a delivery-lanes org's shipped cards to `"merged"`/`"post_deploy_validation"` instead — they never reach `"done"` on their own (see `packages/shared/src/task-board.ts`'s `shippedLane`). The merged-tag sweep hit the exact same gap and was already fixed to gate on the broader `TAGGABLE_MERGED_STATUSES`/`isTaggableMergedStatus` set (see the comment on `listItemsAwaitingMergedTag`), but the archive sweep was left behind on the old literal — so on any org running `delivery_lanes_enabled`, a shipped card never settles into the archive no matter how old it gets.

**Why a maintainer wants this**: the archive sweep is the only thing keeping Done from growing unbounded ("a Done column with 77 cards nobody reads" per its own doc comment); for a delivery-lanes org it currently does nothing at all, and nobody would notice until the board is unusable.

**Fix**: reused the already-established `isTaggableMergedStatus` (`lanes.ts`) and `TAGGABLE_MERGED_STATUSES` (`storage/task-board.ts`) that `tag-merged.ts` uses for the identical problem, in both the SQL candidate query and the in-process re-check gate. Also fixed the activity log recording a hardcoded `from: "done"` on every auto-archive — now records the card's real prior status, which matters once that status can be a delivery lane.

**Regression test**: inverted the existing integration test `"never sweeps a card resting in a delivery lane"` (which asserted the bug as intended behavior, with a misleading comment about lane ordering) into `"sweeps a settled card resting in a delivery lane, same as Done"`, mirroring the shape of `listItemsAwaitingMergedTag`'s own coverage.

**To verify**: `bun test apps/api/src/tools/task-board/archive-merged.integration.test.ts` (needs the real-Postgres test DB — this worktree has none, so I could not run it locally).

**Checked locally**: `bun test apps/api/src/tools/task-board/archive-merged.test.ts` (pure logic, unaffected by this change) passes; `tsc --noEmit` in `apps/api` is clean; `oxlint` on the three touched files is clean; `bun run fmt` applied. Full CI (including the real-Postgres integration test) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The auto-archive sweep now archives settled cards in delivery lanes, not just cards literally in Done.

- Delivery-lane orgs' shipped cards move to `merged`/`post_deploy_validation` and never reach `done`, so the old gate left them unarchived forever.
- Reuses the existing `isTaggableMergedStatus` and `TAGGABLE_MERGED_STATUSES` checks already used by the merged-tag sweep.
- The activity log now records the card's real prior status instead of a hardcoded `from: "done"`.
- Inverts the integration test that previously asserted the buggy behavior.

<sup>Written for commit bb6b2ec5fd5c6a8a10a3dda75b9bc72de88f224e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

