### PR TITLE
fix(git-providers): stop providerForHost matching gitlab as a mid-label substring

### DIFF
--- a/packages/shared/src/git-providers/repo-ref.test.ts
+++ b/packages/shared/src/git-providers/repo-ref.test.ts
@@ -28,6 +28,10 @@ describe("providerForHost", () => {
     expect(providerForHost("git.acme.com")).toBeNull();
     expect(providerForHost("bitbucket.org")).toBeNull();
   });
+  test("does not match gitlab as a mid-label substring", () => {
+    expect(providerForHost("notgitlab.com")).toBeNull();
+    expect(providerForHost("legitlabcorp.com")).toBeNull();
+  });
 });
 
 describe("parseRepoUrl", () => {

--- a/packages/shared/src/git-providers/repo-ref.ts
+++ b/packages/shared/src/git-providers/repo-ref.ts
@@ -28,7 +28,7 @@ export function providerForHost(host: string): GitProviderKind | null {
   const h = host.toLowerCase();
   if (h === "github.com" || h === "www.github.com") return "github";
   if (h === "gitlab.com" || h === "www.gitlab.com") return "gitlab";
-  if (/(^|\.)gitlab(\.|$)|(^|\.)gitlab-|gitlab\./.test(h)) return "gitlab";
+  if (/(^|[.-])gitlab([.-]|$)/.test(h)) return "gitlab";
   return null;
 }
 


### PR DESCRIPTION
**Source**: bug found while reviewing `packages/shared/src/git-providers/repo-ref.ts` for git-provider CLI edge cases (this session's focus area).

**Payoff**: `providerForHost` is the fallback used when a URL is parsed (`parseRepoUrl`) without an explicit provider — e.g. a user pasting a repository URL into an import/connect flow. Its self-hosted-GitLab heuristic ended with an unanchored alternative, `gitlab\.`, that matches anywhere in the host string.

**Failure scenario**: `providerForHost("notgitlab.com")` (or any host that merely contains `gitlab.` as a substring, e.g. `evilgitlab.com`) returned `"gitlab"` even though it isn't a GitLab host by any real convention — it doesn't start with `gitlab.`, isn't `gitlab.<something>`, and doesn't have a `-gitlab-`/`gitlab-` segment boundary. That misclassification would pick the wrong REST API base URL (`apiBaseUrlFor`) and the wrong CLI vocabulary (`glab` instead of erroring/asking for an explicit provider) for a repository that isn't actually hosted on GitLab.

**Fix**: tightened the third alternative to require a label boundary (`.`, `-`, or string start/end) around `gitlab`, matching the same convention already used for the other two branches: `/(^|[.-])gitlab([.-]|$)/`. All existing test cases (`gitlab.com`, `gitlab.acme.com`, `git.gitlab-internal.example`, `gitlab.example.com:8443`, `git.acme.com`, `bitbucket.org`) still pass; added a regression test for `notgitlab.com` / `legitlabcorp.com` returning `null`.

**Verify**: `bun test packages/shared/src/git-providers/repo-ref.test.ts`

**Checked locally**: `bun run fmt`, `bunx tsc --noEmit` (packages/shared), the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `providerForHost` incorrectly identifying hosts like `notgitlab.com` as GitLab, which caused the wrong API base URL and CLI tool selection. Now it only matches `gitlab` as a whole label (e.g., `gitlab.com`, `gitlab.example.com`, `git.gitlab-internal`). Added regression tests for hosts that merely contain `gitlab` as a substring.

<sup>Written for commit 5a314d397616f76596b04a54707cf6f868d92f62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

