### PR TITLE
fix(git-providers): drain the response body on a GitHub rate-limit refusal

### DIFF
--- a/apps/api/src/git-providers/github/http.ts
+++ b/apps/api/src/git-providers/github/http.ts
@@ -88,6 +88,8 @@ export async function githubFetch(
   });
 
   if (isGithubRateLimited(res)) {
+    // Drain the unread body, same as every other discard-and-throw call site here.
+    await res.body?.cancel().catch(() => {});
     const kind =
       res.headers.get("retry-after") !== null ? "secondary" : "primary";
     countGithubRateLimited({ lane: "rest", operation: init.operation, kind });


### PR DESCRIPTION
Every other discard-and-throw call site in `apps/api/src/git-providers/github/` (client.ts, content.ts, graphql.ts, change-requests.ts, and the GitLab equivalents) reads or cancels the response body before moving on. `githubFetch` in `http.ts` — the shared REST plumbing every GitHub caller (App auth mint, provider client, etc.) goes through — was the one place that throws a `GitProviderError` on a rate-limit refusal (429, or 403 with `retry-after`/exhausted primary window) without draining `res.body` first.

Why it matters: under Bun/undici, an unread response body keeps its connection out of the keep-alive pool until GC reclaims it. This path fires on every primary/secondary rate-limit hit — exactly the condition this codebase already tracks (`observability/github-rate-limit.ts`) as a real operational risk (see its own comment about a budget shutting for 17 hours). Left undrained, repeated rate-limit refusals leak sockets from the pool instead of releasing them immediately.

Fix: `await res.body?.cancel().catch(() => {})` before throwing, matching the pattern already used everywhere else in this package.

Behavior-preserving — the thrown `GitProviderError` and its `retryAfterMs`/message are unchanged; only the body handling changes.

To confirm: read `apps/api/src/git-providers/github/http.ts`'s `githubFetch`, and compare against the `res.body?.cancel()` calls in `client.ts`/`content.ts`/`graphql.ts`/`change-requests.ts`.

Verified locally: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint apps/api/src/git-providers/github/http.ts` (0 warnings/errors), and the existing `apps/api/src/git-providers/github/app-auth.test.ts` suite (15 pass) since it exercises this same module's other exports. No unit test exists for `githubFetch` itself — it's pure network plumbing with no mockable logic under this repo's unit-test rules; full CI/e2e covers it end to end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a socket leak in the GitHub REST client by draining the response body before throwing on a rate-limit refusal. Previously, `githubFetch` in `http.ts` would throw a `GitProviderError` without reading the body, leaving the connection out of Bun's keep-alive pool until garbage collection. Now it cancels `res.body` before throwing, matching the pattern used elsewhere in this package. The thrown error and its `retryAfterMs` are unchanged.

<sup>Written for commit a47014a81351ca4041abe63e7d1f708496af3168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

