### PR TITLE
refactor(e2e): use @decocms/shared/std sleep in settings-navigation test

### DIFF
--- a/packages/e2e/tests/settings-navigation.spec.ts
+++ b/packages/e2e/tests/settings-navigation.spec.ts
@@ -5,6 +5,7 @@
  *  tabs merged into one page, so it shows NO strip and carries keys as a
  *  section. */
 
+import { sleep } from "@decocms/shared/std";
 import { expect, test } from "../fixtures/test";
 
 const SIDEBAR = '[data-slot="sidebar"]';
@@ -115,7 +116,7 @@ test.describe("settings tabs", () => {
     // is still loading — the whole page used to blank out at this moment.
     await page.route("**/api/*/mcp", async (route) => {
       if (route.request().postData()?.includes("FILE_CONFIG_LIST")) {
-        await new Promise((resolve) => setTimeout(resolve, 3000));
+        await sleep(3000);
       }
       await route.continue();
     });


### PR DESCRIPTION
Reduction: `packages/e2e/tests/settings-navigation.spec.ts` hand-rolled `new Promise((resolve) => setTimeout(resolve, 3000))` inside a mocked `page.route` handler to hold a fetch open, instead of using the repo's canonical `sleep()` from `@decocms/shared/std` (per CLAUDE.md's async-primitives rule — this exact helper is already imported in the same package, e.g. `commerce-onboarding.spec.ts`).

Why it matters: `@decocms/shared/std` is the single consolidated home for sleep/backoff after the repo deduped ~9 ad-hoc copies; a fresh hand-roll is exactly the kind of copy that rule exists to prevent, and this one lives in test code a reviewer would otherwise have to re-verify by hand.

Behavior-preserving: `sleep(ms)` from `@decocms/shared/std` resolves after `ms`, identical to the `setTimeout` it replaces — same 3s delay before `route.continue()`, no change to what the test asserts.

Net delta: +2/-1 (adds the import, swaps the one call site).

How to verify: `cd packages/e2e && bunx tsc --noEmit` (clean); `bunx oxlint packages/e2e/tests/settings-navigation.spec.ts` (0 warnings/errors). I did not run the Playwright suite itself (needs Docker/Postgres/NATS infra not available in this sandbox) — full CI validates that; the change is a drop-in replacement of one async primitive so the test's own logic is untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hand-rolled `new Promise((resolve) => setTimeout(resolve, 3000))` in the settings-navigation e2e test with the canonical `sleep()` from `@decocms/shared/std`, per the repo's async-primitives rule. Behavior is unchanged — the mocked route still waits 3 seconds before continuing.

<sup>Written for commit 4e92e70e15c0b82457c87f64f4405c3d9d8a83b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

