### PR TITLE
fix(task-board): disambiguate the PR checks footer's React key by index

### DIFF
--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -1970,10 +1970,12 @@ function PrCard({
           </button>
           {checksOpen && (
             <div className="mt-2 flex flex-col gap-2">
-              {checks.map((c) => {
+              {checks.map((c, i) => {
                 const cs = checkRunStyle(c);
+                // Two check runs can share a `name`, so index disambiguates the key.
+                const checkKey = `${c.name}-${i}`;
                 return (
-                  <div key={c.name} className="rounded-md bg-muted/40 p-2">
+                  <div key={checkKey} className="rounded-md bg-muted/40 p-2">
                     <div className="flex items-center gap-2">
                       {cs.spin ? (
                         <Spinner className={cn("size-[13px]", cs.className)} />
@@ -2000,7 +2002,7 @@ function PrCard({
                     {c.summary && (
                       <div className="mt-1.5 max-h-64 overflow-auto text-muted-foreground">
                         <MemoizedMarkdown
-                          id={`${pr.url}-${c.name}`}
+                          id={`${pr.url}-${checkKey}`}
                           text={c.summary}
                         />
                       </div>


### PR DESCRIPTION
The PR checks footer keys each check row on `c.name` alone (`apps/web/src/layouts/task-board/task-dialog.tsx`), and also uses `${pr.url}-${c.name}` as the `MemoizedMarkdown` cache id for that check's summary. GitHub check runs are not unique by name — two different apps (or CI providers) can post a check run with the same `name`, and a re-run can leave more than one run with the same name in the list the server returns (`checks` in `TASK_BOARD_ITEM_PRS_GET`, backend not touched here). A name collision makes React reuse the wrong DOM node/component instance for that row and lets the markdown cache serve one check's failure output under another check's key — the wrong check's icon/summary can show in the footer.

Fix: derive the key/id from `name` + array index instead of `name` alone, guaranteeing uniqueness per render regardless of upstream duplicates.

Why a maintainer wants it: this is a real, if infrequent, correctness bug in a UI a lot of task-board users hit on every failing PR — someone reading a check's CI log could be shown a different check's log entirely, silently.

How to confirm: open a task with a PR that has two GitHub check runs sharing the same `name` (e.g. two CI providers both posting a "build" check), expand the checks footer, and confirm each row shows its own check's icon and (for a failing check) its own summary. Before the fix, React could conflate the two rows.

Verification run locally: `bunx tsc --noEmit` in `apps/web` (no new errors — the file itself is clean; the one pre-existing error is an unrelated prosemirror version-skew issue) and `bunx oxlint apps/web/src/layouts/task-board/task-dialog.tsx` (0 warnings/errors). No existing test covers this render path and the change is a pure key/id derivation, so full CI's typecheck/lint job validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the PR checks footer in the task board so rows are keyed by check name plus array index instead of name alone, preventing React from reusing the wrong row and the markdown cache from showing one check's summary under another when two check runs share a name.

- Appends the array index to the React key and `MemoizedMarkdown` cache id, guaranteeing uniqueness per render.

<sup>Written for commit 04639ea127d38138efae499b1ac9c4a8774054a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

