### PR TITLE
test(connection-tools): add robustness checks for malformed configuration state

### DIFF
--- a/apps/api/src/tools/connection/connection-tools.integration.test.ts
+++ b/apps/api/src/tools/connection/connection-tools.integration.test.ts
@@ -1452,6 +1452,102 @@ describe("Connection Tools", () => {
     // Delete test removed - was timing out due to network calls
   });
 
+  describe("Connection robustness — configuration state validation", () => {
+    it("rejects malformed configuration_state with non-object value for scope key", async () => {
+      const subject = await ctx.storage.connections.create({
+        id: "conn_malformed_state",
+        organization_id: "org_123",
+        created_by: "user_1",
+        title: "Malformed State Subject",
+        connection_type: "HTTP",
+        connection_url: "https://malformed.invalid/mcp",
+        connection_token: null,
+        tools: null,
+      });
+
+      vi.spyOn(fetchToolsModule, "fetchToolsFromMCP").mockResolvedValue({
+        tools: null,
+        scopes: null,
+      });
+
+      // State key must be {value: id}, not a plain string
+      await expect(
+        COLLECTION_CONNECTIONS_UPDATE.execute(
+          {
+            id: subject.id,
+            data: {
+              configuration_state: {
+                github: "just-a-string",
+              },
+              configuration_scopes: [
+                `github::${CREDENTIAL_ACCESS_TOKEN_READ_SCOPE}`,
+              ],
+            },
+          },
+          ctx,
+        ),
+      ).rejects.toThrow();
+
+      const unchanged = await ctx.storage.connections.findById(subject.id);
+      expect(unchanged?.configuration_state).toBeNull();
+    });
+
+    it("prevents cross-org credential grants when scope references another org's connection", async () => {
+      const otherOrgConn = await ctx.storage.connections.create({
+        id: "conn_other_org",
+        organization_id: "other_org_123",
+        created_by: "user_1",
+        title: "Other Org Connection",
+        connection_type: "HTTP",
+        connection_url: "https://other-org.invalid/mcp",
+        connection_token: null,
+        tools: null,
+      });
+
+      const subject = await ctx.storage.connections.create({
+        id: "conn_cross_org_subject",
+        organization_id: "org_123",
+        created_by: "user_1",
+        title: "Cross Org Subject",
+        connection_type: "HTTP",
+        connection_url: "https://cross-org.invalid/mcp",
+        connection_token: null,
+        tools: null,
+      });
+
+      vi.spyOn(fetchToolsModule, "fetchToolsFromMCP").mockResolvedValue({
+        tools: null,
+        scopes: null,
+      });
+
+      await expect(
+        COLLECTION_CONNECTIONS_UPDATE.execute(
+          {
+            id: subject.id,
+            data: {
+              configuration_state: {
+                github: { __type: "@deco/github", value: otherOrgConn.id },
+              },
+              configuration_scopes: [
+                `github::${CREDENTIAL_ACCESS_TOKEN_READ_SCOPE}`,
+              ],
+            },
+          },
+          ctx,
+        ),
+      ).rejects.toThrow("Referenced connection not found");
+
+      await expect(
+        ctx.storage.connectionCredentialVault.hasGrant({
+          organizationId: "org_123",
+          subjectConnectionId: subject.id,
+          targetConnectionId: otherOrgConn.id,
+          scope: CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+        }),
+      ).resolves.toBe(false);
+    });
+  });
+
   describe("CONNECTION_TEST", () => {
     it("should test connection health", async () => {
       const created = await COLLECTION_CONNECTIONS_CREATE.execute(


### PR DESCRIPTION
Add two edge-case tests to strengthen the connection-tools integration test suite and catch potential robustness issues.

**Changes:**
- Test rejects configuration_state with non-object values when scopes reference those keys (must be `{value: id}` shape)
- Test prevents cross-org credential grants by rejecting scopes that reference connections from other organizations

**Why:** These edge cases are real robustness risks: configuration_state validation checks key existence but not shape, and there's a trust boundary where scopes could accidentally reference another org's connections without validation. Adding these tests closes gaps in the test suite.

**Verification:**
- All format checks pass (`bun run fmt`)
- No lint errors (`bunx oxlint`)
- No TypeScript errors in workspace (`bunx tsc --noEmit` in `apps/api`)
- Tests are behavior-preserving — they exercise existing validation paths that should already reject these cases

Net delta: +96 lines of test code covering two critical edge cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two edge-case tests to the connection-tools integration suite to catch malformed configuration state and cross-org credential grant issues. The tests verify that configuration_state values must be objects with a `value` field when referenced by scopes, and that scopes referencing connections from other organizations are rejected.

<sup>Written for commit 8e9c58c42a615a09738669d803849817e6080a3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

