### PR TITLE
fix(organization): make ORGANIZATION_DELETE skip the write when already archived

### DIFF
--- a/apps/api/src/tools/organization/delete.test.ts
+++ b/apps/api/src/tools/organization/delete.test.ts
@@ -62,4 +62,12 @@ describe("ORGANIZATION_DELETE", () => {
     );
     expect(ctx.update.mock.calls.length).toBe(0);
   });
+
+  it("is a no-op when the org is already archived, keeping the original archivedAt", async () => {
+    const ctx = makeCtx({ archived: true, archivedAt: "2026-01-01T00:00:00Z" });
+
+    await ORGANIZATION_DELETE.handler({ id: "org-1" }, ctx);
+
+    expect(ctx.update.mock.calls.length).toBe(0);
+  });
 });

--- a/apps/api/src/tools/organization/delete.ts
+++ b/apps/api/src/tools/organization/delete.ts
@@ -41,12 +41,24 @@ export const ORGANIZATION_DELETE = defineTool({
 
     // Merge into existing metadata — organization.update replaces it wholesale.
     const existing = await ctx.boundAuth.organization.get(input.id);
+    const existingMetadata = (existing?.metadata ?? {}) as Record<
+      string,
+      unknown
+    >;
+
+    // Already archived: skip the write, preserving the original archivedAt.
+    if (existingMetadata.archived === true) {
+      return {
+        success: true,
+        id: input.id,
+      };
+    }
 
     await ctx.boundAuth.organization.update({
       organizationId: input.id,
       data: {
         metadata: {
-          ...existing?.metadata,
+          ...existingMetadata,
           archived: true,
           archivedAt: new Date().toISOString(),
         },


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/tools/organization/delete.ts` (org-delete tool safety focus area).

**Payoff:** `ORGANIZATION_DELETE` declares `idempotentHint: true`, but every call unconditionally re-wrote `metadata.archivedAt` to `new Date().toISOString()`. A retry, a double-click, or two concurrent delete calls each reset the org's original archive timestamp — silently extending any retention/audit window keyed off when the org was actually deleted, and making the "idempotent" annotation false.

**Fix:** read the existing metadata first (already done for the merge) and short-circuit before the write when `metadata.archived === true`, returning the same `{ success, id }` shape without touching `archivedAt`. Added a regression test (`is a no-op when the org is already archived, keeping the original archivedAt`) asserting `update` is never called on a repeat delete.

**Verify:** `cd apps/api && bun test src/tools/organization/delete.test.ts`

**Checked locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `ORGANIZATION_DELETE` a true no-op when the org is already archived, so retries, double-clicks, or concurrent delete calls no longer overwrite the original `archivedAt` timestamp. Previously every call re-wrote `archivedAt` to the current time, silently extending any retention/audit window keyed off when the org was deleted, despite the tool declaring `idempotentHint: true`.

**Tests**
- Adds a regression test asserting `update` is not called on a repeat delete, preserving the original `archivedAt`.

<sup>Written for commit 356da8256d55d5e6ad10adfb20c4a2fa6edb0db9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

