### PR TITLE
fix(storage): route corrupted STDIO envVar decrypt failures into the connection-disable tracker

### DIFF
--- a/apps/api/src/storage/connection-oauth-config-encryption.test.ts
+++ b/apps/api/src/storage/connection-oauth-config-encryption.test.ts
@@ -99,4 +99,32 @@ describe("ConnectionStorage oauth_config encryption", () => {
       before + 2,
     );
   });
+
+  it("feeds an undecryptable STDIO envVar into the same failure tracker as connection_token", async () => {
+    const connectionId = "conn_corrupt_envvar";
+    const before = recordDecryptFailure(connectionId).consecutiveFailures;
+
+    const deserialized = await (
+      storage as unknown as {
+        deserializeConnection: (row: Record<string, unknown>) => Promise<{
+          connection_headers: { envVars?: Record<string, string> } | null;
+        }>;
+      }
+    ).deserializeConnection({
+      id: connectionId,
+      organization_id: "org_test",
+      connection_type: "STDIO",
+      status: "active",
+      connection_headers: JSON.stringify({
+        command: "npx",
+        envVars: { API_KEY: "not-ciphertext" },
+      }),
+    });
+
+    expect(deserialized.connection_headers?.envVars?.API_KEY).toBe("");
+    // Never leak ciphertext into the spawned process's env.
+    expect(recordDecryptFailure(connectionId).consecutiveFailures).toBe(
+      before + 2,
+    );
+  });
 });

--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -713,32 +713,25 @@ export class ConnectionStorage implements ConnectionStoragePort {
       decryptedOAuthConfig = row.oauth_config;
     }
 
-    if (decryptErrors.length > 0) {
-      await this.handleDecryptFailures(row, decryptErrors);
-    } else if (
-      row.connection_token ||
-      row.configuration_state ||
-      row.oauth_config
-    ) {
-      recordDecryptSuccess(row.id);
-    }
-
     // Parse and decrypt connection_headers
     let connectionParameters: ConnectionParameters | null = null;
+    let hasEnvVars = false;
     if (row.connection_headers) {
       try {
         const parsed = JSON.parse(row.connection_headers);
         // For STDIO, decrypt envVars
         if (isStdioParameters(parsed) && parsed.envVars) {
+          hasEnvVars = true;
           const decryptedEnvVars: Record<string, string> = {};
           for (const [envKey, envValue] of Object.entries(parsed.envVars)) {
             try {
               decryptedEnvVars[envKey] = await this.vault.decrypt(
                 envValue as string,
               );
-            } catch {
-              // If decryption fails, keep encrypted value (migration case)
-              decryptedEnvVars[envKey] = envValue as string;
+            } catch (error) {
+              // Don't hand the spawned process raw ciphertext as its env var value.
+              decryptedEnvVars[envKey] = "";
+              decryptErrors.push({ label: `env var "${envKey}"`, error });
             }
           }
           connectionParameters = {
@@ -754,6 +747,17 @@ export class ConnectionStorage implements ConnectionStoragePort {
           error,
         );
       }
+    }
+
+    if (decryptErrors.length > 0) {
+      await this.handleDecryptFailures(row, decryptErrors);
+    } else if (
+      row.connection_token ||
+      row.configuration_state ||
+      row.oauth_config ||
+      hasEnvVars
+    ) {
+      recordDecryptSuccess(row.id);
     }
 
     const parseJson = <T>(value: string | T | null): T | null => {


### PR DESCRIPTION
**Source**: hardening follow-up to #7064 ("route corrupted oauth_config decrypt failures into the connection-disable tracker"), found by auditing `ConnectionStorage.deserializeConnection` for the same asymmetry in the connection-config-encryption area.

**Payoff**: `connection_token`, `configuration_state`, and `oauth_config` all feed decrypt failures into `decryptErrors` → `handleDecryptFailures`, which logs and eventually flips the connection to `status: "error"` after `CONNECTION_DECRYPT_DISABLE_THRESHOLD` consecutive failures (e.g. after a key rotation or bit-rot). A STDIO connection's `connection_headers.envVars` decrypt failures were the one path that skipped this entirely: the `catch` block silently kept the raw ciphertext string as the env var value and moved on, with no log line and no way to ever reach the disable threshold. That means a STDIO MCP server whose secret env var can no longer be decrypted keeps getting spawned forever with a garbage ciphertext string in place of its real credential — a silent, indefinite failure mode invisible to both logs and the connection's `status`.

**Fix**: on an envVar decrypt failure, push `{label, error}` into the same `decryptErrors` array token/configState/oauthConfig already use (moved the `connection_headers` block earlier so it participates in the existing `handleDecryptFailures`/`recordDecryptSuccess` bookkeeping), and store `""` instead of the ciphertext so it's never handed to the spawned process. A `hasEnvVars` flag was added to the existing success-tracking `else if` so an STDIO-only connection (no token/oauth/configState) still records a decrypt success.

Added a regression test mirroring the existing oauth_config one (`connection-oauth-config-encryption.test.ts`): a corrupt envVar now reaches the shared failure tracker exactly like a corrupt `connection_token`, and the deserialized value is `""` rather than the raw ciphertext.

**To verify**: `bun test apps/api/src/storage/connection-oauth-config-encryption.test.ts`

**Checked locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test above (5/5 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes corrupted STDIO envVar decrypt failures into the same connection-disable tracker used for token, config state, and OAuth config, so a failing STDIO connection now gets disabled after repeated failures instead of silently keeping raw ciphertext in the spawned process.

- STDIO envVar decrypt failures now feed the shared `decryptErrors` tracker and store `""` instead of ciphertext.
- Added `hasEnvVars` so STDIO-only connections still record decrypt success.
- Added regression test verifying corrupt envVar reaches the tracker and value is empty.

<sup>Written for commit b50aa526a93a7569072b32270113519cd7a6e6e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

