### PR TITLE
fix(task-board): close a backslash/tab bypass in preview-route validation

### DIFF
--- a/apps/api/src/tools/task-board/preview-routes.test.ts
+++ b/apps/api/src/tools/task-board/preview-routes.test.ts
@@ -24,4 +24,20 @@ describe("normalizePreviewRoutes", () => {
     expect(normalizePreviewRoutes([])).toEqual([]);
     expect(normalizePreviewRoutes(undefined)).toBeUndefined();
   });
+
+  it("drops a backslash-prefixed path `new URL()` would resolve off-origin", () => {
+    // `\` becomes `/` inside `new URL(route, previewUrl)`.
+    expect(new URL("/\\evil.com", "https://trusted.com").hostname).toBe(
+      "evil.com",
+    );
+    expect(normalizePreviewRoutes(["/\\evil.com", "/ok"])).toEqual(["/ok"]);
+  });
+
+  it("drops a tab-smuggled path that resolves to a protocol-relative URL", () => {
+    // A stripped tab collapses "/\t/evil.com" into "//evil.com".
+    expect(new URL("/\t/evil.com", "https://trusted.com").hostname).toBe(
+      "evil.com",
+    );
+    expect(normalizePreviewRoutes(["/\t/evil.com", "/ok"])).toEqual(["/ok"]);
+  });
 });

--- a/apps/api/src/tools/task-board/preview-routes.ts
+++ b/apps/api/src/tools/task-board/preview-routes.ts
@@ -5,9 +5,18 @@ const MAX_ROUTES = 20;
  * The paths a task's work created or edited, as the card can safely use them.
  *
  * Validated here rather than trusted from the caller: each one is joined onto
- * a deploy-preview origin and rendered as a link, so a value that isn't a plain
- * absolute path (`//host`, `https://…`, a relative file path) has to be dropped
- * — it would point the button somewhere other than the preview.
+ * a deploy-preview origin (`new URL(route, previewUrl)`, in the card's
+ * `PreviewButton`) and rendered as a link a reviewer clicks, so a value that
+ * isn't a plain absolute path (`//host`, `https://…`, a relative file path)
+ * has to be dropped — it would point the button somewhere other than the
+ * preview.
+ *
+ * `startsWith("//")` alone isn't enough: the WHATWG URL parser first strips
+ * ASCII tab/CR/LF and rewrites `\` to `/` before resolving, so `"/\evil.com"`
+ * and `"/\t/evil.com"` both become the protocol-relative `"//evil.com"` once
+ * `new URL()` sees them — landing the "Open preview" button on an attacker's
+ * origin instead of the deploy preview. Applying that same normalization here
+ * first is what makes the leading-`//` check catch them too.
  */
 export function normalizePreviewRoutes(
   routes: string[] | undefined,
@@ -15,7 +24,10 @@ export function normalizePreviewRoutes(
   if (routes === undefined) return undefined;
   const cleaned: string[] = [];
   for (const raw of routes) {
-    const route = raw.trim();
+    const route = raw
+      .trim()
+      .replace(/[\t\r\n]/g, "")
+      .replace(/\\/g, "/");
     if (!route.startsWith("/") || route.startsWith("//")) continue;
     if (!cleaned.includes(route)) cleaned.push(route);
     if (cleaned.length === MAX_ROUTES) break;


### PR DESCRIPTION
**Source**: bug found reading `apps/api/src/tools/task-board/preview-routes.ts` (`TASK_BOARD_ITEM_UPDATE`'s `previewRoutes` field) while hunting the task-board tools area for edge-case gaps.

**Why a maintainer wants this**: `normalizePreviewRoutes` exists specifically to keep an attacker-controlled `previewRoutes` entry from resolving off the deploy-preview origin (its own doc comment says so), but its guard — `!startsWith("/") || startsWith("//")` — checks the raw string, while the consumer builds the link with `new URL(route, previewUrl)` (`apps/web/src/layouts/task-board/preview-routes.ts`). The WHATWG URL parser first strips ASCII tab/CR/LF and rewrites `\` to `/` before resolving, so a value like `"/\evil.com"` or `"/\t/evil.com"` sails past the check as a normal absolute path but resolves to `https://evil.com/` once opened. `previewRoutes` is set by an autonomous Super Agent/claude-code run over MCP (`buildClaudeCodeTaskPrompt` tells the model to call `TASK_BOARD_ITEM_UPDATE` with `previewRoutes`), so a prompt-injected or hallucinated value lands a human reviewer's "Open preview" click on an attacker's origin instead of the actual deploy preview.

**Failure scenario**: `TASK_BOARD_ITEM_UPDATE({ id, previewRoutes: ["/\\evil.com"] })` persists the route as-is today; the task-dialog's preview dropdown then renders `<a href={previewRouteUrl(previewUrl, route)}>` which resolves to `https://evil.com/` — an open-redirect a reviewer can click straight from the board. Fixed by applying the same tab/CR/LF-strip + backslash-to-slash normalization the URL parser does *before* the leading-`//` check, so both bypasses are caught and dropped. Regression tests added: `normalizePreviewRoutes(["/\\evil.com", "/ok"])` and `normalizePreviewRoutes(["/\t/evil.com", "/ok"])` now both return `["/ok"]`.

**Verify**: `cd apps/api && bun test src/tools/task-board/preview-routes.test.ts`

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes an open-redirect bypass in task-board preview-route validation. Routes like `"/\evil.com"` and `"/\t/evil.com"` previously passed the validity check but, once built into a preview link with `new URL()`, resolved to an attacker's origin; they're now stripped during normalization.

**Bug Fixes**
- Applies the same tab/CR/LF stripping and backslash-to-slash rewriting that the URL parser does, before the leading-`//` check.
- Adds regression tests covering both bypass patterns.

<sup>Written for commit ee91bf92aa9f1e0fa7c20d9e0ac5e767e6ca74b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

