### PR TITLE
fix(file-storage): retry transient tarball fetch failures during repo sync

### DIFF
--- a/apps/api/src/file-storage/skill-set-sync.test.ts
+++ b/apps/api/src/file-storage/skill-set-sync.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import {
+  isRetriableTarballError,
   isUpToDate,
   parseTar,
   planVolumeTree,
   staleDirs,
+  TarballHttpError,
   tarballRequestFor,
 } from "./skill-set-sync";
 
@@ -178,5 +180,30 @@ describe("tarballRequestFor", () => {
     expect(tarballRequestFor("acme/widget", "feat/x").url).toBe(
       "https://codeload.github.com/acme/widget/tar.gz/feat%2Fx",
     );
+  });
+});
+
+describe("isRetriableTarballError", () => {
+  it("retries codeload 5xx and 429", () => {
+    expect(isRetriableTarballError(new TarballHttpError(503, "x"))).toBe(true);
+    expect(isRetriableTarballError(new TarballHttpError(429, "x"))).toBe(true);
+  });
+
+  it("does not retry a 4xx (bad ref, missing repo, expired token)", () => {
+    expect(isRetriableTarballError(new TarballHttpError(404, "x"))).toBe(false);
+    expect(isRetriableTarballError(new TarballHttpError(401, "x"))).toBe(false);
+  });
+
+  it("does not retry a size-cap refusal", () => {
+    expect(
+      isRetriableTarballError(new Error("tarball for x declares 999 bytes")),
+    ).toBe(false);
+    expect(
+      isRetriableTarballError(new Error("tarball for x exceeds 999 bytes")),
+    ).toBe(false);
+  });
+
+  it("retries an unclassified network error (reset, DNS, timeout)", () => {
+    expect(isRetriableTarballError(new TypeError("fetch failed"))).toBe(true);
   });
 });

--- a/apps/api/src/file-storage/skill-set-sync.ts
+++ b/apps/api/src/file-storage/skill-set-sync.ts
@@ -16,6 +16,7 @@
 import { createHash } from "node:crypto";
 import { gunzipSync } from "node:zlib";
 import type { Kysely } from "kysely";
