### PR TITLE
revert(task-board): stop the pending-CI cache bypass hammering GitHub

### DIFF
--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -13,7 +13,7 @@ import { GitProviderError } from "@/git-providers";
 import {
   asHeadSha,
   cardLifecycle,
-  isAwaitingCi,
+  isAwaitingPreview,
   isRateLimitError,
   isTrustedPreviewHost,
   previewMatchesHead,
@@ -400,30 +400,25 @@ describe("previewMatchesHead", () => {
   });
 });
 
-describe("isAwaitingCi", () => {
-  it("keeps refreshing while CI runs", () => {
-    // Was false whenever a preview URL had already been found, so that card got
-    // the full hit window and showed "Checks pending" long after they passed.
-    expect(isAwaitingCi({ checksStatus: "pending" })).toBe(true);
+describe("isAwaitingPreview", () => {
+  it("keeps refreshing while CI runs with no preview yet", () => {
+    expect(
+      isAwaitingPreview({ previewUrl: null, checksStatus: "pending" }),
+    ).toBe(true);
   });
 
-  it("caches normally once CI settles", () => {
-    expect(isAwaitingCi({ checksStatus: "passing" })).toBe(false);
-    expect(isAwaitingCi({ checksStatus: "failing" })).toBe(false);
-    expect(isAwaitingCi({ checksStatus: null })).toBe(false);
-  });
-});
-
-describe("isAwaitingCi", () => {
-  it("keeps refreshing while CI runs", () => {
-    // Was false whenever a preview URL had already been found, so that card got
-    // the full hit window and showed "Checks pending" long after they passed.
-    expect(isAwaitingCi({ checksStatus: "pending" })).toBe(true);
-  });
-
-  it("caches normally once CI settles", () => {
-    expect(isAwaitingCi({ checksStatus: "passing" })).toBe(false);
-    expect(isAwaitingCi({ checksStatus: "failing" })).toBe(false);
-    expect(isAwaitingCi({ checksStatus: null })).toBe(false);
+  it("caches normally once either settles", () => {
+    expect(
+      isAwaitingPreview({
+        previewUrl: "https://x.vtex.app",
+        checksStatus: "pending",
+      }),
+    ).toBe(false);
+    expect(
+      isAwaitingPreview({ previewUrl: null, checksStatus: "passing" }),
+    ).toBe(false);
+    expect(isAwaitingPreview({ previewUrl: null, checksStatus: null })).toBe(
+      false,
+    );
   });
 });

--- a/apps/api/src/tools/task-board/pr-cache.test.ts
+++ b/apps/api/src/tools/task-board/pr-cache.test.ts
@@ -272,76 +272,7 @@ describe("fetchOrPlaceholder", () => {
   });
 });
 
-describe("per-entry revalidate override (a value still awaiting something)", () => {
-  test("fetch: a not-ready stored value goes stale immediately", async () => {
-    const clock = { now: 0 };
-    const cache = await cacheAt(clock);
-    let calls = 0;
-    const pending: Promise<void>[] = [];
-    const read = (ready: boolean) =>
-      cache.fetch({
-        namespace: "conn_1",
-        key: "deployment",
-        fetchLive: async () => {
-          calls++;
-          return { url: ready ? "https://x.vtex.app" : null };
-        },
-        onRevalidation: (p) => pending.push(p),
-        // Not ready -> 0, so the very next read revalidates.
-        revalidateAfterMs: (stored) =>
-          (stored as { url: string | null }).url === null ? 0 : 55_000,
-      });
-
-    await read(false);
-    expect(calls).toBe(1);
-
-    // One tick later the default window (55s) would still be a HIT; the
-    // override makes it stale, so the deploy's url is picked up on this poll.
-    clock.now = 1_000;
-    await read(true);
-    await Promise.all(pending);
-    expect(calls).toBe(2);
-
-    // Now that it IS ready, the default window applies again.
-    clock.now = 2_000;
-    await read(true);
-    await Promise.all(pending);
-    expect(calls).toBe(2);
-  });
-
-  test("fetch: maxStaleMs 0 makes a pending value a blocking miss", async () => {
-    const clock = { now: 0 };
-    const cache = await cacheAt(clock);
-    let calls = 0;
-    const pending: Promise<void>[] = [];
-    const read = (status: string) =>
-      cache.fetch({
-        namespace: "conn_1",
-        key: "checks",
-        fetchLive: async () => {
-          calls++;
-          return { status };
-        },
-        onRevalidation: (p) => pending.push(p),
-        revalidateAfterMs: () => 0,
-        maxStaleMs: (stored) =>
-          (stored as { status: string }).status === "pending" ? 0 : 55_000,
-      });
-
-    await read("pending");
-    expect(calls).toBe(1);
-
-    // A zero hit window alone would serve the stale "pending" and refresh behind it.
-    clock.now = 1_000;
-    expect(await read("success")).toEqual({ status: "success" });
-    expect(calls).toBe(2);
-
-    // Settled: the normal ceiling applies again (stale-serve + revalidate).
-    clock.now = 2_000;
-    expect(await read("success")).toEqual({ status: "success" });
-    await Promise.all(pending);
-  });
-
+describe("fetchOrPlaceholder per-entry revalidate override", () => {
   test("fetchOrPlaceholder: an incomplete card is never a hit", async () => {
     const clock = { now: 0 };
     const cache = new JetStreamKVPrCache(

--- a/apps/api/src/tools/task-board/pr-cache.ts
+++ b/apps/api/src/tools/task-board/pr-cache.ts
@@ -97,18 +97,6 @@ export interface PrCacheFetch {
   /** Receives the background revalidation so the caller can keep its MCP client
    *  open until it settles. */
   onRevalidation: (promise: Promise<void>) => void;
-  /** Per-entry override of the hit window, computed from the STORED value.
-   *  A read whose value says "not ready yet" — a deploy with no url published —
-   *  should go stale fast, so the next poll refetches instead of serving the
-   *  not-ready answer for the full config window. Omit for the default. */
-  revalidateAfterMs?: (stored: unknown) => number;
-  /** Per-entry override of the STALE ceiling, computed from the stored value.
-   *  Returning 0 makes a stored value a MISS — the caller blocks on a live
-   *  fetch. That is the right trade for a value whose whole point is that it
-   *  ends (CI still running): stale-while-revalidate needs two polls to surface
-   *  a change (this poll serves stale, the background write lands after), and
-   *  if that background write ever fails the entry never moves again. */
-  maxStaleMs?: (stored: unknown) => number;
 }
 
 export class JetStreamKVPrCache {
@@ -174,8 +162,7 @@ export class JetStreamKVPrCache {
 
   async fetch(params: PrCacheFetch): Promise<unknown> {
     const { namespace, key: rawKey, fetchLive, onRevalidation } = params;
-    const { cache, maxStaleMs } = this.config;
-    const defaultRevalidateAfterMs = this.config.revalidateAfterMs;
+    const { cache, maxStaleMs, revalidateAfterMs } = this.config;
     if (!this.kv) {
       return this.fallback.fetch({
         type: "tools/call",
@@ -194,21 +181,13 @@ export class JetStreamKVPrCache {
     const age = stored
       ? this.now() - stored.storedAt
       : Number.POSITIVE_INFINITY;
-    const staleCeilingMs =
-      stored && params.maxStaleMs
-        ? params.maxStaleMs(stored.value)
-        : maxStaleMs;
-
-    if (!stored || age > staleCeilingMs) {
+    if (!stored || age > maxStaleMs) {
       cacheCounter.add(1, { cache, outcome: "miss" });
       const value = await fetchLive();
       await this.write(key, value, cache);
       return value;
     }
 
-    const revalidateAfterMs = params.revalidateAfterMs
-      ? params.revalidateAfterMs(stored.value)
-      : defaultRevalidateAfterMs;
     if (age > revalidateAfterMs && !this.revalidating.has(key)) {
       cacheCounter.add(1, { cache, outcome: "stale" });
       this.revalidating.add(key);

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -28,12 +28,7 @@ import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
 import { readPrStateThrottled } from "./dbos-github-read";
-import {
-  getPrCardCache,
-  getPrReadCache,
-  PR_CARDS_CACHE,
-  PR_READS_CACHE,
-} from "./pr-cache";
+import { getPrCardCache, getPrReadCache, PR_CARDS_CACHE } from "./pr-cache";
 
 export type { ChecksSummary as ChecksStatus };
 
@@ -94,47 +89,20 @@ export const readNamespace = (pr: TaskBoardItemPrRef) =>
   repoIdentityKey(originOf(pr).repo);
 
 /**
- * A card whose CI is still running never gets a cache hit window.
- *
- * Waiting is the one state whose whole point is that it ends: served from
- * cache it left a card on "Checks pending" minutes after the checks went
- * green, because nothing about the change request had changed and the entry
- * was a hit for the full window.
- *
- * Bounded — a settled card (passing, failing, no CI at all) caches normally,
- * so the per-poll rebuild only costs anything while CI is actually running.
+ * A card that should keep refreshing: CI is still running and no preview URL
+ * has been found yet. Once either settles the card caches normally.
  */
-export function isAwaitingCi(card: { checksStatus: ChecksSummary }): boolean {
-  return card.checksStatus === "pending";
+export function isAwaitingPreview(card: {
+  previewUrl: string | null;
+  checksStatus: ChecksSummary;
+}): boolean {
+  return card.previewUrl === null && card.checksStatus === "pending";
 }
 
-/** Zero. Named because it appears as both a hit window and a stale ceiling. */
+/** Hit window for a card still waiting on something. Zero, so the next poll
+ *  revalidates (detached, off the request path) instead of serving the
+ *  not-ready answer for the full window. */
 const NOT_READY_MS = 0;
-
-/**
- * The two cache windows for a read whose answer carries a CI verdict.
- *
- * A zero HIT window alone is not enough: it only starts a background refresh,
- * so the poll still serves the previous read and a fresh result needs a second
- * poll to appear — and never appears at all if that one background write
- * fails. The zero STALE CEILING is what makes a pending read a MISS that asks
- * the provider on the spot.
- *
- * One predicate pair, where the MCP path needed two: its CI verdict was split
- * across a combined-status read and a check-runs read, and this interface
- * answers both in one.
- */
-function ciWindows(checks: ChecksSummary): {
-  revalidateAfterMs: number;
-  maxStaleMs: number;
-} {
-  return checks === "pending"
-    ? { revalidateAfterMs: NOT_READY_MS, maxStaleMs: NOT_READY_MS }
-    : {
-        revalidateAfterMs: PR_READS_CACHE.revalidateAfterMs,
-        maxStaleMs: PR_READS_CACHE.maxStaleMs,
-      };
-}
 
 /**
  * One cached, best-effort provider read. Best-effort in the same sense as the
@@ -151,19 +119,11 @@ async function cachedRead<T>(
   key: string,
   describe: string,
   fetchLive: () => Promise<T>,
-  /** Per-entry windows, computed from the stored value — see {@link ciWindows}. */
-  windows?: (stored: T) => { revalidateAfterMs: number; maxStaleMs: number },
 ): Promise<T | null> {
   try {
     const raw = await getPrReadCache().fetch({
       namespace,
       key,
-      revalidateAfterMs: windows
-        ? (stored) => windows(stored as T).revalidateAfterMs
-        : undefined,
-      maxStaleMs: windows
-        ? (stored) => windows(stored as T).maxStaleMs
-        : undefined,
       fetchLive: () =>
         retry(fetchLive, {
           maxAttempts: 3,
@@ -429,7 +389,6 @@ async function fetchPrLiveState(
     `detail:${pr.number}`,
     prLabel(pr),
     () => client.readDetailed({ number: pr.number }),
-    (stored) => ciWindows(stored?.checks ?? null),
   );
   if (!detail) return NO_LIVE_STATE;
 
@@ -504,7 +463,6 @@ async function readChangeRequest(
     `read:${pr.number}`,
     `${prLabel(pr)} (${label})`,
     () => client.read(pr.number),
-    (stored) => ciWindows(stored?.checks ?? null),
   );
 }
 
@@ -523,7 +481,6 @@ export async function fetchPrChecksStatus(
     `detail:${pr.number}`,
     prLabel(pr),
     () => client.readDetailed({ number: pr.number }),
-    (stored) => ciWindows(stored?.checks ?? null),
   );
   return detail?.checks ?? null;
 }
@@ -803,7 +760,7 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
        * on exactly the cards that are still missing something.
        */
       revalidateAfterMs: (cards) =>
-        cards.some(isAwaitingCi)
+        cards.some(isAwaitingPreview)
           ? NOT_READY_MS
           : PR_CARDS_CACHE.revalidateAfterMs,
       placeholder: linked.map((pr) => ({

--- a/apps/web/src/hooks/use-task-board-item-prs.ts
+++ b/apps/web/src/hooks/use-task-board-item-prs.ts
@@ -21,18 +21,10 @@ const PRS_POLL_INTERVAL_MS = 60_000;
  *  minute. */
 const PRS_UNENRICHED_POLL_INTERVAL_MS = 2_000;
 
-/** Checks that are still running settle on their own, with no webhook to say
- *  when — so while any linked PR reports pending CI, poll faster than the idle
- *  minute. Bounded to a dialog that is open on a PR whose CI is actually
- *  running, and the server answers those from cache while it refreshes. */
-const PRS_PENDING_CHECKS_POLL_INTERVAL_MS = 10_000;
-
 /** A card the server returned before GitHub answered: link fields only. `state`
  *  is null for a PR GitHub could not be read for too, which polls the same way
  *  — the right behavior either way. */
 const isUnenriched = (pr: TaskBoardItemPr) => pr.state === null;
-
-const hasPendingChecks = (pr: TaskBoardItemPr) => pr.checksStatus === "pending";
 
 /**
  * A task's linked PRs, each with live state fetched from GitHub via the
@@ -47,13 +39,10 @@ export function useTaskBoardItemPrs(itemId: string | undefined) {
   return useQuery({
     queryKey: KEYS.taskBoardItemPrs(locator, itemId ?? ""),
     enabled: !!itemId,
-    refetchInterval: (query) => {
-      const prs = query.state.data;
-      if (prs?.some(isUnenriched)) return PRS_UNENRICHED_POLL_INTERVAL_MS;
-      if (prs?.some(hasPendingChecks))
-        return PRS_PENDING_CHECKS_POLL_INTERVAL_MS;
-      return PRS_POLL_INTERVAL_MS;
-    },
+    refetchInterval: (query) =>
+      query.state.data?.some(isUnenriched)
+        ? PRS_UNENRICHED_POLL_INTERVAL_MS
+        : PRS_POLL_INTERVAL_MS,
     // Seeded from localStorage so a cold page load paints the last known cards
     // instead of a skeleton. `initialDataUpdatedAt` carries the real age, so
     // React Query treats the seed as already stale and refetches on mount — the


### PR DESCRIPTION
## Incident

We are rate-limited against GitHub in production. #7033 and #7037 stacked into a
live GitHub read on **every poll** of a pending-CI card:

| what | before | after #7033/#7037 |
|---|---|---|
| raw CI reads (`detail`, `read`) | 55s hit / 30min stale | **hit 0 and stale 0** while pending — a MISS, blocking on the provider |
| card cache | 30s, zeroed only when pending **and** no preview URL | zeroed for **any** pending card |
| dialog poll | 60s | 15s (#7033) then **10s** (#7037) |

Six polls a minute, each a live detail read, per open dialog — against an App
installation floor of 5,000/hr (~83/min). A handful of open dialogs on
mid-flight PRs is the whole budget.

## This PR

Back to the pre-#7033 windows: 55s reads / 30s cards / 60s poll, and the card
predicate back to `isAwaitingPreview` (pending **and** no preview yet). The
per-entry `revalidateAfterMs` / `maxStaleMs` overrides on `JetStreamKVPrCache.fetch`
go with them — nothing else used them, so they would be dead code.

`fetchOrPlaceholder`'s own `revalidateAfterMs` stays: the card cache still uses it.

## Testing

- `bun test apps/api/src/tools/task-board/` — 410 pass, 10 fail, all
  `*.integration.test.ts` needing a live Postgres (fail identically on `main`).
- `bun run --cwd=apps/api check` clean on the touched files, `bun run lint` 0 errors,
  `bun run fmt` applied.

## Follow-up

The freshness this bought comes back in #7039 off GitHub webhooks, at zero
polling cost. This revert is the mitigation, not the answer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the pending-CI polling escalation from #7033 and #7037 that was hitting GitHub's rate limit in production. Pending-CI cards now serve from cache again instead of making a live GitHub read on every poll.

- CI reads, the card cache, and the dialog poll return to their pre-escalation windows (55s/30s/60s).
- Cards only refresh fast when CI is pending and no preview URL has been found yet.
- Removes the per-entry cache window overrides from `JetStreamKVPrCache.fetch`; nothing else used them, so they'd have been dead code.

<sup>Written for commit e0d41aa928df9e6a9a469a6f742e7407250934a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

