### PR TITLE
fix(sandbox): reattach a detached run instead of killing it

### DIFF
--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
@@ -40,6 +40,34 @@ const sandboxGoneCode = "sandbox_gone"
 // shorten it.
 var takeoverTimeout = 10 * time.Second
 
+// How long a run whose client vanished keeps running, waiting to be reattached.
+//
+// A Studio replica is disposable — a rollout, a KEDA scale-in or a node
+// consolidation replaces it routinely — and each of those aborts the HTTP
+// request this run streams into. Killing the harness there threw away whole
+// turns that were minutes deep, on a sandbox pod that was never unhealthy: the
+// client moved, the work did not. So a lost client detaches instead, and the
+// re-dispatch that DBOS recovery sends reattaches to the SAME harness.
+//
+// The window only has to cover a replica coming back (pod termination grace
+// plus reschedule). Past it the run is genuinely abandoned and is cancelled, so
+// nothing outlives its consumer indefinitely. Variable only so the test can
+// shorten it.
+var detachGrace = 3 * time.Minute
+
+// How long a run that FINISHED while detached is kept so the reattaching
+// dispatch can still collect its frames and terminal. Without it a run that
+// completed in the gap looks to the successor like a run that never existed,
+// and the turn is re-executed from the top. Variable only so the test can
+// shorten it.
+var finishedRetention = 2 * time.Minute
+
+// Ceiling on frames buffered for a detached run. Tool results can be large and
+// this memory sits in the pod, so overflow gives up and cancels rather than
+// growing without bound — the run is then lost exactly as it would have been
+// before reattach existed, which is the honest fallback.
+const maxPendingBytes = 32 * 1024 * 1024
+
 // How often a quiet dispatch writes a keepalive byte. A run's whole output only
 // exists at its end, so a long tool call or a slow model puts zero bytes on the
 // wire for minutes; Studio's fetch then dies on the transport's idle timeout and
@@ -89,25 +117,161 @@ type RunInfo struct {
 	McpExpiresAt int64
 }
 
