### PR TITLE
fix(file-storage): retry a transient tarball fetch for first-class-repository syncs

### DIFF
--- a/apps/api/src/file-storage/skill-set-sync.test.ts
+++ b/apps/api/src/file-storage/skill-set-sync.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { GitProviderError } from "../git-providers/types";
 import {
   isRetriableTarballError,
   isUpToDate,
@@ -205,5 +206,20 @@ describe("isRetriableTarballError", () => {
 
   it("retries an unclassified network error (reset, DNS, timeout)", () => {
     expect(isRetriableTarballError(new TypeError("fetch failed"))).toBe(true);
+  });
+
+  it("retries a first-class repository's GitProviderError for 0/5xx/429", () => {
+    const mk = (status: number) =>
+      new GitProviderError({ provider: "github", status, message: "x" });
+    expect(isRetriableTarballError(mk(0))).toBe(true);
+    expect(isRetriableTarballError(mk(503))).toBe(true);
+    expect(isRetriableTarballError(mk(429))).toBe(true);
+  });
+
+  it("does not retry a first-class repository's 4xx GitProviderError", () => {
+    const mk = (status: number) =>
+      new GitProviderError({ provider: "gitlab", status, message: "x" });
+    expect(isRetriableTarballError(mk(404))).toBe(false);
+    expect(isRetriableTarballError(mk(401))).toBe(false);
   });
 });

--- a/apps/api/src/file-storage/skill-set-sync.ts
+++ b/apps/api/src/file-storage/skill-set-sync.ts
@@ -18,6 +18,7 @@ import { gunzipSync } from "node:zlib";
 import type { Kysely } from "kysely";
 import { retry, RetryError } from "@decocms/shared/std";
 import type { Database } from "../storage/types";
+import { GitProviderError } from "../git-providers/types";
 import { OrgFsEntryStorage } from "../storage/org-fs";
 import {
   type BoundObjectStorage,
@@ -211,10 +212,18 @@ export class TarballHttpError extends Error {
  * missing repo, expired token) won't resolve either. Everything else —
  * codeload 5xx/429, and whatever `fetch`/the 60s timeout throw for a reset or
  * DNS hiccup — is the transient case this exists for.
+ *
+ * `GitProviderError` covers the first-class-repository path too: both
+ * provider clients (github/http.ts, gitlab/http.ts) fold a network failure
+ * into `status: 0`, so 0/5xx/429 is the same transient set as the raw-fetch
+ * `TarballHttpError` case above.
  */
 export function isRetriableTarballError(err: unknown): boolean {
   if (err instanceof TarballHttpError) {
     return err.status >= 500 || err.status === 429;
+  }
+  if (err instanceof GitProviderError) {
+    return err.status === 0 || err.status >= 500 || err.status === 429;
   }
   if (
     err instanceof Error &&
@@ -285,8 +294,23 @@ async function repoFilesFor(
   if (!opts.tarball) {
     return fetchRepoFiles(source.repo, source.ref, opts.authToken);
   }
+  const tarball = opts.tarball;
   const label = `${source.repo}@${source.ref}`;
-  const stream = await opts.tarball();
+  let stream: ReadableStream<Uint8Array> | null;
+  try {
+    // Same transient-failure policy as the raw-fetch path.
+    stream = await retry(() => tarball(), {
+      maxAttempts: 3,
+      minTimeout: 500,
+      maxTimeout: 4_000,
+      jitter: 0.5,
+      isRetriable: isRetriableTarballError,
+    });
+  } catch (err) {
+    throw err instanceof RetryError && err.cause instanceof Error
+      ? err.cause
+      : err;
+  }
   if (!stream) throw new Error(`tarball not found for ${label}`);
   return filesFromTarball(await readTarballStream(stream, label), label);
 }


### PR DESCRIPTION
Follows #6939/#7022 (first-class `repositories` behind a provider interface) and #7049 (retry transient tarball fetches during repo sync).

`syncRepoToVolume`'s `repoFilesFor` has two ways to get a repo's tarball: the legacy raw `fetch` against codeload/the GitHub API (for the pre-repository `mcp-github` connection path), and `GitProviderClient.archiveTarball` for a first-class repository (the path #6939/#7022 made the default for both org-repo-sync and the public skill sets going forward). #7049 added retry-with-backoff to the legacy path for transient 5xx/429/network failures, but the newer `archiveTarball` path still made exactly one request and surfaced any failure immediately — a single GitHub/GitLab 503 or reset now fails the whole sync tick for every org-repo-sync config and public skill set backed by a first-class repository, instead of the ~1.5s of retry the legacy path already tolerates.

**Failure scenario:** an org has a repo synced via a first-class `repositories` row (the now-standard path). The DBOS sync tick hits a transient GitHub/GitLab 503 or a dropped connection while fetching the archive — the sync fails outright and records `last_sync_error`, even though the exact same blip on the legacy connection path would have been retried and succeeded.

**Fix:** wrap the `archiveTarball()` call in the same `retry()` (3 attempts, 500ms-4s backoff, jittered) already used for the raw-fetch path, reusing `isRetriableTarballError` — extended with a `GitProviderError` branch, since both provider clients (`github/http.ts`, `gitlab/http.ts`) already fold a network failure into `GitProviderError{status:0}` and an HTTP failure into its real status. 0/5xx/429 retry; 4xx (bad ref, missing repo, expired token) does not, matching the existing policy.

Added two `isRetriableTarballError` cases (retriable 0/5xx/429 and non-retriable 4xx `GitProviderError`) to the existing describe block, mirroring the `TarballHttpError` cases already there.

**To verify:** `bun test apps/api/src/file-storage/skill-set-sync.test.ts` (19 pass, includes the 2 new cases).

**Checked locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/file-storage/skill-set-sync.test.ts` (19 pass), `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient tarball fetch failures during first-class repository syncs, matching the retry policy already applied to legacy raw-fetch syncs.

Previously, syncs using a first-class repository via `GitProviderClient.archiveTarball` made a single request and failed on any network or HTTP error. Now `repoFilesFor` wraps that call in the same `retry` (3 attempts, jittered backoff) used for the legacy path, and `isRetriableTarballError` recognizes `GitProviderError` with status 0/5xx/429 as retriable, while 4xx errors (e.g., bad ref) still fail immediately.

<sup>Written for commit 3b894f959d841b20cf554b6d9f1b256b5225e87b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

