### PR TITLE
fix(sidebar): surface matching organizations when searching the picker

### DIFF
--- a/apps/web/src/components/sidebar/org-project-picker.tsx
+++ b/apps/web/src/components/sidebar/org-project-picker.tsx
@@ -217,6 +217,21 @@ function PickerContent({
   const { hits, isSearching, isStale, isError } = useProjectSearch(
     searching ? term : "",
   );
+  /** Organizations matching the term, filtered CLIENT-side. The full list is
+   *  already in memory (`useActiveOrganizations`), so matching it by name or
+   *  slug is free and instant — no per-org scan, which is the cost the project
+   *  search endpoint exists to avoid. This is what lets the search field honour
+   *  its "organizations and projects" placeholder: without it, typing an org's
+   *  name found nothing, since the project endpoint only knows about projects. */
+  const orgMatches = searching
+    ? allOrgs.filter((candidate) => {
+        const q = term.toLowerCase();
+        return (
+          candidate.name.toLowerCase().includes(q) ||
+          candidate.slug.toLowerCase().includes(q)
+        );
+      })
+    : [];
   /** The settings tree is its own shell; the scope means nothing inside it. */
   const inSettings = useLeafRoutePath().startsWith("/$org/settings");
 
@@ -293,11 +308,14 @@ function PickerContent({
             {isError && (
               <CommandEmpty>{t("sidebar.picker.searchFailed")}</CommandEmpty>
             )}
-            {!isError && !isSearching && hits.length === 0 && (
-              <CommandEmpty>
-                {t("sidebar.picker.noMatches", { query: term })}
-              </CommandEmpty>
-            )}
+            {!isError &&
+              !isSearching &&
+              hits.length === 0 &&
+              orgMatches.length === 0 && (
+                <CommandEmpty>
+                  {t("sidebar.picker.noMatches", { query: term })}
+                </CommandEmpty>
+              )}
             {!isError && hits.length > 0 && (
               /* These rows still answer the PREVIOUS term while the current
                  one is in flight — kept on screen so the list never blinks
@@ -317,6 +335,24 @@ function PickerContent({
                     rows={rows}
                     onScope={scopeTo}
                     onTravel={travelTo}
+                  />
+                ))}
+              </CommandGroup>
+            )}
+            {/* Organizations matching the term, listed after the projects to
+                mirror the browsing order. Local data, so it shows instantly
+                even while the project request is still in flight. */}
+            {orgMatches.length > 0 && (
+              <CommandGroup heading={t("sidebar.picker.orgsHeading")}>
+                {orgMatches.map((candidate: PickerOrg) => (
+                  <OrgRow
+                    key={candidate.id}
+                    candidate={candidate}
+                    currentOrgSlug={org.slug}
+                    currentOrgName={org.name}
+                    rows={rows}
+                    onTravel={travelTo}
+                    onClose={onClose}
                   />
                 ))}
               </CommandGroup>
@@ -392,36 +428,17 @@ function PickerContent({
                   onChanged={refetchInvitations}
                 />
               ))}
-              {allOrgs.map((candidate: PickerOrg) => {
-                const isCurrent = candidate.slug === org.slug;
-                const value = rowValue.org(candidate.slug);
-                /** The current org is not travel — selecting it goes nowhere,
-                 *  so the strip must not offer to leave anything. */
-                rows.set(value, {
-                  kind: isCurrent ? "scope" : "travel",
-                  label: candidate.name,
-                  ...(isCurrent ? {} : { leaves: org.name }),
-                });
-                return (
-                  <CommandItem
-                    key={candidate.id}
-                    value={value}
-                    className={ROW}
-                    onSelect={() =>
-                      isCurrent ? onClose() : travelTo(candidate.slug)
-                    }
-                  >
-                    <OrgIcon org={candidate} size="xs" />
-                    <span className="min-w-0 flex-1 truncate">
-                      {candidate.name}
-                    </span>
-                    {/* The same check the scoped project wears: "where you
-                        are" reads as one mark throughout, rather than a tick
-                        in one group and the word "current" in the next. */}
-                    {isCurrent && <Check size={14} />}
-                  </CommandItem>
-                );
-              })}
+              {allOrgs.map((candidate: PickerOrg) => (
+                <OrgRow
+                  key={candidate.id}
+                  candidate={candidate}
+                  currentOrgSlug={org.slug}
+                  currentOrgName={org.name}
+                  rows={rows}
+                  onTravel={travelTo}
+                  onClose={onClose}
+                />
+              ))}
             </CommandGroup>
           </>
         )}
@@ -429,6 +446,48 @@ function PickerContent({
 
       <VerbStrip active={active} rows={rows} />
     </Command>
+  );
+}
+
+/** One organization row, shared by both modes so an org reads the same whether
+ *  you browsed to it or searched for it. Registers its verb in `rows` as a
+ *  side effect of render, exactly like `SearchHitRow` — the current org SCOPEs
+ *  (a no-op that just closes), every other org TRAVELs and says what it leaves. */
+function OrgRow({
+  candidate,
+  currentOrgSlug,
+  currentOrgName,
+  rows,
+  onTravel,
+  onClose,
+}: {
+  candidate: PickerOrg;
+  currentOrgSlug: string;
+  currentOrgName: string;
+  rows: Map<string, RowMeta>;
+  onTravel: (slug: string) => void;
+  onClose: () => void;
+}) {
+  const isCurrent = candidate.slug === currentOrgSlug;
+  const value = rowValue.org(candidate.slug);
+  rows.set(value, {
+    kind: isCurrent ? "scope" : "travel",
+    label: candidate.name,
+    ...(isCurrent ? {} : { leaves: currentOrgName }),
+  });
+  return (
+    <CommandItem
+      value={value}
+      className={ROW}
+      onSelect={() => (isCurrent ? onClose() : onTravel(candidate.slug))}
+    >
+      <OrgIcon org={candidate} size="xs" />
+      <span className="min-w-0 flex-1 truncate">{candidate.name}</span>
+      {/* The same check the scoped project wears: "where you are" reads as one
+          mark throughout, rather than a tick in one group and the word
+          "current" in the next. */}
+      {isCurrent && <Check size={14} />}
+    </CommandItem>
   );
 }
 


### PR DESCRIPTION
## Summary

The org/project picker in the sidebar wasn't showing organizations when searching. Typing an org's name (e.g. "deco") returned only projects, never the matching organization — even though the search input's placeholder promises "Search organizations and projects…".

**Root cause:** the SEARCHING branch of `org-project-picker.tsx` only rendered hits from the cross-org *project* endpoint (`/api/_me/projects/search`). Organizations were never matched while a term was present.

**Fix:** organizations are already fully loaded client-side (`useActiveOrganizations`), so I filter them locally by name/slug during search and render matches in an Organizations group — instant, no per-org scan (the cost the project endpoint exists to avoid, which only applied to projects).

## Changes

- Filter the in-memory org list by term (name or slug) when a search term is present.
- Render matching orgs in an "Organizations" group after the project hits, mirroring the browsing-mode order; shows immediately even while the project request is in flight.
- "No matches" empty state now considers both project hits and org matches.
- Extracted a shared `OrgRow` component used by both browsing and searching modes, removing duplicated markup and keeping the verb-strip (scope/travel) behavior identical in both.

## Testing

- `bun run check` (apps/web) — passes
- `bun run fmt` — clean
- `bun run lint` — 0 errors

Screenshot before/after welcome — search for an org by name now surfaces it under an Organizations group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The sidebar org/project picker now shows matching organizations when searching, instead of returning only project results. This makes the search behavior match the “organizations and projects” placeholder.

**Bug Fixes**

- Matches loaded organizations by name or slug without another request.
- Displays organization results immediately while project search is still loading.
- Includes organization results in the “no matches” state and reuses the same row behavior in browsing and search modes.

<sup>Written for commit 0ebe8b57871b24b710031e92ea61b04a4ebc2bb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

