### PR TITLE
fix(sandbox-daemon): retry a transient network failure on git push

### DIFF
--- a/packages/sandbox/daemon-go/internal/gitx/publish.go
+++ b/packages/sandbox/daemon-go/internal/gitx/publish.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/decocms/studio/sandbox-daemon/internal/decofile"
 )
@@ -232,6 +233,36 @@ func expandUntrackedDirs(repoDir string, paths []string) []string {
 	return out
 }
 
+// transientPushErrors mirrors setup.transientErrors: the network failures a
+// retry can plausibly outlive, as opposed to an auth/permission/protected-branch
+// rejection where retrying wastes the shutdown-sync window for nothing.
+var transientPushErrors = []string{
+	"Could not resolve host",
+	"early EOF",
+	"unexpected disconnect",
+	"Connection reset by peer",
+	"Connection timed out",
+	"Operation too slow",
+	"transfer closed with",
+	"RPC failed",
+	"the remote end hung up",
+}
+
+const (
+	pushMaxRetries   = 2
+	pushRetryDelayMs = 2000
+)
+
+func isTransientPushError(err error) bool {
+	message := FormatGitError(err)
+	for _, e := range transientPushErrors {
+		if strings.Contains(message, e) {
+			return true
+		}
+	}
+	return false
+}
+
 var gitPushConfig = []string{"-c", "credential.helper=", "-c", "safe.directory=*"}
 
 func pushEnv(repoDir string) map[string]string {
@@ -249,9 +280,16 @@ func pushBranch(repoDir, branch string, reconcileRemote bool) error {
 	// --no-verify: a repo's pre-push script can hang the push, and the shutdown
 	// sync shares this path with no room to wait it out before SIGKILL.
 	args := append(append([]string{}, gitPushConfig...), "push", "--no-verify", "-u", "origin", branch)
-	_, err := Run(args, RunOpts{Cwd: repoDir, Env: pushEnv(repoDir)})
-	if err == nil {
-		return nil
+	var err error
+	for attempt := 0; ; attempt++ {
+		_, err = Run(args, RunOpts{Cwd: repoDir, Env: pushEnv(repoDir)})
+		if err == nil {
+			return nil
+		}
+		if attempt >= pushMaxRetries || !isTransientPushError(err) {
+			break
+		}
+		time.Sleep(pushRetryDelayMs * time.Millisecond)
 	}
 	// origin/<branch> diverged: a prior publish force-pushed a rebased history,
 	// or the sandbox was re-provisioned from base and lost the branch's local

--- a/packages/sandbox/daemon-go/internal/gitx/publish_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/publish_test.go
@@ -119,6 +119,17 @@ func TestPublishAuthorsCommitAsOperator(t *testing.T) {
 	}
 }
 
+func TestIsTransientPushError(t *testing.T) {
+	transient := &GitError{Msg: "git push exited 128: fatal: unable to access 'https://...': Could not resolve host: github.com", Status: 128}
+	if !isTransientPushError(transient) {
+		t.Fatal("expected a DNS failure to be classified as transient")
+	}
+	permanent := &GitError{Msg: "git push exited 1: ! [rejected] feature/x -> feature/x (fetch first)", Status: 1}
+	if isTransientPushError(permanent) {
+		t.Fatal("a non-fast-forward rejection must not be retried as transient")
+	}
+}
+
 // Discarding a staged rename must restore the original file at its original
 // path, not delete it: the new path never existed at HEAD, so treating it as
 // merely "untracked" loses the content entirely once the old path is also


### PR DESCRIPTION
**Source:** bug found while auditing `packages/sandbox/daemon-go/internal/gitx/publish.go` per this tick's focus area (harden the GitX publisher's error paths / transient-network retry policy).

**The gap:** `pushBranch` (called by both interactive `Publish` and the shutdown autosave sync) makes exactly one `git push` attempt. A single flaky network blip (DNS hiccup, connection reset, TLS timeout) permanently fails the publish/sync with no retry — even though the daemon already treats the *same class* of errors as retriable elsewhere: `internal/setup/clone.go` retries a clone/fetch step up to 3x on an identical transient-error string list (`Could not resolve host`, `early EOF`, `Connection reset by peer`, `RPC failed`, etc.). The push path never got that treatment.

**Why it matters:** publish is user-facing ("Publish" button) and also runs unattended on every sandbox teardown (autosave.go) with no chance for the user to just click retry — a transient network error there silently drops the user's work instead of reaching origin.

**Fix:** `pushBranch` now retries the initial `git push` up to `pushMaxRetries` (2) times with a short delay when the failure matches the same transient-network substring list clone.go already uses, mirroring the existing `isTransient`/retry-loop pattern. A non-fast-forward rejection or any other non-transient failure (auth, protected branch, hook rejection) is *not* retried — same behavior as before. The existing reconcile/force-push fallback is unchanged and still runs against the final `err`.

**Regression test:** `TestIsTransientPushError` in `publish_test.go` asserts a DNS-resolution failure is classified transient (would now retry) and a `[rejected] ... (fetch first)` non-fast-forward rejection is not (must not retry — that path needs the reconcile/force-push logic, not a blind retry).

**Verify:** `cd packages/sandbox/daemon-go && go build ./... && go test ./internal/gitx/ -run 'TestIsTransientPushError|TestPublish|TestDiscard|TestInstallSandboxHooks' -v`

**Checked locally:** `go build ./...`, `go vet ./internal/gitx/...`, and the targeted test file above all pass. Full CI (daemon-e2e, rust-checks, etc.) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient network failures during `git push` so a flaky connection no longer fails a publish or silently drops autosaved work on sandbox teardown.

`pushBranch` now retries up to 2 times with a 2-second delay when the failure matches the same transient-error list used in clone/fetch retries. Non-transient failures like auth errors or non-fast-forward rejections are not retried; the existing reconcile/force-push fallback is unchanged.

- Adds `TestIsTransientPushError` covering a DNS failure (retried) and a `[rejected]` non-fast-forward rejection (not retried).

<sup>Written for commit 2ba853e9d95facde39f7d2ee4a83d448e63df9cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

