### PR TITLE
fix(sidebar): let the org/project picker scroll on touch

### DIFF
--- a/apps/web/src/components/sidebar/org-project-picker.tsx
+++ b/apps/web/src/components/sidebar/org-project-picker.tsx
@@ -259,14 +259,23 @@ function PickerContent({
       shouldFilter={false}
       value={active}
       onValueChange={setActive}
-      className="max-h-[min(560px,70dvh)]"
+      /* The third term is what Radix measured between the trigger and the
+         viewport edge, so a picker opened low on a short screen ends where the
+         screen does instead of running off it. */
+      className="max-h-[min(560px,70dvh,var(--radix-popover-content-available-height,70dvh))]"
     >
       <CommandInput
         value={search}
         onValueChange={setSearch}
         placeholder={t("sidebar.picker.searchPlaceholder")}
       />
-      <CommandList>
+      {/* The list is the part that gives, so it owns the Command's height
+          budget rather than `CommandList`'s shared 300px default — which was
+          the smaller of the two and made the number above it a cap nothing
+          ever reached. `min-h-0` so it may shrink inside the flex column;
+          `flex-1` grows it only into space that exists, so a short list stays
+          short and the input and strip keep their own heights. */}
+      <CommandList className="max-h-none min-h-0 flex-1">
         {searching ? (
           <>
             {/* A failed search is not an empty one: saying "nothing matches"
@@ -550,7 +559,16 @@ export function OrgProjectPicker({
 
   return (
     <>
-      <Popover open={open} onOpenChange={setOpen}>
+      {/* `modal`, and it is load-bearing on touch. On mobile the sidebar IS a
+          Radix dialog (the sheet), whose scroll lock cancels every wheel and
+          touchmove that lands outside the dialog's own subtree — and this
+          popover is portalled to the body, so the list clipped at its max
+          height and would not move under a finger. A modal popover brings its
+          own lock, only the innermost lock acts, and that one counts the list
+          as scrollable. Cheaper than teaching the sheet about its portals, and
+          it restores the menu semantics this control inherited from the
+          dropdown it replaced. */}
+      <Popover open={open} onOpenChange={setOpen} modal>
         <PopoverTrigger asChild>{trigger}</PopoverTrigger>
         <PopoverContent
           side={collapsed ? "right" : "bottom"}


### PR DESCRIPTION
## Summary

Reported from a phone: the org/project picker menu would not scroll.

Two defects, one visible:

**1. Touch scroll was being cancelled.** On mobile the sidebar is a Radix `Sheet` — a modal dialog — whose scroll lock (`react-remove-scroll`) calls `preventDefault()` on *every* wheel and touchmove landing outside the dialog's own DOM subtree. The picker's popover is portalled to `document.body`, so it is outside: the list clipped at its max height and would not move under a finger. The repo already knew this failure mode for wheel and patched it by hand in `page-template-select.tsx:87`.

Fix: `<Popover ... modal>`. A modal popover installs its own lock, only the innermost lock acts, and that one counts the list as scrollable. It also restores the menu semantics this control inherited from the dropdown it replaced.

**2. The height cap above it was dead code.** `Command` declared `max-h-[min(560px,70dvh)]`, but `CommandList`'s shared `max-h-[300px]` default is smaller — so the picker was always ~373px tall whatever that number said. The list now takes the Command's budget (`max-h-none min-h-0 flex-1`), and the budget clamps to `--radix-popover-content-available-height` so a picker opened low on a short screen ends where the screen does.

## Testing

Built a throwaway page against the **real** `Sheet` + `PopoverContent` + `Command` components, drove it in Chrome, and dispatched a real touch sequence over the list:

| | `touchmove` prevented? |
|---|---|
| before (non-modal) | **true** → cannot scroll |
| after (`modal`) | **false** → scrolls |
| after, list at its end | true → no scroll chaining to the page behind |

Layout after the change at an 806px viewport: Command 560px, input keeps its full 40px, verb strip 33px, list 487px and scrollable — nothing is squeezed. The repro page is not part of this diff.

`bun run fmt`, `bun run lint` (0 errors), `tsc --noEmit`, and the 89 sidebar unit tests pass.

## Affected areas

`apps/web/src/components/sidebar/org-project-picker.tsx` only. Desktop is unaffected by the lock (the sidebar is not a dialog there); `modal` on desktop means the first outside click closes the popover without also activating what it hit, which is how the dropdown this replaced already behaved. No scrollbar-gap shift, because the org shell is `h-dvh overflow-hidden` and the body never scrolls.

## Follow-ups (not in this PR)

- The account popover (`account-popover.tsx:601`) and the inbox popover (`sidebar/footer/inbox.tsx:134`) sit in the same mobile sheet and carry the identical latent bug — the inbox one has a real scrolling list. One line each.
- With the on-screen keyboard open no CSS unit shrinks (`dvh` tracks the layout viewport, not the visual one), so a tall popover can still extend under the keyboard. Typing filters the list, which makes it mostly moot; a real fix is a separate `visualViewport` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVd1o11cJLXR7HPSTyuyBC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the org/project picker so it scrolls on touch in the mobile sidebar. The picker's popover is now modal, so its own scroll lock handles the list instead of the sheet's lock canceling touch events on the portalled popover. The list also now respects the Command's height budget (`max-h-none min-h-0 flex-1`), removing a dead cap that pinned the picker to ~373px regardless of the set maximum. Desktop behavior is unchanged; `modal` there only closes the popover on outside click without activating the element behind it.

<sup>Written for commit d726fb65cf730ad33142e0c3f56f3ac7550f1b37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

