### PR TITLE
refactor(sandbox): share SUPERSEDED_TERMINAL_CODE with error-codes.ts

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -38,6 +38,7 @@ import {
 import {
   SANDBOX_GONE_TERMINAL_CODE,
   SANDBOX_UNREACHABLE_PREFIX,
+  SUPERSEDED_TERMINAL_CODE,
 } from "@decocms/sandbox/dispatch/error-codes";
 import type { PodTermination } from "@decocms/sandbox/provider";
 import type { AgentSandboxProvider } from "@decocms/sandbox/provider/agent-sandbox";
@@ -204,9 +205,6 @@ export function isRunSuperseded(err: unknown): boolean {
     (err as Error & { superseded?: boolean }).superseded === true
   );
 }
-
-/** The daemon's terminal code for an attempt displaced by a takeover. */
-const SUPERSEDED_TERMINAL_CODE = "superseded";
 
 /**
  * Is a non-2xx dispatch response the sandbox being gone, or the daemon rejecting

--- a/packages/sandbox/dispatch/error-codes.ts
+++ b/packages/sandbox/dispatch/error-codes.ts
@@ -13,6 +13,16 @@
 export const SANDBOX_GONE_TERMINAL_CODE = "sandbox_gone";
 
 /**
+ * The daemon's terminal code for an attempt displaced by a takeover — another
+ * dispatch now owns the run, so this attempt's stream ends without a failure.
+ *
+ * Kept here for the same reason as `SANDBOX_GONE_TERMINAL_CODE`: the daemon
+ * writes the literal (`terminalFrame("superseded", ...)` in dispatch.go),
+ * `sandbox-dispatch-client` maps it to `RunSupersededError`.
+ */
+export const SUPERSEDED_TERMINAL_CODE = "superseded";
+
+/**
  * Stable marker on every `SandboxUnreachableError` message — same convention as
  * `[SUBSCRIPTION_REQUIRED]` and `[CREDITS]`: a prefix that survives the trip
  * through an error part's text, so a reader downstream can recognize the class


### PR DESCRIPTION
Small dedup found while auditing `packages/sandbox/dispatch/error-codes.ts` (the assigned focus area). No real "registry" gap existed there — the file's two existing constants are already well-documented and correctly consumed — but `apps/api/src/harnesses/sandbox-dispatch-client.ts` hand-rolled its own local `SUPERSEDED_TERMINAL_CODE = "superseded"` right next to its import of `SANDBOX_GONE_TERMINAL_CODE` from that same shared file.

Both constants exist for the identical reason, stated in `error-codes.ts`'s own doc comment for `SANDBOX_GONE_TERMINAL_CODE`: "both ends must agree on the literal" — the Go daemon writes the string (`terminalFrame("superseded", ...)` in `packages/sandbox/daemon-go/internal/dispatch/dispatch.go`), and the TS client maps it to an error type. `"superseded"` was left out of that shared home even though it's the exact same cross-language contract, so a future rename of one side wouldn't be caught by grepping the shared file.

**Change**: moved `SUPERSEDED_TERMINAL_CODE` into `packages/sandbox/dispatch/error-codes.ts` (documented the same way as its sibling), and updated `sandbox-dispatch-client.ts` to import it instead of redeclaring it. Behavior-preserving — same string value, same single call site (`errorForTerminal`).

Net: -3 / +10 (net addition is the doc comment mirroring the sibling constant's).

**Verification**: `bunx tsc --noEmit` in `apps/api` is clean; the existing `apps/api/src/harnesses/sandbox-dispatch-client.test.ts` (which already asserts `errorForTerminal("superseded", ...)` behavior) passes all 59 tests unchanged; `bunx oxlint` on both touched files reports 0 warnings/errors.

A reviewer can confirm with:
```
cd apps/api && bunx tsc --noEmit
bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts
```
Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `SUPERSEDED_TERMINAL_CODE` into the shared `packages/sandbox/dispatch/error-codes.ts` so the daemon-terminal literal lives alongside `SANDBOX_GONE_TERMINAL_CODE` instead of being redeclared in the client.

- `sandbox-dispatch-client.ts` now imports the constant rather than defining `"superseded"` locally.
- No behavior change: same string value and same single use in `errorForTerminal`.
- Type-check, lint, and the existing dispatch client tests pass.

<sup>Written for commit be414ae58e2b21b8b4f6dcef02e5c5e339075fad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

