### PR TITLE
fix(sandbox-daemon): send a WS close frame when the upgrade forward fails

### DIFF
--- a/packages/sandbox/daemon-go/internal/proxy/ws.go
+++ b/packages/sandbox/daemon-go/internal/proxy/ws.go
@@ -58,11 +58,26 @@ func ServeWs(w http.ResponseWriter, r *http.Request, deps WsDeps) {
 	}
 	defer upstream.Close()
 
+	serveUpstream(clientConn, clientBuf, r, upstream, deps.OnClientData)
+}
+
+// serveUpstream forwards the upgrade request to an already-dialed upstream and
+// splices the two connections together. Split out from ServeWs so the
+// write-failure branch below — the dial succeeded but the upstream dropped
+// before the handshake could be forwarded, e.g. a dev server still restarting
+// — is exercisable with a fake `upstream` in tests, without a real TCP dial.
+func serveUpstream(clientConn net.Conn, clientBuf io.Reader, r *http.Request, upstream net.Conn, onClientData func()) {
+	// Same "connect then close" contract as ServeWs's two failure branches: the
+	// client gets a clean WebSocket close instead of a bare TCP reset it can't
+	// interpret as anything but a broken connection.
 	if err := writeUpgradeRequest(upstream, r); err != nil {
+		if completeHandshake(clientConn, r) == nil {
+			sendClose(clientConn, 1011, "upstream not reachable")
+		}
 		return
 	}
 
-	splice(clientConn, clientBuf, upstream, deps.OnClientData)
+	splice(clientConn, clientBuf, upstream, onClientData)
 }
 
 // splice pumps bytes bidirectionally between the client and the upstream dev

--- a/packages/sandbox/daemon-go/internal/proxy/ws_test.go
+++ b/packages/sandbox/daemon-go/internal/proxy/ws_test.go
@@ -2,7 +2,9 @@ package proxy
 
 import (
 	"bufio"
+	"bytes"
 	"net"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -30,5 +32,56 @@ func TestSplice_ReturnsWhenUpstreamClosesEvenIfClientNeverDoes(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("splice did not return after upstream closed; client-read goroutine leaked")
+	}
+}
+
+// TestServeUpstream_WriteFailureSendsCloseFrame reproduces the gap this file's
+// ws.go fix closes: a dial that succeeds but whose upstream drops the
+// connection before the upgrade request can be forwarded used to leave the
+// client with a bare TCP reset instead of a proper WebSocket close.
+func TestServeUpstream_WriteFailureSendsCloseFrame(t *testing.T) {
+	clientConn, testClient := net.Pipe()
+	defer testClient.Close()
+
+	// The upstream side is already closed, so writeUpgradeRequest's Write
+	// fails deterministically — no real dial/race needed.
+	upstream, testUpstream := net.Pipe()
+	testUpstream.Close()
+
+	req := httptest.NewRequest("GET", "/ws", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Sec-Websocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+
+	done := make(chan struct{})
+	go func() {
+		serveUpstream(clientConn, bufio.NewReader(clientConn), req, upstream, nil)
+		close(done)
+	}()
+
+	// serveUpstream (unlike ServeWs) doesn't close clientConn on the way out —
+	// that's ServeWs's defer — so read exactly the two writes it makes (the
+	// 101 handshake, then the close frame) instead of looping to EOF/deadline.
+	testClient.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var got bytes.Buffer
+	buf := make([]byte, 512)
+	for range 2 {
+		n, err := testClient.Read(buf)
+		if err != nil {
+			t.Fatalf("reading from client conn: %v", err)
+		}
+		got.Write(buf[:n])
+	}
+
+	if !bytes.Contains(got.Bytes(), []byte("101 Switching Protocols")) {
+		t.Fatalf("expected a completed handshake before the close frame, got: %q", got.Bytes())
+	}
+	if !bytes.Contains(got.Bytes(), []byte{0x88}) {
+		t.Fatalf("expected a close frame (opcode 0x88) after the handshake, got: %q", got.Bytes())
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("serveUpstream did not return after the upstream write failed")
 	}
 }


### PR DESCRIPTION
Follows the CancelAll (#7076) and WS-proxy-leg (#7079) daemon hardening from this same file's area — a third gap in `ServeWs`'s WebSocket-upgrade proxy in `packages/sandbox/daemon-go/internal/proxy/ws.go`.

**The gap:** `ServeWs` has three failure branches before it splices client↔upstream: no dev port configured, dial failure, and write failure forwarding the upgrade request. The first two complete the WebSocket handshake (101) and send a clean close frame (code 1011) — by the time a browser has sent an upgrade request it can only read close codes, not HTTP errors. The third branch (dial succeeded, but the connection dropped before the upgrade request could be written — e.g. a dev server mid-restart) just returned, leaving the client with a bare TCP reset instead of a diagnosable close.

**Fix:** the write-failure branch now goes through the same completeHandshake + sendClose(1011, "upstream not reachable") path as the other two. Split the post-dial logic into `serveUpstream` so the branch is exercisable in a test without a real TCP dial/race.

**Regression test:** `TestServeUpstream_WriteFailureSendsCloseFrame` in `ws_test.go` — drives `serveUpstream` with an upstream `net.Pipe` that's already closed (deterministic write failure) and asserts the client conn receives a 101 handshake followed by a close frame (0x88), rather than nothing.

**To verify:** `cd packages/sandbox/daemon-go && go test ./internal/proxy/...`

**Checks run locally:** `gofmt -l`, `go vet ./internal/proxy/...`, `go build ./...`, `go test ./internal/proxy/...` (all green, package-scoped — CI covers the rest).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the WebSocket upgrade proxy in `packages/sandbox/daemon-go` so a dropped upstream connection sends a clean close frame instead of a bare TCP reset.

- Completes the handshake and sends close code 1011 with "upstream not reachable" when the upgrade write fails after a successful dial.
- Splits post-dial logic into `serveUpstream` so the failure branch is testable without a real TCP dial.
- Adds `TestServeUpstream_WriteFailureSendsCloseFrame` to verify the handshake and close frame are sent.

<sup>Written for commit c23411a8906fdbb7734c2eead737ac6753b5a0b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

