### PR TITLE
fix(site-editor): show publish cluster on default Preview (bare /agents route)

### DIFF
--- a/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
@@ -29,7 +29,7 @@ import { MainPanelTabsBar } from "@/layouts/main-panel-tabs/main-panel-tabs-bar"
 import { VirtualMcpHeaderInfo } from "@/views/virtual-mcp/header-info";
 import { ChatModeRow } from "@/components/chat/pills/chat-mode-row";
 import { isSurfaceTab } from "@/layouts/main-panel-tabs/source-system-tabs";
-import { useActivePanelTabId } from "@/layouts/main-panel-tabs/use-panel-navigate";
+import { useResolvedMainTabId } from "@/layouts/main-panel-tabs/use-panel-navigate";
 import { useOptionalChatTask } from "@/components/chat/context";
 import { NewChatCrumb } from "@/components/header/shell-breadcrumb";
 import { cn } from "@decocms/ui/lib/utils.ts";
@@ -136,11 +136,13 @@ export function WorkspacePanelGroup({
   // to: the branch is the branch the surface is being edited on, and it said
   // nothing useful beside a screen that edits no files.
   const currentBranch = useOptionalChatTask()?.currentBranch ?? null;
-  const activeTab = useActivePanelTabId();
-  const branchSelector =
-    activeTab && isSurfaceTab(activeTab) ? (
-      <ChatModeRow virtualMcp={entity} currentBranch={currentBranch} />
-    ) : null;
+  /** RESOLVED view, not the raw URL segment — same reason as the publish
+   *  cluster it sits beside: the bare `/$org/agents` entry shows the default
+   *  Preview with no `{-$panel}` segment, and a raw read hid the selector. */
+  const activeTab = useResolvedMainTabId(entity.metadata?.ui?.layout ?? null);
+  const branchSelector = isSurfaceTab(activeTab) ? (
+    <ChatModeRow virtualMcp={entity} currentBranch={currentBranch} />
+  ) : null;
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- syncs URL-derived visibility with the resizable panels' imperative layout API
   useEffect(() => {

--- a/apps/web/src/layouts/main-panel-tabs/use-panel-navigate.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-panel-navigate.ts
@@ -19,6 +19,7 @@ import {
   type DestinationRoutePath,
   useLeafRoutePath,
 } from "@/hooks/use-destination-route";
+import { useRouteDefaultMain } from "@/hooks/use-route-default-main";
 import {
   type DestinationPanel,
   isDestinationPanel,
@@ -26,6 +27,7 @@ import {
   type PanelPayload,
   tabIdForPanel,
 } from "./panel-route";
+import { type EntityLayoutMetadata, resolveActiveTabAndOpen } from "./tab-id";
 
 /** Typed against the router's own paths, so a rename in `router.tsx` breaks here. */
 const DESTINATION_ROUTE_BY_PANEL = {
@@ -44,6 +46,32 @@ export function useActivePanelTabId(): string | undefined {
    *  moved to `?virtualmcpid=`. A bookmarked project id in that slot is redirected
    *  by the route's own `beforeLoad` before anything renders. */
   return tabIdForPanel(params.panel, search);
+}
+
+/**
+ * The main-panel view actually SHOWING, resolving the agent's `defaultMainView`
+ * and the route default the SAME way the panel content does (see
+ * {@link resolveActiveTabAndOpen}).
+ *
+ * Unlike {@link useActivePanelTabId}, which returns only what the URL segment
+ * NAMES, this is defined on the bare `/$org/agents` entry that renders the
+ * default Preview without a `{-$panel}` segment. Gates that ask "is the Site
+ * Editor surface on screen?" (the publish cluster, the branch selector) must
+ * use THIS — reading the raw segment made them vanish whenever the surface was
+ * shown by default rather than by an explicit segment.
+ */
+export function useResolvedMainTabId(
+  entityMetadata: EntityLayoutMetadata | null,
+): string {
+  const panelTabId = useActivePanelTabId();
+  const routeDefaultMain = useRouteDefaultMain();
+  const search = useSearch({ strict: false }) as { mainpanel?: boolean };
+  return resolveActiveTabAndOpen({
+    panelTabId,
+    mainPanelParam: search.mainpanel,
+    routeDefaultMain,
+    metadata: entityMetadata,
+  }).activeTab;
 }
 
 export interface OpenPanelOptions {

--- a/apps/web/src/views/virtual-mcp/header-info.tsx
+++ b/apps/web/src/views/virtual-mcp/header-info.tsx
@@ -2,7 +2,7 @@ import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
 import { agentShowsGithubHeaderActions } from "@/lib/agent-capabilities";
 import { useSessionRuntime } from "@/hooks/use-session-runtime";
 import { isSurfaceTab } from "@/layouts/main-panel-tabs/source-system-tabs";
-import { useActivePanelTabId } from "@/layouts/main-panel-tabs/use-panel-navigate";
+import { useResolvedMainTabId } from "@/layouts/main-panel-tabs/use-panel-navigate";
 import { CmsHeaderActions } from "../../components/thread/github/cms-header-actions.tsx";
 import { HeaderActions } from "../../components/thread/github/header-actions.tsx";
 import { DevAgentControl } from "../../components/dev-agent/dev-agent-control.tsx";
@@ -29,8 +29,14 @@ export function VirtualMcpHeaderInfo({
   // The SESSION's runtime, not the project's: a coding session on a CMS-default
   // project gets the sandbox header, and the hooks that header mounts.
   const fastPreviewActive = useSessionRuntime(virtualMcp.id).runtime === "cms";
-  const activeTab = useActivePanelTabId();
-  const onSiteEditor = !!activeTab && isSurfaceTab(activeTab);
+  /** The RESOLVED view, not the raw URL segment: landing on the bare
+   *  `/$org/agents` entry renders this project's default Preview with no
+   *  `{-$panel}` segment, so a raw read reported "no active tab" and hid the
+   *  publish cluster even though the Site Editor was on screen. */
+  const activeTab = useResolvedMainTabId(
+    virtualMcp.metadata?.ui?.layout ?? null,
+  );
+  const onSiteEditor = isSurfaceTab(activeTab);
 
   return (
     <div className="flex items-center gap-2">


### PR DESCRIPTION
## Problem

A user reported the **"Revisar e publicar"** button missing in the Site Editor even though the project (`demo-linkedin`) has a connected GitHub repo and unpublished draft changes.

Root cause is a **URL ↔ gate desync**, not a missing connection. The publish cluster (`VirtualMcpHeaderInfo`) and the adjacent branch selector are gated on:

```ts
const activeTab = useActivePanelTabId();
const onSiteEditor = !!activeTab && isSurfaceTab(activeTab);
```

`useActivePanelTabId()` returns only what the URL's `{-$panel}` segment **names**. Landing on the bare `/$org/agents?virtualmcpid=…` entry renders the project's **default Preview** (from `metadata.ui.layout.defaultMainView`) **without** writing a `site-editor` segment — so `activeTab` is `undefined`, `onSiteEditor` is `false`, and the entire GitHub/publish cluster renders `null` while the Site Editor surface is clearly on screen. Clicking any tab (which materializes the segment) brought the button back.

Confirmed live in the browser: on the bare route the cluster was absent; clicking **Conteúdo** rewrote the URL to `/agents/site-editor?…&main=content` and the button appeared instantly; switching back to Preview (segment kept) kept it.

## Fix

Add `useResolvedMainTabId(entityMetadata)` in `use-panel-navigate.ts`, which resolves the view the **same way the panel content does** — via the existing `resolveActiveTabAndOpen`, honoring the agent's `defaultMainView` and the route default. Both gates (publish cluster + branch selector) now read the resolved tab instead of the raw URL segment, so they agree with what's painted.

## Affected files
- `apps/web/src/layouts/main-panel-tabs/use-panel-navigate.ts` — new `useResolvedMainTabId` hook
- `apps/web/src/views/virtual-mcp/header-info.tsx` — publish cluster gate
- `apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx` — branch selector gate

## Testing
- `bun run --cwd=apps/web check` ✅
- `bun run lint` ✅ (0 errors; 14 pre-existing warnings unrelated to these files)
- Manually verified the button now shows on the default-Preview entry.

## Notes / follow-up
- `FloatingReleaseCard` uses the same raw-segment predicate for a product-tour scoped step, but its author deliberately keeps it URL-only for first-frame stability (no entity fetch), and the stakes are a tour step, not the publish action — left as-is intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Revisar e publicar" publish cluster and branch selector not showing on the default Preview route in the Site Editor. They were gated on the raw URL `{-$panel}` segment, which the bare `/$org/agents` entry doesn't write, so both rendered null even though the Site Editor surface was on screen.

**Bug Fixes**
- Adds `useResolvedMainTabId`, which resolves the visible view the same way panel content does via `resolveActiveTabAndOpen`, honoring `defaultMainView` and route defaults.
- Switches both gates to the resolved tab so they agree with what's actually painted.
- `FloatingReleaseCard` keeps its URL-only predicate intentionally; it's a product-tour step, not the publish action.

<sup>Written for commit 60b26563a87132f19c6a2f2b202eb1ed9955de1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

