### PR TITLE
fix(virtual-mcp): show a removable placeholder for a deleted connection reference

### DIFF
--- a/apps/web/src/i18n/en/virtual-mcp.ts
+++ b/apps/web/src/i18n/en/virtual-mcp.ts
@@ -43,6 +43,7 @@ export const virtualMcp = {
   "virtualMcp.connectionItem.configureResources": "Configure resources",
   "virtualMcp.connectionItem.connectionDisabled": "Connection disabled",
   "virtualMcp.connectionItem.connectionEnabled": "Connection enabled",
+  "virtualMcp.connectionItem.connectionNotFound": "Connection not found",
   "virtualMcp.connectionItem.connectionSettings": "Connection settings",
   "virtualMcp.connectionItem.disable": "Disable",
   "virtualMcp.connectionItem.disableConnection": "Disable connection",

--- a/apps/web/src/i18n/pt-br/virtual-mcp.ts
+++ b/apps/web/src/i18n/pt-br/virtual-mcp.ts
@@ -47,6 +47,7 @@ export const virtualMcp = {
   "virtualMcp.connectionItem.configureResources": "Configurar recursos",
   "virtualMcp.connectionItem.connectionDisabled": "Conexão desativada",
   "virtualMcp.connectionItem.connectionEnabled": "Conexão ativada",
+  "virtualMcp.connectionItem.connectionNotFound": "Conexão não encontrada",
   "virtualMcp.connectionItem.connectionSettings": "Configurações de conexão",
   "virtualMcp.connectionItem.disable": "Desativar",
   "virtualMcp.connectionItem.disableConnection": "Desativar conexão",

--- a/apps/web/src/views/virtual-mcp/connection-item.tsx
+++ b/apps/web/src/views/virtual-mcp/connection-item.tsx
@@ -61,7 +61,8 @@ export function ConnectionItem({
   const connection = useConnection(connection_id);
   const { org } = useProjectContext();
 
-  if (!connection) return null;
+  // The referenced connection was deleted elsewhere — offer a way to remove it.
+  if (!connection) return <MissingConnectionItem onRemove={onRemove} />;
 
   const slug = getConnectionSlug(connection);
 
@@ -393,6 +394,36 @@ function ConnectionItemAuthFallback({
       <div className="flex items-center px-4 py-2 border-t border-border bg-muted/25">
         <div className="h-5 w-20 rounded bg-muted animate-pulse" />
       </div>
+    </div>
+  );
+}
+
+function MissingConnectionItem({ onRemove }: { onRemove: () => void }) {
+  const t = useT();
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-destructive/50 bg-destructive/5">
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-destructive font-medium truncate">
+          {t("virtualMcp.connectionItem.connectionNotFound")}
+        </p>
+      </div>
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground hover:text-destructive shrink-0"
+            onClick={onRemove}
+            aria-label={t("virtualMcp.connectionItem.removeConnection")}
+          >
+            <XClose size={13} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {t("virtualMcp.connectionItem.remove")}
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 }


### PR DESCRIPTION
Bug found while auditing the Virtual MCP page (apps/web/src/views/virtual-mcp/index.tsx) for fallback UI on missing data.

`VirtualMcpDetailViewWithData` renders one `<ConnectionItem>` per entry in `virtualMcp.connections` (the persisted `connection_id` list). `ConnectionItem` calls `useConnection(connection_id)` and does `if (!connection) return null;` — so if the connection a virtual MCP references was deleted elsewhere (e.g. from Settings, or by another org member), that slot silently disappears from the list. Worse, the item's own "Remove" button lives inside the component that never renders, so the stale `connection_id` has no UI path to get cleaned out of the agent's `connections` array — it just persists forever as an invisible, permanently-broken reference.

Fix: when `useConnection` returns null, render a small destructive-styled placeholder ("Connection not found") with the same Remove action already wired up via the `onRemove` prop, instead of returning null. This gives the user visibility into the broken reference and a way to fix it, matching how the same file already surfaces other broken/needs-auth connection states (`needsAuth`, `isDisabled`).

Failure scenario before the fix: agent A has connections [X, Y]; connection Y gets deleted from Settings; agent A's page now silently shows only X, with Y's dead reference permanently stuck in the saved form data and no way to remove it short of editing the DB.

Reviewer check: `cd apps/web && bunx tsc --noEmit` (no new errors — the file has one pre-existing unrelated prosemirror version-mismatch error) and `bunx oxlint apps/web/src/views/virtual-mcp/connection-item.tsx apps/web/src/i18n/en/virtual-mcp.ts apps/web/src/i18n/pt-br/virtual-mcp.ts` (0 warnings/errors). `bun run fmt` is a no-op on this diff.

Locally verified: targeted typecheck + per-file oxlint + biome format, as above. Full CI (bun test / e2e) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Virtual MCP page so deleted connection references show a "Connection not found" placeholder with a remove button instead of silently disappearing.

- Stale `connection_id` entries previously had no UI to remove them because the item component returned `null` before rendering its Remove action.
- The placeholder uses the same `onRemove` action as normal connection items so users can clean up broken references.
- Adds the new label to the English and Brazilian Portuguese i18n files.

<sup>Written for commit f2af80ee90fcfa7060b893c82646f563971a5761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

