### PR TITLE
fix(agents): localize the agent's "created" date

### DIFF
--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -1,4 +1,4 @@
-import { formatDistanceToNow } from "date-fns";
+import { format, formatDistanceToNow } from "date-fns";
 import { ptBR as ptBRLocale } from "date-fns/locale/pt-BR";
 import { generatePrefixedId } from "@decocms/shared/utils/generate-id";
 import {
@@ -1090,11 +1090,7 @@ function VirtualMcpDetailViewWithData({
               <span className="text-muted-foreground/50">·</span>
               <span>
                 {t("virtualMcp.virtualMcp.created")}{" "}
-                {new Date(virtualMcp.created_at).toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                  year: "numeric",
-                })}
+                {format(new Date(virtualMcp.created_at), "PP", { locale })}
               </span>
               <span className="text-muted-foreground/50">·</span>
               <span>


### PR DESCRIPTION
The agent settings header (`apps/web/src/views/virtual-mcp/index.tsx`) shows two dates on the same line: "Last used" via `formatDistanceToNow(..., { locale })`, using the `locale` this component already resolves from `usePreferences()` (pt-BR or undefined), and "Created" via `toLocaleDateString("en-US", ...)`, hardcoded regardless of the user's language.

A pt-BR user sees an English month name ("Sep 8, 2026") right next to a Portuguese relative time ("há 2 horas") in the same metadata row — an inconsistency introduced when the locale-aware `lastUsedAt` line was added but `created_at` was left on its original hardcoded format.

Fix: format `created_at` with date-fns `format(..., "PP", { locale })`, reusing the same `locale` variable the component already computes, instead of a second ad-hoc date formatter.

How to confirm: switch the app language to Portuguese (pt-BR) in preferences, open any agent's settings page, and check the "Created" date now renders in Portuguese month format instead of English.

Checks run locally: `bun run fmt`, `bunx tsc --noEmit` in `apps/web` (no new errors — the one pre-existing unrelated prosemirror-model version-mismatch error is untouched by this file), `bunx oxlint` on the changed file (0 warnings/errors). No unit test exists for this render-only formatting line; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the agent settings header so the "Created" date now renders in the user's language, matching the already-localized "Last used" date. Previously it was hardcoded to English (`en-US`), so pt-BR users saw an English month name next to a Portuguese relative time.

<sup>Written for commit f203ff8abdfa9d2bd5223a25269a22c2a07d1436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

