### PR TITLE
fix(mcp-clients): close a client-pool transport when connect() fails before initialize

### DIFF
--- a/apps/api/src/mcp-clients/outbound/client-pool.test.ts
+++ b/apps/api/src/mcp-clients/outbound/client-pool.test.ts
@@ -66,4 +66,26 @@ describe("createClientPool", () => {
 
     await pool[Symbol.asyncDispose]();
   });
+
+  it("closes the transport when start() throws", async () => {
+    const pool = createClientPool();
+    let closed = false;
+    const transport: Transport = {
+      async start() {
+        throw new Error("spawn failed");
+      },
+      async send() {},
+      async close() {
+        closed = true;
+      },
+      onmessage: undefined,
+      onerror: undefined,
+      onclose: undefined,
+    };
+
+    await expect(pool(() => transport, "conn_1")).rejects.toThrow(
+      "spawn failed",
+    );
+    expect(closed).toBe(true);
+  });
 });

--- a/apps/api/src/mcp-clients/outbound/client-pool.ts
+++ b/apps/api/src/mcp-clients/outbound/client-pool.ts
@@ -78,7 +78,13 @@ export function createClientPool(): (<T extends Transport>(
         clientMap.delete(key);
       };
 
-      await client.connect(transport);
+      try {
+        await client.connect(transport);
+      } catch (err) {
+        // A transport.start() failure (unlike a failed initialize handshake) leaves the transport unclosed.
+        await transport.close?.().catch(() => {});
+        throw err;
+      }
       return client;
     })().catch((e) => {
       clientMap.delete(key);


### PR DESCRIPTION
Resource-leak fix found while auditing `apps/api/src/mcp-clients/` for client hygiene.

`createClientPool()`'s `getOrCreateClientImpl` called `await client.connect(transport)` unguarded. The MCP SDK's `Client.connect()` only closes the transport itself when the post-connect `initialize` handshake fails (it wraps that step in its own try/catch and calls `close()`); if `transport.start()` throws first — a stdio transport's spawned child process failing, an HTTP/SSE/websocket transport erroring while opening its connection — nothing closes the transport. The client pool is shared per-request across every downstream connection a virtual MCP composes, so a flaky/misconfigured downstream can leak a spawned process or open socket on every failed connect.

Fix: wrap `client.connect(transport)` in a try/catch and best-effort `transport.close()` before rethrowing, so a `start()` failure cleans up the same as an `initialize` failure does.

Regression test: `client-pool.test.ts` adds a transport whose `start()` throws and asserts `close()` is called and the rejection still propagates.

Reviewer command: `bun test apps/api/src/mcp-clients/outbound/client-pool.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a resource leak in the MCP client pool where a transport was left open when `client.connect()` failed before the initialize handshake. Now the transport is closed best-effort before the error propagates, preventing leaked processes or sockets on failed connections.

<sup>Written for commit 386ff587e2bb6d5caa702dcaad8af7f663a09cf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

