### PR TITLE
fix(git-providers): retry a stale GitLab token once instead of failing outright

### DIFF
--- a/apps/api/src/git-providers/gitlab/client.ts
+++ b/apps/api/src/git-providers/gitlab/client.ts
@@ -260,21 +260,22 @@ export class GitlabProviderClient implements GitProviderClient {
     repo: RepoRef,
     ref?: string,
   ): Promise<ReadableStream<Uint8Array> | null> {
-    const { token } = await this.tokenForRepo(repo);
-    const res = await gitlabRequest(
+    const res = await this.authedFetch(
       `${this.apiBase}${gitlabArchivePath(repo, ref)}`,
-      token,
       {
         accept: "application/octet-stream, */*",
         timeoutMs: ARCHIVE_TIMEOUT_MS,
       },
     );
-    return res?.body ?? null;
+    if (res.status === 404) return null;
+    if (!res.ok) throw await gitlabFailure(res);
+    return res.body;
   }
 
   async identity(): Promise<GitIdentity | null> {
-    const { token } = await this.accountToken();
-    const user = await fetchGitlabUser(this.host, token);
+    const res = await this.authedFetch(`${this.apiBase}/user`);
+    if (!res.ok) throw await gitlabFailure(res);
+    const user = GitlabUserSchema.parse(await res.json());
     return {
       name: user.name || user.username,
       email:
@@ -289,7 +290,26 @@ export class GitlabProviderClient implements GitProviderClient {
     pathAndQuery: string,
     init?: { accept?: string },
   ): Promise<Response | null> {
-    const { token } = await this.accountToken();
-    return gitlabRequest(`${this.apiBase}${pathAndQuery}`, token, init);
+    const res = await this.authedFetch(`${this.apiBase}${pathAndQuery}`, init);
+    if (res.status === 404) return null;
+    if (!res.ok) throw await gitlabFailure(res);
+    return res;
+  }
+
+  /**
+   * One authenticated REST call. A 401 means the token died before
+   * `expiresAt` said so (revoked, rotated): re-mint/refresh once and retry,
+   * matching `GithubProviderClient.request`'s behaviour for the same case.
+   */
+  private async authedFetch(
+    url: string,
+    init: { accept?: string; timeoutMs?: number } = {},
+  ): Promise<Response> {
+    const first = await this.accountToken();
+    const res = await gitlabFetch(url, first.token, init);
+    if (res.status !== 401) return res;
+    await res.body?.cancel().catch(() => {});
+    const refreshed = await this.accountToken({ forceRefresh: true });
+    return gitlabFetch(url, refreshed.token, init);
   }
 }


### PR DESCRIPTION
**Source:** bug found auditing `apps/api/src/git-providers/{types,github/client,gitlab/client}.ts` for consistency between the GitHub and GitLab provider clients.

**The gap:** `GithubProviderClient.request()` already handles a token dying before its cached `expiresAt` says so (revoked, rotated externally) — it re-mints with `forceRefresh: true` and retries once on a 401. `GitlabProviderClient` uses the exact same `TokenSource` / `getValidDownstreamAccessToken` machinery (see `grantTokenSource` in `credentials.ts`, shared by both providers) but never got that retry: its `get()` sent one request and threw on any 401. Same failure class, same fix already proven on the GitHub side — GitLab just never got it.

**Why it matters:** a GitLab connection whose token is revoked/rotated mid-session (or just past its cached freshness window) now fails every repo list/read/archive call until the next unrelated refresh, instead of self-healing like the GitHub client already does.

**Fix:** added `authedFetch()` — one authenticated request, retry once with `forceRefresh: true` on a 401 — and routed `getRepo`/`listRepos`/`readFile` (via `get()`), `archiveTarball`, and `identity()` through it, mirroring `GithubProviderClient.request()`.

**Verify:** `cd apps/api && bunx tsc --noEmit` (green) and `bun test apps/api/src/git-providers/gitlab/client.test.ts` (20 pass, unaffected — those cover the pure mapping/encoding functions, which are untouched). Per `TESTING.md`, a class-level test of the retry itself would need a mocked `fetch`, which belongs in e2e, not unit — CI's e2e/full suite is left to validate the network path.

**Local checks run:** `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bun test apps/api/src/git-providers/gitlab/client.test.ts`, `bunx oxlint apps/api/src/git-providers/gitlab/client.ts` (0 warnings/errors). Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitLab provider client so a revoked or externally rotated token is refreshed and retried once instead of failing every request until the next unrelated refresh.

- `GitlabProviderClient` now retries once with `forceRefresh: true` on a 401, matching `GithubProviderClient.request()`.
- Routes `getRepo`, `listRepos`, `readFile`, `archiveTarball`, and `identity()` through the new retry path.

<sup>Written for commit 9b3015b8fbf55afa60144d96b3225dd798f4c354. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

