### PR TITLE
fix(mcp): rewrite LLM-unsafe schema property keys in the MCP proxy

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/mcp-tools.ts
+++ b/apps/api/src/harnesses/lib/decopilot/mcp-tools.ts
@@ -9,6 +9,7 @@ import {
   type ToolSet,
   type UIMessageStreamWriter,
 } from "ai";
+import { llmSafeInputSchema, restoreOriginalKeys } from "@decocms/mcp-utils";
 import {
   MAX_RESULT_TOKENS,
   createOutputPreview,
@@ -30,81 +31,6 @@ export function toolNeedsApproval(
   }
   if (level === "auto") return false;
   return readOnlyHint !== true;
-}
-
-/** Anthropic rejects the WHOLE request (400) if any tool's
- *  `input_schema.properties` has a key outside this pattern, so one bad MCP
- *  tool kills every run. Rename those keys for the model and map them back on
- *  call. Only top-level keys are validated upstream, so only those are touched.
- */
-const LLM_SAFE_PROPERTY_KEY = /^[a-zA-Z0-9_.-]{1,64}$/;
-
-function sanitizePropertyKey(key: string): string {
-  const safe = key.replace(/[^a-zA-Z0-9_.-]/g, "_").slice(0, 64);
-  return safe.length > 0 ? safe : "_";
-}
-
-/** Schema with LLM-safe top-level property keys, plus safeKey -> originalKey
- *  for the renamed ones (empty when nothing needed renaming). */
-export function llmSafeInputSchema(inputSchema: unknown): {
-  schema: unknown;
-  keyMap: Map<string, string>;
-} {
-  const keyMap = new Map<string, string>();
-  const properties = (inputSchema as { properties?: unknown } | null)
-    ?.properties;
-  if (properties == null || typeof properties !== "object") {
-    return { schema: inputSchema, keyMap };
-  }
-  const keys = Object.keys(properties);
-  if (keys.every((k) => LLM_SAFE_PROPERTY_KEY.test(k))) {
-    return { schema: inputSchema, keyMap };
-  }
-
-  const used = new Set(keys.filter((k) => LLM_SAFE_PROPERTY_KEY.test(k)));
-  const rename = new Map<string, string>();
-  for (const key of keys) {
-    if (LLM_SAFE_PROPERTY_KEY.test(key)) continue;
-    let safe = sanitizePropertyKey(key);
-    if (used.has(safe)) {
-      const base = safe.slice(0, 60);
-      let i = 2;
-      while (used.has(`${base}_${i}`)) i++;
-      safe = `${base}_${i}`;
-    }
-    used.add(safe);
-    rename.set(key, safe);
-    keyMap.set(safe, key);
-  }
-
-  const source = properties as Record<string, unknown>;
-  const renamedProperties: Record<string, unknown> = {};
-  for (const key of keys) {
-    renamedProperties[rename.get(key) ?? key] = source[key];
-  }
-  const original = inputSchema as Record<string, unknown>;
-  const schema: Record<string, unknown> = {
-    ...original,
-    properties: renamedProperties,
-  };
-  if (Array.isArray(original.required)) {
-    schema.required = original.required.map((k) =>
-      typeof k === "string" ? (rename.get(k) ?? k) : k,
-    );
-  }
-  return { schema, keyMap };
-}
-
-function restoreOriginalKeys(
-  input: Record<string, unknown>,
-  keyMap: Map<string, string>,
-): Record<string, unknown> {
-  if (keyMap.size === 0) return input;
-  const restored: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(input)) {
-    restored[keyMap.get(key) ?? key] = value;
-  }
-  return restored;
 }
 
 export function sanitizeToolName(name: string): string {

--- a/packages/mcp-utils/src/index.ts
+++ b/packages/mcp-utils/src/index.ts
@@ -15,3 +15,7 @@ export {
   BridgeServerTransport,
   type BridgeTransportPair,
 } from "./bridge-transport.ts";
+export {
+  llmSafeInputSchema,
+  restoreOriginalKeys,
+} from "./llm-safe-property-keys.ts";

--- a/packages/mcp-utils/src/llm-safe-property-keys.test.ts
+++ b/packages/mcp-utils/src/llm-safe-property-keys.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { llmSafeInputSchema } from "./mcp-tools";
+import { llmSafeInputSchema } from "./llm-safe-property-keys.ts";
 
 describe("llmSafeInputSchema", () => {
   it("passes safe schemas through untouched", () => {

--- a/packages/mcp-utils/src/llm-safe-property-keys.ts
+++ b/packages/mcp-utils/src/llm-safe-property-keys.ts
@@ -1,0 +1,77 @@
+/**
+ * Anthropic rejects the WHOLE request (400 `tools.<i>.custom.input_schema
+ * .properties: Property keys should match pattern …`) if any tool's
+ * `input_schema.properties` has a key outside this pattern, so one bad MCP tool
+ * kills every run. Rename those keys on the way out and map them back on call.
+ * Only top-level keys are validated upstream, so only those are touched.
+ */
+const LLM_SAFE_PROPERTY_KEY = /^[a-zA-Z0-9_.-]{1,64}$/;
+
+function sanitizePropertyKey(key: string): string {
+  const safe = key.replace(/[^a-zA-Z0-9_.-]/g, "_").slice(0, 64);
+  return safe.length > 0 ? safe : "_";
+}
+
+/** Schema with LLM-safe top-level property keys, plus safeKey -> originalKey
+ *  for the renamed ones (empty when nothing needed renaming). */
+export function llmSafeInputSchema(inputSchema: unknown): {
+  schema: unknown;
+  keyMap: Map<string, string>;
+} {
+  const keyMap = new Map<string, string>();
+  const properties = (inputSchema as { properties?: unknown } | null)
+    ?.properties;
+  if (properties == null || typeof properties !== "object") {
+    return { schema: inputSchema, keyMap };
+  }
+  const keys = Object.keys(properties);
+  if (keys.every((k) => LLM_SAFE_PROPERTY_KEY.test(k))) {
+    return { schema: inputSchema, keyMap };
+  }
+
+  const used = new Set(keys.filter((k) => LLM_SAFE_PROPERTY_KEY.test(k)));
+  const rename = new Map<string, string>();
+  for (const key of keys) {
+    if (LLM_SAFE_PROPERTY_KEY.test(key)) continue;
+    let safe = sanitizePropertyKey(key);
+    if (used.has(safe)) {
+      const base = safe.slice(0, 60);
+      let i = 2;
+      while (used.has(`${base}_${i}`)) i++;
+      safe = `${base}_${i}`;
+    }
+    used.add(safe);
+    rename.set(key, safe);
+    keyMap.set(safe, key);
+  }
+
+  const source = properties as Record<string, unknown>;
+  const renamedProperties: Record<string, unknown> = {};
+  for (const key of keys) {
+    renamedProperties[rename.get(key) ?? key] = source[key];
+  }
+  const original = inputSchema as Record<string, unknown>;
+  const schema: Record<string, unknown> = {
+    ...original,
+    properties: renamedProperties,
+  };
+  if (Array.isArray(original.required)) {
+    schema.required = original.required.map((k) =>
+      typeof k === "string" ? (rename.get(k) ?? k) : k,
+    );
+  }
+  return { schema, keyMap };
+}
+
+/** Undo `llmSafeInputSchema`'s renaming on a tool call's arguments. */
+export function restoreOriginalKeys(
+  input: Record<string, unknown>,
+  keyMap: Map<string, string>,
+): Record<string, unknown> {
+  if (keyMap.size === 0) return input;
+  const restored: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    restored[keyMap.get(key) ?? key] = value;
+  }
+  return restored;
+}

--- a/packages/mcp-utils/src/server-from-client.test.ts
+++ b/packages/mcp-utils/src/server-from-client.test.ts
@@ -110,6 +110,76 @@ describe("createServerFromClient", () => {
     });
   });
 
+  describe("LLM-safe property keys", () => {
+    const unsafeClient = () =>
+      createMockClient({
+        listTools: mock(async (_params) => ({
+          tools: [
+            {
+              name: "vtex_doc",
+              inputSchema: {
+                type: "object" as const,
+                properties: { acronym: {}, "{fieldName}": {} },
+                required: ["{fieldName}"],
+              },
+            },
+          ] as Tool[],
+        })),
+      });
+
+    it("renames keys Anthropic rejects and restores them on call", async () => {
+      const client = unsafeClient();
+      const server = createServerFromClient(client, {
+        name: "test",
+        version: "1.0.0",
+      });
+      const list = (server.server as any)._requestHandlers.get(
+        ListToolsRequestSchema.shape.method.value,
+      );
+      const call = (server.server as any)._requestHandlers.get(
+        CallToolRequestSchema.shape.method.value,
+      );
+
+      const listed = await list({ method: "tools/list", params: {} });
+      expect(Object.keys(listed.tools[0].inputSchema.properties)).toEqual([
+        "acronym",
+        "_fieldName_",
+      ]);
+      expect(listed.tools[0].inputSchema.required).toEqual(["_fieldName_"]);
+
+      await call({
+        method: "tools/call",
+        params: { name: "vtex_doc", arguments: { _fieldName_: "email" } },
+      });
+      expect(client.callTool).toHaveBeenCalledWith(
+        { name: "vtex_doc", arguments: { "{fieldName}": "email" } },
+        undefined,
+        undefined,
+      );
+    });
+
+    it("restores keys for a client that calls without listing first", async () => {
+      const client = unsafeClient();
+      const server = createServerFromClient(client, {
+        name: "test",
+        version: "1.0.0",
+      });
+      const call = (server.server as any)._requestHandlers.get(
+        CallToolRequestSchema.shape.method.value,
+      );
+
+      await call({
+        method: "tools/call",
+        params: { name: "vtex_doc", arguments: { _fieldName_: "email" } },
+      });
+      expect(client.callTool).toHaveBeenCalledWith(
+        { name: "vtex_doc", arguments: { "{fieldName}": "email" } },
+        undefined,
+        undefined,
+      );
+    });
+  });
+
   describe("callTool", () => {
     it("passes timeout option when toolCallTimeoutMs is set", async () => {
       const client = createMockClient();

--- a/packages/mcp-utils/src/server-from-client.ts
+++ b/packages/mcp-utils/src/server-from-client.ts
@@ -28,6 +28,10 @@
  */
 
 import type { IClient } from "./client-like.ts";
+import {
+  llmSafeInputSchema,
+  restoreOriginalKeys,
+} from "./llm-safe-property-keys.ts";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { sharedJsonSchemaValidator } from "./shared-schema-validator.ts";
 import type {
@@ -100,23 +104,64 @@ export function createServerFromClient(
   // doesn't perfectly match the downstream server's declared schema.
   // A proxy should pass through responses as-is — validation is the
   // responsibility of the originating server, not intermediaries.
+  //
+  // Property keys an upstream server is free to use (`{fieldName}`,
+  // `request.paymentDetails[0].id`, `"group "`) make Anthropic reject the
+  // ENTIRE request, so one such tool anywhere in the org silences every run of
+  // a client that forwards our listing verbatim (the Claude Code SDK does).
+  // Rename them here — the one place every MCP client reads through — and undo
+  // the renaming on the call, so upstream still sees its own key names.
+  const keyMaps = new Map<string, Map<string, string>>();
+  let listed = false;
+
+  /** Rewrite unsafe keys, remembering how to undo it per tool. */
+  const toSafeTools = (
+    tools: Awaited<ReturnType<IClient["listTools"]>>["tools"],
+  ) =>
+    tools.map(({ outputSchema: _, ...tool }) => {
+      const { schema, keyMap } = llmSafeInputSchema(tool.inputSchema);
+      if (keyMap.size === 0) {
+        keyMaps.delete(tool.name);
+        return tool;
+      }
+      keyMaps.set(tool.name, keyMap);
+      return { ...tool, inputSchema: schema as typeof tool.inputSchema };
+    });
+
   server.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
     const result = await client.listTools(request.params);
-    return {
-      ...result,
-      tools: result.tools.map(({ outputSchema: _, ...tool }) => tool),
-    };
+    const tools = toSafeTools(result.tools);
+    // Only an unpaginated listing describes every tool; a single page must not
+    // be mistaken for one when restoring a call's arguments.
+    listed ||= request.params?.cursor == null && result.nextCursor == null;
+    return { ...result, tools };
   });
 
-  server.server.setRequestHandler(CallToolRequestSchema, (request) =>
-    client.callTool(
-      request.params,
+  server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    // A client that calls without listing first has no map yet — build it once.
+    // `listTools` is cached upstream, so this costs a round-trip at most once
+    // per bridge.
+    if (!listed && request.params.arguments) {
+      const result = await client.listTools({});
+      toSafeTools(result.tools);
+      listed = result.nextCursor == null;
+    }
+    const keyMap = keyMaps.get(request.params.name);
+    const params =
+      keyMap && request.params.arguments
+        ? {
+            ...request.params,
+            arguments: restoreOriginalKeys(request.params.arguments, keyMap),
+          }
+        : request.params;
+    return client.callTool(
+      params,
       undefined,
       options?.toolCallTimeoutMs
         ? { timeout: options.toolCallTimeoutMs }
         : undefined,
-    ),
-  );
+    );
+  });
 
   // Resources handlers (only if capabilities include resources)
   if (capabilities?.resources) {


### PR DESCRIPTION
## The bug #6874 missed

The failing runs are `harness_id = claude-code`, not decopilot:

| thread | when (UTC) | error |
|---|---|---|
| `thrd_329O-RjagoObItUJXTYtm` | 2026-09-04 14:59 | `tools.669.custom.input_schema.properties` |
| `thrd_WFzZmR_5xx6Bd9tm1Uuyu` | 2026-09-04 15:00 | `tools.627.…` |
| `thrd_c48HCwAX10bpltCZTPJOJ` | 2026-09-04 11:52 | `tools.674.…` |

All in `montecarlo`, all after #6874 was deployed (verified the sanitizer is in the running image).

`llmSafeInputSchema` lives in `apps/api/src/harnesses/lib/decopilot/mcp-tools.ts`, which a Claude Code run never executes. That run mounts the org's connections as HTTP MCP servers (`orgMcpServers` → `/api/:org/mcp/:connectionId`) and the Claude Code SDK builds the Anthropic tool array from the raw `tools/list` itself.

Culprit tools — the org's VTEX connection (`sites-vtex.deco.site`, 718 tools) exposes 10 with illegal top-level property keys, e.g.

- `VTEX_MDV1_CREATE_NEW_DOCUMENT` → `{fieldName}`
- `VTEX_PAYMENTS_GATEWAY_INSTALLMENT_OPTIONS` → `request.paymentDetails[0].id`
- `VTEX_MARKETPLACE_GET_LIST_SELLERS` → `"group "`

Anthropic rejects the **whole** request, so one bad tool killed every run of the org. Indexes 627/669/674 all land inside the VTEX block.

## The fix

Rewriting moves to `createServerFromClient` — the single bridge every MCP client reads through (`mcp-proxy-factory`, `virtual-mcp`, `mcp-clients/server`), so Claude Code, Cursor and the web UI are all covered — and is undone on `tools/call` so upstream still sees its own key names. A client that calls without listing first gets the map built lazily from one (cached) `listTools`.

The sanitizer itself moved to `packages/mcp-utils/src/llm-safe-property-keys.ts` with its tests; decopilot now imports it instead of keeping a copy.

## Testing

- `bun test packages/mcp-utils` — new bridge tests cover rename-on-list, restore-on-call, and the call-without-list path.
- `bun test apps/api/src/harnesses/lib/decopilot` — 182 pass.
- `tsc --noEmit` clean in both workspaces; `bun run fmt` / `lint` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP proxy to rewrite LLM-unsafe tool schema property keys that Anthropic rejects, so Claude Code runs no longer fail with 400 errors. The sanitizer previously only ran in the decopilot harness; it now runs in `createServerFromClient`, the bridge every MCP client reads through, and is undone on tool call so upstream still sees its own keys.

- Moves `llmSafeInputSchema` and `restoreOriginalKeys` to `@decocms/mcp-utils` and exports them.
- Adds lazy key-map building for clients that call a tool without listing first.

<sup>Written for commit 96e8373ee90e68bacdeb20e9d0a8553addfaeeda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

