### PR TITLE
fix(storage): correct the migration number cited for repositories/git_provider_accounts

### DIFF
--- a/apps/api/src/storage/git-provider-accounts.ts
+++ b/apps/api/src/storage/git-provider-accounts.ts
@@ -7,7 +7,7 @@ import type {
 import type { Database } from "./types";
 
 /**
- * `git_provider_accounts` (migration 199): the credential holder behind every
+ * `git_provider_accounts` (migration 204): the credential holder behind every
  * first-class repository. Every org-facing method takes the organizationId in
  * the WHERE clause — tenancy by construction.
  */

--- a/apps/api/src/storage/repositories.ts
+++ b/apps/api/src/storage/repositories.ts
@@ -9,7 +9,7 @@ import {
 import type { Database } from "./types";
 
 /**
- * `repositories` (migration 199): first-class repos, one row per
+ * `repositories` (migration 204): first-class repos, one row per
  * (org, host, path) case-insensitively. Every org-facing method takes the
  * organizationId in the WHERE clause — tenancy by construction.
  */


### PR DESCRIPTION
Follows the same doc-drift pattern already fixed in #7053 (a wrong migration number in a schema comment).

Both `apps/api/src/storage/repositories.ts` and `apps/api/src/storage/git-provider-accounts.ts` open with a doc comment claiming the table was created in "migration 199". Migration 199 (`199-drop-jira-mirror-and-org-columns.ts`) drops jira mirror/org columns and has nothing to do with either table — both `repositories` and `git_provider_accounts` were actually created in migration 204 (`204-git-provider-accounts-and-repositories.ts`), confirmed by reading that migration directly.

The payoff: these are brand-new tables (merged this week in #7035) and the wrong citation actively misdirects anyone tracing schema history or debugging a backfill issue back to an unrelated migration.

**Verify:** `grep -n 'migration 199' apps/api/src/storage/repositories.ts apps/api/src/storage/git-provider-accounts.ts` now returns nothing; `cat apps/api/migrations/204-git-provider-accounts-and-repositories.ts | head -5` confirms it's the actual origin.

Comment-only change, no logic touched. Ran `bun run fmt` and `bunx oxlint` on both files locally; full CI covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the migration number cited in the `repositories` and `git_provider_accounts` schema comments from 199 to 204, so anyone tracing schema history or debugging a backfill no longer lands on the unrelated jira-mirror migration. Comment-only change, no logic touched.

<sup>Written for commit a5e2d4c2b433768344f3a78f4208fabb20f5400d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

