### PR TITLE
perf(git-providers): batch account lookups in listOrgRepoChoices

### DIFF
--- a/apps/api/src/git-providers/repo-choices.ts
+++ b/apps/api/src/git-providers/repo-choices.ts
@@ -26,7 +26,7 @@ import {
   repoWebUrl,
   splitOwnerName,
 } from "@decocms/shared/git-providers";
-import { repositoryUsesStudioCredentials } from "./credentials";
+import { accountIsServable } from "./credentials";
 import {
   type LegacyRepoChoice,
   listLegacyRepoChoices,
@@ -107,17 +107,26 @@ export function mergeRepoChoices(
 }
 
 /** The org's clonable repos, looked up fresh each call (one can be linked
- *  while a run is in flight). */
+ *  while a run is in flight).
+ *
+ * The org's accounts are fetched once and matched in memory rather than
+ * re-querying `git_provider_accounts` per repository — repositories in one
+ * org routinely share an account, and this runs on the dispatch-time "which
+ * repo can I offer" path. */
 export async function listOrgRepoChoices(
   ctx: StudioContext,
   orgId: string,
 ): Promise<RepoChoice[]> {
-  const linked = await ctx.storage.repositories.listByOrg(orgId);
-  const servable: RepositoryRecord[] = [];
-  for (const repository of linked) {
-    if (await repositoryUsesStudioCredentials(ctx.storage, repository)) {
-      servable.push(repository);
-    }
-  }
+  const [linked, accounts] = await Promise.all([
+    ctx.storage.repositories.listByOrg(orgId),
+    ctx.storage.gitProviderAccounts.listByOrg(orgId),
+  ]);
+  const accountById = new Map(accounts.map((account) => [account.id, account]));
+  const servable: RepositoryRecord[] = linked.filter((repository) => {
+    const account = repository.accountId
+      ? accountById.get(repository.accountId)
+      : undefined;
+    return account !== undefined && accountIsServable(account);
+  });
   return mergeRepoChoices(servable, await listLegacyRepoChoices(ctx, orgId));
 }


### PR DESCRIPTION
**Source:** an N+1-query perf bug found reading `apps/api/src/git-providers/repo-choices.ts`, this tick's focus area (git provider selection logic).

**Why:** `listOrgRepoChoices` looped over every linked repository and awaited `repositoryUsesStudioCredentials` sequentially, which issues its own `git_provider_accounts.getUnscoped(id)` DB round trip per repository. Repositories in one org routinely share the same account (one GitHub App install, many repos), so this was N sequential round trips for N repos instead of at most one per distinct account. This function is on the dispatch-time "which repo can this agent clone" hot path, called from `claude-code-task-run.ts`, `add-repo.ts`, and `load-repo.ts` (the Decopilot `load_repo` built-in) — so the latency adds up per call, scaling with the org's linked-repo count.

**Fix:** fetch the org's accounts once via the already-existing `gitProviderAccounts.listByOrg(orgId)` (in parallel with the repositories fetch), then match each repository's `accountId` against that map in memory using the existing `accountIsServable` check — same logic `repositoryUsesStudioCredentials` runs, just without a query per row. `repositoryUsesStudioCredentials` itself is untouched and still used by its other three callers (`sync-git-credentials.ts`, `start.ts`, `org-repo-sync.ts`); only `listOrgRepoChoices`'s internal per-repo lookup is batched.

Net effect: an org with R linked repositories across A distinct accounts goes from R sequential DB round trips to 2 parallel ones (repositories + accounts), for every dispatch/load-repo call.

**Verification:**
- `cd apps/api && bunx tsc --noEmit` — clean.
- `bun test apps/api/src/git-providers/repo-choices.test.ts` — 8/8 pass (pure `mergeRepoChoices` behavior unchanged; `listOrgRepoChoices` itself has no unit test since it needs a real DB — only integration-testable, out of scope for a local check).
- `bunx oxlint apps/api/src/git-providers/repo-choices.ts` — 0 warnings/errors.
- `bun run fmt` — clean.

Reviewer command: `cd apps/api && bunx tsc --noEmit && cd .. && bun test apps/api/src/git-providers/repo-choices.test.ts`. Full CI (including any integration coverage of `listOrgRepoChoices`) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches git provider account lookups in `listOrgRepoChoices` so repo selection no longer makes one sequential DB round trip per linked repository.

- Fetches the org's accounts once, in parallel with the repositories fetch, and matches each repository's `accountId` in memory using the existing `accountIsServable` check.
- Cuts the dispatch-time "which repo can this agent clone" path from N sequential queries to 2 parallel ones for orgs with many linked repos.
- Behavior is unchanged; `repositoryUsesStudioCredentials` is untouched and still used by its other callers.

<sup>Written for commit 1bb3b35eb499896014c0c562171e1a1d34183f39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

