### PR TITLE
fix(agents): send "improve instructions" to an agent that can act on it

### DIFF
--- a/apps/web/src/components/chat/tiptap/build-improve-prompt-doc.test.ts
+++ b/apps/web/src/components/chat/tiptap/build-improve-prompt-doc.test.ts
@@ -3,9 +3,9 @@ import { buildImprovePromptDoc } from "./build-improve-prompt-doc";
 import { derivePartsFromTiptapDoc } from "../derive-parts";
 
 const baseInput = {
-  managerAgentId: "agent_mgr_auto",
-  managerName: "Automation Manager",
-  kind: "automation" as const,
+  managerAgentId: "agent_mgr_123",
+  managerName: "Agent Manager",
+  kind: "agent" as const,
   id: "vmcp_abc",
   instructions: "Help users with onboarding.\nBe concise.",
 };
@@ -23,15 +23,15 @@ describe("buildImprovePromptDoc", () => {
 
     expect(mention?.type).toBe("mention");
     expect(mention?.attrs).toMatchObject({
-      id: "agent_mgr_auto",
-      name: "Automation Manager",
+      id: "agent_mgr_123",
+      name: "Agent Manager",
       char: "@",
-      metadata: { agentId: "agent_mgr_auto", title: "Automation Manager" },
+      metadata: { agentId: "agent_mgr_123", title: "Agent Manager" },
     });
 
     expect(trailing?.type).toBe("text");
     expect(trailing?.text).toContain(
-      'to improve the instructions of automation "vmcp_abc"',
+      'to improve the instructions of agent "vmcp_abc"',
     );
     expect(trailing?.text).toContain("Here are its current instructions.");
     expect(trailing?.text).toContain(
@@ -48,38 +48,28 @@ describe("buildImprovePromptDoc", () => {
       .filter((p): p is { type: "text"; text: string } => p.type === "text")
       .map((p) => p.text)
       .join("\n");
+    expect(text).toContain("Use @Agent Manager to improve the instructions");
     expect(text).toContain(
-      "Use @Automation Manager to improve the instructions",
-    );
-    expect(text).toContain(
-      "[DELEGATE TO AGENT: Automation Manager (agent_id: agent_mgr_auto)]",
+      "[DELEGATE TO AGENT: Agent Manager (agent_id: agent_mgr_123)]",
     );
     expect(text).toContain("subtask tool");
     expect(text).toContain("<current_instructions>");
   });
 
-  /* No manager: the Super Agent owns the agent tools itself, so the agent
-     editor sends this with no mention and no delegation directive. */
-  test("omits the mention when no manager is given", () => {
+  test("handles automation kind", () => {
     const doc = buildImprovePromptDoc({
-      kind: "agent",
-      id: "vmcp_abc",
-      instructions: "Help users with onboarding.",
+      managerAgentId: "agent_mgr_auto",
+      managerName: "Automation Manager",
+      kind: "automation",
+      id: "auto_42",
+      instructions: "ping every minute",
     });
-    expect(doc.content?.[0]?.content).toHaveLength(1);
-    const [only] = doc.content?.[0]?.content ?? [];
-    expect(only?.type).toBe("text");
-    expect(only?.text).toContain(
-      'Improve the instructions of agent "vmcp_abc"',
+    const trailing = doc.content?.[0]?.content?.[2]?.text ?? "";
+    expect(trailing).toContain(
+      'to improve the instructions of automation "auto_42"',
     );
-
-    const parts = derivePartsFromTiptapDoc(
-      doc as Parameters<typeof derivePartsFromTiptapDoc>[0],
+    expect(trailing).toContain(
+      "<current_instructions>ping every minute</current_instructions>",
     );
-    const text = parts
-      .filter((p): p is { type: "text"; text: string } => p.type === "text")
-      .map((p) => p.text)
-      .join("\n");
-    expect(text).not.toContain("DELEGATE TO AGENT");
   });
 });

--- a/apps/web/src/components/chat/tiptap/build-improve-prompt-doc.ts
+++ b/apps/web/src/components/chat/tiptap/build-improve-prompt-doc.ts
@@ -1,10 +1,8 @@
 import type { TiptapDoc } from "../types";
 
 export interface ImprovePromptDocInput {
-  /** Manager to delegate to. Omit to address the Super Agent directly — it
-   *  owns the agent CRUD tools itself, so an agent rewrite needs no mention. */
-  managerAgentId?: string;
-  managerName?: string;
+  managerAgentId: string;
+  managerName: string;
   kind: "agent" | "automation";
   id: string;
   instructions: string;
@@ -18,20 +16,22 @@ export interface ImprovePromptDocInput {
  *
  * The mention is shaped so derivePartsFromTiptapDoc emits the standard
  * `[DELEGATE TO AGENT: ...]` directive that Decopilot's SUBTASK tool
- * picks up. Without a manager the sentence opens with "Improve the
- * instructions of ..." and no delegation is requested.
+ * picks up.
  */
 export function buildImprovePromptDoc(input: ImprovePromptDocInput): TiptapDoc {
   const { managerAgentId, managerName, kind, id, instructions } = input;
 
-  const tail =
-    `the instructions of ${kind} "${id}". ` +
+  const trailing =
+    ` to improve the instructions of ${kind} "${id}". ` +
     `Here are its current instructions.\n` +
     `<current_instructions>${instructions}</current_instructions>`;
 
-  const content =
-    managerAgentId && managerName
-      ? [
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
           { type: "text", text: "Use " },
           {
             type: "mention",
@@ -42,12 +42,9 @@ export function buildImprovePromptDoc(input: ImprovePromptDocInput): TiptapDoc {
               metadata: { agentId: managerAgentId, title: managerName },
             },
           },
-          { type: "text", text: ` to improve ${tail}` },
-        ]
-      : [{ type: "text", text: `Improve ${tail}` }];
-
-  return {
-    type: "doc",
-    content: [{ type: "paragraph", content }],
+          { type: "text", text: trailing },
+        ],
+      },
+    ],
   };
 }

--- a/apps/web/src/i18n/en/orgs.ts
+++ b/apps/web/src/i18n/en/orgs.ts
@@ -72,6 +72,7 @@ export const orgs = {
   "orgs.connections.commandPlaceholder": "node, bun, python...",
   "orgs.connections.communityMcpRegistry": "Community MCP Registry",
   "orgs.connections.connectedSuccessfully": "Connected successfully",
+  "orgs.connections.openConnection": "Open connection",
   "orgs.connections.connectionDisabled": "Connection disabled",
   "orgs.connections.connectionEnabled": "Connection enabled",
   "orgs.connections.createConnection": "Create Connection",

--- a/apps/web/src/i18n/pt-br/orgs.ts
+++ b/apps/web/src/i18n/pt-br/orgs.ts
@@ -75,6 +75,7 @@ export const orgs = {
   "orgs.connections.commandPlaceholder": "node, bun, python...",
   "orgs.connections.communityMcpRegistry": "Registro MCP da Comunidade",
   "orgs.connections.connectedSuccessfully": "Conectado com sucesso",
+  "orgs.connections.openConnection": "Abrir conexão",
   "orgs.connections.connectionDisabled": "Conexão desativada",
   "orgs.connections.connectionEnabled": "Conexão ativada",
   "orgs.connections.createConnection": "Criar Conexão",

--- a/apps/web/src/routes/orgs/connections.tsx
+++ b/apps/web/src/routes/orgs/connections.tsx
@@ -285,7 +285,8 @@ function ConnectionResults({
         return;
       }
 
-      const { id } = await actions.create.mutateAsync(connectionData);
+      const created = await actions.create.mutateAsync(connectionData);
+      const { id } = created;
 
       // Handle OAuth flow (if needed) + persist, via the shared helper.
       const auth = await authenticateAndPersistOAuth({
@@ -328,15 +329,7 @@ function ConnectionResults({
         toast.success(t("orgs.connections.authenticationSuccessful"));
       }
 
-      toast.success(t("orgs.connections.connectedSuccessfully"));
-
-      // Land the user IN the MCP they just connected: its first app if it
-      // ships one, otherwise its own page (which opens on the tools tab). A
-      // server that answers with no tools isn't worth opening, so the catalog
-      // stays put — the toast is the whole feedback in that case.
-      // Its own try: the connection is already created and the success toast
-      // already fired, so a server that won't list tools must not surface as
-      // "failed to connect" from the outer catch.
+      // Own try: the connection exists; a failed listTools isn't a failed connect.
       let target: ReturnType<typeof resolveConnectedMcpTarget> = null;
       try {
         const client = await queryClient.fetchQuery(
@@ -348,14 +341,14 @@ function ConnectionResults({
         );
         target = resolveConnectedMcpTarget((await client.listTools()).tools);
       } catch {
-        return;
+        // No target — the toast below just loses its button.
       }
-      if (!target) return;
 
-      const appSlug = getConnectionSlug({ ...connectionData, id });
-      navigate(
-        target.appToolName
-          ? {
+      const appSlug = getConnectionSlug(created);
+      const to = !target
+        ? null
+        : target.appToolName
+          ? ({
               to: "/$org/settings/connections/$appSlug/$collectionName/$itemId",
               params: {
                 org: org.slug,
@@ -363,11 +356,22 @@ function ConnectionResults({
                 collectionName: "tools",
                 itemId: encodeURIComponent(target.appToolName),
               },
-            }
-          : {
+            } as const)
+          : ({
               to: "/$org/settings/connections/$appSlug",
               params: { org: org.slug, appSlug },
-            },
+            } as const);
+
+      toast.success(
+        t("orgs.connections.connectedSuccessfully"),
+        to
+          ? {
+              action: {
+                label: t("orgs.connections.openConnection"),
+                onClick: () => navigate(to),
+              },
+            }
+          : undefined,
       );
     } catch (error) {
       toast.error(

--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -48,6 +48,7 @@ import {
 } from "@decocms/ui/components/tooltip.tsx";
 import {
   ENV_VAR_KEY_RE,
+  getWellKnownDecopilotVirtualMCP,
   SUBMODULE_HOST_RE,
   useConnectionActions,
   useProjectContext,
@@ -452,10 +453,12 @@ function VirtualMcpDetailViewWithData({
 
       openSidePanel();
 
+      // This chat runs as the agent being edited; agent CRUD is Super-Agent-only.
+      const superAgent = getWellKnownDecopilotVirtualMCP(org.id);
       await sendMessage({
-        // No manager mention: the Super Agent owns the agent CRUD tools
-        // itself now, so this goes straight to whoever is in the chat.
         tiptapDoc: buildImprovePromptDoc({
+          managerAgentId: superAgent.id,
+          managerName: superAgent.title,
           kind: "agent",
           id: virtualMcp.id,
           instructions: currentInstructions,

--- a/packages/shared/src/sdk/lib/constants.ts
+++ b/packages/shared/src/sdk/lib/constants.ts
@@ -249,8 +249,7 @@ function defineWellKnownAgentVMCP(opts: {
 }
 
 // ---- Decopilot ----
-// Default agent that aggregates ALL org connections. Gateway populates
-// the connections array at lookup time.
+// Default agent. Aggregates no connections — see `storage/virtual.ts` findById.
 const decopilotPrefix = createWellKnownAgentPrefix("decopilot_");
 export const isDecopilot = decopilotPrefix.is;
 export const getDecopilotId = decopilotPrefix.get;


### PR DESCRIPTION
Follow-up to #7027.

### The bug
#7027 retired the Agent Manager and moved agent CRUD into Super-Agent-only built-ins (gated on `isDecopilot`). The agent editor's **improve instructions** button dropped its manager mention along with it, so the message goes to whoever the side panel chat runs as. On `/$org/agents` that is *the agent being edited* — `useRouteVirtualMcpId` resolves `?virtualmcpid=` (`layouts/thread-route.ts:139`, `chat-context.tsx:377`) — and that agent has no agent CRUD tools. The request had nowhere to land.

Fixed by mentioning the Super Agent, so the SUBTASK runs under a decopilot id that carries the built-ins. With both callers passing a manager again, `buildImprovePromptDoc`'s optional-manager branch is dead code — reverted it and its tests.

### Catalog connect
Connecting an MCP from the catalog no longer navigates on its own. The existing success toast gains an **Open connection** action, keeping the same target logic: the first tool carrying a `ui://` resource, else the connection's own page (tools tab), and no button when the server lists no tools. The slug for that link now comes from the created row rather than the request payload — the server owns it.

### Also
`isDecopilot`'s comment claimed Decopilot aggregates all org connections; `storage/virtual.ts` `findById` returns none. That fact is the premise the built-ins rest on.

### Testing
`bun run lint` (0 errors), `bun test` on the touched files, `bun run --cwd=apps/web check`. Not exercised in a browser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the agent editor's "improve instructions" button so it directs the request to the Super Agent, which owns the agent CRUD tools, instead of the agent being edited (which can't act on it). Also changes catalog MCP connection success to show an "Open connection" action on the toast instead of navigating automatically.

- Mentions the Super Agent in the improve instructions doc so SUBTASK runs under a decopilot id.
- Reverts the optional-manager branch in `buildImprovePromptDoc` since both callers now pass a manager.
- Catalog connection toast gets a button linking to the first tool carrying a `ui://` resource, else the connection's own tools tab; no button when the server lists no tools.
- The link slug now comes from the created row rather than the request payload.
- Corrects the `isDecopilot` comment about Decopilot aggregating connections.

<sup>Written for commit 2bb5f39e61d25f47e84ae03b180c508c821c76a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