-// activeRun is one in-flight run: the handle to stop it, plus a channel closed
-// when its handler has actually returned. The channel is what makes a takeover
-// safe — a replacement run must not exec its harness until the displaced one's
-// process group is gone.
+// activeRun is one in-flight run. It owns the harness, not the HTTP handler
+// that started it: `done` closes when the harness goroutine exits, which is
+// what makes a takeover safe (a replacement must not exec until the displaced
+// process group is gone) and what a reattaching dispatch waits on.
+//
+// `sink` is the response body currently carrying the run's frames, or nil when
+// no client is attached. While detached the frames queue in `pending` and are
+// replayed to whoever attaches next.
 type activeRun struct {
+	ctx    context.Context
 	cancel context.CancelFunc
 	done   chan struct{}
+
+	mu       sync.Mutex
+	sink     *bodyWriter
+	detached bool
+	pending  [][]byte
+	pendingN int
+	finished bool
+	reaper   *time.Timer
+}
+
+// emit delivers one frame to the attached client, or queues it when none is.
+// Returns false only when the run must stop: the buffer is full and there is
+// nobody to drain it.
+func (a *activeRun) emit(frame []byte) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.sink != nil {
+		if a.sink.write(frame) {
+			return true
+		}
+		// The write failed, so this client is gone. Detaching rather than
+		// ending the run is the whole point: its replacement is on the way.
+		a.detachLocked()
+	}
+	if a.pendingN+len(frame) > maxPendingBytes {
+		slog.Error("dispatch buffer full for detached run; cancelling",
+			"harness", sandboxHarnessID, "pending_bytes", a.pendingN)
+		return false
+	}
+	a.pending = append(a.pending, frame)
+	a.pendingN += len(frame)
+	return true
+}
+
+// keepaliveTo writes the idle byte only when a client is attached. A keepalive
+// exists to hold a connection open, so buffering one for a client that is not
+// there would spend the pending budget on padding.
+func (a *activeRun) keepaliveTo() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.sink == nil {
+		return true
+	}
+	if !a.sink.write([]byte("\n")) {
+		a.detachLocked()
+	}
+	return true
+}
+
+// attach makes `body` this run's client: everything buffered is replayed first,
+// in order, then live frames follow. Returns false when the run is already over
+// and the replay was all there is — the caller then just returns.
+func (a *activeRun) attach(body *bodyWriter) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, frame := range a.pending {
+		if !body.write(frame) {
+			return false
+		}
+	}
+	a.pending, a.pendingN = nil, 0
+	if a.finished {
+		return false
+	}
+	a.sink = body
+	a.detached = false
+	if a.reaper != nil {
+		a.reaper.Stop()
+		a.reaper = nil
+	}
+	return true
+}
+
+// detach releases `body` if it is still the attached sink. Called by the
+// handler before it returns, because net/http forbids writing to a
+// ResponseWriter once that happens — after this the harness buffers instead.
+func (a *activeRun) detach(body *bodyWriter) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.sink == body {
+		a.detachLocked()
+	}
+}
+
+func (a *activeRun) detachLocked() {
+	a.sink = nil
+	a.detached = true
+	if a.reaper == nil {
+		// Nobody came back for it: this is where an abandoned run is finally
+		// stopped, so a detached harness cannot outlive its consumer forever.
+		a.reaper = time.AfterFunc(detachGrace, func() {
+			slog.Info("dispatch detach grace expired; cancelling run",
+				"harness", sandboxHarnessID, "grace_s", int(detachGrace.Seconds()))
+			a.cancel()
+		})
+	}
+}
+
+// isDetached reports whether this run HAD a client and lost it — the only
+// state a new dispatch may reattach to. A run that has not been attached yet is
+// not detached: a second dispatch arriving then is a genuine double-dispatch and
+// must take it over, not adopt it.
+func (a *activeRun) isDetached() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.detached
+}
+
+// markFinished freezes the run: no more frames, and any client attaching later
+// gets the replay and nothing else.
+func (a *activeRun) markFinished() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.finished = true
+	a.sink = nil
+	a.detached = false
+	if a.reaper != nil {
+		a.reaper.Stop()
+		a.reaper = nil
+	}
+}
+
+func (a *activeRun) hasPending() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.pending) > 0
 }
 
 type Registry struct {
 	mu         sync.Mutex
 	activeRuns map[string]*activeRun
-	tombstones map[string]time.Time
+	// finishedRuns holds runs that completed with nobody attached, so the
+	// dispatch that arrives just after can still collect the result instead of
+	// re-running the turn. Cleared by a timer, never by size.
+	finishedRuns map[string]*activeRun
+	tombstones   map[string]time.Time
 }
 
 func NewRegistry() *Registry {
 	return &Registry{
-		activeRuns: map[string]*activeRun{},
-		tombstones: map[string]time.Time{},
+		activeRuns:   map[string]*activeRun{},
+		finishedRuns: map[string]*activeRun{},
+		tombstones:   map[string]time.Time{},
 	}
 }
 
@@ -125,27 +289,48 @@ func (reg *Registry) tombstoned(runId string) bool {
 	return false
 }
 
-// claim makes this run the single writer for `runId`, displacing whatever run
-// held it. Returns the new entry and a wait function the caller MUST call
-// before starting its harness: it blocks until the displaced run's handler has
-// returned (bounded by `takeoverTimeout`).
+// claimOrAttach resolves what a dispatch for `runId` should do.
 //
