### PR TITLE
fix(docs): correct docker-compose env var defaults for self-hosting

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/docker-compose.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/docker-compose.mdx
@@ -51,7 +51,7 @@ open http://localhost:3000
 The `docker-compose.postgres.yml` file wires `DATABASE_URL` automatically from the `POSTGRES_*` variables, using the `postgres` service as the host.
 
 <Callout type="tip">
-  `BETTER_AUTH_SECRET` is the only strictly required variable for the app. The `POSTGRES_*` variables have defaults, but always set a real password.
+  `BETTER_AUTH_SECRET` falls back to an insecure dev-only default if unset — always set a real one. The `POSTGRES_*` variables also have defaults, but always set a real password.
 </Callout>
 
 ## Environment variables
@@ -60,13 +60,13 @@ Set these in `.env` alongside the compose file:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BETTER_AUTH_SECRET` | **required** | Authentication secret. Generate with `openssl rand -base64 32` |
+| `BETTER_AUTH_SECRET` | `local-dev-better-auth-secret-change-me` (insecure) | Authentication secret — always set a real one. Generate with `openssl rand -base64 32` |
 | `IMAGE_REPOSITORY` | `ghcr.io/decocms/studio/studio` | Image repository |
 | `IMAGE_TAG` | `latest` | Image tag |
 | `PORT` | `3000` | Port exposed on the host |
 | `BASE_URL` / `BETTER_AUTH_URL` | `http://localhost:3000` | Public URLs for the app |
 | `DATABASE_URL` | see below | PostgreSQL connection string |
-| `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | `studio_user` / — / `studio_db` | Credentials for the bundled Postgres (postgres compose file only) |
+| `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | `studio` / `studio` / `studio` | Credentials for the bundled Postgres (postgres compose file only) |
 
 The container runs as user `1001:1001` and persists data to the `studio-data` volume; the bundled Postgres persists to `postgres-data`.
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/docker-compose.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/docker-compose.mdx
@@ -51,7 +51,7 @@ open http://localhost:3000
 O arquivo `docker-compose.postgres.yml` monta o `DATABASE_URL` automaticamente a partir das variáveis `POSTGRES_*`, usando o serviço `postgres` como host.
 
 <Callout type="tip">
-  `BETTER_AUTH_SECRET` é a única variável estritamente obrigatória para a aplicação. As variáveis `POSTGRES_*` têm valores padrão, mas sempre defina uma senha de verdade.
+  `BETTER_AUTH_SECRET` cai para um valor padrão inseguro (só para dev) se não for definido — sempre defina um de verdade. As variáveis `POSTGRES_*` também têm valores padrão, mas sempre defina uma senha de verdade.
 </Callout>
 
 ## Variáveis de ambiente
@@ -60,13 +60,13 @@ Defina estas no `.env` ao lado do arquivo de compose:
 
 | Variável | Padrão | Descrição |
 |----------|---------|-------------|
-| `BETTER_AUTH_SECRET` | **obrigatório** | Secret de autenticação. Gere com `openssl rand -base64 32` |
+| `BETTER_AUTH_SECRET` | `local-dev-better-auth-secret-change-me` (inseguro) | Secret de autenticação — sempre defina um de verdade. Gere com `openssl rand -base64 32` |
 | `IMAGE_REPOSITORY` | `ghcr.io/decocms/studio/studio` | Repositório da imagem |
 | `IMAGE_TAG` | `latest` | Tag da imagem |
 | `PORT` | `3000` | Porta exposta no host |
 | `BASE_URL` / `BETTER_AUTH_URL` | `http://localhost:3000` | URLs públicas da aplicação |
 | `DATABASE_URL` | veja abaixo | Connection string do PostgreSQL |
-| `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | `studio_user` / — / `studio_db` | Credenciais do Postgres embutido (apenas no compose postgres) |
+| `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | `studio` / `studio` / `studio` | Credenciais do Postgres embutido (apenas no compose postgres) |
 
 O container roda como usuário `1001:1001` e persiste dados no volume `studio-data`; o Postgres embutido persiste em `postgres-data`.
 


### PR DESCRIPTION
Doc-vs-code drift in the self-hosting docker-compose guide (both `en` and `pt-br`).

`deploy/docker-compose/docker-compose.postgres.yml` actually defaults `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` all to `studio` (not `studio_user`/`studio_db` as the docs claimed), and `BETTER_AUTH_SECRET` falls back to the insecure literal `local-dev-better-auth-secret-change-me` rather than being strictly required as the docs stated. A reader following the guide with an unset `.env` gets different Postgres credentials and a silently-working (but insecure) auth secret than the docs describe.

Why it matters: the "Environment variables" reference table and the tip callout are the first thing an operator checks when the compose stack behaves differently than expected (e.g. wrong Postgres user when connecting manually, or wondering why the app didn't fail without `BETTER_AUTH_SECRET`) — wrong defaults there send people debugging the wrong thing.

Confirmed by reading `deploy/docker-compose/docker-compose.postgres.yml` directly (lines defining `POSTGRES_USER:-studio`, `POSTGRES_PASSWORD:-studio`, `POSTGRES_DB:-studio`, and `BETTER_AUTH_SECRET:-local-dev-better-auth-secret-change-me`).

How to verify: `cat deploy/docker-compose/docker-compose.postgres.yml` and compare against the updated table/callout in both docs files.

Checks run locally: `bun run fmt` (no changes needed for these two `.mdx` files). No code/type changes, so no `tsc`/test run needed — this is a docs-only content fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the self-hosting docker-compose guide (en and pt-br) so the documented defaults for `POSTGRES_*` and `BETTER_AUTH_SECRET` match what `docker-compose.postgres.yml` actually uses. Previously the docs claimed `POSTGRES_USER`/`POSTGRES_DB` default to `studio_user`/`studio_db` and that `BETTER_AUTH_SECRET` is strictly required, but the compose file defaults all three Postgres vars to `studio` and falls back to an insecure dev-only secret. The guide now reflects the real behavior, so operators debugging wrong credentials or missing auth secrets will see the correct defaults.

<sup>Written for commit 2a1ad8d12a04a6e944e46588e1df2641a45ee58e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

