### PR TITLE
fix(agents): hide retired Agent Manager from the projects menu

### DIFF
--- a/apps/api/src/tools/virtual/studio-pack/index.ts
+++ b/apps/api/src/tools/virtual/studio-pack/index.ts
@@ -1,4 +1,7 @@
-import { WellKnownOrgMCPId } from "@decocms/shared/sdk";
+import {
+  RETIRED_STUDIO_PACK_AGENT_ID_PREFIXES,
+  WellKnownOrgMCPId,
+} from "@decocms/shared/sdk";
 import type { VirtualMCPStorage } from "@/storage/virtual";
 import type { StudioContext } from "@/core/studio-context";
 import type { VirtualMCPEntity } from "../schema";
@@ -33,11 +36,7 @@ export type {
  * the org's agents page. Deleting a virtual MCP also deletes its threads —
  * intentional here: these are system-managed board-management chats.
  */
-const RETIRED_AGENT_ID_PREFIXES = [
-  "studio-task-manager_",
-  // Its tools are Super Agent built-ins now (`built-in-tools/agent-tools.ts`).
-  "studio-agent-manager_",
-];
+const RETIRED_AGENT_ID_PREFIXES = RETIRED_STUDIO_PACK_AGENT_ID_PREFIXES;
 
 export const STUDIO_PACK_AGENTS = [
   brandManagerAgent,

--- a/apps/web/src/hooks/use-project-scope.ts
+++ b/apps/web/src/hooks/use-project-scope.ts
@@ -13,6 +13,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
 import {
   isDecopilot,
+  isRetiredStudioPackAgent,
   isStudioPackAgent,
   useVirtualMCPNonBlocking,
   useVirtualMCPsNonBlocking,
@@ -42,7 +43,8 @@ export function scopableProjects(
     (project) =>
       !devIds.has(project.id) &&
       !isDecopilot(project.id) &&
-      !isStudioPackAgent(project.id),
+      !isStudioPackAgent(project.id) &&
+      !isRetiredStudioPackAgent(project.id),
   );
 }
 

--- a/packages/shared/src/sdk/lib/constants.ts
+++ b/packages/shared/src/sdk/lib/constants.ts
@@ -455,6 +455,33 @@ export function isStudioPackAgent(id: string | null | undefined): boolean {
   );
 }
 
+/**
+ * Retired Studio Pack agent ID prefixes: agents that used to be installed
+ * per-org but no longer exist. Their rows linger in orgs that once had them
+ * (the backfill that deletes them is version-gated), so the UI must keep
+ * hiding them as scaffolding even though they are no longer part of the pack.
+ */
+export const RETIRED_STUDIO_PACK_AGENT_ID_PREFIXES = [
+  "studio-agent-manager_",
+  "studio-task-manager_",
+] as const;
+
+const retiredStudioPackAgentPrefixes =
+  RETIRED_STUDIO_PACK_AGENT_ID_PREFIXES.map(createWellKnownAgentPrefix);
+
+/**
+ * Check if a connection or virtual MCP ID is a retired Studio Pack agent whose
+ * leftover row should be hidden from users.
+ */
+export function isRetiredStudioPackAgent(
+  id: string | null | undefined,
+): boolean {
+  if (!id) return false;
+  return retiredStudioPackAgentPrefixes.some(
+    (prefix) => prefix.is(id) !== null,
+  );
+}
+
 export function getWellKnownDecopilotConnection(
   organizationId: string,
 ): ConnectionEntity {


### PR DESCRIPTION
## Summary

The **Agent Manager** project shows up in the "Projetos" sidebar for orgs that once had it installed, even though it was retired in #7027.

**Why:** Agent Manager was a per-org Studio Pack agent (id `studio-agent-manager_<orgId>`). Its retirement (#7027) did two things:
1. Removed `studio-agent-manager_` from `studioPackAgentPrefixes`, so `isStudioPackAgent()` no longer recognizes it as plumbing → `scopableProjects` stops hiding it and it surfaces in the sidebar.
2. Added the delete to the install/backfill flow — but **without bumping `INSTALL_VERSION`** (still `v6`). DBOS OAOO dedup skips the already-completed `install-studio-pack:v6:<orgId>` run for existing orgs, so the leftover row is never deleted.

Result: every org that ever had Agent Manager installed still has its own undeleted row, now leaking into the menu.

## Change

This is the **UI defense** (hides it immediately for everyone, regardless of whether the deletion backfill runs):

- `packages/shared`: new shared source of truth `RETIRED_STUDIO_PACK_AGENT_ID_PREFIXES` (`studio-agent-manager_`, `studio-task-manager_`) + `isRetiredStudioPackAgent()`.
- `apps/web`: `scopableProjects()` now also filters `isRetiredStudioPackAgent`, so residual rows stay hidden from the projects sidebar/switcher.
- `apps/api`: the studio-pack `RETIRED_AGENT_ID_PREFIXES` now imports the same shared constant, so web and api can't drift.

## Not included (deliberate)

The root-cause backend cleanup — bumping `INSTALL_VERSION` to `v7` so the backfill actually deletes the rows — is intentionally left out, because that re-runs the install workflow for all orgs and deletes the retired agents' threads. Can be a follow-up if we want the DB rows gone too.

## Testing

- `bun run fmt` ✅
- typecheck (`shared` / `web` / `api`) ✅
- `bun run lint` ✅ (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides retired Studio Pack agents from the projects sidebar so orgs that once had Agent Manager installed no longer see its leftover row in the menu.

- Adds `RETIRED_STUDIO_PACK_AGENT_ID_PREFIXES` and `isRetiredStudioPackAgent()` in `packages/shared` as the single source of truth.
- Filters retired agent IDs out of `scopableProjects()` in `apps/web`.
- Makes `apps/api` import the same shared constant instead of its own list, so web and API can't drift.
- Deliberately leaves the deletion backfill out; it would re-run the install workflow and delete retired agents' threads.

<sup>Written for commit 05ac47195dca31332509edcba19eba92b930f4e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

