### PR TITLE
fix(chat): translate the queue-cancel failure toast

### DIFF
--- a/apps/web/src/components/chat/use-message-queue.ts
+++ b/apps/web/src/components/chat/use-message-queue.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from "react";
 import { useProjectContext } from "@/sdk";
 import { toast } from "sonner";
+import { useT } from "@/i18n/use-t.ts";
 import type { QueueItemDTO } from "./queue-items";
 import {
   enqueueMessage,
@@ -36,6 +37,7 @@ export interface MessageQueueActions {
 /** Mutators over the frontend message queue, bound to the active org. */
 export function useMessageQueueActions(): MessageQueueActions {
   const { org } = useProjectContext();
+  const t = useT();
   return {
     enqueue: enqueueMessage,
     refresh: (threadId) => refreshMessageQueue(org.slug, threadId),
@@ -51,8 +53,8 @@ export function useMessageQueueActions(): MessageQueueActions {
           throw new Error(`Cancel failed: ${res.status}`);
         }
         return true;
-      } catch (err) {
-        toast.error(err instanceof Error ? err.message : "Failed to cancel");
+      } catch {
+        toast.error(t("chat.queueTray.cancelFailed"));
         return false;
       } finally {
         await refreshMessageQueue(org.slug, threadId);

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -358,6 +358,7 @@ export const chat = {
   "chat.proposePlan.planReady": "Plan ready",
   "chat.proposePlan.rejected": "Rejected",
   "chat.proposePlan.viewPlan": "View plan",
+  "chat.queueTray.cancelFailed": "Failed to cancel",
   "chat.queueTray.queuedMessage": "{count} queued message",
   "chat.queueTray.queuedMessages": "{count} queued messages",
   "chat.queueTray.removeFromQueue": "Remove from queue",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -367,6 +367,7 @@ export const chat = {
   "chat.proposePlan.planReady": "Plano pronto",
   "chat.proposePlan.rejected": "Rejeitado",
   "chat.proposePlan.viewPlan": "Ver plano",
+  "chat.queueTray.cancelFailed": "Falha ao cancelar",
   "chat.queueTray.queuedMessage": "{count} mensagem na fila",
   "chat.queueTray.queuedMessages": "{count} mensagens na fila",
   "chat.queueTray.removeFromQueue": "Remover da fila",


### PR DESCRIPTION
The composer's QueueTray "remove from queue" action (`useMessageQueueActions().cancel` in `apps/web/src/components/chat/use-message-queue.ts`) showed a raw, hardcoded English string via `toast.error` on failure — either the literal `"Failed to cancel"` fallback, or the client-constructed `Error`'s own English message (`Cancel failed: <status>`, thrown by this same function, not a server-originated string). Every other user-facing string in the queue tray already goes through `t()` (`chat.queueTray.*`), so this was the one string in the flow bypassing i18n — a pt-br user cancelling a queued message during a network hiccup would see English.

Fix: route the failure toast through a new `t("chat.queueTray.cancelFailed")` key (added to both `en/chat.ts` and `pt-br/chat.ts`), and stop surfacing the internal Error's message to the user since it's an implementation detail, not something translatable.

A reviewer can confirm by reading the diff: `use-message-queue.ts`'s `catch` block now calls `t("chat.queueTray.cancelFailed")` instead of branching on `err instanceof Error`.

Verified locally: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean on the touched files — the only pre-existing errors are unrelated prosemirror dependency-version conflicts in `mention-suggestion.tsx`), and `bunx oxlint` on the three changed files (0 warnings/errors). No test added — this is a plain string-routing fix with no logic branch to regress-test. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the queue-cancel failure toast so it shows translated text instead of hardcoded English. The toast now uses the `chat.queueTray.cancelFailed` translation key, and the internal `Error` message is no longer shown to the user.

<sup>Written for commit 9b8d629b4c5c2c9921df38545f96d17f0e2ec911. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

