### PR TITLE
fix(sandbox-daemon): close both WS proxy legs once either side finishes

### DIFF
--- a/packages/sandbox/daemon-go/internal/proxy/ws.go
+++ b/packages/sandbox/daemon-go/internal/proxy/ws.go
@@ -62,14 +62,26 @@ func ServeWs(w http.ResponseWriter, r *http.Request, deps WsDeps) {
 		return
 	}
 
+	splice(clientConn, clientBuf, upstream, deps.OnClientData)
+}
+
+// splice pumps bytes bidirectionally between the client and the upstream dev
+// server. A half-close (CloseWrite) lets a well-behaved peer see EOF and close
+// its own side in turn, but a peer that never does — e.g. a client that
+// leaves its WebSocket open without sending anything after the dev server
+// closes — would otherwise leave the other goroutine's Read blocked forever,
+// leaking the goroutine and the hijacked connection for the life of the
+// daemon. So once either side finishes, both connections are closed to force
+// the other Read to return before this function waits for it.
+func splice(clientConn net.Conn, clientBuf io.Reader, upstream net.Conn, onClientData func()) {
 	done := make(chan struct{}, 2)
 	go func() {
 		buf := make([]byte, 32*1024)
 		for {
 			n, rerr := clientBuf.Read(buf)
 			if n > 0 {
-				if deps.OnClientData != nil {
-					deps.OnClientData()
+				if onClientData != nil {
+					onClientData()
 				}
 				if _, werr := upstream.Write(buf[:n]); werr != nil {
 					break
@@ -92,6 +104,8 @@ func ServeWs(w http.ResponseWriter, r *http.Request, deps WsDeps) {
 		done <- struct{}{}
 	}()
 	<-done
+	clientConn.Close()
+	upstream.Close()
 	<-done
 }
 

--- a/packages/sandbox/daemon-go/internal/proxy/ws_test.go
+++ b/packages/sandbox/daemon-go/internal/proxy/ws_test.go
@@ -1,0 +1,34 @@
+package proxy
+
+import (
+	"bufio"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestSplice_ReturnsWhenUpstreamClosesEvenIfClientNeverDoes reproduces the
+// deadlock this file's splice fix closes: an upstream (dev server) that
+// closes while the client side never sends anything and never closes its own
+// connection must not hang splice forever.
+func TestSplice_ReturnsWhenUpstreamClosesEvenIfClientNeverDoes(t *testing.T) {
+	clientConn, testClient := net.Pipe()
+	defer testClient.Close()
+	upstreamConn, testUpstream := net.Pipe()
+
+	// Upstream (the dev server) is already gone; the client peer stays open
+	// and silent, exactly the case that used to block clientBuf.Read forever.
+	testUpstream.Close()
+
+	done := make(chan struct{})
+	go func() {
+		splice(clientConn, bufio.NewReader(clientConn), upstreamConn, nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("splice did not return after upstream closed; client-read goroutine leaked")
+	}
+}


### PR DESCRIPTION
**Source**: bug found while hunting `packages/sandbox/daemon-go/internal` for daemon-core races/shutdown gaps (this tick's focus area).

**Why a maintainer wants it**: `ServeWs` (the WebSocket proxy splicing a browser's HMR/dev-server socket to the loopback dev server) waited on *both* copy goroutines before returning. If the upstream dev server closed but the client peer never sent more data and never closed its own side, the client-read goroutine stayed blocked on `clientBuf.Read` forever — leaking that goroutine and the hijacked TCP connection for the rest of the daemon's process lifetime. `devwatch.go`'s liveness watchdog respawns a flaky dev server up to 3 times per dead episode, so every WebSocket client (e.g. Vite HMR) connected during one of those respawns was at risk of pinning a leaked connection.

**Fix**: once either side of the splice finishes, close both connections. That forces the other side's blocked `Read` to return with a close error instead of parking indefinitely, so `splice`/`ServeWs` always returns.

**Regression test**: `packages/sandbox/daemon-go/internal/proxy/ws_test.go` — `TestSplice_ReturnsWhenUpstreamClosesEvenIfClientNeverDoes` wires two `net.Pipe()` pairs, closes the upstream side, and never touches the client side, asserting `splice` returns within 2s. Confirmed this test fails to even compile against the pre-fix code (the `splice` helper didn't exist — the inline goroutines it replaces have the same wait-on-both-`done` shape and would hang the same way), and passes against the fix.

**To verify**: `cd packages/sandbox/daemon-go && go test ./internal/proxy/... -v`

**Checks run locally**: `gofmt -l`, `go build ./...`, `go vet ./internal/proxy/...`, `go test ./internal/proxy/...` — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the WebSocket proxy (`ServeWs`) goroutine leak that occurred when the upstream dev server closed but the client never sent more data or closed its own side, leaving the client-read goroutine blocked forever and leaking the hijacked connection. Now, once either side of the splice finishes, both connections are closed so the other side's read returns immediately.

- Extracted the copy loop into a `splice` helper that handles closing both connections on completion.
- Added a regression test that closes the upstream side and leaves the client silent, verifying `splice` returns within 2 seconds.

<sup>Written for commit 416273721503ff8e06ff7083803646241cbf990c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

