### PR TITLE
fix(task-board): never cache a PR card whose CI is still running

### DIFF
--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -12,7 +12,7 @@ import {
   extractPreviewUrlFromDeployment,
   headShaFromPrGet,
   headShaFromStatus,
-  isAwaitingPreview,
+  isAwaitingCi,
   isRateLimitError,
   extractPreviewUrlFromCheckRuns,
   extractPreviewUrlFromComments,
@@ -644,27 +644,16 @@ describe("previewMatchesHead", () => {
   });
 });
 
-describe("isAwaitingPreview", () => {
-  it("only a running-CI card with no preview keeps refreshing", () => {
-    expect(
-      isAwaitingPreview({ previewUrl: null, checksStatus: "pending" }),
-    ).toBe(true);
-    // Preview found — nothing left to wait for.
-    expect(
-      isAwaitingPreview({
-        previewUrl: "https://x.vtex.app",
-        checksStatus: "pending",
-      }),
-    ).toBe(false);
-    // CI settled without ever posting one; refreshing forever would not help.
-    expect(
-      isAwaitingPreview({ previewUrl: null, checksStatus: "passing" }),
-    ).toBe(false);
-    expect(
-      isAwaitingPreview({ previewUrl: null, checksStatus: "failing" }),
-    ).toBe(false);
-    expect(isAwaitingPreview({ previewUrl: null, checksStatus: null })).toBe(
-      false,
-    );
+describe("isAwaitingCi", () => {
+  it("keeps refreshing while CI runs", () => {
+    // Was false whenever a preview URL had already been found, so that card got
+    // the full hit window and showed "Checks pending" long after they passed.
+    expect(isAwaitingCi({ checksStatus: "pending" })).toBe(true);
+  });
+
+  it("caches normally once CI settles", () => {
+    expect(isAwaitingCi({ checksStatus: "passing" })).toBe(false);
+    expect(isAwaitingCi({ checksStatus: "failing" })).toBe(false);
+    expect(isAwaitingCi({ checksStatus: null })).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -57,18 +57,38 @@ import {
 } from "./pr-cache";
 
 /** Hit window for a cached value that is still waiting on something — a deploy
- *  with no published url, or a card with no preview while checks run. Zero, so
- *  the next poll always revalidates (detached, off the request path) instead of
- *  serving the not-ready answer for the full window. */
-const AWAITING_PREVIEW_REVALIDATE_MS = 0;
+ *  with no published url, or CI that hasn't finished. Zero, so the next poll
+ *  always revalidates (detached, off the request path) instead of serving the
+ *  not-ready answer for the full window. */
+const NOT_READY_REVALIDATE_MS = 0;
 
-/** A card that should keep refreshing: CI is still running and no preview URL
- *  has been found yet. Once either settles the card caches normally. */
-export function isAwaitingPreview(card: {
-  previewUrl: string | null;
-  checksStatus: ChecksStatus;
-}): boolean {
-  return card.previewUrl === null && card.checksStatus === "pending";
+/**
+ * A card that should keep refreshing: CI is still running, so both what it
+ * reports and the preview URL a deploy check publishes are still moving.
+ *
+ * Pending CI counts on its own — it used to additionally require a missing
+ * preview URL, which is what left a card sitting on "Checks pending" minutes
+ * after the checks went green. Nothing about the PR had changed; the checks
+ * simply finished, and with a preview already found the card was a cache HIT
+ * for the full window, rebuilt from reads that were themselves a window stale.
+ * Waiting is the one state whose whole point is that it ends, so it never gets
+ * a hit window.
+ *
+ * Bounded: a settled card (passing/failing/no CI) caches normally, so the
+ * per-poll rebuild this costs only runs while CI is actually running.
+ */
+export function isAwaitingCi(card: { checksStatus: ChecksStatus }): boolean {
+  return card.checksStatus === "pending";
+}
+
+/** Hit window for one raw GitHub read: zero while it says CI is still running,
+ *  for the same reason as {@link isAwaitingCi}. Without this the card
+ *  cache revalidates on every poll only to rebuild from a read that is itself
+ *  up to a full read-window stale, and the two lags add up. */
+function ciRevalidateAfterMs(status: ChecksStatus): number {
+  return status === "pending"
+    ? NOT_READY_REVALIDATE_MS
+    : PR_READS_CACHE.revalidateAfterMs;
 }
 
 export function invalidatePrReads(connectionId: string): Promise<void> {
@@ -841,7 +861,10 @@ async function fetchPrStatusExtras(
   checks: PrCheck[];
   previewUrl: string | null;
 }> {
-  const read = (method: "get_status" | "get_check_runs" | "get_comments") =>
+  const read = (
+    method: "get_status" | "get_check_runs" | "get_comments",
+    revalidateAfterMs?: (stored: unknown) => number,
+  ) =>
     cachedPrRead(
       getClient,
       connectionId,
@@ -854,13 +877,18 @@ async function fetchPrStatusExtras(
       },
       `${prLabel(pr)} (${method})`,
       pending,
+      revalidateAfterMs,
     );
   // The three reads are independent — run them CONCURRENTLY. Serial was the
   // slowness (each is a remote MCP → GitHub round-trip, ~1.5-2s; the card made
   // 4-5 of them in a row).
   const [statusObj, runsRaw, commentsRaw] = await Promise.all([
-    read("get_status"),
-    read("get_check_runs"),
+    read("get_status", (stored) =>
+      ciRevalidateAfterMs(toChecksStatus(toolResultJson(stored))),
+    ),
+    read("get_check_runs", (stored) =>
+      ciRevalidateAfterMs(toCheckRunsStatus(toolResultJson(stored))),
+    ),
     read("get_comments"),
   ]);
   // Combined Status API ∪ Checks API → one summary.
@@ -897,7 +925,7 @@ async function fetchPrStatusExtras(
             extractPreviewUrlFromDeployment(
               stored as Record<string, unknown> | null,
             ) === null
-              ? AWAITING_PREVIEW_REVALIDATE_MS
+              ? NOT_READY_REVALIDATE_MS
               : PR_READS_CACHE.revalidateAfterMs,
         ),
       );
@@ -1303,8 +1331,8 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
       // instead: the revalidation is detached, so this costs a background
       // rebuild per poll on exactly the cards that are still missing something.
       revalidateAfterMs: (cards) =>
-        cards.some(isAwaitingPreview)
-          ? AWAITING_PREVIEW_REVALIDATE_MS
+        cards.some(isAwaitingCi)
+          ? NOT_READY_REVALIDATE_MS
           : PR_CARDS_CACHE.revalidateAfterMs,
       placeholder: linked.map((pr) => ({
         url: pr.url,

--- a/apps/web/src/hooks/use-task-board-item-prs.ts
+++ b/apps/web/src/hooks/use-task-board-item-prs.ts
@@ -21,10 +21,18 @@ const PRS_POLL_INTERVAL_MS = 60_000;
  *  minute. */
 const PRS_UNENRICHED_POLL_INTERVAL_MS = 2_000;
 
+/** Checks that are still running settle on their own, with no webhook to say
+ *  when — so while any linked PR reports pending CI, poll faster than the idle
+ *  minute. Bounded to a dialog that is open on a PR whose CI is actually
+ *  running, and the server answers those from cache while it refreshes. */
+const PRS_PENDING_CHECKS_POLL_INTERVAL_MS = 15_000;
+
 /** A card the server returned before GitHub answered: link fields only. `state`
  *  is null for a PR GitHub could not be read for too, which polls the same way
  *  — the right behavior either way. */
 const isUnenriched = (pr: TaskBoardItemPr) => pr.state === null;
+
+const hasPendingChecks = (pr: TaskBoardItemPr) => pr.checksStatus === "pending";
 
 /**
  * A task's linked PRs, each with live state fetched from GitHub via the
@@ -39,10 +47,13 @@ export function useTaskBoardItemPrs(itemId: string | undefined) {
   return useQuery({
     queryKey: KEYS.taskBoardItemPrs(locator, itemId ?? ""),
     enabled: !!itemId,
-    refetchInterval: (query) =>
-      query.state.data?.some(isUnenriched)
-        ? PRS_UNENRICHED_POLL_INTERVAL_MS
-        : PRS_POLL_INTERVAL_MS,
+    refetchInterval: (query) => {
+      const prs = query.state.data;
+      if (prs?.some(isUnenriched)) return PRS_UNENRICHED_POLL_INTERVAL_MS;
+      if (prs?.some(hasPendingChecks))
+        return PRS_PENDING_CHECKS_POLL_INTERVAL_MS;
+      return PRS_POLL_INTERVAL_MS;
+    },
     // Seeded from localStorage so a cold page load paints the last known cards
     // instead of a skeleton. `initialDataUpdatedAt` carries the real age, so
     // React Query treats the seed as already stale and refetches on mount — the


### PR DESCRIPTION
## The bug
A task card kept showing **Checks pending** for minutes after GitHub reported the PR fully green (screenshot: card pending on `pages` / `Workers Builds`, GitHub says 2 successful + 1 skipped — same commit, just time passed).

No cache was stuck; every layer was one hit-window behind, and the windows stacked:

| layer | before |
|---|---|
| card cache (`DECOCMS_PR_CARDS`) | window dropped to 0 only when `previewUrl === null` **and** checks pending — a PR with a Cloudflare preview already found kept the full 30s |
| read cache (`get_status`, `get_check_runs`) | always 55s, so even a per-poll card rebuild was assembled from a read up to 55s old |
| dialog poll | 60s flat |

Worst case ≈ 60s + 30s + 55s of lag on the one state whose whole point is that it ends.

## The fix
- `isAwaitingPreview` → `isAwaitingCi`: pending CI zeroes the card's hit window **on its own**, no longer gated on a missing preview URL.
- The `get_status` / `get_check_runs` reads get the same per-entry override: window 0 while the stored value says pending.
- Dialog polls every 15s (was 60s) while any linked PR reports pending checks.

Bounded: all three revert to the normal windows the moment CI settles (passing / failing / no CI), so the extra reads only happen on a card someone is watching while its CI actually runs. Values are still served immediately — the refresh is detached, off the request path.

## Testing
`bun test apps/api/src/tools/task-board/checks-status.test.ts` — 61 pass; the `isAwaitingPreview` case that asserted the old "preview found ⇒ cache it" behavior is inverted rather than appended to. `bun run --cwd=apps/api check` clean. (The 10 failures in the full task-board suite are the Postgres-backed integration tests — no DB in this shell; they fail identically on `main`.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops PR cards from showing "Checks pending" long after CI has actually finished, by treating a pending CI state as not-ready at every cache layer.

- Pending CI now zeroes the card's hit window even when a preview URL is already known; the `get_status` / `get_check_runs` reads get the same per-entry override.
- The dialog polls every 15s instead of 60s while any linked PR reports pending checks.
- All three revert to normal caching the moment CI settles, so the extra refreshes only run while a watched card's CI is genuinely running; values are still served immediately.

<sup>Written for commit d04c170a06e271ebdc1f5f5b1b125df1c03a35ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

