### PR TITLE
fix(storage): route corrupted oauth_config decrypt failures into the connection-disable tracker

### DIFF
--- a/apps/api/src/storage/connection-oauth-config-encryption.test.ts
+++ b/apps/api/src/storage/connection-oauth-config-encryption.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { Kysely } from "kysely";
 import { CredentialVault } from "../encryption/credential-vault";
 import { ConnectionStorage } from "./connection";
+import { recordDecryptFailure } from "./decrypt-failure-tracker";
 import type { Database } from "./types";
 
 describe("ConnectionStorage oauth_config encryption", () => {
@@ -72,5 +73,30 @@ describe("ConnectionStorage oauth_config encryption", () => {
     });
 
     expect(deserialized.oauth_config).toEqual(oauthConfig);
+  });
+
+  it("feeds an undecryptable, non-JSON oauth_config into the same failure tracker as connection_token", async () => {
+    const connectionId = "conn_corrupt_oauth";
+    const before = recordDecryptFailure(connectionId).consecutiveFailures;
+
+    const deserialized = await (
+      storage as unknown as {
+        deserializeConnection: (
+          row: Record<string, unknown>,
+        ) => Promise<{ oauth_config: unknown }>;
+      }
+    ).deserializeConnection({
+      id: connectionId,
+      organization_id: "org_test",
+      connection_type: "HTTP",
+      status: "active",
+      oauth_config: "not-ciphertext-and-not-json",
+    });
+
+    expect(deserialized.oauth_config).toBeNull();
+    // A real decrypt failure must reach the same tracker as connection_token.
+    expect(recordDecryptFailure(connectionId).consecutiveFailures).toBe(
+      before + 2,
+    );
   });
 });

--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -706,10 +706,7 @@ export class ConnectionStorage implements ConnectionStoragePort {
         try {
           decryptedOAuthConfig = JSON.parse(row.oauth_config);
         } catch (error) {
-          console.error(
-            `Failed to parse oauth_config for connection ${row.id}:`,
-            error,
-          );
+          decryptErrors.push({ label: "oauth config", error });
         }
       }
     } else {
@@ -718,7 +715,11 @@ export class ConnectionStorage implements ConnectionStoragePort {
 
     if (decryptErrors.length > 0) {
       await this.handleDecryptFailures(row, decryptErrors);
-    } else if (row.connection_token || row.configuration_state) {
+    } else if (
+      row.connection_token ||
+      row.configuration_state ||
+      row.oauth_config
+    ) {
       recordDecryptSuccess(row.id);
     }
 


### PR DESCRIPTION
Follows #7042 ("fix(storage): encrypt oauth_config at rest, matching connection_token"). That PR added `oauth_config` decryption but its failure path never actually matched `connection_token`'s: `deserializeConnection` decrypts `connection_token`/`configuration_state` into a shared `decryptErrors` array which, on any failure, goes through `handleDecryptFailures` — this is the tracker (`decrypt-failure-tracker.ts`) that disables a connection (`status="error"`) after `CONNECTION_DECRYPT_DISABLE_THRESHOLD` consecutive failures so a permanently-undecryptable connection (tampered ciphertext, rotated vault key) doesn't spam logs forever. `oauth_config`'s catch block instead fell through to a bare `console.error` and never touched `decryptErrors`/`recordDecryptFailure` — so a corrupted `oauth_config` would fail open on every single read, forever, without ever tripping the same safety net its sibling fields get.

Why a maintainer wants this: it's the exact gap the #7042 PR comment ("encrypt oauth_config at rest, matching connection_token") claims to close but didn't for the failure path — a maintainer debugging a connection stuck silently re-failing decrypt on `oauth_config` would expect the existing disable-after-N-failures behavior to apply.

Fix: on a genuine decrypt failure (decrypt fails *and* the raw value isn't legacy plaintext JSON — the existing pre-#7042 fallback case, which is not a failure), push onto the same `decryptErrors` array `connection_token` uses, so it flows through `handleDecryptFailures` identically. Also included `oauth_config` in the `recordDecryptSuccess` condition so a successful decrypt resets the tracker like the other two fields do.

Regression test added in `connection-oauth-config-encryption.test.ts`: feeds an undecryptable, non-JSON `oauth_config` through `deserializeConnection` and asserts `recordDecryptFailure` for that connection id was bumped (proving it reached the shared tracker), while the existing legacy-plaintext-fallback and round-trip tests still pass unchanged.

To confirm: `cd apps/api && bun test src/storage/connection-oauth-config-encryption.test.ts` (4 pass).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test file above, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes corrupted `oauth_config` decrypt failures into the same connection-disable tracker as `connection_token` and `configuration_state`, so a permanently undecryptable `oauth_config` now disables the connection after N consecutive failures instead of failing open on every read.

**Bug Fixes**
- A failed `oauth_config` decrypt previously only logged via `console.error` and never fed the tracker.
- Decrypt failures now push onto the shared `decryptErrors` array and flow through `handleDecryptFailures`; successful decrypts reset the tracker.
- Adds a regression test that an undecryptable, non-JSON `oauth_config` bumps `recordDecryptFailure`.

<sup>Written for commit 523317eb1c597f56c78c05b122f981835aa814b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

