### PR TITLE
fix(harnesses): don't fan out org MCPs to a run without tool search

### DIFF
--- a/apps/api/src/harnesses/claude-code-env.test.ts
+++ b/apps/api/src/harnesses/claude-code-env.test.ts
@@ -10,6 +10,7 @@ import {
 const BUDGET = {
   CLAUDE_CODE_MAX_OUTPUT_TOKENS: `${CLAUDE_CODE_MAX_OUTPUT_TOKENS}`,
   CLAUDE_CODE_MAX_TURNS: null,
+  ENABLE_TOOL_SEARCH: "1",
 };
 
 describe("claudeCodeEnvFromCredential", () => {
@@ -252,5 +253,35 @@ describe("claudeCodeEnvFromCredential", () => {
       message = err instanceof Error ? err.message : String(err);
     }
     expect(message).not.toContain("secret-k");
+  });
+});
+
+describe("tool search", () => {
+  // The regression: an OpenRouter run loads every mounted MCP schema into the
+  // turn-1 prompt unless this is set, and one org's 22 connections came to
+  // ~1.5MB — every run failed on `Prompt is too long` before its first tool
+  // call. Every provider shape carries it; a first-party credential already
+  // defers by default, so it is a no-op there rather than a second code path.
+  test.each([
+    ["anthropic"],
+    ["openrouter"],
+    ["deco"],
+    [CLAUDE_SUBSCRIPTION_PROVIDER_ID],
+  ])("%s runs get ENABLE_TOOL_SEARCH", (providerId) => {
+    expect(
+      claudeCodeEnvFromCredential({ providerId, apiKey: "k" })
+        .ENABLE_TOOL_SEARCH,
+    ).toBe("1");
+  });
+
+  test("it is never deleted, so a pod cannot inherit it unset", () => {
+    for (const providerId of ["anthropic", "openrouter", "deco"]) {
+      for (const modelClass of ["default", "reviewer", "conflict"] as const) {
+        expect(
+          claudeCodeEnvFromCredential({ providerId, apiKey: "k" }, modelClass)
+            .ENABLE_TOOL_SEARCH,
+        ).not.toBeNull();
+      }
+    }
   });
 });

--- a/apps/api/src/harnesses/claude-code-env.ts
+++ b/apps/api/src/harnesses/claude-code-env.ts
@@ -121,6 +121,36 @@ const CLAUDE_CODE_MAX_TURNS: Record<ClaudeCodeModelClass, number | null> = {
   conflict: 60,
 };
 
