### PR TITLE
fix(sandbox-daemon): reject duplicate secondary repoName entries

### DIFF
--- a/packages/sandbox/daemon-go/internal/config/validate.go
+++ b/packages/sandbox/daemon-go/internal/config/validate.go
@@ -81,6 +81,7 @@ func validateGit(git *GitConfig) string {
 			return fmt.Sprintf("git.repository.branch invalid: %s", b)
 		}
 	}
+	seenRepoNames := make(map[string]bool, len(git.Repositories))
 	for i, repo := range git.Repositories {
 		if repo.CloneUrl == nil || *repo.CloneUrl == "" {
 			return fmt.Sprintf("git.repositories[%d].cloneUrl is required", i)
@@ -89,6 +90,13 @@ func validateGit(git *GitConfig) string {
 		if repo.RepoName == nil || !repoNameRe.MatchString(*repo.RepoName) {
 			return fmt.Sprintf("git.repositories[%d].repoName invalid", i)
 		}
+		// Two repos resolving to the same directory would clone concurrently
+		// into it (cloneSecondaryRepos fans out before any dir exists to skip
+		// on), corrupting both checkouts.
+		if seenRepoNames[*repo.RepoName] {
+			return fmt.Sprintf("git.repositories[%d].repoName duplicates another entry: %s", i, *repo.RepoName)
+		}
+		seenRepoNames[*repo.RepoName] = true
 		if repo.Branch != nil {
 			b := *repo.Branch
 			if !IsSyntheticBranch(b) && (!branchRe.MatchString(b) || strings.HasPrefix(b, "-")) {

--- a/packages/sandbox/daemon-go/internal/config/validate_test.go
+++ b/packages/sandbox/daemon-go/internal/config/validate_test.go
@@ -37,3 +37,16 @@ func TestValidateApplicationRejectsEscapingPmPath(t *testing.T) {
 		t.Fatal("validateApplication accepted a packageManager.path that escapes the repo root")
 	}
 }
+
+func TestValidateGitRejectsDuplicateSecondaryRepoNames(t *testing.T) {
+	git := &GitConfig{
+		Repository: &GitRepository{CloneUrl: Str("https://example.com/primary.git")},
+		Repositories: []GitRepository{
+			{CloneUrl: Str("https://example.com/a.git"), RepoName: Str("storefront")},
+			{CloneUrl: Str("https://example.com/b.git"), RepoName: Str("storefront")},
+		},
+	}
+	if reason := validateGit(git); reason == "" {
+		t.Fatal("validateGit accepted two secondary repositories with the same repoName, which resolve to the same clone directory")
+	}
+}


### PR DESCRIPTION
Bug found while auditing `packages/sandbox/daemon-go/internal/config/` and `internal/gitx/` for missing validation/error-handling gaps.

**Failure scenario:** `git.repositories` is a config patch surface reaching in from off-pod (the org's own client). `paths.SecondaryRepoDir(repoDir, name)` maps a `repoName` deterministically to one clone directory, but `validateGit` only validated each `repoName`'s shape individually — never that it's unique across the array. `Orchestrator.cloneSecondaryRepos` (internal/setup/orchestrator.go) builds its full job list (one job per repository) *before* any directory exists to skip on, then fans every job out concurrently (`secondaryCloneConcurrency = 4`) via `SpawnClone`. Two entries with the same `repoName` therefore become two `git clone` processes racing to write the same directory at once — a corrupted checkout, not a clean rejection.

**Fix:** `validateGit` now tracks seen `repoName`s and rejects a duplicate at the same trust boundary where every other per-repo shape check already lives, before it ever reaches the orchestrator's fan-out.

**Regression test:** `TestValidateGitRejectsDuplicateSecondaryRepoNames` in `validate_test.go` — two repositories with the same `repoName`, asserts `validateGit` returns a rejection reason instead of "".

**Reviewer command:** `cd packages/sandbox/daemon-go && go test ./internal/config/...`

**Local checks run:** `go test ./internal/config/...` (green), `gofmt -l` on both touched files (clean), `go vet ./internal/config/...` (clean). Full CI (daemon-e2e, rust-checks etc.) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects duplicate secondary `repoName` entries in `git.repositories` so two entries pointing to the same clone directory no longer race to clone concurrently. Previously, `validateGit` only checked each entry individually, so the orchestrator could launch two `git clone` processes into the same directory, corrupting the checkout. Now the validation rejects duplicates at the trust boundary before they reach the fan-out.

<sup>Written for commit 610c8856ce83f1c064df340d9dedc1350a8eaaef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

