### PR TITLE
refactor(task-board): remove redundant defensive code from useTaskBoardItemPrs

### DIFF
--- a/apps/web/src/hooks/use-task-board-item-prs.ts
+++ b/apps/web/src/hooks/use-task-board-item-prs.ts
@@ -51,9 +51,9 @@ export function useTaskBoardItemPrs(itemId: string | undefined) {
     // cached data, so the parse doesn't run on every render.
     initialData: () =>
       itemId
-        ? ((readCachedTaskPrs(locator, itemId)?.data as
+        ? (readCachedTaskPrs(locator, itemId)?.data as
             | TaskBoardItemPr[]
-            | undefined) ?? undefined)
+            | undefined)
         : undefined,
     initialDataUpdatedAt: () =>
       itemId ? readCachedTaskPrs(locator, itemId)?.updatedAt : undefined,


### PR DESCRIPTION
Simplify the `initialData` function in `useTaskBoardItemPrs` by removing a redundant no-op fallback. The cast to `TaskBoardItemPr[] | undefined` already includes undefined as a valid type, making the trailing `?? undefined` unnecessary.

**Why:** Removes unnecessary defensive code, improving code clarity without changing behavior.

**Changes:** -2 lines in `apps/web/src/hooks/use-task-board-item-prs.ts`

**Verification:**
- ✅ `bun test apps/web/src/lib/task-board-prs-cache.test.ts` — 5 pass
- ✅ `bunx oxlint` on both files — 0 warnings, 0 errors
- ✅ Behavior unchanged; cast still safely handles null/undefined

**To verify:** `bun test apps/web/src/lib/task-board-prs-cache.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the redundant `?? undefined` fallback in `useTaskBoardItemPrs`'s `initialData` function. The type cast already includes `undefined`, so the fallback is a no-op and behavior is unchanged.

<sup>Written for commit ae4ff369979df4e9f8bfbc3dcdea5c6dd81b6622. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

