### PR TITLE
fix(connections): clear the oauth refresh backoff tracker on connection delete

### DIFF
--- a/apps/api/src/tools/connection/delete.test.ts
+++ b/apps/api/src/tools/connection/delete.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, mock } from "bun:test";
 import { WellKnownOrgMCPId } from "@decocms/shared/sdk";
+import {
+  clearRefreshBackoff,
+  refreshAndStore,
+} from "../../oauth/token-refresh";
 import { COLLECTION_CONNECTIONS_DELETE } from "./delete";
 
 function makeCtx(options: {
@@ -79,6 +83,56 @@ describe("COLLECTION_CONNECTIONS_DELETE", () => {
 
     expect(result.item.id).toBe("conn_repo");
     expect(deleteConnection).toHaveBeenCalledWith("conn_repo");
+  });
+
+  it("clears the oauth refresh backoff tracker on delete", async () => {
+    // Regression: an unbounded tracker entry lingered past delete, suppressing a reconnect's first refresh.
+    const { ctx } = makeCtx({ referencedByThread: false });
+    const tokenStorage = {
+      get: async () => null,
+      delete: async () => {},
+      isExpired: () => false,
+      upsert: async () => ({}) as never,
+    };
+    const unrefreshableToken = {
+      id: "dtok_1",
+      connectionId: "conn_repo",
+      accessToken: "old",
+      refreshToken: null,
+      scope: null,
+      expiresAt: null,
+      createdAt: "",
+      updatedAt: "",
+      clientId: null,
+      clientSecret: null,
+      tokenEndpoint: null,
+    };
+    // Arms the backoff window without a network call (no refresh_token to try).
+    await refreshAndStore(unrefreshableToken, tokenStorage);
+
+    await COLLECTION_CONNECTIONS_DELETE.handler({ id: "conn_repo" }, ctx);
+
+    const originalFetch = global.fetch;
+    let fetchCalled = false;
+    global.fetch = mock(async () => {
+      fetchCalled = true;
+      return new Response(JSON.stringify({ access_token: "new" }));
+    }) as unknown as typeof fetch;
+    try {
+      await refreshAndStore(
+        {
+          ...unrefreshableToken,
+          refreshToken: "rt",
+          clientId: "cid",
+          tokenEndpoint: "https://example.com/token",
+        },
+        tokenStorage,
+      );
+    } finally {
+      global.fetch = originalFetch;
+      clearRefreshBackoff("conn_repo");
+    }
+    expect(fetchCalled).toBe(true);
   });
 
   it("revokes the connection's trigger callback token on delete", async () => {

--- a/apps/api/src/tools/connection/delete.ts
+++ b/apps/api/src/tools/connection/delete.ts
@@ -18,6 +18,7 @@ import {
 } from "../../core/studio-context";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
 import { invalidateConnectionCaches } from "../../mcp-clients/mcp-cache-invalidation";
+import { clearRefreshBackoff } from "../../oauth/token-refresh";
 import { isDevAssetsConnection, usesLocalObjectStorage } from "./dev-assets";
 import { ConnectionEntitySchema } from "./schema";
 
@@ -132,6 +133,9 @@ export const COLLECTION_CONNECTIONS_DELETE = defineTool({
 
     // Delete connection
     await ctx.storage.connections.delete(input.id);
+
+    // Drop the unbounded oauth refresh backoff tracker entry so it doesn't linger.
+    clearRefreshBackoff(input.id);
 
     // trigger_callback_tokens.connection_id has no FK either — same class of orphan.
     await ctx.storage.triggerCallbackTokens.deleteByConnection(


### PR DESCRIPTION
The in-memory oauth refresh backoff tracker (`refreshBackoff` in `apps/api/src/oauth/token-refresh.ts`) is keyed by `connectionId` with no cap or TTL — unlike the sibling decrypt-failure tracker, which is LRU-bounded (`CIRCUIT_BREAKER_MAX_ENTRIES`). Deleting a connection never clears its entry, so the map only grows as connections churn (disconnect/reconnect flows mint a fresh connection id each time), and a rare id collision would incorrectly suppress a fresh connection's very first refresh attempt.

This follows the exact pattern already applied to the sibling tracker in #6987 ("clear the decrypt-failure tracker entry on connection delete") and to the OAuth-backoff-adjacent tracker in #6980 — same class of orphaned in-memory state, same fix shape.

**Failure scenario:** delete a connection whose refresh had recently failed and armed the backoff window, then quickly reconnect and reuse the same connectionId (or just let the process run long enough for many short-lived connections to accumulate) — the stale entry either unnecessarily suppresses the next refresh or leaks memory forever.

**Fix:** call the existing (previously test-only) `clearRefreshBackoff(connectionId)` from `COLLECTION_CONNECTIONS_DELETE`'s handler right after the connection row is deleted, alongside the other per-connection cleanup it already does (trigger callback tokens, registry config, cache invalidation).

**Regression test:** `apps/api/src/tools/connection/delete.test.ts` — arms the backoff window via a real `refreshAndStore` call with an unrefreshable token (no network involved), runs the delete handler, then asserts a subsequent `refreshAndStore` call for the same connectionId actually reaches `fetch` instead of being silently suppressed.

**To verify:** `cd apps/api && bun test src/tools/connection/delete.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the OAuth refresh backoff tracker entry when a connection is deleted, so stale entries no longer linger and suppress the first refresh after a reconnect.

Adds a regression test that arms the backoff, deletes the connection, and verifies the next refresh actually reaches `fetch`.

<sup>Written for commit 5e1fc67f149e5f9da0c71e3611fd9a68bf03524c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

