### PR TITLE
fix(sandbox-daemon): make CancelAll wait for runs to actually exit before returning

### DIFF
--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
@@ -58,6 +58,13 @@ var takeoverTimeout = 10 * time.Second
 // supersedes — it just does so this much later.
 var supersedeGrace = 5 * time.Second
 
+// How long CancelAll waits for a killed run to actually finish exiting before
+// giving up on it. Bounded: shutdown must not hang forever on a harness whose
+// process refuses to die, but a run that reaps promptly (the common case — a
+// SIGKILL to a process group is fast) is worth waiting for, since what comes
+// right after CancelAll is the shutdown publish committing the same tree.
+var cancelAllWait = 10 * time.Second
+
 // How long a run whose client vanished keeps running, waiting to be reattached.
 //
 // A Studio replica is disposable — a rollout, a KEDA scale-in or a node
@@ -442,9 +449,12 @@ func (reg *Registry) HasActiveRuns() bool {
 	return len(reg.activeRuns) > 0
 }
 
-// CancelAll kills every in-flight run. Used on daemon shutdown: a running
-// harness holds CLIs writing into the tree the shutdown publish is about to
-// commit.
+// CancelAll kills every in-flight run and waits (bounded by cancelAllWait) for
+// each to actually exit. Used on daemon shutdown: a running harness holds CLIs
+// writing into the tree the shutdown publish is about to commit — cancelling
+// the context only asks the process group to die, it does not confirm it has,
+// so returning before `done` closes would let the publish race a CLI that is
+// still mid-write to the same files.
 func (reg *Registry) CancelAll() {
 	reg.mu.Lock()
 	entries := make([]*activeRun, 0, len(reg.activeRuns))
@@ -454,6 +464,18 @@ func (reg *Registry) CancelAll() {
 	reg.mu.Unlock()
 	for _, entry := range entries {
 		entry.cancel()
+	}
+	deadline := time.Now().Add(cancelAllWait)
+	for _, entry := range entries {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return
+		}
+		select {
+		case <-entry.done:
+		case <-time.After(remaining):
+			return
+		}
 	}
 }
 

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
@@ -302,6 +302,9 @@ func TestTombstoneMarksOnlyAskedForCancels(t *testing.T) {
 	const token = "tkn"
 	reg := NewRegistry()
 	entry, _ := claimForTest(reg, "run-1", func() {})
+	// Simulates the harness having already exited by the time CancelAll waits
+	// on it, so the test doesn't pay cancelAllWait's real timeout.
+	close(entry.done)
 
 	// Shutdown (`CancelAll`) and a dropped connection leave no tombstone: the
 	// run is continuable, so it must NOT be reported as cancelled.
@@ -328,6 +331,43 @@ func TestTombstoneMarksOnlyAskedForCancels(t *testing.T) {
 	// Scoped to the run it named — a sibling run on the same pod is untouched.
 	if reg.tombstoned("run-2") {
 		t.Fatal("a cancel must not tombstone another run")
+	}
+}
+
+// CancelAll's caller (the shutdown publish) needs the harness's writes to have
+// actually stopped, not merely asked to stop — cancelling a context only
+// requests that, the process group takes real time to die. Without waiting on
+// `done`, CancelAll returned the instant it fired the kill signal and the
+// publish could start committing the tree while the CLI was still writing to
+// it.
+func TestCancelAllWaitsForRunsToActuallyExit(t *testing.T) {
+	restore := cancelAllWait
+	cancelAllWait = 200 * time.Millisecond
+	defer func() { cancelAllWait = restore }()
+
+	reg := NewRegistry()
+	claimForTest(reg, "run-1", func() {})
+	// Nobody ever closes the entry's `done` here — simulates a harness process
+	// that does not reap within the shutdown budget.
+	started := time.Now()
+	reg.CancelAll()
+	if elapsed := time.Since(started); elapsed < cancelAllWait {
+		t.Fatalf("CancelAll returned after %s, before its own wait budget of %s — "+
+			"it isn't actually waiting for the run to exit", elapsed, cancelAllWait)
+	}
+
+	// A run that DOES exit in time is not held past its own completion.
+	reg2 := NewRegistry()
+	entry2, _ := claimForTest(reg2, "run-2", func() {})
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		close(entry2.done)
+	}()
+	started = time.Now()
+	reg2.CancelAll()
+	if elapsed := time.Since(started); elapsed >= cancelAllWait {
+		t.Fatalf("CancelAll waited the full budget (%s) for a run that exited "+
+			"promptly", elapsed)
 	}
 }
 


### PR DESCRIPTION
**Source:** a real concurrency bug found while auditing `packages/sandbox/daemon-go` error propagation and shutdown for the focus area "sandbox daemon & tooling health", following the recent superseded-code refactor (#7063).

**The bug:** `Registry.CancelAll()` is called from `daemon.shutdown()` on SIGTERM specifically so that "a running harness holds CLIs that would otherwise keep writing into the tree the publish is about to commit" (see the comment right above the call site in `main.go`). But `CancelAll` only called each run's `context.CancelFunc` and returned immediately — it never waited for the harness process to actually die. Cancelling a context just *asks* `exec.CommandContext`'s cancel hook to SIGKILL the process group; the kill, the pipe EOF, and `cmd.Wait()` reaping all happen asynchronously afterward. So the shutdown publish (`gitx.Publish`, right after `CancelAll()` in `main.go`) could start committing the working tree while a harness CLI was still mid-write to the same files it manages — silent data loss/corruption on shutdown, exactly the race the surrounding comment says it's supposed to prevent.

**The fix:** `CancelAll` now cancels every run as before, then waits (bounded by a new `cancelAllWait` = 10s) for each run's `done` channel — which only closes after `runHarness`'s `cmd.Wait()` has actually reaped the process — before returning. Bounded so a stuck harness can't hang shutdown forever; the common case (SIGKILL to a process group) reaps promptly and the wait costs nothing.

**Regression test:** `TestCancelAllWaitsForRunsToActuallyExit` in `internal/dispatch/dispatch_test.go` — asserts `CancelAll` blocks for the full budget when a run's `done` never closes, and returns promptly when it closes early. Also updated the existing `TestTombstoneMarksOnlyAskedForCancels` to close its fake run's `done` up front so it doesn't pay the new wait.

**To verify:** `cd packages/sandbox/daemon-go && go test ./internal/dispatch/...`

**Checked locally:** `gofmt -l`, `go build ./...`, `go vet ./internal/dispatch/...`, and the full `internal/dispatch` test suite — all clean. CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race on daemon shutdown where CancelAll returned before harness processes actually exited, letting the shutdown publish commit the tree while a CLI was still writing to it. CancelAll now waits up to 10 seconds for each run's done channel to close after cancelling.

- Adds `TestCancelAllWaitsForRunsToActuallyExit` covering both the timeout and prompt-exit cases.

<sup>Written for commit 8a44358c7682823a140490e2e2b978f74b832c11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

