### PR TITLE
fix(storage): prune expired oauth_pkce_states rows on create

### DIFF
--- a/apps/api/src/storage/oauth-pkce-states.ts
+++ b/apps/api/src/storage/oauth-pkce-states.ts
@@ -11,6 +11,9 @@ export class OAuthPkceStateStorage {
     organizationId: string,
     userId: string,
   ): Promise<string> {
+    // Prunes abandoned states — consume() is the only other deletion path.
+    await this.deleteExpired(organizationId);
+
     const id = crypto.randomUUID();
     const expiresAt = new Date(Date.now() + STATE_TTL_MS);
 
@@ -27,6 +30,14 @@ export class OAuthPkceStateStorage {
       .execute();
 
     return id;
+  }
+
+  private async deleteExpired(organizationId: string): Promise<void> {
+    await this.db
+      .deleteFrom("oauth_pkce_states")
+      .where("organization_id", "=", organizationId)
+      .where("expires_at", "<", new Date())
+      .execute();
   }
 
   /** Atomically retrieve and delete the verifier (single-use). Validates org/user ownership. */


### PR DESCRIPTION
**Source**: bug found sweeping `apps/api/src/storage` for lingering state — no issue.

**Why**: `oauth_pkce_states` rows are only ever deleted by `consume()`, which runs when an OAuth flow completes. Any abandoned redirect (user never finishes, or a bot/scanner mints a state and never returns) leaves its row in the table forever — unbounded growth with no cap, TTL sweep, or reaper anywhere in the codebase. The table already carries `idx_oauth_pkce_states_expires_at` (migration 038), built for exactly this cleanup, but nothing ever queried it. `GitProviderOAuthStateStorage` (a near-identical single-use OAuth-state table) already does this correctly — it prunes its own org's expired rows on `create()`.

**Fix**: mirror that pattern — `create()` now deletes this org's expired rows (scoped, indexed delete) before inserting the new one.

**How to verify**: `cd apps/api && bunx tsc --noEmit` (green) and `bunx oxlint src/storage/oauth-pkce-states.ts` (0 warnings/errors). No existing unit test covers this file (it's a thin DB-only wrapper — a real test needs Postgres, which isn't available in this environment); full CI will run any integration coverage.

**Local checks run**: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bunx oxlint` on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes expired `oauth_pkce_states` rows on `create()` so abandoned OAuth flows can no longer leave rows that grow the table without bound. Previously rows were only removed by `consume()` when a flow finished; now `create()` deletes the organization's expired rows before inserting a new one, using the existing `expires_at` index. No migration or rollout steps needed.

<sup>Written for commit e676764436e83d6e940850b8da26ec4ce7c44989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

