### PR TITLE
refactor(task-board): dedupe a repeated paragraph in TASK_ADD_REPO's CLI-auth comment

### DIFF
--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -237,13 +237,6 @@ export function parseRepoProbe(stdout: string): {
  * configure `gh` from the primary's remote and leave `glab` unauthenticated.
  * The two providers keep separate config files, so a mixed-provider sandbox
  * ends up with both authenticated; a second host of the SAME provider replaces
- * the first, which is why one provider account per host is the supported shape.
- *
- * Run in the checkout being added, NOT the daemon's default cwd: that is the
- * primary, so a GitLab secondary added to a GitHub sandbox would otherwise
- * configure `gh` from the primary's remote and leave `glab` unauthenticated.
- * The two providers keep separate config files, so a mixed-provider sandbox
- * ends up with both authenticated; a second host of the SAME provider replaces
  * the first, which is why one account per host is the supported shape.
  *
  * The userinfo username tells the two apart, exactly as the daemon does:


### PR DESCRIPTION
Small doc cleanup found while auditing `apps/api/src/tools/task-board/` for the CREATIVE session (task-board tooling is otherwise exhaustively hardened — see prior audit notes; no other gap cleared the bar).

`cliAuthCommand`'s doc comment in `add-repo.ts` had the same explanatory paragraph ("Run in the checkout being added, NOT the daemon's default cwd...") pasted twice back to back, verbatim except for one word ("one provider account per host" vs "one account per host") — a leftover from an edit that refined the wording without deleting the old copy.

Removes the earlier, less-refined copy and keeps the later one. Comment-only, net -7/+0 lines, no behavior change.

How to confirm: `git diff` shows only the duplicate paragraph removed from the JSDoc above `cliAuthCommand` in `apps/api/src/tools/task-board/add-repo.ts`.

Verified locally: `bun run fmt` (clean) and `bunx oxlint apps/api/src/tools/task-board/add-repo.ts` (0 warnings/errors). No types or logic touched, so no targeted test/typecheck was needed; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a duplicated paragraph from the `cliAuthCommand` doc comment in `apps/api/src/tools/task-board/add-repo.ts`, keeping only the refined version. Comment-only change with no behavior impact.

<sup>Written for commit 7e99e793752cf797b26cb13880f0ad707c4e62b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

