### PR TITLE
fix(sandbox): translate ItemRow's hardcoded select-checkbox aria-label

### DIFF
--- a/apps/web/src/components/sandbox/content/item-row.tsx
+++ b/apps/web/src/components/sandbox/content/item-row.tsx
@@ -7,6 +7,7 @@ import {
 } from "@decocms/ui/components/tooltip.tsx";
 import { cn } from "@decocms/ui/lib/utils.ts";
 import { GLOBAL_SECTION_ICON_COLOR } from "@/components/sections-editor/section-types";
+import { useT } from "@/i18n/use-t.ts";
 
 export function ItemRow({
   icon: Icon,
@@ -51,6 +52,7 @@ export function ItemRow({
   onClick: () => void;
   menu?: React.ReactNode;
 }) {
+  const t = useT();
   const isGlobal = accent === "global";
   const rowIcon =
     variantCount && variantCount > 1 ? (
@@ -113,7 +115,7 @@ export function ItemRow({
           <Checkbox
             checked={selected}
             onCheckedChange={() => onToggleSelect?.()}
-            aria-label={`Select ${title}`}
+            aria-label={t("sandbox.itemRow.selectItem", { title })}
           />
         </span>
       )}

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -248,6 +248,7 @@ export const sandbox = {
   "sandbox.itemActions.moreActions": "More actions",
   "sandbox.itemActions.rename": "Rename",
   "sandbox.itemActions.viewJson": "View JSON",
+  "sandbox.itemRow.selectItem": "Select {title}",
   "sandbox.listBlocks.addCard": "Add card",
   "sandbox.listBlocks.addItem": "Add item",
   "sandbox.listBlocks.addStat": "Add stat",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -257,6 +257,7 @@ export const sandbox = {
   "sandbox.itemActions.moreActions": "Mais ações",
   "sandbox.itemActions.rename": "Renomear",
   "sandbox.itemActions.viewJson": "Visualizar JSON",
+  "sandbox.itemRow.selectItem": "Selecionar {title}",
   "sandbox.listBlocks.addCard": "Adicionar card",
   "sandbox.listBlocks.addItem": "Adicionar item",
   "sandbox.listBlocks.addStat": "Adicionar estatística",


### PR DESCRIPTION
Every other file in `apps/web/src/components/sandbox/content/` routes its aria-labels through `useT()` (see `item-actions.tsx`, `post-toolbar.tsx`, `runnable-block-editor.tsx`), but `item-row.tsx`'s per-row select checkbox used a raw template string (`` `Select ${title}` ``), which violates the repo's i18n rule (never hardcode user-facing strings in `apps/web/src`) and leaves pt-br users with an English screen-reader label on every list row (pages, sections, posts, apps, blog entries) in the content browser.

This PR adds `sandbox.itemRow.selectItem` ("Select {title}" / "Selecionar {title}") to the en/pt-br dictionaries — following the same `{param}` interpolation pattern already used by `sandbox.runnableBlockEditor.runAriaLabel` — and switches `ItemRow` to `useT()`.

Reviewer check: open any content-browser list (Pages/Sections/Posts) with the org's language set to pt-br and hover a row's checkbox with a screen reader / inspect its `aria-label` — it now reads "Selecionar <título>" instead of "Select <title>".

Verified locally:
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/web` (no new errors; one pre-existing unrelated prosemirror version-mismatch error in `mention-suggestion.tsx` is untouched by this diff)
- `bunx oxlint` on the three changed files (0 warnings/errors)

No test added: this is a one-line string-source swap with no branching logic to regress-test. Full CI (typecheck, lint, unit) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `ItemRow`'s select-checkbox `aria-label` through `useT()` instead of a hardcoded English string, so pt-br users now get "Selecionar {title}" in screen readers instead of "Select {title}". Adds the new `sandbox.itemRow.selectItem` key to the en and pt-br dictionaries.

<sup>Written for commit b11b6ff7413aab1dce3b1a6fd4ac80ef55709521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

