### PR TITLE
fix(i18n): standardize sandbox editing breadcrumb translation in pt-br

### DIFF
--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -7,7 +7,8 @@ export const sandbox = {
   "sandbox.appEditor.loadingSchema": "Carregando schema do app…",
   "sandbox.appEditor.noEditableSchema":
     "Nenhum schema editável foi encontrado para este app.",
-  "sandbox.availableSectionEditor.editingBreadcrumb": "Navegação de edição",
+  "sandbox.availableSectionEditor.editingBreadcrumb":
+    "Trilha de navegação de edição",
   "sandbox.availableSectionEditor.localEditsHint":
     "{typeLabel} — edições permanecem locais até que você salve isto como uma seção global.",
   "sandbox.availableSectionEditor.noEditableFields":
@@ -617,7 +618,7 @@ export const sandbox = {
   "sandbox.runnableBlockEditor.collapseResult": "Recolher resultado",
   "sandbox.runnableBlockEditor.editAsJson": "Editar como JSON",
   "sandbox.runnableBlockEditor.editingBreadcrumb":
-    "Trilha de migalhas da edição",
+    "Trilha de navegação de edição",
   "sandbox.runnableBlockEditor.expand": "Expandir",
   "sandbox.runnableBlockEditor.expandResult": "Expandir resultado",
   "sandbox.runnableBlockEditor.failedToRun": "Falha ao executar {singular}",
@@ -672,7 +673,8 @@ export const sandbox = {
     "Caminho (relativo à raiz do repositório) do diretório que contém package.json. Deixe em branco para a raiz do repositório.",
   "sandbox.savedSectionEditor.closeJsonEditor": "Fechar editor JSON",
   "sandbox.savedSectionEditor.editAsJson": "Editar como JSON",
-  "sandbox.savedSectionEditor.editingBreadcrumb": "Trilha de edição",
+  "sandbox.savedSectionEditor.editingBreadcrumb":
+    "Trilha de navegação de edição",
   "sandbox.savedSectionEditor.globalSectionDescription":
     "Seção global — alterações são salvas automaticamente e aplicadas em todos os locais onde é usada.",
   "sandbox.savedSectionEditor.invalidJsonError":


### PR DESCRIPTION
## Summary
Standardize inconsistent Portuguese translations for the "editingBreadcrumb" concept across four sandbox editor components.

## Issue
All four keys share the same English value "Editing breadcrumb" but had four different Portuguese translations:
- `appEditor.editingBreadcrumb` → "Trilha de navegação de edição"
- `availableSectionEditor.editingBreadcrumb` → "Navegação de edição"
- `runnableBlockEditor.editingBreadcrumb` → "Trilha de migalhas da edição"
- `savedSectionEditor.editingBreadcrumb` → "Trilha de edição"

## Fix
Updated all four to consistently use "Trilha de navegação de edição" (the most complete and descriptive translation).

## Line delta
-3 / +5 (net +2 lines due to formatting; no logic changes)

## Verification
✅ `bun run fmt` — no issues
✅ `bunx tsc --ignoreConfig --noEmit` on pt-br/sandbox.ts — passes (satisfies constraint verified)
✅ `bunx oxlint apps/web/src/i18n/pt-br/sandbox.ts` — 0 warnings, 0 errors

## How to confirm
```bash
grep -A1 "editingBreadcrumb" apps/web/src/i18n/pt-br/sandbox.ts | grep -oE '"[^"]+"$' | sort -u
```
Should show only one unique translation across all four keys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the pt-br translation for the sandbox editing breadcrumb across four editor components, replacing three inconsistent translations with "Trilha de navegação de edição". No behavior change.

<sup>Written for commit c3efcda7030ad12333435a6a15b5a787dd3ba541. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

