### PR TITLE
fix(task-board): don't cache "no preview yet" for a full window

### DIFF
--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -12,6 +12,7 @@ import {
   extractPreviewUrlFromDeployment,
   headShaFromPrGet,
   headShaFromStatus,
+  isAwaitingPreview,
   isRateLimitError,
   extractPreviewUrlFromCheckRuns,
   extractPreviewUrlFromComments,
@@ -640,5 +641,30 @@ describe("previewMatchesHead", () => {
     };
     expect(previewMatchesHead([closed, merged, pr("passing")])).toBe(true);
     expect(previewMatchesHead([])).toBe(true);
+  });
+});
+
+describe("isAwaitingPreview", () => {
+  it("only a running-CI card with no preview keeps refreshing", () => {
+    expect(
+      isAwaitingPreview({ previewUrl: null, checksStatus: "pending" }),
+    ).toBe(true);
+    // Preview found — nothing left to wait for.
+    expect(
+      isAwaitingPreview({
+        previewUrl: "https://x.vtex.app",
+        checksStatus: "pending",
+      }),
+    ).toBe(false);
+    // CI settled without ever posting one; refreshing forever would not help.
+    expect(
+      isAwaitingPreview({ previewUrl: null, checksStatus: "passing" }),
+    ).toBe(false);
+    expect(
+      isAwaitingPreview({ previewUrl: null, checksStatus: "failing" }),
+    ).toBe(false);
+    expect(isAwaitingPreview({ previewUrl: null, checksStatus: null })).toBe(
+      false,
+    );
   });
 });

--- a/apps/api/src/tools/task-board/pr-cache.test.ts
+++ b/apps/api/src/tools/task-board/pr-cache.test.ts
@@ -271,3 +271,82 @@ describe("fetchOrPlaceholder", () => {
     });
   });
 });
+
+describe("per-entry revalidate override (a value still awaiting something)", () => {
+  test("fetch: a not-ready stored value goes stale immediately", async () => {
+    const clock = { now: 0 };
+    const cache = await cacheAt(clock);
+    let calls = 0;
+    const pending: Promise<void>[] = [];
+    const read = (ready: boolean) =>
+      cache.fetch({
+        namespace: "conn_1",
+        key: "deployment",
+        fetchLive: async () => {
+          calls++;
+          return { url: ready ? "https://x.vtex.app" : null };
+        },
+        onRevalidation: (p) => pending.push(p),
+        // Not ready -> 0, so the very next read revalidates.
+        revalidateAfterMs: (stored) =>
+          (stored as { url: string | null }).url === null ? 0 : 55_000,
+      });
+
+    await read(false);
+    expect(calls).toBe(1);
+
+    // One tick later the default window (55s) would still be a HIT; the
+    // override makes it stale, so the deploy's url is picked up on this poll.
+    clock.now = 1_000;
+    await read(true);
+    await Promise.all(pending);
+    expect(calls).toBe(2);
+
+    // Now that it IS ready, the default window applies again.
+    clock.now = 2_000;
+    await read(true);
+    await Promise.all(pending);
+    expect(calls).toBe(2);
+  });
+
+  test("fetchOrPlaceholder: an incomplete card is never a hit", async () => {
+    const clock = { now: 0 };
+    const cache = new JetStreamKVPrCache(
+      PR_CARDS_CACHE,
+      { getJetStream: () => null },
+      () => clock.now,
+    );
+    await cache.init(fakeKv());
+
+    let calls = 0;
+    const get = (previewUrl: string | null) =>
+      cache.fetchOrPlaceholder<{ previewUrl: string | null }>({
+        namespace: "org_1",
+        key: "task_1",
+        fetchLive: async () => {
+          calls++;
+          return { previewUrl };
+        },
+        placeholder: { previewUrl: null },
+        revalidateAfterMs: (card) =>
+          card.previewUrl === null ? 0 : PR_CARDS_CACHE.revalidateAfterMs,
+      });
+
+    await get(null); // placeholder + detached fill
+    await Bun.sleep(0);
+    expect(calls).toBe(1);
+
+    // Inside the 30s default window, so unpatched this was a hit and the
+    // preview waited for the window to age out.
+    clock.now = 1_000;
+    await get("https://x.vtex.app");
+    await Bun.sleep(0);
+    expect(calls).toBe(2);
+
+    // Complete card: back to the normal window, no rebuild per poll.
+    clock.now = 2_000;
+    await get("https://x.vtex.app");
+    await Bun.sleep(0);
+    expect(calls).toBe(2);
+  });
+});

