### PR TITLE
fix(organization): scope ORGANIZATION_MEMBER_UPDATE_ROLE to the authenticated org

### DIFF
--- a/apps/api/src/tools/organization/member-update-role.test.ts
+++ b/apps/api/src/tools/organization/member-update-role.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import { ORGANIZATION_MEMBER_UPDATE_ROLE } from "./member-update-role";
 
 describe("ORGANIZATION_MEMBER_UPDATE_ROLE outputSchema", () => {
@@ -29,5 +29,40 @@ describe("ORGANIZATION_MEMBER_UPDATE_ROLE outputSchema", () => {
       role: ["user", "admin"],
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe("ORGANIZATION_MEMBER_UPDATE_ROLE handler", () => {
+  it("rejects an organizationId other than the authenticated one", async () => {
+    const updateMemberRole = mock(async () => ({}));
+    const ctx = {
+      auth: { user: { id: "user-1" } },
+      access: { check: mock(async () => {}) },
+      organization: { id: "org-1", slug: "acme", name: "Acme" },
+      db: {
+        selectFrom: () => ({
+          select: () => ({
+            where: () => ({
+              where: () => ({
+                executeTakeFirst: async () => ({ role: "owner" }),
+              }),
+            }),
+          }),
+        }),
+      },
+      boundAuth: { organization: { updateMemberRole } },
+    } as unknown as Parameters<
+      typeof ORGANIZATION_MEMBER_UPDATE_ROLE.handler
+    >[1];
+
+    await expect(
+      ORGANIZATION_MEMBER_UPDATE_ROLE.handler(
+        { organizationId: "org-2", memberId: "member-1", role: ["admin"] },
+        ctx,
+      ),
+    ).rejects.toThrow(
+      "Organization ID does not match authenticated organization",
+    );
+    expect(updateMemberRole.mock.calls.length).toBe(0);
   });
 });

--- a/apps/api/src/tools/organization/member-update-role.ts
+++ b/apps/api/src/tools/organization/member-update-role.ts
@@ -55,6 +55,13 @@ export const ORGANIZATION_MEMBER_UPDATE_ROLE = defineTool({
       );
     }
 
+    // Validate organization ID matches context (mirrors member-add.ts/update.ts).
+    if (organizationId !== ctx.organization?.id) {
+      throw new Error(
+        "Organization ID does not match authenticated organization",
+      );
+    }
+
     // Validate the caller is allowed to assign every target role. `organizationId`
     // may be an explicit override (not the session's active org), and
     // `ctx.auth.user?.role` only ever reflects the active-org role — using it here


### PR DESCRIPTION
Follows the org-scoping lane (#3388, and the same class already fixed in `update.ts`/`member-add.ts`/`member-remove.ts`/`delete.ts`).

`ORGANIZATION_MEMBER_UPDATE_ROLE` accepts an optional `organizationId` input, but unlike its siblings it never checked that value against `ctx.organization?.id` (the path-resolved org `ctx.access.check()` actually authorized the caller against). Every other org-mutation tool (`member-add.ts`, `member-remove.ts`, `update.ts`, `delete.ts`) has this exact guard; this one was missed.

**Why it matters:** `ctx.access.check()` verifies the caller's permission in `ctx.organization` (resolved from the URL slug), not in whatever `organizationId` the request body carries. Without the guard, a caller authorized for org A could pass `organizationId: <org B>` and have the tool operate against org B instead of the org the request was actually authorized for — the same scope-confusion bug class fixed in `ORGANIZATION_UPDATE` (#6541-era fix). The existing `canAssignRole` check against the target org's real membership row still gates privilege *escalation*, but doesn't stop the tool acting on an org outside the one `ctx.access.check()` validated.

**Fix:** add the identical `if (organizationId !== ctx.organization?.id) throw ...` guard already present in the sibling tools, plus a regression test asserting the mismatch is rejected before `updateMemberRole` is ever called.

**Verify:** `cd apps/api && bun test src/tools/organization/member-update-role.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a missing org-scoping guard in `ORGANIZATION_MEMBER_UPDATE_ROLE` so callers can no longer act on an organization other than the one the request was authorized for. Previously the tool accepted an `organizationId` without checking it against the authenticated org, so a caller authorized for org A could pass org B's ID and the tool would operate on org B.

- Adds the same `organizationId !== ctx.organization?.id` guard already present in `member-add.ts`, `member-remove.ts`, `update.ts`, and `delete.ts`.
- Includes a regression test asserting the mismatch is rejected before `updateMemberRole` is called.

<sup>Written for commit 641419db7d1389284aebe2177e6c36fd8fd54c9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

