### PR TITLE
fix(storage): encrypt oauth_config at rest, matching connection_token

### DIFF
--- a/apps/api/src/storage/connection-oauth-config-encryption.test.ts
+++ b/apps/api/src/storage/connection-oauth-config-encryption.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import type { Kysely } from "kysely";
+import { CredentialVault } from "../encryption/credential-vault";
+import { ConnectionStorage } from "./connection";
+import type { Database } from "./types";
+
+describe("ConnectionStorage oauth_config encryption", () => {
+  const vault = new CredentialVault("test-encryption-key-for-unit-tests");
+  const storage = new ConnectionStorage({} as Kysely<Database>, vault);
+  const oauthConfig = {
+    authorizationEndpoint: "https://example.com/authorize",
+    tokenEndpoint: "https://example.com/token",
+    clientId: "client-id",
+    clientSecret: "super-secret",
+    scopes: ["read"],
+    grantType: "authorization_code" as const,
+  };
+
+  it("encrypts oauth_config at rest instead of storing it as plain JSON", async () => {
+    const serialized = await (
+      storage as unknown as {
+        serializeConnection: (
+          data: Record<string, unknown>,
+        ) => Promise<Record<string, unknown>>;
+      }
+    ).serializeConnection({ oauth_config: oauthConfig });
+
+    const stored = serialized.oauth_config as string;
+    expect(stored).not.toContain("super-secret");
+    expect(() => JSON.parse(stored)).toThrow();
+  });
+
+  it("round-trips a freshly encrypted oauth_config on read", async () => {
+    const serialized = await (
+      storage as unknown as {
+        serializeConnection: (
+          data: Record<string, unknown>,
+        ) => Promise<Record<string, unknown>>;
+      }
+    ).serializeConnection({ oauth_config: oauthConfig });
+
+    const deserialized = await (
+      storage as unknown as {
+        deserializeConnection: (
+          row: Record<string, unknown>,
+        ) => Promise<{ oauth_config: unknown }>;
+      }
+    ).deserializeConnection({
+      id: "conn_test",
+      organization_id: "org_test",
+      connection_type: "HTTP",
+      oauth_config: serialized.oauth_config,
+    });
+
+    expect(deserialized.oauth_config).toEqual(oauthConfig);
+  });
+
+  it("falls back to plain JSON for a legacy unencrypted row", async () => {
+    const legacyRow = JSON.stringify(oauthConfig);
+
+    const deserialized = await (
+      storage as unknown as {
+        deserializeConnection: (
+          row: Record<string, unknown>,
+        ) => Promise<{ oauth_config: unknown }>;
+      }
+    ).deserializeConnection({
+      id: "conn_legacy",
+      organization_id: "org_test",
+      connection_type: "HTTP",
+      oauth_config: legacyRow,
+    });
+
+    expect(deserialized.oauth_config).toEqual(oauthConfig);
+  });
+});

