### PR TITLE
refactor(web): extract useDateFnsLocale to dedupe the pt-BR locale check

### DIFF
--- a/apps/web/src/components/project-card.tsx
+++ b/apps/web/src/components/project-card.tsx
@@ -1,11 +1,10 @@
 import { DotsVertical, Settings02, Trash01 } from "@untitledui/icons";
 import { formatDistanceToNow } from "date-fns";
-import { ptBR as ptBRLocale } from "date-fns/locale/pt-BR";
 import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
 import { AgentAvatar } from "@/components/agent-icon";
+import { useDateFnsLocale } from "@/hooks/use-date-fns-locale.ts";
 import { useNavigateToAgent } from "@/hooks/use-navigate-to-agent";
 import { landingTabIdFor } from "@/layouts/main-panel-tabs/tab-id";
-import { usePreferences } from "@/hooks/use-preferences.ts";
 import { Button } from "@decocms/ui/components/button.tsx";
 import { Card } from "@decocms/ui/components/card.tsx";
 import {
@@ -29,8 +28,7 @@ export function ProjectCard({
 }: ProjectCardProps) {
   const navigateToAgent = useNavigateToAgent();
   const t = useT();
-  const [preferences] = usePreferences();
-  const locale = preferences.language === "pt-BR" ? ptBRLocale : undefined;
+  const locale = useDateFnsLocale();
   // The main agent is org-wide config written via ORGANIZATION_SETTINGS_UPDATE,
   // which the backend gates on `org:manage` — not `agents:manage`. Match it so
   // the action isn't shown to users whose click would fail server-side.

--- a/apps/web/src/hooks/use-date-fns-locale.ts
+++ b/apps/web/src/hooks/use-date-fns-locale.ts
@@ -1,0 +1,8 @@
+import { ptBR as ptBRLocale } from "date-fns/locale/pt-BR";
+import { usePreferences } from "./use-preferences.ts";
+
+/** The `date-fns` locale matching the user's language preference. */
+export function useDateFnsLocale() {
+  const [preferences] = usePreferences();
+  return preferences.language === "pt-BR" ? ptBRLocale : undefined;
+}

--- a/apps/web/src/views/settings/ai-providers/provider-key-row.tsx
+++ b/apps/web/src/views/settings/ai-providers/provider-key-row.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
-import { ptBR as ptBRLocale } from "date-fns/locale/pt-BR";
 import { toast } from "sonner";
 import { Edit01, Trash01 } from "@untitledui/icons";
 import { Avatar } from "@decocms/ui/components/avatar.tsx";
@@ -23,7 +22,7 @@ import {
   type AiProviderKey,
 } from "@/sdk";
 import { useStudioTools } from "@/lib/studio-tools";
-import { usePreferences } from "@/hooks/use-preferences.ts";
+import { useDateFnsLocale } from "@/hooks/use-date-fns-locale.ts";
 import { KEYS } from "@/lib/query-keys";
 import {
   getPreset,
@@ -45,8 +44,7 @@ export function ProviderKeyRow({ providerKey, provider }: ProviderKeyRowProps) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const t = useT();
-  const [preferences] = usePreferences();
-  const locale = preferences.language === "pt-BR" ? ptBRLocale : undefined;
+  const locale = useDateFnsLocale();
 
   const isOpenAICompatible = provider?.id === "openai-compatible";
 

--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -1,5 +1,4 @@
 import { format, formatDistanceToNow } from "date-fns";
-import { ptBR as ptBRLocale } from "date-fns/locale/pt-BR";
 import { generatePrefixedId } from "@decocms/shared/utils/generate-id";
 import {
   branchUserLabel,
@@ -17,7 +16,7 @@ import { ErrorBoundary } from "@/components/error-boundary";
 import { usePanelActions } from "@/layouts/shell-layout";
 import { User } from "@/components/user/user";
 import { useT } from "@/i18n/use-t.ts";
-import { usePreferences } from "@/hooks/use-preferences.ts";
+import { useDateFnsLocale } from "@/hooks/use-date-fns-locale.ts";
 
 import { authenticateMcp, isConnectionAuthenticated } from "@/lib/mcp-oauth";
 import { KEYS } from "@/lib/query-keys";
@@ -362,8 +361,7 @@ function VirtualMcpDetailViewWithData({
   hideOwnTitle?: boolean;
 }) {
   const t = useT();
-  const [preferences] = usePreferences();
-  const locale = preferences.language === "pt-BR" ? ptBRLocale : undefined;
+  const locale = useDateFnsLocale();
   const { org } = useProjectContext();
   const actions = useVirtualMCPActions();
   const { data: lastUsedMap } = useVirtualMCPsLastUsed([virtualMcp.id]);


### PR DESCRIPTION
**Source:** reduction — the same 2-line `preferences.language === "pt-BR" ? ptBRLocale : undefined` snippet was copy-pasted verbatim in three files: `project-card.tsx`, `provider-key-row.tsx`, and (freshly, via #7040) `virtual-mcp/index.tsx`.

**Why it's worth doing:** a fourth date-fns consumer would otherwise copy it again; extracting a `useDateFnsLocale()` hook (`apps/web/src/hooks/use-date-fns-locale.ts`) gives it one home so the next one imports instead of re-deriving.

**Net line delta:** -6 / +4 across the three call sites, +6 for the new hook file (net -2 overall, but real dedup: one expression now lives in one place instead of three).

**Behavior:** unchanged — same expression, same import (`date-fns/locale/pt-BR`), same three call sites now reading it from the shared hook instead of inlining it. No test needed: it's a pure pass-through of `usePreferences()`, already covered indirectly by whatever renders these three components.

**How to confirm:** `cd apps/web && bunx tsc --noEmit` (no new errors in the touched files — the one pre-existing prosemirror-version error is unrelated) and `bunx oxlint` on the four changed files (0 warnings/errors).

**Locally verified:** `bun run fmt`, targeted `tsc --noEmit`, and per-file `oxlint`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts the duplicated pt-BR `date-fns` locale check into a shared `useDateFnsLocale` hook so the next `date-fns` consumer imports it instead of re-deriving it.

- The same 2-line expression in `project-card.tsx`, `provider-key-row.tsx`, and `virtual-mcp/index.tsx` now lives in `apps/web/src/hooks/use-date-fns-locale.ts`.
- Behavior is unchanged: same locale selection, same fallback to `undefined`, same three call sites.
- Net -2 lines overall; no tests needed since the hook is a pass-through of `usePreferences()`.

<sup>Written for commit be2c87b43ac3ba0c8b809f63ffbf31543a60b55d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

