### PR TITLE
fix(secrets): cap SECRET_CREATE's value at 64KB

### DIFF
--- a/apps/api/src/tools/secrets/create.test.ts
+++ b/apps/api/src/tools/secrets/create.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { MAX_SECRET_VALUE_LENGTH, SECRET_CREATE } from "./create";
+
+describe("SECRET_CREATE input schema", () => {
+  const base = { scope: "organization" as const, name: "api-key" };
+
+  test("accepts a value at the length cap", () => {
+    const result = SECRET_CREATE.inputSchema.safeParse({
+      ...base,
+      value: "a".repeat(MAX_SECRET_VALUE_LENGTH),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a value over the length cap", () => {
+    const result = SECRET_CREATE.inputSchema.safeParse({
+      ...base,
+      value: "a".repeat(MAX_SECRET_VALUE_LENGTH + 1),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/tools/secrets/create.ts
+++ b/apps/api/src/tools/secrets/create.ts
@@ -3,6 +3,9 @@ import { defineTool } from "../../core/define-tool";
 import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { secretInfoSchema } from "./schema";
 
+// Caps the encrypted-at-rest text column against an unbounded caller payload.
+export const MAX_SECRET_VALUE_LENGTH = 65_536;
+
 export const SECRET_CREATE = defineTool({
   name: "SECRET_CREATE",
   description:
@@ -17,7 +20,7 @@ export const SECRET_CREATE = defineTool({
         message:
           "Name may only contain letters, digits, underscore, dot, and hyphen.",
       }),
-    value: z.string().min(1),
+    value: z.string().min(1).max(MAX_SECRET_VALUE_LENGTH),
     description: z.string().max(500).optional(),
   }),
   outputSchema: secretInfoSchema,


### PR DESCRIPTION
**Source:** bug found while hunting the storage layer for validation gaps on untrusted input (the `SECRET_CREATE` value crosses a trust boundary — it's caller-supplied and gets encrypted into a `text` column with no DB-level bound).

**Why it matters:** `SECRET_CREATE`'s `value` field had `z.string().min(1)` with no upper bound, while every sibling field on the same tool (`name`, `description`) and every comparable free-text input elsewhere in the repo (`MAX_TASK_DESCRIPTION_LENGTH`, `MAX_COMMENT_BODY_LENGTH`, etc., all capped at 50k) is bounded. An org member (or a compromised/misbehaving MCP client) could push an arbitrarily large payload into the `secrets.encrypted_value` `text` column — unbounded storage growth and vault-encryption cost per secret.

**Fix:** added `MAX_SECRET_VALUE_LENGTH = 65_536` (64KB — generous headroom over real credentials like API keys, tokens, or PEM certs) and applied it to the `value` field's Zod schema in `SECRET_CREATE`.

**Regression test:** `apps/api/src/tools/secrets/create.test.ts` asserts the input schema accepts a value at the cap and rejects one byte over it.

**To verify:** `bun test apps/api/src/tools/secrets/create.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `SECRET_CREATE`'s `value` field at 64KB so callers can no longer push arbitrarily large payloads into the encrypted-at-rest secrets column. The schema previously allowed any value length; now it rejects values over 65,536 characters.

- Adds a regression test asserting the boundary behavior.

<sup>Written for commit 2ff12479403d2b89b424e18cb1f2cceb4b63f5b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

