### PR TITLE
feat(content): create redirects via a modal instead of inline placeholder

### DIFF
--- a/apps/web/src/components/sandbox/content/content-browser.tsx
+++ b/apps/web/src/components/sandbox/content/content-browser.tsx
@@ -79,12 +79,14 @@ import {
   nextUniquePagePath,
 } from "./content-mutations";
 import { PageFormDialog, type PageFormMode } from "./page-form-dialog";
+import { RedirectFormDialog } from "./redirect-form-dialog";
 import { SectionRenameDialog } from "./section-rename-dialog";
 import {
   buildRedirectBlock,
   extractRedirects,
   generateRedirectBlockKey,
   type RedirectEntry,
+  type RedirectPayload,
 } from "./redirect-data";
 import { RedirectTypeBadge } from "./redirect-type-badge";
 import {
@@ -488,6 +490,10 @@ function ContentBrowserReady({
   // Dialog state
   const [pageDialog, setPageDialog] = useState<PageDialogState>(null);
   const [pageDialogError, setPageDialogError] = useState<string | undefined>();
+  const [redirectDialogOpen, setRedirectDialogOpen] = useState(false);
+  const [redirectDialogError, setRedirectDialogError] = useState<
+    string | undefined
+  >();
   const [renameSectionKey, setRenameSectionKey] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget>(null);
   const [jsonPageKey, setJsonPageKey] = useState<string | null>(null);
@@ -804,23 +810,22 @@ function ContentBrowserReady({
   // ------------------ Redirect CRUD ------------------
   // Redirects are standalone `website/loaders/redirect.ts` blocks; the site's
   // routes auto-discover them, so create/delete is a plain block write.
-  const handleCreateRedirect = async () => {
-    // Seed non-empty placeholder paths so the new block is a valid redirect
-    // (never an empty from/to that would emit a broken route once published).
-    const from = "/redirect-from";
-    const key = generateRedirectBlockKey(decofile, from);
-    const data = buildRedirectBlock({
-      from,
-      to: "/redirect-to",
-      type: "temporary",
-      discardQueryParameters: false,
-    });
+  // Open the create dialog; the block is written only on submit.
+  const openCreateRedirect = () => {
+    setRedirectDialogError(undefined);
+    setRedirectDialogOpen(true);
+  };
+
+  const submitRedirectDialog = async (values: RedirectPayload) => {
+    const key = generateRedirectBlockKey(decofile, values.from);
+    const data = buildRedirectBlock(values);
     try {
       await saveBlock.mutateAsync({ blockKey: key, data });
       toast.success("Created redirect");
+      setRedirectDialogOpen(false);
       setSelection({ collection: "redirects", key });
     } catch (err) {
-      toast.error(
+      setRedirectDialogError(
         err instanceof Error ? err.message : "Could not create redirect",
       );
     }
@@ -1131,7 +1136,7 @@ function ContentBrowserReady({
               if (activeCollection === "pages") {
                 openCreatePage();
               } else if (activeCollection === "redirects") {
-                void handleCreateRedirect();
+                openCreateRedirect();
               } else if (isBlogKind(activeCollection)) {
                 void handleCreateBlog(activeCollection);
               }
@@ -1422,6 +1427,20 @@ function ContentBrowserReady({
           }}
         />
       )}
+
+      {/* Redirect create dialog */}
+      <RedirectFormDialog
+        open={redirectDialogOpen}
+        isPending={saveBlock.isPending}
+        error={redirectDialogError}
+        onSubmit={submitRedirectDialog}
+        onOpenChange={(next) => {
+          if (!next) {
+            setRedirectDialogOpen(false);
+            setRedirectDialogError(undefined);
+          }
+        }}
+      />
 
       {/* Section rename dialog */}
       {renameSectionKey && (

--- a/apps/web/src/components/sandbox/content/redirect-form-dialog.tsx
+++ b/apps/web/src/components/sandbox/content/redirect-form-dialog.tsx
@@ -1,0 +1,201 @@
+import { type FormEvent, useState } from "react";
+import { Spinner } from "@decocms/ui/components/spinner.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@decocms/ui/components/dialog.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Checkbox } from "@decocms/ui/components/checkbox.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@decocms/ui/components/select.tsx";
+import { useT } from "@/i18n/use-t.ts";
+import type { TranslationKey } from "@/i18n/en/index.ts";
+import {
+  REDIRECT_STATUS,
+  type RedirectPayload,
+  type RedirectType,
+} from "./redirect-data";
+
+const TYPE_OPTIONS: Array<{ value: RedirectType; labelKey: TranslationKey }> = [
+  { value: "temporary", labelKey: "sandbox.redirectEditor.typeTemporary" },
+  { value: "permanent", labelKey: "sandbox.redirectEditor.typePermanent" },
+];
+
+const EMPTY: RedirectPayload = {
+  from: "",
+  to: "",
+  type: "temporary",
+  discardQueryParameters: false,
+};
+
+/**
+ * Modal form for creating a redirect. Unlike the right-pane editor (which
+ * autosaves), nothing is written until the user submits a complete payload,
+ * so the list never shows a placeholder `/redirect-from → /redirect-to` row.
+ */
+export function RedirectFormDialog({
+  open,
+  isPending = false,
+  error,
+  onSubmit,
+  onOpenChange,
+}: {
+  open: boolean;
+  isPending?: boolean;
+  error?: string;
+  onSubmit: (values: RedirectPayload) => void | Promise<void>;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const t = useT();
+  const [payload, setPayload] = useState<RedirectPayload>(EMPTY);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [prevOpen, setPrevOpen] = useState(open);
+
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setPayload(EMPTY);
+      setLocalError(null);
+    }
+  }
+
+  const setField = (patch: Partial<RedirectPayload>) =>
+    setPayload((prev) => ({ ...prev, ...patch }));
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && !isPending) {
+      setLocalError(null);
+      onOpenChange(false);
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const from = payload.from.trim();
+    const to = payload.to.trim();
+    if (!from || !to || isPending) {
+      setLocalError(t("sandbox.redirectFormDialog.errorRequired"));
+      return;
+    }
+    setLocalError(null);
+    await onSubmit({ ...payload, from, to });
+  };
+
+  const displayError = localError ?? error;
+  const canSubmit = !!payload.from.trim() && !!payload.to.trim() && !isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>{t("sandbox.redirectFormDialog.title")}</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="redirect-form-from">
+                {t("sandbox.redirectEditor.fromLabel")}
+              </Label>
+              <Input
+                id="redirect-form-from"
+                value={payload.from}
+                onChange={(e) => setField({ from: e.target.value })}
+                placeholder={t("sandbox.redirectEditor.fromPlaceholder")}
+                autoFocus
+                disabled={isPending}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="redirect-form-to">
+                {t("sandbox.redirectEditor.toLabel")}
+              </Label>
+              <Input
+                id="redirect-form-to"
+                value={payload.to}
+                onChange={(e) => setField({ to: e.target.value })}
+                placeholder={t("sandbox.redirectEditor.toPlaceholder")}
+                disabled={isPending}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="redirect-form-type">
+                {t("sandbox.redirectEditor.typeLabel")}
+              </Label>
+              <Select
+                value={payload.type}
+                onValueChange={(v) => setField({ type: v as RedirectType })}
+                disabled={isPending}
+              >
+                <SelectTrigger id="redirect-form-type" className="w-full">
+                  <SelectValue
+                    placeholder={t("sandbox.redirectEditor.typePlaceholder")}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {TYPE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {t(option.labelKey, {
+                        status: REDIRECT_STATUS[option.value],
+                      })}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <label className="flex cursor-pointer items-center gap-2.5">
+              <Checkbox
+                checked={payload.discardQueryParameters}
+                disabled={isPending}
+                onCheckedChange={(checked) =>
+                  setField({ discardQueryParameters: checked === true })
+                }
+              />
+              <span className="text-sm">
+                {t("sandbox.redirectEditor.discardQueryParameters")}
+              </span>
+            </label>
+
+            {displayError && (
+              <p className="text-xs text-destructive">{displayError}</p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              {t("sandbox.redirectFormDialog.cancel")}
+            </Button>
+            <Button type="submit" disabled={!canSubmit}>
+              {isPending ? (
+                <>
+                  <Spinner className="size-3.5" />
+                  {t("sandbox.redirectFormDialog.pending")}
+                </>
+              ) : (
+                t("sandbox.redirectFormDialog.submit")
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -533,6 +533,11 @@ export const sandbox = {
   "sandbox.recordEditor.optionPerson": "Person",
   "sandbox.recordEditor.placeholderEmail": "author@example.com",
   "sandbox.recordEditor.titleAuthor": "Author",
+  "sandbox.redirectFormDialog.title": "Create redirect",
+  "sandbox.redirectFormDialog.submit": "Create",
+  "sandbox.redirectFormDialog.pending": "Creating…",
+  "sandbox.redirectFormDialog.cancel": "Cancel",
+  "sandbox.redirectFormDialog.errorRequired": "From and To are required.",
   "sandbox.redirectEditor.discardQueryParameters": "Discard query parameters",
   "sandbox.redirectEditor.fromDescription":
     "The source path to match. Supports URLPattern syntax (e.g. /product/:slug).",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -556,6 +556,11 @@ export const sandbox = {
   "sandbox.recordEditor.optionPerson": "Pessoa",
   "sandbox.recordEditor.placeholderEmail": "autor@exemplo.com",
   "sandbox.recordEditor.titleAuthor": "Autor",
+  "sandbox.redirectFormDialog.title": "Criar redirecionamento",
+  "sandbox.redirectFormDialog.submit": "Criar",
+  "sandbox.redirectFormDialog.pending": "Criando…",
+  "sandbox.redirectFormDialog.cancel": "Cancelar",
+  "sandbox.redirectFormDialog.errorRequired": "De e Para são obrigatórios.",
   "sandbox.redirectEditor.discardQueryParameters":
     "Descartar parâmetros de consulta",
   "sandbox.redirectEditor.fromDescription":


### PR DESCRIPTION
## Summary
Clicking **+** in the Content → Redirects list used to immediately write a placeholder `/redirect-from → /redirect-to` (307) block and drop you into the editor. Now it opens a **Create redirect** modal, and the block is only written when you submit a filled-in form.

## Changes
- **New** `redirect-form-dialog.tsx` — modal mirroring the existing `PageFormDialog` pattern, with the redirect editor's fields: **From**, **To**, **Type** (Temporary 307 / Permanent 301), and a **Discard query parameters** checkbox. Submit is blocked with an inline error until From and To are both non-empty (trimmed); state resets on open; closing is prevented while a save is in flight.
- `content-browser.tsx` — replaced the inline `handleCreateRedirect` write with `openCreateRedirect` (opens dialog) + `submitRedirectDialog` (generates key, saves via `useSaveBlock`, selects the new redirect). Save failures now surface inline in the dialog. Added dialog state and wired the `redirects` collection's `onCreate`.
- i18n — added `sandbox.redirectFormDialog.*` keys to `en` and `pt-br`; field labels/placeholders reuse existing `redirectEditor` keys.

## Testing
- `bun run fmt` clean
- `apps/web` `tsc --noEmit` passes
- `bun run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creating a redirect now opens a modal instead of immediately writing a placeholder `/redirect-from → /redirect-to` (307) block into the list. The block is only written when you submit the dialog with filled-in From and To fields.

- Adds `RedirectFormDialog` with From, To, Type (temporary 307 / permanent 301), and Discard query parameters fields; submit stays disabled until From and To are non-empty, and closing is blocked while a save is in flight.
- Save failures now surface inline in the dialog instead of a toast.
- Adds English and Brazilian Portuguese strings for the new dialog.

<sup>Written for commit fe12feb35fe44a87fb878fb628f853b020e245b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

