### PR TITLE
fix(org-home): resolve the feed's project filter through entryForFilter

### DIFF
--- a/apps/web/src/components/org-home/project-feed.test.ts
+++ b/apps/web/src/components/org-home/project-feed.test.ts
@@ -74,6 +74,23 @@ describe("buildFeed", () => {
     expect(ids(feed)).toEqual(["mine"]);
   });
 
+  /** REGRESSION. A repo-less project is keyed by its `vir_…` id; the day a
+   *  repository lands on it, its bucket re-keys to `owner/name` (same rule
+   *  `entryForFilter` documents). A filter picked before the rekey used to
+   *  compare a card's CURRENT bucket id against the STALE id straight from
+   *  state and find nothing — an empty feed under a header that still named
+   *  the project correctly. */
+  it("keeps narrowing to a bucket re-keyed since the filter was picked", () => {
+    const beforeRekey = buildProjectIndex([project("p_a", "alpha")]);
+    const afterRekey = buildProjectIndex([A]);
+    const cards = [
+      task("mine", "2026-01-01T00:00:00Z", { virtualMcpId: "p_a" }),
+    ];
+
+    expect(ids(buildFeed(beforeRekey, cards, "p_a"))).toEqual(["mine"]);
+    expect(ids(buildFeed(afterRekey, cards, "p_a"))).toEqual(["mine"]);
+  });
+
   it("carries the project on every entry, so a card can name it", () => {
     const feed = buildFeed(
       buildProjectIndex([A]),

--- a/apps/web/src/components/org-home/project-feed.tsx
+++ b/apps/web/src/components/org-home/project-feed.tsx
@@ -105,13 +105,20 @@ export function buildFeed(
   tasks: TaskBoardItem[],
   bucketId: string | null,
 ): FeedEntry[] {
+  /** Resolved ONCE, the way `ProjectFilter` resolves it for the header — a
+   *  bucket's id is not stable for the lifetime of a link (a repo-less
+   *  project re-keyed to `owner/name` once a repository landed). Comparing
+   *  a task's CURRENT bucket id against the stale id straight from state
+   *  found nothing after a rekey, even though the header still named the
+   *  bucket correctly via this same lookup. */
+  const filterEntry = bucketId ? entryForFilter(bucketId, index) : undefined;
   const entries: FeedEntry[] = [];
   for (const task of tasks) {
     /** Deleted work is not activity; every other lane belongs here. */
     if (task.status === "archived") continue;
     const bucket = entryForTask(task, index);
     if (!bucket) continue;
-    if (bucketId && bucket.id !== bucketId) continue;
+    if (bucketId && bucket !== filterEntry) continue;
     entries.push({ task, bucket, project: projectForTask(task, index) });
   }
 


### PR DESCRIPTION
`buildFeed` (the org-home project-feed's filtering logic) compared a task's CURRENT bucket id against the raw `bucketId` value straight from React state. A bucket's id is not stable for the lifetime of a link — `project-index.ts`'s own `entryForFilter` docstring spells this out: a repo-less project is keyed by its `vir_...` id, and re-keys to `owner/name` the day a repository lands on it. `ProjectFilter`'s header already resolves the selected bucket through `entryForFilter` for exactly this reason, but `buildFeed` did a raw `bucket.id !== bucketId` compare instead.

Concretely: pick a project filter before a repo is attached to that project, then attach a repo. The header keeps naming the project correctly (via `entryForFilter`), but the feed under it goes silently empty, because every card's *current* bucket id (`owner/name`) no longer equals the *stale* id captured in `bucketId` state (`vir_...`) — a stale-state bug a maintainer would otherwise have to reproduce by hand.

Fix: resolve `bucketId` to its current `ProjectIndexEntry` once via the already-exported `entryForFilter` (the same helper the header uses), then compare identity against that instead of comparing ids directly.

Regression test added: `buildFeed > keeps narrowing to a bucket re-keyed since the filter was picked` in `project-feed.test.ts` — builds the index before and after a project gains a repo, and asserts the same filter value still matches. I verified it fails against the pre-fix code and passes after.

Reviewer check: `bun test apps/web/src/components/org-home/project-feed.test.ts` — all 13 pass.

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in apps/web (one pre-existing, unrelated prosemirror-version typecheck error in `mention-suggestion.tsx`, nothing in project-feed.tsx), `bunx oxlint` on both touched files (0 warnings/errors), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the org-home project feed so it keeps narrowing correctly when a project filter was picked before the project gains a repository. Previously `buildFeed` compared each task's current bucket id against the raw `bucketId` from state; after a repo-less project re-keys from its `vir_...` id to `owner/name`, the feed silently emptied even though the header still named the project via `entryForFilter`. Now `buildFeed` resolves the selected bucket through `entryForFilter` once and compares identity instead of ids. Adds a regression test covering the re-key scenario.

<sup>Written for commit ce1ad5df57ae50365b796528f147ed3e6cfa1632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

