### PR TITLE
fix(github): drain the response body before discarding it in GITHUB_LIST_USER_ORGS

### DIFF
--- a/apps/api/src/tools/github/list-user-orgs.ts
+++ b/apps/api/src/tools/github/list-user-orgs.ts
@@ -172,6 +172,8 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
       });
 
       if (isGithubRateLimited(res)) {
+        // Drain the unread body before discarding, like github/http.ts.
+        await res.body?.cancel().catch(() => {});
         const kind =
           res.headers.get("retry-after") !== null ? "secondary" : "primary";
         countGithubRateLimited({
@@ -188,6 +190,7 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
       }
 
       if (!res.ok) {
+        await res.body?.cancel().catch(() => {});
         throw new Error(`GitHub /user/installations failed: ${res.status}`);
       }
 


### PR DESCRIPTION
Follows #7067, which fixed the identical bug in `git-providers/github/http.ts`'s shared `githubFetch` helper: on a rate-limit refusal, the `Response` body was thrown away unread instead of drained, which under Bun's fetch implementation holds the underlying connection open instead of releasing it. `GITHUB_LIST_USER_ORGS` (`apps/api/src/tools/github/list-user-orgs.ts`) makes its own raw `fetch` call (it predates/duplicates `githubFetch`) and has the same two discard-and-throw sites — the rate-limit branch and the generic `!res.ok` branch — neither of which drained the body before throwing.

This mirrors the same fix (`await res.body?.cancel().catch(() => {})` before the throw) at both sites in this file, matching the established convention already used at ~15 other call sites across `git-providers/**` (e.g. `github/http.ts`, `github/client.ts`, `github/content.ts`, `gitlab/client.ts`).

Behavior-preserving: the thrown errors and their messages are unchanged; only the body is now drained before the throw. Confirmed via:
- `cd apps/api && bunx tsc --noEmit` — clean
- `bunx oxlint src/tools/github/list-user-orgs.ts` — 0 warnings/errors
- `bun test apps/api/src/tools/github/list-user-orgs.test.ts` — 3 pass (pure-function coverage for this file; the drain itself isn't independently testable without a live/mocked GitHub HTTP layer, same as the original `githubFetch` fix, which also shipped without a dedicated body-drain test)

Reviewer check: `git diff` shows two one-line additions in `apps/api/src/tools/github/list-user-orgs.ts`, each immediately before an existing `throw`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `GITHUB_LIST_USER_ORGS` to drain the unread response body before throwing on rate-limit or non-OK responses, so the underlying connection is released instead of held open. This mirrors the existing fix in `githubFetch` and does not change the thrown errors or messages.

<sup>Written for commit 7c85438d15f6f6c33fcf2faf020c17f7092909a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

