### PR TITLE
fix(git-providers): prune expired entries from the installation token cache

### DIFF
--- a/apps/api/src/git-providers/github/app-auth.test.ts
+++ b/apps/api/src/git-providers/github/app-auth.test.ts
@@ -7,8 +7,10 @@ import {
 import {
   buildAppJwt,
   installationCacheKey,
+  type InstallationToken,
   mapInstallation,
   nextPermissionSet,
+  pruneExpiredTokens,
   usableAppKey,
 } from "./app-auth";
 
@@ -208,6 +210,35 @@ describe("installationCacheKey", () => {
       }),
     ).not.toBe(base);
     expect(installationCacheKey(1, {})).not.toBe(base);
+  });
+});
+
+describe("pruneExpiredTokens", () => {
+  function tokenExpiringAt(ms: number): InstallationToken {
+    return { token: "t", expiresAt: new Date(ms), permissions: {} };
+  }
+
+  test("removes only entries whose expiry is at or before now", () => {
+    const cache = new Map<string, InstallationToken>([
+      ["expired", tokenExpiringAt(1_000)],
+      ["boundary", tokenExpiringAt(2_000)],
+      ["live", tokenExpiringAt(3_000)],
+    ]);
+
+    pruneExpiredTokens(cache, 2_000);
+
+    expect([...cache.keys()]).toEqual(["live"]);
+  });
+
+  test("leaves the cache untouched when nothing has expired", () => {
+    const cache = new Map<string, InstallationToken>([
+      ["a", tokenExpiringAt(5_000)],
+      ["b", tokenExpiringAt(6_000)],
+    ]);
+
+    pruneExpiredTokens(cache, 1_000);
+
+    expect(cache.size).toBe(2);
   });
 });
 

--- a/apps/api/src/git-providers/github/app-auth.ts
+++ b/apps/api/src/git-providers/github/app-auth.ts
@@ -123,6 +123,25 @@ export function installationCacheKey(
   return `${installationId}|${repositories.join(",")}|${permissions.join(",")}`;
 }
 
+/**
+ * Remove every entry in `cache` that has already expired.
+ *
+ * Cache keys are per (installation, repositories, permissions) — a busy
+ * deployment mints one entry per distinct repository an installation ever
+ * touches, and nothing ever removed a stale one, so the map only grew for the
+ * life of the process. Called opportunistically on every mint, which bounds
+ * it to roughly the installations/repos actually touched inside one token
+ * lifetime rather than every one ever seen.
+ */
+export function pruneExpiredTokens(
+  cache: Map<string, InstallationToken>,
+  now: number,
+): void {
+  for (const [key, token] of cache) {
+    if (token.expiresAt.getTime() <= now) cache.delete(key);
+  }
+}
+
 /** Neutral shape of a GitHub App installation, as the account layer stores it. */
 export interface GithubInstallation {
   installationId: number;
@@ -243,6 +262,7 @@ export class GithubAppAuth {
     const mint = this.mint(installationId, opts)
       .then((token) => {
         this.cache.set(key, token);
+        pruneExpiredTokens(this.cache, Date.now());
         return token;
       })
       .finally(() => {


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/git-providers/credentials.ts`/`clients.ts` (the GitHub App credential ladder that lives underneath them) for the git-provider credential-rotation focus area.

**Payoff:** `GithubAppAuth`'s installation-token cache (`apps/api/src/git-providers/github/app-auth.ts`) is keyed per `(installationId, repositories, permissions)` and every mint calls `this.cache.set(key, token)` — but nothing ever removed an entry once its token expired. On a long-running deployment, every distinct repository an installation ever touches leaves a permanent (if tiny) entry, so the map only grows for the life of the process instead of tracking the installations/repos actually in use.

**Fix:** added `pruneExpiredTokens(cache, now)`, a small pure sweep that deletes cache entries whose `expiresAt` has passed, and call it opportunistically right after each successful mint (`installationToken`'s `.then`). This bounds the cache to roughly what's been touched inside one token lifetime (GitHub installation tokens expire in ~1h) rather than every repo ever seen, with no behavior change to token minting itself — cache hits/misses and the refresh-buffer logic are untouched.

**Verify:** `bun test apps/api/src/git-providers/github/app-auth.test.ts` — new `pruneExpiredTokens` describe block asserts it removes only entries at/before `now` and leaves a cache with nothing expired untouched (17/17 pass, including all pre-existing tests unchanged).

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes expired entries from the GitHub App installation token cache so the cache no longer grows without bound on long-running deployments. Previously every distinct repository an installation ever touched left a permanent entry; now each successful token mint also removes entries whose `expiresAt` has passed. Token minting, cache hits/misses, and the refresh buffer are unchanged.

<sup>Written for commit a0699d2d7d6036bbb567b41b80d36ef11d758060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

