### PR TITLE
fix(task-board): show the GitLab icon on a GitLab merge-request card

### DIFF
--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -131,6 +131,8 @@ import {
 } from "./review-status";
 import { formatTimeAgo } from "@/lib/format-time";
 import { GitHubIcon } from "@/components/icons/github-icon";
+import { GitLabIcon } from "@/components/icons/gitlab-icon";
+import { parseChangeRequestUrl } from "@decocms/shared/git-providers";
 import { useConnections, useProjectContext } from "@/sdk";
 import { NO_TASKS, useProjectIndex } from "@/hooks/use-project-index";
 import { entryForFilter, stampableEntries } from "@/lib/project-index";
@@ -1905,7 +1907,11 @@ function PrCard({
       )}
     >
       <div className="flex items-center gap-3">
-        <GitHubIcon className="size-4 shrink-0 text-foreground" />
+        {parseChangeRequestUrl(pr.url)?.repo.provider === "gitlab" ? (
+          <GitLabIcon className="size-4 shrink-0 text-foreground" />
+        ) : (
+          <GitHubIcon className="size-4 shrink-0 text-foreground" />
+        )}
         <span className="min-w-0 flex-1 truncate text-sm text-foreground">
           {pr.title ?? `${pr.repoOwner}/${pr.repoName}`}
         </span>


### PR DESCRIPTION
Follows #7022, which made the task board's PR panel provider-neutral (GitHub pull requests and GitLab merge requests). Its `PrCard` component, however, still hardcoded `<GitHubIcon>` for every linked change request, so a GitLab merge request now shows the wrong provider icon on its own card in the task dialog.

A reviewer/user working a mixed-provider org would see a GitHub logo on a card that links to a `gitlab.com/.../-/merge_requests/N` URL — a visible provider-identity mismatch introduced by the dual-provider work.

Fix: derive the provider from the card's own `pr.url` with the already-shipped `parseChangeRequestUrl` (it already distinguishes `.../pull/N` from `.../-/merge_requests/N` and is covered by `packages/shared/src/git-providers/change-request-ref.test.ts`), and render `GitLabIcon` vs `GitHubIcon` accordingly. No backend/schema change needed — the URL already carries the host, so this is a pure frontend fix.

To confirm: open a task with both a GitHub PR and a GitLab MR linked; each card now shows its own provider's icon instead of both showing GitHub's.

Checks run locally: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean on this file — the only tsc error in the workspace is a pre-existing, unrelated prosemirror version-mismatch error in `mention-suggestion.tsx`), `bunx oxlint apps/web/src/layouts/task-board/task-dialog.tsx` (0 warnings/errors). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the task board's PR card so GitLab merge requests show the GitLab icon instead of the GitHub icon that was hardcoded for every linked change request. The provider is now derived from the card's own URL via the existing `parseChangeRequestUrl`, so each card shows the icon matching its actual provider — no backend changes needed.

<sup>Written for commit b0496b1b37ff6bb16898879b9278c5c908b4d29b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

