### PR TITLE
fix(task-board): trust any *.vtex.app preview host, not only *.preview.vtex.app

### DIFF
--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -289,9 +289,11 @@ describe("isTrustedPreviewHost", () => {
     expect(isTrustedPreviewHost("https://evilvercel.app/")).toBe(false);
   });
 
-  it("accepts VTEX preview subdomains but not other vtex.app hosts", () => {
+  it("accepts any vtex.app subdomain, not just *.preview.vtex.app", () => {
     expect(isTrustedPreviewHost("https://acme.preview.vtex.app/")).toBe(true);
-    expect(isTrustedPreviewHost("https://acme.vtex.app/")).toBe(false);
+    // FastStore WebOps publishes some deploys (e.g. a `staging` environment)
+    // straight on `<account>.vtex.app`; the narrower rule dropped those.
+    expect(isTrustedPreviewHost("https://acme.vtex.app/")).toBe(true);
     expect(isTrustedPreviewHost("https://preview.vtex.app.evil.com/")).toBe(
       false,
     );

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -367,7 +367,7 @@ export function isTrustedPreviewHost(url: string): boolean {
     hostname.endsWith(".deco-cx.workers.dev") ||
     hostname.endsWith(".deco.site") ||
     hostname.endsWith(".vercel.app") ||
-    hostname.endsWith(".preview.vtex.app")
+    hostname.endsWith(".vtex.app")
   );
 }
 


### PR DESCRIPTION
## Summary

A deploy preview that GitHub clearly shows on the PR ("This branch was successfully deployed — staging, by `faststore-webops[bot]`") never reached the Task UI's Links card.

The API *does* read it: `extractPreviewUrlFromDeployment` in `apps/api/src/tools/task-board/prs-get.ts` pulls the newest successful Deployment status's `environmentUrl`. But every candidate URL is then gated through `isTrustedPreviewHost`, whose only VTEX entry was `*.preview.vtex.app`. FastStore WebOps publishes some deploys (a `staging` environment among them) straight on `<account>.vtex.app`, so the URL was dropped, `previewUrl` came back `null`, and the card rendered **no** preview button — not even the disabled "unavailable" one, which is why the failure was invisible.

Widened the allow-list to any `*.vtex.app` subdomain. Same trust class as the already-allowed `*.vercel.app`: a VTEX-owned apex, still a strict hostname check, so decoys like `https://preview.vtex.app.evil.com/` remain rejected.

## Testing

- Inverted the test that encoded the old narrow behavior (`accepts VTEX preview subdomains but not other vtex.app hosts` → `accepts any vtex.app subdomain`).
- `bun test apps/api/src/tools/task-board/checks-status.test.ts` — 59 pass, 0 fail.
- `bun run fmt` clean.

## Follow-up

Not verified against the reporting PR itself (private repo, not visible to any token here). If the button now renders as "Preview unavailable", the next suspect is `TASK_BOARD_PREVIEW_PROBE` — FastStore previews are VTEX-auth-gated and may answer 401/403 — not the extraction path this PR fixes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Task Board Links card so FastStore WebOps deploy previews on `<account>.vtex.app` hosts are recognized; previously only `*.preview.vtex.app` was trusted, so those URLs were discarded and the card rendered no preview button.

- Applies the same trust level already granted to `*.vercel.app`.
- Keeps the strict hostname suffix check, so `preview.vtex.app.evil.com` is still rejected.
- Updates the test that asserted the old narrow rule.

<sup>Written for commit 5b26a021d45e693d270e7def25efb9b319ad966d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

