### PR TITLE
fix(dev-assets): reuse the shared sanitizeKey instead of a weaker local copy

### DIFF
--- a/apps/api/src/api/routes/dev-assets.test.ts
+++ b/apps/api/src/api/routes/dev-assets.test.ts
@@ -1,7 +1,7 @@
 import { createHmac } from "node:crypto";
 import { describe, expect, test } from "bun:test";
 import { getSettings } from "../../settings";
-import { verifySignature } from "./dev-assets";
+import { getFilePath, verifySignature } from "./dev-assets";
 
 function sign(
   orgId: string,
@@ -45,5 +45,18 @@ describe("verifySignature", () => {
     expect(
       verifySignature("org_1", "logo.png", 9999999999, "PUT", signature),
     ).toBe(false);
+  });
+});
+
+describe("getFilePath", () => {
+  test("keeps a percent-encoded traversal key contained under the org dir", () => {
+    const path = getFilePath("org_1", "%2e%2e/%2e%2e/etc/passwd");
+    expect(path.startsWith("data/assets/org_1")).toBe(true);
+    expect(path).not.toContain("..");
+  });
+
+  test("resolves a literal traversal key back under the org dir", () => {
+    const path = getFilePath("org_1", "../../../etc/passwd");
+    expect(path.startsWith("data/assets/org_1")).toBe(true);
   });
 });

--- a/apps/api/src/api/routes/dev-assets.ts
+++ b/apps/api/src/api/routes/dev-assets.ts
@@ -17,6 +17,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { StudioContext } from "../../core/studio-context";
 import { getSettings } from "../../settings";
+import { sanitizeKey } from "../../object-storage/key-utils";
 import { safeEqual } from "./credential-vault";
 
 // Base directory for dev assets (relative to cwd)
@@ -36,18 +37,13 @@ function getOrgAssetsDir(orgId: string): string {
 }
 
 /**
- * Sanitize a file key to prevent directory traversal
+ * Get the full file path for a key within an org's assets.
+ * Uses the same `sanitizeKey` as DevObjectStorage (which mints the signed
+ * URLs this route serves) so a key that reaches the filesystem here has had
+ * percent-encoded traversal sequences decoded and stripped, not just a
+ * literal ".." substring removed.
  */
-function sanitizeKey(key: string): string {
-  // Remove leading slashes and normalize path
-  const normalized = key.replace(/^\/+/, "").replace(/\.\./g, "");
-  return normalized;
-}
-
-/**
- * Get the full file path for a key within an org's assets
- */
-function getFilePath(orgId: string, key: string): string {
+export function getFilePath(orgId: string, key: string): string {
   const baseDir = getOrgAssetsDir(orgId);
   const sanitizedKey = sanitizeKey(key);
   return join(baseDir, sanitizedKey);


### PR DESCRIPTION
**Source:** a reduction/hardening found reviewing `apps/api/src/tools/connection/dev-assets.ts` and its sibling helpers (this tick's focus area). `apps/api/src/api/routes/dev-assets.ts` (the HTTP routes that serve the presigned dev-assets URLs) had its own hand-rolled `sanitizeKey` that only strips a literal `".."` substring, duplicating — and weakening — the `sanitizeKey` already in `object-storage/key-utils.ts`, which the very same feature's `DevObjectStorage` uses to build the keys these routes sign. The shared version decodes percent-encoded sequences before resolving path segments; the local copy didn't, so a key like `"%2e%2e/etc/passwd"` has no literal `".."` for the naive regex to catch (Hono's own path decoding doesn't unescape `%2f`, so this wasn't reachable through a normal request today, but it's a real gap in defense-in-depth and a real duplication either way).

**Payoff:** one sanitize implementation instead of two divergent ones for the same trust boundary (an externally-supplied file key feeding a filesystem path) — the next person who touches file-key handling only has one function to get right.

**Change:** `dev-assets.ts` now imports `sanitizeKey` from `object-storage/key-utils.ts` and drops its local copy; `getFilePath` is exported for testing. Net diff: -1 function (12 lines removed), +2 regression tests (one percent-encoded traversal key, one plain literal-`".."` key), both asserting the resolved path stays under the org's asset directory.

**Reviewer check:** `bun test apps/api/src/api/routes/dev-assets.test.ts` (6 pass, including the 2 new cases).

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test file above, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the dev-assets route's local `sanitizeKey` (which only stripped literal `..` substrings) with the shared `sanitizeKey` from `object-storage/key-utils.ts`. The shared version also decodes percent-encoded sequences, closing a path-traversal gap that the local copy missed. Exports `getFilePath` and adds two regression tests for encoded and literal traversal keys.

<sup>Written for commit edf1a8fed5d233831bb3915927f6aab86b5a2bbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

