### PR TITLE
fix(auth): stop a client-set x-caller-id header overriding the JWT connectionId

### DIFF
--- a/apps/api/src/core/context-factory.ts
+++ b/apps/api/src/core/context-factory.ts
@@ -173,6 +173,14 @@ interface AuthenticatedUser {
   role?: string;
 }
 
+/** Prefers the JWT-verified connectionId over the client-set x-caller-id header. */
+export function resolveCallerConnectionId(
+  req: Request | undefined,
+  user: Pick<AuthenticatedUser, "connectionId"> | undefined,
+): string | undefined {
+  return user?.connectionId ?? req?.headers.get("x-caller-id") ?? undefined;
+}
+
 /**
  * Extract the canonical organization slug from an org-scoped API path.
  * Header hints are still supported for legacy, unscoped routes, but the URL
@@ -1498,14 +1506,8 @@ export async function createStudioContextFactory(
         )
       : { user: undefined };
 
-    // Resolve caller connection ID: explicit header takes priority, then fall
-    // back to the connectionId embedded in the studio JWT. This ensures that
-    // management tools on _self see the caller's connection ID even when the
-    // runtime doesn't set x-caller-id.
-    const connectionId =
-      req?.headers.get("x-caller-id") ??
-      authResult.user?.connectionId ??
-      undefined;
+    // The signed JWT's connectionId is authoritative; x-caller-id is a client-set header, only a fallback.
+    const connectionId = resolveCallerConnectionId(req, authResult.user);
 
     // Create bound auth client (encapsulates HTTP headers and auth context)
     const boundAuth = createBoundAuthClient({

--- a/apps/api/src/core/resolve-caller-connection-id.test.ts
+++ b/apps/api/src/core/resolve-caller-connection-id.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { resolveCallerConnectionId } from "./context-factory";
+
+describe("resolveCallerConnectionId", () => {
+  it("prefers the JWT-verified connectionId over a client-set x-caller-id header", () => {
+    const req = new Request("https://studio.test", {
+      headers: { "x-caller-id": "conn_attacker" },
+    });
+    expect(
+      resolveCallerConnectionId(req, { connectionId: "conn_verified" }),
+    ).toBe("conn_verified");
+  });
+
+  it("falls back to the header when there is no authenticated connectionId", () => {
+    const req = new Request("https://studio.test", {
+      headers: { "x-caller-id": "conn_fallback" },
+    });
+    expect(resolveCallerConnectionId(req, undefined)).toBe("conn_fallback");
+  });
+
+  it("returns undefined with no request and no authenticated connectionId", () => {
+    expect(resolveCallerConnectionId(undefined, undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Found while auditing `apps/api/src/mcp-clients/outbound/` for header handling: `outbound/headers.ts` sets `x-caller-id` on *outbound* requests Studio makes to downstream MCP connections, purely so the downstream server knows who's calling. `context-factory.ts` reuses that same header name to resolve `ctx.connectionId` on *incoming* requests to Studio itself — and gave the raw client header priority over the connectionId embedded in the signed Studio JWT.

Nothing in the codebase legitimately sets `x-caller-id` on a request *into* Studio (grepped the whole tree) — it's an outbound-only convention that any caller can freely set on their own HTTP request. `ctx.connectionId` is what `DATABASES_RUN_SQL` (`apps/api/src/tools/database/index.ts`) uses to pick the Postgres schema/role to run SQL in (`app_<connectionId>`), and that tool's own permission check (`ctx.access.check()`) is scoped to `"self"` (the caller's org-wide management permissions), not to the specific connectionId. So any authenticated caller with permission to run `DATABASES_RUN_SQL` could set `x-caller-id: <victim-connection-id>` on their request and run SQL in another connection's isolated schema — a cross-tenant DB access path via header spoofing, not a hypothetical.

Fix: the JWT-verified `connectionId` (`authResult.user.connectionId`, from the signed `studioTokenPayload`) is now authoritative; the client-set header is only a fallback for callers with no JWT-derived identity, matching how every other trust-boundary fix in this repo resolves identity off a verified source instead of a request header. Extracted the one-line priority logic into an exported `resolveCallerConnectionId` so it's unit-testable without spinning up auth/DB.

Trust-boundary test gate: this parses/selects an identity used for both authorization and DB-schema targeting straight from an incoming, otherwise-unauthenticated request header — a textbook trust-boundary case, and the regression covered is a concrete cross-connection DB access vuln, not a display/formatting concern.

Reviewer check: `cd apps/api && bun test src/core/resolve-caller-connection-id.test.ts`

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the new targeted test (3 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI (including `context-factory.integration.test.ts`, which needs Postgres unavailable in this sandbox) will validate the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a header-spoofing vulnerability where a client-set `x-caller-id` header could override the JWT-verified connectionId, letting an authenticated caller run SQL in another connection's isolated schema. The JWT connectionId is now authoritative; the header only serves as a fallback for callers without JWT identity.

**Bug Fixes**
- `resolveCallerConnectionId` now prioritizes the signed JWT's connectionId over the incoming `x-caller-id` header.
- Extracted the priority logic into an exported function for unit testing.
- Added tests covering JWT priority, header fallback, and the no-identity case.

<sup>Written for commit 23fc9fb2015320782994ad11fb8f66a4eef49167. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

