### PR TITLE
feat(task-board): add bulk "assign project" action to selection bar

### DIFF
--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -59,6 +59,7 @@ export const taskBoard = {
   "taskBoard.taskBoard.moveToButton": "Move to",
   "taskBoard.taskBoard.changePriorityButton": "Change priority",
   "taskBoard.taskBoard.assignButton": "Assign",
+  "taskBoard.taskBoard.assignProjectButton": "Assign project",
   "taskBoard.taskBoard.dueDateButton": "Due date",
   "taskBoard.taskBoard.addTagButton": "Add tag",
   "taskBoard.taskBoard.deleteSelectedButton": "Delete",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -61,6 +61,7 @@ export const taskBoard = {
   "taskBoard.taskBoard.moveToButton": "Mover para",
   "taskBoard.taskBoard.changePriorityButton": "Mudar prioridade",
   "taskBoard.taskBoard.assignButton": "Atribuir",
+  "taskBoard.taskBoard.assignProjectButton": "Atribuir projeto",
   "taskBoard.taskBoard.dueDateButton": "Data de entrega",
   "taskBoard.taskBoard.addTagButton": "Adicionar tag",
   "taskBoard.taskBoard.deleteSelectedButton": "Excluir",

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -158,7 +158,12 @@ import {
 } from "./filters-search";
 import { useProjectScope } from "@/hooks/use-project-scope";
 import { useProjectIndex } from "@/hooks/use-project-index";
-import { filterAfterCreate } from "@/lib/project-index";
+import {
+  filterAfterCreate,
+  stampableEntries,
+  type ProjectIndexEntry,
+} from "@/lib/project-index";
+import { ProjectEntryRow } from "@/components/project-entry";
 import { usePanelActions } from "@/layouts/shell-layout";
 import { Navigate, useNavigate, useParams } from "@tanstack/react-router";
 import { DESTINATION_ROUTE } from "@/hooks/use-destination-route";
@@ -908,6 +913,9 @@ export function TaskBoardPage() {
   /** The board's buckets, closed over every repo a loaded card names so the
    *  "No project" bucket cannot claim a card that plainly has one. */
   const projectIndex = useProjectIndex(items, repos);
+  /** The projects a card can be stamped for — the same reachability-gated
+   *  subset the task dialog's Project picker offers, reused by the bulk bar. */
+  const projectEntries = stampableEntries(projectIndex);
   const [preferences] = usePreferences();
   const [selection, setSelection] = useState<Set<string>>(new Set());
   const toggleSelect = (id: string) =>
@@ -1482,6 +1490,11 @@ export function TaskBoardPage() {
         <SelectionBar
           count={selectedIds.size}
           members={members}
+          projectEntries={projectEntries}
+          onSetRepo={(repo) => {
+            for (const id of selectedIds) actions.update.mutate({ id, repo });
+            clearSelection();
+          }}
           onMoveTo={(status) => {
             for (const id of selectedIds) actions.update.mutate({ id, status });
             clearSelection();
@@ -1582,6 +1595,8 @@ export function TaskBoardPage() {
 function SelectionBar({
   count,
   members,
+  projectEntries,
+  onSetRepo,
   onMoveTo,
   onSetPriority,
   onAddTag,
@@ -1594,6 +1609,10 @@ function SelectionBar({
 }: {
   count: number;
   members: Member[];
+  /** The projects a card can be stamped for — same set as the task dialog. */
+  projectEntries: ProjectIndexEntry[];
+  /** Bulk-assign the project (persisted as the underlying repo), or clear it. */
+  onSetRepo: (repo: string | null) => void;
   onMoveTo: (status: TaskBoardItemStatus) => void;
   onSetPriority: (priority: TaskBoardItemPriority) => void;
   onAddTag: (tagId: string) => void;
@@ -1672,6 +1691,27 @@ function SelectionBar({
                 <AssigneePickerContent members={members} onSelect={onAssign} />
               </DropdownMenuSubContent>
             </DropdownMenuSub>
+            {projectEntries.length > 0 && (
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  {t("taskBoard.taskBoard.assignProjectButton")}
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="w-64">
+                  <DropdownMenuItem onClick={() => onSetRepo(null)}>
+                    {t("taskBoard.taskDialog.noProject")}
+                  </DropdownMenuItem>
+                  {projectEntries.map((entry) => (
+                    <DropdownMenuItem
+                      key={entry.id}
+                      className="gap-2"
+                      onClick={() => onSetRepo(entry.repo)}
+                    >
+                      <ProjectEntryRow entry={entry} />
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            )}
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 {t("taskBoard.taskBoard.dueDateButton")}


### PR DESCRIPTION
## Summary

The task-board bulk-actions menu (shown when multiple cards are selected) covered **move / priority / assign / due-date / tag / delete** but had no way to set a task's repo/project. That action only existed per-task in the task dialog, surfaced as **"Projeto" / "Project"** (which persists the underlying `repo` field).

This adds an **"Atribuir projeto" / "Assign project"** sub-menu to the bulk **Ações** menu, mirroring the dialog's picker.

## Changes

- **`apps/web/src/layouts/task-board/index.tsx`**
  - New "Assign project" sub-menu in `SelectionBar`: a "No project" item to clear plus one row per reachable project (`ProjectEntryRow`).
  - Handler loops the selection and fires the same `TASK_BOARD_ITEM_UPDATE` mutation the single-task path uses (`actions.update.mutate({ id, repo })`), then clears the selection — consistent with the other bulk actions.
  - Reuses the board's existing `projectIndex` via `stampableEntries(...)` — the same reachability-gated set the dialog offers (you can only pick projects the org can actually reach). The sub-menu is hidden when there are none, matching how "Add tag" is gated on available tags.
- **i18n** — added `taskBoard.taskBoard.assignProjectButton` to `en` and `pt-br`; the "No project" item reuses the existing `taskBoard.taskDialog.noProject` key.

## Testing

- `bun run check` (tsc) — passes
- `bun run lint` — 0 errors (pre-existing warnings only, in unrelated files)
- `bun run fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Assign project" sub-menu to the task board's bulk-actions bar so you can set or clear a project on multiple selected cards at once.

- Project assignment previously only existed per-task in the task dialog; the bulk menu had no way to set it.
- The sub-menu mirrors the dialog's picker — reachability-gated projects plus a "No project" item to clear — and fires the same update mutation per selected card.
- The sub-menu is hidden when no reachable projects exist, matching the "Add tag" gating.

<sup>Written for commit eb2fb41fb617c017985cb37ebe1c81ae67e33147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

