### PR TITLE
fix(sandbox): a dev server answering 5xx on every route is not "serving"

### DIFF
--- a/packages/sandbox/daemon-go/internal/probe/probe.go
+++ b/packages/sandbox/daemon-go/internal/probe/probe.go
@@ -27,6 +27,12 @@ type State struct {
 	Status      string
 	Port        int
 	HtmlSupport bool
+	// HTTPStatus is the status code of the last successful probe request, or 0
+	// when nothing answered. A dev server that answers every request with 5xx
+	// is reachable but useless — `Status` alone cannot tell those apart, and a
+	// warm-pool pod handed over with a half-built framework directory looks
+	// perfectly online without this.
+	HTTPStatus int
 }
 
 type Deps struct {
@@ -131,7 +137,7 @@ func (p *Prober) tick() {
 	}
 	if up {
 		p.consecutiveFailures = 0
-		next := State{Status: StatusOnline, Port: p.state.Port, HtmlSupport: isHtml}
+		next := State{Status: StatusOnline, Port: p.state.Port, HtmlSupport: isHtml, HTTPStatus: status}
 		prevStatus := p.state.Status
 		p.applyLocked(next)
 		if prevStatus == StatusBooting && p.deps.OnLog != nil {

--- a/packages/sandbox/daemon-go/internal/probe/probe_status_test.go
+++ b/packages/sandbox/daemon-go/internal/probe/probe_status_test.go
@@ -1,0 +1,66 @@
+package probe
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// A dev server answering every request with 500 is reachable, so Status stays
+// online — but HTTPStatus must carry the code so a caller can tell the two
+// apart. This is the warm-pool handover bug: `.faststore/src/pages` missing,
+// every route 500, watchdog silent.
+func TestStateCarriesHTTPStatus(t *testing.T) {
+	for _, code := range []int{200, 500} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(code)
+		}))
+		port := serverPort(t, srv.URL)
+
+		got := make(chan State, 8)
+		p := Start(Deps{
+			GetPort:  func() int { return port },
+			OnChange: func(s State) { got <- s },
+			Fast:     5 * time.Millisecond,
+			Slow:     5 * time.Millisecond,
+		})
+
+		var seen State
+		deadline := time.After(3 * time.Second)
+	wait:
+		for {
+			select {
+			case s := <-got:
+				if s.Status == StatusOnline {
+					seen = s
+					break wait
+				}
+			case <-deadline:
+				t.Fatalf("code %d: never reported online", code)
+			}
+		}
+		p.Stop()
+		srv.Close()
+
+		if seen.HTTPStatus != code {
+			t.Fatalf("code %d: HTTPStatus = %d, want %d", code, seen.HTTPStatus, code)
+		}
+	}
+}
+
+func serverPort(t *testing.T, raw string) int {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return n
+}

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -457,6 +457,14 @@ func envDuration(name string, def, min time.Duration) time.Duration {
 	return def
 }
 
+// restartOn5xx gates treating an all-5xx dev server as dead. Default off: a
+// user's app can legitimately 5xx from its own bug, and restarting that fixes
+// nothing, so this ships dormant and is enabled per-deployment.
+func restartOn5xx() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("DEV_RESTART_ON_5XX")))
+	return v == "1" || v == "true"
+}
+
 // envInt reads an int from env, clamped to at least min, def when unset/bad.
 func envInt(name string, def, min int) int {
 	if v := os.Getenv(name); v != "" {
@@ -484,7 +492,16 @@ func (d *daemon) devWatchTick() {
 	portKnown := sniffed != 0 || lastRunning != 0
 	// Read synchronously, not via a mirror an out-of-order callback could
 	// leave stale (see probe.Prober.Current).
-	serving := d.prober.Current().Status == probe.StatusOnline
+	probeState := d.prober.Current()
+	serving := probeState.Status == probe.StatusOnline
+	if serving && restartOn5xx() && probeState.HTTPStatus >= 500 {
+		// Reachable but serving nothing usable. A warm-pool pod has been handed
+		// over with a half-built framework directory (every route 5xx) and the
+		// watchdog sat it out, because "answered the request" was the whole
+		// liveness test. Treating that as dead lets the existing grace window
+		// and MaxRestarts budget rebuild it exactly once.
+		serving = false
+	}
 
 	d.devWatchMu.Lock()
 	action := d.devTracker.Observe(devwatch.Snapshot{


### PR DESCRIPTION
## Problem

The dev-server liveness probe tested *"did anything answer"*, not *"is it usable"*.

`probe.head()` already computes the HTTP status code — and `probe.State` throws it away, keeping it only for a log string. So a dev server returning **500 on every route** reports `StatusOnline`. `devwatch` keys its restart on `!Serving` (`devwatch.go:186`), so the watchdog never fires, and the pod is handed over as ready.

Two prod runs today (`ELEC-244`, `ELEC-245`) were handed tenant warm-pool pods whose `.faststore/` was missing `src/pages`:

```
Error: ENOENT: no such file or directory, scandir '/app/repo/.faststore/src/pages'
```

`.faststore/` still contained `404.tsx`, `500.tsx` and `api/`, so it looked present; every route 500'd; the watchdog stayed silent. The agents detected and rebuilt it by hand, spending **25 of 55** and **~15 of 82** tool calls on it — plus fighting `<defunct>` `next-server` processes left by the pool's own pre-boot.

## Change

- `probe.State` gains `HTTPStatus`, set from the code `head()` already returns.
- `devWatchTick` treats a 5xx as not-serving, so devwatch's existing grace window and `MaxRestarts` budget rebuild the server **once**.

Gated by `DEV_RESTART_ON_5XX`, **default off** — a user's app can legitimately 5xx from its own bug, and restarting that fixes nothing. Ships dormant; enable per-deployment.

## Testing

`internal/probe/probe_status_test.go` stands up real 200 and 500 servers and asserts `State.HTTPStatus` carries each code while `Status` stays `online` — the exact pair the old code could not distinguish. `go build ./...`, `go vet ./...`, `gofmt -l`, and the `probe` + `devwatch` suites pass.

## Scope

This makes the symptom self-healing. It does **not** explain why the framework directory ends up half-built on a warm-pool handover — the claim deliberately runs `git checkout -f -B` under a live dev server (`orchestrator.go:265-277`), and I have a hypothesis but no reproduction, so I left it alone rather than guess at a second fix. Two follow-ups worth filing:

- health-gate the pool handover so a 5xx pod is recycled instead of claimed (fixes it without touching a running user app);
- add PID-1 reaping — the `<defunct>` `next-server` processes never clear.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the dev-server watchdog treat an all-5xx dev server as not serving, so warm-pool pods with a half-built framework directory get rebuilt instead of handed over ready.

The liveness probe previously counted "answered the request" as online, discarding the HTTP status code it already computed. Now `probe.State` carries the status code, and `devWatchTick` treats a 5xx as not-serving when `DEV_RESTART_ON_5XX` is set. The flag defaults off since a user's app can legitimately 5xx from its own bug.

**Testing**
- Adds a test that spins up real 200 and 500 servers and asserts `State.HTTPStatus` carries each code while `Status` stays `online`.

Does not address why the framework directory ends up half-built on warm-pool handover.

<sup>Written for commit 78317fbad65db4ee94df9d9433f3895423bde78e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

