### PR TITLE
fix(virtual-mcp): translate the untitled-project avatar fallback name

### DIFF
--- a/apps/web/src/i18n/en/virtual-mcp.ts
+++ b/apps/web/src/i18n/en/virtual-mcp.ts
@@ -139,6 +139,7 @@ export const virtualMcp = {
   "virtualMcp.subAgentsSection.title": "Sub-projects",
   "virtualMcp.virtualMcp.addConnection": "Add connection",
   "virtualMcp.virtualMcp.agentDeleted": 'Deleted "{title}"',
+  "virtualMcp.virtualMcp.agentNameFallback": "Agent",
   "virtualMcp.virtualMcp.agentNamePlaceholder": "Project name",
   "virtualMcp.virtualMcp.authenticationFailed":
     "Authentication failed: {error}",

--- a/apps/web/src/i18n/pt-br/virtual-mcp.ts
+++ b/apps/web/src/i18n/pt-br/virtual-mcp.ts
@@ -142,6 +142,7 @@ export const virtualMcp = {
   "virtualMcp.subAgentsSection.title": "Sub-projetos",
   "virtualMcp.virtualMcp.addConnection": "Adicionar conexão",
   "virtualMcp.virtualMcp.agentDeleted": 'Excluído "{title}"',
+  "virtualMcp.virtualMcp.agentNameFallback": "Agente",
   "virtualMcp.virtualMcp.agentNamePlaceholder": "Nome do projeto",
   "virtualMcp.virtualMcp.authenticationFailed":
     "Falha na autenticação: {error}",

--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -990,7 +990,10 @@ function VirtualMcpDetailViewWithData({
                       });
                       flushAndSave();
                     }}
-                    name={form.watch("title") || "Agent"}
+                    name={
+                      form.watch("title") ||
+                      t("virtualMcp.virtualMcp.agentNameFallback")
+                    }
                     size="md"
                     className="shrink-0"
                     avatarClassName="[&_svg]:w-1/2 [&_svg]:h-1/2"


### PR DESCRIPTION
**Source**: hardening/i18n hunt in the Virtual MCP view (`apps/web/src/views/virtual-mcp/index.tsx`) per this tick's focus area.

**Why**: The repo's i18n rule (see `CLAUDE.md`) is "never hardcode user-facing strings in `apps/web/src`" — this one slipped through because it's a prop value (`IconPicker`'s `name`), not obvious JSX text, but it still drives the avatar's rendered fallback initial for a project with no title yet, so it showed up as English ("Agent") regardless of the user's selected language (e.g. pt-BR).

**Fix**: Added a translated `virtualMcp.virtualMcp.agentNameFallback` key ("Agent" / "Agente") to both `en/virtual-mcp.ts` and `pt-br/virtual-mcp.ts`, and swapped the hardcoded `"Agent"` literal in `index.tsx` for `t("virtualMcp.virtualMcp.agentNameFallback")`. `t` was already in scope in that component.

**How to confirm**: Open a new/untitled virtual MCP project with pt-BR selected as the language and check the avatar/icon-picker initial — it should now derive from "Agente" instead of the English "Agent".

**Checks run locally**:
- `bun run fmt` — clean
- `cd apps/web && bunx tsc --noEmit` — no new errors (one pre-existing, unrelated prosemirror-model version-mismatch error in `mention-suggestion.tsx` remains, untouched by this diff)
- `bunx oxlint` on the 3 touched files — 0 warnings/errors

Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the untitled virtual MCP project avatar fallback so it respects the selected language instead of always rendering the English "Agent".

- Adds a `virtualMcp.virtualMcp.agentNameFallback` i18n key to the `en` and `pt-br` locale files.
- Uses `t("virtualMcp.virtualMcp.agentNameFallback")` in the IconPicker's `name` prop when the project title is empty.

<sup>Written for commit 0cba67133fbce2c31e7cd116791d88a771b676a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

