### PR TITLE
feat(sandbox): let a task run bind its org's tenant warm pool

### DIFF
--- a/deploy/helm/sandbox-env/templates/sandbox-tenant-pools.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-tenant-pools.yaml
@@ -11,10 +11,19 @@
 # STUDIO_SANDBOX_TENANT_POOLS. Additive to the generic `warmPool` above — a
 # tenant pool does not replace it, and every path still works at size 0.
 #
-# Deliberately reuses the shared SandboxTemplate: a per-pool template exists
-# only to carry per-pool node placement (on-demand / do-not-disrupt), which
-# v1 doesn't do. Adding it means rendering a second full template, so it waits
-# for someone who needs it.
+# Reuses the shared `-medium` SandboxTemplate. Medium, not the default one,
+# because the operator binds warm pods by TEMPLATE HASH: a claim naming a
+# different template gets a cold pod, silently. Task-board runs (`harness-run`)
+# always claim `-medium` — that is where the 4Gi OOMKills were — so a tenant
+# pool on the default template could never serve the runs that most need it,
+# which is why every Electrolux task started cold with four warm pods idle.
+#
+# Interactive claims that match a tenant pool now also name `-medium`, so both
+# kinds agree on one template and one pool. Medium is the roomier of the two,
+# so that is a ceiling raise for them, not a cut.
+#
+# A per-pool template still doesn't exist: it would only carry per-pool node
+# placement (on-demand / do-not-disrupt), which v1 doesn't do.
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxWarmPool
 metadata:
@@ -29,5 +38,5 @@ spec:
   updateStrategy:
     type: OnReplenish
   sandboxTemplateRef:
