### PR TITLE
fix(oauth): degrade a corrupted downstream token row instead of throwing

### DIFF
--- a/apps/api/src/storage/downstream-token-decrypt.test.ts
+++ b/apps/api/src/storage/downstream-token-decrypt.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import { CredentialVault } from "../encryption/credential-vault";
+import {
+  decryptDownstreamTokenRow,
+  type RawDownstreamTokenRow,
+} from "./downstream-token";
+
+function row(overrides: Partial<RawDownstreamTokenRow>): RawDownstreamTokenRow {
+  return {
+    id: "dtok_1",
+    connectionId: "conn_1",
+    accessToken: "not-ciphertext",
+    refreshToken: null,
+    scope: null,
+    expiresAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    clientId: null,
+    clientSecret: null,
+    tokenEndpoint: null,
+    ...overrides,
+  };
+}
+
+describe("decryptDownstreamTokenRow", () => {
+  it("decrypts a well-formed row", async () => {
+    const vault = new CredentialVault(CredentialVault.generateKey());
+    const accessToken = await vault.encrypt("secret-access");
+    const refreshToken = await vault.encrypt("secret-refresh");
+
+    const result = await decryptDownstreamTokenRow(
+      vault,
+      row({ accessToken, refreshToken }),
+    );
+
+    expect(result?.accessToken).toBe("secret-access");
+    expect(result?.refreshToken).toBe("secret-refresh");
+  });
+
+  // A tampered/undecryptable row must degrade to "no cached token", not throw.
+  it("returns null instead of throwing on corrupted ciphertext", async () => {
+    const vault = new CredentialVault(CredentialVault.generateKey());
+
+    const result = await decryptDownstreamTokenRow(
+      vault,
+      row({ accessToken: "definitely-not-valid-aes-gcm-ciphertext" }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the row was encrypted under a different vault key", async () => {
+    const oldVault = new CredentialVault(CredentialVault.generateKey());
+    const currentVault = new CredentialVault(CredentialVault.generateKey());
+    const accessToken = await oldVault.encrypt("secret-access");
+
+    const result = await decryptDownstreamTokenRow(
+      currentVault,
+      row({ accessToken }),
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/storage/downstream-token.ts
+++ b/apps/api/src/storage/downstream-token.ts
@@ -43,7 +43,7 @@ export class DownstreamTokenStorage {
 
     if (!row) return null;
 
-    return this.decryptToken(row);
+    return decryptDownstreamTokenRow(this.vault, row);
   }
 
   async upsert(data: DownstreamTokenData): Promise<DownstreamToken> {
@@ -137,29 +137,44 @@ export class DownstreamTokenStorage {
 
     return expiryTime - bufferMs < Date.now();
   }
+}
 
-  /**
-   * Decrypt sensitive fields from a database row
-   */
-  private async decryptToken(row: {
-    id: string;
-    connectionId: string;
-    accessToken: string;
-    refreshToken: string | null;
-    scope: string | null;
-    expiresAt: Date | string | null;
-    createdAt: Date | string;
-    updatedAt: Date | string;
-    clientId: string | null;
-    clientSecret: string | null;
-    tokenEndpoint: string | null;
-  }): Promise<DownstreamToken> {
-    const accessToken = await this.vault.decrypt(row.accessToken);
+/**
+ * Row shape as read back from `downstream_tokens`, before decryption.
+ */
+export interface RawDownstreamTokenRow {
+  id: string;
+  connectionId: string;
+  accessToken: string;
+  refreshToken: string | null;
+  scope: string | null;
+  expiresAt: Date | string | null;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+  clientId: string | null;
+  clientSecret: string | null;
+  tokenEndpoint: string | null;
+}
+
+/**
+ * Decrypt sensitive fields from a database row. Corrupted ciphertext (a
+ * tampered value, or a row encrypted under a vault key that has since been
+ * rotated) makes AES-GCM's tag check throw — that must not crash the caller.
+ * Callers already treat a missing row as "no cached token, go refresh/reconnect";
+ * an undecryptable row degrades to the same outcome instead of a 500.
+ * Exported standalone (no `this.db`) so it's unit-testable without Postgres.
+ */
+export async function decryptDownstreamTokenRow(
+  vault: CredentialVault,
+  row: RawDownstreamTokenRow,
+): Promise<DownstreamToken | null> {
+  try {
+    const accessToken = await vault.decrypt(row.accessToken);
     const refreshToken = row.refreshToken
-      ? await this.vault.decrypt(row.refreshToken)
+      ? await vault.decrypt(row.refreshToken)
       : null;
     const clientSecret = row.clientSecret
-      ? await this.vault.decrypt(row.clientSecret)
+      ? await vault.decrypt(row.clientSecret)
       : null;
 
     return {
@@ -175,5 +190,11 @@ export class DownstreamTokenStorage {
       clientSecret,
       tokenEndpoint: row.tokenEndpoint,
     };
+  } catch (error) {
+    console.warn("[DownstreamToken] failed to decrypt token row", {
+      connectionId: row.connectionId,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return null;
   }
 }


### PR DESCRIPTION
**Source:** bug found while hardening the OAuth token-refresh stack (`apps/api/src/oauth/token-refresh.ts` and its callers all go through `DownstreamTokenStorage.get()`).

**Why:** `DownstreamTokenStorage.get()` decrypted a row's `accessToken`/`refreshToken`/`clientSecret` inline and let any decrypt error propagate uncaught. AES-256-GCM's tag check throws (`"Unsupported state or unable to authenticate data"`) on a tampered ciphertext or a row encrypted under a vault key that has since rotated — that exception was never caught, so a single corrupted `downstream_tokens` row crashed every caller (`getValidDownstreamAccessToken`, `githubConnectionAccessToken`, the `/oauth-token/status` route) instead of degrading to "no cached token", which is exactly the state that already triggers a graceful reconnect/refresh flow elsewhere in this same module. This mirrors the existing `connections` table pattern (`storage/connection.ts` + `decrypt-failure-tracker.ts`) that already treats an undecryptable `oauth_config`/`connection_token` as a soft failure rather than a crash — `downstream_tokens` had no equivalent guard.

**Fix:** extracted the row-decryption into a standalone `decryptDownstreamTokenRow(vault, row)` function that catches the decrypt error, logs a warning with the connection id, and returns `null` (same as "row not found") instead of rethrowing. `get()` now calls this instead of inlining the decrypt calls.

**Regression test:** `apps/api/src/storage/downstream-token-decrypt.test.ts` — a pure unit test (no DB, no mocks; a real `CredentialVault`) asserting: (1) a well-formed row still decrypts correctly, (2) corrupted ciphertext returns `null` instead of throwing, (3) a row encrypted under a different vault key (simulating key rotation) also returns `null` instead of throwing.

**Reviewer command:** `cd apps/api && bun test src/storage/downstream-token-decrypt.test.ts`

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace), the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest (including the existing `downstream-token.integration.test.ts`, unaffected by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `DownstreamTokenStorage.get()` so a corrupted or undecryptable `downstream_tokens` row returns `null` instead of throwing, letting OAuth callers fall back to the existing reconnect/refresh flow instead of crashing.

- Extracts row decryption into a standalone `decryptDownstreamTokenRow()` that catches decrypt errors, logs a warning with the connection id, and returns `null`.
- Matches the existing `connections` table pattern that already treats undecryptable rows as soft failures.
- Adds unit tests for well-formed rows, corrupted ciphertext, and key rotation.

<sup>Written for commit f4cc7b83dcf50a49d352d3b92abaf800e5c26051. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

