### PR TITLE
fix(core): cap the x-studio-properties header before it lands in monitoring logs

### DIFF
--- a/apps/api/src/core/context-factory.ts
+++ b/apps/api/src/core/context-factory.ts
@@ -83,12 +83,19 @@ import { readStudioHeader } from "./studio-headers";
 // Helper Functions
 // ============================================================================
 
+const MAX_PROPERTIES_COUNT = 50;
+const MAX_PROPERTY_STRING_LENGTH = 500;
+
 /**
  * Parse the Studio properties header into a Record<string, string>.
  * The header value should be a JSON object with string values.
  * Returns undefined if the header is missing, empty, or invalid.
+ *
+ * Capped at MAX_PROPERTIES_COUNT entries / MAX_PROPERTY_STRING_LENGTH chars
+ * each — this unsigned, caller-set header lands verbatim in the monitoring
+ * log's `properties` column on every request (see mergeProperties).
  */
-function parsePropertiesHeader(
+export function parsePropertiesHeader(
   headerValue: string | null | undefined,
 ): Record<string, string> | undefined {
   if (!headerValue) return undefined;
@@ -106,7 +113,12 @@ function parsePropertiesHeader(
     // Validate all values are strings
     const result: Record<string, string> = {};
     for (const [key, value] of Object.entries(parsed)) {
-      if (typeof value === "string") {
+      if (Object.keys(result).length >= MAX_PROPERTIES_COUNT) break;
+      if (
+        typeof value === "string" &&
+        key.length <= MAX_PROPERTY_STRING_LENGTH &&
+        value.length <= MAX_PROPERTY_STRING_LENGTH
+      ) {
         result[key] = value;
       }
     }

--- a/apps/api/src/core/parse-properties-header.test.ts
+++ b/apps/api/src/core/parse-properties-header.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { parsePropertiesHeader } from "./context-factory";
+
+describe("parsePropertiesHeader", () => {
+  it("parses a valid JSON object of strings", () => {
+    expect(parsePropertiesHeader('{"a":"1","b":"2"}')).toEqual({
+      a: "1",
+      b: "2",
+    });
+  });
+
+  it("returns undefined for missing/empty/invalid input", () => {
+    expect(parsePropertiesHeader(null)).toBeUndefined();
+    expect(parsePropertiesHeader("")).toBeUndefined();
+    expect(parsePropertiesHeader("not json")).toBeUndefined();
+    expect(parsePropertiesHeader("[]")).toBeUndefined();
+    expect(parsePropertiesHeader("null")).toBeUndefined();
+  });
+
+  it("drops an oversized key/value instead of persisting it", () => {
+    const huge = "x".repeat(501);
+    expect(
+      parsePropertiesHeader(JSON.stringify({ [huge]: "ok" })),
+    ).toBeUndefined();
+    expect(parsePropertiesHeader(JSON.stringify({ ok: huge }))).toBeUndefined();
+  });
+
+  it("caps the number of entries an attacker-controlled header can inject", () => {
+    const many: Record<string, string> = {};
+    for (let i = 0; i < 200; i++) many[`k${i}`] = "v";
+
+    const result = parsePropertiesHeader(JSON.stringify(many));
+    expect(Object.keys(result ?? {}).length).toBe(50);
+  });
+});


### PR DESCRIPTION
**Source:** hardening gap found while auditing `apps/api/src/core/context-factory.ts` for resilience/validation gaps (assigned focus area this tick).

**Payoff:** `parsePropertiesHeader` accepted any JSON object off the unsigned, caller-controlled `x-studio-properties` header with no bound on entry count or string length. Its parsed output is persisted verbatim into the monitoring log's `properties` JSON column on *every* proxied request (`mergeProperties` in `apps/api/src/mcp-clients/outbound/transports/monitoring.ts`), so a single request could inject an unbounded number of oversized keys/values into that column forever — the same class of gap the repo has already closed elsewhere (`MAX_TASK_DESCRIPTION_LENGTH`, `MAX_COMMENT_BODY_LENGTH`, `MAX_SECRET_VALUE_LENGTH`, etc).

**Fix:** cap `parsePropertiesHeader` at 50 entries / 500 chars per key or value (`MAX_PROPERTIES_COUNT` / `MAX_PROPERTY_STRING_LENGTH`). Over-limit entries are silently dropped, same behavior the function already had for a wrong-typed value — no behavior change for any request under the caps.

**Test:** `apps/api/src/core/parse-properties-header.test.ts` (new) exercises the valid/invalid/empty branches (previously untested — the function was module-private) plus the new count and length caps. Exported `parsePropertiesHeader` from `context-factory.ts` to test it directly, matching the existing pattern for `isOnBehalfOfTokenOrgAllowed` in the same file.

**Reviewer check:** `cd apps/api && bun test src/core/parse-properties-header.test.ts`

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test above, and `bunx oxlint` on both changed files — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the `x-studio-properties` header to 50 entries and 500 characters per key/value so attacker-controlled payloads can't be unboundedly written into the monitoring log's `properties` column. Entries over the limits are dropped, so any request under the caps is unaffected.

- Adds tests covering the new caps and the existing valid/invalid parsing branches.

<sup>Written for commit 96ab7e988b573b03901014936193f229da4b11e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

