### PR TITLE
fix(task-board): judge PR checks against the head sha

### DIFF
--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -13,6 +13,7 @@ import {
   headShaFromPrGet,
   headShaFromStatus,
   isAwaitingPreview,
+  runsForHead,
   isRateLimitError,
   extractPreviewUrlFromCheckRuns,
   extractPreviewUrlFromComments,
@@ -665,6 +666,32 @@ describe("isAwaitingPreview", () => {
     ).toBe(false);
     expect(isAwaitingPreview({ previewUrl: null, checksStatus: null })).toBe(
       false,
+    );
+  });
+});
+
+describe("runsForHead", () => {
+  const head = "4f800cc";
+  const runs = [
+    { name: "cubic", head_sha: head, status: "completed" },
+    { name: "pages", head_sha: "0000001", status: "in_progress" },
+    { name: "no-sha", status: "completed" },
+  ];
+
+  it("drops runs from a superseded commit, keeps head's and sha-less ones", () => {
+    expect(
+      runsForHead({ check_runs: runs }, head).map((r) => (r as any).name),
+    ).toEqual(["cubic", "no-sha"]);
+  });
+
+  it("keeps everything when the head sha is unknown", () => {
+    expect(runsForHead(runs, null)).toHaveLength(3);
+  });
+
+  it("makes a green head stop reporting the old commit as pending", () => {
+    expect(toCheckRunsStatus({ check_runs: runs })).toBe("pending");
+    expect(toCheckRunsStatus(runsForHead({ check_runs: runs }, head))).toBe(
+      "passing",
     );
   });
 });

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -426,11 +426,7 @@ export function extractPreviewUrl(
 const WORKERS_DEV_SUBDOMAIN = "deco-cx";
 
 export function extractPreviewUrlFromCheckRuns(raw: unknown): string | null {
-  const runs = Array.isArray(raw)
-    ? raw
-    : Array.isArray((raw as { check_runs?: unknown })?.check_runs)
-      ? (raw as { check_runs: unknown[] }).check_runs
-      : [];
+  const runs = toRunsArray(raw);
   for (const r of runs) {
     if (!r || typeof r !== "object") continue;
     const o = r as { name?: unknown; output?: { summary?: unknown } };
@@ -586,6 +582,36 @@ const FAILED_CHECK_CONCLUSIONS = new Set([
   "stale",
 ]);
 
+/** Normalize a `get_check_runs` result (`{ check_runs }` or an array). */
+function toRunsArray(raw: unknown): unknown[] {
+  return Array.isArray(raw)
+    ? raw
+    : Array.isArray((raw as { check_runs?: unknown })?.check_runs)
+      ? (raw as { check_runs: unknown[] }).check_runs
+      : [];
+}
+
+/**
+ * Drop check-runs belonging to a commit that is no longer the PR's head.
+ *
+ * The reads behind a card are cached by PR number, not by sha, so right after a
+ * push the card is assembled from the PREVIOUS commit's runs — which is how a
+ * PR GitHub reports as fully green kept rendering "Checks pending" with the
+ * superseded commit's still-running checks.
+ *
+ * Unconditional: on a fresh read every run already carries the head sha, so
+ * this only ever removes stale ones. A run without a `head_sha` is kept.
+ * Exported for the unit test.
+ */
+export function runsForHead(raw: unknown, headSha: string | null): unknown[] {
+  const runs = toRunsArray(raw);
+  if (!headSha) return runs;
+  return runs.filter((r) => {
+    const sha = (r as { head_sha?: unknown } | null)?.head_sha;
+    return typeof sha !== "string" || sha === headSha;
+  });
+}
+
 /** Map GitHub check-runs (Checks API) to our three-value summary. Repos on
  *  GitHub Actions post check-runs, NOT legacy commit statuses (which
  *  `toChecksStatus` reads), so this is often the only signal — e.g. a deco site
@@ -593,11 +619,7 @@ const FAILED_CHECK_CONCLUSIONS = new Set([
  *  Accepts the raw `get_check_runs` result (`{ check_runs }` or an array).
  *  `null` when there are no check-runs. Exported for the unit test. */
 export function toCheckRunsStatus(raw: unknown): ChecksStatus {
-  const runs = Array.isArray(raw)
-    ? raw
-    : Array.isArray((raw as { check_runs?: unknown })?.check_runs)
-      ? (raw as { check_runs: unknown[] }).check_runs
-      : [];
+  const runs = toRunsArray(raw);
   if (runs.length === 0) return null;
   let failing = false;
   let pending = false;
@@ -643,11 +665,7 @@ type RawCheckRun = {
 
 /** Parse a `get_check_runs` result into a flat list. Exported for the test. */
 export function parseCheckRuns(raw: unknown): RawCheckRun[] {
-  const runs = Array.isArray(raw)
-    ? raw
-    : Array.isArray((raw as { check_runs?: unknown })?.check_runs)
-      ? (raw as { check_runs: unknown[] }).check_runs
-      : [];
+  const runs = toRunsArray(raw);
   const out: RawCheckRun[] = [];
   for (const r of runs) {
     if (!r || typeof r !== "object") continue;
@@ -863,23 +881,30 @@ async function fetchPrStatusExtras(
     read("get_check_runs"),
     read("get_comments"),
   ]);
+  // The PR's head sha — everything below is judged against it, so a cached read
+  // taken before the last push can't report the old commit's CI as this PR's.
+  const headSha = headShaFromPrGet(await prGet) ?? headShaFromStatus(statusObj);
+  const runs = runsForHead(runsRaw, headSha);
+  // Same for the combined status. Only an explicit MISMATCH drops it — a
+  // response without a sha says nothing about which commit it describes.
+  const statusSha = headShaFromStatus(statusObj);
+  const statusForHead =
+    headSha && statusSha && statusSha !== headSha ? null : statusObj;
   // Combined Status API ∪ Checks API → one summary.
   const checksStatus = mergeChecksStatus(
-    toChecksStatus(statusObj),
-    toCheckRunsStatus(runsRaw),
+    toChecksStatus(statusForHead),
+    toCheckRunsStatus(runs),
   );
   // Preview: the Workers Builds version (exact, and present even when
   // Cloudflare's PR comment omits its Preview URL column), else a status
   // `target_url` (rare), else the deploy bot's PR comment.
   let previewUrl =
-    extractPreviewUrlFromCheckRuns(runsRaw) ??
-    extractPreviewUrl(statusObj) ??
+    extractPreviewUrlFromCheckRuns(runs) ??
+    extractPreviewUrl(statusForHead) ??
     extractPreviewUrlFromComments(commentsRaw);
   // TODO(e2e): cover the miss-path gate + head-sha threading below (only the pure extractors are unit-tested).
   if (!previewUrl) {
     // Last resort: a GitHub Deployment env url (VTEX FastStore posts it only there), scanned only on the miss path once the head sha is known.
-    const headSha =
-      headShaFromPrGet(await prGet) ?? headShaFromStatus(statusObj);
     if (headSha) {
       previewUrl = extractPreviewUrlFromDeployment(
         await cachedPrRead(
@@ -906,7 +931,7 @@ async function fetchPrStatusExtras(
   // Per-check list for the footer; pull the output markdown only for failing
   // runs (bounded, in parallel).
   const checks = await Promise.all(
-    parseCheckRuns(runsRaw).map(
+    parseCheckRuns(runs).map(
       async (r): Promise<PrCheck> => ({
         name: r.name,
         status: r.status,


### PR DESCRIPTION
## Summary
The task card kept showing **Checks pending** for PRs GitHub reports as fully green.

The GitHub reads behind a card are cached by PR *number*, not by commit (`pull_request_read get_check_runs` + `get_status`, 55s revalidate / up to 30min stale). Right after a push — or whenever a revalidation is skipped/rate-limited — the card is assembled from the **previous** commit's check runs, which are still `in_progress`. That's the screenshotted state: card says pending on `pages` / `Workers Builds`, GitHub says 2 successful + 1 skipped on head.

## Change
`runsForHead(raw, headSha)` filters check runs to the PR head sha (runs without a `head_sha` are kept; no filtering when the head sha is unknown). The combined status is dropped only on an explicit sha mismatch. `checksStatus`, the per-check footer list and the preview URL all now come from head-only data. The head sha was already fetched concurrently (`prGet`), so no extra round-trip.

## Testing
`bun test apps/api/src/tools/task-board/checks-status.test.ts` — 63 pass, incl. 3 new cases pinning that a stale in-progress run no longer turns a green head into `pending`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the task board showing “Checks pending” for PRs GitHub reports as fully green by judging check runs against the PR’s head commit instead of a cached read from a previous commit.

- Filters check runs and the combined status to the head sha before deriving the summary, per-check list, and preview URL.
- Runs without a `head_sha` are kept; filtering is skipped when the head sha is unknown.
- No extra API round-trip — the head sha was already fetched concurrently.

<sup>Written for commit 087a479bbf3aab5f609603748c6c8c0edabfc2f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