+import { retry, RetryError } from "@decocms/shared/std";
 import type { Database } from "../storage/types";
 import { OrgFsEntryStorage } from "../storage/org-fs";
 import {
@@ -193,6 +194,37 @@ async function readTarballStream(
   return out;
 }
 
+/** A non-2xx tarball response, carrying the status so retry can classify it. */
+export class TarballHttpError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "TarballHttpError";
+  }
+}
+
+/**
+ * Whether a tarball fetch failure is worth retrying. A declared/actual
+ * size-cap refusal is permanent (the archive won't shrink). A 4xx (bad ref,
+ * missing repo, expired token) won't resolve either. Everything else —
+ * codeload 5xx/429, and whatever `fetch`/the 60s timeout throw for a reset or
+ * DNS hiccup — is the transient case this exists for.
+ */
+export function isRetriableTarballError(err: unknown): boolean {
+  if (err instanceof TarballHttpError) {
+    return err.status >= 500 || err.status === 429;
+  }
+  if (
+    err instanceof Error &&
+    /declares .* bytes|exceeds .* bytes/.test(err.message)
+  ) {
+    return false;
+  }
+  return true;
+}
+
 /** Fetch `owner/repo@ref` and return files keyed by repo-relative path. */
 async function fetchRepoFiles(
   repo: string,
@@ -200,29 +232,43 @@ async function fetchRepoFiles(
   authToken?: string,
 ): Promise<Map<string, Uint8Array>> {
   const { url, headers } = tarballRequestFor(repo, ref, authToken);
-  // Bound the whole download — a stalled codeload socket would otherwise hang
-  // this sync cycle (and the boot loop's first iteration) indefinitely.
-  const res = await fetch(url, {
-    headers,
-    signal: AbortSignal.timeout(60_000),
-  });
-  if (!res.ok) {
-    throw new Error(
-      `tarball fetch failed for ${repo}@${ref}: HTTP ${res.status}`,
-    );
+  const label = `${repo}@${ref}`;
+  const attempt = async (): Promise<Uint8Array> => {
+    // Bounds the whole download so a stalled codeload socket can't hang this sync cycle.
+    const res = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(60_000),
+    });
+    if (!res.ok) {
+      throw new TarballHttpError(
+        res.status,
+        `tarball fetch failed for ${label}: HTTP ${res.status}`,
+      );
+    }
+    // Refuse before buffering when the server declares the size; the post-download check backstops chunked responses.
+    const declared = Number(res.headers.get("content-length") ?? 0);
+    if (declared > MAX_TARBALL_BYTES) {
+      throw new Error(
+        `tarball for ${label} declares ${declared} bytes (cap ${MAX_TARBALL_BYTES})`,
+      );
+    }
+    return new Uint8Array(await res.arrayBuffer());
+  };
+  try {
+    const gz = await retry(attempt, {
+      maxAttempts: 3,
+      minTimeout: 500,
+      maxTimeout: 4_000,
+      jitter: 0.5,
+      isRetriable: isRetriableTarballError,
+    });
+    return filesFromTarball(gz, label);
+  } catch (err) {
+    if (err instanceof RetryError) {
+      throw err.cause instanceof Error ? err.cause : err;
+    }
+    throw err;
   }
-  // Refuse before buffering when the server declares the size; the
-  // post-download check stays as the backstop for chunked responses.
-  const declared = Number(res.headers.get("content-length") ?? 0);
-  if (declared > MAX_TARBALL_BYTES) {
-    throw new Error(
-      `tarball for ${repo}@${ref} declares ${declared} bytes (cap ${MAX_TARBALL_BYTES})`,
-    );
-  }
-  return filesFromTarball(
-    new Uint8Array(await res.arrayBuffer()),
-    `${repo}@${ref}`,
-  );
 }
 
 /**


### PR DESCRIPTION
Bug found while auditing file-storage sync reliability (org-repo-sync.ts / skill-set-sync.ts) per this tick's focus area.

Both org-repo-sync and the public skill-set sync share `fetchRepoFiles` in `skill-set-sync.ts` for the anonymous/legacy-token GitHub codeload path. It fired exactly one fetch and let any transient codeload 5xx/429 or network blip (reset, DNS hiccup, the 60s timeout) fail the whole sync tick — landing in `last_sync_error` on the config row even though the same request would very likely succeed a moment later.

Why a maintainer wants this: these syncs run on an unattended DBOS schedule; a transient codeload hiccup shouldn't need a human to notice `last_sync_error` and manually re-trigger `ORG_REPO_SYNC_RUN`/`ORG_FS_PUBLIC_SETS_SYNC` — the next scheduled tick would just hit the same one-shot fetch and fail again if the org happens to sync during a bad window.

Fix: `fetchRepoFiles` now retries (3 attempts, exponential backoff with jitter, via the repo's canonical `@decocms/shared/std` `retry()` — no hand-rolled backoff) only on codeload 5xx/429 and unclassified fetch/timeout errors. A 4xx (bad ref, missing repo, expired token) and the size-cap refusals stay permanent and fail on the first attempt, so a real misconfiguration doesn't burn 3 attempts before surfacing.

Regression test: `apps/api/src/file-storage/skill-set-sync.test.ts` — `isRetriableTarballError` classification (5xx/429 retriable, 4xx and size-cap refusals not, unclassified network errors retriable).

Reviewer check: `cd apps/api && bunx tsc --noEmit && bun test apps/api/src/file-storage/skill-set-sync.test.ts`

Verified locally: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file, and `bunx oxlint` on both changed files. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes tarball fetches during repo sync retry transient errors so a codeload hiccup no longer fails the entire sync tick.

**Retry behavior**
- Retries codeload 5xx/429 and unclassified network errors up to 3 attempts with exponential backoff and jitter.
- 4xx responses (bad ref, missing repo, expired token) and size-cap refusals stay permanent and fail on the first attempt.
- Both `org-repo-sync` and the public skill-set sync use this shared `fetchRepoFiles` path, so the fix covers both.

<sup>Written for commit f58490f6146b86821f9e3e5516c24e69277496c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

