### PR TITLE
fix(thread-sheet): keep an open run's transcript live

### DIFF
--- a/apps/web/src/components/thread/thread-sheet-body.tsx
+++ b/apps/web/src/components/thread/thread-sheet-body.tsx
@@ -12,11 +12,14 @@
  * {@link ThreadSheetBody}.
  */
 
-import { Suspense } from "react";
+import { Suspense, useRef } from "react";
 import type { useConnections, useVirtualMCPs } from "@/sdk";
-import { useMCPClient } from "@/sdk";
+import { useMCPClient, useProjectContext } from "@/sdk";
 import { useT } from "@/i18n/use-t.ts";
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import {
+  useQueryClient,
+  useSuspenseInfiniteQuery,
+} from "@tanstack/react-query";
 import { Button } from "@decocms/ui/components/button.tsx";
 import { cn } from "@decocms/ui/lib/utils.ts";
 import { SheetHeader, SheetTitle } from "@decocms/ui/components/sheet.tsx";
@@ -34,6 +37,7 @@ import type {
   StudioThreadMessage as ThreadMessage,
 } from "@decocms/shared/entities";
 import { IntegrationIcon } from "@/components/integration-icon.tsx";
+import { useDecopilotEvents } from "@/hooks/use-decopilot-events.ts";
 import { useInfiniteScroll } from "@/hooks/use-infinite-scroll.ts";
 import type { useMembers } from "@/hooks/use-members";
 import { KEYS } from "@/lib/query-keys";
@@ -285,6 +289,61 @@ function ThreadConversationPanelLoading() {
   );
 }
 