--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -45,10 +45,10 @@ import {
 import type { ConnectionStoragePort } from "./ports";
 import type { Database } from "./types";
 
-/** JSON fields that need serialization/deserialization */
+/** JSON fields that need serialization/deserialization. oauth_config is handled
+ * separately below since it's encrypted (it may carry a client secret). */
 const JSON_FIELDS = [
   "connection_headers",
-  "oauth_config",
   "configuration_scopes",
   "metadata",
   "bindings",
@@ -586,6 +586,9 @@ export class ConnectionStorage implements ConnectionStoragePort {
         // Encrypt configuration state
         const stateJson = JSON.stringify(value);
         result[key] = await this.vault.encrypt(stateJson);
+      } else if (key === "oauth_config" && value) {
+        // May carry an OAuth client secret — encrypt like connection_token.
+        result[key] = await this.vault.encrypt(JSON.stringify(value));
       } else if (key === "connection_headers" && value) {
         // For STDIO, encrypt envVars before storing
         const params = value as ConnectionParameters;
@@ -692,6 +695,27 @@ export class ConnectionStorage implements ConnectionStoragePort {
       }
     }
 
+    // Falls back to plain JSON for connections written before encryption.
+    let decryptedOAuthConfig: OAuthConfig | null = null;
+    if (typeof row.oauth_config === "string") {
+      try {
+        decryptedOAuthConfig = JSON.parse(
+          await this.vault.decrypt(row.oauth_config),
+        );
+      } catch {
+        try {
+          decryptedOAuthConfig = JSON.parse(row.oauth_config);
+        } catch (error) {
+          console.error(
+            `Failed to parse oauth_config for connection ${row.id}:`,
+            error,
+          );
+        }
+      }
+    } else {
+      decryptedOAuthConfig = row.oauth_config;
+    }
+
     if (decryptErrors.length > 0) {
       await this.handleDecryptFailures(row, decryptErrors);
     } else if (row.connection_token || row.configuration_state) {
@@ -758,7 +782,7 @@ export class ConnectionStorage implements ConnectionStoragePort {
       connection_url: row.connection_url,
       connection_token: decryptedToken,
       connection_headers: connectionParameters,
-      oauth_config: parseJson<OAuthConfig>(row.oauth_config),
+      oauth_config: decryptedOAuthConfig,
       configuration_state: decryptedConfigState,
       configuration_scopes: parseJson<string[]>(row.configuration_scopes),
       metadata: parseJson<Record<string, unknown>>(row.metadata),


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/storage/connection.ts` (assigned focus area: storage connection layer).

**Why a maintainer wants this:** `OAuthConfigSchema.clientSecret` is a real credential stored on the `connections.oauth_config` column, but `ConnectionStorage` only `JSON.stringify`'d it — every other secret-bearing column on the same row (`connection_token`, `configuration_state`) is already passed through the `CredentialVault` (AES-256-GCM) before being written. Anyone with read access to the `connections` table (a DB backup, a replica, a leaked pg dump) gets OAuth client secrets in plaintext even though the table's own comments (`"oauth_config excluded — contains client secrets and tokens"`) show this was already recognized as sensitive.

**The fix:** `serializeConnection` now encrypts `oauth_config` the same way `connection_token`/`configuration_state` are encrypted. `deserializeConnection` decrypts on read, and if decryption fails it falls back to parsing the value as plain JSON — so rows written before this change (currently plaintext) keep working unchanged and get re-encrypted transparently the next time that connection is updated. No migration needed; this doesn't touch the failure-tracking/auto-disable path used for `connection_token`/`configuration_state`, since a legacy plaintext row failing decrypt once is expected, not a real failure.

**Regression test:** `apps/api/src/storage/connection-oauth-config-encryption.test.ts` (unit, no DB — constructs `ConnectionStorage` with a real `CredentialVault` and a stub `Kysely` handle, since `serializeConnection`/`deserializeConnection` never touch `this.db`) asserts: (1) a serialized `oauth_config` is not valid JSON and doesn't contain the plaintext secret, (2) a freshly-encrypted value round-trips back to the original object, (3) a legacy plain-JSON row still deserializes correctly.

**Reviewer command:** `bun test apps/api/src/storage/connection-oauth-config-encryption.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/storage/connection.ts apps/api/src/storage/connection-oauth-config-encryption.test.ts` (0 warnings/errors), the targeted test above. Full CI validates the rest (including the existing `connection.integration.test.ts` / `connection-credential-vault.integration.test.ts`, which need real Postgres unavailable in this sandbox).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encrypts `oauth_config` at rest so OAuth client secrets are no longer stored as plaintext, matching how `connection_token` and `configuration_state` are already encrypted.

- `serializeConnection` now encrypts `oauth_config` with the `CredentialVault`; `deserializeConnection` decrypts it and falls back to plain JSON for legacy rows.
- Adds a unit test covering encryption, round-trip, and legacy plaintext fallback.

<sup>Written for commit e54968778a827c86faa2e1ead51b9bde04980485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

