### PR TITLE
fix(sandbox): resolve thread repo from input.threadId, not just the branch

### DIFF
--- a/apps/api/src/tools/sandbox/start.test.ts
+++ b/apps/api/src/tools/sandbox/start.test.ts
@@ -399,6 +399,26 @@ describe("SANDBOX_START", () => {
     );
   });
 
+  it("resolves the thread's bound repo from input.threadId, not just a thread:-prefixed branch", async () => {
+    // Only input.threadId names the thread here — the branch and ctx.metadata don't.
+    const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
+    const ctx = makeCtx({
+      virtualMcp,
+      thread: {
+        created_by: USER_ID,
+        metadata: { githubRepo: { owner: "acme", name: "thread-repo" } },
+      },
+    });
+
+    await SANDBOX_START.handler(
+      { virtualMcpId: VMCP_ID, branch: BRANCH, threadId: "t1" },
+      ctx,
+    );
+
+    const [, opts] = mockEnsure.mock.calls[0]! as [SandboxId, EnsureOptions];
+    expect(opts.repo?.displayName).toBe("acme/thread-repo");
+  });
+
   it("keys a thread-scoped sandbox by the thread's creator, not the caller", async () => {
     // A teammate opening the thread must resume the ONE sandbox that thread has.
     // Keyed by the caller they got a second sandbox on the same git branch —

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -192,16 +192,8 @@ export const SANDBOX_START = defineTool({
       resolvedBranch,
     );
 
-    // Thread-scoped repo (bound by `load_repo`) wins over the agent's repo — the
-    // same rule as `ensureSandbox`. Without this the frontend's auto-start
-    // provisions a repo-LESS sandbox for the synthetic Decopilot agent (whose
-    // metadata has no repo), so nothing clones and the dev server stays idle.
-    // Derive the thread id from the branch since this path has no
-    // `ctx.metadata.threadId`.
-    const threadRepo = await getThreadGithubRepo(
-      ctx,
-      threadIdFromBranch(resolvedBranch) ?? ctx.metadata?.threadId,
-    );
+    // Thread-scoped repo wins over the agent's repo — reuse askingThreadId (not a re-derivation that drops input.threadId).
+    const threadRepo = await getThreadGithubRepo(ctx, askingThreadId);
     const githubRepo =
       threadRepo ?? (metadata as GithubRepoMeta).githubRepo ?? null;
 
@@ -214,10 +206,7 @@ export const SANDBOX_START = defineTool({
       branch: resolvedBranch,
       metadata,
       githubRepo,
-      threadRepos: await getThreadGithubRepos(
-        ctx,
-        threadIdFromBranch(resolvedBranch) ?? ctx.metadata?.threadId,
-      ),
+      threadRepos: await getThreadGithubRepos(ctx, askingThreadId),
       existing,
       runner,
     });


### PR DESCRIPTION
**Bug, found auditing `apps/api/src/tools/sandbox/start.ts`.**

`SANDBOX_START` derives the acting thread id twice. Once, correctly, as `askingThreadId` (`threadIdFromBranch(branch) ?? input.threadId ?? ctx.metadata?.threadId`) for the CMS-session guard and `stampRuntimeIfAbsent`. Then again for the thread-bound repo lookup (`getThreadGithubRepo`/`getThreadGithubRepos`), but that second derivation drops `input.threadId` entirely: `threadIdFromBranch(branch) ?? ctx.metadata?.threadId`.

**Failure scenario:** a caller passes an explicit `input.threadId` while the branch isn't `thread:`-prefixed and `ctx.metadata.threadId` is unset (true on the frontend's non-thread-branch SANDBOX_START path). The call correctly gets stamped/guarded against that thread, but the thread's `load_repo`-bound repo is silently ignored — provisioning falls back to the agent's own `metadata.githubRepo` instead of the repo the thread is actually bound to. This is exactly the bug the surrounding comment says the thread-repo-wins-over-agent-repo rule exists to prevent, just reached through the other id source.

**Fix:** reuse the already-computed `askingThreadId` for both `getThreadGithubRepo` and `getThreadGithubRepos` calls, so the two derivations can't disagree.

**Regression test:** added `resolves the thread's bound repo from input.threadId, not just a thread:-prefixed branch` in `start.test.ts`. Verified it fails on the pre-fix code (asserts `opts.repo?.displayName` is the thread's repo; pre-fix it resolves to the agent's `acme/app` instead) and passes after the fix.

**To verify:** `bun test apps/api/src/tools/sandbox/start.test.ts` (21 pass).

**Checked locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/tools/sandbox/start.ts apps/api/src/tools/sandbox/start.test.ts` (0 warnings/errors), targeted test file above. Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `SANDBOX_START` so it uses the thread ID from `input.threadId` when resolving the thread-bound repo, not just the branch or metadata. Previously, when a caller passed an explicit `threadId` without a `thread:`-prefixed branch, the thread's bound repo was ignored and provisioning fell back to the agent's repo. Now both repo lookups reuse the same `askingThreadId`, so they can't disagree.

**Bug Fixes**
- Adds a regression test for the case where only `input.threadId` identifies the thread.

<sup>Written for commit 7c5cd86cbf309e470629374029376b229ac0cca5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

