### PR TITLE
feat(task-board): push PR checks and preview url from a GitHub webhook

### DIFF
--- a/apps/api/migrations/204-task-board-prs-repo-idx.ts
+++ b/apps/api/migrations/204-task-board-prs-repo-idx.ts
@@ -1,0 +1,22 @@
+/**
+ * Index `task_board_item_prs` by (repo_owner, repo_name, pr_number).
+ *
+ * The GitHub webhook arrives knowing only a repo and a PR number and has to
+ * find the card, if any. The table's only index is (organization_id,
+ * task_board_item_id) and its PK is (task_board_item_id, url), so that lookup
+ * was a full scan — on a path that fires for every check suite and PR comment
+ * across every repo the App is installed on, most of which link to no card.
+ */
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createIndex("task_board_item_prs_repo_idx")
+    .on("task_board_item_prs")
+    .columns(["repo_owner", "repo_name", "pr_number"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("task_board_item_prs_repo_idx").execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -202,6 +202,7 @@ import * as migration200jirarruntrigger from "./200-jira-run-trigger.ts";
 import * as migration201organizationnotices from "./201-organization-notices.ts";
 import * as migration202redactbase64threadparts from "./202-redact-base64-thread-parts.ts";
 import * as migration203taskboardpreviewroutes from "./203-task-board-preview-routes.ts";
+import * as migration204taskboardprsrepoidx from "./204-task-board-prs-repo-idx.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -439,6 +440,7 @@ const migrations: Record<string, Migration> = {
   "201-organization-notices": migration201organizationnotices,
   "202-redact-base64-thread-parts": migration202redactbase64threadparts,
   "203-task-board-preview-routes": migration203taskboardpreviewroutes,
+  "204-task-board-prs-repo-idx": migration204taskboardprsrepoidx,
 };
 
 export default migrations;

--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -114,7 +114,7 @@ import publicConfigRoutes from "./routes/public-config";
 import { createReportPagesRoutes } from "./routes/report-pages";
 import reportsRoutes from "./routes/reports";
 import { stripeWebhookRoutes } from "./routes/stripe-webhook";
-import { githubWebhookRoutes } from "./routes/github-webhook";
+import { createGithubWebhookRoutes } from "./routes/github-webhook";
 import { createJiraAttachmentRoutes } from "./routes/jira-attachments";
 import { createJiraWebhookRoutes } from "./routes/jira-webhook";
 import {
@@ -1498,7 +1498,13 @@ export async function createApp(options: CreateAppOptions = {}) {
   // GitHub push webhook (tenant warm-pool freshness): HMAC-authed, no session.
   // Optional — 503 without GITHUB_WEBHOOK_SECRET, and pools refresh on their
   // own schedule regardless.
-  app.route("/api/_github", githubWebhookRoutes);
+  app.route(
+    "/api/_github",
+    createGithubWebhookRoutes({
+      taskBoard: () => projectorTaskBoard,
+      contextFactory: () => automationContextFactory,
+    }),
+  );
   // Jira: the issue-event intake that starts runs, and the attachment grant
   // route those runs download through. Both authenticate by capability
   // (per-org secret, signed token), not by session.

--- a/apps/api/src/api/routes/github-webhook.test.ts
+++ b/apps/api/src/api/routes/github-webhook.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { verifyGithubSignature } from "./github-webhook";
+import { prRefsFromGithubEvent, verifyGithubSignature } from "./github-webhook";
 
 const SECRET = "s3cret";
 const BODY = JSON.stringify({ ref: "refs/heads/main" });
@@ -25,5 +25,45 @@ describe("verifyGithubSignature", () => {
       verifyGithubSignature(BODY, VALID.slice("sha256=".length), SECRET),
     ).toBe(false);
     expect(verifyGithubSignature(BODY, "sha256=abc", SECRET)).toBe(false);
+  });
+});
+
+describe("prRefsFromGithubEvent", () => {
+  const repository = { name: "storefront", owner: { login: "deco-cx" } };
+
+  it("reads every PR a check suite belongs to, deduped", () => {
+    expect(
+      prRefsFromGithubEvent("check_suite", {
+        repository,
+        check_suite: { pull_requests: [{ number: 7 }, { number: 7 }] },
+      }),
+    ).toEqual([{ repoOwner: "deco-cx", repoName: "storefront", number: 7 }]);
+  });
+
+  it("reads a PR comment but not an issue comment", () => {
+    const issue = { number: 12, pull_request: { url: "https://api/pulls/12" } };
+    expect(
+      prRefsFromGithubEvent("issue_comment", { repository, issue }),
+    ).toEqual([{ repoOwner: "deco-cx", repoName: "storefront", number: 12 }]);
+    // No `pull_request` key — a comment on a plain issue names no PR.
+    expect(
+      prRefsFromGithubEvent("issue_comment", {
+        repository,
+        issue: { number: 12 },
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns nothing for a push-to-no-PR suite, a wrong shape or another event", () => {
+    expect(
+      prRefsFromGithubEvent("check_suite", {
+        repository,
+        check_suite: { pull_requests: [] },
+      }),
+    ).toEqual([]);
+    expect(prRefsFromGithubEvent("check_suite", { check_suite: {} })).toEqual(
+      [],
+    );
+    expect(prRefsFromGithubEvent("push", { repository })).toEqual([]);
   });
 });

--- a/apps/api/src/api/routes/github-webhook.ts
+++ b/apps/api/src/api/routes/github-webhook.ts
@@ -176,10 +176,21 @@ async function refreshPrCardsForRefs(
 ): Promise<number> {
   let refreshed = 0;
   for (const ref of refs) {
+    const taskBoard = deps.taskBoard();
+    let links: Awaited<ReturnType<typeof taskBoard.findPrLinks>>;
     try {
-      const taskBoard = deps.taskBoard();
-      const links = await taskBoard.findPrLinks(ref);
-      for (const link of links) {
+      links = await taskBoard.findPrLinks(ref);
+    } catch (err) {
+      // Same reason `refreshItemPrCards` swallows its own: a 500 here makes
+      // GitHub retry the delivery, and a database blip is not something a
+      // replay fixes. The count in the response is the signal instead.
+      console.error("[github-webhook] pr link lookup failed:", err);
+      continue;
+    }
+    for (const link of links) {
+      // Per link, so one card whose owner or context is unreadable doesn't cost
+      // the other cards linked to the same PR their refresh.
+      try {
         const item = await taskBoard.getById(
           link.taskBoardItemId,
           link.organizationId,
@@ -200,12 +211,12 @@ async function refreshPrCardsForRefs(
           link.taskBoardItemId,
         );
         if (cards !== null) refreshed++;
+      } catch (err) {
+        console.error(
+          `[github-webhook] pr card refresh failed for ${link.taskBoardItemId}:`,
+          err,
+        );
       }
-    } catch (err) {
-      // Same reason `refreshItemPrCards` swallows its own: a 500 here makes
-      // GitHub retry the delivery, and a database blip is not something a
-      // replay fixes. The count in the response is the signal instead.
-      console.error("[github-webhook] pr card refresh failed:", err);
     }
   }
   return refreshed;

--- a/apps/api/src/api/routes/github-webhook.ts
+++ b/apps/api/src/api/routes/github-webhook.ts
@@ -1,21 +1,35 @@
 /**
- * POST /api/_github/webhook — GitHub push intake for tenant warm pools.
+ * POST /api/_github/webhook — GitHub event intake.
+ *
+ * Two consumers, one endpoint (GitHub Apps have exactly one webhook url):
+ *  - `push` refreshes tenant warm pools.
+ *  - `check_suite` / `issue_comment` re-read the task board PR cards for the
+ *    PR the event names, so CI results and a deploy bot's preview url reach the
+ *    open dialog in about a second instead of on a poll.
  *
  * OPTIONAL everywhere. Without `GITHUB_WEBHOOK_SECRET` the route answers 503
- * and warm pools still pick up new commits on their periodic refresh — the
- * webhook only makes that immediate. Instance-level (underscore namespace,
- * mounted before the /api/:org catch-all) and outside session auth: the caller
- * is GitHub, authenticated exclusively by the HMAC over the RAW body.
+ * and both consumers still catch up on their own polling. Instance-level
+ * (underscore namespace, mounted before the /api/:org catch-all) and outside
+ * session auth: the caller is GitHub, authenticated exclusively by the HMAC
+ * over the RAW body.
  */
 
 import { timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { getOrInitSharedRunner } from "@/sandbox/lifecycle";
+import type { StudioContextFactory } from "@/automations/fire";
+import type { TaskBoardStorage } from "@/storage/task-board";
+import { refreshItemPrCards } from "@/tools/task-board/prs-get";
 
 // A push event with a large commit list is still small; the route is
 // unauthenticated, so cap the body before buffering it.
 const MAX_BODY_SIZE = 5_242_880; // 5MB
+
+/** Events that can change a PR card. `check_suite` covers third-party checks
+ *  (Cloudflare Pages / Workers Builds) as well as Actions; `issue_comment`
+ *  carries the deploy bots that publish the preview url as a comment. */
+const PR_CARD_EVENTS = new Set(["check_suite", "issue_comment"]);
 
 export function verifyGithubSignature(
   rawBody: string,
@@ -31,49 +45,160 @@ export function verifyGithubSignature(
   return timingSafeEqual(Buffer.from(received), Buffer.from(expected));
 }
 
-export const githubWebhookRoutes = new Hono();
+export interface GithubPrEventRef {
+  repoOwner: string;
+  repoName: string;
+  number: number;
+}
 
-githubWebhookRoutes.post(
-  "/webhook",
-  bodyLimit({
-    maxSize: MAX_BODY_SIZE,
-    onError: (c) => c.json({ error: "payload too large" }, 413),
-  }),
-  async (c) => {
-    const secret = process.env.GITHUB_WEBHOOK_SECRET;
-    if (!secret) return c.json({ error: "github webhook not configured" }, 503);
-
-    // Raw body FIRST — the signature covers the exact bytes.
-    const rawBody = await c.req.text();
-    if (
-      !verifyGithubSignature(
-        rawBody,
-        c.req.header("x-hub-signature-256"),
-        secret,
-      )
-    ) {
-      return c.json({ error: "invalid signature" }, 400);
+/**
+ * Which PRs an event is about. A `check_suite` names them in `pull_requests[]`
+ * (empty for a push to a branch with no PR — nothing to refresh). An
+ * `issue_comment` is about a PR only when the issue carries a `pull_request`
+ * key; a comment on a plain issue is not one.
+ *
+ * Pure, so the payload shapes are unit-tested without a server. Exported for
+ * that test.
+ */
+export function prRefsFromGithubEvent(
+  event: string,
+  payload: unknown,
+): GithubPrEventRef[] {
+  const body = payload as {
+    repository?: { name?: unknown; owner?: { login?: unknown } };
+    check_suite?: { pull_requests?: unknown };
+    issue?: { number?: unknown; pull_request?: unknown };
+  };
+  const repoName = body?.repository?.name;
+  const repoOwner = body?.repository?.owner?.login;
+  if (typeof repoName !== "string" || typeof repoOwner !== "string") return [];
+  const numbers: number[] = [];
+  if (event === "check_suite") {
+    const prs = body.check_suite?.pull_requests;
+    for (const pr of Array.isArray(prs) ? prs : []) {
+      const n = (pr as { number?: unknown })?.number;
+      if (typeof n === "number") numbers.push(n);
     }
+  } else if (event === "issue_comment" && body.issue?.pull_request) {
+    const n = body.issue.number;
+    if (typeof n === "number") numbers.push(n);
+  }
+  return [...new Set(numbers)].map((number) => ({
+    repoOwner,
+    repoName,
+    number,
+  }));
+}
 
-    // 200-and-ignore everything that isn't a push: GitHub retries on non-2xx,
-    // and there is nothing to retry for an event we don't handle.
-    if (c.req.header("x-github-event") !== "push") {
-      return c.json({ ok: true, ignored: "event" });
+/** Resolved lazily: the route is mounted before the /api/:org catch-all, which
+ *  is earlier than where the storage and the context factory are built. */
+export interface GithubWebhookDeps {
+  taskBoard: () => TaskBoardStorage;
+  contextFactory: () => StudioContextFactory;
+}
+
+export function createGithubWebhookRoutes(deps: GithubWebhookDeps): Hono {
+  const routes = new Hono();
+
+  routes.post(
+    "/webhook",
+    bodyLimit({
+      maxSize: MAX_BODY_SIZE,
+      onError: (c) => c.json({ error: "payload too large" }, 413),
+    }),
+    async (c) => {
+      const secret = process.env.GITHUB_WEBHOOK_SECRET;
+      if (!secret) {
+        return c.json({ error: "github webhook not configured" }, 503);
+      }
+
+      // Raw body FIRST — the signature covers the exact bytes.
+      const rawBody = await c.req.text();
+      if (
+        !verifyGithubSignature(
+          rawBody,
+          c.req.header("x-hub-signature-256"),
+          secret,
+        )
+      ) {
+        return c.json({ error: "invalid signature" }, 400);
+      }
+
+      const event = c.req.header("x-github-event");
+      // 200-and-ignore everything we don't handle: GitHub retries on non-2xx,
+      // and there is nothing to retry for an event nobody consumes.
+      if (event !== "push" && !PR_CARD_EVENTS.has(event ?? "")) {
+        return c.json({ ok: true, ignored: "event" });
+      }
+
+      let payload: {
+        ref?: string;
+        repository?: { full_name?: string };
+      };
+      try {
+        payload = JSON.parse(rawBody);
+      } catch {
+        return c.json({ error: "invalid payload" }, 400);
+      }
+
+      if (event === "push") {
+        const ref = payload.ref;
+        const repo = payload.repository?.full_name;
+        if (!ref || !repo) return c.json({ ok: true, ignored: "shape" });
+        const runner = await getOrInitSharedRunner();
+        // The pool reconciler refreshes on its next tick; nothing waits here.
+        const pools = runner?.markTenantPoolsDirty(repo, ref) ?? [];
+        return c.json({ ok: true, pools });
+      }
+
+      const refs = prRefsFromGithubEvent(event ?? "", payload);
+      if (refs.length === 0) return c.json({ ok: true, ignored: "shape" });
+      const refreshed = await refreshPrCardsForRefs(deps, refs);
+      return c.json({ ok: true, refreshed });
+    },
+  );
+
+  return routes;
+}
+
+/**
+ * Refresh every task card linked to any of `refs`. Almost always zero: the App
+ * is installed on far more repos than the board links PRs from, so the indexed
+ * lookup is the whole cost of an event nobody is watching.
+ *
+ * Awaited rather than detached so GitHub's delivery log reflects whether the
+ * work actually happened — the deliveries page is the only debugging surface
+ * this path has.
+ */
+async function refreshPrCardsForRefs(
+  deps: GithubWebhookDeps,
+  refs: GithubPrEventRef[],
+): Promise<number> {
+  let refreshed = 0;
+  for (const ref of refs) {
+    const taskBoard = deps.taskBoard();
+    const links = await taskBoard.findPrLinks(ref);
+    for (const link of links) {
+      const item = await taskBoard.getById(
+        link.taskBoardItemId,
+        link.organizationId,
+      );
+      // The context is the org's, built from the card's owner: a webhook has no
+      // principal of its own, and the GitHub connection it reads through is the
+      // organization's.
+      const ctx = item
+        ? await deps.contextFactory()(
+            link.organizationId,
+            item.assignedBy ?? item.createdBy,
+          )
+        : null;
+      if (!ctx) continue;
+      if (
+        await refreshItemPrCards(ctx, link.organizationId, link.taskBoardItemId)
+      ) {
+        refreshed++;
+      }
     }
-
-    let payload: { ref?: string; repository?: { full_name?: string } };
-    try {
-      payload = JSON.parse(rawBody);
-    } catch {
-      return c.json({ error: "invalid payload" }, 400);
-    }
-    const ref = payload.ref;
-    const repo = payload.repository?.full_name;
-    if (!ref || !repo) return c.json({ ok: true, ignored: "shape" });
-
-    const runner = await getOrInitSharedRunner();
-    // The pool reconciler refreshes on its next tick; nothing here waits on it.
-    const pools = runner?.markTenantPoolsDirty(repo, ref) ?? [];
-    return c.json({ ok: true, pools });
-  },
-);
+  }
+  return refreshed;
+}

--- a/apps/api/src/api/routes/github-webhook.ts
+++ b/apps/api/src/api/routes/github-webhook.ts
@@ -176,28 +176,36 @@ async function refreshPrCardsForRefs(
 ): Promise<number> {
   let refreshed = 0;
   for (const ref of refs) {
-    const taskBoard = deps.taskBoard();
-    const links = await taskBoard.findPrLinks(ref);
-    for (const link of links) {
-      const item = await taskBoard.getById(
-        link.taskBoardItemId,
-        link.organizationId,
-      );
-      // The context is the org's, built from the card's owner: a webhook has no
-      // principal of its own, and the GitHub connection it reads through is the
-      // organization's.
-      const ctx = item
-        ? await deps.contextFactory()(
-            link.organizationId,
-            item.assignedBy ?? item.createdBy,
-          )
-        : null;
-      if (!ctx) continue;
-      if (
-        await refreshItemPrCards(ctx, link.organizationId, link.taskBoardItemId)
-      ) {
-        refreshed++;
+    try {
+      const taskBoard = deps.taskBoard();
+      const links = await taskBoard.findPrLinks(ref);
+      for (const link of links) {
+        const item = await taskBoard.getById(
+          link.taskBoardItemId,
+          link.organizationId,
+        );
+        // The context is the org's, built from the card's owner: a webhook has
+        // no principal of its own, and the GitHub connection it reads through
+        // is the organization's.
+        const ctx = item
+          ? await deps.contextFactory()(
+              link.organizationId,
+              item.assignedBy ?? item.createdBy,
+            )
+          : null;
+        if (!ctx) continue;
+        const cards = await refreshItemPrCards(
+          ctx,
+          link.organizationId,
+          link.taskBoardItemId,
+        );
+        if (cards !== null) refreshed++;
       }
+    } catch (err) {
+      // Same reason `refreshItemPrCards` swallows its own: a 500 here makes
+      // GitHub retry the delivery, and a database blip is not something a
+      // replay fixes. The count in the response is the signal instead.
+      console.error("[github-webhook] pr card refresh failed:", err);
     }
   }
   return refreshed;

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1357,6 +1357,40 @@ export class TaskBoardStorage {
       .execute();
   }
 
+  /**
+   * Every card linked to one GitHub PR, across all orgs — the GitHub webhook's
+   * reverse lookup, which knows a repo and a number and nothing else. Empty for
+   * the common case: a repo the App is installed on with no card linked to it.
+   */
+  async findPrLinks(pr: {
+    repoOwner: string;
+    repoName: string;
+    number: number;
+  }): Promise<
+    {
+      taskBoardItemId: string;
+      organizationId: string;
+      connectionId: string | null;
+    }[]
+  > {
+    const rows = await this.db
+      .selectFrom("task_board_item_prs")
+      .select([
+        "task_board_item_id as taskBoardItemId",
+        "organization_id as organizationId",
+        "connection_id as connectionId",
+      ])
+      .where("repo_owner", "=", pr.repoOwner)
+      .where("repo_name", "=", pr.repoName)
+      .where("pr_number", "=", pr.number)
+      .execute();
+    return rows.map((r) => ({
+      taskBoardItemId: r.taskBoardItemId,
+      organizationId: r.organizationId,
+      connectionId: r.connectionId ?? null,
+    }));
+  }
+
   /** PRs linked to a task (most-recent first), identity only. */
   async listPrs(
     taskBoardItemId: string,

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1366,29 +1366,18 @@ export class TaskBoardStorage {
     repoOwner: string;
     repoName: string;
     number: number;
-  }): Promise<
-    {
-      taskBoardItemId: string;
-      organizationId: string;
-      connectionId: string | null;
-    }[]
-  > {
+  }): Promise<{ taskBoardItemId: string; organizationId: string }[]> {
     const rows = await this.db
       .selectFrom("task_board_item_prs")
       .select([
         "task_board_item_id as taskBoardItemId",
         "organization_id as organizationId",
-        "connection_id as connectionId",
       ])
       .where("repo_owner", "=", pr.repoOwner)
       .where("repo_name", "=", pr.repoName)
       .where("pr_number", "=", pr.number)
       .execute();
-    return rows.map((r) => ({
-      taskBoardItemId: r.taskBoardItemId,
-      organizationId: r.organizationId,
-      connectionId: r.connectionId ?? null,
-    }));
+    return rows;
   }
 
   /** PRs linked to a task (most-recent first), identity only. */

--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -12,7 +12,7 @@ import {
   extractPreviewUrlFromDeployment,
   headShaFromPrGet,
   headShaFromStatus,
-  isAwaitingCi,
+  isCardNotReady,
   isRateLimitError,
   extractPreviewUrlFromCheckRuns,
   extractPreviewUrlFromComments,
@@ -644,16 +644,153 @@ describe("previewMatchesHead", () => {
   });
 });
 
-describe("isAwaitingCi", () => {
+describe("isCardNotReady", () => {
+  const NOW = Date.parse("2026-09-08T12:00:00Z");
+  const recent = new Date(NOW - 60_000).toISOString();
+  const old = new Date(NOW - 30 * 60_000).toISOString();
+  const open = { state: "open" as string | null, updatedAt: recent };
+
   it("keeps refreshing while CI runs", () => {
-    // Was false whenever a preview URL had already been found, so that card got
-    // the full hit window and showed "Checks pending" long after they passed.
-    expect(isAwaitingCi({ checksStatus: "pending" })).toBe(true);
+    expect(
+      isCardNotReady(
+        { ...open, checksStatus: "pending", previewUrl: null },
+        NOW,
+      ),
+    ).toBe(true);
+    // Preview already found used to make this false — hence "Checks pending".
+    expect(
+      isCardNotReady(
+        { ...open, checksStatus: "pending", previewUrl: "https://x.vtex.app" },
+        NOW,
+      ),
+    ).toBe(true);
+    // Pending CI ends by itself, so it isn't subject to the preview bound.
+    expect(
+      isCardNotReady(
+        { ...open, updatedAt: old, checksStatus: "pending", previewUrl: null },
+        NOW,
+      ),
+    ).toBe(true);
   });
 
-  it("caches normally once CI settles", () => {
-    expect(isAwaitingCi({ checksStatus: "passing" })).toBe(false);
-    expect(isAwaitingCi({ checksStatus: "failing" })).toBe(false);
-    expect(isAwaitingCi({ checksStatus: null })).toBe(false);
+  it("keeps refreshing after CI settles until a preview url is found", () => {
+    // The deploy bot's comment lands AFTER the checks go green.
+    expect(
+      isCardNotReady(
+        { ...open, checksStatus: "passing", previewUrl: null },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("stops chasing a preview that never came", () => {
+    // previewUrl stays null forever on a repo that publishes no preview.
+    expect(
+      isCardNotReady(
+        { ...open, updatedAt: old, checksStatus: "passing", previewUrl: null },
+        NOW,
+      ),
+    ).toBe(false);
+    // Unknown activity time doesn't chase — safe direction for the rate limit.
+    expect(
+      isCardNotReady(
+        { ...open, updatedAt: null, checksStatus: "passing", previewUrl: null },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("caches normally once CI settled and a preview is known", () => {
+    for (const checksStatus of ["passing", "failing"] as const) {
+      expect(
+        isCardNotReady(
+          { ...open, checksStatus, previewUrl: "https://x.vtex.app" },
+          NOW,
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("never chases a PR that is not open", () => {
+    for (const state of ["closed", null]) {
+      expect(
+        isCardNotReady(
+          { state, updatedAt: recent, checksStatus: null, previewUrl: null },
+          NOW,
+        ),
+      ).toBe(false);
+    }
+  });
+});
+
+describe("extractPreviewUrlFromCheckRuns — preview without a bot comment", () => {
+  const run = (o: Record<string, unknown>) => ({ check_runs: [o] });
+
+  it("reads the url out of a deploy check's output", () => {
+    expect(
+      extractPreviewUrlFromCheckRuns(
+        run({
+          name: "Cloudflare Pages",
+          conclusion: "success",
+          output: { summary: "Deployed to https://abc.deco.site 🎉" },
+        }),
+      ),
+    ).toBe("https://abc.deco.site");
+  });
+
+  it("falls back to the details link", () => {
+    expect(
+      extractPreviewUrlFromCheckRuns(
+        run({ name: "deploy", details_url: "https://x.vtex.app/" }),
+      ),
+    ).toBe("https://x.vtex.app/");
+  });
+
+  it("prefers a successful run over a failed earlier attempt", () => {
+    expect(
+      extractPreviewUrlFromCheckRuns({
+        check_runs: [
+          {
+            name: "deploy",
+            conclusion: "failure",
+            details_url: "https://bad.deco.site",
+          },
+          {
+            name: "deploy",
+            conclusion: "success",
+            details_url: "https://good.deco.site",
+          },
+        ],
+      }),
+    ).toBe("https://good.deco.site");
+  });
+
+  it("ignores a url that is not a trusted preview host", () => {
+    expect(
+      extractPreviewUrlFromCheckRuns(
+        run({
+          name: "lint",
+          output: { summary: "see https://evil.example.com" },
+        }),
+      ),
+    ).toBe(null);
+  });
+
+  it("still prefers the exact Workers Builds url over a scanned one", () => {
+    expect(
+      extractPreviewUrlFromCheckRuns({
+        check_runs: [
+          {
+            name: "other",
+            conclusion: "success",
+            details_url: "https://x.vtex.app",
+          },
+          {
+            name: "Workers Builds: my-site",
+            output: { summary: "Version ID: abcd1234" },
+          },
+        ],
+      }),
+    ).toBe("https://abcd1234-my-site.deco-cx.workers.dev");
   });
 });

--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -711,15 +711,29 @@ describe("isCardNotReady", () => {
     }
   });
 
-  it("never chases a PR that is not open", () => {
-    for (const state of ["closed", null]) {
-      expect(
-        isCardNotReady(
-          { state, updatedAt: recent, checksStatus: null, previewUrl: null },
-          NOW,
-        ),
-      ).toBe(false);
-    }
+  it("never chases a PR GitHub reported as not open", () => {
+    expect(
+      isCardNotReady(
+        {
+          state: "closed",
+          updatedAt: recent,
+          checksStatus: null,
+          previewUrl: null,
+        },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("always refreshes the placeholder, which GitHub was never asked about", () => {
+    // Every live field is null on the card served before the first read; a
+    // settled-looking `state: null` must not park it for the full hit window.
+    expect(
+      isCardNotReady(
+        { state: null, updatedAt: null, checksStatus: null, previewUrl: null },
+        NOW,
+      ),
+    ).toBe(true);
   });
 });
 

--- a/apps/api/src/tools/task-board/pr-cache.test.ts
+++ b/apps/api/src/tools/task-board/pr-cache.test.ts
@@ -309,6 +309,39 @@ describe("per-entry revalidate override (a value still awaiting something)", () 
     expect(calls).toBe(2);
   });
 
+  test("fetch: maxStaleMs 0 makes a pending value a blocking miss", async () => {
+    const clock = { now: 0 };
+    const cache = await cacheAt(clock);
+    let calls = 0;
+    const pending: Promise<void>[] = [];
+    const read = (status: string) =>
+      cache.fetch({
+        namespace: "conn_1",
+        key: "checks",
+        fetchLive: async () => {
+          calls++;
+          return { status };
+        },
+        onRevalidation: (p) => pending.push(p),
+        revalidateAfterMs: () => 0,
+        maxStaleMs: (stored) =>
+          (stored as { status: string }).status === "pending" ? 0 : 55_000,
+      });
+
+    await read("pending");
+    expect(calls).toBe(1);
+
+    // A zero hit window alone would serve the stale "pending" and refresh behind it.
+    clock.now = 1_000;
+    expect(await read("success")).toEqual({ status: "success" });
+    expect(calls).toBe(2);
+
+    // Settled: the normal ceiling applies again (stale-serve + revalidate).
+    clock.now = 2_000;
+    expect(await read("success")).toEqual({ status: "success" });
+    await Promise.all(pending);
+  });
+
   test("fetchOrPlaceholder: an incomplete card is never a hit", async () => {
     const clock = { now: 0 };
     const cache = new JetStreamKVPrCache(

--- a/apps/api/src/tools/task-board/pr-cache.ts
+++ b/apps/api/src/tools/task-board/pr-cache.ts
@@ -30,7 +30,7 @@ import { meter } from "../../observability";
 
 const cacheCounter = meter.createCounter("pr_read_cache.fetches", {
   description:
-    "Task board PR cache outcomes (hit, stale, miss, placeholder, error, store_rejected)",
+    "Task board PR cache outcomes (hit, stale, miss, placeholder, refresh, error, store_rejected)",
   unit: "{fetches}",
 });
 
@@ -289,6 +289,26 @@ export class JetStreamKVPrCache {
     return usable
       ? { value: stored!.value as T, live: true }
       : { value: placeholder, live: false };
+  }
+
+  /**
+   * Fetch live and store, ignoring whatever is cached — the webhook's push
+   * path, where GitHub has just told us the value changed. Rejects if the fetch
+   * does, so a failed refresh leaves the previous value in place.
+   */
+  async refresh<T>(params: {
+    namespace: string;
+    key: string;
+    fetchLive: () => Promise<T>;
+  }): Promise<T> {
+    const value = await params.fetchLive();
+    await this.write(
+      this.storageKey(params.namespace, params.key),
+      value,
+      this.config.cache,
+    );
+    cacheCounter.add(1, { cache: this.config.cache, outcome: "refresh" });
+    return value;
   }
 
   private async read(key: string): Promise<StoredRead | null> {

--- a/apps/api/src/tools/task-board/pr-cache.ts
+++ b/apps/api/src/tools/task-board/pr-cache.ts
@@ -102,6 +102,13 @@ export interface PrCacheFetch {
    *  should go stale fast, so the next poll refetches instead of serving the
    *  not-ready answer for the full config window. Omit for the default. */
   revalidateAfterMs?: (stored: unknown) => number;
+  /** Per-entry override of the STALE ceiling, computed from the stored value.
+   *  Returning 0 makes a stored value a MISS — the caller blocks on a live
+   *  fetch. That is the right trade for a value whose whole point is that it
+   *  ends (CI still running): stale-while-revalidate needs two polls to surface
+   *  a change (this poll serves stale, the background write lands after), and
+   *  if that background write ever fails the entry never moves again. */
+  maxStaleMs?: (stored: unknown) => number;
 }
 
 export class JetStreamKVPrCache {
@@ -187,8 +194,12 @@ export class JetStreamKVPrCache {
     const age = stored
       ? this.now() - stored.storedAt
       : Number.POSITIVE_INFINITY;
+    const staleCeilingMs =
+      stored && params.maxStaleMs
+        ? params.maxStaleMs(stored.value)
+        : maxStaleMs;
 
-    if (!stored || age > maxStaleMs) {
+    if (!stored || age > staleCeilingMs) {
       cacheCounter.add(1, { cache, outcome: "miss" });
       const value = await fetchLive();
       await this.write(key, value, cache);

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -91,6 +91,17 @@ function ciRevalidateAfterMs(status: ChecksStatus): number {
     : PR_READS_CACHE.revalidateAfterMs;
 }
 
+/** Stale ceiling for one raw GitHub read: zero while it says CI is running, so
+ *  the read is a MISS and asks GitHub synchronously instead of serving the
+ *  pending answer one more time. A zero HIT window alone wasn't enough — it
+ *  only starts a background refresh, so the assembled card was still built from
+ *  the previous read and a fresh result needed a second poll to appear (and
+ *  never appeared at all if that one background write failed). Bounded to a
+ *  pending PR someone has the dialog open on. */
+function ciMaxStaleMs(status: ChecksStatus): number {
+  return status === "pending" ? 0 : PR_READS_CACHE.maxStaleMs;
+}
+
 export function invalidatePrReads(connectionId: string): Promise<void> {
   return getPrReadCache().invalidate(connectionId);
 }
@@ -209,12 +220,14 @@ async function cachedPrRead(
   describe: string,
   pending: Promise<void>[],
   revalidateAfterMs?: (stored: unknown) => number,
+  maxStaleMs?: (stored: unknown) => number,
 ): Promise<Record<string, unknown> | null> {
   try {
     const raw = await getPrReadCache().fetch({
       namespace: connectionId,
       key: JSON.stringify({ name, args }),
       revalidateAfterMs,
+      maxStaleMs,
       fetchLive: () =>
         retry(
           async () => {
@@ -864,6 +877,7 @@ async function fetchPrStatusExtras(
   const read = (
     method: "get_status" | "get_check_runs" | "get_comments",
     revalidateAfterMs?: (stored: unknown) => number,
+    maxStaleMs?: (stored: unknown) => number,
   ) =>
     cachedPrRead(
       getClient,
@@ -878,16 +892,22 @@ async function fetchPrStatusExtras(
       `${prLabel(pr)} (${method})`,
       pending,
       revalidateAfterMs,
+      maxStaleMs,
     );
   // The three reads are independent — run them CONCURRENTLY. Serial was the
   // slowness (each is a remote MCP → GitHub round-trip, ~1.5-2s; the card made
   // 4-5 of them in a row).
   const [statusObj, runsRaw, commentsRaw] = await Promise.all([
-    read("get_status", (stored) =>
-      ciRevalidateAfterMs(toChecksStatus(toolResultJson(stored))),
+    read(
+      "get_status",
+      (stored) => ciRevalidateAfterMs(toChecksStatus(toolResultJson(stored))),
+      (stored) => ciMaxStaleMs(toChecksStatus(toolResultJson(stored))),
     ),
-    read("get_check_runs", (stored) =>
-      ciRevalidateAfterMs(toCheckRunsStatus(toolResultJson(stored))),
+    read(
+      "get_check_runs",
+      (stored) =>
+        ciRevalidateAfterMs(toCheckRunsStatus(toolResultJson(stored))),
+      (stored) => ciMaxStaleMs(toCheckRunsStatus(toolResultJson(stored))),
     ),
     read("get_comments"),
   ]);

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -72,8 +72,9 @@ const FORCE_FRESH = () => 0;
  *  `updated_at`. */
 const PREVIEW_CHASE_MS = 10 * 60_000;
 
-/** A card waiting on something that ends by itself: CI running, or no preview
- *  url yet (time-bounded — a repo may publish none, ever). */
+/** A card waiting on something that ends by itself: never asked GitHub yet, CI
+ *  running, or no preview url yet (time-bounded — a repo may publish none,
+ *  ever). */
 export function isCardNotReady(
   card: {
     checksStatus: ChecksStatus;
@@ -83,7 +84,11 @@ export function isCardNotReady(
   },
   now: number = Date.now(),
 ): boolean {
-  if (card.state !== "open") return false;
+  // `null` is the placeholder: we have not asked GitHub yet, so it is the least
+  // ready a card can be. Only a state GitHub actually reported as not-open is
+  // settled.
+  if (card.state !== null && card.state !== "open") return false;
+  if (card.state === null) return true;
   if (card.checksStatus === "pending") return true;
   if (card.previewUrl !== null) return false;
   const activeAt = card.updatedAt ? Date.parse(card.updatedAt) : Number.NaN;

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -13,10 +13,13 @@ import {
 } from "@decocms/shared/task-board";
 import { retry, RetryError } from "@decocms/shared/std";
 import { TaskBoardItemPrSchema } from "./schema";
+
+/** One assembled PR card — the tool's output shape, and what the card cache stores. */
+export type TaskBoardItemPrCard = z.infer<typeof TaskBoardItemPrSchema>;
 import { cardWorkLanded } from "./archive-merged";
 import { recordTaskActivity } from "./activity";
 import { inReviewPhase, movesForward } from "./lanes";
-import { emitTaskBoardUpdated } from "./run-reactions";
+import { emitTaskBoardPrsUpdated, emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
 import { readPrStateThrottled } from "./dbos-github-read";
@@ -62,27 +65,33 @@ import {
  *  not-ready answer for the full window. */
 const NOT_READY_REVALIDATE_MS = 0;
 
-/**
- * A card that should keep refreshing: CI is still running, so both what it
- * reports and the preview URL a deploy check publishes are still moving.
- *
- * Pending CI counts on its own — it used to additionally require a missing
- * preview URL, which is what left a card sitting on "Checks pending" minutes
- * after the checks went green. Nothing about the PR had changed; the checks
- * simply finished, and with a preview already found the card was a cache HIT
- * for the full window, rebuilt from reads that were themselves a window stale.
- * Waiting is the one state whose whole point is that it ends, so it never gets
- * a hit window.
- *
- * Bounded: a settled card (passing/failing/no CI) caches normally, so the
- * per-poll rebuild this costs only runs while CI is actually running.
- */
-export function isAwaitingCi(card: { checksStatus: ChecksStatus }): boolean {
-  return card.checksStatus === "pending";
+/** Stale ceiling that makes any stored read a miss. */
+const FORCE_FRESH = () => 0;
+
+/** Bound on chasing a preview url that may never arrive, from GitHub's
+ *  `updated_at`. */
+const PREVIEW_CHASE_MS = 10 * 60_000;
+
+/** A card waiting on something that ends by itself: CI running, or no preview
+ *  url yet (time-bounded — a repo may publish none, ever). */
+export function isCardNotReady(
+  card: {
+    checksStatus: ChecksStatus;
+    previewUrl: string | null;
+    state: string | null;
+    updatedAt: string | null;
+  },
+  now: number = Date.now(),
+): boolean {
+  if (card.state !== "open") return false;
+  if (card.checksStatus === "pending") return true;
+  if (card.previewUrl !== null) return false;
+  const activeAt = card.updatedAt ? Date.parse(card.updatedAt) : Number.NaN;
+  return Number.isFinite(activeAt) && now - activeAt < PREVIEW_CHASE_MS;
 }
 
 /** Hit window for one raw GitHub read: zero while it says CI is still running,
- *  for the same reason as {@link isAwaitingCi}. Without this the card
+ *  for the same reason as {@link isCardNotReady}. Without this the card
  *  cache revalidates on every poll only to rebuild from a read that is itself
  *  up to a full read-window stale, and the two lags add up. */
 function ciRevalidateAfterMs(status: ChecksStatus): number {
@@ -100,6 +109,16 @@ function ciRevalidateAfterMs(status: ChecksStatus): number {
  *  pending PR someone has the dialog open on. */
 function ciMaxStaleMs(status: ChecksStatus): number {
   return status === "pending" ? 0 : PR_READS_CACHE.maxStaleMs;
+}
+
+/** Hit window for `get_comments`, the read the deploy bot's comment arrives in:
+ *  zero until the list actually carries a preview url. It was the only read
+ *  still on the full 55s window, so a per-poll card rebuild kept re-extracting
+ *  the preview from a list fetched before the bot posted. */
+function commentsRevalidateAfterMs(stored: unknown): number {
+  return extractPreviewUrlFromComments(toolResultJson(stored)) === null
+    ? NOT_READY_REVALIDATE_MS
+    : PR_READS_CACHE.revalidateAfterMs;
 }
 
 export function invalidatePrReads(connectionId: string): Promise<void> {
@@ -378,6 +397,7 @@ export type PrCheck = {
 type PrLiveState = {
   title: string | null;
   body: string | null;
+  updatedAt: string | null;
   state: "open" | "closed" | null;
   draft: boolean | null;
   merged: boolean | null;
@@ -394,6 +414,7 @@ type PrLiveState = {
 const NO_LIVE_STATE: PrLiveState = {
   title: null,
   body: null,
+  updatedAt: null,
   state: null,
   draft: null,
   merged: null,
@@ -423,6 +444,17 @@ export function isTrustedPreviewHost(url: string): boolean {
     hostname.endsWith(".deco.site") ||
     hostname.endsWith(".vercel.app") ||
     hostname.endsWith(".vtex.app")
+  );
+}
+
+/** The first url in `text` that is on a trusted preview host. The character
+ *  class stops at `)`/`]` so a markdown link's url doesn't absorb its syntax. */
+function firstTrustedUrl(text: unknown): string | null {
+  if (typeof text !== "string") return null;
+  return (
+    (text.match(/https?:\/\/[^\s"'<>)\]]+/g) ?? []).find(
+      isTrustedPreviewHost,
+    ) ?? null
   );
 }
 
@@ -458,6 +490,18 @@ export function extractPreviewUrl(
  *  ponytail: hardcoded; make it configurable if sites land in another account. */
 const WORKERS_DEV_SUBDOMAIN = "deco-cx";
 
+/**
+ * Pull the preview URL out of a PR's check runs — the source that works when
+ * the deploy bot posts no comment at all, which happens often enough that the
+ * comment can't be the only path.
+ *
+ * Two passes. First the exact one: Workers Builds names the worker and prints
+ * the version id, which composes the immutable per-deploy url. Then the generic
+ * one: any check whose output or details link carries a trusted preview host —
+ * Cloudflare Pages, Vercel and the deco bots all print theirs somewhere in
+ * there. Successful runs win over unfinished or failed ones, so a retried
+ * deploy doesn't hand back the broken attempt's url.
+ */
 export function extractPreviewUrlFromCheckRuns(raw: unknown): string | null {
   const runs = Array.isArray(raw)
     ? raw
@@ -478,6 +522,30 @@ export function extractPreviewUrlFromCheckRuns(raw: unknown): string | null {
     if (!version) continue;
     const url = `https://${version}-${worker}.${WORKERS_DEV_SUBDOMAIN}.workers.dev`;
     if (isTrustedPreviewHost(url)) return url;
+  }
+  return previewUrlFromRunOutput(runs);
+}
+
+/** Second pass of {@link extractPreviewUrlFromCheckRuns}: scan each run's
+ *  output and details link, successful runs first. */
+function previewUrlFromRunOutput(runs: unknown[]): string | null {
+  const isSuccess = (r: unknown) =>
+    (r as { conclusion?: unknown })?.conclusion === "success";
+  for (const r of [
+    ...runs.filter(isSuccess),
+    ...runs.filter((r) => !isSuccess(r)),
+  ]) {
+    if (!r || typeof r !== "object") continue;
+    const o = r as {
+      output?: { summary?: unknown; text?: unknown; title?: unknown };
+      details_url?: unknown;
+    };
+    const url =
+      firstTrustedUrl(o.output?.summary) ??
+      firstTrustedUrl(o.output?.text) ??
+      firstTrustedUrl(o.output?.title) ??
+      firstTrustedUrl(o.details_url);
+    if (url) return url;
   }
   return null;
 }
@@ -533,9 +601,7 @@ export function extractPreviewUrlFromComments(raw: unknown): string | null {
     // prefer the branch URL, which stays valid as the PR gets new commits.
     const branch = body.match(/href=['"]([^'"]+)['"][^>]*>\s*Branch Preview/i);
     if (branch?.[1] && isTrustedPreviewHost(branch[1])) return branch[1];
-    const url = (body.match(/https?:\/\/[^\s"'<>)\]]+/g) ?? []).find((u) =>
-      isTrustedPreviewHost(u),
-    );
+    const url = firstTrustedUrl(body);
     if (url) return url;
   }
   return null;
@@ -869,6 +935,7 @@ async function fetchPrStatusExtras(
   pr: TaskBoardItemPrRef,
   pending: Promise<void>[],
   prGet: Promise<Record<string, unknown> | null>,
+  fresh = false,
 ): Promise<{
   checksStatus: ChecksStatus;
   checks: PrCheck[];
@@ -892,7 +959,7 @@ async function fetchPrStatusExtras(
       `${prLabel(pr)} (${method})`,
       pending,
       revalidateAfterMs,
-      maxStaleMs,
+      fresh ? FORCE_FRESH : maxStaleMs,
     );
   // The three reads are independent — run them CONCURRENTLY. Serial was the
   // slowness (each is a remote MCP → GitHub round-trip, ~1.5-2s; the card made
@@ -909,7 +976,7 @@ async function fetchPrStatusExtras(
         ciRevalidateAfterMs(toCheckRunsStatus(toolResultJson(stored))),
       (stored) => ciMaxStaleMs(toCheckRunsStatus(toolResultJson(stored))),
     ),
-    read("get_comments"),
+    read("get_comments", commentsRevalidateAfterMs),
   ]);
   // Combined Status API ∪ Checks API → one summary.
   const checksStatus = mergeChecksStatus(
@@ -1050,6 +1117,8 @@ async function fetchPrLiveState(
   ctx: StudioContext,
   orgId: string,
   pr: TaskBoardItemPrRef,
+  /** Skip the read cache entirely — GitHub has just told us it changed. */
+  fresh = false,
 ): Promise<PrLiveState> {
   const conn = await resolveGithubConnection(ctx, orgId, pr.connectionId, {
     owner: pr.repoOwner,
@@ -1078,10 +1147,12 @@ async function fetchPrLiveState(
       },
       `${prLabel(pr)} (get)`,
       pending,
+      undefined,
+      fresh ? FORCE_FRESH : undefined,
     );
     const [obj, extras] = await Promise.all([
       prGet,
-      fetchPrStatusExtras(getClient, conn.id, pr, pending, prGet),
+      fetchPrStatusExtras(getClient, conn.id, pr, pending, prGet, fresh),
     ]);
     if (!obj) return NO_LIVE_STATE;
     const rawState = obj.state;
@@ -1090,6 +1161,7 @@ async function fetchPrLiveState(
     return {
       title: typeof obj.title === "string" ? obj.title : null,
       body: typeof obj.body === "string" ? obj.body : null,
+      updatedAt: typeof obj.updated_at === "string" ? obj.updated_at : null,
       state: rawState === "closed" ? "closed" : isOpen ? "open" : null,
       draft: typeof obj.draft === "boolean" ? obj.draft : null,
       merged: typeof obj.merged === "boolean" ? obj.merged : null,
@@ -1278,6 +1350,66 @@ export async function pickActivePr(
   return prs[pickActivePrIndex(states)];
 }
 
+/** One GitHub round-trip per linked PR, in parallel, each best-effort. */
+function assemblePrCards(
+  ctx: StudioContext,
+  orgId: string,
+  linked: TaskBoardItemPrRef[],
+  fresh = false,
+): Promise<TaskBoardItemPrCard[]> {
+  return Promise.all(
+    linked.map(async (pr) => {
+      const live = await fetchPrLiveState(ctx, orgId, pr, fresh);
+      return {
+        url: pr.url,
+        number: pr.number,
+        repoOwner: pr.repoOwner,
+        repoName: pr.repoName,
+        createdAt: pr.createdAt,
+        ...live,
+      };
+    }),
+  );
+}
+
+/**
+ * Re-read a task's PR cards from GitHub and push them out — the GitHub
+ * webhook's entry point, where an event has just told us CI finished or a
+ * deploy bot commented.
+ *
+ * Reads bypass the read cache (`fresh`), because the event IS the invalidation
+ * and a 55s-old read is exactly what it supersedes. The result is written
+ * straight into the card cache, so the dialog's next poll is a hit, and emitted
+ * on the org's SSE stream, so a dialog that is already open updates without
+ * waiting for that poll.
+ *
+ * Best-effort and never throws: a webhook delivery must not retry because one
+ * org's GitHub connection is unreachable.
+ */
+export async function refreshItemPrCards(
+  ctx: StudioContext,
+  orgId: string,
+  taskBoardItemId: string,
+): Promise<TaskBoardItemPrCard[] | null> {
+  try {
+    const linked = await ctx.storage.taskBoard.listPrs(taskBoardItemId, orgId);
+    if (linked.length === 0) return null;
+    const prs = await getPrCardCache().refresh({
+      namespace: orgId,
+      key: taskBoardItemId,
+      fetchLive: () => assemblePrCards(ctx, orgId, linked, true),
+    });
+    emitTaskBoardPrsUpdated(orgId, taskBoardItemId, prs);
+    return prs;
+  } catch (err) {
+    console.error(
+      `[task-board] pr card refresh failed for ${taskBoardItemId}:`,
+      err,
+    );
+    return null;
+  }
+}
+
 export const TASK_BOARD_ITEM_PRS_GET = defineTool({
   name: "TASK_BOARD_ITEM_PRS_GET",
   description:
@@ -1314,21 +1446,7 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
       taskBoardItemId,
       organizationId,
     );
-    // One GitHub round-trip per linked PR, in parallel, each best-effort.
-    const assemble = () =>
-      Promise.all(
-        linked.map(async (pr) => {
-          const live = await fetchPrLiveState(ctx, organizationId, pr);
-          return {
-            url: pr.url,
-            number: pr.number,
-            repoOwner: pr.repoOwner,
-            repoName: pr.repoName,
-            createdAt: pr.createdAt,
-            ...live,
-          };
-        }),
-      );
+    const assemble = () => assemblePrCards(ctx, organizationId, linked);
 
     // Serve the assembled card, not the raw reads it was built from. The read
     // cache underneath still helps the sweeps, but it could not make THIS fast:
@@ -1345,13 +1463,9 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
       namespace: organizationId,
       key: taskBoardItemId,
       fetchLive: assemble,
-      // A card whose deploy is still running has no preview yet. At the default
-      // window that card is a cache HIT for 30s, so the url can be a poll or
-      // two late even after the read above refreshes. Go stale immediately
-      // instead: the revalidation is detached, so this costs a background
-      // rebuild per poll on exactly the cards that are still missing something.
+      // Detached, so a mid-flight card costs one rebuild per poll, not a 30s wait.
       revalidateAfterMs: (cards) =>
-        cards.some(isAwaitingCi)
+        cards.some((c) => isCardNotReady(c))
           ? NOT_READY_REVALIDATE_MS
           : PR_CARDS_CACHE.revalidateAfterMs,
       placeholder: linked.map((pr) => ({

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -41,6 +41,7 @@ import {
   LANES,
   SUPER_AGENT_ASSIGNEE_ID,
   TASK_BOARD_ITEM_DELETED_EVENT,
+  TASK_BOARD_ITEM_PRS_UPDATED_EVENT,
   TASK_BOARD_ITEM_UPDATED_EVENT,
 } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
@@ -76,6 +77,22 @@ export function emitTaskBoardUpdated(orgId: string, item: TaskBoardItem): void {
     source: "task-board",
     subject: item.id,
     data: item,
+    time: new Date().toISOString(),
+  });
+}
+
+/** Push a task's freshly re-read PR cards to every SSE listener on its org. */
+export function emitTaskBoardPrsUpdated(
+  orgId: string,
+  itemId: string,
+  prs: unknown[],
+): void {
+  sseHub.emit(orgId, {
+    id: crypto.randomUUID(),
+    type: TASK_BOARD_ITEM_PRS_UPDATED_EVENT,
+    source: "task-board",
+    subject: itemId,
+    data: { id: itemId, prs },
     time: new Date().toISOString(),
   });
 }

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -112,6 +112,10 @@ export const TaskBoardItemPrSchema = z.object({
   repoOwner: z.string(),
   repoName: z.string(),
   createdAt: z.string(),
+  /** GitHub's `updated_at` for the PR — bumped by a push, a comment or a review.
+   *  Bounds how long a card with no preview url keeps chasing one. `null` when
+   *  GitHub hasn't been read yet or the fetch failed. */
+  updatedAt: z.string().nullable(),
   title: z.string().nullable(),
   body: z.string().nullable(),
   state: z.enum(["open", "closed"]).nullable(),

--- a/apps/web/src/hooks/use-task-board-item-prs-events.ts
+++ b/apps/web/src/hooks/use-task-board-item-prs-events.ts
@@ -1,0 +1,62 @@
+/**
+ * useTaskBoardItemPrsEvents — live PR cards for one open task dialog.
+ *
+ * Subscribes to the shared `/api/:org/watch` connection, filtered to
+ * `task-board.item.prs.updated`, and hands the fresh cards for THIS task to
+ * `onPrs`. The GitHub webhook pushes that event when CI finishes or a deploy
+ * bot posts a preview url, so the dialog's checks and Preview button update
+ * without waiting for its poll.
+ *
+ * Mirrors `useTaskBoardEvents`: useSyncExternalStore for React 19 lifecycle,
+ * callback read from a ref so the connection stays stable across re-renders.
+ */
+
+import type { TaskBoardItemPr } from "@/layouts/task-board/config";
+import { useRef, useSyncExternalStore } from "react";
+import { taskBoardPrsWatchView } from "./watch-sse-pool";
+
+const getSnapshot = () => 0;
+
+export function useTaskBoardItemPrsEvents(options: {
+  orgSlug: string;
+  itemId: string | undefined;
+  onPrs: (prs: TaskBoardItemPr[]) => void;
+}): void {
+  const { orgSlug, itemId, onPrs } = options;
+
+  const onPrsRef = useRef(onPrs);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- callback kept fresh without re-subscribing
+  onPrsRef.current = onPrs;
+
+  const subscribeRef = useRef<
+    ((onStoreChange: () => void) => () => void) | null
+  >(null);
+  const prevKey = useRef<string>("");
+  const key = `${orgSlug}:${itemId ?? ""}`;
+
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- escape hatch for stable subscription identity
+  if (!subscribeRef.current || prevKey.current !== key) {
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- escape hatch for stable subscription identity
+    prevKey.current = key;
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- escape hatch for stable subscription identity
+    subscribeRef.current = (onStoreChange: () => void) => {
+      if (!orgSlug || !itemId) return () => {};
+      const handler = (e: MessageEvent) => {
+        let event: { data?: { id?: string; prs?: TaskBoardItemPr[] } };
+        try {
+          event = JSON.parse(e.data);
+        } catch {
+          return;
+        }
+        // Org-wide stream: every open dialog sees every task's push.
+        if (event.data?.id !== itemId || !Array.isArray(event.data.prs)) return;
+        onPrsRef.current(event.data.prs);
+        onStoreChange();
+      };
+      return taskBoardPrsWatchView.subscribe(orgSlug, handler);
+    };
+  }
+
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- escape hatch for stable subscription identity
+  useSyncExternalStore(subscribeRef.current!, getSnapshot, getSnapshot);
+}

--- a/apps/web/src/hooks/use-task-board-item-prs.ts
+++ b/apps/web/src/hooks/use-task-board-item-prs.ts
@@ -1,8 +1,9 @@
 import { useProjectContext } from "@/sdk";
 import type { TaskBoardItemPr } from "@/layouts/task-board/config";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { KEYS } from "@/lib/query-keys";
 import { useStudioTools } from "@/lib/studio-tools";
+import { useTaskBoardItemPrsEvents } from "./use-task-board-item-prs-events";
 import {
   readCachedTaskPrs,
   writeCachedTaskPrs,
@@ -21,18 +22,26 @@ const PRS_POLL_INTERVAL_MS = 60_000;
  *  minute. */
 const PRS_UNENRICHED_POLL_INTERVAL_MS = 2_000;
 
-/** Checks that are still running settle on their own, with no webhook to say
- *  when — so while any linked PR reports pending CI, poll faster than the idle
- *  minute. Bounded to a dialog that is open on a PR whose CI is actually
- *  running, and the server answers those from cache while it refreshes. */
-const PRS_PENDING_CHECKS_POLL_INTERVAL_MS = 10_000;
+/** CI and a deploy preview settle on their own, with no webhook to say when, so
+ *  a PR waiting on either polls faster than the idle minute. Bounded to an open
+ *  dialog; the server answers from cache while it refreshes. */
+const PRS_IN_FLIGHT_POLL_INTERVAL_MS = 10_000;
 
 /** A card the server returned before GitHub answered: link fields only. `state`
  *  is null for a PR GitHub could not be read for too, which polls the same way
  *  — the right behavior either way. */
 const isUnenriched = (pr: TaskBoardItemPr) => pr.state === null;
 
-const hasPendingChecks = (pr: TaskBoardItemPr) => pr.checksStatus === "pending";
+/** Mirrors `isCardNotReady` on the server, including its 10-minute bound on
+ *  chasing a preview url that may never arrive. */
+const PREVIEW_CHASE_MS = 10 * 60_000;
+const isInFlight = (pr: TaskBoardItemPr) => {
+  if (pr.state !== "open") return false;
+  if (pr.checksStatus === "pending") return true;
+  if (pr.previewUrl !== null) return false;
+  const activeAt = pr.updatedAt ? Date.parse(pr.updatedAt) : Number.NaN;
+  return Number.isFinite(activeAt) && Date.now() - activeAt < PREVIEW_CHASE_MS;
+};
 
 /**
  * A task's linked PRs, each with live state fetched from GitHub via the
@@ -41,8 +50,22 @@ const hasPendingChecks = (pr: TaskBoardItemPr) => pr.checksStatus === "pending";
  * while the dialog is open, so poll it.
  */
 export function useTaskBoardItemPrs(itemId: string | undefined) {
-  const { locator } = useProjectContext();
+  const { org, locator } = useProjectContext();
   const studio = useStudioTools();
+  const queryClient = useQueryClient();
+
+  // The webhook's push path: fresh cards land here as soon as GitHub reports
+  // CI finished or the deploy bot commented, ahead of the poll below.
+  useTaskBoardItemPrsEvents({
+    orgSlug: org.slug,
+    itemId,
+    onPrs: (prs) => {
+      queryClient.setQueryData(
+        KEYS.taskBoardItemPrs(locator, itemId ?? ""),
+        prs,
+      );
+    },
+  });
 
   return useQuery({
     queryKey: KEYS.taskBoardItemPrs(locator, itemId ?? ""),
@@ -50,8 +73,7 @@ export function useTaskBoardItemPrs(itemId: string | undefined) {
     refetchInterval: (query) => {
       const prs = query.state.data;
       if (prs?.some(isUnenriched)) return PRS_UNENRICHED_POLL_INTERVAL_MS;
-      if (prs?.some(hasPendingChecks))
-        return PRS_PENDING_CHECKS_POLL_INTERVAL_MS;
+      if (prs?.some(isInFlight)) return PRS_IN_FLIGHT_POLL_INTERVAL_MS;
       return PRS_POLL_INTERVAL_MS;
     },
     // Seeded from localStorage so a cold page load paints the last known cards

--- a/apps/web/src/hooks/use-task-board-item-prs.ts
+++ b/apps/web/src/hooks/use-task-board-item-prs.ts
@@ -25,7 +25,7 @@ const PRS_UNENRICHED_POLL_INTERVAL_MS = 2_000;
  *  when — so while any linked PR reports pending CI, poll faster than the idle
  *  minute. Bounded to a dialog that is open on a PR whose CI is actually
  *  running, and the server answers those from cache while it refreshes. */
-const PRS_PENDING_CHECKS_POLL_INTERVAL_MS = 15_000;
+const PRS_PENDING_CHECKS_POLL_INTERVAL_MS = 10_000;
 
 /** A card the server returned before GitHub answered: link fields only. `state`
  *  is null for a PR GitHub could not be read for too, which polls the same way

--- a/apps/web/src/hooks/watch-sse-pool.ts
+++ b/apps/web/src/hooks/watch-sse-pool.ts
@@ -7,6 +7,7 @@
 import { ALL_DECOPILOT_EVENT_TYPES } from "@/sdk";
 import {
   TASK_BOARD_ITEM_DELETED_EVENT,
+  TASK_BOARD_ITEM_PRS_UPDATED_EVENT,
   TASK_BOARD_ITEM_UPDATED_EVENT,
 } from "@decocms/shared/task-board";
 import { NOTIFICATION_CREATED_EVENT } from "@decocms/shared/notification-types";
@@ -21,6 +22,7 @@ const WATCH_TYPES = [
   ...ALL_DECOPILOT_EVENT_TYPES,
   TASK_BOARD_ITEM_UPDATED_EVENT,
   TASK_BOARD_ITEM_DELETED_EVENT,
+  TASK_BOARD_ITEM_PRS_UPDATED_EVENT,
   NOTIFICATION_CREATED_EVENT,
 ];
 
@@ -54,6 +56,12 @@ export const taskBoardWatchView: SSESubscription = filterEventTypes(watchSSE, [
   TASK_BOARD_ITEM_UPDATED_EVENT,
   TASK_BOARD_ITEM_DELETED_EVENT,
 ]);
+
+/** A task's PR cards, re-read because a GitHub webhook said they changed. */
+export const taskBoardPrsWatchView: SSESubscription = filterEventTypes(
+  watchSSE,
+  [TASK_BOARD_ITEM_PRS_UPDATED_EVENT],
+);
 
 /** Inbox fan-out (`notification.created`). Org-wide — the consumer matches the
  *  event's `subject` against its own user id. */

--- a/apps/web/src/layouts/task-board/build-task-chat-context.test.ts
+++ b/apps/web/src/layouts/task-board/build-task-chat-context.test.ts
@@ -24,6 +24,7 @@ const pr = (o: Partial<TaskBoardItemPr>): TaskBoardItemPr => ({
   repoOwner: "x",
   repoName: "y",
   createdAt: "",
+  updatedAt: null,
   title: null,
   body: null,
   state: "open",

--- a/apps/web/src/layouts/task-board/pr-card-actions.test.ts
+++ b/apps/web/src/layouts/task-board/pr-card-actions.test.ts
@@ -20,6 +20,7 @@ function pr(overrides: Partial<TaskBoardItemPr> = {}): TaskBoardItemPr {
     repoOwner: "o",
     repoName: "r",
     createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: null,
     title: "A PR",
     body: null,
     state: "open",

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -56,7 +56,7 @@ const jiraStubPort = process.env.JIRA_STUB_PORT || "4103";
 // the config isn't a spec module).
 const vaultServiceToken = "e2e-vault-service-token";
 
-const apiServerCommand = `MCP_CACHE_ENABLED=true VAULT_SERVICE_TOKEN=${vaultServiceToken} REPORTS_INTERNAL_API_URL=${commerceMockOrigin} REPORTS_INTERNAL_API_KEY=${commerceMockKey} GITHUB_API_BASE_URL=${githubStubOrigin} JIRA_ALLOW_LOCAL_SITE_URL=1 BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} RUN_IDLE_TIMEOUT_MS=120000 DEPLOYMENT_ADMIN_EMAILS=deployment-admin@e2e.local,deployment-admin-2@e2e.local bun run dev`;
+const apiServerCommand = `MCP_CACHE_ENABLED=true GITHUB_WEBHOOK_SECRET=e2e-github-webhook-secret VAULT_SERVICE_TOKEN=${vaultServiceToken} REPORTS_INTERNAL_API_URL=${commerceMockOrigin} REPORTS_INTERNAL_API_KEY=${commerceMockKey} GITHUB_API_BASE_URL=${githubStubOrigin} JIRA_ALLOW_LOCAL_SITE_URL=1 BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} RUN_IDLE_TIMEOUT_MS=120000 DEPLOYMENT_ADMIN_EMAILS=deployment-admin@e2e.local,deployment-admin-2@e2e.local bun run dev`;
 // CI serves the PRODUCTION build via `vite preview` (same Node proxy as dev —
 // see apps/web/vite.config.ts): the suite's charter is production-like
 // behavior, and the dev server's on-demand transform inflated browser-heavy

--- a/packages/e2e/tests/task-board-pr-webhook.spec.ts
+++ b/packages/e2e/tests/task-board-pr-webhook.spec.ts
@@ -1,0 +1,388 @@
+/**
+ * The GitHub webhook → PR card path, end to end over the wire.
+ *
+ * A PR card's checks and preview url used to be poll-only, so they landed
+ * minutes after GitHub had them. GitHub now posts `check_suite` /
+ * `issue_comment` to `/api/_github/webhook`, which re-reads the card and pushes
+ * it on the org's `/watch` stream. This spec walks that whole chain:
+ *
+ *   HMAC-signed delivery → repo/PR reverse lookup → fresh GitHub read →
+ *   card cache write → SSE push → the open dialog's checks + preview control.
+ *
+ * GitHub is a local MCP server (the card path reads GitHub through an
+ * `mcp-github` connection, not the REST stub), whose answers flip mid-test from
+ * "CI running, no preview" to "CI passed, preview url in the deploy check's
+ * output" — the shape where no bot ever comments the url, only the check does.
+ *
+ * `GITHUB_WEBHOOK_SECRET` is set on the API server by playwright.config.ts;
+ * the literal is duplicated here by hand (the config isn't a spec module),
+ * matching how commerce-diagnostic-share.spec.ts carries the vault token.
+ */
+
+import { createHmac } from "node:crypto";
+import { z } from "zod";
+import type { APIRequestContext } from "@playwright/test";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { startTestMcpServer } from "../fixtures/test-mcp-server";
+import { expect, test } from "../fixtures/test";
+
+const WEBHOOK_SECRET = "e2e-github-webhook-secret";
+
+// Black-box wire-contract shapes (owned by this test, per e2e isolation rules).
+interface TaskBoardItem {
+  id: string;
+}
+interface TaskBoardItemPr {
+  url: string;
+  number: number;
+  checksStatus: "pending" | "passing" | "failing" | null;
+  previewUrl: string | null;
+  state: "open" | "closed" | null;
+}
+interface PrsWatchEvent {
+  type: string;
+  subject: string;
+  data: { id: string; prs: TaskBoardItemPr[] };
+}
+
+declare global {
+  interface Window {
+    __prsEvents?: PrsWatchEvent[];
+  }
+}
+
+/** GitHub's own signature scheme: HMAC-SHA256 over the exact request bytes. */
+function sign(body: string): string {
+  return `sha256=${createHmac("sha256", WEBHOOK_SECRET).update(body).digest("hex")}`;
+}
+
+function postWebhook(
+  request: APIRequestContext,
+  event: string,
+  payload: unknown,
+  signature?: string,
+) {
+  const body = JSON.stringify(payload);
+  return request.post("/api/_github/webhook", {
+    data: body,
+    headers: {
+      "content-type": "application/json",
+      "x-github-event": event,
+      "x-hub-signature-256": signature ?? sign(body),
+    },
+  });
+}
+
+/**
+ * A stand-in for the org's `mcp-github` connection. One `pull_request_read`
+ * tool dispatching on `method`, exactly as the card path calls it, plus the
+ * deployment lookup it falls back to.
+ *
+ * `state.ciDone` flips what the check runs report — an in-flight deploy first,
+ * then a finished one whose output carries the preview url.
+ */
+async function startGithubMcp(state: { ciDone: boolean }, previewUrl: string) {
+  return startTestMcpServer({
+    tools: [
+      {
+        name: "pull_request_read",
+        inputSchema: {
+          method: z.string(),
+          owner: z.string().optional(),
+          repo: z.string().optional(),
+          pullNumber: z.number().optional(),
+        },
+        handler: (args) => {
+          switch (args.method) {
+            case "get":
+              return {
+                title: "Ship the widget",
+                body: "",
+                state: "open",
+                draft: false,
+                merged: false,
+                mergeable: true,
+                updated_at: new Date().toISOString(),
+                head: { sha: "a".repeat(40) },
+              };
+            case "get_status":
+              return { sha: "a".repeat(40), statuses: [] };
+            case "get_check_runs":
+              return {
+                check_runs: [
+                  state.ciDone
+                    ? {
+                        id: 1,
+                        name: "Deploy Preview",
+                        status: "completed",
+                        conclusion: "success",
+                        html_url: "https://github.com/x/y/runs/1",
+                        // The point of the test: the url is HERE, not in a comment.
+                        output: { summary: `Deployed to ${previewUrl}` },
+                      }
+                    : {
+                        id: 1,
+                        name: "Deploy Preview",
+                        status: "in_progress",
+                        conclusion: null,
+                        html_url: "https://github.com/x/y/runs/1",
+                        output: { summary: "Building…" },
+                      },
+                ],
+              };
+            // No bot comment, ever — the case the comment-only path missed.
+            case "get_comments":
+              return [];
+            default:
+              return {};
+          }
+        },
+      },
+      {
+        name: "GET_PREVIEW_DEPLOYMENT",
+        inputSchema: {
+          owner: z.string().optional(),
+          repo: z.string().optional(),
+          sha: z.string().optional(),
+        },
+        handler: () => ({ environmentUrl: null }),
+      },
+    ],
+  });
+}
+
+/** The org-level GitHub connection the card path resolves for any repo. */
+async function createGithubConnection(
+  request: APIRequestContext,
+  orgSlug: string,
+  connectionUrl: string,
+): Promise<void> {
+  const created = await callSelfMcpTool<{ item: { id: string } }>(
+    request,
+    orgSlug,
+    "COLLECTION_CONNECTIONS_CREATE",
+    {
+      data: {
+        title: `GitHub ${Date.now()}`,
+        app_name: "mcp-github",
+        connection_type: "HTTP",
+        connection_url: connectionUrl,
+      },
+    },
+  );
+  expect(created.item.id).toBeTruthy();
+}
+
+test.describe("github webhook → PR card", () => {
+  test("a check_suite delivery refreshes the card, pushes it, and updates the dialog", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const request = page.context().request;
+    const call = <T>(name: string, args: unknown) =>
+      callSelfMcpTool<T>(request, orgSlug, name, args);
+
+    // Tenant-scoped repo name so parallel workers can't collide on the lookup.
+    const repoOwner = "acme-e2e";
+    const repoName = `widget-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const prNumber = 4242;
+    const prUrl = `https://github.com/${repoOwner}/${repoName}/pull/${prNumber}`;
+    const previewUrl = `https://${repoName}.deco.site`;
+
+    const state = { ciDone: false };
+    const github = await startGithubMcp(state, previewUrl);
+    try {
+      await createGithubConnection(request, orgSlug, github.url);
+
+      const { item } = await call<{ item: TaskBoardItem }>(
+        "TASK_BOARD_ITEM_CREATE",
+        { title: "Ship the widget", status: "in_review", prUrl },
+      );
+
+      // Warm the card while CI is still running: pending, and no preview yet.
+      // The first read is a cache placeholder (it never blocks on GitHub), so
+      // poll until the live read lands.
+      await expect
+        .poll(
+          async () =>
+            (
+              await call<{ prs: TaskBoardItemPr[] }>(
+                "TASK_BOARD_ITEM_PRS_GET",
+                {
+                  taskBoardItemId: item.id,
+                },
+              )
+            ).prs[0],
+          { timeout: 30_000 },
+        )
+        .toMatchObject({ checksStatus: "pending", previewUrl: null });
+
+      // The dialog, open on that card, showing the pre-webhook state.
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await page.goto(`/${orgSlug}/tasks`);
+      await page.locator('button:has-text("Ship the widget")').first().click();
+      await expect(page.getByText("Checks pending")).toBeVisible({
+        timeout: 30_000,
+      });
+
+      // The board's real listener, on the app origin so the session rides along.
+      await page.evaluate(async (slug) => {
+        const received: PrsWatchEvent[] = [];
+        window.__prsEvents = received;
+        const es = new EventSource(
+          `/api/${encodeURIComponent(slug)}/watch?types=task-board.item.prs.updated`,
+        );
+        es.addEventListener("task-board.item.prs.updated", (e) => {
+          received.push(JSON.parse((e as MessageEvent).data) as PrsWatchEvent);
+        });
+        if (es.readyState === EventSource.OPEN) return;
+        await new Promise<void>((resolve, reject) => {
+          es.onopen = () => resolve();
+          es.onerror = () => reject(new Error("watch stream failed to open"));
+        });
+      }, orgSlug);
+
+      // CI finishes on GitHub's side, then GitHub tells us about it.
+      state.ciDone = true;
+      const res = await postWebhook(request, "check_suite", {
+        action: "completed",
+        repository: { name: repoName, owner: { login: repoOwner } },
+        check_suite: {
+          status: "completed",
+          conclusion: "success",
+          pull_requests: [{ number: prNumber }],
+        },
+      });
+      expect(res.status()).toBe(200);
+      // The delivery did the work synchronously — GitHub's delivery log is the
+      // only debugging surface this path has, so it must report it.
+      expect(await res.json()).toMatchObject({ ok: true, refreshed: 1 });
+
+      // 1. It reached the browser as an event, with the fresh cards inline.
+      await expect
+        .poll(() => page.evaluate(() => window.__prsEvents ?? []), {
+          timeout: 15_000,
+        })
+        .toEqual([
+          expect.objectContaining({
+            subject: item.id,
+            data: expect.objectContaining({
+              id: item.id,
+              prs: [
+                expect.objectContaining({
+                  number: prNumber,
+                  checksStatus: "passing",
+                  previewUrl,
+                }),
+              ],
+            }),
+          }),
+        ]);
+
+      // 2. It was written to the card cache, so a fresh reader sees it too —
+      //    no second GitHub round-trip needed to observe the change.
+      const { prs } = await call<{ prs: TaskBoardItemPr[] }>(
+        "TASK_BOARD_ITEM_PRS_GET",
+        { taskBoardItemId: item.id },
+      );
+      expect(prs[0]).toMatchObject({ checksStatus: "passing", previewUrl });
+
+      // 3. The already-open dialog repainted from the push: green checks, and a
+      //    preview control for the url. The probe can't reach a fake
+      //    `*.deco.site` from CI, so the control renders in its unavailable
+      //    form — either label proves `previewUrl` reached the UI.
+      await expect(page.getByText("Checks passing")).toBeVisible({
+        timeout: 15_000,
+      });
+      await expect(
+        page.getByRole("button", { name: /Open preview|Preview unavailable/ }),
+      ).toBeVisible({ timeout: 15_000 });
+    } finally {
+      await github.stop();
+    }
+  });
+
+  test("an issue_comment on a PR refreshes it; one on a plain issue does not", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const request = page.context().request;
+
+    const repoOwner = "acme-e2e";
+    const repoName = `commented-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const prNumber = 77;
+    const prUrl = `https://github.com/${repoOwner}/${repoName}/pull/${prNumber}`;
+    const previewUrl = `https://${repoName}.deco.site`;
+
+    const state = { ciDone: true };
+    const github = await startGithubMcp(state, previewUrl);
+    try {
+      await createGithubConnection(request, orgSlug, github.url);
+      const { item } = await callSelfMcpTool<{ item: TaskBoardItem }>(
+        request,
+        orgSlug,
+        "TASK_BOARD_ITEM_CREATE",
+        { title: "Commented card", status: "in_review", prUrl },
+      );
+      expect(item.id).toBeTruthy();
+
+      const repository = { name: repoName, owner: { login: repoOwner } };
+      const onPr = await postWebhook(request, "issue_comment", {
+        action: "created",
+        repository,
+        issue: { number: prNumber, pull_request: { url: "https://api/x" } },
+      });
+      expect(await onPr.json()).toMatchObject({ ok: true, refreshed: 1 });
+
+      // No `pull_request` key: a comment on a plain issue names no PR, so the
+      // reverse lookup must not run on the issue number as if it were one.
+      const onIssue = await postWebhook(request, "issue_comment", {
+        action: "created",
+        repository,
+        issue: { number: prNumber },
+      });
+      expect(await onIssue.json()).toMatchObject({
+        ok: true,
+        ignored: "shape",
+      });
+    } finally {
+      await github.stop();
+    }
+  });
+
+  test("rejects a bad signature, ignores unhandled events and unlinked PRs", async ({
+    authedPage,
+  }) => {
+    const request = authedPage.page.context().request;
+    const repository = {
+      name: "nobody-links-me",
+      owner: { login: "acme-e2e" },
+    };
+
+    // The route's only authentication is the HMAC — a wrong one is a 400, and
+    // must not be treated as an unsigned-but-harmless ping.
+    const forged = await postWebhook(
+      request,
+      "check_suite",
+      { repository },
+      "sha256=" + "0".repeat(64),
+    );
+    expect(forged.status()).toBe(400);
+
+    // An event nobody consumes is a 200: GitHub retries non-2xx, and there is
+    // nothing here to retry.
+    const unhandled = await postWebhook(request, "star", { repository });
+    expect(unhandled.status()).toBe(200);
+    expect(await unhandled.json()).toMatchObject({ ignored: "event" });
+
+    // A real event for a repo no card links: the indexed lookup finds nothing
+    // and the delivery still succeeds. This is the common case in prod, where
+    // the App is installed on far more repos than the board tracks.
+    const unlinked = await postWebhook(request, "check_suite", {
+      action: "completed",
+      repository,
+      check_suite: { pull_requests: [{ number: 1 }] },
+    });
+    expect(await unlinked.json()).toMatchObject({ ok: true, refreshed: 0 });
+  });
+});

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -466,6 +466,15 @@ export const TASK_BOARD_ITEM_UPDATED_EVENT = "task-board.item.updated";
 export const TASK_BOARD_ITEM_DELETED_EVENT = "task-board.item.deleted";
 
 /**
+ * Org-scoped SSE event pushed on `sseHub` whenever a task's linked PR cards are
+ * re-read from GitHub because a webhook said they changed — CI finished, or a
+ * deploy bot commented. Its `data` is `{ id, prs }` (the task id and the fresh
+ * cards); the open task dialog writes them straight into its react-query cache,
+ * so checks and the preview url land without waiting for the next poll.
+ */
+export const TASK_BOARD_ITEM_PRS_UPDATED_EVENT = "task-board.item.prs.updated";
+
+/**
  * Cap on the org's task system prompt. It rides in the system prompt of EVERY
  * task run, so an unbounded textarea is a per-run token bill. Shared so the
  * settings tool rejects what the textarea already refuses.

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -378,8 +378,8 @@ export interface StudioToolIO {
         dueDate: string | null;
         sortOrder: number;
         keySeq: number | null;
-        previewRoutes: string[];
         externalUrl: string | null;
+        previewRoutes: string[];
         source: "jira" | null;
         retryAttempts: number;
         reviewCycleStartedAt: string | null;
@@ -448,8 +448,8 @@ export interface StudioToolIO {
         dueDate: string | null;
         sortOrder: number;
         keySeq: number | null;
-        previewRoutes: string[];
         externalUrl: string | null;
+        previewRoutes: string[];
         source: "jira" | null;
         retryAttempts: number;
         reviewCycleStartedAt: string | null;
@@ -545,8 +545,8 @@ export interface StudioToolIO {
         dueDate: string | null;
         sortOrder: number;
         keySeq: number | null;
-        previewRoutes: string[];
         externalUrl: string | null;
+        previewRoutes: string[];
         source: "jira" | null;
         retryAttempts: number;
         reviewCycleStartedAt: string | null;
@@ -626,6 +626,7 @@ export interface StudioToolIO {
         repoOwner: string;
         repoName: string;
         createdAt: string;
+        updatedAt: string | null;
         title: string | null;
         body: string | null;
         state: "open" | "closed" | null;


### PR DESCRIPTION
## The problem

Checks go green on GitHub and the deploy bot posts a preview url, but the card
shows neither for **1–3 minutes**. Nothing is stuck — every layer is one window
behind, and the windows stack:

| layer | window |
|---|---|
| card cache (`DECOCMS_PR_CARDS`) | 30s |
| raw reads (`get_status`, `get_check_runs`, `get_comments`) | 55s |
| dialog poll | 60s |

#7033 zeroed the first two *while CI is pending*, which is the wrong half of the
timeline: the preview comment lands **after** the checks turn green, and at that
instant every layer reverts to its full window.

Turning the polling up further is not the fix — at a 10s poll one open dialog on
a mid-flight PR costs ~30 GitHub calls/min, and an App installation's floor is
5,000/hr (~83/min). Three open dialogs would exceed it, against the same limit
`review-sweeper.ts` says already took the App out once.

## The fix: use the events GitHub already sends

Most of this was already built and dormant:

- The **receiver exists** — `/api/_github/webhook` has been HMAC-verifying `push`
  deliveries for tenant warm pools. It had no consumer for PR-card events.
- The **App already emits** them — `deco-cms` (owner `deco-cx`) subscribes to
  `issue_comment` and `push`; `check_suite` was added for this (it covers
  Cloudflare Pages / Workers Builds, which Actions-only `workflow_run` does not).
- The **SSE lane exists** — `/api/:org/watch`, same hub the board already uses
  for `task-board.item.updated`.

What this PR adds:

1. `check_suite` / `issue_comment` deliveries resolve the PR → its cards via a
   new `findPrLinks`, plus **an index for that lookup** (migration 204 — the
   table's only index was `(organization_id, task_board_item_id)` and its PK
   `(task_board_item_id, url)`, so a repo/number lookup was a full scan on a
   path that fires for every repo the App is installed on).
2. The refresh re-reads GitHub **bypassing the read cache** — the event *is* the
   invalidation, and a 55s-old read is exactly what it supersedes — writes the
   result to the card cache, and emits `task-board.item.prs.updated`.
3. The open dialog writes those cards straight into its query cache. Checks and
   the Preview button land in ~1s.
4. Polling stays as the fallback for repos the App isn't installed on.

## Also: a preview url that only the deploy check knows

Reported alongside: *"sometimes the bot doesn't comment the preview url, but the
info is available on the deploy check."* True — `extractPreviewUrlFromCheckRuns`
only understood `Workers Builds: <name>` + `Version ID:`. Now any deploy check
that prints its url in `output.summary` / `output.text` / `output.title` /
`details_url` counts, successful runs first, still gated through
`isTrustedPreviewHost`. The exact Workers Builds path still wins when present.

## Bounded / reversible

- No secret → the route still answers **503** and everything falls back to
  today's polling. Nothing here is load-bearing until `GITHUB_WEBHOOK_SECRET` is
  deployed.
- An event for a repo no card links costs **one indexed lookup** — the common
  case in prod.
- The poll ladder is unchanged as the fallback, and its preview chase is bounded
  to 10 min past the PR's `updated_at` (a repo that never publishes a preview
  stops costing reads).

## Deploy steps (not code)

1. `GITHUB_WEBHOOK_SECRET` into AWS SM `prod/studio/application` (us-west-2) —
   ESO syncs it into `deco-studio-secrets` within 1h. **Confirmed missing today:**
   `POST https://studio.decocms.com/api/_github/webhook` → `503 {"error":"github webhook not configured"}`.
2. The same string in the App's *Webhook secret* field, URL pointing at
   `/api/_github/webhook`.

Side effect worth knowing: this switches on the **warm-pool push acceleration**
that has been dormant since it shipped, for the same reason (no secret).

## Testing

**Unit** (`bun test`, 91 pass in the touched files): `prRefsFromGithubEvent`
payload shapes (check_suite fan-out + dedupe, PR comment vs plain-issue comment,
wrong shape); the generalized check-run preview scan (output, details_url,
success-preferred, untrusted host rejected, Workers Builds still wins);
`isCardNotReady` including its bound.

**E2E** — `packages/e2e/tests/task-board-pr-webhook.spec.ts` walks the whole
chain black-box, with GitHub as a local MCP server (the card path reads GitHub
through an `mcp-github` connection, not the REST stub) whose answers flip
mid-test from "CI running, no preview" to "CI passed, url in the deploy check's
output" — and **never** a bot comment:

HMAC-signed delivery → reverse lookup → fresh read → card cache write → SSE push
→ the already-open dialog showing *Checks passing* and a preview control.

Plus: bad signature → 400, unhandled event → 200 ignored, unlinked PR →
`refreshed: 0`, `issue_comment` on a plain issue → not treated as a PR.

Migration 204 verified against real Postgres (`task_board_item_prs_repo_idx`
present after `bun run migrate`).

`bun run fmt`, `bun run lint` (0 errors) and `apps/api` typecheck clean. The 10
failing task-board unit tests are the Postgres-backed ones and fail identically
on `main` in this shell; the 2 remaining `apps/web` type errors are the
pre-existing duplicate-prosemirror ones.

## One open decision

`ciMaxStaleMs` (from the commit before this one) gives a pending read a **zero
stale ceiling**, so a rate-limited `get_status` returns `null` →
`checksStatus: null` → `prReadyForReview` passes → the reviewer gets handed a PR
whose CI is still running. With this webhook path in place that blocking read
buys much less; I'd give it a short ceiling instead of 0, or gate the reconciles
on a positively-live checks answer. Left as-is here — say the word and it's a
two-line follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Task-board PR cards were poll-only, so CI results and preview URLs could appear 1–3 minutes late. This adds GitHub webhook refreshes plus SSE updates so open dialogs receive changes in about a second, while polling remains the fallback.

**New Features**

- Handles signed `check_suite` and `issue_comment` events and refreshes linked cards with uncached GitHub reads; failures are logged and the delivery returns 200, so GitHub doesn't retry transient errors, and one failing card doesn't block the others on the same PR.
- Adds an indexed PR reverse lookup and emits `task-board.item.prs.updated` to update the open dialog immediately.
- Extracts trusted preview URLs from deploy check output and details links, even when no bot comment exists.
- Bounds preview polling to 10 minutes after the PR's last update and never parks pending CI or unenriched card reads.

**Migration**

- Run migration 204 to add `task_board_item_prs_repo_idx`.
- Set `GITHUB_WEBHOOK_SECRET` in AWS Secrets Manager and use the same value for the GitHub App webhook at `/api/_github/webhook`.
- Without the secret, the endpoint returns 503 and existing polling continues; enabling it also activates warm-pool push refreshes.

<sup>Written for commit aa0a028553482d4f02314656d3812507611d2cd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