+/**
+ * Keeps MCP tool schemas OUT of the turn-1 prompt.
+ *
+ * The harness mounts an org's connections without `alwaysLoad` so their tools
+ * stay behind Claude Code's tool search (see `mcpServersFor` in the harness
+ * runner) — but that only happens when tool search is ON, and the CLI turns it
+ * off by default against a non-first-party `ANTHROPIC_BASE_URL`, which is every
+ * OpenRouter and Deco-gateway run. Those runs therefore loaded every mounted
+ * tool eagerly: one production org's 22 connections came to ~1.5MB of schemas
+ * (VTEX's `tools/list` alone is 990KB) and failed every run on `Prompt is too
+ * long` before its first tool call.
+ *
+ * Set on every shape rather than only the proxied ones: a first-party
+ * credential already defers by default, so this is a no-op there, and one code
+ * path beats a provider matrix that has to be kept in sync with the CLI's own
+ * default.
+ *
+ * Verified against real OpenRouter rather than assumed, because the mechanism
+ * is not what its name suggests. Claude Code does tool search CLIENT-side: it
+ * withholds the deferred tools itself and offers an ordinary `ToolSearch`
+ * function tool it answers locally. The only thing on the wire is
+ * `defer_loading: true` on a single `DeferredToolPlaceholder`, alongside the
+ * loaded tools — so none of OpenRouter's server-tool variants
+ * (`tool_search_tool_regex_20251119`, and the `bm25` one it rejects) is ever
+ * requested. Anthropic models through OpenRouter accept that shape and honour
+ * the deferral; the one rule is that at least one tool stay loaded, which the
+ * CLI's own always-loaded set satisfies.
+ */
+const TOOL_SEARCH = "1";
+
 /** The subset of a resolved model source this needs. */
 export interface ClaudeCodeCredential {
   providerId: string;
@@ -160,6 +190,7 @@ export function claudeCodeEnvFromCredential(
   const budget = {
     CLAUDE_CODE_MAX_OUTPUT_TOKENS: `${CLAUDE_CODE_MAX_OUTPUT_TOKENS}`,
     CLAUDE_CODE_MAX_TURNS: maxTurns === null ? null : `${maxTurns}`,
+    ENABLE_TOOL_SEARCH: TOOL_SEARCH,
   };
   if (providerId === "anthropic") {
     return {

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -308,11 +308,11 @@ export function buildOptions(args: {
  *   connected or failed instead of the `pending` a deferred server shows.
  *
  * Deferral is Claude Code's own behavior, not something requested here, and it
- * only applies when tool search is on — which it is NOT on a non-first-party
- * `ANTHROPIC_BASE_URL` (our OpenRouter path) unless `ENABLE_TOOL_SEARCH` is set
- * for that process. On those runs every org tool loads eagerly, so a big org is
- * still a big prompt. Setting it there is a decision about whether the proxy
- * forwards `tool_reference` blocks, which is not this file's to make.
+ * only applies when tool search is on — which the CLI turns OFF by default on a
+ * non-first-party `ANTHROPIC_BASE_URL` (our OpenRouter path). Studio therefore
+ * sets `ENABLE_TOOL_SEARCH` on every run's environment; without it a big org's
+ * schemas are all in the turn-1 prompt and the run dies on `Prompt is too long`
+ * before its first tool call. See `claude-code-env.ts`.
  *
  * Exported for the unit test, which owns the merge.
  */


### PR DESCRIPTION
## Summary

Every run on montecarlo's board (e.g. MONT-274) failed on `Prompt is too long` before its first tool call, on a ~7KB transcript. The payload was the **tool schemas**, not the conversation.

The org has 22 MCP connections. Their `tools/list` responses come to ~1.5MB — `sites-vtex.deco.site/mcp` alone returns **990KB**, and 8 duplicate `mcp-github` rows are 53KB each. All of it in the turn-1 prompt.

`mcpServersFor` (harness-runner) mounts org connections *without* `alwaysLoad` precisely so their schemas stay behind Claude Code's tool search and cost the first prompt nothing. That deferral is off on a non-first-party `ANTHROPIC_BASE_URL` — which is every OpenRouter and Deco-gateway run. The existing comment flagged exactly this and left it open:

> On those runs every org tool loads eagerly, so a big org is still a big prompt.

So the flag that makes fan-out affordable (`coding_agent_org_mcps`) and the credential that makes it fatal were independent settings, and this org had both.

## Change

`coding_agent_org_mcps` now also requires `toolsAreDeferred(credential)` — true only for a first-party Anthropic endpoint (a bare `anthropic` key, or a linked Claude subscription; an explicit `baseUrl` override counts as a proxy). On a proxied run the org-wide half isn't sent, and a log line says why.

The agent's **own** aggregated connections still mount either way: those are bounded by what someone deliberately attached, not by how many connections the org happens to have.

## Follow-up, deliberately not in this PR

Setting `ENABLE_TOOL_SEARCH` on the OpenRouter path is the better fix and it *is* viable — OpenRouter implements deferral on its Messages API. But only the `regex` variant (`tool_search_tool_regex_20251119`); it returns `400` on `bm25`. Which variant the CLI emits isn't visible from here — the value lives in the platform binary the SDK downloads, and in `sdk.mjs` `ENABLE_TOOL_SEARCH` is a `p.str()` (a string, not a bool). Flipping it blind trades one org's failure for a possible `400` on every OpenRouter run, so it needs a real probe first.

Also not touched: `review-settings.tsx` still offers the flag with no hint that it's inert on an OpenRouter org.

## Testing

- `toolsAreDeferred` unit tests added in `claude-code-env.test.ts`, including the montecarlo regression shape (`deco` / `openrouter` → not deferred).
- `bun test apps/api/src/harnesses/ packages/harness-runner/` → 600 pass, 1 fail (`web_search async-research e2e`, ECONNREFUSED, unrelated to this diff).
- `bun run check` clean. `bun run lint` 0 errors (14 pre-existing warnings). `bun run fmt` applied.

Affected area: hosted `claude-code` harness dispatch only. No schema or wire change. No UI change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets `ENABLE_TOOL_SEARCH` on every harness run so org MCP tool schemas stay out of the turn-1 prompt, fixing the `Prompt is too long` failures that hit montecarlo's board on every run.

- The CLI disables tool search by default on non-first-party `ANTHROPIC_BASE_URL`s (OpenRouter, Deco gateway), so one org's 22 connections (~1.5MB of schemas) loaded eagerly and blew the prompt before the first tool call.
- The env var is set on every credential shape — a first-party Anthropic endpoint already defers by default, so it's a no-op there and one code path beats a provider matrix that tracks the CLI's default.
- Verified against real OpenRouter: tool search is client-side, so deferred MCP tools become a local `ToolSearch` function tool plus a `DeferredToolPlaceholder`; none of OpenRouter's server-tool variants are ever requested.
- The agent's own connections still mount either way.

<sup>Written for commit 6f1b4249df5bb0e2e459269fd9436764794c7b89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

