### PR TITLE
fix(org-repo-sync): don't report a successful sync as failed on a status-write blip

### DIFF
--- a/apps/api/src/file-storage/org-repo-sync.ts
+++ b/apps/api/src/file-storage/org-repo-sync.ts
@@ -125,9 +125,10 @@ export async function syncOrgRepoSafe(
       authToken,
       skipVolumeQuota: false,
     });
-    await ctx.storage.orgRepoSyncs.recordSyncResult(config.id, {
-      error: null,
-    });
+    // Best-effort: the sync already succeeded, so a failed status write must not fall into the catch below and report a spurious failure.
+    await ctx.storage.orgRepoSyncs
+      .recordSyncResult(config.id, { error: null })
+      .catch(() => {});
     return { id: config.id, volume: config.volume, ...counts };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
**Bug**: in `syncOrgRepoSafe` (`apps/api/src/file-storage/org-repo-sync.ts`), the success-path status write `await ctx.storage.orgRepoSyncs.recordSyncResult(config.id, { error: null })` ran unguarded, unlike the error-path write a few lines below it which is already `.catch(() => {})`-wrapped.

**Failure scenario**: the repo tarball sync (`syncRepoToVolume`) completes successfully, but the follow-up DB write that clears `last_sync_error` throws (a transient connection blip, pool exhaustion, etc). That throw escapes into `syncOrgRepoSafe`'s outer `catch`, which then records *and returns* `{ error: message }` for a sync that actually succeeded — clobbering the real result with a spurious failure. The config's `last_sync_error` then shows a false failure to the user even though the volume is correctly synced, and it repeats every ~10-minute cron tick until the blip stops.

**Fix**: wrap the success-path status write in the same best-effort `.catch(() => {})` the error path already uses, so a failed status write can't fall into the catch block and overwrite a real success.

**Net change**: +4/-3, one file, behavior-preserving on the happy path (still records success normally); only changes what happens when the status write itself fails.

**Verification**: `bunx tsc --noEmit` in `apps/api` is clean; `bun test apps/api/src/file-storage/org-repo-sync.test.ts` passes (6/6); `bunx oxlint apps/api/src/file-storage/org-repo-sync.ts` is clean. I did not add a new unit test: `syncOrgRepoSafe` calls several free-function imports (`ensureGithubCloneToken`, `getValidDownstreamAccessToken`, `syncRepoToVolume`) that would need `mock.module` to isolate, which this repo's testing tiers (see TESTING.md) reserve for the e2e suite, not co-located unit tests — and e2e needs Postgres/NATS infra unavailable in this environment. Full CI validates the rest.

Reviewer check: `bun test apps/api/src/file-storage/org-repo-sync.test.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where a successful repo sync could be reported as failed if the follow-up status write to the database threw. The success-path status write is now best-effort (wrapped in a catch), matching the error path, so a transient DB blip no longer masks a real success and the config's `last_sync_error` stays accurate.

<sup>Written for commit 9cf38f2e8818f946c6613ebe22a3b6303f684132. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

