### PR TITLE
fix(sandbox): stop /tmp evictions killing runs, and say when one does

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -800,3 +800,30 @@ describe("a lost sandbox's cause reaches the agent and the thread", () => {
     expect(chunks.map((c) => c.type)).toEqual(["start", "finish"]);
   });
 });
+
+describe("describeTermination — eviction", () => {
+  // An eviction was explicitly in the "carries no information" list, so a run
+  // whose pod was taken away for filling a volume reported only that the
+  // sandbox went away. The kubelet's message names the resource and the limit,
+  // which is the difference between an unexplained failure and a fixable one.
+  test("names the resource the pod ran out of", () => {
+    const text = describeTermination({
+      reason: "Evicted",
+      oomKilled: false,
+      evictionMessage:
+        'Usage of EmptyDir volume "tmp" exceeds the limit "1Gi".',
+    });
+
+    expect(text).toContain("evicted");
+    expect(text).toContain('EmptyDir volume "tmp"');
+    expect(text).toContain('"1Gi"');
+  });
+
+  // Retrying an eviction onto a fresh pod hits the same cap, so the text has to
+  // say so — otherwise the run loops and every attempt reads as bad luck.
+  test("says a retry will hit the same limit", () => {
+    expect(
+      describeTermination({ reason: "Evicted", oomKilled: false }),
+    ).toContain("same limit");
+  });
+});

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -746,7 +746,13 @@ function resumeReason(errorMessage: string, infra: string | null): string {
  * and the user is not is how "it just stopped" survived in prod.
  *
  * Null for a stop that carries no information beyond the broken stream we
- * already reported (a graceful shutdown, an eviction, a pod already gone).
+ * already reported (a graceful shutdown, a pod already gone).
+ *
+ * An eviction used to be in that list and should not have been: it is the most
+ * actionable stop there is, because the kubelet says which resource ran out.
+ * Silently swallowing it is how 41 pods evicted for filling `/tmp` in one
+ * afternoon produced nothing but a generic "the sandbox went away", on runs
+ * that then retried onto fresh pods and filled it again.
  */
 export function describeTermination(
   termination: PodTermination | null,
@@ -757,6 +763,16 @@ export function describeTermination(
       ? ` (memory limit ${termination.memoryLimit})`
       : "";
     return `it was killed by the kernel for exceeding its memory limit${limit} — OOMKilled`;
+  }
+  if (termination.reason === "Evicted") {
+    const detail = termination.evictionMessage
+      ? `: ${termination.evictionMessage.replace(/\.$/, "")}`
+      : "";
+    return (
+      `the sandbox pod was evicted by the kubelet${detail} — the run filled a ` +
+      `resource the pod is capped at, so retrying it on a fresh pod will hit ` +
+      `the same limit unless it writes less`
+    );
   }
   if (termination.reason === "Completed") return null;
   const code =

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -379,17 +379,26 @@ spec:
       volumes:
         {{- if .Values.readOnlyRootFilesystem }}
         # Sized to match the per-container ephemeral-storage limit shape;
-        # individual mounts get a slice. Adjust if a workload needs more.
+        # individual mounts get a slice.
+        #
+        # These are HARD limits: exceed one and the kubelet evicts the whole
+        # pod immediately, killing a run mid-turn with no error the agent or
+        # the user can see. `/tmp` at 1Gi was under that line for any Node
+        # build — a single package-manager cache clears it — and evicted 41
+        # pods in one afternoon in prod, each retry landing on a fresh pod
+        # that filled it again. Sized from what a real install actually
+        # writes, and configurable so raising one does not need a template
+        # edit.
         - name: workdir
           emptyDir:
-            sizeLimit: 4Gi
+            sizeLimit: {{ .Values.volumeSizes.workdir | default "4Gi" }}
         - name: tmp
           emptyDir:
-            sizeLimit: 1Gi
+            sizeLimit: {{ .Values.volumeSizes.tmp | default "4Gi" }}
         {{- end }}
         - name: home
           emptyDir:
-            sizeLimit: 5Gi
+            sizeLimit: {{ .Values.volumeSizes.home | default "5Gi" }}
         {{- if .Values.depsCache.enabled }}
         # Node-local package cache shared across sandbox pods (see the
         # depsCache comment in values.yaml for the hardlink + isolation

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -308,6 +308,18 @@ orgFs:
       cpu: 500m
       memory: 512Mi
 
+# Per-sandbox ephemeral volume sizes (emptyDir `sizeLimit`).
+#
+# HARD limits: exceeding one evicts the pod instantly, which surfaces as a run
+# that died mid-turn rather than as an error. `tmp` was 1Gi and is the one that
+# bites — a package-manager cache alone can clear that — so it now matches
+# `workdir`. Raise rather than economize: the cost of a too-large emptyDir is
+# node disk pressure, the cost of a too-small one is silently killed runs.
+volumeSizes:
+  workdir: 4Gi
+  tmp: 4Gi
+  home: 5Gi
+
 # Read-only root filesystem. When true, /app + /tmp + /home/sandbox are
 # remounted as emptyDirs and `safe.directory '*'` is set so git works
 # against the chowned mount.

--- a/packages/sandbox/server/provider/agent-sandbox/client.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.test.ts
@@ -796,3 +796,41 @@ describe("readPodTermination", () => {
     ).toBeNull();
   });
 });
