### PR TITLE
fix(task-board): a pending-CI read misses the cache instead of stale-serving

### DIFF
--- a/apps/api/src/tools/task-board/pr-cache.test.ts
+++ b/apps/api/src/tools/task-board/pr-cache.test.ts
@@ -309,6 +309,39 @@ describe("per-entry revalidate override (a value still awaiting something)", () 
     expect(calls).toBe(2);
   });
 
+  test("fetch: maxStaleMs 0 makes a pending value a blocking miss", async () => {
+    const clock = { now: 0 };
+    const cache = await cacheAt(clock);
+    let calls = 0;
+    const pending: Promise<void>[] = [];
+    const read = (status: string) =>
+      cache.fetch({
+        namespace: "conn_1",
+        key: "checks",
+        fetchLive: async () => {
+          calls++;
+          return { status };
+        },
+        onRevalidation: (p) => pending.push(p),
+        revalidateAfterMs: () => 0,
+        maxStaleMs: (stored) =>
+          (stored as { status: string }).status === "pending" ? 0 : 55_000,
+      });
+
+    await read("pending");
+    expect(calls).toBe(1);
+
+    // A zero hit window alone would serve the stale "pending" and refresh behind it.
+    clock.now = 1_000;
+    expect(await read("success")).toEqual({ status: "success" });
+    expect(calls).toBe(2);
+
+    // Settled: the normal ceiling applies again (stale-serve + revalidate).
+    clock.now = 2_000;
+    expect(await read("success")).toEqual({ status: "success" });
+    await Promise.all(pending);
+  });
+
   test("fetchOrPlaceholder: an incomplete card is never a hit", async () => {
     const clock = { now: 0 };
     const cache = new JetStreamKVPrCache(

--- a/apps/api/src/tools/task-board/pr-cache.ts
+++ b/apps/api/src/tools/task-board/pr-cache.ts
@@ -102,6 +102,13 @@ export interface PrCacheFetch {
    *  should go stale fast, so the next poll refetches instead of serving the
    *  not-ready answer for the full config window. Omit for the default. */
   revalidateAfterMs?: (stored: unknown) => number;
+  /** Per-entry override of the STALE ceiling, computed from the stored value.
+   *  Returning 0 makes a stored value a MISS — the caller blocks on a live
+   *  fetch. That is the right trade for a value whose whole point is that it
+   *  ends (CI still running): stale-while-revalidate needs two polls to surface
+   *  a change (this poll serves stale, the background write lands after), and
+   *  if that background write ever fails the entry never moves again. */
+  maxStaleMs?: (stored: unknown) => number;
 }
 
 export class JetStreamKVPrCache {
@@ -187,8 +194,12 @@ export class JetStreamKVPrCache {
     const age = stored
       ? this.now() - stored.storedAt
       : Number.POSITIVE_INFINITY;
+    const staleCeilingMs =
+      stored && params.maxStaleMs
+        ? params.maxStaleMs(stored.value)
+        : maxStaleMs;
 
-    if (!stored || age > maxStaleMs) {
+    if (!stored || age > staleCeilingMs) {
       cacheCounter.add(1, { cache, outcome: "miss" });
       const value = await fetchLive();
       await this.write(key, value, cache);

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -91,6 +91,17 @@ function ciRevalidateAfterMs(status: ChecksStatus): number {
     : PR_READS_CACHE.revalidateAfterMs;
 }
 
+/** Stale ceiling for one raw GitHub read: zero while it says CI is running, so
+ *  the read is a MISS and asks GitHub synchronously instead of serving the
+ *  pending answer one more time. A zero HIT window alone wasn't enough — it
+ *  only starts a background refresh, so the assembled card was still built from
+ *  the previous read and a fresh result needed a second poll to appear (and
+ *  never appeared at all if that one background write failed). Bounded to a
+ *  pending PR someone has the dialog open on. */
+function ciMaxStaleMs(status: ChecksStatus): number {
+  return status === "pending" ? 0 : PR_READS_CACHE.maxStaleMs;
+}
+
 export function invalidatePrReads(connectionId: string): Promise<void> {
   return getPrReadCache().invalidate(connectionId);
 }
@@ -209,12 +220,14 @@ async function cachedPrRead(
   describe: string,
   pending: Promise<void>[],
   revalidateAfterMs?: (stored: unknown) => number,
+  maxStaleMs?: (stored: unknown) => number,
 ): Promise<Record<string, unknown> | null> {
   try {
     const raw = await getPrReadCache().fetch({
       namespace: connectionId,
       key: JSON.stringify({ name, args }),
       revalidateAfterMs,
+      maxStaleMs,
       fetchLive: () =>
         retry(
           async () => {
@@ -864,6 +877,7 @@ async function fetchPrStatusExtras(
   const read = (
     method: "get_status" | "get_check_runs" | "get_comments",
     revalidateAfterMs?: (stored: unknown) => number,
+    maxStaleMs?: (stored: unknown) => number,
   ) =>
     cachedPrRead(
       getClient,
@@ -878,16 +892,22 @@ async function fetchPrStatusExtras(
       `${prLabel(pr)} (${method})`,
       pending,
       revalidateAfterMs,
+      maxStaleMs,
     );
   // The three reads are independent — run them CONCURRENTLY. Serial was the
   // slowness (each is a remote MCP → GitHub round-trip, ~1.5-2s; the card made
   // 4-5 of them in a row).
   const [statusObj, runsRaw, commentsRaw] = await Promise.all([
-    read("get_status", (stored) =>
-      ciRevalidateAfterMs(toChecksStatus(toolResultJson(stored))),
+    read(
+      "get_status",
+      (stored) => ciRevalidateAfterMs(toChecksStatus(toolResultJson(stored))),
+      (stored) => ciMaxStaleMs(toChecksStatus(toolResultJson(stored))),
     ),
-    read("get_check_runs", (stored) =>
-      ciRevalidateAfterMs(toCheckRunsStatus(toolResultJson(stored))),
+    read(
+      "get_check_runs",
+      (stored) =>
+        ciRevalidateAfterMs(toCheckRunsStatus(toolResultJson(stored))),
+      (stored) => ciMaxStaleMs(toCheckRunsStatus(toolResultJson(stored))),
     ),
     read("get_comments"),
   ]);

--- a/apps/web/src/hooks/use-task-board-item-prs.ts
+++ b/apps/web/src/hooks/use-task-board-item-prs.ts
@@ -25,7 +25,7 @@ const PRS_UNENRICHED_POLL_INTERVAL_MS = 2_000;
  *  when — so while any linked PR reports pending CI, poll faster than the idle
  *  minute. Bounded to a dialog that is open on a PR whose CI is actually
  *  running, and the server answers those from cache while it refreshes. */
-const PRS_PENDING_CHECKS_POLL_INTERVAL_MS = 15_000;
+const PRS_PENDING_CHECKS_POLL_INTERVAL_MS = 10_000;
 
 /** A card the server returned before GitHub answered: link fields only. `state`
  *  is null for a PR GitHub could not be read for too, which polls the same way


### PR DESCRIPTION
## Why #7033 had no effect

#7033 gave the pending PR reads a zero **hit window**. That only makes them *stale*, and stale means: serve the old value, refresh behind it. So on a pending card, per poll:

1. card cache (window 0) → stale → serves old card, fires a detached rebuild
2. the rebuild's `get_status` / `get_check_runs` (window 0) → stale → **return the previous read**, fire their own background revalidation
3. the card is therefore reassembled from stale GitHub data and written back
4. the fresh read lands in the read KV *after* that

Two consequences: a fresh GitHub result needs **two** polls to reach the screen, and step 2's background write is a single point of failure — if it errors, or the pod goes away, the card rebuilds from the same stale read indefinitely. Which is what we saw in prod.

## The fix

`PrCacheFetch` gets an optional `maxStaleMs(stored)` alongside the existing `revalidateAfterMs(stored)`. Returning 0 makes a stored value a **miss**, so the caller blocks on a live fetch instead of serving it again.

`ciMaxStaleMs` returns 0 while the stored read says `pending`, wired onto `get_status` and `get_check_runs`. The detached card rebuild now asks GitHub for real, and one poll converges.

The **card** cache still stale-serves deliberately — treating it as a miss would return the placeholder and flash a skeleton on every pending poll.

Dialog poll on a pending card: 15s → 10s.

Bounded the same way as before: only a PR whose CI is actually running, only while someone has the dialog open, and it is off the request path (the blocking read happens inside the detached rebuild, not in the poll's own response).

## Testing

`bun test apps/api/src/tools/task-board/pr-cache.test.ts` — 13 pass, including a new case that fails on `main`'s behavior: with only the zero hit window, the second read returns the stale `pending`; with the ceiling it returns the fresh value.
`bun test apps/api/src/tools/task-board/checks-status.test.ts` — 61 pass. `bun run --cwd=apps/api check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pending-CI PR reads so they miss the cache instead of stale-serving, making a fresh GitHub result appear on the next poll instead of needing two.

- Adds an optional `maxStaleMs` to `PrCacheFetch`; returning 0 turns a stored value into a miss.
- Applies a zero stale ceiling to `get_status` and `get_check_runs` while the stored status says `pending`.
- The card cache still stale-serves; the dialog poll interval for pending cards drops from 15s to 10s.

<sup>Written for commit 297fb539c2770fab708ff57e8d4f98aadeb4c134. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

