### PR TITLE
fix(sandbox): a dev server killed while running crashed, it did not fail to start

### DIFF
--- a/packages/sandbox/daemon-go/internal/setup/devexit_test.go
+++ b/packages/sandbox/daemon-go/internal/setup/devexit_test.go
@@ -1,0 +1,25 @@
+package setup
+
+import (
+	"testing"
+
+	"github.com/decocms/studio/sandbox-daemon/internal/events"
+)
+
+// A dev server that reached `running` and then died was killed, not broken at
+// startup — and only `crashed` is restartable (see main.restartablePhase), so
+// calling it `start-failed` disarms the watchdog for the life of the pod. Prod
+// hit this via an external SIGTERM, which yarn reports as exit code 1.
+func TestDevExitPhase(t *testing.T) {
+	for _, tc := range []struct{ from, want string }{
+		{events.PhaseRunning, events.PhaseCrashed},
+		{events.PhaseStarting, events.PhaseStartFailed},
+		{events.PhaseInstalling, events.PhaseStartFailed},
+		{events.PhaseCrashed, events.PhaseCrashed},
+		{events.PhaseStartFailed, events.PhaseStartFailed},
+	} {
+		if got := DevExitPhase(tc.from); got != tc.want {
+			t.Errorf("DevExitPhase(%q) = %q, want %q", tc.from, got, tc.want)
+		}
+	}
+}

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -92,11 +92,36 @@ func NewOrchestrator(deps OrchestratorDeps) *Orchestrator {
 		reason := fmt.Sprintf("dev script exited with code %d", *s.ExitCode)
 		o.chunk("\r\n[orchestrator] " + reason + "\r\n")
 		o.deps.SetStatus(events.DaemonStatus{State: "error", Reason: reason})
-		if o.deps.Lifecycle.Current().Phase != events.PhaseStartFailed {
-			o.deps.Lifecycle.Transition(events.LifecycleState{Phase: events.PhaseStartFailed, Error: reason})
+		// A server that reached `running` started fine — it died. That is a
+		// CRASH, and `crashed` is restartable, so devwatch respawns it. Calling
+		// it `start-failed` disarms the watchdog for the life of the pod
+		// (restartablePhase excludes it), and nothing else calls RestartDev, so
+		// the sandbox stays permanently dark while still reporting ready. The
+		// path that produced this in prod: something SIGTERMs dev, yarn reports
+		// the signal as exit code 1, and a pool pod serving 200 a moment ago
+		// latches start-failed and is then handed to a run with nothing on the
+		// dev port. `start-failed` stays correct for a server that never came
+		// up (still `starting`) — that is a real failure to start.
+		phase := o.deps.Lifecycle.Current().Phase
+		target := DevExitPhase(phase)
+		if phase != target {
+			o.deps.Lifecycle.Transition(events.LifecycleState{Phase: target, Error: reason})
 		}
 	})
 	return o
+}
+
+// DevExitPhase is the lifecycle phase a non-zero, unintentional dev-script exit
+// moves to, given the phase it happened in. See the call site in OnTaskExit for
+// why `running` must not become `start-failed`.
+func DevExitPhase(current string) string {
+	// Already crashed and died again: stay crashed. devwatch owns the bound on
+	// repeated failures (MaxRestarts, then its own ActionGiveUp transition to
+	// start-failed) — latching here instead would disarm it after one retry.
+	if current == events.PhaseRunning || current == events.PhaseCrashed {
+		return events.PhaseCrashed
+	}
+	return events.PhaseStartFailed
 }
 
 func (o *Orchestrator) ResumeFrom(step Step) {


### PR DESCRIPTION
## Root cause

`orchestrator.go` `OnTaskExit` mapped **every** non-zero, unintentional dev-script exit to `PhaseStartFailed` — regardless of the phase it happened in.

`restartablePhase` (`main.go:406`) allows only `running | starting | crashed`. So `start-failed` **permanently disarms `devwatch`**, and nothing else calls `RestartDev`. `OnTaskExit` also sets `status.State = "error"`, and `stepStart` skips starting unless status is `running` — so a config re-apply won't revive it either. The sandbox stays dark for the life of the pod while still reporting ready.

## Why it fires constantly

An agent has **no endpoint to restart the dev server** — `RestartDev` is called only by `devwatch`. So it uses `pkill`, which it legitimately must to pick up `discovery.config.js` or `FASTSTORE_THEME` (both read once at boot). yarn reports the signal as exit code 1, and the daemon reads a deliberate restart of a perfectly healthy server as a failure to start.

Observed live on `tenant-electrolux-prod-jg6qk`:

```
[probe] server responded on port 3000 (status 200)
error Command failed with signal "SIGTERM"
task exit  task=dev status=exited exit_code=1
[orchestrator] dev script exited with code 1
lifecycle transition  from=running to=start-failed
```

At the time of writing that pod — and 3 of the other 7 `tenant-electrolux-prod-*` pods — had **nothing listening on 3000**. Two prod runs (`ELEC-244`, `ELEC-245`) then spent **25 of 55** and **~15 of 82** tool calls killing, rebuilding and re-polling the dev server by hand, next to a watchdog that had been switched off.

## Change

`DevExitPhase(current)` — extracted so the decision is unit-testable:

| exited from | phase | restartable? |
|---|---|---|
| `running` | `crashed` | yes — devwatch respawns |
| `crashed` | `crashed` | yes — devwatch owns the bound |
| `starting` | `start-failed` | no — it really did fail to start |
| anything else | `start-failed` | no |

Recovery chain verified end to end in code: `devwatch` → `ActionRestart` → `RestartDev` → `clearCrashError` (`error`→`running`) → `stopDevTask` → `enqueue(StepStart)`, whose status guard now passes.

`crashed` must re-enter itself rather than latch, or one retry would disarm the watchdog and defeat `MaxRestarts` — repeated failures stay bounded by devwatch's own `ActionGiveUp`, which transitions to `start-failed` deliberately.

## Testing

`internal/setup/devexit_test.go` pins the table above. `go build ./...`, `go vet ./...`, `gofmt -l` clean; `setup`, `devwatch`, `lifecycle` suites pass.

## Relation to #7023

#7023 makes the probe distinguish "answering 5xx" from "healthy". It is **not** the fix for this — the watchdog is disarmed before the probe's opinion is ever consulted. This PR is the one that matters; #7023 is a complementary net and can be merged, deferred, or closed independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox dev server lifecycle so a dev process killed while running is treated as a crash (restartable) instead of a startup failure, which permanently disarmed the watchdog and left the sandbox dark.

- Exits from `running` or `crashed` now transition to `crashed`; exits from `starting` still become `start-failed`.
- `start-failed` is not restartable, so misclassifying a running server's death as a startup failure disabled devwatch for the pod's lifetime.
- Repeated failures stay bounded by devwatch's `MaxRestarts` and `ActionGiveUp` because `crashed` re-enters itself.

<sup>Written for commit b36713f6067f63dfdb15f00a43a3c8ddca0ed799. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