+
+describe("podTermination", () => {
+  // An eviction is reported on the POD, not on a container: the kubelet takes
+  // the pod away before its containers record a terminated state. Reading only
+  // container statuses returned null, so every eviction reached the user as an
+  // unexplained lost sandbox — including the 41 pods evicted in one afternoon
+  // for filling `/tmp`, each retry landing on a fresh pod that filled it again.
+  it("reports an eviction and the kubelet's message", () => {
+    expect(
+      podTermination(
+        {
+          status: {
+            phase: "Failed",
+            reason: "Evicted",
+            message: 'Usage of EmptyDir volume "tmp" exceeds the limit "1Gi".',
+            containerStatuses: [{ name: "sandbox" }],
+          },
+        },
+        "sandbox",
+      ),
+    ).toEqual({
+      reason: "Evicted",
+      oomKilled: false,
+      evictionMessage:
+        'Usage of EmptyDir volume "tmp" exceeds the limit "1Gi".',
+    });
+  });
+
+  // A pod that is merely gone still carries nothing worth saying.
+  it("stays null for a pod with no verdict", () => {
+    expect(
+      podTermination(
+        { status: { containerStatuses: [{ name: "sandbox" }] } },
+        "sandbox",
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/sandbox/server/provider/agent-sandbox/client.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.ts
@@ -694,6 +694,10 @@ interface PodTerminationSource {
     }>;
   };
   status?: {
+    /** Pod-level verdict. An eviction lands here, never in a container status. */
+    phase?: string;
+    reason?: string;
+    message?: string;
     containerStatuses?: Array<{
       name?: string;
       state?: { terminated?: TerminatedState };
@@ -711,7 +715,24 @@ export function podTermination(
     (c) => c.name === containerName,
   );
   const terminated = status?.state?.terminated ?? status?.lastState?.terminated;
-  if (!terminated?.reason) return null;
+  // An eviction is reported on the POD (`status.reason`), and its containers
+  // often carry no terminated state at all — the kubelet takes the pod away
+  // before they record one. Reading only container statuses therefore returned
+  // null for every eviction, so a run whose pod was evicted for filling a
+  // volume was reported as an unexplained lost sandbox. The message is the
+  // actionable half: it names the volume and the limit.
+  if (!terminated?.reason) {
+    if (pod.status?.reason === "Evicted") {
+      return {
+        reason: "Evicted",
+        oomKilled: false,
+        ...(pod.status.message === undefined
+          ? {}
+          : { evictionMessage: pod.status.message }),
+      };
+    }
+    return null;
+  }
   const memoryLimit = (pod.spec?.containers ?? []).find(
     (c) => c.name === containerName,
   )?.resources?.limits?.memory;

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -185,6 +185,15 @@ export interface PodTermination {
   exitCode?: number;
   /** The limit that was hit, as k8s spells it (`4Gi`). */
   memoryLimit?: string;
+  /**
+   * The kubelet's eviction message when `reason` is `Evicted`, verbatim — it
+   * names the resource and the limit, e.g.
+   * `Usage of EmptyDir volume "tmp" exceeds the limit "1Gi".`
+   *
+   * Without it an eviction is indistinguishable from any other lost pod, which
+   * is how a run that filled a volume looked like "the sandbox went away".
+   */
+  evictionMessage?: string;
 }
 
 export function sandboxIdKey(id: SandboxId): string {


### PR DESCRIPTION
## What happened

`studio-sandbox-prod-medium-*` pods were being evicted in a loop:

```
Warning  Evicted  pod/studio-sandbox-prod-medium-t6fgk
         Usage of EmptyDir volume "tmp" exceeds the limit "1Gi"
```

**41 evictions in one afternoon.** `t6fgk` was running a live task; the run died mid-turn, the worker retried (`attempt: 1, 2, 3, 4`), each retry landed on a fresh pod, and that pod filled `/tmp` the same way. From the task it looked like the agent kept restarting for no reason.

Volume limits on a sandbox pod were:

```
workdir=4Gi   home=5Gi   tmp=1Gi   orgfs-org=1Gi
```

An emptyDir `sizeLimit` is a hard limit — the kubelet evicts the whole pod the moment it is crossed. 1Gi is under what any Node build needs: a single package-manager cache clears it.

## Why nobody could see it

Two places conspired to throw the information away:

- `describeTermination` listed **"an eviction"** among the stops that "carry no information beyond the broken stream we already reported".
- `podTermination` only inspected `status.containerStatuses`. An eviction is a **pod-level** verdict (`status.reason` / `status.message`), and the kubelet takes the pod away before its containers record a terminated state — so every eviction extracted to `null`.

Net effect: the most actionable stop there is (the kubelet names the exact resource that ran out) reached the user as a generic "the sandbox went away".

## Changes

- **`/tmp` 1Gi → 4Gi**, and `workdir`/`tmp`/`home` become `volumeSizes.*` values so raising one no longer requires a template edit.
- **`podTermination`** reads the pod-level eviction verdict and carries the kubelet's message verbatim.
- **`describeTermination`** renders it, and adds that a retry will hit the same limit — because retrying onto a fresh pod is precisely what the run does next, and without saying so each attempt reads as bad luck.

## Tests

`packages/sandbox` — the extractor reports an eviction with its message, and still returns null for a pod with no verdict.
`apps/api` — the rendered sentence names the volume and the limit, and warns that a retry hits the same cap.

`bun test` green on both files (39 and 56). `tsc --noEmit` clean in `apps/api` and `packages/sandbox`. `helm template` renders.

## Note on the trigger

Part of what filled `/tmp` was agent guidance I wrote — a skill telling the agent to run `yarn install --cache-folder /tmp/ycache` (a workaround for an unwritable `~/.cache/yarn`), plus unzipped design assets and screenshots under `/tmp`. That skill has been changed to use `/app/scratch` on the 4Gi workdir volume. This PR is the platform half: `/tmp` should not be small enough for ordinary work to trip it, and an eviction should never again be silent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandbox runs being silently killed when a pod fills its `/tmp` volume, and surfaces the kubelet's eviction message so the cause is visible.

- Raises `/tmp` from 1Gi to 4Gi and makes `workdir`, `tmp`, and `home` sizes configurable via `volumeSizes` values instead of a template edit.
- Reads eviction verdicts from the pod status, where the kubelet reports them, instead of only container statuses, so evictions are no longer extracted as null.
- Renders the eviction message verbatim and warns that retrying on a fresh pod will hit the same limit.

**Migration**
- Helm deployments should set `volumeSizes.tmp` to at least 4Gi; the default is 4Gi but existing values may override it.

<sup>Written for commit e00cc55274dc9ded3779d7da59ffe83c6dd84d76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

