### PR TITLE
fix(core): stop the org-archived cache evicting hot orgs first

### DIFF
--- a/apps/api/src/core/context-factory.archived-cache.test.ts
+++ b/apps/api/src/core/context-factory.archived-cache.test.ts
@@ -4,7 +4,10 @@
  * ever overwritten on its own next lookup, never dropped otherwise).
  */
 import { describe, expect, it } from "bun:test";
-import { evictExpiredOrgArchivedEntries } from "./context-factory";
+import {
+  evictExpiredOrgArchivedEntries,
+  refreshOrgArchivedCacheEntry,
+} from "./context-factory";
 
 describe("evictExpiredOrgArchivedEntries", () => {
   it("leaves the cache untouched when under the cap", () => {
@@ -33,6 +36,23 @@ describe("evictExpiredOrgArchivedEntries", () => {
     ]);
     evictExpiredOrgArchivedEntries(cache, 1, 60_000);
     expect(cache.size).toBe(1);
+    expect(cache.has("org_c")).toBe(true);
+  });
+});
+
+describe("refreshOrgArchivedCacheEntry", () => {
+  it("moves a re-looked-up org past older untouched ones, so a hot org isn't the first evicted", () => {
+    const cache = new Map<string, { archived: boolean; at: number }>();
+    refreshOrgArchivedCacheEntry(cache, "org_a", false);
+    refreshOrgArchivedCacheEntry(cache, "org_b", false);
+    refreshOrgArchivedCacheEntry(cache, "org_c", false);
+    // org_a is looked up again — same key, but it's the hot one now.
+    refreshOrgArchivedCacheEntry(cache, "org_a", false);
+
+    evictExpiredOrgArchivedEntries(cache, 2, 60_000);
+
+    expect(cache.has("org_b")).toBe(false);
+    expect(cache.has("org_a")).toBe(true);
     expect(cache.has("org_c")).toBe(true);
   });
 });

--- a/apps/api/src/core/context-factory.ts
+++ b/apps/api/src/core/context-factory.ts
@@ -604,6 +604,22 @@ const ARCHIVED_CACHE_TTL_MS = 60_000;
 const ARCHIVED_CACHE_MAX_SIZE = 10_000;
 const orgArchivedCache = new Map<string, { archived: boolean; at: number }>();
 
+/** Write (or refresh) a cache entry, moving it to the most-recently-set
+ *  position. `Map.set` on an existing key updates the value in place but
+ *  keeps its original iteration position, so a hot org that's refreshed on
+ *  every lookup would otherwise sit at the "oldest" end forever and be the
+ *  first thing `evictExpiredOrgArchivedEntries` trims once the cache is
+ *  full — evicting the entry the cache most needs to keep. Exported for
+ *  unit testing. */
+export function refreshOrgArchivedCacheEntry(
+  cache: Map<string, { archived: boolean; at: number }>,
+  organizationId: string,
+  archived: boolean,
+): void {
+  cache.delete(organizationId);
+  cache.set(organizationId, { archived, at: Date.now() });
+}
+
 /** Exported for unit testing. */
 export function evictExpiredOrgArchivedEntries(
   cache: Map<string, { archived: boolean; at: number }>,
@@ -643,7 +659,7 @@ async function isOrgArchivedCached(
       .executeTakeFirst(),
   );
   const archived = isOrgArchived(orgRow);
-  orgArchivedCache.set(organizationId, { archived, at: Date.now() });
+  refreshOrgArchivedCacheEntry(orgArchivedCache, organizationId, archived);
   evictExpiredOrgArchivedEntries(
     orgArchivedCache,
     ARCHIVED_CACHE_MAX_SIZE,


### PR DESCRIPTION
Follows #7083 (which added the size cap to `orgArchivedCache` in `context-factory.ts`).

`isOrgArchivedCached` wrote every cache refresh with a raw `orgArchivedCache.set(organizationId, ...)`. `Map.set()` on an *existing* key updates the value but keeps the key's original iteration position — it does not move it to the end. `evictExpiredOrgArchivedEntries` (added in #7083) trims non-expired entries oldest-first by iteration order once the cache is over its 10k cap. So a frequently-looked-up org, refreshed on every request past its TTL, would still sit at the "oldest" end forever and be the very first one evicted once the cache filled up — defeating the point of caching it and forcing an extra DB round trip on its next lookup, on the exact hot path (`x-studio-properties`/API-key auth on every proxied request) this cache exists to keep off.

Fix: extracted the write into `refreshOrgArchivedCacheEntry`, which deletes the key before re-setting it so a refreshed entry moves to the newest position, same as a real LRU touch.

Regression test added in `context-factory.archived-cache.test.ts`: seeds three orgs, re-touches the first one (simulating a repeated lookup), then evicts down to size 2 — asserts the untouched middle org is evicted while the re-touched (hot) one survives. Without the fix this test fails (the hot org is evicted instead).

Reviewer check: `bun test apps/api/src/core/context-factory.archived-cache.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the org-archived cache so refreshed organizations are treated as recent. Previously, `Map.set()` left existing entries in their original order, causing frequently accessed organizations to be evicted first when the 10,000-entry cap was reached and triggering extra database lookups.

- Adds regression coverage confirming a re-accessed organization survives eviction ahead of untouched entries.

<sup>Written for commit 22a8638d5a511dae6e9ce12a3135c257ce3a3551. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

