### PR TITLE
fix(admin-prompts): bound PR title and prompt-content length

### DIFF
--- a/apps/api/src/api/routes/admin-prompts.test.ts
+++ b/apps/api/src/api/routes/admin-prompts.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { applyPromptEdits, PromptEditorError } from "./admin-prompts";
+import {
+  applyPromptEdits,
+  createAdminPromptRoutes,
+  PromptEditorError,
+} from "./admin-prompts";
 
 const REVIEWER_PATH = "apps/api/src/tools/task-board/enqueue-reviewer.ts";
 const SUPER_AGENT_PATH = "apps/api/src/tools/task-board/enqueue-super-agent.ts";
@@ -61,5 +65,35 @@ describe("applyPromptEdits", () => {
     ]);
     expect(sources.get(REVIEWER_PATH)).toContain('reviewer: "be lenient"');
     expect(sources.get(SUPER_AGENT_PATH)).toContain('hosted: "be slow"');
+  });
+});
+
+// Bounds reject before the route reads `studioContext`, so no fake DB is needed.
+describe("POST /prompts/pull-request input bounds", () => {
+  const app = createAdminPromptRoutes();
+
+  it("rejects a title longer than the cap", async () => {
+    const res = await app.request("/prompts/pull-request", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "x".repeat(201),
+        edits: [{ id: "reviewer", content: "be picky" }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("Title");
+  });
+
+  it("rejects prompt content longer than the cap", async () => {
+    const res = await app.request("/prompts/pull-request", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        edits: [{ id: "reviewer", content: "x".repeat(20_001) }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("reviewer");
   });
 });

--- a/apps/api/src/api/routes/admin-prompts.ts
+++ b/apps/api/src/api/routes/admin-prompts.ts
@@ -65,6 +65,10 @@ const PROMPTS = [
 
 type PromptId = (typeof PROMPTS)[number]["id"];
 
+/** A generous ceiling, not a real limit — just enough to reject a runaway body. */
+const MAX_TITLE_LENGTH = 200;
+const MAX_PROMPT_LENGTH = 20_000;
+
 export class PromptEditorError extends Error {
   constructor(
     message: string,
@@ -234,6 +238,12 @@ export function createAdminPromptRoutes(): Hono<Env> {
       typeof body.title === "string" && body.title.trim()
         ? body.title.trim()
         : "chore(prompts): edit agent prompts";
+    if (title.length > MAX_TITLE_LENGTH) {
+      return c.json(
+        { error: `Title must be at most ${MAX_TITLE_LENGTH} characters` },
+        400,
+      );
+    }
     const known = new Set<string>(PROMPTS.map((p) => p.id));
     const edits = (Array.isArray(body.edits) ? body.edits : [])
       .filter(
@@ -248,6 +258,15 @@ export function createAdminPromptRoutes(): Hono<Env> {
       .map((e) => ({ id: e.id, content: e.content }));
     if (edits.length === 0) {
       return c.json({ error: "No prompt edits to commit" }, 400);
+    }
+    const oversized = edits.find((e) => e.content.length > MAX_PROMPT_LENGTH);
+    if (oversized) {
+      return c.json(
+        {
+          error: `Prompt "${oversized.id}" must be at most ${MAX_PROMPT_LENGTH} characters`,
+        },
+        400,
+      );
     }
 
     const { gh } = await clientForActor(c.get("studioContext"));


### PR DESCRIPTION
The `POST /prompts/pull-request` handler on the admin-prompts route (an instance-level, deployment-admin-gated surface) accepted an unbounded `title` and unbounded per-prompt `content` from the request body and fed both straight into a GitHub branch name, commit message, and PR title/content with no length cap. A pathological or accidental request (a pasted multi-KB document into a prompt textarea, or a huge title string) would ship as-is to the GitHub API.

Added a `MAX_TITLE_LENGTH` (200) and `MAX_PROMPT_LENGTH` (20,000) cap, rejecting with 400 before any GitHub call or DB lookup happens — same shape as the existing `MAX_TERM_LENGTH`/`MAX_BLOCK_KEY_LENGTH` caps elsewhere in `apps/api/src/api/routes/`.

Reviewer: run `bun test apps/api/src/api/routes/admin-prompts.test.ts` — two new cases assert a 400 for an oversized title and an oversized prompt body, added alongside the existing `applyPromptEdits` splice tests. Both new tests reject before the route ever reads `studioContext`, so no DB/StudioContext fixture was needed.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above (5/5 pass), and `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the title and per-prompt content length in the admin-prompts `POST /prompts/pull-request` route so oversized payloads are rejected with 400 before hitting GitHub. Adds caps of 200 characters for the title and 20,000 per prompt, matching existing length checks elsewhere in the API.

<sup>Written for commit dcb3c651f96f4b7a2c1d866a742fbbd876596483. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