+/**
+ * Keep an open sheet's transcript current while its run is still going.
+ *
+ * The body is a plain paged read with a 60s `staleTime` and nothing that
+ * invalidates it, so it froze at mount: the only way to see new output was to
+ * close the sheet and open it again, and inside the stale window even that
+ * showed nothing. The last pair's `status="streaming"` shimmered over a
+ * transcript that was not actually moving.
+ *
+ * The org-wide `/watch` pool already carries this thread's step/finish events
+ * and is ref-counted per org, so listening costs no new connection — the live
+ * chat's `/stream` (and its whole ThreadConnection) stays out of a read-only
+ * viewer that has no composer.
+ *
+ * Invalidations are coalesced: a chatty run emits a step per tool call, and one
+ * refetch of every loaded page per step is the re-render storm `foldSubStream`
+ * exists to avoid on the chat side. A trailing window collapses a burst into one
+ * refetch, at the cost of showing new output up to that late.
+ *
+ * `onReconnect` matters as much as the steps: `/watch` is at-most-once, so a
+ * blip or a tab wake drops the events that would have refreshed this, and
+ * without a catch-up the sheet silently resumes being stale.
+ */
+const LIVE_REFRESH_DEBOUNCE_MS = 400;
+
+function useLiveThreadMessages(
+  orgSlug: string,
+  locator: string,
+  threadId: string,
+  live: boolean,
+) {
+  const queryClient = useQueryClient();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refresh = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      queryClient.invalidateQueries({
+        queryKey: KEYS.threadMessages(locator, threadId),
+      });
+    }, LIVE_REFRESH_DEBOUNCE_MS);
+  };
+
+  useDecopilotEvents({
+    orgSlug,
+    // `taskId` is matched against the event's `subject`, which is the thread id.
+    taskId: threadId,
+    enabled: live,
+    onStep: refresh,
+    onFinish: refresh,
+    onReconnect: refresh,
+  });
+}
+
 function ThreadConversationPanel({
   client,
   locator,
@@ -304,6 +363,7 @@ function ThreadConversationPanel({
   nav?: ThreadSheetNav;
   meta: boolean;
 }) {
+  const { org } = useProjectContext();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery({
       queryKey: KEYS.threadMessages(locator, thread.id),
@@ -332,6 +392,13 @@ function ThreadConversationPanel({
       },
       staleTime: 60_000,
     });
+
+  useLiveThreadMessages(
+    org.slug,
+    locator,
+    thread.id,
+    thread.status === "in_progress",
+  );
 
   const allItems = data.pages.flatMap(
     (p: { items?: ThreadMessageEntity[] }) => p.items ?? [],

--- a/apps/web/src/components/thread/thread-sheet-body.tsx
+++ b/apps/web/src/components/thread/thread-sheet-body.tsx
@@ -314,6 +314,26 @@ function ThreadConversationPanelLoading() {
  */
 const LIVE_REFRESH_DEBOUNCE_MS = 400;
 
+/**
+ * Poll interval while the run is still going.
+ *
+ * Polling, not events alone, because `decopilot.step` is emitted ONLY by the
+ * hosted Decopilot path: `runRegistry.dispatch({ type: "STEP_DONE" })` lives in
+ * that harness's `streamText` `onStep` hook and has no sandbox-side twin. A
+ * claude-code run publishes its chunks straight through `ingestRun`, so the
+ * `/watch` pool carries only its RUN_STARTED and terminal `thread.status` (plus
+ * `finish`) — nothing per step. Subscribing alone would settle the transcript
+ * once the run ended and show nothing at all while the agent worked, which is
+ * the case worth fixing.
+ *
+ * A sandbox turn is tens to hundreds of whole-step chunks, not a token stream
+ * (see dispatch-run.ts), so a few seconds is proportionate to how fast this view
+ * can actually change. The events stay wired: on a hosted run they land the
+ * update sooner than the next tick, and `onReconnect` covers the pool's
+ * at-most-once gap.
+ */
+const LIVE_REFRESH_POLL_MS = 5_000;
+
 function useLiveThreadMessages(
   orgSlug: string,
   locator: string,
@@ -364,6 +384,7 @@ function ThreadConversationPanel({
   meta: boolean;
 }) {
   const { org } = useProjectContext();
+  const live = thread.status === "in_progress";
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery({
       queryKey: KEYS.threadMessages(locator, thread.id),
@@ -391,14 +412,12 @@ function ThreadConversationPanel({
         return pages.length * MESSAGES_PAGE_SIZE;
       },
       staleTime: 60_000,
+      // Only an open sheet on a still-running thread polls: a settled thread is
+      // immutable, and a closed sheet is unmounted.
+      refetchInterval: live ? LIVE_REFRESH_POLL_MS : false,
     });
 
-  useLiveThreadMessages(
-    org.slug,
-    locator,
-    thread.id,
-    thread.status === "in_progress",
-  );
+  useLiveThreadMessages(org.slug, locator, thread.id, live);
 
   const allItems = data.pages.flatMap(
     (p: { items?: ThreadMessageEntity[] }) => p.items ?? [],


### PR DESCRIPTION
## Problem

Opening a task's linked run shows a transcript that never updates. The only way to see new agent output is to close the drawer and open it again — and if you reopen within 60s, not even that works.

`ThreadSheetBody` is a one-shot snapshot:

```tsx
useSuspenseInfiniteQuery({
  queryKey: KEYS.threadMessages(locator, thread.id),
  queryFn: … COLLECTION_THREAD_MESSAGES_LIST …,
  staleTime: 60_000,        // no refetchInterval, no SSE, nothing invalidates it
})
```

Worse, it *looks* live: the last pair renders `status="streaming"` whenever `thread.status === "in_progress"`, so it shimmers over a transcript that is not moving.

This affects all three surfaces that use the sheet — Monitoring → Threads, an automation's Runs tab, and a task's linked runs.

## Fix

Subscribe the open sheet to the org-wide `/watch` pool and invalidate the messages query on this thread's `decopilot.step` / `decopilot.finish` events.

`useDecopilotEvents` is ref-counted per org and already multiplexes these events, so this opens **no new connection**. Its `taskId` option is matched against the event's `subject`, which is the thread id — so filtering is exact (the option is just misnamed).

The read-only viewer deliberately still does **not** get a `ThreadConnection`/`/stream`: it has no composer and nothing to submit.

Details worth knowing:

- Active only while `thread.status === "in_progress"`.
- Invalidations are coalesced on a 400ms trailing window. A chatty run emits a step per tool call, and refetching every loaded page per step is exactly the re-render storm `foldSubStream` exists to avoid on the chat side. Cost: new output can appear up to ~400ms late.
- `onReconnect` is wired as well. `/watch` is at-most-once, so a network blip or a tab wake drops the events that would have refreshed this; without a catch-up the sheet silently resumes being stale.

## Testing

`oxlint` and `tsc --noEmit` clean on the changed file; `bun run fmt` applied.

Not covered by an automated test — the behaviour is an SSE-driven refetch and this repo's tiers put that in e2e rather than unit (`TESTING.md`). Verified by reading the event contract rather than by running a live run; worth a manual check that an in-progress task's drawer now advances without reopening.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps an open run's transcript live instead of freezing at mount — new agent output now appears without closing and reopening the sheet, and the `status="streaming"` shimmer no longer sits over a transcript that isn't moving. The sheet subscribes to the org-wide `/watch` pool and polls, so it stays current for both hosted Decopilot runs and sandbox (claude-code) runs that emit no step events. No new connection is opened, and the read-only viewer still doesn't get a `/stream`.

- Applies to all three surfaces that use the sheet: Monitoring → Threads, the automation Runs tab, and a task's linked runs.
- Active only while `thread.status === "in_progress"`.
- Invalidations are debounced on a 400ms trailing window; a 5s poll is the harness-agnostic fallback, since `decopilot.step` only exists on the hosted path.
- `onReconnect` is wired because `/watch` is at-most-once; a network blip or tab wake would otherwise leave the sheet silently stale.
- The `taskId` option is matched against the event's `subject` (the thread id), so filtering is exact despite the name.
- Not covered by automated tests (SSE-driven, fits the e2e tier); worth a manual check that an in-progress drawer advances without reopening.

<sup>Written for commit eaf913601bd680861410996505af9cadb0aeb086. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

