### PR TITLE
fix(core): cap the org-archived-status cache in context-factory

### DIFF
--- a/apps/api/src/core/context-factory.archived-cache.test.ts
+++ b/apps/api/src/core/context-factory.archived-cache.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Unit test for the org-archived-status cache's eviction: without a bound,
+ * every org id ever seen stays in the map forever (a stale entry is only
+ * ever overwritten on its own next lookup, never dropped otherwise).
+ */
+import { describe, expect, it } from "bun:test";
+import { evictExpiredOrgArchivedEntries } from "./context-factory";
+
+describe("evictExpiredOrgArchivedEntries", () => {
+  it("leaves the cache untouched when under the cap", () => {
+    const cache = new Map([["org_1", { archived: false, at: Date.now() }]]);
+    evictExpiredOrgArchivedEntries(cache, 10, 60_000);
+    expect(cache.size).toBe(1);
+  });
+
+  it("drops expired entries first when over the cap", () => {
+    const now = Date.now();
+    const cache = new Map([
+      ["org_stale", { archived: false, at: now - 120_000 }],
+      ["org_fresh", { archived: false, at: now }],
+    ]);
+    evictExpiredOrgArchivedEntries(cache, 1, 60_000);
+    expect(cache.has("org_stale")).toBe(false);
+    expect(cache.has("org_fresh")).toBe(true);
+  });
+
+  it("trims the oldest entries when still over the cap after expiry", () => {
+    const now = Date.now();
+    const cache = new Map([
+      ["org_a", { archived: false, at: now }],
+      ["org_b", { archived: false, at: now }],
+      ["org_c", { archived: false, at: now }],
+    ]);
+    evictExpiredOrgArchivedEntries(cache, 1, 60_000);
+    expect(cache.size).toBe(1);
+    expect(cache.has("org_c")).toBe(true);
+  });
+});

--- a/apps/api/src/core/context-factory.ts
+++ b/apps/api/src/core/context-factory.ts
@@ -600,7 +600,32 @@ export async function fetchRolePermissions(
 // request, so caching keeps the lookup off the hot path. Archiving is a
 // one-way soft-delete, so a short TTL is plenty.
 const ARCHIVED_CACHE_TTL_MS = 60_000;
+// Cap: entries are only ever overwritten on their own next lookup, never dropped otherwise.
+const ARCHIVED_CACHE_MAX_SIZE = 10_000;
 const orgArchivedCache = new Map<string, { archived: boolean; at: number }>();
+
+/** Exported for unit testing. */
+export function evictExpiredOrgArchivedEntries(
+  cache: Map<string, { archived: boolean; at: number }>,
+  maxSize: number,
+  ttlMs: number,
+): void {
+  if (cache.size <= maxSize) return;
+  const now = Date.now();
+  for (const [key, entry] of cache) {
+    if (now - entry.at >= ttlMs) cache.delete(key);
+  }
+  // Trims oldest first (Map iteration order = insertion order).
+  if (cache.size > maxSize) {
+    const excess = cache.size - maxSize;
+    let removed = 0;
+    for (const key of cache.keys()) {
+      if (removed >= excess) break;
+      cache.delete(key);
+      removed++;
+    }
+  }
+}
 
 async function isOrgArchivedCached(
   db: Kysely<Database>,
@@ -619,6 +644,11 @@ async function isOrgArchivedCached(
   );
   const archived = isOrgArchived(orgRow);
   orgArchivedCache.set(organizationId, { archived, at: Date.now() });
+  evictExpiredOrgArchivedEntries(
+    orgArchivedCache,
+    ARCHIVED_CACHE_MAX_SIZE,
+    ARCHIVED_CACHE_TTL_MS,
+  );
   return archived;
 }
 


### PR DESCRIPTION
**Source:** bug found while hunting `apps/api/src/core/context-factory.ts` for robustness gaps (context-factory sits in the request hot path — it's rebuilt with a fresh singleton `orgArchivedCache` per process, and lives for the process lifetime).

**The bug:** `orgArchivedCache` (a module-level `Map<orgId, {archived, at}>` used by the Studio-JWT and API-key auth paths to avoid an org-archived DB lookup on every request) had no size cap. An entry is only ever *overwritten* on its own next lookup — nothing ever deletes a stale one. On a long-lived server process that authenticates requests across many distinct orgs over time, the map only ever grows: a slow, unbounded memory leak. This is the same bug class as several past fixes cited in repo history (`decopilot-file-materializer-storage-refs-bound`, `mcp-list-cache-revalidation-leak`, etc.) — cap a tracking map that accumulates one entry per distinct key seen.

**Fix:** added `ARCHIVED_CACHE_MAX_SIZE` (10k, matching `member-role-cache.ts`'s existing bound in the same file) and an `evictExpiredOrgArchivedEntries` helper, run after each cache write: once over the cap, it first drops TTL-expired entries, then trims the oldest remaining ones (Map iteration order = insertion order) until back under the cap. Same eviction shape already used by `createMemberRoleCache` a few lines below in this file — no new abstraction, just applied consistently.

Behavior-preserving for normal load (map stays under 10k entries in practice): reads/writes are unchanged, only an eviction pass is added.

**Regression test:** `apps/api/src/core/context-factory.archived-cache.test.ts` — exercises `evictExpiredOrgArchivedEntries` directly (exported like the file's other pure helpers, e.g. `isOnBehalfOfTokenOrgAllowed`): under the cap it's a no-op, over the cap it drops expired entries first, and still-over-cap trims the oldest remaining ones.

**To verify:** `cd apps/api && bunx tsc --noEmit` and `bun test apps/api/src/core/context-factory.archived-cache.test.ts`.

**Locally ran:** `bun run fmt`, targeted `tsc --noEmit` (apps/api), the one new test file, and `bunx oxlint` on both changed files — all green. Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an unbounded memory leak in `context-factory` where the org-archived cache grew one entry per distinct org ID seen and never dropped stale entries.

The cache is now capped at 10k entries; once over the cap, expired entries are evicted first, then the oldest remaining ones are trimmed. Behavior is unchanged for normal load. Adds a regression test covering the eviction logic.

<sup>Written for commit f422e7422846c9df1688e601579ed3b3fd6ffd00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

