### PR TITLE
fix(web): keep the settings sidebar always open

### DIFF
--- a/apps/web/src/components/sidebar/header.tsx
+++ b/apps/web/src/components/sidebar/header.tsx
@@ -14,6 +14,7 @@ import {
   TooltipTrigger,
 } from "@decocms/ui/components/tooltip.tsx";
 import { ToolbarIconButton } from "@/components/toolbar-icon-button";
+import { useInSettings } from "@/hooks/use-in-settings";
 import { useSidebarCollapsed } from "@/hooks/use-sidebar-collapsed";
 import { useT } from "@/i18n/use-t.ts";
 import { OrgProjectPicker } from "./org-project-picker";
@@ -22,11 +23,14 @@ const ICON_SIZE = 16;
 
 export function SidebarPickerHeader() {
   const collapsed = useSidebarCollapsed();
+  /** Settings is forced open (see `OrgLayout`), so a collapse toggle there is a
+   *  control with nothing to do — hidden rather than dead. */
+  const inSettings = useInSettings();
 
   return (
     <>
       <OrgProjectPicker collapsed={collapsed} />
-      <CollapseToggle />
+      {!inSettings && <CollapseToggle />}
     </>
   );
 }

--- a/apps/web/src/layouts/org-layout.tsx
+++ b/apps/web/src/layouts/org-layout.tsx
@@ -22,6 +22,7 @@ import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import { OrgNoticeBanner } from "@/components/org-notice-banner";
 import { StudioSidebar } from "@/components/sidebar";
 import { SidebarResizeHandle } from "@/components/sidebar/sidebar-resize-handle";
+import { useInSettings } from "@/hooks/use-in-settings";
 import { useSidebarResize } from "@/hooks/use-sidebar-resize";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 import { LOCALSTORAGE_KEYS } from "@/lib/localstorage-keys";
@@ -40,9 +41,18 @@ export default function OrgLayout() {
     true,
   );
   const { width, wrapperRef, onStartResize, resetWidth } = useSidebarResize();
+  /** Settings has no icon rail: its group headings ("Organização", "Código"…)
+   *  are plain text, not the row `span:last-child` the collapsed rail hides, so
+   *  a collapsed sidebar there paints them truncated to "O…/C…/G…". The tree is
+   *  a labelled nav that only reads open, so it stays open regardless of the
+   *  persisted preference — which is preserved and restored on the way out. */
+  const inSettings = useInSettings();
 
   return (
-    <SidebarProvider open={sidebarOpen} onOpenChange={setSidebarOpen}>
+    <SidebarProvider
+      open={inSettings || sidebarOpen}
+      onOpenChange={setSidebarOpen}
+    >
       <div className="app-shell-root flex flex-col h-dvh overflow-hidden">
         <OrgNoticeBanner />
         <SidebarLayout


### PR DESCRIPTION
## Summary

In org **Settings**, the left sidebar could render in a broken narrow state showing group headings truncated to `O…`, `C…`, `G…`, `A.` instead of a usable nav.

**Cause:** the sidebar's collapse is binary — the collapsed rail hides exactly each row's `span:last-child`. But `SettingsNav` renders its **group headings** (`Organização`, `Código`, `Geral`, `Avançado`…) as plain `<p>`/`<button>` text, which isn't that span. So a collapsed sidebar while in settings kept those headings visible and truncated them to garbage.

**Fix:** the settings tree is a labelled nav with no icon-rail affordance, so it now stays **always open**:
- `org-layout.tsx` — force `open={inSettings || sidebarOpen}`. The user's persisted collapse preference is preserved and restored the moment they leave settings.
- `header.tsx` — hide the collapse toggle while in settings (it'd be an inert control).

Behavior outside settings is unchanged.

## Testing
- `bun run --cwd=apps/web check` — clean
- `bun run lint` — 0 errors (14 pre-existing warnings in unrelated e2e tests)
- `bun run fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the org Settings sidebar so it no longer breaks when collapsed—group headings like `Organização` were truncated to `O…` because the settings nav's text headings aren't hidden by the collapsed rail. The sidebar now stays open in settings, and the collapse toggle is hidden there.

- The user's persisted collapse preference is preserved and restored when leaving settings.
- Outside settings, behavior is unchanged.

<sup>Written for commit 6405949c7bb2d996c3c7364b9a8eab1c6c9d9226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