-    name: {{ include "sandbox-env.sandboxName" $ }}
+    name: {{ include "sandbox-env.sandboxName" $ }}-medium
 {{- end }}

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -1320,7 +1320,6 @@ export class AgentSandboxProvider {
     const tenantPool = resolveTenantPool(this.tenantPools, {
       orgId: opts.tenant?.orgId,
       cloneUrl: opts.repo?.cloneUrl,
-      purpose: opts.purpose,
     });
     const envEntries = warmPoolMode
       ? []
@@ -1389,7 +1388,6 @@ export class AgentSandboxProvider {
     const pool = resolveTenantPool(this.tenantPools, {
       orgId: opts.tenant?.orgId,
       cloneUrl: opts.repo?.cloneUrl,
-      purpose: opts.purpose,
     });
     const claim = this.buildClaim(
       handle,
@@ -1488,7 +1486,12 @@ export class AgentSandboxProvider {
       handle,
     );
     const daemonUrl = `http://127.0.0.1:${daemonForward.localPort}`;
-    const configPayload = this.workloadConfigPayload(opts);
+    // Cold Sandboxes are named after the claim, adopted ones after their pool.
+    const boundToPoolPod = adoptedSandboxName !== handle;
+    const configPayload = this.workloadConfigPayload(
+      opts,
+      pool !== null && boundToPoolPod,
+    );
     // Warm-pool path: pod boots with the SandboxTemplate's sentinel token;
     // studio authenticates the first /config call with the sentinel and
     // rotates to `token` (per-claim) atomically with the workload patch.
@@ -1558,23 +1561,14 @@ export class AgentSandboxProvider {
     };
   }
 
-  /** Whether these opts resolve to a tenant pool — see `workloadConfigPayload`. */
-  private claimTookTenantPool(opts: EnsureOptions | null): boolean {
-    if (!opts) return false;
-    return (
-      resolveTenantPool(this.tenantPools, {
-        orgId: opts.tenant?.orgId,
-        cloneUrl: opts.repo?.cloneUrl,
-        purpose: opts.purpose,
-      }) !== null
-    );
-  }
-
   /**
    * Daemon `/config` payload from ensure opts. Shared by fresh provision and
    * warm-pool re-bootstrap so a recreated pool pod re-clones the same workload.
    */
-  private workloadConfigPayload(opts: EnsureOptions | null) {
+  private workloadConfigPayload(
+    opts: EnsureOptions | null,
+    tenantPoolPodBound: boolean,
+  ) {
     return buildConfigPayload({
       runtime: opts?.workload?.runtime ?? "node",
       packageManager: opts?.workload?.packageManager
@@ -1592,19 +1586,9 @@ export class AgentSandboxProvider {
       // Sent on every ensure that carries opts, so a warm-pool pod inheriting a
       // previous claim's clone-only config gets it cleared on a normal one.
       //
-      // A claim that landed on a TENANT pool never sends it. `cloneOnly` makes
-      // the daemon's clone step stop the dev task, which would de-warm the pod
-      // the run just took — the exact damage that used to justify keeping
-      // harness runs out of tenant pools altogether. A pool pod is already
-      // cloned, installed and serving THIS repo, so there is nothing for
-      // clone-only to save and everything for it to throw away. The pipeline
-      // still short-circuits install and start when the tree is unchanged, so
-      // adopting one costs a branch checkout, not a rebuild.
+      // Dropped on a bound tenant-pool pod: its clone step would stop the warm dev task.
       ...(opts
-        ? {
-            cloneOnly:
-              opts.cloneOnly === true && !this.claimTookTenantPool(opts),
-          }
+        ? { cloneOnly: opts.cloneOnly === true && !tenantPoolPodBound }
         : {}),
     });
   }
@@ -2047,7 +2031,8 @@ export class AgentSandboxProvider {
     ensureOpts: EnsureOptions | null,
   ): Promise<boolean> {
     if (this.sentinelToken === null) return false;
-    const payload = this.workloadConfigPayload(ensureOpts) ?? {};
+    // A recreated pool pod is empty — nothing warm to preserve.
+    const payload = this.workloadConfigPayload(ensureOpts, false) ?? {};
     try {
       await postConfig(daemonUrl, this.sentinelToken, payload, {
         rotateToken: token,

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -1283,9 +1283,11 @@ export class AgentSandboxProvider {
    */
   private async resolveTemplateName(
     purpose: EnsureOptions["purpose"],
+    tenantPool: TenantPool | null,
   ): Promise<string> {
     const { name, probe } = await resolveClaimTemplateName({
       purpose,
+      tenantPool,
       templateName: this.sandboxTemplateName,
       probe: this.mediumTemplateProbe,
       now: Date.now(),
@@ -1381,11 +1383,19 @@ export class AgentSandboxProvider {
     const token = this.tokenGenerator();
     const daemonBootId = randomUUID();
     const workdir = DEFAULT_WORKDIR;
+    // Resolved BEFORE the template, because a tenant-pool claim must name the
+    // template that pool's pods were built from — the operator binds warm pods
+    // by template hash and a mismatch silently yields a cold pod.
+    const pool = resolveTenantPool(this.tenantPools, {
+      orgId: opts.tenant?.orgId,
+      cloneUrl: opts.repo?.cloneUrl,
+      purpose: opts.purpose,
+    });
     const claim = this.buildClaim(
       handle,
       opts,
       { token, daemonBootId, workdir },
-      await this.resolveTemplateName(opts.purpose),
+      await this.resolveTemplateName(opts.purpose, pool),
     );
     try {
       await createSandboxClaim(this.kubeConfig, this.namespace, claim);
@@ -1548,6 +1558,18 @@ export class AgentSandboxProvider {
     };
   }
 
+  /** Whether these opts resolve to a tenant pool — see `workloadConfigPayload`. */
+  private claimTookTenantPool(opts: EnsureOptions | null): boolean {
+    if (!opts) return false;
+    return (
+      resolveTenantPool(this.tenantPools, {
+        orgId: opts.tenant?.orgId,
+        cloneUrl: opts.repo?.cloneUrl,
+        purpose: opts.purpose,
+      }) !== null
+    );
+  }
+
   /**
    * Daemon `/config` payload from ensure opts. Shared by fresh provision and
    * warm-pool re-bootstrap so a recreated pool pod re-clones the same workload.
@@ -1569,7 +1591,21 @@ export class AgentSandboxProvider {
       tenant: opts?.tenant ?? undefined,
       // Sent on every ensure that carries opts, so a warm-pool pod inheriting a
       // previous claim's clone-only config gets it cleared on a normal one.
-      ...(opts ? { cloneOnly: opts.cloneOnly === true } : {}),
+      //
+      // A claim that landed on a TENANT pool never sends it. `cloneOnly` makes
+      // the daemon's clone step stop the dev task, which would de-warm the pod
+      // the run just took — the exact damage that used to justify keeping
+      // harness runs out of tenant pools altogether. A pool pod is already
+      // cloned, installed and serving THIS repo, so there is nothing for
+      // clone-only to save and everything for it to throw away. The pipeline
+      // still short-circuits install and start when the tree is unchanged, so
+      // adopting one costs a branch checkout, not a rebuild.
+      ...(opts
+        ? {
+            cloneOnly:
+              opts.cloneOnly === true && !this.claimTookTenantPool(opts),
+          }
+        : {}),
     });
   }
 

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
@@ -86,47 +86,15 @@ describe("resolveTenantPool", () => {
     ).toBe("tenant-acme-site");
   });
 
-  it("a harness-run claim for the pool's own repo takes a tenant pod", () => {
-    // Inverted deliberately. This used to return null: a harness run posts
-    // `cloneOnly`, whose clone step stops the dev task, so binding a warm pod
-    // consumed a slot AND de-warmed the pod it took. The destructive part is
-    // `cloneOnly`, not the run — a pool pod for the SAME org and repo is
-    // already cloned, installed and serving exactly what the run needs. So the
-    // claim keeps the workload instead (runner drops `cloneOnly` for a
-    // tenant-pool claim), and every Electrolux task no longer starts cold with
-    // four warm pods idle beside it.
-    expect(
-      resolveTenantPool(POOLS, {
-        orgId: "org-acme",
-        cloneUrl: url,
-        purpose: "harness-run",
-      })?.name,
-    ).toBe("tenant-acme-site");
-    // An explicit `interactive` is unchanged.
-    expect(
-      resolveTenantPool(POOLS, {
-        orgId: "org-acme",
-        cloneUrl: url,
-        purpose: "interactive",
-      })?.name,
-    ).toBe("tenant-acme-site");
-  });
-
-  // The isolation rule is the thing that must NOT relax with it: a run may only
-  // ever adopt a pod warmed for its own org and its own repo.
+  // Purpose no longer excludes a run; org+repo isolation must not relax with it.
   it("still refuses another org's pool and another repo's pool", () => {
     expect(
-      resolveTenantPool(POOLS, {
-        orgId: "org-other",
-        cloneUrl: url,
-        purpose: "harness-run",
-      }),
+      resolveTenantPool(POOLS, { orgId: "org-other", cloneUrl: url }),
     ).toBeNull();
     expect(
       resolveTenantPool(POOLS, {
         orgId: "org-acme",
         cloneUrl: "https://github.com/acme/other-repo.git",
-        purpose: "harness-run",
       }),
     ).toBeNull();
   });

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
@@ -86,17 +86,23 @@ describe("resolveTenantPool", () => {
     ).toBe("tenant-acme-site");
   });
 
-  it("a harness-run claim never takes a tenant pod", () => {
-    // The Claude Code dispatch path. It wants no dev server, and binding a warm
-    // pod would stop the one already running on it.
+  it("a harness-run claim for the pool's own repo takes a tenant pod", () => {
+    // Inverted deliberately. This used to return null: a harness run posts
+    // `cloneOnly`, whose clone step stops the dev task, so binding a warm pod
+    // consumed a slot AND de-warmed the pod it took. The destructive part is
+    // `cloneOnly`, not the run — a pool pod for the SAME org and repo is
+    // already cloned, installed and serving exactly what the run needs. So the
+    // claim keeps the workload instead (runner drops `cloneOnly` for a
+    // tenant-pool claim), and every Electrolux task no longer starts cold with
+    // four warm pods idle beside it.
     expect(
       resolveTenantPool(POOLS, {
         orgId: "org-acme",
         cloneUrl: url,
         purpose: "harness-run",
-      }),
-    ).toBeNull();
-    // ...but an explicit `interactive` is a normal claim.
+      })?.name,
+    ).toBe("tenant-acme-site");
+    // An explicit `interactive` is unchanged.
     expect(
       resolveTenantPool(POOLS, {
         orgId: "org-acme",
@@ -104,6 +110,25 @@ describe("resolveTenantPool", () => {
         purpose: "interactive",
       })?.name,
     ).toBe("tenant-acme-site");
+  });
+
+  // The isolation rule is the thing that must NOT relax with it: a run may only
+  // ever adopt a pod warmed for its own org and its own repo.
+  it("still refuses another org's pool and another repo's pool", () => {
+    expect(
+      resolveTenantPool(POOLS, {
+        orgId: "org-other",
+        cloneUrl: url,
+        purpose: "harness-run",
+      }),
+    ).toBeNull();
+    expect(
+      resolveTenantPool(POOLS, {
+        orgId: "org-acme",
+        cloneUrl: "https://github.com/acme/other-repo.git",
+        purpose: "harness-run",
+      }),
+    ).toBeNull();
   });
 
   it("a user of another org never resolves this pool", () => {
@@ -318,5 +343,24 @@ describe("poolsMatchingPush", () => {
     expect(poolsMatchingPush(POOLS, "acme/other", "refs/heads/main")).toEqual(
       [],
     );
+  });
+});
+
+describe("claimTemplateName with a tenant pool", () => {
+  const pool = POOLS[0]!;
+
+  // The operator binds warm pods by TEMPLATE HASH, so a claim naming a template
+  // the pool's pods were not built from gets a cold pod and no error. The chart
+  // renders tenant pools from `-medium` (the template harness runs already
+  // claim), so both kinds must name it or the pool is unreachable — which is
+  // exactly how four warm pods sat idle while every task run started cold.
+  it("names -medium for a tenant-pool claim, whatever the purpose", () => {
+    expect(claimTemplateName("interactive", "sbx", pool)).toBe("sbx-medium");
+    expect(claimTemplateName("harness-run", "sbx", pool)).toBe("sbx-medium");
+  });
+
+  it("leaves a non-pool interactive claim on the default template", () => {
+    expect(claimTemplateName("interactive", "sbx", null)).toBe("sbx");
+    expect(claimTemplateName(undefined, "sbx")).toBe("sbx");
   });
 });

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
@@ -92,18 +92,25 @@ export function resolveTenantPool(
     orgId: string | undefined;
     cloneUrl: string | undefined;
     /**
-     * A `harness-run` claim must never take a tenant pod. It doesn't want a dev
-     * server, and binding one is actively destructive: Studio posts `cloneOnly`
-     * + the thread branch, the daemon classifies `branch-change`, and its clone
-     * step stops the dev task — so a dispatch would consume a warm slot AND
-     * de-warm the pod it took. It gets its own pool instead (see
-     * `claimTemplateName`), which is exactly what an empty pod is for.
+     * Kept for `claimTemplateName` (a harness run still gets the roomier
+     * `-medium` template), but no longer excludes a run from the pool.
+     *
+     * It used to: a `harness-run` posts `cloneOnly`, and the daemon's clone
+     * step stops the dev task, so binding a warm pod consumed a slot AND
+     * de-warmed the pod it took. The destructive part there is `cloneOnly`,
+     * not the run — a pool pod matching the SAME org and repo is already
+     * cloned, installed and serving exactly what the run needs, so the fix is
+     * to stop sending `cloneOnly` when the claim lands on one (see
+     * `tenantPoolKeepsWorkload` in runner.ts) rather than to send the run to a
+     * cold pod and make it install from scratch inside its own turn.
+     *
+     * The isolation rule is unchanged: org AND repo must both match, so a run
+     * can only ever adopt a pod warmed for its own repo.
      */
     purpose?: SandboxPurpose;
   },
 ): TenantPool | null {
   const { orgId, cloneUrl } = claim;
-  if (claim.purpose === "harness-run") return null;
   if (!orgId || !cloneUrl) return null;
   const repoKey = repoKeyFromCloneUrl(cloneUrl);
   if (!repoKey) return null;
@@ -144,17 +151,23 @@ export function claimWarmPoolName(
  * that is where prod's 4Gi OOMKills happened, and a SandboxClaim cannot
  * override resources, so the ceiling can only come from another template.
  *
- * The returned name is also the warm pool's name (the chart names pool after
- * template), so it feeds `claimWarmPoolName`: naming the pool built from this
- * template is what lets the claim bind a warm pod at all. It is not what keeps
- * the ceiling right — operator v0.4.5 matches warm pods by template hash, so a
- * mismatched pool costs a warm bind (cold pod), never a wrong-size pod.
+ * A claim that matched a TENANT POOL also names `-medium`, because the chart
+ * now renders tenant pools from that template. This has to agree: operator
+ * v0.4.5 binds warm pods by template hash, so a claim naming a template the
+ * pool wasn't built from gets a cold pod and no error. That mismatch is
+ * precisely why task runs kept starting cold with warm tenant pods idle.
+ *
+ * The returned name is also the warm pool's name for the GENERIC pools (the
+ * chart names those after their template), so it feeds `claimWarmPoolName`.
  */
 export function claimTemplateName(
   purpose: SandboxPurpose | undefined,
   templateName: string,
+  tenantPool?: TenantPool | null,
 ): string {
-  return purpose === "harness-run" ? `${templateName}-medium` : templateName;
+  return purpose === "harness-run" || tenantPool
+    ? `${templateName}-medium`
+    : templateName;
 }
 
 /** Result of the last `-medium` template lookup, cached for `ttlMs`. */
@@ -179,6 +192,8 @@ export interface MediumTemplateProbe {
  */
 export async function resolveClaimTemplateName(args: {
   purpose: SandboxPurpose | undefined;
+  /** Set when the claim matched a tenant pool — see `claimTemplateName`. */
+  tenantPool?: TenantPool | null;
   templateName: string;
   probe: MediumTemplateProbe | null;
   now: number;
@@ -186,7 +201,11 @@ export async function resolveClaimTemplateName(args: {
   exists: (name: string) => Promise<boolean>;
   onAbsent?: (name: string) => void;
 }): Promise<{ name: string; probe: MediumTemplateProbe | null }> {
-  const wanted = claimTemplateName(args.purpose, args.templateName);
+  const wanted = claimTemplateName(
+    args.purpose,
+    args.templateName,
+    args.tenantPool,
+  );
   if (wanted === args.templateName) return { name: wanted, probe: args.probe };
   const fresh =
     args.probe !== null && args.now - args.probe.checkedAt < args.ttlMs

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
@@ -85,30 +85,15 @@ export function repoKeyFromCloneUrl(cloneUrl: string): string | null {
  * served*, never a request field — the operator has no notion of a tenant and
  * will happily bind any pool a claim names, so the claim (built server-side)
  * is the only thing keeping one org's warm pods away from another's.
+ *
+ * Purpose is deliberately not a factor: a `harness-run` used to be excluded
+ * because it posts `cloneOnly`, which stops the pod's dev task. The fix is to
+ * drop `cloneOnly` once such a run actually binds a pool pod (see
+ * `workloadConfigPayload` in runner.ts), not to send it to a cold pod.
  */
 export function resolveTenantPool(
   pools: readonly TenantPool[],
-  claim: {
-    orgId: string | undefined;
-    cloneUrl: string | undefined;
-    /**
-     * Kept for `claimTemplateName` (a harness run still gets the roomier
-     * `-medium` template), but no longer excludes a run from the pool.
-     *
-     * It used to: a `harness-run` posts `cloneOnly`, and the daemon's clone
-     * step stops the dev task, so binding a warm pod consumed a slot AND
-     * de-warmed the pod it took. The destructive part there is `cloneOnly`,
-     * not the run — a pool pod matching the SAME org and repo is already
-     * cloned, installed and serving exactly what the run needs, so the fix is
-     * to stop sending `cloneOnly` when the claim lands on one (see
-     * `tenantPoolKeepsWorkload` in runner.ts) rather than to send the run to a
-     * cold pod and make it install from scratch inside its own turn.
-     *
-     * The isolation rule is unchanged: org AND repo must both match, so a run
-     * can only ever adopt a pod warmed for its own repo.
-     */
-    purpose?: SandboxPurpose;
-  },
+  claim: { orgId: string | undefined; cloneUrl: string | undefined },
 ): TenantPool | null {
   const { orgId, cloneUrl } = claim;
   if (!orgId || !cloneUrl) return null;


### PR DESCRIPTION
## Problem

Every Electrolux task run starts cold — cloning and running `yarn install` inside its own turn, minutes before it can do any work — while **four fully warm pods for that exact repo sit unclaimed**.

```
18:35:14  claim  ELX-LATAM-DevOps/electrolux-poc  →  studio-sandbox-prod-medium-ngk4v   (generic, cold)

tenant-electrolux-prod-gnjl6   ready, unclaimed
tenant-electrolux-prod-nwn2l   ready, unclaimed
tenant-electrolux-prod-wt7gc   ready, unclaimed
tenant-electrolux-prod-xbgvr   ready, unclaimed
```

Two independent causes, both fixed here. Fixing either alone changes nothing.

## 1. Harness runs were refused outright

```ts
if (claim.purpose === "harness-run") return null;
```

The stated damage was real but misattributed. A harness run posts `cloneOnly`; the daemon's clone step stops the dev task; so binding a warm pod consumed a slot **and** de-warmed the pod it took. That is `cloneOnly`'s doing, not the run's.

A pool pod for the **same org and repo** is already cloned, installed and serving precisely what the run needs. So a claim that lands on a tenant pool no longer sends `cloneOnly` at all. The orchestrator already short-circuits install and start when the tree is unchanged (same commit + same fingerprint), so adopting a pod costs a branch checkout, not a rebuild.

## 2. Even unrefused, it could not have bound one

The chart renders tenant pools from the **default** template, while a `harness-run` claims **`-medium`** (the roomier one added after the 4Gi OOMKills). Operator v0.4.5 binds warm pods **by template hash**, so a claim naming a different template gets a cold pod — with no error anywhere. The pool was unreachable by construction for exactly the claims that most need it.

Tenant pools now render from `-medium`, and a tenant-pool claim names `-medium` whatever its purpose, so both kinds agree on one template and one pool. Interactive claims matching a pool move to `-medium` as well — that is the roomier template, so a ceiling raise, not a cut.

## Isolation is unchanged

`orgId` **and** repo must both match, so a run can only ever adopt a pod warmed for its own repo. Two tests pin this under the new behaviour (another org's pool, another repo's pool).

## Tests

- **Inverted** the test that asserted `a harness-run claim never takes a tenant pod` — it encoded the bug, so per `CLAUDE.md` it is inverted rather than appended to.
- Added the isolation test above, and coverage for the template agreement that makes the pool reachable.
- `bun test packages/sandbox` → 199 pass. `bun test apps/api/src/tools/sandbox` → 90 pass. `tsc --noEmit` clean in both workspaces. `helm template` renders `sandboxTemplateRef: studio-sandbox-prod-medium` for a tenant pool.

## Deploy order

The chart half only reaches a cluster via a `targetRevision` bump in deco-apps-cd, and the two halves must land together — Studio naming `-medium` against pools still rendered from the default template is the same silent cold-pod mismatch in reverse. Existing tenant pods will be replaced on the new template hash (they re-clone/install/boot, which is what a pool does).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task-board runs so they can bind their org's warm tenant pool instead of starting cold: previously every run cloned and installed from scratch while up to four warm pods for the same repo sat unclaimed. Both independent causes are fixed here — fixing either alone changes nothing — and an adopted pod now costs a branch checkout rather than a rebuild.

**Bug Fixes**
- `resolveTenantPool` refused every harness-run; that refusal is gone, and `cloneOnly` is now suppressed only when the claim actually binds a pool pod (keyed on the adopted sandbox name), so an exhausted pool still gets a normal cold claim and the empty re-bootstrap path still honors `cloneOnly`.
- Tenant pools were rendered from the default template while harness runs claim `-medium`, and the operator binds warm pods by template hash — the mismatch silently yielded cold pods. Pools now render from `-medium`, and tenant-pool claims name `-medium` for both purposes; interactive claims matching a pool move to `-medium` too, which is the roomier template, so that is a ceiling raise.
- Isolation is unchanged: org and repo must both match, pinned by an inverted test plus new tests for another org's pool and another repo's pool.
- Deploy order matters: the chart half ships via a `targetRevision` bump in deco-apps-cd, and both halves must land together or the reverse mismatch silently yields cold pods again; existing tenant pods restart on the new template hash as the pool refreshes.

<sup>Written for commit f1f783556000222611869abc71580e87d3c6564b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

