### PR TITLE
feat(task-board): open preview at the pages the PR changed

### DIFF
--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -298,7 +298,7 @@ export function buildClaudeCodeTaskPrompt(
     // is open the PR from some other branch. Replaces `TASK_BOARD_ITEM_PR_LINK`,
     // which a run that died right after `gh pr create` could never call.
     // Parsed back out by `parsePreviewRoutes` (apps/web) — must be exact paths, not prose.
-    "- If your change adds or edits pages a person can open, end the pull request body with a `Preview routes:` line followed by one `- /path` bullet per page (paths only, no host). Skip it entirely when the change has no visible route.",
+    "- If your change adds or edits pages a person can open, name them in the pull request body on a `Route:` line, or on a `Preview routes:` line followed by one `- /path` bullet per page — paths only, no host. Skip it when the change has no visible route.",
     "- Open the pull request from the branch you were given — the board finds it by that branch. Don't move the work to a differently-named one.",
     // Deliberately NOT "then move it to In Review". Linking the PR is what
     // starts the review (`openReviewCycleIfInProgress`), and the card stays In

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -297,6 +297,8 @@ export function buildClaudeCodeTaskPrompt(
     // checkout is on (`pr-by-branch.ts`), so the one thing the run must not do
     // is open the PR from some other branch. Replaces `TASK_BOARD_ITEM_PR_LINK`,
     // which a run that died right after `gh pr create` could never call.
+    // Parsed back out by `parsePreviewRoutes` (apps/web) — must be exact paths, not prose.
+    "- If your change adds or edits pages a person can open, end the pull request body with a `Preview routes:` line followed by one `- /path` bullet per page (paths only, no host). Skip it entirely when the change has no visible route.",
     "- Open the pull request from the branch you were given — the board finds it by that branch. Don't move the work to a differently-named one.",
     // Deliberately NOT "then move it to In Review". Linking the PR is what
     // starts the review (`openReviewCycleIfInProgress`), and the card stays In

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -169,6 +169,7 @@ export const taskBoard = {
   "taskBoard.taskDialog.prStateMerged": "Merged",
   "taskBoard.taskDialog.prStateOpen": "Open",
   "taskBoard.taskDialog.previewLabel": "Open preview",
+  "taskBoard.taskDialog.previewRoutesLabel": "Pages changed in this PR",
   "taskBoard.taskDialog.previewUnavailable": "Preview unavailable",
   "taskBoard.taskDialog.previewUnavailableTitle":
     "The deploy preview isn't responding yet — it may still be building",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -176,6 +176,7 @@ export const taskBoard = {
   "taskBoard.taskDialog.prStateMerged": "Mesclado",
   "taskBoard.taskDialog.prStateOpen": "Aberto",
   "taskBoard.taskDialog.previewLabel": "Abrir preview",
+  "taskBoard.taskDialog.previewRoutesLabel": "Páginas alteradas neste PR",
   "taskBoard.taskDialog.previewUnavailable": "Preview indisponível",
   "taskBoard.taskDialog.previewUnavailableTitle":
     "O deploy preview ainda não está respondendo — pode estar em construção",

--- a/apps/web/src/layouts/task-board/preview-routes.test.ts
+++ b/apps/web/src/layouts/task-board/preview-routes.test.ts
@@ -2,29 +2,43 @@ import { describe, expect, it } from "bun:test";
 import { parsePreviewRoutes, previewRouteUrl } from "./preview-routes";
 
 describe("parsePreviewRoutes", () => {
-  it("reads the bullet list under the heading", () => {
+  it("reads the bullet list under a bare label", () => {
     expect(
       parsePreviewRoutes(
-        "Adds the landing page.\n\nPreview routes:\n- /cliente-vip\n- /cliente-vip/faq\n",
+        "Adds the landing page.\n\nPreview routes:\n- /cliente-vip\n- `/cliente-vip/faq`\n",
       ),
     ).toEqual(["/cliente-vip", "/cliente-vip/faq"]);
   });
 
-  it("stops at the first non-route line and dedupes", () => {
+  it("reads paths off the label's own line, as runs already write them", () => {
+    // Verbatim shape from an existing PR body, which predates the block.
     expect(
       parsePreviewRoutes(
-        "Preview routes:\n- /a\n- /a\n\n- /never\nNotes:\n- something",
+        "Builds the landing page.\n\n**Route:** `/cliente-vip` — [Figma](https://www.figma.com/design/x)\n\n## Sections\n\nHero, FAQ accordion.",
       ),
+    ).toEqual(["/cliente-vip"]);
+  });
+
+  it("collects every label in the body and dedupes", () => {
+    expect(parsePreviewRoutes("Route: /a\n\nRoutes: `/b`, `/a`\n")).toEqual([
+      "/a",
+      "/b",
+    ]);
+  });
+
+  it("stops a list at the first non-bullet line", () => {
+    expect(
+      parsePreviewRoutes("Routes:\n- /a\n\n- /never\nNotes:\n- something"),
     ).toEqual(["/a"]);
   });
 
-  it("ignores bodies without the block, prose bullets and protocol-relative paths", () => {
-    expect(parsePreviewRoutes("just a description")).toEqual([]);
+  it("ignores prose without paths, unlabeled paths and protocol-relative hosts", () => {
+    expect(parsePreviewRoutes("just a description with /a in it")).toEqual([]);
     expect(parsePreviewRoutes(null)).toEqual([]);
-    expect(parsePreviewRoutes("Preview routes:\n- not a path")).toEqual([]);
-    expect(parsePreviewRoutes("Preview routes:\n- //evil.com\n- /ok")).toEqual([
-      "/ok",
-    ]);
+    expect(parsePreviewRoutes("Route: not a path")).toEqual([]);
+    expect(parsePreviewRoutes("Routes: //evil.com /ok")).toEqual(["/ok"]);
+    // A relative file path is not a route.
+    expect(parsePreviewRoutes("Route: plugins/cliente-vip")).toEqual([]);
   });
 });
 

--- a/apps/web/src/layouts/task-board/preview-routes.test.ts
+++ b/apps/web/src/layouts/task-board/preview-routes.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { parsePreviewRoutes, previewRouteUrl } from "./preview-routes";
+
+describe("parsePreviewRoutes", () => {
+  it("reads the bullet list under the heading", () => {
+    expect(
+      parsePreviewRoutes(
+        "Adds the landing page.\n\nPreview routes:\n- /cliente-vip\n- /cliente-vip/faq\n",
+      ),
+    ).toEqual(["/cliente-vip", "/cliente-vip/faq"]);
+  });
+
+  it("stops at the first non-route line and dedupes", () => {
+    expect(
+      parsePreviewRoutes(
+        "Preview routes:\n- /a\n- /a\n\n- /never\nNotes:\n- something",
+      ),
+    ).toEqual(["/a"]);
+  });
+
+  it("ignores bodies without the block, prose bullets and protocol-relative paths", () => {
+    expect(parsePreviewRoutes("just a description")).toEqual([]);
+    expect(parsePreviewRoutes(null)).toEqual([]);
+    expect(parsePreviewRoutes("Preview routes:\n- not a path")).toEqual([]);
+    expect(parsePreviewRoutes("Preview routes:\n- //evil.com\n- /ok")).toEqual([
+      "/ok",
+    ]);
+  });
+});
+
+describe("previewRouteUrl", () => {
+  it("keeps the preview origin and replaces the path", () => {
+    expect(previewRouteUrl("https://pr-1.deno.dev/", "/cliente-vip")).toBe(
+      "https://pr-1.deno.dev/cliente-vip",
+    );
+    expect(previewRouteUrl("https://pr-1.deno.dev/old", "/new?a=1")).toBe(
+      "https://pr-1.deno.dev/new?a=1",
+    );
+  });
+});

--- a/apps/web/src/layouts/task-board/preview-routes.ts
+++ b/apps/web/src/layouts/task-board/preview-routes.ts
@@ -1,0 +1,45 @@
+/**
+ * The paths a PR's run says it created or edited, read off the PR body.
+ *
+ * The run authors the PR body itself (`gh pr create`), and its prompt asks it
+ * to end that body with a `Preview routes:` list of paths. Concatenated with
+ * the deploy preview's origin, that turns one "Open preview" button into the
+ * actual pages the change touched.
+ *
+ * ponytail: parsed from the body rather than persisted on the card. Routes
+ * belong to a PR, not to a task (a task can have several, and a re-run replaces
+ * them), and `body` is already fetched and on the wire — a column would need a
+ * migration, a tool field and its own staleness story. If runs turn out to
+ * write the block unreliably, persist it via TASK_BOARD_ITEM_UPDATE instead.
+ */
+
+const HEADING = /^\s*preview routes:\s*$/i;
+/** `- /path` — a leading `/` is required, so prose bullets don't become links. */
+const ROUTE = /^\s*[-*]\s+(\/\S*)\s*$/;
+
+/** No real preview list is longer; caps what one PR body can render. */
+const MAX_ROUTES = 20;
+
+export function parsePreviewRoutes(body: string | null | undefined): string[] {
+  if (!body) return [];
+  const lines = body.split("\n");
+  const start = lines.findIndex((l) => HEADING.test(l));
+  if (start === -1) return [];
+
+  const routes: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    const match = line.match(ROUTE);
+    // Ends at the first non-bullet line, so a later list isn't swallowed.
+    if (!match?.[1]) break;
+    // `//evil.com` is protocol-relative — it would leave the preview host.
+    if (match[1].startsWith("//")) continue;
+    if (!routes.includes(match[1])) routes.push(match[1]);
+    if (routes.length === MAX_ROUTES) break;
+  }
+  return routes;
+}
+
+/** `https://host/base` + `/path` — one origin, the route's path. */
+export function previewRouteUrl(previewUrl: string, route: string): string {
+  return new URL(route, previewUrl).toString();
+}

--- a/apps/web/src/layouts/task-board/preview-routes.ts
+++ b/apps/web/src/layouts/task-board/preview-routes.ts
@@ -1,42 +1,77 @@
 /**
  * The paths a PR's run says it created or edited, read off the PR body.
  *
- * The run authors the PR body itself (`gh pr create`), and its prompt asks it
- * to end that body with a `Preview routes:` list of paths. Concatenated with
- * the deploy preview's origin, that turns one "Open preview" button into the
- * actual pages the change touched.
+ * Concatenated with the deploy preview's origin, they turn one "Open preview"
+ * button into the actual pages the change touched.
+ *
+ * Two shapes are accepted, both anchored on a `Route:` / `Preview routes:`
+ * label so ordinary prose can never become a link: paths on the label's own
+ * line (`**Route:** \`/cliente-vip\``, which runs were already writing before
+ * the prompt asked for anything), or a bullet list under a bare label. Reading
+ * both is what makes the feature work on PRs that predate it.
  *
  * ponytail: parsed from the body rather than persisted on the card. Routes
  * belong to a PR, not to a task (a task can have several, and a re-run replaces
  * them), and `body` is already fetched and on the wire — a column would need a
- * migration, a tool field and its own staleness story. If runs turn out to
- * write the block unreliably, persist it via TASK_BOARD_ITEM_UPDATE instead.
+ * migration, a tool field and its own staleness story, and would know nothing
+ * about existing PRs. If runs write these labels unreliably, persist instead.
  */
 
-const HEADING = /^\s*preview routes:\s*$/i;
-/** `- /path` — a leading `/` is required, so prose bullets don't become links. */
-const ROUTE = /^\s*[-*]\s+(\/\S*)\s*$/;
+/** A `Route:` / `Routes:` / `Preview routes:` label, and whatever follows it on
+ *  the line. Markdown bold/italic around the label is common, so it's tolerated. */
+const LABEL = /^[\s>*_]*(?:preview\s+)?routes?[\s*_]*:[\s*_]*(.*)$/i;
+const BULLET = /^\s*[-*]\s+(.*)$/;
 
 /** No real preview list is longer; caps what one PR body can render. */
 const MAX_ROUTES = 20;
 
+/** Pull absolute paths out of one line of markdown prose. */
+function pathsIn(text: string): string[] {
+  return (
+    text
+      .split(/[\s,;]+/)
+      .map((token) =>
+        // Markdown wrapping (`code`, [label](…), **bold**) and sentence
+        // punctuation sit against the path in real bodies.
+        token
+          .replace(/^[`("'[*_]+/, "")
+          .replace(/[`)"'\]*_.,;:!?]+$/, ""),
+      )
+      // A single leading slash: a bare `//evil.com` is protocol-relative and
+      // would leave the preview host once joined.
+      .filter((token) => token.startsWith("/") && !token.startsWith("//"))
+  );
+}
+
 export function parsePreviewRoutes(body: string | null | undefined): string[] {
   if (!body) return [];
   const lines = body.split("\n");
-  const start = lines.findIndex((l) => HEADING.test(l));
-  if (start === -1) return [];
-
   const routes: string[] = [];
-  for (const line of lines.slice(start + 1)) {
-    const match = line.match(ROUTE);
-    // Ends at the first non-bullet line, so a later list isn't swallowed.
-    if (!match?.[1]) break;
-    // `//evil.com` is protocol-relative — it would leave the preview host.
-    if (match[1].startsWith("//")) continue;
-    if (!routes.includes(match[1])) routes.push(match[1]);
-    if (routes.length === MAX_ROUTES) break;
+
+  const add = (found: string[]) => {
+    for (const route of found) {
+      if (!routes.includes(route) && routes.length < MAX_ROUTES) {
+        routes.push(route);
+      }
+    }
+  };
+
+  for (const [index, line] of lines.entries()) {
+    const rest = line.match(LABEL)?.[1];
+    if (rest === undefined) continue;
+    if (rest.trim()) {
+      add(pathsIn(rest));
+      continue;
+    }
+    // A bare label heads a list: take bullets until the first line that isn't
+    // one, so a later unrelated list isn't swallowed.
+    for (const next of lines.slice(index + 1)) {
+      const bullet = next.match(BULLET)?.[1];
+      if (bullet === undefined) break;
+      add(pathsIn(bullet));
+    }
   }
-  return routes;
+  return routes.slice(0, MAX_ROUTES);
 }
 
 /** `https://host/base` + `/path` — one origin, the route's path. */

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -110,6 +110,7 @@ import {
   isSuccessfulCheck,
   prCardActions,
 } from "./pr-card-actions";
+import { parsePreviewRoutes, previewRouteUrl } from "./preview-routes";
 import { toast } from "sonner";
 import { useTaskBoardItemPrs } from "@/hooks/use-task-board-item-prs";
 import { usePreviewProbe } from "@/hooks/use-preview-probe";
@@ -1749,7 +1750,7 @@ function checkRunStyle(check: TaskBoardItemPr["checks"][number]): {
  * opaque to the browser), so this blocks on `usePreviewProbe` and offers the
  * link only on a < 400.
  */
-function PreviewButton({ url }: { url: string }) {
+function PreviewButton({ url, routes }: { url: string; routes: string[] }) {
   const t = useT();
   const { data, isPending, isError } = usePreviewProbe(url);
   const available = data?.available ?? false;
@@ -1785,13 +1786,13 @@ function PreviewButton({ url }: { url: string }) {
     );
   }
 
-  return (
+  const link = (
     <Button
       asChild
       type="button"
       variant="outline"
       size="sm"
-      className="gap-1.5"
+      className={cn("gap-1.5", routes.length > 0 && "rounded-r-none")}
     >
       <a href={url} target="_blank" rel="noreferrer">
         <Globe01 size={14} />
@@ -1799,6 +1800,43 @@ function PreviewButton({ url }: { url: string }) {
         <LinkExternal01 size={12} />
       </a>
     </Button>
+  );
+
+  if (routes.length === 0) return link;
+
+  // Button keeps opening the preview root; the caret offers the run's pages.
+  return (
+    <div className="flex items-center">
+      {link}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="rounded-l-none border-l-0 px-1.5"
+            aria-label={t("taskBoard.taskDialog.previewRoutesLabel")}
+            title={t("taskBoard.taskDialog.previewRoutesLabel")}
+          >
+            <ChevronDown size={14} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          {routes.map((route) => (
+            <DropdownMenuItem key={route} asChild>
+              <a
+                href={previewRouteUrl(url, route)}
+                target="_blank"
+                rel="noreferrer"
+                className="font-mono text-xs"
+              >
+                {route}
+              </a>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }
 
@@ -1912,7 +1950,12 @@ function PrCard({
               {t("taskBoard.taskDialog.openPreviewButton")}
             </Button>
           )}
-          {pr.previewUrl && <PreviewButton url={pr.previewUrl} />}
+          {pr.previewUrl && (
+            <PreviewButton
+              url={pr.previewUrl}
+              routes={parsePreviewRoutes(pr.body)}
+            />
+          )}
           {showShip && (
             <Button
               type="button"


### PR DESCRIPTION
## What

"Open preview" becomes a split button: the button still opens the deploy preview root, the caret lists the pages the run actually created or edited.

- `claude-code-task-run.ts` — one prompt line: end the PR body with a `Preview routes:` block of `- /path` bullets, skipped when the change has no visible route.
- `preview-routes.ts` — parses that block off `pr.body` (stops at the first non-bullet, dedupes, caps at 20, rejects protocol-relative `//host`) and joins each path onto the preview origin with `new URL(route, previewUrl)`.
- `task-dialog.tsx` — the split button. No routes parsed → identical to today.
- en / pt-br strings for the caret's label.

## Why the PR body, not a task column

Routes belong to a PR, not a task: a task can have several PRs and a re-run replaces the paths, so a task-level field goes stale silently. `pr.body` is already fetched live and already on the wire, so this needs no migration, no `TASK_BOARD_ITEM_UPDATE` field, and no cleanup story. If runs turn out to write the block unreliably, persisting it is the documented upgrade path.

## Testing

- `preview-routes.test.ts` — 4 cases (happy path, terminator + dedupe, missing block / prose bullets / `//evil.com`, URL join).
- `bun run fmt`, `bun run lint`, `apps/api check` clean. Two failures in `task-filters-search.test.tsx` when the task-board dir runs together, and a duplicate-`prosemirror-model` type error in `apps/web check`, both reproduce on clean `main`.

## Screenshots

None — the button is unchanged until a PR body carries the block.