### PR TITLE
fix(task-board): stop nesting a remove-tag button inside the tag chip button

### DIFF
--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -1292,44 +1292,40 @@ function TaskBoardItemEditor({
                       const tag = orgTags.find((ot) => ot.id === tagId);
                       if (!tag) return null;
                       return (
-                        <button
+                        // Two sibling buttons, not one nested in the other — a <button> can't validly contain another interactive element.
+                        <div
                           key={tagId}
-                          type="button"
-                          onClick={() => setTagsOpen(true)}
                           className="inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-sm font-medium text-foreground transition-colors hover:bg-muted"
                         >
-                          <span
-                            className="size-2 shrink-0 rounded-full"
-                            style={{ backgroundColor: tagDotColor(tag.color) }}
-                          />
-                          <span className="truncate">{tag.name}</span>
-                          <span
-                            role="button"
-                            tabIndex={0}
+                          <button
+                            type="button"
+                            onClick={() => setTagsOpen(true)}
+                            className="inline-flex items-center gap-1.5"
+                          >
+                            <span
+                              className="size-2 shrink-0 rounded-full"
+                              style={{
+                                backgroundColor: tagDotColor(tag.color),
+                              }}
+                            />
+                            <span className="truncate">{tag.name}</span>
+                          </button>
+                          <button
+                            type="button"
                             aria-label={t(
                               "taskBoard.taskDialog.removeTagAriaLabel",
                               { name: tag.name },
                             )}
                             className="-mr-0.5 flex size-3.5 items-center justify-center rounded-sm text-muted-foreground hover:bg-background hover:text-foreground"
-                            onClick={(e) => {
-                              e.stopPropagation();
+                            onClick={() => {
                               patch({
                                 tagIds: tagIds.filter((id) => id !== tagId),
                               });
                             }}
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter" || e.key === " ") {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                patch({
-                                  tagIds: tagIds.filter((id) => id !== tagId),
-                                });
-                              }
-                            }}
                           >
                             <X size={10} />
-                          </span>
-                        </button>
+                          </button>
+                        </div>
                       );
                     })}
                     <PopoverTrigger asChild>


### PR DESCRIPTION
Each tag chip in the task dialog's tag row (`apps/web/src/layouts/task-board/task-dialog.tsx`) rendered as a `<button>` (opens the tag editor) with a `<span role="button" tabIndex={0}>` (removes the tag) nested inside it. A `<button>` can't validly contain another interactive element — invalid HTML, and it puts two focusable controls with overlapping semantics on one DOM node, which is exactly the pattern flagged and fixed in #6898 for a different component in this repo.

Fix: the chip is now a plain `<div>` wrapping two sibling `<button>`s — one for the tag name/dot (opens the tag popover), one for the remove `X`. Same visual layout and click behavior, but no nested interactive elements, and the remove button no longer needs the manual `stopPropagation`/`onKeyDown` Enter/Space shim a real `<button>` already gets for free.

Behavior-preserving: clicking the tag name still opens the tag editor, clicking the `X` still removes the tag, same aria-label on the remove control.

How to verify: open a task with tags assigned in the task board dialog, confirm clicking a tag name opens the tag popover and clicking the `X` removes just that tag (keyboard: click reaches both controls via Tab/Enter as normal buttons).

Checks run locally: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (no new errors), `bunx oxlint apps/web/src/layouts/task-board/task-dialog.tsx` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the task dialog's tag chip, which previously rendered a remove-tag control nested inside the tag button — invalid HTML with two overlapping focusable elements. The chip is now a `<div>` with two sibling `<button>`s.

- The tag-name button opens the tag popover; the `X` button removes the tag.
- The `X` is now a native button, so the manual `stopPropagation` and Enter/Space key handler are gone.
- Click behavior and the remove control's aria-label are unchanged.

<sup>Written for commit cf38fbd428833db02aaae8078bd1030e99d71e74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

