### PR TITLE
fix(sandbox-daemon): cap the PUT /_sandbox/config request body size

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/config.go
+++ b/packages/sandbox/daemon-go/internal/routes/config.go
@@ -18,6 +18,15 @@ const (
 	tokenMaxLength = 256
 )
 
+// maxConfigUpdateBodyBytes bounds the PUT /_sandbox/config request body. A
+// config patch is small structured JSON (git/application/operator fields plus
+// an env map whose individual values are already capped at envValueMax), never
+// a file transfer — but nothing bounds how many env keys or repositories a
+// caller sends. Without a limit, io.ReadAll streams an unbounded body into
+// memory and could crash the daemon, tearing down the sandbox pod on the next
+// missed health probe.
+const maxConfigUpdateBodyBytes = 1024 * 1024
+
 type OrchestratorState struct {
 	Running bool `json:"running"`
 	Pending int  `json:"pending"`
@@ -108,7 +117,7 @@ func ConfigRead(deps ConfigDeps) http.HandlerFunc {
 
 func ConfigUpdate(deps ConfigDeps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		raw, err := io.ReadAll(r.Body)
+		raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxConfigUpdateBodyBytes))
 		if err != nil {
 			httpx.Error(w, 400, "bad body: "+err.Error())
 			return

--- a/packages/sandbox/daemon-go/internal/routes/config_body_limit_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/config_body_limit_test.go
@@ -1,0 +1,29 @@
+package routes
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/decocms/studio/sandbox-daemon/internal/config"
+)
+
+// PUT /_sandbox/config used io.ReadAll with no size limit: an oversized body
+// (e.g. an env map with many large values) would be streamed entirely into
+// memory before validation ever rejects it.
+func TestConfigUpdateRejectsOversizedBody(t *testing.T) {
+	oversized := strings.Repeat("a", maxConfigUpdateBodyBytes+1)
+	body := `{"env":{"K":"` + oversized + `"}}`
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/_sandbox/config", strings.NewReader(body))
+	store := config.NewStore()
+	ConfigUpdate(ConfigDeps{Store: store})(rec, req)
+
+	if rec.Code != 400 {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if store.Read() != nil {
+		t.Fatal("oversized body must not reach the store")
+	}
+}


### PR DESCRIPTION
PUT /_sandbox/config reads the whole request body with `io.ReadAll` and no size limit — unlike the daemon's other two body-consuming routes, `dispatch.go` (`maxDispatchBodyBytes`, 32MB) and `tools.go` (`maxToolsSyncBodyBytes`, 1MB), both of which wrap `r.Body` in `http.MaxBytesReader`.

A config patch validates each env value at 32KB (`envValueMax` in `validate.go`), but nothing bounds the *number* of env keys or secondary repositories a caller sends. So an oversized payload streams entirely into memory before `Validate()` ever gets a chance to reject it — a config-update caller (buggy or malicious) can OOM the daemon, which tears the sandbox pod down on the next missed health probe (per this repo's own daemon health-probe contract).

Fix: wrap `r.Body` in `http.MaxBytesReader` the same way the other two routes do, capped at 1MB (matches `tools.go`'s config-shaped route — generous headroom for real git/application/operator/env patches, but no longer unbounded).

Regression test: `TestConfigUpdateRejectsOversizedBody` in `packages/sandbox/daemon-go/internal/routes/config_body_limit_test.go` sends a body over the new cap and asserts a 400 and that nothing reaches the store.

To verify: `cd packages/sandbox/daemon-go && go test ./internal/routes/... -run TestConfigUpdateRejectsOversizedBody -v`

Locally ran: `go test ./internal/routes/... ./internal/config/...` (all green), `gofmt -l` (clean), `go vet ./internal/routes/...` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the `PUT /_sandbox/config` request body at 1MB. Previously the route read the whole body with no size limit, so a caller could send enough env keys or repositories to exhaust daemon memory and crash the sandbox pod; oversized updates are now rejected with a 400 before reaching the store.

- Adds a regression test verifying bodies over the limit are rejected with 400 and never reach the store.

<sup>Written for commit fdbb6ad710be62825b6d48d955c6cb44fba40913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

