### PR TITLE
docs(self-hosting): document ENCRYPTION_KEY for Docker Compose deploys

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/docker-compose.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/docker-compose.mdx
@@ -33,9 +33,10 @@ The self-host files use a Docker volume for persistence and an automatic `/healt
 git clone https://github.com/decocms/studio.git
 cd studio/deploy/docker-compose
 
-# 2. Create a .env with an auth secret and Postgres credentials
+# 2. Create a .env with an auth secret, a vault key, and Postgres credentials
 cat > .env << EOF
 BETTER_AUTH_SECRET=$(openssl rand -base64 32)
+ENCRYPTION_KEY=$(openssl rand -base64 32)
 POSTGRES_USER=studio_user
 POSTGRES_PASSWORD=$(openssl rand -base64 24)
 POSTGRES_DB=studio_db
@@ -51,7 +52,7 @@ open http://localhost:3000
 The `docker-compose.postgres.yml` file wires `DATABASE_URL` automatically from the `POSTGRES_*` variables, using the `postgres` service as the host.
 
 <Callout type="tip">
-  `BETTER_AUTH_SECRET` falls back to an insecure dev-only default if unset — always set a real one. The `POSTGRES_*` variables also have defaults, but always set a real password.
+  `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` both fall back to insecure dev-only defaults if unset — always set real values for anything shared. The `POSTGRES_*` variables also have defaults, but always set a real password.
 </Callout>
 
 ## Environment variables
@@ -61,6 +62,7 @@ Set these in `.env` alongside the compose file:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `BETTER_AUTH_SECRET` | `local-dev-better-auth-secret-change-me` (insecure) | Authentication secret — always set a real one. Generate with `openssl rand -base64 32` |
+| `ENCRYPTION_KEY` | deterministic dev-only fallback (insecure) | Credential-vault key for encrypting stored secrets/tokens — must stay stable across restarts. Always set a real one for anything shared. |
 | `IMAGE_REPOSITORY` | `ghcr.io/decocms/studio/studio` | Image repository |
 | `IMAGE_TAG` | `latest` | Image tag |
 | `PORT` | `3000` | Port exposed on the host |
@@ -148,6 +150,6 @@ docker compose -f docker-compose.postgres.yml up -d
 
 ## Security
 
-- Always generate a strong `BETTER_AUTH_SECRET` (`openssl rand -base64 32`) and a real `POSTGRES_PASSWORD`.
+- Always generate strong `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` values (`openssl rand -base64 32`) and a real `POSTGRES_PASSWORD`.
 - Don't commit `.env` (`echo ".env" >> .gitignore`; `chmod 600 .env`).
 - Don't commit secrets (client secrets, API keys) into `.env` or the compose file.

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/docker-compose.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/docker-compose.mdx
@@ -33,9 +33,10 @@ Os arquivos de self-host usam um volume Docker para persistência e um health ch
 git clone https://github.com/decocms/studio.git
 cd studio/deploy/docker-compose
 
-# 2. Crie um .env com um auth secret e credenciais do Postgres
+# 2. Crie um .env com um auth secret, uma chave do vault e credenciais do Postgres
 cat > .env << EOF
 BETTER_AUTH_SECRET=$(openssl rand -base64 32)
+ENCRYPTION_KEY=$(openssl rand -base64 32)
 POSTGRES_USER=studio_user
 POSTGRES_PASSWORD=$(openssl rand -base64 24)
 POSTGRES_DB=studio_db
@@ -51,7 +52,7 @@ open http://localhost:3000
 O arquivo `docker-compose.postgres.yml` monta o `DATABASE_URL` automaticamente a partir das variáveis `POSTGRES_*`, usando o serviço `postgres` como host.
 
 <Callout type="tip">
-  `BETTER_AUTH_SECRET` cai para um valor padrão inseguro (só para dev) se não for definido — sempre defina um de verdade. As variáveis `POSTGRES_*` também têm valores padrão, mas sempre defina uma senha de verdade.
+  `BETTER_AUTH_SECRET` e `ENCRYPTION_KEY` caem para valores padrão inseguros (só para dev) se não forem definidos — sempre defina valores de verdade para qualquer ambiente compartilhado. As variáveis `POSTGRES_*` também têm valores padrão, mas sempre defina uma senha de verdade.
 </Callout>
 
 ## Variáveis de ambiente
@@ -61,6 +62,7 @@ Defina estas no `.env` ao lado do arquivo de compose:
 | Variável | Padrão | Descrição |
 |----------|---------|-------------|
 | `BETTER_AUTH_SECRET` | `local-dev-better-auth-secret-change-me` (inseguro) | Secret de autenticação — sempre defina um de verdade. Gere com `openssl rand -base64 32` |
+| `ENCRYPTION_KEY` | fallback determinístico só para dev (inseguro) | Chave do vault de credenciais para criptografar secrets/tokens armazenados — precisa se manter estável entre reinicializações. Sempre defina um valor de verdade para qualquer ambiente compartilhado. |
 | `IMAGE_REPOSITORY` | `ghcr.io/decocms/studio/studio` | Repositório da imagem |
 | `IMAGE_TAG` | `latest` | Tag da imagem |
 | `PORT` | `3000` | Porta exposta no host |
@@ -148,6 +150,6 @@ docker compose -f docker-compose.postgres.yml up -d
 
 ## Segurança
 
-- Sempre gere um `BETTER_AUTH_SECRET` forte (`openssl rand -base64 32`) e um `POSTGRES_PASSWORD` de verdade.
+- Sempre gere valores fortes para `BETTER_AUTH_SECRET` e `ENCRYPTION_KEY` (`openssl rand -base64 32`) e um `POSTGRES_PASSWORD` de verdade.
 - Não faça commit do `.env` (`echo ".env" >> .gitignore`; `chmod 600 .env`).
 - Não faça commit de secrets (client secrets, API keys) no `.env` ou no arquivo do compose.


### PR DESCRIPTION
**Source:** documentation gap found while sweeping `apps/docs/client/src/content/deco-studio/` for stale/incomplete self-hosting docs.

**The gap:** `deploy/docker-compose/docker-compose.postgres.yml` sets `ENCRYPTION_KEY` (the credential-vault key used to encrypt stored secrets/tokens, per `apps/api/src/settings/resolve-config.ts`) with an insecure deterministic fallback if unset — the exact same risk class as `BETTER_AUTH_SECRET`, which the docs already warn about. But the Docker Compose self-hosting guide's "Environment variables" table, quick-start `.env` snippet, and "Security" checklist never mention `ENCRYPTION_KEY` at all, in either the English or pt-br version. By contrast, the Kubernetes deploy doc *does* already list `ENCRYPTION_KEY` as a required secret alongside `DATABASE_URL`/`BETTER_AUTH_SECRET` — so this is an inconsistency between the two self-hosting paths, not a design choice.

**Why it matters:** a self-hoster following the Docker Compose guide as written would deploy with the insecure fallback vault key and never know it needs rotating, silently weakening at-rest credential encryption.

**What changed:** added `ENCRYPTION_KEY` to the env-var table, the quick-start `.env` example, the `<Callout>` about insecure defaults, and the Security checklist — mirrored in both `en/` and `pt-br/` `docker-compose.mdx`. Pure documentation, no code/config changed.

**How to verify:** read the two diffed files; cross-check against `deploy/docker-compose/docker-compose.postgres.yml` (line defining `ENCRYPTION_KEY`) and `apps/api/src/settings/resolve-config.ts` (`describeEncryptionKeyForLog`) to confirm the described behavior.

**Checks run locally:** `bun run fmt` (no-op on mdx). No code was touched, so no typecheck/test/lint was needed for this change; CI's docs build will validate the mdx compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the `ENCRYPTION_KEY` environment variable in the Docker Compose self-hosting guide (English and pt-br) so self-hosters don't deploy with the insecure dev-only fallback vault key.

<sup>Written for commit 986d21121c682486dccc7919d654efddd38e341a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

