### PR TITLE
fix(oauth): clear the token-refresh backoff when a downstream token is saved

### DIFF
--- a/apps/api/src/api/routes/downstream-token.integration.test.ts
+++ b/apps/api/src/api/routes/downstream-token.integration.test.ts
@@ -9,7 +9,13 @@ import {
   seedCommonTestPgFixtures,
 } from "../../database/test-db-pg";
 import type { StudioDatabase } from "../../database";
-import { createDownstreamTokenRoutes } from "./downstream-token";
+const mockClearRefreshBackoff = mock((_connectionId?: string) => {});
+mock.module("../../oauth/token-refresh", () => ({
+  canRefresh: () => false,
+  clearRefreshBackoff: mockClearRefreshBackoff,
+}));
+
+const { createDownstreamTokenRoutes } = await import("./downstream-token");
 
 describe("Downstream Token Routes", () => {
   let database: StudioDatabase;
@@ -102,6 +108,20 @@ describe("Downstream Token Routes", () => {
     const body = (await res.json()) as { success: boolean; expiresAt: string };
     expect(body.success).toBe(true);
     expect(body.expiresAt).toBeTruthy();
+  });
+
+  it("clears the token-refresh backoff entry on save", async () => {
+    // Regression: a stale backoff from the previous dead token would falsely bounce a refresh right after reconnect.
+    mockClearRefreshBackoff.mockClear();
+
+    const res = await app.request("/connections/conn_1/oauth-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ accessToken: "at", refreshToken: "rt" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockClearRefreshBackoff).toHaveBeenCalledWith("conn_1");
   });
 
   it("stores expiresIn: 0 as already-expired, not never-expiring", async () => {

--- a/apps/api/src/api/routes/downstream-token.ts
+++ b/apps/api/src/api/routes/downstream-token.ts
@@ -7,7 +7,7 @@
 
 import { Hono } from "hono";
 import type { StudioContext } from "../../core/studio-context";
-import { canRefresh } from "../../oauth/token-refresh";
+import { canRefresh, clearRefreshBackoff } from "../../oauth/token-refresh";
 import { resolveOriginTokenEndpoint } from "../../oauth/resolve-token-endpoint";
 import {
   DownstreamTokenStorage,
@@ -137,6 +137,9 @@ export const createDownstreamTokenRoutes = () => {
     };
 
     const token = await tokenStorage.upsert(tokenData);
+
+    // A freshly saved token has never failed - drop any backoff armed by the previous dead token.
+    clearRefreshBackoff(connectionId);
 
     return c.json({
       success: true,


### PR DESCRIPTION
**Bug** in `apps/api/src/oauth/token-refresh.ts` / `apps/api/src/api/routes/downstream-token.ts`.

`refreshAndStore` arms a per-connection exponential backoff (`refreshBackoff`, up to `REFRESH_BACKOFF_CAP_MS` = 5 minutes) after a failed refresh, so a broken upstream isn't hammered. That map is keyed only by `connectionId` and, until now, was only ever cleared on a *successful* refresh or on connection delete (#6980).

**Failure scenario:** a connection's token refresh keeps failing (upstream blip, or a refresh_token that's dead but not classified `permanent`) and arms the backoff window. The user then reconnects — the frontend calls `POST /connections/:id/oauth-token` with a brand-new, never-used access+refresh token. If a proxy request needs a *forced* refresh (e.g. it just got a 401) before the old backoff window naturally expires, `refreshAndStore` short-circuits on the stale backoff entry and returns `null` immediately, without even attempting the new refresh_token. The connection looks broken for up to 5 minutes after the user did everything right to fix it.

**Fix:** call `clearRefreshBackoff(connectionId)` right after the token upsert in the `oauth-token` POST route — a freshly saved token has never failed, so any suppression window is stale.

**Regression test:** added `clears the token-refresh backoff entry on save` to `downstream-token.integration.test.ts`, mocking `../../oauth/token-refresh` (same `mock.module` pattern as `delete.test.ts`'s equivalent case for #6980) and asserting `clearRefreshBackoff` is called with the connection id after a successful save.

**To confirm:** `bun test apps/api/src/api/routes/downstream-token.integration.test.ts` (needs a running Postgres — this laptop has none, so I verified with `cd apps/api && bunx tsc --noEmit` (clean) and `bunx oxlint` on both changed files (0 warnings/errors); full CI runs the integration suite.

Does not touch `delete.ts`/`delete.test.ts` (already covered by open PR #6980) — this is the reconnect/save path, not the delete path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the token-refresh backoff when a downstream token is saved, so reconnects aren't blocked by a stale suppression window from the previous dead token.

- Previously, a failed refresh armed a per-connection backoff that could bounce forced refreshes for up to 5 minutes even after a fresh token was saved.
- The `POST /connections/:id/oauth-token` route now calls `clearRefreshBackoff` immediately after the token upsert.
- Adds a regression test that asserts the backoff is cleared on save.

<sup>Written for commit 568eb012822453facfbf04dc4a6a4d4a265f0a19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

