### PR TITLE
fix(connections): clear the decrypt-failure tracker entry on connection delete

### DIFF
--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -37,6 +37,7 @@ import {
 import { getConnectionSlug } from "@decocms/shared/utils/connection-slug";
 import { CONNECTION_DECRYPT_DISABLE_THRESHOLD } from "../core/constants";
 import {
+  clearDecryptFailure,
   isDecryptDisabled,
   markDecryptDisabled,
   recordDecryptFailure,
@@ -484,6 +485,8 @@ export class ConnectionStorage implements ConnectionStoragePort {
 
   async delete(id: string): Promise<void> {
     await this.db.deleteFrom("connections").where("id", "=", id).execute();
+    // Drop the tracker entry so it doesn't linger in the bounded map until LRU-evicted.
+    clearDecryptFailure(id);
   }
 
   async testConnection(

--- a/apps/api/src/storage/decrypt-failure-tracker.test.ts
+++ b/apps/api/src/storage/decrypt-failure-tracker.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { CONNECTION_DECRYPT_DISABLE_THRESHOLD } from "../core/constants";
 import {
+  clearDecryptFailure,
   isDecryptDisabled,
   markDecryptDisabled,
   recordDecryptFailure,
@@ -48,5 +49,15 @@ describe("decrypt-failure-tracker", () => {
     recordDecryptFailure("conn_x");
     const y = recordDecryptFailure("conn_y");
     expect(y.consecutiveFailures).toBe(1);
+  });
+
+  it("clearDecryptFailure drops all tracked state for the connection", () => {
+    const id = "conn_deleted";
+    markDecryptDisabled(id);
+    expect(isDecryptDisabled(id)).toBe(true);
+    clearDecryptFailure(id);
+    expect(isDecryptDisabled(id)).toBe(false);
+    // A fresh connection reusing the id starts its own clean failure count.
+    expect(recordDecryptFailure(id).consecutiveFailures).toBe(1);
   });
 });

--- a/apps/api/src/storage/decrypt-failure-tracker.ts
+++ b/apps/api/src/storage/decrypt-failure-tracker.ts
@@ -95,6 +95,11 @@ export function recordDecryptSuccess(connectionId: string): void {
   entries.delete(connectionId);
 }
 
+/** Drop all tracked state for a connection. Call when the connection itself is deleted. */
+export function clearDecryptFailure(connectionId: string): void {
+  entries.delete(connectionId);
+}
+
 /** Reset all tracked state. Exposed for testing only. */
 export function resetAll(): void {
   entries.clear();


### PR DESCRIPTION
Follows the same connection-delete cleanup pattern as #6980 (OAuth refresh backoff): `storage/connection.ts`'s `delete()` removed the DB row but never cleared the connection's entry in `decrypt-failure-tracker.ts`'s in-memory `entries` Map, which keys purely on connection id with no FK behind it.

Why it matters: the tracker's map is bounded (`CIRCUIT_BREAKER_MAX_ENTRIES = 1000`, LRU-evicted), so this isn't unbounded growth, but a deleted connection's failure/disabled state lingers and occupies a slot until evicted instead of being freed immediately — the same class of stale-record leak the focus area asked to audit for.

Fix: added `clearDecryptFailure(connectionId)` to `decrypt-failure-tracker.ts` (a thin wrapper around the existing `entries.delete`, mirroring `recordDecryptSuccess`'s clear but named for the delete-path call site) and call it from `ConnectionStorage.delete()`.

Regression test: `decrypt-failure-tracker.test.ts` now asserts that after `markDecryptDisabled` + `clearDecryptFailure`, `isDecryptDisabled` reports false and a fresh failure count starts at 1 — i.e. no stale disabled/failure state survives past the clear.

Reviewer check: `bun test apps/api/src/storage/decrypt-failure-tracker.test.ts`.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test above (5 pass), and `bunx oxlint` on the three touched files (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a leak in the decrypt-failure tracker where deleted connections kept their failure/disabled state in memory until LRU eviction.

**Changes**
- Adds `clearDecryptFailure()` to the tracker and calls it from `ConnectionStorage.delete()`.
- Adds a regression test asserting state is cleared and a fresh failure count starts at 1.

<sup>Written for commit ad529f07a6020de05c607f6f7c7e1a73f7e9d5b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

