### PR TITLE
fix(sandbox): let a reconnecting worker adopt its run, not restart it

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -1413,20 +1413,35 @@ export async function createApp(options: CreateAppOptions = {}) {
     }
   });
 
-  // Backlog size (ENQUEUED count) for one DBOS queue, e.g. for a KEDA
-  // metrics-api trigger: `{ "queue_length": <n> }`. Restricted to the
-  // queues we actually register — DBOS.listQueuedWorkflows would happily
-  // query a made-up name and just return an empty list.
+  // Depth of one DBOS queue for a KEDA metrics-api trigger, split by what the
+  // two numbers mean for scaling:
+  //
+  //   queue_length — ENQUEUED, work waiting for any pod. Scales UP.
+  //   in_flight    — PENDING, runs executing on some pod right now. A FLOOR:
+  //                  targeted at the queue's `workerConcurrency`, it asks for
+  //                  exactly the replicas needed to hold the running work.
+  //
+  // Reporting only the backlog is what made KEDA scale in a busy worker: a run
+  // streams for minutes with nothing enqueued behind it, the trigger reads
+  // `0/5 (avg)`, and the pod holding a live DBOS workflow is the one taken away
+  // (prod 2026-09-04). The daemon can now reattach when that happens; this stops
+  // it happening for a queue that is merely busy rather than backed up.
+  //
+  // Restricted to the queues we actually register — DBOS.listQueuedWorkflows
+  // would happily query a made-up name and just return an empty list.
   app.get(`${SYSTEM_PATHS.DBOS_QUEUE_DEPTH_PREFIX}:queueName`, async (c) => {
     const queueName = c.req.param("queueName");
     if (!DBOS_QUEUE_NAMES.has(queueName)) {
       return c.json({ error: `Unknown queue: ${queueName}` }, 404);
     }
-    const queued = await DBOS.listQueuedWorkflows({
-      queueName,
-      status: "ENQUEUED",
+    const [enqueued, running] = await Promise.all([
+      DBOS.listQueuedWorkflows({ queueName, status: "ENQUEUED" }),
+      DBOS.listQueuedWorkflows({ queueName, status: "PENDING" }),
+    ]);
+    return c.json({
+      queue_length: enqueued.length,
+      in_flight: running.length,
     });
-    return c.json({ queue_length: queued.length });
   });
 
   // ============================================================================

--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -1417,9 +1417,17 @@ export async function createApp(options: CreateAppOptions = {}) {
   // two numbers mean for scaling:
   //
   //   queue_length — ENQUEUED, work waiting for any pod. Scales UP.
-  //   in_flight    — PENDING, runs executing on some pod right now. A FLOOR:
-  //                  targeted at the queue's `workerConcurrency`, it asks for
-  //                  exactly the replicas needed to hold the running work.
+  //   in_flight    — PENDING, runs executing on some pod right now. Targeted at
+  //                  the queue's `workerConcurrency`, so it asks for exactly the
+  //                  replicas needed to hold the work already running.
+  //
+  // `in_flight` behaves as a FLOOR while recovery is healthy — every PENDING row
+  // belongs to a live executor, and per-pod PENDING is capped at
+  // `workerConcurrency` by the dequeue, so it can never ask for more replicas
+  // than are already busy. It is NOT an unconditional floor: during a rollout,
+  // and until DBOS recovery re-enqueues a dead pod's rows, the dead and the live
+  // rows are both counted and the trigger can briefly ask for more. That
+  // over-ask is bounded by `dequeuedAfter` below and self-corrects on recovery.
   //
   // Reporting only the backlog is what made KEDA scale in a busy worker: a run
   // streams for minutes with nothing enqueued behind it, the trigger reads
@@ -1429,14 +1437,44 @@ export async function createApp(options: CreateAppOptions = {}) {
   //
   // Restricted to the queues we actually register — DBOS.listQueuedWorkflows
   // would happily query a made-up name and just return an empty list.
+  //
+  // How stale a PENDING row may be and still count as in flight. Comfortably
+  // above `RUN_IDLE_TIMEOUT_MS` (10 min), the point at which Studio itself stops
+  // believing a run is alive — so this never clips a real run's floor, it only
+  // stops an unrecovered row from holding a replica up indefinitely.
+  const IN_FLIGHT_STALENESS_MS = 30 * 60 * 1000;
   app.get(`${SYSTEM_PATHS.DBOS_QUEUE_DEPTH_PREFIX}:queueName`, async (c) => {
     const queueName = c.req.param("queueName");
     if (!DBOS_QUEUE_NAMES.has(queueName)) {
       return c.json({ error: `Unknown queue: ${queueName}` }, 404);
     }
+    // `loadInput: false` on both: the rows are counted, never read, and a
+    // hosted-harness workflow's input is the whole run request — deserializing
+    // every one of them twice per KEDA poll to call `.length` on the array is
+    // pure waste.
     const [enqueued, running] = await Promise.all([
-      DBOS.listQueuedWorkflows({ queueName, status: "ENQUEUED" }),
-      DBOS.listQueuedWorkflows({ queueName, status: "PENDING" }),
+      DBOS.listQueuedWorkflows({
+        queueName,
+        status: "ENQUEUED",
+        loadInput: false,
+        loadOutput: false,
+      }),
+      DBOS.listQueuedWorkflows({
+        queueName,
+        status: "PENDING",
+        loadInput: false,
+        loadOutput: false,
+        // PENDING is not proof of a LIVE executor: a pod that was SIGKILLed
+        // leaves its rows PENDING with `queue_name` intact until DBOS recovery
+        // re-enqueues them, and a workflow that recovery never reaches stays
+        // that way indefinitely. Unbounded, those rows would hold worker
+        // replicas up forever. Bounded here to runs dequeued recently enough
+        // to still be plausibly executing, so a stuck row ages out of the
+        // floor instead of pinning capacity to it.
+        dequeuedAfter: new Date(
+          Date.now() - IN_FLIGHT_STALENESS_MS,
+        ).toISOString(),
+      }),
     ]);
     return c.json({
       queue_length: enqueued.length,

--- a/packages/e2e/tests/dbos-queue-depth.spec.ts
+++ b/packages/e2e/tests/dbos-queue-depth.spec.ts
@@ -3,13 +3,13 @@ import { expect, test } from "../fixtures/test";
 // KEDA hits the API process directly (the worker Service), not the web origin
 // the rest of the suite uses — `/dbos-queue-depth` is not under `/api`, so the
 // Vite proxy would answer it with index.html.
-const apiOrigin = `http://localhost:${process.env.PORT ?? "3000"}`;
+const apiOrigin = `http://localhost:${process.env.PORT || "3000"}`;
 
 // The ScaledObject in deco-apps-cd reads these two field NAMES out of this
 // unauthenticated endpoint (`valueLocation: queue_length` / `in_flight`). A
-// rename here is silent: KEDA's scaler errors and the worker stops scaling,
-// which is how a pod holding a live run got scaled in. So the shape is
-// asserted, not the numbers.
+// rename here is silent — KEDA's scaler errors and the HPA freezes — so the
+// shape is asserted, not the numbers. This holds up only THIS half of the
+// contract: nothing here fails if someone edits the chart.
 test("dbos queue depth reports both backlog and in-flight work", async ({
   playwright,
 }) => {
@@ -24,4 +24,6 @@ test("dbos queue depth reports both backlog and in-flight work", async ({
 
   const unknown = await ctx.get("/dbos-queue-depth/not-a-queue");
   expect(unknown.status()).toBe(404);
+
+  await ctx.dispose();
 });

--- a/packages/e2e/tests/dbos-queue-depth.spec.ts
+++ b/packages/e2e/tests/dbos-queue-depth.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "../fixtures/test";
+
+// KEDA hits the API process directly (the worker Service), not the web origin
+// the rest of the suite uses — `/dbos-queue-depth` is not under `/api`, so the
+// Vite proxy would answer it with index.html.
+const apiOrigin = `http://localhost:${process.env.PORT ?? "3000"}`;
+
+// The ScaledObject in deco-apps-cd reads these two field NAMES out of this
+// unauthenticated endpoint (`valueLocation: queue_length` / `in_flight`). A
+// rename here is silent: KEDA's scaler errors and the worker stops scaling,
+// which is how a pod holding a live run got scaled in. So the shape is
+// asserted, not the numbers.
+test("dbos queue depth reports both backlog and in-flight work", async ({
+  playwright,
+}) => {
+  const ctx = await playwright.request.newContext({ baseURL: apiOrigin });
+
+  const res = await ctx.get("/dbos-queue-depth/decopilot-hosted-harness");
+  expect(res.status()).toBe(200);
+  expect(await res.json()).toEqual({
+    queue_length: expect.any(Number),
+    in_flight: expect.any(Number),
+  });
+
+  const unknown = await ctx.get("/dbos-queue-depth/not-a-queue");
+  expect(unknown.status()).toBe(404);
+});

--- a/packages/sandbox/daemon-e2e/daemon.dispatch.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.dispatch.e2e.test.ts
@@ -437,4 +437,49 @@ describe("daemon e2e: dispatch runs a harness", () => {
     },
     HOOK_TIMEOUT_MS,
   );
+
+  it(
+    "a stop pressed while a re-dispatch is waiting out the grace is not restarted",
+    async () => {
+      // A re-dispatch for a live run waits ~5s for the incumbent to hang up
+      // before calling itself a takeover. A DELETE landing inside that window is
+      // exactly what ENDS the wait (cancelling closes the run), so the waiting
+      // dispatch used to wake up, find the run gone, and start it again — a stop
+      // button that relaunches the turn it just stopped, holding the checkout
+      // for a full run. It must resolve to the tombstone instead.
+      const runId = "run-cancel-in-grace";
+      const first = await dispatch("hang", runId);
+      expect(first.status).toBe(200);
+      const firstEnded = (async () => {
+        const frames: DispatchFrame[] = [];
+        for await (const { frame } of readFrames(first)) frames.push(frame);
+        return frames;
+      })();
+
+      // Let the daemon exec the harness, then re-dispatch: the second request is
+      // now parked in the grace with the first still attached.
+      await new Promise((r) => setTimeout(r, 500));
+      const second = dispatch("frames", runId);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const cancel = await fetch(url(d, `/_sandbox/runs/${runId}`), {
+        method: "DELETE",
+        headers: authHeaders(),
+      });
+      expect(cancel.status).toBe(204);
+
+      const secondRes = await second;
+      expect(secondRes.status).toBe(410);
+      expect(((await secondRes.json()) as { error: string }).error).toBe(
+        "tombstoned",
+      );
+
+      // And the cancelled run really is the one that ended — no replacement
+      // harness produced frames behind it.
+      const terminal = (await firstEnded).at(-1);
+      expect(terminal?.done).toBe(true);
+      expect(terminal?.error?.code).toBe("cancelled");
+    },
+    HOOK_TIMEOUT_MS,
+  );
 });

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
@@ -296,6 +296,11 @@ func NewRegistry() *Registry {
 func (reg *Registry) tombstoned(runId string) bool {
 	reg.mu.Lock()
 	defer reg.mu.Unlock()
+	return reg.tombstonedLocked(runId)
+}
+
+// tombstonedLocked is `tombstoned` for a caller that already holds `reg.mu`.
+func (reg *Registry) tombstonedLocked(runId string) bool {
 	expiry, ok := reg.tombstones[runId]
 	if !ok {
 		return false
@@ -322,6 +327,9 @@ func (reg *Registry) tombstoned(runId string) bool {
 // after its own replica died is NOT that case — there is no second writer, only
 // a second reader — which is exactly what reattach distinguishes.
 //
+// A nil entry means the run was cancelled (tombstoned) while we waited: the
+// caller answers 410, exactly as the handler's pre-wait check would have.
+//
 // The returned wait function MUST be called before starting a harness: it blocks
 // until a displaced run's handler has returned (bounded by `takeoverTimeout`).
 func (reg *Registry) claimOrAttach(
@@ -339,15 +347,27 @@ func (reg *Registry) claimOrAttach(
 		// before concluding this is a competing writer. See `supersedeGrace`.
 		// (Already-detached runs fall through this immediately.)
 		reg.mu.Unlock()
+		waitStart := time.Now()
 		waitForDetach(prev, supersedeGrace)
 		reg.mu.Lock()
 		// The wait is lock-free, so the decision is made from the registry as
-		// it is NOW, never from the pointer we waited on. Three outcomes, and
-		// `prev` may have been replaced by an entirely different dispatch:
+		// it is NOW, never from the pointer we waited on — `prev` may even have
+		// been replaced by an entirely different dispatch:
+		//   - tombstoned       → cancelled while we waited; not ours to start
 		//   - in finishedRuns  → it ended detached; collect its frames
 		//   - gone from the map → it ended with its client still reading, so
 		//     the terminal was already delivered; this dispatch is a new turn
 		//   - still there      → detached ? reattach : genuine second writer
+		//
+		// The tombstone re-read is what the grace makes necessary: DELETE is
+		// exactly the thing that ends the wait early (cancelling closes
+		// `prev.done`), so a stop pressed during the grace would otherwise be
+		// answered by STARTING the run it just cancelled. The pre-wait check in
+		// the handler covers only the instant before this.
+		if reg.tombstonedLocked(runId) {
+			reg.mu.Unlock()
+			return nil, false, func() {}
+		}
 		if done, ok := reg.finishedRuns[runId]; ok {
 			reg.mu.Unlock()
 			return done, false, func() {}
@@ -361,7 +381,7 @@ func (reg *Registry) claimOrAttach(
 		if prev != nil {
 			slog.Info("dispatch incumbent still attached; taking over",
 				"harness", sandboxHarnessID, "run_id", runId,
-				"waited_s", int(supersedeGrace.Seconds()))
+				"waited_ms", time.Since(waitStart).Milliseconds())
 		}
 	}
 	created, cancel := newCancel()
@@ -456,9 +476,15 @@ func (reg *Registry) displaced(runId string, entry *activeRun) bool {
 // collects the real result, instead of finding nothing and re-running a turn
 // that had already completed.
 func (reg *Registry) release(runId string, entry *activeRun) {
+	// All of it under `reg.mu`, including `close(done)`. A dispatch deciding
+	// what to do about this run holds that same lock, so it cannot observe the
+	// half-retired state in between — a run marked finished but still listed in
+	// `activeRuns` reads as "attached", and taking it over there would discard a
+	// terminal that had already been produced.
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
 	entry.markFinished()
 	retain := entry.hasPending()
-	reg.mu.Lock()
 	if reg.activeRuns[runId] == entry {
 		delete(reg.activeRuns, runId)
 		if retain {
@@ -472,7 +498,6 @@ func (reg *Registry) release(runId string, entry *activeRun) {
 			})
 		}
 	}
-	reg.mu.Unlock()
 	close(entry.done)
 }
 
@@ -613,6 +638,12 @@ func (reg *Registry) HandleDispatch(w http.ResponseWriter, r *http.Request, deps
 		ctx, cancel := context.WithCancel(context.Background())
 		return &activeRun{ctx: ctx, done: make(chan struct{})}, cancel
 	})
+	if entry == nil {
+		// Cancelled during the supersede grace — same answer as the pre-wait
+		// tombstone check above, just decided later.
+		jsonError(w, 410, map[string]string{"error": "tombstoned"})
+		return
+	}
 	slog.Info("dispatch received", "harness", sandboxHarnessID, "run_id", runId,
 		"fresh", fresh)
 

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
@@ -334,33 +334,34 @@ func (reg *Registry) claimOrAttach(
 		return done, false, func() {}
 	}
 	prev := reg.activeRuns[runId]
-	if prev != nil && prev.isDetached() {
-		reg.mu.Unlock()
-		slog.Info("dispatch reattach", "harness", sandboxHarnessID, "run_id", runId)
-		return prev, false, func() {}
-	}
 	if prev != nil {
 		// Live-looking incumbent: give its connection a moment to finish dying
 		// before concluding this is a competing writer. See `supersedeGrace`.
+		// (Already-detached runs fall through this immediately.)
 		reg.mu.Unlock()
-		if waitForDetach(prev, supersedeGrace) {
-			slog.Info("dispatch reattach after incumbent hung up",
-				"harness", sandboxHarnessID, "run_id", runId)
-			return prev, false, func() {}
-		}
-		slog.Info("dispatch incumbent still attached; taking over",
-			"harness", sandboxHarnessID, "run_id", runId,
-			"waited_s", int(supersedeGrace.Seconds()))
+		waitForDetach(prev, supersedeGrace)
 		reg.mu.Lock()
-		// Re-read: the wait is lock-free, so the map may have moved under it.
-		// A run that ENDED while we waited leaves nothing to displace, and one
-		// that was replaced is no longer ours to cancel.
+		// The wait is lock-free, so the decision is made from the registry as
+		// it is NOW, never from the pointer we waited on. Three outcomes, and
+		// `prev` may have been replaced by an entirely different dispatch:
+		//   - in finishedRuns  → it ended detached; collect its frames
+		//   - gone from the map → it ended with its client still reading, so
+		//     the terminal was already delivered; this dispatch is a new turn
+		//   - still there      → detached ? reattach : genuine second writer
 		if done, ok := reg.finishedRuns[runId]; ok {
 			reg.mu.Unlock()
 			return done, false, func() {}
 		}
-		if reg.activeRuns[runId] != prev {
-			prev = reg.activeRuns[runId]
+		prev = reg.activeRuns[runId]
+		if prev != nil && prev.isDetached() {
+			reg.mu.Unlock()
+			slog.Info("dispatch reattach", "harness", sandboxHarnessID, "run_id", runId)
+			return prev, false, func() {}
+		}
+		if prev != nil {
+			slog.Info("dispatch incumbent still attached; taking over",
+				"harness", sandboxHarnessID, "run_id", runId,
+				"waited_s", int(supersedeGrace.Seconds()))
 		}
 	}
 	created, cancel := newCancel()
@@ -387,28 +388,27 @@ func (reg *Registry) claimOrAttach(
 }
 
 // waitForDetach blocks until `entry` loses its client or finishes, up to
-// `limit`. Reports whether it can now be reattached to rather than displaced.
+// `limit`. It reports nothing: the caller re-reads the registry under the lock
+// afterwards, because by then `entry` may have been released, replaced, or
+// moved to finishedRuns — and only the map says which.
 //
 // Polled rather than signalled on purpose: detaching happens under the run's
 // own mutex from two places (a failed frame write, the handler returning), and
 // a condition variable there would put the notify inside the write path of
 // every frame. The wait is seconds long and happens once per re-dispatch.
-func waitForDetach(entry *activeRun, limit time.Duration) bool {
+func waitForDetach(entry *activeRun, limit time.Duration) {
 	deadline := time.Now().Add(limit)
 	for {
 		if entry.isDetached() {
-			return true
+			return
 		}
 		select {
 		case <-entry.done:
-			// It finished while we waited. `attach` replays whatever it
-			// buffered and reports that the run is over, which is the correct
-			// outcome for a re-dispatch that arrived just too late.
-			return true
+			return
 		case <-time.After(50 * time.Millisecond):
 		}
 		if time.Now().After(deadline) {
-			return false
+			return
 		}
 	}
 }

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
@@ -40,6 +40,24 @@ const sandboxGoneCode = "sandbox_gone"
 // shorten it.
 var takeoverTimeout = 10 * time.Second
 
+// How long a dispatch for a run that is already live waits for the incumbent
+// connection to close before treating itself as a takeover.
+//
+// The daemon has no attach verb: reconnecting and starting a competing turn are
+// the SAME wire call (`POST /dispatch`), so the only signal separating them is
+// whether the previous connection is still open. That signal describes a
+// socket, not a worker. When KEDA scales in the worker holding a run, DBOS
+// recovers the workflow and re-dispatches within a second or two — routinely
+// faster than the dying pod's TCP close is observed here. The daemon then saw a
+// live client, called it a second writer, SIGKILLed a healthy harness and
+// re-ran the turn.
+//
+// There is no second writer in that case, only a slow-closing one. Waiting
+// briefly costs a re-dispatch nothing (it is about to stream anyway) and turns
+// the common case back into a reattach. A genuine double-dispatch still
+// supersedes — it just does so this much later.
+var supersedeGrace = 5 * time.Second
+
 // How long a run whose client vanished keeps running, waiting to be reattached.
 //
 // A Studio replica is disposable — a rollout, a KEDA scale-in or a node
@@ -321,6 +339,30 @@ func (reg *Registry) claimOrAttach(
 		slog.Info("dispatch reattach", "harness", sandboxHarnessID, "run_id", runId)
 		return prev, false, func() {}
 	}
+	if prev != nil {
+		// Live-looking incumbent: give its connection a moment to finish dying
+		// before concluding this is a competing writer. See `supersedeGrace`.
+		reg.mu.Unlock()
+		if waitForDetach(prev, supersedeGrace) {
+			slog.Info("dispatch reattach after incumbent hung up",
+				"harness", sandboxHarnessID, "run_id", runId)
+			return prev, false, func() {}
+		}
+		slog.Info("dispatch incumbent still attached; taking over",
+			"harness", sandboxHarnessID, "run_id", runId,
+			"waited_s", int(supersedeGrace.Seconds()))
+		reg.mu.Lock()
+		// Re-read: the wait is lock-free, so the map may have moved under it.
+		// A run that ENDED while we waited leaves nothing to displace, and one
+		// that was replaced is no longer ours to cancel.
+		if done, ok := reg.finishedRuns[runId]; ok {
+			reg.mu.Unlock()
+			return done, false, func() {}
+		}
+		if reg.activeRuns[runId] != prev {
+			prev = reg.activeRuns[runId]
+		}
+	}
 	created, cancel := newCancel()
 	created.cancel = cancel
 	reg.activeRuns[runId] = created
@@ -340,6 +382,33 @@ func (reg *Registry) claimOrAttach(
 			// means two harnesses may briefly share the checkout.
 			slog.Error("dispatch takeover timed out; previous run may still be writing",
 				"run_id", runId, "waited_s", int(takeoverTimeout.Seconds()))
+		}
+	}
+}
+
+// waitForDetach blocks until `entry` loses its client or finishes, up to
+// `limit`. Reports whether it can now be reattached to rather than displaced.
+//
+// Polled rather than signalled on purpose: detaching happens under the run's
+// own mutex from two places (a failed frame write, the handler returning), and
+// a condition variable there would put the notify inside the write path of
+// every frame. The wait is seconds long and happens once per re-dispatch.
+func waitForDetach(entry *activeRun, limit time.Duration) bool {
+	deadline := time.Now().Add(limit)
+	for {
+		if entry.isDetached() {
+			return true
+		}
+		select {
+		case <-entry.done:
+			// It finished while we waited. `attach` replays whatever it
+			// buffered and reports that the run is over, which is the correct
+			// outcome for a re-dispatch that arrived just too late.
+			return true
+		case <-time.After(50 * time.Millisecond):
+		}
+		if time.Now().After(deadline) {
+			return false
 		}
 	}
 }

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
@@ -148,6 +148,7 @@ func TestRebaseWorkspaceCwd(t *testing.T) {
 // the run it displaces and wait for it to exit — two harnesses editing one
 // checkout is the failure this prevents.
 func TestClaimTakesOverAnInFlightRun(t *testing.T) {
+	shortSupersedeGrace(t)
 	reg := NewRegistry()
 	cancelled := make(chan struct{})
 	first, waitFirst := claimForTest(reg, "run-1", func() { close(cancelled) })
@@ -192,6 +193,7 @@ func TestClaimTakesOverAnInFlightRun(t *testing.T) {
 // "cancelled" terminal from the loser is what settled a live thread as
 // `Error: cancelled: run cancelled` in prod on 2026-08-07.
 func TestDisplacedReportsOnlyTheLoserOfATakeover(t *testing.T) {
+	shortSupersedeGrace(t)
 	reg := NewRegistry()
 	first, _ := claimForTest(reg, "run-1", func() {})
 	if reg.displaced("run-1", first) {
@@ -218,6 +220,7 @@ func TestDisplacedReportsOnlyTheLoserOfATakeover(t *testing.T) {
 // The takeover wait is bounded: a displaced run whose process refuses to die
 // must not wedge the thread forever.
 func TestClaimTakeoverGivesUpAfterTheTimeout(t *testing.T) {
+	shortSupersedeGrace(t)
 	restore := takeoverTimeout
 	takeoverTimeout = 10 * time.Millisecond
 	defer func() { takeoverTimeout = restore }()
@@ -357,6 +360,14 @@ func TestDispatchRejectsOversizedBody(t *testing.T) {
 	}
 }
 
+// shortSupersedeGrace keeps the suite fast: every takeover path now waits out
+// `supersedeGrace` for the incumbent to hang up first.
+func shortSupersedeGrace(t *testing.T) {
+	restore := supersedeGrace
+	supersedeGrace = 20 * time.Millisecond
+	t.Cleanup(func() { supersedeGrace = restore })
+}
+
 // claimForTest keeps the pre-reattach ergonomics the takeover tests are written
 // against: one call, one fresh run, its cancel.
 func claimForTest(reg *Registry, runId string, cancel func()) (*activeRun, func()) {
@@ -418,6 +429,7 @@ func TestLostClientDetachesInsteadOfEndingTheRun(t *testing.T) {
 // holding live connections for one runId is a real double-dispatch, and letting
 // both harnesses write one checkout is two agents in one worktree.
 func TestALiveClientIsStillTakenOverNotAdopted(t *testing.T) {
+	shortSupersedeGrace(t)
 	reg := NewRegistry()
 	cancelled := make(chan struct{})
 	first, _ := attachedRun(reg, "run-1", func() { close(cancelled) })
@@ -485,5 +497,90 @@ func TestAbandonedDetachedRunIsCancelledAfterTheGrace(t *testing.T) {
 	case <-cancelled:
 	case <-time.After(time.Second):
 		t.Fatal("a detached run nobody reattached to must be cancelled")
+	}
+}
+
+// The case that kept losing work in prod. KEDA scales in the worker holding a
+// run; DBOS recovers the workflow and re-dispatches within a second or two —
+// faster than the dying pod's TCP close is observed here. The daemon has no
+// attach verb, so that reconnect arrives as the same `POST /dispatch` a
+// competing turn would, and the only thing separating them was whether the
+// previous connection looked open. It did, so a healthy harness was SIGKILLed
+// and the turn re-run. There was never a second writer, only a slow-closing
+// one.
+func TestIncumbentHangingUpDuringTheGraceIsReattachedNotSuperseded(t *testing.T) {
+	restore := supersedeGrace
+	supersedeGrace = time.Second
+	defer func() { supersedeGrace = restore }()
+
+	reg := NewRegistry()
+	cancelled := make(chan struct{})
+	first, sink := attachedRun(reg, "run-1", func() { close(cancelled) })
+
+	// The incumbent's connection dies just after the re-dispatch arrives.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		first.detach(sink)
+	}()
+
+	entry, fresh, _ := reg.claimOrAttach("run-1", func() (*activeRun, context.CancelFunc) {
+		t.Fatal("a re-dispatch must not displace a run whose client is hanging up")
+		return nil, func() {}
+	})
+	if fresh || entry != first {
+		t.Fatal("the reconnect must adopt the running harness")
+	}
+	select {
+	case <-cancelled:
+		t.Fatal("the running harness must not be killed for a reconnect")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// The grace must not become a way for two live writers to share a checkout: an
+// incumbent that is genuinely still streaming is still displaced, just later.
+func TestIncumbentThatStaysAttachedIsStillSuperseded(t *testing.T) {
+	shortSupersedeGrace(t)
+
+	reg := NewRegistry()
+	cancelled := make(chan struct{})
+	first, _ := attachedRun(reg, "run-1", func() { close(cancelled) })
+
+	entry, fresh, _ := reg.claimOrAttach("run-1", func() (*activeRun, context.CancelFunc) {
+		return &activeRun{done: make(chan struct{})}, func() {}
+	})
+	if !fresh || entry == first {
+		t.Fatal("a live incumbent must still be displaced after the grace")
+	}
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("the displaced run must be cancelled")
+	}
+}
+
+// A run that finishes inside the grace has nothing left to displace: the
+// re-dispatch collects its buffered frames and terminal instead of re-running a
+// turn that already completed.
+func TestRunFinishingDuringTheGraceIsCollectedNotRestarted(t *testing.T) {
+	restore := supersedeGrace
+	supersedeGrace = time.Second
+	defer func() { supersedeGrace = restore }()
+
+	reg := NewRegistry()
+	first, sink := attachedRun(reg, "run-1", func() {})
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		first.detach(sink)
+		first.emit(terminalFrame("", ""))
+		reg.release("run-1", first)
+	}()
+
+	entry, fresh, _ := reg.claimOrAttach("run-1", func() (*activeRun, context.CancelFunc) {
+		t.Fatal("a finished run must be collected, not re-run")
+		return nil, func() {}
+	})
+	if fresh || entry != first {
+		t.Fatal("the re-dispatch must find the finished run")
 	}
 }

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
@@ -559,9 +559,11 @@ func TestIncumbentThatStaysAttachedIsStillSuperseded(t *testing.T) {
 	}
 }
 
-// A run that finishes inside the grace has nothing left to displace: the
-// re-dispatch collects its buffered frames and terminal instead of re-running a
-// turn that already completed.
+// A run that hangs up and then FINISHES inside the grace has nothing left to
+// displace: the re-dispatch collects its buffered frames and terminal instead of
+// re-running a turn that already completed. Asserting the terminal actually
+// arrives is the point — "did not start a fresh run" alone is also true of an
+// adopted corpse with nothing left to replay.
 func TestRunFinishingDuringTheGraceIsCollectedNotRestarted(t *testing.T) {
 	restore := supersedeGrace
 	supersedeGrace = time.Second
@@ -569,7 +571,9 @@ func TestRunFinishingDuringTheGraceIsCollectedNotRestarted(t *testing.T) {
 
 	reg := NewRegistry()
 	first, sink := attachedRun(reg, "run-1", func() {})
+	released := make(chan struct{})
 	go func() {
+		defer close(released)
 		time.Sleep(30 * time.Millisecond)
 		first.detach(sink)
 		first.emit(terminalFrame("", ""))
@@ -582,6 +586,15 @@ func TestRunFinishingDuringTheGraceIsCollectedNotRestarted(t *testing.T) {
 	})
 	if fresh || entry != first {
 		t.Fatal("the re-dispatch must find the finished run")
+	}
+
+	<-released
+	rec := httptest.NewRecorder()
+	if entry.attach(newBodyWriter(rec)) {
+		t.Fatal("attaching to a finished run must report that it is over")
+	}
+	if !strings.Contains(rec.Body.String(), `"done":true`) {
+		t.Fatalf("the successor must receive the run's terminal, got %q", rec.Body.String())
 	}
 }
 
@@ -625,13 +638,15 @@ func TestReplacementIncumbentThatIsDetachedIsAdoptedNotKilled(t *testing.T) {
 	cancelled := make(chan struct{})
 	second, sink := newDetachedRun(func() { close(cancelled) })
 
+	// `second` is detached BEFORE it becomes the claim: the waiter must never be
+	// able to observe it mid-swap and call it a live second writer.
+	second.detach(sink)
 	go func() {
 		time.Sleep(30 * time.Millisecond)
 		reg.mu.Lock()
 		reg.activeRuns["run-1"] = second
 		reg.mu.Unlock()
 		first.detach(firstSink) // unblocks the wait; `first` is no longer the claim
-		second.detach(sink)
 	}()
 
 	entry, fresh, _ := reg.claimOrAttach("run-1", func() (*activeRun, context.CancelFunc) {
@@ -652,4 +667,33 @@ func newDetachedRun(cancel func()) (*activeRun, *bodyWriter) {
 	sink := newBodyWriter(httptest.NewRecorder())
 	entry.attach(sink)
 	return entry, sink
+}
+
+// The grace's own side effect. DELETE is exactly what ends the wait early — it
+// cancels the run, which closes `done` — so a stop pressed during those seconds
+// used to be answered by STARTING the run it had just cancelled, and that
+// harness then held the checkout for a full turn. The handler's pre-wait
+// tombstone check covers only the instant before the wait.
+func TestRunCancelledDuringTheGraceIsNotRestarted(t *testing.T) {
+	restore := supersedeGrace
+	supersedeGrace = time.Second
+	defer func() { supersedeGrace = restore }()
+
+	reg := NewRegistry()
+	first, _ := attachedRun(reg, "run-1", func() {})
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		reg.mu.Lock()
+		reg.tombstones["run-1"] = time.Now().Add(tombstoneTTL)
+		reg.mu.Unlock()
+		reg.release("run-1", first)
+	}()
+
+	entry, fresh, _ := reg.claimOrAttach("run-1", func() (*activeRun, context.CancelFunc) {
+		t.Fatal("a cancelled run must never be restarted by the dispatch behind it")
+		return nil, func() {}
+	})
+	if entry != nil || fresh {
+		t.Fatal("a tombstoned run must resolve to nothing, so the handler answers 410")
+	}
 }

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
@@ -584,3 +584,72 @@ func TestRunFinishingDuringTheGraceIsCollectedNotRestarted(t *testing.T) {
 		t.Fatal("the re-dispatch must find the finished run")
 	}
 }
+
+// A run that finishes with its client STILL READING has already delivered its
+// terminal, and `release` keeps nothing (there is no buffer to hand on). A
+// dispatch arriving after that must start a new turn — adopting the drained
+// entry would stream zero frames and no terminal, and the thread would never
+// settle.
+func TestRunFinishingAttachedDuringTheGraceStartsAFreshRun(t *testing.T) {
+	restore := supersedeGrace
+	supersedeGrace = time.Second
+	defer func() { supersedeGrace = restore }()
+
+	reg := NewRegistry()
+	first, _ := attachedRun(reg, "run-1", func() {})
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		first.emit(terminalFrame("", ""))
+		reg.release("run-1", first)
+	}()
+
+	entry, fresh, _ := reg.claimOrAttach("run-1", func() (*activeRun, context.CancelFunc) {
+		return &activeRun{done: make(chan struct{})}, func() {}
+	})
+	if !fresh || entry == first {
+		t.Fatal("a run whose terminal was already delivered must not be re-adopted")
+	}
+}
+
+// The wait is lock-free, so the incumbent can be replaced while it runs. The
+// replacement is judged on its own state: an already-detached one is another
+// reconnect and must be adopted, not SIGKILLed — the very thing the grace
+// exists to prevent, one race narrower.
+func TestReplacementIncumbentThatIsDetachedIsAdoptedNotKilled(t *testing.T) {
+	restore := supersedeGrace
+	supersedeGrace = time.Second
+	defer func() { supersedeGrace = restore }()
+
+	reg := NewRegistry()
+	first, firstSink := attachedRun(reg, "run-1", func() {})
+	cancelled := make(chan struct{})
+	second, sink := newDetachedRun(func() { close(cancelled) })
+
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		reg.mu.Lock()
+		reg.activeRuns["run-1"] = second
+		reg.mu.Unlock()
+		first.detach(firstSink) // unblocks the wait; `first` is no longer the claim
+		second.detach(sink)
+	}()
+
+	entry, fresh, _ := reg.claimOrAttach("run-1", func() (*activeRun, context.CancelFunc) {
+		return &activeRun{done: make(chan struct{})}, func() {}
+	})
+	if fresh || entry != second {
+		t.Fatal("a detached replacement must be reattached to, not displaced")
+	}
+	select {
+	case <-cancelled:
+		t.Fatal("the replacement's harness must not be killed")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func newDetachedRun(cancel func()) (*activeRun, *bodyWriter) {
+	entry := &activeRun{done: make(chan struct{}), cancel: cancel}
+	sink := newBodyWriter(httptest.NewRecorder())
+	entry.attach(sink)
+	return entry, sink
+}


### PR DESCRIPTION
## The bug

Runs keep restarting mid-job and losing work. Root cause is a protocol gap.

The daemon exposes exactly two run verbs:

```
POST   /_sandbox/dispatch        ← carries the full harness input
DELETE /_sandbox/runs/{runId}    ← cancel
```

There is **no attach verb**. So a replacement worker has no way to say *"I am the new reader for run X, stream me from seq 199"* — the only thing it can do is `POST /dispatch` again, and the daemon has to guess whether that means *reconnect* or *a competing turn*. It guessed from whether the incumbent's connection was still open, which describes a **socket**, not a worker.

## What actually happens

```
2m4s   Scaled down replica set deco-studio-worker-59cfcffd68 from 2 to 1
2m4s   Killing pod/deco-studio-worker-59cfcffd68-fmkzl
119s   SuccessfulRescale  New size: 2; reason: Current number of replicas below Spec.MinReplicas
```

KEDA scales in the worker holding a run (then immediately back up, because 1 is below `minReplicas`). DBOS recovers the workflow and re-dispatches within a second or two — faster than the dying pod's TCP close is observed by the daemon. The daemon sees a live client, takes the **takeover** branch, SIGKILLs a healthy harness and re-runs the turn:

```
run ended  chunks=197 elapsedMs=295253 error="superseded"
[decopilot] attempt superseded by a newer dispatch; leaving the terminal to it
[hostedHarness] ... fromSeq: 199
```

There was never a second writer. Only a slow-closing one.

#7006 made the daemon able to reattach, but only once the run is already marked detached — so it does not fire when the reconnect wins the race against the socket close, which is the common case.

## The change

A dispatch for a run that still looks live now waits `supersedeGrace` (5s) for the incumbent to hang up, and **reattaches** if it does. Waiting costs a reconnect nothing — it is about to stream anyway.

Preserved:

- **A genuine double-dispatch still supersedes**, just that much later. The "two agents, one worktree" guarantee (2026-08-07) is unchanged.
- **A run that finishes inside the grace is collected**, not re-run — the re-dispatch gets its buffered frames and terminal.
- The wait is lock-free, so the registry is re-read afterwards: a run that ended or was replaced during it is no longer ours to cancel.

## Tests

Four, one per branch: reconnect-during-grace reattaches and does **not** cancel the harness; a genuinely-attached incumbent is still superseded; a run finishing inside the grace is collected; plus the existing takeover suite, with the grace shortened so the suite stays fast.

`go test ./...` and `go test -race ./internal/dispatch/` pass; `go vet` clean.

## This is a mitigation, not the fix

The protocol should carry an explicit attach — `GET /_sandbox/runs/{runId}/stream?fromSeq=N` — so a reconnect can never be read as a competing turn and `POST /dispatch` goes back to meaning "start this turn" only. Two things to settle first: the frame buffer currently spans only from the moment of detach, so an attach arriving later would still gap, and `ingestRun`/JetStream may be the better replay source since it already holds every chunk by seq.

## The trigger, fixed too

`keda-hpa-deco-studio-worker` reported `0/5 (avg)` while a run was in flight: the metrics-api triggers count **ENQUEUED** work only, and a hosted run is dequeued the instant it starts, then streams for minutes with nothing behind it. KEDA saw an idle worker and scaled in the pod holding a live DBOS workflow.

`/dbos-queue-depth/:queueName` now reports `in_flight` (PENDING) alongside `queue_length` (ENQUEUED). The two numbers mean different things for scaling and are wired to separate triggers: backlog scales **up**, in-flight sets a replica **floor** (`ceil(in_flight / workerConcurrency)`) so running work can never be scaled out from under itself.

`in_flight` is a floor *while DBOS recovery is healthy* — per-pod PENDING is capped at `workerConcurrency` by the dequeue, so it can never ask for more replicas than are already busy. It is not unconditional: a PENDING row survives its executor's death until recovery re-enqueues it, so a rollout briefly counts dead pods' rows too. That is bounded by a 30-minute `dequeuedAfter` window (above the 10-minute run-liveness ceiling, so it never clips a real run) rather than left to pin a replica forever. Both queries pass `loadInput: false` — they count rows, and a hosted-harness input is the whole run request.

The chart half is **decocms/deco-apps-cd#479**, and it must land only after this is **fully rolled out**: KEDA resolves `valueLocation` with `gjson`, an absent path errors rather than reading 0, and the HPA then freezes at its current replica count.

An e2e (`packages/e2e/tests/dbos-queue-depth.spec.ts`) pins both field names: they are a wire contract with a ScaledObject in another repo, where a rename would be silent.

## Follow-up commit: the two edge paths

The grace's wait is lock-free, so its result described a pointer that could already be stale by the time it returned. Two ways that went wrong:

- A run that finished with its client **still reading** has delivered its terminal, and `release` retains nothing (no buffer to hand on). The dispatch behind it adopted that drained entry — zero frames, no terminal — and the thread never settled.
- An incumbent **replaced during the wait** was displaced on the strength of the old entry's state. An already-detached replacement — another reconnect — got SIGKILLed: the exact case the grace exists to prevent, one race narrower.

Both are now impossible by construction. `waitForDetach` reports nothing; the decision is read from the registry under the lock afterwards. In `finishedRuns` → collect. Gone from the map → its terminal was delivered, so this dispatch is a new turn. Still there → detached ? reattach : supersede. Two tests, each verified red against the previous commit.

## Third commit: the holes the grace itself opened

A review pass on the two commits above, and this is the one that matters:

**A stop pressed during the grace restarted the run.** `DELETE` is exactly what *ends* the wait — cancelling closes the run's `done` — so the waiting dispatch woke, found the run gone, and started it. A stop button that relaunches the turn it just stopped, with that harness holding the checkout for a full run. The handler's tombstone check ran once at the door; the grace put five seconds between it and the decision. The tombstone is now re-read inside the post-wait critical section and resolves to a 410. Covered at both tiers — a Go unit test and a black-box `daemon-e2e` one that gets `200` (restarted) without the fix and `410` with it.

**`release` was not atomic.** It called `markFinished()` (which clears `detached`) *before* taking `reg.mu`, so a dispatch could observe a run that had finished but was still listed in `activeRuns`, read it as "attached", take it over, and discard a terminal that had already been produced. All of `release` now runs under one lock, `close(done)` included.

Plus: the takeover log reported the grace *constant* instead of the measured wait; one test passed via the wrong branch and never checked the successor got a terminal; another swapped a replacement into the registry before detaching it, so a poll landing between the two would see a live second writer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runs restarting mid-job and losing work when KEDA scales in the worker holding them. The daemon has no attach verb, so a reconnect and a competing turn arrive as the same `POST /dispatch`; a dispatch for a live run now waits up to 5s for the incumbent to hang up and reattaches instead of taking over. The queue-depth endpoint also now reports in-flight work, so KEDA stops scaling in a worker that is merely busy rather than backed up.

**Daemon reattach**
- A genuine double-dispatch still supersedes, just 5s later.
- A run that finishes during the wait is collected, not re-run.
- The wait's decision is re-read from the registry afterwards, so a replaced or drained entry can't be adopted by mistake.
- A stop pressed during the wait resolves to a tombstone instead of restarting the run it just cancelled.

**KEDA trigger**
- `/dbos-queue-depth/:queue` now returns `queue_length` and `in_flight` (PENDING count).
- `in_flight` counts only runs dequeued within the last 30 minutes, so a stuck PENDING row ages out of the replica floor instead of pinning capacity forever.
- The `decocms/deco-apps-cd` ScaledObject needs the new `in_flight` trigger — deploy the chart side first, or the scaler errors on the missing field.

This is a mitigation: the protocol should gain an explicit attach verb so a reconnect can never look like a competing turn.

<sup>Written for commit d22a4251c56c11fe01df848be4820ee7c0566593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->