### PR TITLE
fix(storage): correct migration numbers in quota/subsidy table comments

### DIFF
--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1218,7 +1218,7 @@ export interface ThreadMessagePartTable {
 // Member Tags Table Definitions
 // ============================================================================
 
-/** Per-org subsidy gateway key (migration 159) — vault-encrypted; see
+/** Per-org subsidy gateway key (migration 160) — vault-encrypted; see
  *  storage/subsidized-gateway-keys.ts. */
 export interface SubsidizedGatewayKeyTable {
   organization_id: string;
@@ -1226,7 +1226,7 @@ export interface SubsidizedGatewayKeyTable {
   created_at: ColumnType<Date, Date | string | undefined, never>;
 }
 
-/** Quota ledger for reports-pushed task executions (migration 158) — one
+/** Quota ledger for reports-pushed task executions (migration 160) — one
  *  claim per task, bucketed by period_key (see billing/task-quota.ts). */
 /** `held` = charged (counts toward the period); `released` = refunded
  *  because the run produced nothing. A union, so a typo in a comparison is a


### PR DESCRIPTION
Follows #7053, which fixed the same drift for `repository_id` column comments (migration 199 → 204). Auditing the rest of `apps/api/src/storage/types.ts` for the same class of error turned up two more.

**What's wrong:** `SubsidizedGatewayKeyTable` and `TaskQuotaClaimTable` both carry `(migration 159)` / `(migration 158)` doc comments, but `subsidized_gateway_keys` and `task_quota_claims` are both actually created by `apps/api/migrations/160-task-quota-billing.ts` — migration 158 is `drop-github-child-single-parent.ts` and 159 is `task-board-comments.ts`, unrelated tables. A stale/wrong migration-number comment misdirects anyone tracing a column's provenance or writing a follow-up migration against it.

**Fix:** update both comments to point at migration 160, the actual origin. I cross-checked every other `(migration N)` comment in the same file against the migrations directory (139, 142, 158→160 dup fix, 159→160 dup fix, 162, 164, 172, 174, 187, 189, 197, 198, 204, 205) — no other mismatches found.

Comment-only change, no type/behavior change.

**To verify:** `grep -n "createTable" apps/api/migrations/160-task-quota-billing.ts` shows it creates both `task_quota_claims` and `subsidized_gateway_keys`.

Checked locally: `bun run fmt` (clean) and `bunx oxlint apps/api/src/storage/types.ts` (0 warnings/errors). No test needed — this is a doc-comment correction, not a logic change; full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects migration numbers in two table comments in `apps/api/src/storage/types.ts` so they point to migration 160, which actually creates both `subsidized_gateway_keys` and `task_quota_claims`. The previous comments referenced unrelated migrations 159 and 158; this is a comment-only fix with no behavior change.

<sup>Written for commit 2407cb93da5dcc74c2df188a2ec81921246fe7a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