--- a/apps/api/src/tools/task-board/pr-cache.ts
+++ b/apps/api/src/tools/task-board/pr-cache.ts
@@ -97,6 +97,11 @@ export interface PrCacheFetch {
   /** Receives the background revalidation so the caller can keep its MCP client
    *  open until it settles. */
   onRevalidation: (promise: Promise<void>) => void;
+  /** Per-entry override of the hit window, computed from the STORED value.
+   *  A read whose value says "not ready yet" — a deploy with no url published —
+   *  should go stale fast, so the next poll refetches instead of serving the
+   *  not-ready answer for the full config window. Omit for the default. */
+  revalidateAfterMs?: (stored: unknown) => number;
 }
 
 export class JetStreamKVPrCache {
@@ -162,7 +167,8 @@ export class JetStreamKVPrCache {
 
   async fetch(params: PrCacheFetch): Promise<unknown> {
     const { namespace, key: rawKey, fetchLive, onRevalidation } = params;
-    const { cache, revalidateAfterMs, maxStaleMs } = this.config;
+    const { cache, maxStaleMs } = this.config;
+    const defaultRevalidateAfterMs = this.config.revalidateAfterMs;
     if (!this.kv) {
       return this.fallback.fetch({
         type: "tools/call",
@@ -189,6 +195,9 @@ export class JetStreamKVPrCache {
       return value;
     }
 
+    const revalidateAfterMs = params.revalidateAfterMs
+      ? params.revalidateAfterMs(stored.value)
+      : defaultRevalidateAfterMs;
     if (age > revalidateAfterMs && !this.revalidating.has(key)) {
       cacheCounter.add(1, { cache, outcome: "stale" });
       this.revalidating.add(key);
@@ -228,15 +237,22 @@ export class JetStreamKVPrCache {
     key: string;
     fetchLive: () => Promise<T>;
     placeholder: T;
+    /** Per-entry override of the hit window, computed from the STORED value —
+     *  see {@link PrCacheFetch.revalidateAfterMs}. */
+    revalidateAfterMs?: (stored: T) => number;
   }): Promise<{ value: T; live: boolean }> {
     const { namespace, key: rawKey, fetchLive, placeholder } = params;
-    const { cache, revalidateAfterMs, maxStaleMs } = this.config;
+    const { cache, maxStaleMs } = this.config;
     const key = this.storageKey(namespace, rawKey);
     const stored = await this.read(key);
     const age = stored
       ? this.now() - stored.storedAt
       : Number.POSITIVE_INFINITY;
     const usable = stored != null && age <= maxStaleMs;
+    const revalidateAfterMs =
+      stored && params.revalidateAfterMs
+        ? params.revalidateAfterMs(stored.value as T)
+        : this.config.revalidateAfterMs;
 
     if (usable && age <= revalidateAfterMs) {
       cacheCounter.add(1, { cache, outcome: "hit" });

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -49,7 +49,27 @@ export function isRateLimitError(err: unknown): boolean {
  * only moves to Done once a poll observes `merged`, and a minute of "did my ship
  * button work?" is exactly the confusion this cache must not introduce.
  */
-import { getPrCardCache, getPrReadCache } from "./pr-cache";
+import {
+  getPrCardCache,
+  getPrReadCache,
+  PR_CARDS_CACHE,
+  PR_READS_CACHE,
+} from "./pr-cache";
+
+/** Hit window for a cached value that is still waiting on something — a deploy
+ *  with no published url, or a card with no preview while checks run. Zero, so
+ *  the next poll always revalidates (detached, off the request path) instead of
+ *  serving the not-ready answer for the full window. */
+const AWAITING_PREVIEW_REVALIDATE_MS = 0;
+
+/** A card that should keep refreshing: CI is still running and no preview URL
+ *  has been found yet. Once either settles the card caches normally. */
+export function isAwaitingPreview(card: {
+  previewUrl: string | null;
+  checksStatus: ChecksStatus;
+}): boolean {
+  return card.previewUrl === null && card.checksStatus === "pending";
+}
 
 export function invalidatePrReads(connectionId: string): Promise<void> {
   return getPrReadCache().invalidate(connectionId);
@@ -168,11 +188,13 @@ async function cachedPrRead(
   args: Record<string, unknown>,
   describe: string,
   pending: Promise<void>[],
+  revalidateAfterMs?: (stored: unknown) => number,
 ): Promise<Record<string, unknown> | null> {
   try {
     const raw = await getPrReadCache().fetch({
       namespace: connectionId,
       key: JSON.stringify({ name, args }),
+      revalidateAfterMs,
       fetchLive: () =>
         retry(
           async () => {
@@ -867,6 +889,16 @@ async function fetchPrStatusExtras(
           { owner: pr.repoOwner, repo: pr.repoName, sha: headSha },
           `${prLabel(pr)} (deployment preview)`,
           pending,
+          // An in-flight deploy answers "no environment url yet". Holding that
+          // for the full read window means the card keeps rebuilding from a
+          // stale not-ready answer even once GitHub has the url, so the preview
+          // shows up minutes after the deploy finished.
+          (stored) =>
+            extractPreviewUrlFromDeployment(
+              stored as Record<string, unknown> | null,
+            ) === null
+              ? AWAITING_PREVIEW_REVALIDATE_MS
+              : PR_READS_CACHE.revalidateAfterMs,
         ),
       );
     }
@@ -1265,6 +1297,15 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
       namespace: organizationId,
       key: taskBoardItemId,
       fetchLive: assemble,
+      // A card whose deploy is still running has no preview yet. At the default
+      // window that card is a cache HIT for 30s, so the url can be a poll or
+      // two late even after the read above refreshes. Go stale immediately
+      // instead: the revalidation is detached, so this costs a background
+      // rebuild per poll on exactly the cards that are still missing something.
+      revalidateAfterMs: (cards) =>
+        cards.some(isAwaitingPreview)
+          ? AWAITING_PREVIEW_REVALIDATE_MS
+          : PR_CARDS_CACHE.revalidateAfterMs,
       placeholder: linked.map((pr) => ({
         url: pr.url,
         number: pr.number,


### PR DESCRIPTION
## Problem

A PR card read while its deploy is still running has no preview URL yet — and both caches store that not-ready answer as a normal value, then serve it as a **fresh hit**: the reads cache for 55s, the assembled card for 30s, layered. So the preview link shows up minutes after GitHub actually has it.

Seen on `ELEC-245`: the VTEX FastStore preview (`sfj-a14bf72--electroluxecfaststore.preview.vtex.app`) was live on PR #305 while the task card still showed only "3/9 successful checks" and no preview button.

## Change

A per-entry hit-window override on `fetch` and `fetchOrPlaceholder`, computed from the **stored** value, used in the two places that can be incomplete:

- the `GET_PREVIEW_DEPLOYMENT` read, when it carries no `environmentUrl` yet;
- the assembled card, while `checksStatus === "pending"` and no preview has been found.

Both go stale immediately, so the next poll revalidates. Revalidation is already detached from the request path, so this costs one background rebuild per poll on exactly the cards still missing something — and nothing on the rest. A card that has its preview, or whose CI settled without one, caches normally again (`isAwaitingPreview`).

No TTL constants changed; no behaviour change for complete cards.

## Testing

`pr-cache.test.ts` — two new cases pinning that a not-ready value is never a hit inside the default window, and that the override stops applying once the value is complete. `checks-status.test.ts` — `isAwaitingPreview` truth table (preview found, CI passing, CI failing, no CI all cache normally).

`bun test apps/api/src/tools/task-board/` → 465 pass. The 10 failures are `ECONNREFUSED :5432` integration tests needing a local Postgres, unrelated. `bun run fmt`, `bun run lint` (0 errors), `tsc --noEmit` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the task board caching "no preview yet" for the full window, so preview links now appear as soon as GitHub has them.

While a deploy is still running, both caches served the not-ready answer as a fresh hit — 55s for reads, 30s for the assembled card, layered — so the preview could show up minutes after GitHub had it (seen on `ELEC-245`).

**What changed**
- Adds a per-entry hit-window override on `fetch` and `fetchOrPlaceholder`, computed from the stored value.
- Applies it where a value can be incomplete: the `GET_PREVIEW_DEPLOYMENT` read with no environment URL yet, and the assembled card while checks are pending and no preview is found.
- Incomplete values go stale immediately, so the next poll revalidates; the detached rebuild costs one background pass per poll on those cards only.
- Cards that have a preview, or whose CI settled without one, cache normally again.
- Adds tests for the override and the `isAwaitingPreview` logic.

<sup>Written for commit 725152aeec0e51a2d72a3deeffe85a395a31ddd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

