### PR TITLE
refactor(blog): dedupe the 'string-or-JSON.stringify' block field shape

### DIFF
--- a/apps/web/src/components/sandbox/content/blog/blocks/block-registry.tsx
+++ b/apps/web/src/components/sandbox/content/blog/blocks/block-registry.tsx
@@ -29,6 +29,11 @@ import { str } from "./primitives";
 
 export type RawBlock = { __resolveType?: string } & Record<string, unknown>;
 
+/** A block field that's already a JSON string, or an array/object to stringify. */
+function jsonStr(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value ?? []);
+}
+
 /**
  * Render a single block as its native, inline-editable representation
  * (Notion-style). Common blocks get bespoke editors matched by component
@@ -141,11 +146,7 @@ export function BlockEditor({
       case "CardGroup":
         return (
           <CardGroupBlock
-            cards={
-              typeof block.cards === "string"
-                ? block.cards
-                : JSON.stringify(block.cards ?? [])
-            }
+            cards={jsonStr(block.cards)}
             onChange={(cards) => onChange({ ...block, cards })}
           />
         );
@@ -176,16 +177,8 @@ export function BlockEditor({
       case "Table":
         return (
           <TableBlock
-            headers={
-              typeof block.headers === "string"
-                ? block.headers
-                : JSON.stringify(block.headers ?? [])
-            }
-            rows={
-              typeof block.rows === "string"
-                ? block.rows
-                : JSON.stringify(block.rows ?? [])
-            }
+            headers={jsonStr(block.headers)}
+            rows={jsonStr(block.rows)}
             onChange={(next) => onChange({ ...block, ...next })}
           />
         );


### PR DESCRIPTION
**Source:** reduction found while auditing `apps/web/src/components/sandbox/content/blog/` (blog sandbox UI area) for dead code/duplication, per the ship-it checklist's dedup guidance.

**What:** `BlockEditor` in `blocks/block-registry.tsx` repeated the identical ternary — "if this block field is already a JSON string, pass it through, otherwise `JSON.stringify` it (defaulting to `[]`)" — three times (CardGroup's `cards`, Table's `headers`, Table's `rows`). Extracted the one-line `jsonStr()` helper (matching the existing local `str()` helper's style/placement in this file) and replaced all three call sites.

**Why a maintainer wants it:** removes copy-pasted logic that would otherwise need three edits if the field-normalization rule ever changes (e.g. a null vs `[]` default), with zero behavior change.

**Net delta:** -15 / +8 lines, purely mechanical — same runtime behavior (verified by reading: `jsonStr(v)` is byte-identical to each removed ternary).

**Reviewer check:** `cd apps/web && bunx tsc --noEmit -p .` (no new errors from this file) and `bunx oxlint src/components/sandbox/content/blog/blocks/block-registry.tsx` (0 warnings/errors).

**Locally verified:** `bun run fmt`, `bunx oxlint` on the changed file, and a scoped `tsc --noEmit` in `apps/web` (no errors touching this file). No existing test covers this file's render branches, so nothing to invert; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts the repeated `string-or-JSON.stringify` block field normalization logic in `BlockEditor` into a single `jsonStr()` helper, removing three copies of the same ternary. Behavior is unchanged; future changes to the default (e.g., null vs `[]`) become a one-line edit.

<sup>Written for commit 55c49eed12f04faff2c1b06b156c14c3e67ea349. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

