### PR TITLE
docs(pt-br): translate model-tier picker terminology across agent documentation

### DIFF
--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/agents.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/agents.mdx
@@ -27,7 +27,7 @@ Você chega a um agent pela home grid, pela lista de threads na sidebar ou pelo 
 Quando você abre um agent, a navegação permanente dele fica na seção do projeto na sidebar, e o workspace pode se dividir em duas partes:
 
 - **Sidebar — views do projeto.** Em **Layout**, escolha se Home, Reports, Tasks, Site Editor, Automations e cada view disponível de Assets, Hosting, E2E, Deco Analytics, Monitor ou de MCP apps fixados aparece aqui. Selecionar uma delas a abre como main view; esses destinos não aparecem também como tabs de nível superior no painel.
-- **Esquerda — chat.** Converse com o agent em linguagem natural; ele usa as tools anexadas para fazer o trabalho. Suas mensagens e threads passadas com este agent ficam aqui. Acima do input estão o **model picker** e o **runtime picker** (veja [Onde um agent roda](#onde-um-agent-roda)).
+- **Esquerda — chat.** Converse com o agent em linguagem natural; ele usa as tools anexadas para fazer o trabalho. Suas mensagens e threads passadas com este agent ficam aqui. Acima do input estão o **model-tier picker** (Fast, Smart, Thinking — veja [AI Providers](/pt-br/studio/ai-providers)) e o **runtime picker** (veja [Onde um agent roda](#onde-um-agent-roda)).
 - **Direita — main view.** Esta é a view selecionada na sidebar ou configurada como padrão do projeto. Uma view ainda pode ter suas próprias tabs contextuais — por exemplo, Preview, Content e Code dentro do Site Editor — e outputs temporários do chat podem aparecer aqui sem virar navegação permanente na sidebar.
 
 Um agent baseado em Git também mostra um **branch selector** ao lado do runtime picker, e um indicador de **status do sandbox** enquanto seu ambiente inicializa.

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/concepts.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/concepts.mdx
@@ -37,7 +37,7 @@ A sidebar fixa à esquerda é a mesma em qualquer lugar que você vá:
 
 Abra um agent — ou inicie uma thread com ele — e a tela se divide em duas:
 
-- **Esquerda — chat.** Converse com o agent em linguagem natural; ele usa as tools anexadas para fazer o trabalho. As mensagens anteriores ficam aqui. Acima do campo de entrada ficam o **model picker** e o **runtime picker** (onde o agent roda — veja [Agents](/pt-br/studio/agents#onde-um-agent-roda)).
+- **Esquerda — chat.** Converse com o agent em linguagem natural; ele usa as tools anexadas para fazer o trabalho. As mensagens anteriores ficam aqui. Acima do campo de entrada ficam o **model-tier picker** e o **runtime picker** (onde o agent roda — veja [Agents](/pt-br/studio/agents#onde-um-agent-roda)).
 - **Direita — um painel com abas.** Quais abas aparecem depende do agent:
   - **Settings** — instruções, connections anexadas, files & skills (exibido se você pode gerenciar agents)
   - **Automations** — schedules e gatilhos de eventos (sempre disponível)

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/quickstart.mdx
@@ -49,7 +49,7 @@ Quando estiver pronto para criar um worker focado e reutilizável, crie um agent
 
 Use o botão **+** / "Browse agents" na sidebar para criar um novo agent. Assim que ele abrir, a tela se divide em duas partes:
 
-- **Esquerda** — o chat. Acima do input ficam o **model picker** (nível do modelo) e o **runtime picker** (onde o agent roda — na cloud ou na sua própria máquina; veja [Agents](/pt-br/studio/agents#onde-um-agent-roda)).
+- **Esquerda** — o chat. Acima do input ficam o **model-tier picker** e o **runtime picker** (onde o agent roda — na cloud ou na sua própria máquina; veja [Agents](/pt-br/studio/agents#onde-um-agent-roda)).
 - **Direita** — um painel com abas. A aba **Settings** guarda instruções, connections e arquivos; **Automations** guarda schedules e triggers. Outras abas (Preview, Content, Review changes) aparecem apenas para agents vinculados a um repo ou site.
 
 Abra a aba **Settings** e escreva uma instrução de uma linha descrevendo o que este agent deve fazer.


### PR DESCRIPTION
**Translation drift fix:** Align Portuguese documentation terminology with English by translating "model-tier picker" references across three files.

## Changes

Fixed translation gaps in Portuguese documentation:

1. **agents.mdx line 30**: Added missing "tier" designation and complete reference to AI Providers with model tier options (Fast, Smart, Thinking) and link to `/pt-br/studio/ai-providers`
2. **concepts.mdx line 40**: Added missing "tier" designation to match English terminology
3. **quickstart.mdx line 52**: Replaced explanatory "(nível do modelo)" with standardized term "model-tier picker"

## Verification

- All three Portuguese files now have consistent "model-tier picker" terminology matching English counterparts
- Formatting: `bun run fmt` passed (no changes needed)
- Linting: `bunx oxlint` passed (0 errors)
- No TypeScript changes
- Net diff: -3 insertions / +3 deletions (terminology standardization only)

## Confirmation

Run `git diff origin/main docs/pt-br-model-tier-picker-translation-w3` to verify the three-line translation improvements.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the "model-tier picker" term across three Portuguese docs pages so the terminology matches the English docs.

- Renames "model picker" to "model-tier picker" in `agents.mdx` and `concepts.mdx`.
- Replaces the explanatory "(nível do modelo)" with "model-tier picker" in `quickstart.mdx`.
- Adds the Fast, Smart, and Thinking tier options and a link to AI Providers in `agents.mdx`.

<sup>Written for commit 8cfe1c5e4f3f1a3a8e923c50dc4e98dfc56ad521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

