### PR TITLE
fix(oauth): narrow MINT_REPO_TOKEN's response with typeof before storing it

### DIFF
--- a/apps/api/src/oauth/github-mint.test.ts
+++ b/apps/api/src/oauth/github-mint.test.ts
@@ -1,6 +1,66 @@
 import { describe, expect, it } from "bun:test";
-import { resolveGhsExpiry } from "./github-mint";
-import { GHS_TOKEN_LIFETIME_MS } from "./token-refresh";
+import { extractMintedToken, resolveGhsExpiry } from "./github-mint";
+import { GHS_TOKEN_LIFETIME_MS, RECONNECT_ERROR } from "./token-refresh";
+
+describe("extractMintedToken", () => {
+  it("returns the token and parsed expiry on a well-formed result", () => {
+    const result = extractMintedToken({
+      structuredContent: {
+        token: "ghs_abc",
+        expiresAt: "2026-01-01T00:00:00Z",
+      },
+    });
+    expect(result.accessToken).toBe("ghs_abc");
+    expect(result.expiresAt?.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("defaults expiresAt to null when absent", () => {
+    const result = extractMintedToken({
+      structuredContent: { token: "ghs_abc" },
+    });
+    expect(result.expiresAt).toBeNull();
+  });
+
+  it("throws when the tool reports isError", () => {
+    expect(() =>
+      extractMintedToken({
+        isError: true,
+        structuredContent: { token: "ghs_abc" },
+      }),
+    ).toThrow(RECONNECT_ERROR);
+  });
+
+  it("throws when token is missing", () => {
+    expect(() => extractMintedToken({ structuredContent: {} })).toThrow(
+      RECONNECT_ERROR,
+    );
+  });
+
+  it("throws when token is not a string (malformed tool response)", () => {
+    expect(() =>
+      extractMintedToken({
+        structuredContent: { token: { nested: "object" } as unknown as string },
+      }),
+    ).toThrow(RECONNECT_ERROR);
+  });
+
+  it("falls back to null expiry when expiresAt is not a string", () => {
+    const result = extractMintedToken({
+      structuredContent: {
+        token: "ghs_abc",
+        expiresAt: 12345 as unknown as string,
+      },
+    });
+    expect(result.expiresAt).toBeNull();
+  });
+
+  it("falls back to null expiry when expiresAt is an unparseable string", () => {
+    const result = extractMintedToken({
+      structuredContent: { token: "ghs_abc", expiresAt: "not-a-date" },
+    });
+    expect(result.expiresAt).toBeNull();
+  });
+});
 
 describe("resolveGhsExpiry", () => {
   const now = Date.now();

--- a/apps/api/src/oauth/github-mint.ts
+++ b/apps/api/src/oauth/github-mint.ts
@@ -32,6 +32,34 @@ interface MintedToken {
   expiresAt: Date | null;
 }
 
+type MintResult = {
+  isError?: boolean;
+  structuredContent?: { token?: unknown; expiresAt?: unknown };
+  content?: Array<{ type?: string; text?: string }>;
+};
+
+/**
+ * MINT_REPO_TOKEN's structuredContent is untrusted output from a called MCP
+ * tool — narrow with typeof (like `access_token` in refresh-access-token.ts)
+ * rather than trusting the `MintResult` cast, so a malformed/non-string token
+ * or expiresAt can't reach the token vault or produce an Invalid Date.
+ * Exported for unit testing; not part of the module's public API.
+ */
+export function extractMintedToken(res: MintResult): MintedToken {
+  const token = res.structuredContent?.token;
+  if (res.isError || typeof token !== "string" || !token) {
+    throw new Error(RECONNECT_ERROR);
+  }
+  const expiresAtRaw = res.structuredContent?.expiresAt;
+  const expiresAt =
+    typeof expiresAtRaw === "string" ? new Date(expiresAtRaw) : null;
+  return {
+    accessToken: token,
+    expiresAt:
+      expiresAt && !Number.isNaN(expiresAt.getTime()) ? expiresAt : null,
+  };
+}
+
 /**
  * Mint a fresh repo-scoped token by calling MINT_REPO_TOKEN through the org
  * connection named in the recipe. Validates org ownership of the source
@@ -69,12 +97,6 @@ async function mintRepoToken(
   // injected as the bearer either way (the gate needs the user-to-server token).
   const client = await clientFromConnection(orgConn, ctx, true);
   try {
-    type MintResult = {
-      isError?: boolean;
-      structuredContent?: { token?: string; expiresAt?: string };
-      content?: Array<{ type?: string; text?: string }>;
-    };
-
     // Self-heal legacy recipes: re-add the optional reads each re-mint, shedding whichever the installation hasn't granted yet (see the helper's note).
     const { result: res } = await mintRepoTokenWithFallback<MintResult>(
       (permissions) =>
@@ -90,15 +112,7 @@ async function mintRepoToken(
       withOptionalReadPermissions(recipe.permissions),
     );
 
-    const token = res.structuredContent?.token;
-    if (res.isError || !token) {
-      throw new Error(RECONNECT_ERROR);
-    }
-    const expiresAtRaw = res.structuredContent?.expiresAt;
-    return {
-      accessToken: token,
-      expiresAt: expiresAtRaw ? new Date(expiresAtRaw) : null,
-    };
+    return extractMintedToken(res);
   } finally {
     await client.close().catch(() => {});
   }


### PR DESCRIPTION
**Source:** bug found while hardening the OAuth token-refresh lane (`apps/api/src/oauth/`).

**Why:** `github-mint.ts`'s `mintRepoToken` reads `res.structuredContent?.token` from the (untrusted) response of the `MINT_REPO_TOKEN` MCP tool call and passes it straight through as the connection's `accessToken`, trusting an unchecked `as MintResult` cast. Every sibling OAuth response-parsing path in this same directory (`refresh-access-token.ts`'s `access_token`/`expires_in` handling) explicitly narrows with `typeof` before trusting server-controlled fields — this one didn't, so a malformed or non-string `token`/`expiresAt` from a misbehaving/misconfigured `mcp-github`-slugged connection would reach the token vault (`tokenStorage.upsert`) as a non-string `accessToken`, or produce an `Invalid Date` for `expiresAt`.

**Fix:** extracted the parsing into a pure `extractMintedToken(res)` helper that:
- rejects (`RECONNECT_ERROR`) when `structuredContent.token` isn't a non-empty string (matches the `access_token` typeof-guard pattern in `refresh-access-token.ts`)
- only accepts `expiresAt` when it's a string that parses to a valid `Date`, otherwise falls back to `null` (the existing `resolveGhsExpiry` fallback then computes a safe expiry)

Behavior-preserving for well-formed responses (byte-identical logic, just extracted + typeof-guarded); the only behavior change is refusing to persist a malformed field instead of silently trusting it.

**Verify:** `bun test apps/api/src/oauth/github-mint.test.ts` — 6 new cases covering isError, missing/non-string token, and non-string/unparseable expiresAt, plus the existing `resolveGhsExpiry` suite, all green.

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the OAuth token-refresh lane by type-checking `MINT_REPO_TOKEN`'s response before persisting it, so malformed tool output can't reach the token vault.

- Extracts parsing into `extractMintedToken`, which rejects non-string tokens and falls back to `null` expiry for invalid dates.
- Throws `RECONNECT_ERROR` when the token is missing or not a string, matching the pattern in `refresh-access-token.ts`.
- Behavior is unchanged for well-formed responses; only malformed fields are now rejected.

<sup>Written for commit c49a095b93ecb324aa9a41f6197184f6cc9bb913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

