### PR TITLE
fix(git-providers): drain the response body on a GitLab 404 before discarding

### DIFF
--- a/apps/api/src/git-providers/gitlab/client.ts
+++ b/apps/api/src/git-providers/gitlab/client.ts
@@ -133,7 +133,10 @@ async function gitlabRequest(
   init: { accept?: string; timeoutMs?: number } = {},
 ): Promise<Response | null> {
   const res = await gitlabFetch(url, token, init);
-  if (res.status === 404) return null;
+  if (res.status === 404) {
+    await res.body?.cancel().catch(() => {});
+    return null;
+  }
   if (!res.ok) throw await gitlabFailure(res);
   return res;
 }
@@ -272,7 +275,10 @@ export class GitlabProviderClient implements GitProviderClient {
         timeoutMs: ARCHIVE_TIMEOUT_MS,
       },
     );
-    if (res.status === 404) return null;
+    if (res.status === 404) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
     if (!res.ok) throw await gitlabFailure(res);
     return res.body;
   }
@@ -296,7 +302,10 @@ export class GitlabProviderClient implements GitProviderClient {
     init?: { accept?: string },
   ): Promise<Response | null> {
     const res = await this.authedFetch(`${this.apiBase}${pathAndQuery}`, init);
-    if (res.status === 404) return null;
+    if (res.status === 404) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
     if (!res.ok) throw await gitlabFailure(res);
     return res;
   }


### PR DESCRIPTION
**Source**: bug found while hardening `apps/api/src/git-providers/gitlab/client.ts` (this tick's focus area). Same fix pattern as #7087 ("drain the response body before discarding it in GITHUB_LIST_USER_ORGS"), applied here to the GitLab client instead.

**Payoff**: `gitlabRequest`, the private `get()` helper, and `archiveTarball()` all treat a 404 as "not found" and return `null` without ever reading the response body. Under Bun/undici, an unread response body can keep its connection out of the keep-alive pool until GC reclaims it, so repeated not-found lookups (e.g. probing for a file/repo that may not exist) can needlessly exhaust the connection pool under load.

**Fix**: in all three spots, drain the body (`await res.body?.cancel().catch(() => {})`) before returning `null` on a 404 — matching the existing 401-retry path in `authedFetch`, which already does this. Pure resource hygiene, no change to any return value or error shape.

**Verify**: `bun test apps/api/src/git-providers/gitlab/client.test.ts` (20/20 pass, unchanged) and `cd apps/api && bunx tsc --noEmit` (clean).

**Checks run locally**: `bun run fmt`, targeted `tsc --noEmit` in `apps/api`, the one test file above, and `bunx oxlint apps/api/src/git-providers/gitlab/client.ts` (0 warnings/errors). Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GitLab 404 handling now cancels the response body before returning `null`; previously, these bodies were left unread, which could keep connections out of the keep-alive pool and exhaust it under repeated not-found requests. Return values and error behavior are unchanged.

<sup>Written for commit 93a752f5fb19e4c0660ff678dae914c2827d9f14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

