### PR TITLE
fix(thread-sheet): poll an open run viewer without a liveness gate

### DIFF
--- a/apps/web/src/components/thread/thread-sheet-body.tsx
+++ b/apps/web/src/components/thread/thread-sheet-body.tsx
@@ -315,7 +315,7 @@ function ThreadConversationPanelLoading() {
 const LIVE_REFRESH_DEBOUNCE_MS = 400;
 
 /**
- * Poll interval while the run is still going.
+ * Poll interval for an open sheet.
  *
  * Polling, not events alone, because `decopilot.step` is emitted ONLY by the
  * hosted Decopilot path: `runRegistry.dispatch({ type: "STEP_DONE" })` lives in
@@ -338,7 +338,6 @@ function useLiveThreadMessages(
   orgSlug: string,
   locator: string,
   threadId: string,
-  live: boolean,
 ) {
   const queryClient = useQueryClient();
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -357,7 +356,6 @@ function useLiveThreadMessages(
     orgSlug,
     // `taskId` is matched against the event's `subject`, which is the thread id.
     taskId: threadId,
-    enabled: live,
     onStep: refresh,
     onFinish: refresh,
     onReconnect: refresh,
@@ -384,7 +382,6 @@ function ThreadConversationPanel({
   meta: boolean;
 }) {
   const { org } = useProjectContext();
-  const live = thread.status === "in_progress";
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery({
       queryKey: KEYS.threadMessages(locator, thread.id),
@@ -411,13 +408,17 @@ function ThreadConversationPanel({
         if ((page?.items?.length ?? 0) < MESSAGES_PAGE_SIZE) return undefined;
         return pages.length * MESSAGES_PAGE_SIZE;
       },
-      staleTime: 60_000,
-      // Only an open sheet on a still-running thread polls: a settled thread is
-      // immutable, and a closed sheet is unmounted.
-      refetchInterval: live ? LIVE_REFRESH_POLL_MS : false,
+      // A settled thread is immutable, so a stale window would be free — but
+      // the only status this view has is the snapshot the card handed it, and a
+      // run that started (or is still starting) after that read looks settled
+      // here. Polling an open sheet unconditionally costs one small read every
+      // few seconds and cannot be wrong; a closed sheet is unmounted.
+      // ponytail: poll while open, no liveness gate.
+      staleTime: 0,
+      refetchInterval: LIVE_REFRESH_POLL_MS,
     });
 
-  useLiveThreadMessages(org.slug, locator, thread.id, live);
+  useLiveThreadMessages(org.slug, locator, thread.id);
 
   const allItems = data.pages.flatMap(
     (p: { items?: ThreadMessageEntity[] }) => p.items ?? [],


### PR DESCRIPTION
## Summary

Opening a task's Super Agent run in the drawer showed a transcript frozen at mount — new output only appeared after closing and reopening it.

#7010 added polling for exactly this, but gated it on `thread.status === "in_progress"`. That status is the **snapshot the task card handed the sheet**, not a live read: a run that started (or was still starting) after that read looks settled to the sheet, so it never polls.

This drops the gate. An open sheet polls every 5s with no stale window; the `/watch` events stay wired for the faster hosted-run path. A closed sheet is unmounted, so the cost is one small read every few seconds while someone is actually watching a run.

## Testing

- `bun run --cwd=apps/web check` clean, `bun run fmt` clean.
- Verified #7010's polling is already live in the prod bundle (4.330.1), so a stale tab could also explain the report — this fixes the case where the fresh bundle still doesn't poll.

## Follow-up

The last pair's `status="streaming"` shimmer is still driven by the same snapshot status, so it can shimmer a finished run or miss a fresh one. Cosmetic; left alone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the run viewer transcript freezing when a run starts after the sheet is opened. Previously, polling was gated on `thread.status === "in_progress"`, but that status is a snapshot from the card, not live, so new output never appeared until the drawer was closed and reopened. Now an open sheet polls every 5 seconds with no stale window; a closed sheet unmounts, so the cost is one small read every few seconds while someone is watching.

- Sets the query `staleTime` to 0 so the refetch always gets fresh data.
- The `/watch` event subscription remains for the faster hosted-run path.

<sup>Written for commit 88c11d25838222ca630ad5548fd5dbb2f173a8be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

