### PR TITLE
fix(storage): correct the migration number in repository_id column comments

### DIFF
--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1640,7 +1640,7 @@ export interface OrgRepoSyncTable {
     string
   >;
   volume: string;
-  /** First-class repository (migration 199); null until backfilled/linked. */
+  /** First-class repository (migration 204); null until backfilled/linked. */
   repository_id: ColumnType<
     string | null,
     string | null | undefined,
@@ -1715,7 +1715,7 @@ export interface TaskBoardItemTable {
   assignee_id: string | null;
   assigned_by: string | null;
   repo: string | null;
-  /** First-class repository (migration 199); null until backfilled/linked. */
+  /** First-class repository (migration 204); null until backfilled/linked. */
   repository_id: ColumnType<
     string | null,
     string | null | undefined,
@@ -1871,7 +1871,7 @@ export interface TaskBoardItemPrTable {
   /** Source GitHub MCP connection, when the PR was opened via MCP. Null for
    *  bash-opened PRs — the live fetcher falls back to the org's shared conn. */
   connection_id: string | null;
-  /** First-class repository (migration 199); null until backfilled/linked. */
+  /** First-class repository (migration 204); null until backfilled/linked. */
   repository_id: string | null;
   created_at: ColumnType<Date, Date | string | undefined, never>;
 }


### PR DESCRIPTION
**Source:** storage-types audit — checked `apps/api/src/storage/types.ts` against the DB schema and recent migrations for drift.

**What's wrong:** three `repository_id` column comments (on `OrgRepoSyncTable`, `TaskBoardItemTable`, `TaskBoardItemPrTable`) say "First-class repository (migration 199)", but migration 199 (`199-drop-jira-mirror-and-org-columns.ts`) only drops columns — it never touches `repository_id`. The column is actually added by migration 204 (`204-git-provider-accounts-and-repositories.ts`, `ADD COLUMN repository_id text REFERENCES repositories(id) ...` on all three tables). A future reader tracing when/why this column exists via `git log`/migration history would land on the wrong migration.

**Fix:** updated the three comments to cite migration 204.

**How I confirmed it:** `grep -n "repository_id" migrations/199-drop-jira-mirror-and-org-columns.ts migrations/204-git-provider-accounts-and-repositories.ts` — 199 has zero hits, 204 has the `ADD COLUMN repository_id` statements for `org_repo_sync`, `task_board_items`, and `task_board_item_prs`.

**Reviewer check:** read the diff — it's a comment-only change, no type or behavior change.

**Local verification:** `bun run fmt` (clean) and `bunx oxlint apps/api/src/storage/types.ts` (0 warnings/errors) on the touched file. No type or test changes, so `tsc`/targeted tests don't apply here; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the migration reference in three `repository_id` column comments from 199 to 204, so readers tracing the column's origin land on the migration that actually adds it. Comment-only change; no behavior impact.

<sup>Written for commit 3fc8b7c6e2534a1b0400677f49051e2237fe2f76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

