### PR TITLE
refactor(git-providers): dedupe gitlab client's own fetch/error-parsing into the shared http.ts transport

### DIFF
--- a/apps/api/src/git-providers/gitlab/client.ts
+++ b/apps/api/src/git-providers/gitlab/client.ts
@@ -24,8 +24,8 @@ import {
   type TokenOptions,
   type TokenSource,
 } from "../types";
+import { gitlabFailure, gitlabFetch } from "./http";
 
-const REQUEST_TIMEOUT_MS = 15_000;
 /** A whole-repo archive is a download, not a REST call — it needs room to stream. */
 const ARCHIVE_TIMEOUT_MS = 60_000;
 const DEFAULT_PER_PAGE = 30;
@@ -121,60 +121,20 @@ const GitlabUserSchema = z.object({
 });
 type GitlabUser = z.infer<typeof GitlabUserSchema>;
 
-function describeCause(cause: unknown): string {
-  return cause instanceof Error ? cause.message : String(cause);
-}
-
-async function errorMessage(res: Response): Promise<string> {
-  const text = await res.text().catch(() => "");
-  if (!text) return res.statusText || `HTTP ${res.status}`;
-  try {
-    const json = JSON.parse(text) as { message?: unknown; error?: unknown };
-    if (typeof json.message === "string") return json.message;
-    if (typeof json.error === "string") return json.error;
-  } catch {
-    // Not JSON: fall through to the raw body.
-  }
-  return text.slice(0, 200);
-}
-
 /**
- * Authenticated GET against the GitLab API. 404 resolves to null so callers
- * can express "not found" without try/catch; every other non-2xx becomes a
- * `GitProviderError`, with a wait hint when GitLab rate-limited us.
+ * Authenticated GET against the GitLab API via the shared transport. 404
+ * resolves to null so callers can express "not found" without try/catch;
+ * every other non-2xx becomes a `GitProviderError` (`./http`'s `gitlabFailure`
+ * flattens GitLab's various error-body shapes and carries a rate-limit hint).
  */
 async function gitlabRequest(
   url: string,
   token: string,
   init: { accept?: string; timeoutMs?: number } = {},
 ): Promise<Response | null> {
-  let res: Response;
-  try {
-    res = await fetch(url, {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: init.accept ?? "application/json",
-      },
-      signal: AbortSignal.timeout(init.timeoutMs ?? REQUEST_TIMEOUT_MS),
-    });
-  } catch (cause) {
-    throw new GitProviderError({
-      provider: "gitlab",
-      status: 0,
-      message: `GitLab request failed: ${describeCause(cause)}`,
-      cause,
-    });
-  }
+  const res = await gitlabFetch(url, token, init);
   if (res.status === 404) return null;
-  if (!res.ok) {
-    throw new GitProviderError({
-      provider: "gitlab",
-      status: res.status,
-      message: `GitLab API ${res.status}: ${await errorMessage(res)}`,
-      retryAfterMs: res.status === 429 ? gitlabRetryAfterMs(res.headers) : null,
-    });
-  }
+  if (!res.ok) throw await gitlabFailure(res);
   return res;
 }
 


### PR DESCRIPTION
**Source:** reduction (C1) found by auditing `apps/api/src/git-providers/` for duplicated logic.

`gitlab/http.ts` (added in #6939) exists specifically to give every GitLab caller one shared REST transport — its own doc comment says it was extracted because the change-request and content clients would otherwise each restate the same 404-is-null / error-body-flattening rules. But `gitlab/client.ts` (the original owner of that logic) was never migrated over: it kept its own local `gitlabRequest` + `errorMessage` + `describeCause`, a near copy of `http.ts`'s `gitlabFetch` + `gitlabFailure` + `gitlabErrorMessage`.

The local copy is also strictly weaker: it only reads a top-level string `message`/`error` field, while `http.ts`'s `gitlabErrorMessage` flattens GitLab's other real error shapes (`{"message": [...]}` for merge requests, `{"message": {"base": [...]}}` for model validation) — so `GitlabProviderClient` (used for `getRepo`/`listRepos`/`readFile`/`archiveTarball`/`identity`) was surfacing a less complete error message than the change-request and content clients for the exact same kind of GitLab response.

**Payoff:** one fewer hand-rolled fetch/error-parsing implementation to keep in sync, and richer error messages from `GitlabProviderClient` on a non-2xx GitLab response.

**Change:** `gitlab/client.ts`'s local `gitlabRequest` now delegates to the shared `gitlabFetch`/`gitlabFailure` from `./http` instead of re-implementing `fetch` + timeout + error-body parsing; dropped the now-dead local `errorMessage`, `describeCause`, and `REQUEST_TIMEOUT_MS` (already `GITLAB_TIMEOUT_MS = 15_000` in `http.ts`). Net: -47 / +7 lines. Behavior-preserving for the happy path (same URL, token, timeout, 404→null semantics); the only observable difference is more complete error text on a non-2xx response, which is the pre-existing behavior of the other two GitLab clients.

**Verify:** `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/git-providers/gitlab/client.test.ts` (20 pass), `bunx oxlint apps/api/src/git-providers/gitlab/client.ts` (0 warnings/errors).

**Checked locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace), the targeted test file, and per-file oxlint — all green. Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `gitlab/client.ts` to use the shared `gitlabFetch`/`gitlabFailure` transport from `gitlab/http.ts`, removing a near-duplicate fetch/error-parsing implementation. Happy-path behavior (URL, token, timeout, 404→null) is unchanged, but non-2xx responses now surface the full error message—including nested shapes—instead of only a top-level string.

Also drops the now-dead `errorMessage`, `describeCause`, and `REQUEST_TIMEOUT_MS` helpers.

<sup>Written for commit 78188bbceba9bd6209acc99c195cddbb15b0b204. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

