### PR TITLE
fix(blog-editor): preserve focus & scroll when autosave echoes block list

### DIFF
--- a/apps/web/src/components/sandbox/content/blog/block-document.tsx
+++ b/apps/web/src/components/sandbox/content/blog/block-document.tsx
@@ -20,8 +20,12 @@ import { discoverBlogBlockTypes } from "./blog-data";
 import { InsertBlockDivider } from "./block-picker";
 import { BlockRow } from "./blocks/block-row";
 import { type RawBlock } from "./blocks/block-registry";
-
-type BlockItem = { id: string; block: RawBlock };
+import {
+  reseedBlockItems,
+  seedBlockItems,
+  uid,
+  type BlockItem,
+} from "./block-items";
 
 export function asBlocks(value: unknown): RawBlock[] {
   return Array.isArray(value) ? (value as RawBlock[]) : [];
@@ -50,13 +54,13 @@ export function BlockDocument({
   const blockTypes = discoverBlogBlockTypes(meta);
 
   const [blockItems, setBlockItems] = useState<BlockItem[]>(() =>
-    value.map((blk) => ({ id: uid(), block: blk })),
+    seedBlockItems(value),
   );
   // Re-seed when `value` changes for a reason other than our own onChange echo.
   const [lastEmitted, setLastEmitted] = useState(value);
   if (value !== lastEmitted) {
     setLastEmitted(value);
-    setBlockItems(value.map((blk) => ({ id: uid(), block: blk })));
+    setBlockItems(reseedBlockItems(blockItems, value));
   }
 
   const ids = blockItems.map((x) => x.id);
@@ -156,8 +160,4 @@ export function BlockDocument({
       </DndContext>
     </div>
   );
-}
-
-function uid(): string {
-  return crypto.randomUUID();
 }

--- a/apps/web/src/components/sandbox/content/blog/block-items.test.ts
+++ b/apps/web/src/components/sandbox/content/blog/block-items.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { reseedBlockItems, seedBlockItems } from "./block-items";
+import { type RawBlock } from "./blocks/block-registry";
+
+const block = (
+  resolveType: string,
+  extra?: Record<string, unknown>,
+): RawBlock => ({ __resolveType: resolveType, ...extra }) as RawBlock;
+
+describe("reseedBlockItems", () => {
+  test("keeps every id when a save echo returns an equal-content new array", () => {
+    // The bug: regenerating ids here remounts the list, losing focus + scroll.
+    const seeded = seedBlockItems([block("paragraph"), block("heading")]);
+    const echo = [block("paragraph"), block("heading")];
+    const reseeded = reseedBlockItems(seeded, echo);
+
+    expect(reseeded.map((x) => x.id)).toEqual(seeded.map((x) => x.id));
+    expect(reseeded[0]!.block).toBe(echo[0]!);
+    expect(reseeded[1]!.block).toBe(echo[1]!);
+  });
+
+  test("reuses ids by position and mints fresh ones for appended blocks", () => {
+    const seeded = seedBlockItems([block("paragraph")]);
+    const reseeded = reseedBlockItems(seeded, [
+      block("paragraph"),
+      block("heading"),
+    ]);
+
+    expect(reseeded[0]!.id).toBe(seeded[0]!.id);
+    expect(reseeded[1]!.id).not.toBe(seeded[0]!.id);
+    expect(reseeded).toHaveLength(2);
+  });
+
+  test("drops trailing ids when the value shrinks", () => {
+    const seeded = seedBlockItems([block("paragraph"), block("heading")]);
+    const reseeded = reseedBlockItems(seeded, [block("paragraph")]);
+
+    expect(reseeded).toHaveLength(1);
+    expect(reseeded[0]!.id).toBe(seeded[0]!.id);
+  });
+
+  test("seeds fresh ids from an empty previous list", () => {
+    const reseeded = reseedBlockItems(
+      [],
+      [block("paragraph"), block("heading")],
+    );
+
+    expect(reseeded).toHaveLength(2);
+    expect(reseeded[0]!.id).not.toBe(reseeded[1]!.id);
+  });
+});

--- a/apps/web/src/components/sandbox/content/blog/block-items.ts
+++ b/apps/web/src/components/sandbox/content/blog/block-items.ts
@@ -1,0 +1,35 @@
+import { type RawBlock } from "./blocks/block-registry";
+
+/**
+ * A block plus a stable client-side id. The id keys the dnd-kit sortable rows
+ * and the React list; it is never persisted (the caller owns only the block).
+ */
+export type BlockItem = { id: string; block: RawBlock };
+
+export function uid(): string {
+  return crypto.randomUUID();
+}
+
+/** Wrap each block with a fresh id — the initial seed for a document. */
+export function seedBlockItems(value: RawBlock[]): BlockItem[] {
+  return value.map((block) => ({ id: uid(), block }));
+}
+
+/**
+ * Rebuild the id-keyed items from a new `value`, preserving each row's existing
+ * id by position. An autosave round-trip re-reads the block and hands back a
+ * new array (often with new block objects) whose content is identical; minting
+ * a fresh id per block would change every React key and remount the whole
+ * list — dropping the focused input and scrolling the document back to its
+ * first block. Reusing ids keeps keys stable (so no row remounts) while the new
+ * `block` still flows in as a prop update for genuinely changed content.
+ */
+export function reseedBlockItems(
+  prev: BlockItem[],
+  value: RawBlock[],
+): BlockItem[] {
+  return value.map((block, i) => {
+    const existing = prev[i];
+    return { id: existing ? existing.id : uid(), block };
+  });
+}


### PR DESCRIPTION
## Summary

Fixes a bug in the blog post editor (the Notion-style "gerenciador"): **when you add or edit a block, autosave scrolls the document back to the first block and the focused input loses focus** — slowing down publishing new posts.

### Root cause

`BlockDocument` (`apps/web/src/components/sandbox/content/blog/block-document.tsx`) owns dnd-kit row identity via `uid()`-keyed items. Its re-seed guard minted a **fresh `uid()` for every block** on any external `value` reference change:

```js
if (value !== lastEmitted) {
  setBlockItems(value.map((blk) => ({ id: uid(), block: blk }))); // every key changes
}
```

An autosave round-trip (decofile cache write / commit-triggered refetch in Fast Preview) returns a **new `sections` array with identical content**. The guard treated it as an external change → all React keys changed → the whole list remounted → the focused input was destroyed and the `overflow-y-auto` scroll container reset to the top.

### Fix

Reconcile ids **positionally** instead of regenerating them: `reseedBlockItems(prev, value)` reuses each row's existing id at its position, minting new ids only for appended blocks. Keys stay stable → no remount → focus and scroll are preserved. Genuinely changed content still flows in as a `block` prop update.

The pure identity logic was extracted to `block-items.ts`. The `useAutosave` `pending` guard already prevents clobbering in-flight edits, so there is no data-loss risk.

## Changes
- `block-document.tsx` — use `seedBlockItems` / `reseedBlockItems`
- `block-items.ts` (new) — pure row-identity helpers
- `block-items.test.ts` (new) — unit coverage (stable ids on echo, append, shrink, empty seed)

## Testing
- `bun test .../block-items.test.ts` — 4 pass
- `bun run --cwd=apps/web check` (tsc) — clean
- `bun run lint` — 0 errors
- `bun run fmt` + knip — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the blog post editor so autosave no longer scrolls the document to the top or drops the focused input when a block is added or edited. Row ids are now reused by position instead of regenerated on every external value change, so React keys stay stable and the list no longer remounts.

**Bug Fixes**
- Extract the id reconciliation into `block-items.ts` with unit coverage for echo, append, shrink, and empty seed cases.
- The existing autosave pending guard continues to protect in-flight edits, so there is no data-loss risk.

<sup>Written for commit d1336a5f8c727e6a514f0abb30d16ce3f45327d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