-// Studio re-dispatches the same runId whenever the pod that owned the run died
-// and another picked the work up (DBOS recovery). Registering over the old
-// entry — what this used to do — dropped the old run's cancel on the floor and
-// left its `claude` running in the same checkout as the new one: two agents,
-// one worktree, and no way to stop the first.
-func (reg *Registry) claim(runId string, cancel context.CancelFunc) (*activeRun, func()) {
-	entry := &activeRun{cancel: cancel, done: make(chan struct{})}
+//   - no run under way          → a fresh run (`fresh` true); caller starts the harness
+//   - a run whose client is gone → REATTACH to it; the harness keeps running and
+//     the buffered frames replay to the new connection
+//   - a run finished while detached → reattach to the corpse, which replays its
+//     frames and terminal and ends
+//   - a run with a live client   → takeover, as before
+//
+// The takeover case is the one that must stay: two live dispatches for one
+// runId means a real double-dispatch, and letting both harnesses write the same
+// checkout is how two agents end up editing one worktree. Studio re-dispatching
+// after its own replica died is NOT that case — there is no second writer, only
+// a second reader — which is exactly what reattach distinguishes.
+//
+// The returned wait function MUST be called before starting a harness: it blocks
+// until a displaced run's handler has returned (bounded by `takeoverTimeout`).
+func (reg *Registry) claimOrAttach(
+	runId string,
+	newCancel func() (*activeRun, context.CancelFunc),
+) (entry *activeRun, fresh bool, awaitTakeover func()) {
 	reg.mu.Lock()
+	if done, ok := reg.finishedRuns[runId]; ok {
+		reg.mu.Unlock()
+		return done, false, func() {}
+	}
 	prev := reg.activeRuns[runId]
-	reg.activeRuns[runId] = entry
+	if prev != nil && prev.isDetached() {
+		reg.mu.Unlock()
+		slog.Info("dispatch reattach", "harness", sandboxHarnessID, "run_id", runId)
+		return prev, false, func() {}
+	}
+	created, cancel := newCancel()
+	created.cancel = cancel
+	reg.activeRuns[runId] = created
 	reg.mu.Unlock()
+
 	if prev == nil {
-		return entry, func() {}
+		return created, true, func() {}
 	}
 	prev.cancel()
-	return entry, func() {
+	return created, true, func() {
 		select {
 		case <-prev.done:
 			slog.Info("dispatch takeover", "run_id", runId)
@@ -196,10 +381,27 @@ func (reg *Registry) displaced(runId string, entry *activeRun) bool {
 // release retires this run's claim. Only clears the map when the entry is still
 // the current one — a run that was taken over must not delete its successor's
 // claim on the way out.
+//
+// A run that finished with nobody attached keeps its frames for
+// `finishedRetention`: the dispatch racing in behind a replica restart then
+// collects the real result, instead of finding nothing and re-running a turn
+// that had already completed.
 func (reg *Registry) release(runId string, entry *activeRun) {
+	entry.markFinished()
+	retain := entry.hasPending()
 	reg.mu.Lock()
 	if reg.activeRuns[runId] == entry {
 		delete(reg.activeRuns, runId)
+		if retain {
+			reg.finishedRuns[runId] = entry
+			time.AfterFunc(finishedRetention, func() {
+				reg.mu.Lock()
+				if reg.finishedRuns[runId] == entry {
+					delete(reg.finishedRuns, runId)
+				}
+				reg.mu.Unlock()
+			})
+		}
 	}
 	reg.mu.Unlock()
 	close(entry.done)
@@ -332,12 +534,42 @@ func (reg *Registry) HandleDispatch(w http.ResponseWriter, r *http.Request, deps
 		return
 	}
 
-	ctx, cancel := context.WithCancel(r.Context())
-	entry, awaitTakeover := reg.claim(runId, cancel)
-	slog.Info("dispatch received", "harness", sandboxHarnessID, "run_id", runId)
-	awaitTakeover()
+	entry, fresh, awaitTakeover := reg.claimOrAttach(runId, func() (*activeRun, context.CancelFunc) {
+		// context.Background(), NOT r.Context(): binding the harness to the
+		// request meant a Studio replica going away — a rollout, a scale-in —
+		// SIGKILLed the `claude` process group on a healthy sandbox pod, and
+		// the turn was re-run from the top. The run is cancelled by a real
+		// decision now: a takeover, a DELETE, daemon shutdown, or nobody
+		// reattaching within `detachGrace`.
+		ctx, cancel := context.WithCancel(context.Background())
+		return &activeRun{ctx: ctx, done: make(chan struct{})}, cancel
+	})
+	slog.Info("dispatch received", "harness", sandboxHarnessID, "run_id", runId,
+		"fresh", fresh)
 
-	reg.runHarness(ctx, w, deps, runId, entry, rebaseInput(input, deps.AppRoot))
+	writeResultHeaders(w)
+	sink := newBodyWriter(w)
+	// Replay first: a reattaching client needs the frames produced while it was
+	// away before it can follow the live ones. False means the replay was the
+	// whole run — it had already finished — so there is nothing to wait for.
+	if !entry.attach(sink) {
+		return
+	}
+	if fresh {
+		awaitTakeover()
+		go reg.runHarness(entry.ctx, deps, runId, entry, rebaseInput(input, deps.AppRoot))
+	}
+
+	select {
+	case <-entry.done:
+	case <-r.Context().Done():
+		// This client left; the run has NOT. Detach before returning — net/http
+		// forbids touching the ResponseWriter afterwards — and the harness
+		// buffers from here until someone reattaches.
+		entry.detach(sink)
+		slog.Info("dispatch client gone; run continues detached",
+			"harness", sandboxHarnessID, "run_id", runId)
+	}
 }
 
 // runHarness runs the harness for one run and streams its frames as this
@@ -352,7 +584,6 @@ func (reg *Registry) HandleDispatch(w http.ResponseWriter, r *http.Request, deps
 // while the first is a terminal it must report as-is.
 func (reg *Registry) runHarness(
 	ctx context.Context,
-	w http.ResponseWriter,
 	deps Deps,
 	runId string,
 	entry *activeRun,
@@ -360,19 +591,20 @@ func (reg *Registry) runHarness(
 ) {
 	defer reg.release(runId, entry)
 
-	// Headers and the keepalive FIRST — before `BeforeRun`, not after it.
+	// The keepalive starts FIRST — before `BeforeRun`, not after it.
 	//
 	// Studio calls the pod gone after `DAEMON_SILENCE_TIMEOUT_MS` (90s) without
 	// a byte, and `BeforeRun` legitimately waits on org-fs for up to its own
-	// ~90s budget plus a session copy. Preparing the workspace before opening
-	// the body spent that budget as silence on the wire, so a sandbox whose home
+	// ~90s budget plus a session copy. Preparing the workspace before writing
+	// anything spent that budget as silence on the wire, so a sandbox whose home
 	// volume was late lost its first turn to a "the pod died" verdict and had
 	// the turn continued elsewhere — on a pod that was fine. The keepalive is
 	// what makes waiting for the org's content safe to do at all.
-	writeResultHeaders(w)
-	body := newBodyWriter(w)
+	//
+	// The response headers are already written by the handler that started (or
+	// reattached to) this run: the body outlives any one of them.
 	startedAt := time.Now()
-	stopKeepalive := startKeepalive(ctx, body, runId)
+	stopKeepalive := startKeepalive(ctx, entry, runId)
 	defer stopKeepalive()
 
 	// Per-run workspace state, before the harness can touch the workspace.
@@ -394,7 +626,7 @@ func (reg *Registry) runHarness(
 	}
 
 	if len(deps.HarnessRunnerCmd) == 0 {
-		body.write(terminalFrame("unknown_harness",
+		entry.emit(terminalFrame("unknown_harness",
 			"no harness runner configured (HARNESS_RUNNER_CMD unset)"))
 		return
 	}
@@ -419,7 +651,7 @@ func (reg *Registry) runHarness(
 			slog.Info("dispatch frame", "harness", sandboxHarnessID, "run_id", runId,
 				"seq", seq, "bytes", len(frame),
 				"elapsed_s", int(time.Since(startedAt).Seconds()))
-			return body.write(append(frame, '\n'))
+			return entry.emit(append(frame, '\n'))
 		})
 	elapsed := int(time.Since(startedAt).Seconds())
 
@@ -442,7 +674,7 @@ func (reg *Registry) runHarness(
 		if reg.displaced(runId, entry) {
 			slog.Info("dispatch superseded by takeover",
 				"harness", sandboxHarnessID, "run_id", runId, "elapsed_s", elapsed)
-			body.write(terminalFrame("superseded",
+			entry.emit(terminalFrame("superseded",
 				"a newer dispatch took over this run"))
 			return
 		}
@@ -452,31 +684,33 @@ func (reg *Registry) runHarness(
 		// stop.
 		if reg.tombstoned(runId) {
 			slog.Info("dispatch cancelled", "harness", sandboxHarnessID, "run_id", runId, "elapsed_s", elapsed)
-			body.write(terminalFrame("cancelled", "run cancelled"))
+			entry.emit(terminalFrame("cancelled", "run cancelled"))
 			return
 		}
 		// Nobody asked. The ctx died because this daemon is going away
-		// (SIGTERM → `CancelAll`, i.e. the pod was evicted or scaled in) or the
-		// client's connection dropped. Reporting `cancelled` here is how a
-		// pod eviction settled a live thread as `Error: cancelled: run
-		// cancelled` — a verdict Studio never retries, on a turn that was
-		// mid-edit. `sandbox_gone` says the pod could not finish, not that the
-		// run should not: the checkout is intact, the shutdown publish pushes it
-		// to the branch, and a replacement pod can pick the turn up.
+		// (SIGTERM → `CancelAll`, i.e. the pod was evicted or scaled in) or
+		// because no client reattached within `detachGrace`. A dropped
+		// connection no longer reaches here at all — that is the reattach path.
+		// Reporting `cancelled` here is how a pod eviction settled a live thread
+		// as `Error: cancelled: run cancelled` — a verdict Studio never retries,
+		// on a turn that was mid-edit. `sandbox_gone` says the pod could not
+		// finish, not that the run should not: the checkout is intact, the
+		// shutdown publish pushes it to the branch, and a replacement pod can
+		// pick the turn up.
 		slog.Info("dispatch sandbox gone", "harness", sandboxHarnessID, "run_id", runId, "elapsed_s", elapsed)
-		body.write(terminalFrame(sandboxGoneCode,
+		entry.emit(terminalFrame(sandboxGoneCode,
 			"the sandbox stopped mid-run (pod shutting down or connection dropped)"))
 		return
 	}
 	if err != nil {
 		slog.Error("harness crashed", "harness", sandboxHarnessID, "run_id", runId,
 			"elapsed_s", elapsed, "err", err)
-		body.write(terminalFrame("harness_crashed", err.Error()))
+		entry.emit(terminalFrame("harness_crashed", err.Error()))
 		return
 	}
 	slog.Info("dispatch done", "harness", sandboxHarnessID, "run_id", runId,
 		"elapsed_s", elapsed, "frames", frames)
-	body.write(terminalFrame("", ""))
+	entry.emit(terminalFrame("", ""))
 }
 
 // startKeepalive writes an insignificant byte into the JSON body while the
@@ -489,7 +723,7 @@ func (reg *Registry) runHarness(
 // racing the handler's last write.
 func startKeepalive(
 	ctx context.Context,
-	body *bodyWriter,
+	entry *activeRun,
 	runId string,
 ) func() {
 	ctx, cancel := context.WithCancel(ctx)
@@ -504,7 +738,7 @@ func startKeepalive(
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if !body.write([]byte("\n")) {
+				if !entry.keepaliveTo() {
 					return
 				}
 				// A quiet run is still a live run — see the frame callback's

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
@@ -24,7 +24,9 @@ func TestKeepaliveWritesWhitespaceWhileQuiet(t *testing.T) {
 	dispatchHeartbeat = 5 * time.Millisecond
 	defer func() { dispatchHeartbeat = restore }()
 
-	stop := startKeepalive(context.Background(), body, "run-1")
+	ka := &activeRun{done: make(chan struct{})}
+	ka.attach(body)
+	stop := startKeepalive(context.Background(), ka, "run-1")
 	time.Sleep(60 * time.Millisecond)
 	stop()
 	body.write(terminalFrame("harness_crashed", "boom"))
@@ -148,10 +150,10 @@ func TestRebaseWorkspaceCwd(t *testing.T) {
 func TestClaimTakesOverAnInFlightRun(t *testing.T) {
 	reg := NewRegistry()
 	cancelled := make(chan struct{})
-	first, waitFirst := reg.claim("run-1", func() { close(cancelled) })
+	first, waitFirst := claimForTest(reg, "run-1", func() { close(cancelled) })
 	waitFirst() // nothing displaced, so this returns immediately
 
-	second, waitSecond := reg.claim("run-1", func() {})
+	second, waitSecond := claimForTest(reg, "run-1", func() {})
 	select {
 	case <-cancelled:
 	case <-time.After(time.Second):
@@ -191,12 +193,12 @@ func TestClaimTakesOverAnInFlightRun(t *testing.T) {
 // `Error: cancelled: run cancelled` in prod on 2026-08-07.
 func TestDisplacedReportsOnlyTheLoserOfATakeover(t *testing.T) {
 	reg := NewRegistry()
-	first, _ := reg.claim("run-1", func() {})
+	first, _ := claimForTest(reg, "run-1", func() {})
 	if reg.displaced("run-1", first) {
 		t.Fatal("the only claimant must not report as displaced")
 	}
 
-	second, _ := reg.claim("run-1", func() {})
+	second, _ := claimForTest(reg, "run-1", func() {})
 	if !reg.displaced("run-1", first) {
 		t.Fatal("the run that lost the claim must report as displaced")
 	}
@@ -207,7 +209,7 @@ func TestDisplacedReportsOnlyTheLoserOfATakeover(t *testing.T) {
 	// A cancel with nothing replacing the run (client hangup, DELETE) is the
 	// run's real outcome, so it must still write its terminal.
 	reg.release("run-1", second)
-	solo, _ := reg.claim("run-2", func() {})
+	solo, _ := claimForTest(reg, "run-2", func() {})
 	if reg.displaced("run-2", solo) {
 		t.Fatal("an uncontested run must not report as displaced")
 	}
@@ -221,8 +223,8 @@ func TestClaimTakeoverGivesUpAfterTheTimeout(t *testing.T) {
 	defer func() { takeoverTimeout = restore }()
 
 	reg := NewRegistry()
-	reg.claim("run-1", func() {}) // never released
-	_, wait := reg.claim("run-1", func() {})
+	claimForTest(reg, "run-1", func() {}) // never released
+	_, wait := claimForTest(reg, "run-1", func() {})
 
 	returned := make(chan struct{})
 	go func() { wait(); close(returned) }()
@@ -277,7 +279,9 @@ func TestKeepaliveCountsAsActivity(t *testing.T) {
 	defer func() { dispatchHeartbeat = restore }()
 
 	activity.Bump()
-	stop := startKeepalive(context.Background(), newBodyWriter(httptest.NewRecorder()), "run-1")
+	ka := &activeRun{done: make(chan struct{})}
+	ka.attach(newBodyWriter(httptest.NewRecorder()))
+	stop := startKeepalive(context.Background(), ka, "run-1")
 	time.Sleep(200 * time.Millisecond)
 	stop()
 
@@ -294,7 +298,7 @@ func TestKeepaliveCountsAsActivity(t *testing.T) {
 func TestTombstoneMarksOnlyAskedForCancels(t *testing.T) {
 	const token = "tkn"
 	reg := NewRegistry()
-	entry, _ := reg.claim("run-1", func() {})
+	entry, _ := claimForTest(reg, "run-1", func() {})
 
 	// Shutdown (`CancelAll`) and a dropped connection leave no tombstone: the
 	// run is continuable, so it must NOT be reported as cancelled.
@@ -328,7 +332,7 @@ func TestTombstoneMarksOnlyAskedForCancels(t *testing.T) {
 // permanent one.
 func TestUnauthorizedCancelLeavesNoTombstone(t *testing.T) {
 	reg := NewRegistry()
-	reg.claim("run-1", func() {})
+	claimForTest(reg, "run-1", func() {})
 	rec := httptest.NewRecorder()
 	reg.HandleCancel(rec, httptest.NewRequest("DELETE", "/runs/run-1", nil),
 		func() string { return "tkn" })
@@ -350,5 +354,136 @@ func TestDispatchRejectsOversizedBody(t *testing.T) {
 	NewRegistry().HandleDispatch(rec, req, Deps{DaemonToken: func() string { return token }})
 	if rec.Code != 413 {
 		t.Fatalf("dispatch with oversized body returned %d, want 413", rec.Code)
+	}
+}
+
+// claimForTest keeps the pre-reattach ergonomics the takeover tests are written
+// against: one call, one fresh run, its cancel.
+func claimForTest(reg *Registry, runId string, cancel func()) (*activeRun, func()) {
+	entry, _, wait := reg.claimOrAttach(runId, func() (*activeRun, context.CancelFunc) {
+		return &activeRun{done: make(chan struct{})}, context.CancelFunc(cancel)
+	})
+	return entry, wait
+}
+
+// attachedRun is a run with a live client, which is what makes a second
+// dispatch a takeover rather than a reattach.
+func attachedRun(reg *Registry, runId string, cancel func()) (*activeRun, *bodyWriter) {
+	entry, _ := claimForTest(reg, runId, cancel)
+	sink := newBodyWriter(httptest.NewRecorder())
+	entry.attach(sink)
+	return entry, sink
+}
+
+// The fix this file exists for. A Studio replica is disposable — a rollout or a
+// scale-in aborts the request a run streams into — but the run is executing on a
+// sandbox pod that is perfectly healthy. Killing it there re-ran whole turns
+// from the top (prod, 2026-09-04: a run at seq 52 restarted at seq 23 when
+// deco-studio rolled). A lost client must detach, not end the run.
+func TestLostClientDetachesInsteadOfEndingTheRun(t *testing.T) {
+	reg := NewRegistry()
+	cancelled := make(chan struct{})
+	entry, sink := attachedRun(reg, "run-1", func() { close(cancelled) })
+
+	entry.detach(sink)
+	select {
+	case <-cancelled:
+		t.Fatal("a client going away must not cancel the run")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Work produced while nobody is reading has to survive for the successor.
+	if !entry.emit([]byte("{\"chunks\":[1]}\n")) {
+		t.Fatal("a detached run must keep accepting frames")
+	}
+
+	next, fresh, _ := reg.claimOrAttach("run-1", func() (*activeRun, context.CancelFunc) {
+		t.Fatal("a detached run must be reattached, not replaced")
+		return nil, func() {}
+	})
+	if fresh || next != entry {
+		t.Fatal("the re-dispatch must adopt the running harness")
+	}
+
+	rec := httptest.NewRecorder()
+	if !next.attach(newBodyWriter(rec)) {
+		t.Fatal("attaching to a live run must keep the connection open")
+	}
+	if got := rec.Body.String(); got != "{\"chunks\":[1]}\n" {
+		t.Fatalf("frames buffered while detached must replay; got %q", got)
+	}
+}
+
+// Reattach must not weaken the guarantee it sits next to: two dispatches BOTH
+// holding live connections for one runId is a real double-dispatch, and letting
+// both harnesses write one checkout is two agents in one worktree.
+func TestALiveClientIsStillTakenOverNotAdopted(t *testing.T) {
+	reg := NewRegistry()
+	cancelled := make(chan struct{})
+	first, _ := attachedRun(reg, "run-1", func() { close(cancelled) })
+
+	second, fresh, _ := reg.claimOrAttach("run-1", func() (*activeRun, context.CancelFunc) {
+		return &activeRun{done: make(chan struct{})}, func() {}
+	})
+	if !fresh || second == first {
+		t.Fatal("a run with a live client must be displaced, not adopted")
+	}
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("the displaced run must be cancelled")
+	}
+}
+
+// A run can finish in the gap between one client leaving and the next arriving.
+// Dropping it there tells the successor the run never existed, and the turn is
+// re-executed even though its result was already computed and paid for.
+func TestRunFinishedWhileDetachedIsRetainedForTheSuccessor(t *testing.T) {
+	reg := NewRegistry()
+	entry, sink := attachedRun(reg, "run-1", func() {})
+	entry.detach(sink)
+	entry.emit(terminalFrame("", ""))
+	reg.release("run-1", entry)
+
+	got, fresh, _ := reg.claimOrAttach("run-1", func() (*activeRun, context.CancelFunc) {
+		t.Fatal("a finished-but-undelivered run must be replayed, not re-run")
+		return nil, func() {}
+	})
+	if fresh || got != entry {
+		t.Fatal("the successor must find the finished run")
+	}
+
+	rec := httptest.NewRecorder()
+	if got.attach(newBodyWriter(rec)) {
+		t.Fatal("attaching to a finished run must report that it is over")
+	}
+	var frame struct {
+		Done bool `json:"done"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(rec.Body.String())), &frame); err != nil {
+		t.Fatalf("replayed terminal must parse: %v", err)
+	}
+	if !frame.Done {
+		t.Fatal("the successor must receive the run's terminal frame")
+	}
+}
+
+// Detaching cannot mean "runs forever with nobody listening": if no replacement
+// client arrives, the run is abandoned and must be stopped, which is what keeps
+// a detached harness from outliving its consumer.
+func TestAbandonedDetachedRunIsCancelledAfterTheGrace(t *testing.T) {
+	restore := detachGrace
+	detachGrace = 10 * time.Millisecond
+	defer func() { detachGrace = restore }()
+
+	reg := NewRegistry()
+	cancelled := make(chan struct{})
+	entry, sink := attachedRun(reg, "run-1", func() { close(cancelled) })
+	entry.detach(sink)
+
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("a detached run nobody reattached to must be cancelled")
 	}
 }


### PR DESCRIPTION
## What

A dispatched run's harness was bound to the **inbound HTTP request**:

```go
ctx, cancel := context.WithCancel(r.Context())   // dispatch.go
```

and `RunHarness` execs it with `exec.CommandContext(ctx, ...)` plus a process-group `SIGKILL` on cancel.

So when the Studio replica holding that request went away — a rollout, a KEDA scale-in, a node consolidation — the `claude` process group was killed **on a sandbox pod that was never unhealthy**. Studio's DBOS recovery then re-dispatched, the daemon superseded the remains, and the turn re-ran from the top.

The sandbox is the server; Studio is the client. A disposable client was ending work running somewhere else.

## Evidence (prod, 2026-09-04)

```
14:22:48  dispatch frame   run_id=thrd_SVT... seq=52  elapsed_s=125
14:27:58  dispatch waiting run_id=thrd_SVT...         elapsed_s=435
14:29:17  ← deco-studio rolls to 4.329.5 (new ReplicaSet)
14:29:49  [Decopilot] stream pump error: a newer dispatch took over this run
14:30:10  dispatch frame   run_id=thrd_SVT... seq=23  elapsed_s=24
```

Reached seq 52, restarted at seq 23. Sandbox pod `studio-sandbox-prod-medium-fd2wb` stayed `Running` the whole time. The task shipped nothing.

This is not rare: `deco-studio` runs `terminationGracePeriodSeconds: 120` with `maxSurge: 0` and no preStop drain on the api/worker containers, against runs that take 10–20 minutes. Every rollout severs every in-flight run.

## How

A run now owns its own context (`context.Background()`-derived) and its own frame sink. A client that goes away **detaches** rather than ending the run; the harness keeps going, frames queue, and the re-dispatch **reattaches** to the same run and replays what it missed.

Guarantees kept:

- **Takeover still happens when a client is live.** Two dispatches both holding connections for one `runId` is a genuine double-dispatch — the 2026-08-07 "two agents, one worktree" failure — so that path is unchanged. Reattach applies only to a run that *had* a client and lost it.
- **A detached run cannot outlive its consumer.** Nobody reattaches within `detachGrace` (3 min) → cancelled.
- **A run that finishes while detached is retained** for `finishedRetention` (2 min), so the successor collects the result already computed rather than re-running the turn.
- **The pending buffer is capped** (`maxPendingBytes`); overflow cancels rather than growing unbounded in the pod.

## Tests

Four new tests in `internal/dispatch/dispatch_test.go`, one per guarantee above, plus the existing takeover suite unchanged (shimmed onto the new `claimOrAttach` signature so it keeps asserting what it asserted).

`go test ./...` and `go test -race ./internal/dispatch/` both pass.

## Not in this PR

- The `preStop`/grace-period change on `deco-studio` (lives in deco-apps-cd). This PR makes rollouts survivable; that one makes them graceful.
- `CAPACITY_WAIT_MS = 150s` in `apps/api/src/tools/sandbox/start.ts` is shorter than Karpenter node provisioning, which fails ~10.7% of dispatch windows separately. Different bug, filed separately.
- `packages/sandbox/daemon-e2e` was not run locally (needs the built binary); worth a CI pass before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps sandbox runs alive when the dispatching Studio connection disappears instead of cancelling the harness with the HTTP request. A later dispatch reattaches to the existing run and replays missed frames, so rollouts and scale-ins no longer restart work; abandoned runs still stop automatically.

**Bug Fixes**

- Preserves takeover behavior when another client is still attached, preventing concurrent harnesses from sharing a checkout.
- Cancels detached runs after 3 minutes, retains completed results for 2 minutes, and caps buffered output at 32 MB.
- Adds coverage for detaching, reattachment, takeover, completed-run retention, and abandonment cancellation.

<sup>Written for commit f10278f879405a0d156d35c6a305617c0a68db1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

