### PR TITLE
[chore](task-board): drop mentions of the removed TASK_BOARD_ITEM_PR_LINK tool

### DIFF
--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -40,15 +40,12 @@ describe("buildClaudeCodeTaskPrompt", () => {
   // review now, and the card stays In Progress until the REVIEWER decides — so
   // asking the model for that move would put the card in the wrong lane for
   // the whole time an agent is still working on it.
-  // Inverted: the run used to be told to report its PR with
-  // `TASK_BOARD_ITEM_PR_LINK`. The board finds it by branch now
-  // (`pr-by-branch.ts`), so the prompt pins the BRANCH instead — asking for a
-  // tool that no longer exists would just burn a turn on `not_found`.
+  // Inverted: the run used to be told to report its own PR. The board finds it
+  // by branch now (`pr-by-branch.ts`), so the prompt pins the BRANCH instead.
   test("asks for a pull request on the given branch, not a board move", () => {
     const prompt = buildClaudeCodeTaskPrompt(task, repo);
     expect(prompt).toContain("open a pull request");
     expect(prompt).toContain("branch you were given");
-    expect(prompt).not.toContain("TASK_BOARD_ITEM_PR_LINK");
     expect(prompt).toContain("(task id: tbi_1)");
     expect(prompt).not.toContain('status "in_review"');
   });

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -295,8 +295,8 @@ export function buildClaudeCodeTaskPrompt(
     '- A browser is installed globally, NOT in the repo\'s `node_modules` — don\'t go looking for playwright there. `qa-screenshot <url> <path>.png [--mobile] [--full] [--selector=<css>]` renders any URL (localhost included) in headless Chromium, runs the page\'s JS, and writes a file you must then `Read` — a screenshot you never opened is not verification. To INTERACT (click, fill, `document.elementFromPoint`), write a throwaway node script: `const { chromium } = require("/usr/local/lib/node_modules/playwright-core"); chromium.launch({ executablePath: "/usr/bin/chromium", args: ["--no-sandbox"] })`.',
     // How the board finds the PR now: it looks GitHub up by the branch this
     // checkout is on (`pr-by-branch.ts`), so the one thing the run must not do
-    // is open the PR from some other branch. Replaces `TASK_BOARD_ITEM_PR_LINK`,
-    // which a run that died right after `gh pr create` could never call.
+    // is open the PR from some other branch. Replaces asking the run to report
+    // it, which a run that died right after `gh pr create` could never do.
     "- Open the pull request from the branch you were given — the board finds it by that branch. Don't move the work to a differently-named one.",
     // Deliberately NOT "then move it to In Review". Linking the PR is what
     // starts the review (`openReviewCycleIfInProgress`), and the card stays In

--- a/apps/api/src/tools/task-board/pr-by-branch.ts
+++ b/apps/api/src/tools/task-board/pr-by-branch.ts
@@ -4,10 +4,10 @@
  *
  * The board used to learn a `claude-code` run's PR two ways, both of them the
  * model's word for it: a regex over the run's closing message (which linked
- * nothing whenever it wrote "PR #269 opened" instead of a URL), and then
- * `TASK_BOARD_ITEM_PR_LINK`, a tool the run had to remember to call. Both share
- * a failure mode no prompt fixes — a run that opens the PR and then dies, runs
- * out of budget, or simply doesn't call the tool strands its card, and reviewers
+ * nothing whenever it wrote "PR #269 opened" instead of a URL), and a link tool
+ * the run had to remember to call. Both share a failure mode no prompt fixes —
+ * a run that opens the PR and then dies, runs out of budget, or simply doesn't
+ * call the tool strands its card, and reviewers
  * are only dispatched for a card with a linked PR.
  *
  * Studio already knows everything needed to look it up: the repository is bound
@@ -194,8 +194,8 @@ export async function linkPrFromRunBranch(
             repoName: pr.repo,
             connectionId: conn.id,
           });
-          // The one piece of bookkeeping the deleted `TASK_BOARD_ITEM_PR_LINK`
-          // did alongside its link that nothing else on this path does.
+          // The one piece of bookkeeping the deleted PR-link tool did
+          // alongside its link that nothing else on this path does.
           // Idempotent, and a no-op for the case this file exists for — a run
           // that opened its PR and then died is already In Review by the time
           // we get here, and keeps a null cycle. It matters for a run still

--- a/apps/api/src/tools/task-board/task-run-context.test.ts
+++ b/apps/api/src/tools/task-board/task-run-context.test.ts
@@ -55,15 +55,11 @@ describe("resolveTaskRunToolNames", () => {
     expect(REVIEW_RUN_TOOL_NAMES).toContain("TASK_BOARD_ITEM_PRS_GET");
   });
 
-  // Both inverted from "a task run can link / look up the PR it opened". The
-  // board no longer takes the run's word for its PR — it finds it by the branch
-  // the run was given (`pr-by-branch.ts`), so a Super Agent run needs neither
-  // tool and `TASK_BOARD_ITEM_PR_LINK` no longer exists.
-  test("a task run neither links nor looks up its own PR", () => {
+  // Inverted from "a task run can look up the PR it opened". The board no
+  // longer takes the run's word for its PR — it finds it by the branch the run
+  // was given (`pr-by-branch.ts`), so a Super Agent run needs no PR tool.
+  test("a task run does not look up its own PR", () => {
     expect(TASK_RUN_TOOL_NAMES).not.toContain("TASK_BOARD_ITEM_PRS_GET");
-    expect(TASK_RUN_TOOL_NAMES as readonly string[]).not.toContain(
-      "TASK_BOARD_ITEM_PR_LINK",
-    );
   });
 
   test("the review surface only ADDS to the narrow one", () => {


### PR DESCRIPTION
## Summary

`TASK_BOARD_ITEM_PR_LINK` no longer exists — the board finds a run's PR by branch (`pr-by-branch.ts`). All that was left were references to the dead symbol:

- 4 comments in `claude-code-task-run.{ts,test.ts}`, `pr-by-branch.ts`, `task-run-context.test.ts` — reworded to describe the old behaviour without naming the tool.
- 2 `not.toContain("TASK_BOARD_ITEM_PR_LINK")` assertions — removed. They guard against a tool that cannot be registered; the surviving assertions (`not.toContain("TASK_BOARD_ITEM_PRS_GET")`, prompt pins the branch) still cover the real behaviour.

No behaviour change.

## Testing

`bun test apps/api/src/tools/task-board/{task-run-context,claude-code-task-run}.test.ts` → 35 pass. `bun run fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up comments and tests that still named the removed `TASK_BOARD_ITEM_PR_LINK` tool, which the board replaced with branch-based PR lookup. No behavior change; the remaining `not.toContain` assertions still cover the real behavior.

<sup>Written for commit ae3a6bf4a042a65dcb812397564d74541628e027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

