### PR TITLE
fix(git-providers): degrade gracefully on corrupted account-credential ciphertext

### DIFF
--- a/apps/api/src/storage/git-provider-account-credentials.test.ts
+++ b/apps/api/src/storage/git-provider-account-credentials.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import { CredentialVault } from "../encryption/credential-vault";
+import {
+  decryptGitProviderAccountCredentialRow,
+  type RawGitProviderAccountCredentialRow,
+} from "./git-provider-account-credentials";
+
+function row(
+  overrides: Partial<RawGitProviderAccountCredentialRow>,
+): RawGitProviderAccountCredentialRow {
+  return {
+    account_id: "acc_1",
+    access_token: "not-ciphertext",
+    refresh_token: null,
+    scope: null,
+    expires_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    client_id: null,
+    client_secret: null,
+    token_endpoint: null,
+    ...overrides,
+  };
+}
+
+describe("decryptGitProviderAccountCredentialRow", () => {
+  it("decrypts a well-formed row", async () => {
+    const vault = new CredentialVault(CredentialVault.generateKey());
+    const access_token = await vault.encrypt("secret-access");
+    const refresh_token = await vault.encrypt("secret-refresh");
+
+    const result = await decryptGitProviderAccountCredentialRow(
+      vault,
+      row({ access_token, refresh_token }),
+    );
+
+    expect(result?.accessToken).toBe("secret-access");
+    expect(result?.refreshToken).toBe("secret-refresh");
+  });
+
+  // A tampered/undecryptable row must degrade to "no cached credential", not throw.
+  it("returns null instead of throwing on corrupted ciphertext", async () => {
+    const vault = new CredentialVault(CredentialVault.generateKey());
+
+    const result = await decryptGitProviderAccountCredentialRow(
+      vault,
+      row({ access_token: "definitely-not-valid-aes-gcm-ciphertext" }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the row was encrypted under a different vault key", async () => {
+    const oldVault = new CredentialVault(CredentialVault.generateKey());
+    const currentVault = new CredentialVault(CredentialVault.generateKey());
+    const access_token = await oldVault.encrypt("secret-access");
+
+    const result = await decryptGitProviderAccountCredentialRow(
+      currentVault,
+      row({ access_token }),
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/storage/git-provider-account-credentials.ts
+++ b/apps/api/src/storage/git-provider-account-credentials.ts
@@ -1,7 +1,11 @@
 import type { Kysely } from "kysely";
 import type { CredentialVault } from "../encryption/credential-vault";
 import type { DownstreamTokenData } from "./downstream-token";
-import type { Database, DownstreamToken } from "./types";
+import type {
+  Database,
+  DownstreamToken,
+  GitProviderAccountCredentialTable,
+} from "./types";
 
 /**
  * `git_provider_account_credentials` (migration 199): the OAuth grant or
@@ -24,23 +28,7 @@ export class GitProviderAccountCredentialStorage {
       .where("account_id", "=", accountId)
       .executeTakeFirst();
     if (!row) return null;
-    return {
-      id: row.account_id,
-      connectionId: row.account_id,
-      accessToken: await this.vault.decrypt(row.access_token),
-      refreshToken: row.refresh_token
-        ? await this.vault.decrypt(row.refresh_token)
-        : null,
-      scope: row.scope,
-      expiresAt: row.expires_at,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-      clientId: row.client_id,
-      clientSecret: row.client_secret
-        ? await this.vault.decrypt(row.client_secret)
-        : null,
-      tokenEndpoint: row.token_endpoint,
-    };
+    return decryptGitProviderAccountCredentialRow(this.vault, row);
   }
 
   /** `data.connectionId` is the account id (see module doc). */
@@ -97,5 +85,69 @@ export class GitProviderAccountCredentialStorage {
     const expiryTime = expiresAt.getTime();
     if (Number.isNaN(expiryTime)) return true;
     return expiryTime - bufferMs < Date.now();
+  }
+}
+
+/**
+ * Row shape as read back from `git_provider_account_credentials`, before
+ * decryption.
+ */
+export type RawGitProviderAccountCredentialRow = Pick<
+  GitProviderAccountCredentialTable,
+  | "access_token"
+  | "refresh_token"
+  | "scope"
+  | "client_id"
+  | "client_secret"
+  | "token_endpoint"
+> & {
+  account_id: string;
+  expires_at: Date | string | null;
+  created_at: Date | string;
+  updated_at: Date | string;
+};
+
+/**
+ * Decrypt sensitive fields from a `git_provider_account_credentials` row.
+ * Mirrors `decryptDownstreamTokenRow`: corrupted ciphertext (a tampered
+ * value, or a row encrypted under a vault key that has since been rotated)
+ * makes AES-GCM's tag check throw — that must not crash the caller. Callers
+ * already treat a missing row as "no cached credential, go re-authorize"; an
+ * undecryptable row degrades to the same outcome instead of a 500.
+ */
+export async function decryptGitProviderAccountCredentialRow(
+  vault: CredentialVault,
+  row: RawGitProviderAccountCredentialRow,
+): Promise<DownstreamToken | null> {
+  try {
+    const accessToken = await vault.decrypt(row.access_token);
+    const refreshToken = row.refresh_token
+      ? await vault.decrypt(row.refresh_token)
+      : null;
+    const clientSecret = row.client_secret
+      ? await vault.decrypt(row.client_secret)
+      : null;
+    return {
+      id: row.account_id,
+      connectionId: row.account_id,
+      accessToken,
+      refreshToken,
+      scope: row.scope,
+      expiresAt: row.expires_at,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      clientId: row.client_id,
+      clientSecret,
+      tokenEndpoint: row.token_endpoint,
+    };
+  } catch (error) {
+    console.warn(
+      "[GitProviderAccountCredential] failed to decrypt credential row",
+      {
+        accountId: row.account_id,
+        message: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return null;
   }
 }


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/storage` for encryption/error-tracking consistency across repository helpers.

**Payoff:** `GitProviderAccountCredentialStorage.get()` is used as an `OAuthGrantStore` inside `getValidDownstreamAccessToken` — the git-provider OAuth token-refresh hot path. It called `vault.decrypt()` directly with no try/catch, unlike its sibling `DownstreamTokenStorage`, which already has `decryptDownstreamTokenRow` for exactly this case (see its own doc comment: "Corrupted ciphertext ... must not crash the caller"). A tampered `access_token`/`refresh_token`/`client_secret` column, or a row encrypted under a vault key that's since been rotated, makes AES-GCM's tag check throw `"Unsupported state or unable to authenticate data"` — this propagated as an uncaught exception instead of degrading to "no cached credential, go re-authorize" the way the connection-token path already does.

**Fix:** extracted `decryptGitProviderAccountCredentialRow` (mirroring `decryptDownstreamTokenRow`) that catches the decrypt failure, logs a warning, and returns `null` — same shape, same behavior as the existing pattern, just applied to the second store that needed it.

**Regression test:** `apps/api/src/storage/git-provider-account-credentials.test.ts` — asserts a well-formed row still decrypts, and that corrupted ciphertext / a wrong vault key return `null` instead of throwing (mirrors `downstream-token-decrypt.test.ts`).

**To confirm:** `bun test apps/api/src/storage/git-provider-account-credentials.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test above. Full CI runs the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Git-provider account credential reads now degrade gracefully when encrypted fields cannot be decrypted. Previously, corrupted ciphertext or a rotated vault key caused `getValidDownstreamAccessToken` to throw; reads now log a warning and return no cached credential so the caller can re-authorize.

**Bug Fixes**

- Adds regression coverage for valid credentials, corrupted ciphertext, and credentials encrypted with a different vault key.

<sup>Written for commit 4dcc2e7892136b24c88158b5a1963c958a332074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

