### PR TITLE
fix(organization): cap BrandContextSchema's id field length

### DIFF
--- a/packages/shared/src/organization/schema.test.ts
+++ b/packages/shared/src/organization/schema.test.ts
@@ -106,6 +106,14 @@ describe("BrandContextSchema JSON field caps", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects an oversized id", () => {
+    // Regression: `id` was the one field on this schema left unbounded.
+    expect(
+      BrandContextSchema.safeParse(baseBrandContext({ id: "x".repeat(501) }))
+        .success,
+    ).toBe(false);
+  });
+
   it("rejects an oversized overview, name, domain, or logo URL", () => {
     expect(
       BrandContextSchema.safeParse(

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -298,7 +298,7 @@ const MAX_BRAND_OVERVIEW_LENGTH = 5000;
  * Brand context schema - org-scoped company profile
  */
 export const BrandContextSchema = z.object({
-  id: z.string().describe("Brand context ID"),
+  id: z.string().max(MAX_BRAND_STRING_LENGTH).describe("Brand context ID"),
   name: z.string().max(MAX_BRAND_STRING_LENGTH).describe("Company name"),
   domain: z
     .string()


### PR DESCRIPTION
Every free-text field on `BrandContextSchema` (`packages/shared/src/organization/schema.ts`) is capped at `MAX_BRAND_STRING_LENGTH` (500 chars) except `id` — the one field left as a bare `z.string()`.

`id` is client-supplied on `BRAND_CONTEXT_UPDATE` (`apps/api/src/tools/organization/brand-context-update.ts`) and flows straight into a Kysely `WHERE id = ...` lookup (`apps/api/src/storage/brand-context.ts`). The query is parametrized so there's no injection risk, but an org member with ordinary brand-write permission could send an arbitrarily large `id` string in the request body with no validation catching it before it reaches storage — the same missing-validation-on-untrusted-input class every sibling field on this schema already guards against.

Fix: add the existing `MAX_BRAND_STRING_LENGTH` cap to `id`, matching every other field on the schema.

Failure scenario before the fix: `BRAND_CONTEXT_UPDATE` with a multi-KB `id` string passes schema validation and reaches the DB lookup unchecked.

Reviewer check: `bun test packages/shared/src/organization/schema.test.ts` — includes a new regression test asserting a 501-char id is rejected.

Locally ran: `bun run fmt`, `cd packages/shared && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `BrandContextSchema`'s `id` field at `MAX_BRAND_STRING_LENGTH` (500 characters), matching the validation on every other free-text field. Previously, `id` was an unbounded string, so a client could submit an arbitrarily long id that reached storage without being caught. Now such inputs are rejected during schema validation.

<sup>Written for commit bf6becabe4d05cdf5acf31ad49d3b3f7d9391fce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

