### PR TITLE
fix(repositories): restore connected account avatars

### DIFF
--- a/apps/web/src/components/repository-picker.tsx
+++ b/apps/web/src/components/repository-picker.tsx
@@ -1,6 +1,7 @@
 import { GitAccountConnect } from "@/components/git-account-connect";
 import { useDeferredValue, useState } from "react";
 import { ArrowLeft, ChevronRight, GitBranch01 } from "@untitledui/icons";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Dialog,
@@ -250,12 +251,19 @@ function AccountList({
           disabled={disabled}
           className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-accent transition-colors focus-visible:outline-none focus-visible:bg-accent disabled:opacity-50"
         >
-          <div className="size-8 rounded-lg bg-muted flex items-center justify-center shrink-0">
-            <ProviderIcon
-              provider={account.type}
-              className="text-muted-foreground"
-            />
-          </div>
+          <Avatar
+            url={account.avatarUrl?.trim() || undefined}
+            fallback={
+              <ProviderIcon
+                provider={account.type}
+                className="text-muted-foreground"
+              />
+            }
+            shape="circle"
+            size="sm"
+            className="size-8"
+            muted
+          />
           <span className="flex-1 min-w-0">
             <span className="block text-sm font-medium truncate">
               {account.login}
@@ -363,6 +371,21 @@ export function RepositoryPicker({
             </Button>
           ) : (
             <GitBranch01 size={16} className="text-muted-foreground shrink-0" />
+          )}
+          {account && (
+            <Avatar
+              url={account.avatarUrl?.trim() || undefined}
+              fallback={
+                <ProviderIcon
+                  provider={account.type}
+                  className="text-muted-foreground"
+                />
+              }
+              shape="circle"
+              size="sm"
+              className="size-6"
+              muted
+            />
           )}
           <span className="text-sm font-medium truncate">
             {account ? account.login : title}

--- a/apps/web/src/views/settings/repositories.tsx
+++ b/apps/web/src/views/settings/repositories.tsx
@@ -24,6 +24,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@decocms/ui/components/alert-dialog.tsx";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import { Badge } from "@decocms/ui/components/badge.tsx";
 import { Button } from "@decocms/ui/components/button.tsx";
 
@@ -103,9 +104,14 @@ function AccountRow({
   return (
     <div className="flex items-center justify-between gap-4 py-3 border-b border-border/60 last:border-b-0">
       <div className="flex items-start gap-3 min-w-0">
-        <div className="size-9 rounded-md bg-muted flex items-center justify-center shrink-0">
-          <ProviderIcon provider={account.type} />
-        </div>
+        <Avatar
+          url={account.avatarUrl?.trim() || undefined}
+          fallback={<ProviderIcon provider={account.type} />}
+          shape="circle"
+          size="sm"
+          className="size-9"
+          muted
+        />
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <span className="font-medium text-sm truncate">

--- a/packages/e2e/tests/git-account-avatars.spec.ts
+++ b/packages/e2e/tests/git-account-avatars.spec.ts
@@ -1,0 +1,93 @@
+import { connectDevDb } from "../fixtures/db";
+import { findOrgId } from "../fixtures/mcp-tools";
+import { expect, test } from "../fixtures/test";
+
+// Self-contained, synthetic images keep this UI check independent of providers.
+const organizationAvatar = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" fill="#4338ca"/><path d="M16 42V24l16-9 16 9v18l-16 9z" fill="white"/></svg>')}`;
+const userAvatar = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" fill="#047857"/><circle cx="32" cy="24" r="11" fill="white"/><path d="M12 60v-6a20 20 0 0 1 40 0v6" fill="white"/></svg>')}`;
+
+test("account avatars appear in settings and the picker, with fallbacks for missing and broken images", async ({
+  authedPage: { page, orgSlug },
+}, testInfo) => {
+  const orgId = await findOrgId(page.request, orgSlug);
+  const db = await connectDevDb();
+  try {
+    for (const account of [
+      {
+        provider: "github",
+        login: "example-organization",
+        avatar: organizationAvatar,
+      },
+      { provider: "gitlab", login: "example-user", avatar: userAvatar },
+      { provider: "gitlab", login: "missing-avatar", avatar: null },
+      {
+        provider: "gitlab",
+        login: "broken-avatar",
+        avatar: "data:image/png;base64,invalid-image",
+      },
+    ]) {
+      await db.query(
+        `INSERT INTO git_provider_accounts
+          (organization_id, type, host, auth_kind, external_account_id, login, avatar_url, installation_id)
+         VALUES ($1, $2, $3, $4, $5, $5, $6, $7)`,
+        [
+          orgId,
+          account.provider,
+          `${account.provider}.com`,
+          account.provider === "github" ? "github_app" : "token",
+          account.login,
+          account.avatar,
+          account.provider === "github" ? 123 : null,
+        ],
+      );
+    }
+  } finally {
+    await db.end();
+  }
+
+  await page.goto(`/${orgSlug}/settings/repositories`);
+  const accounts = page.getByTestId("git-accounts-list");
+  await expect(accounts.getByText("example-user", { exact: true })).toBeVisible(
+    { timeout: 15000 },
+  );
+  await expect(accounts.getByRole("img")).toHaveCount(2);
+  await expect(accounts.locator("img").nth(0)).toHaveAttribute(
+    "src",
+    organizationAvatar,
+  );
+  await expect(accounts.locator("img").nth(1)).toHaveAttribute(
+    "src",
+    userAvatar,
+  );
+  await expect(
+    accounts.locator('[data-slot="avatar-fallback"] svg'),
+  ).toHaveCount(2);
+  await page.screenshot({
+    path: testInfo.outputPath("connected-account-avatars.png"),
+    animations: "disabled",
+  });
+
+  await page
+    .getByRole("button", { name: "Add repository", exact: true })
+    .click();
+  const picker = page.getByRole("dialog");
+  const userRow = picker.getByRole("button", { name: /example-user/ });
+  await expect(userRow.getByRole("img")).toHaveAttribute("src", userAvatar);
+  for (const login of ["missing-avatar", "broken-avatar"]) {
+    const row = picker.getByRole("button", { name: new RegExp(login) });
+    await expect(row.getByRole("img")).toHaveCount(0);
+    await expect(
+      row.locator('[data-slot="avatar-fallback"] svg'),
+    ).toBeVisible();
+  }
+  await page.screenshot({
+    path: testInfo.outputPath("picker-account-avatars.png"),
+    animations: "disabled",
+  });
+  await userRow.click();
+  await expect(picker.getByRole("img")).toHaveAttribute("src", userAvatar);
+  await picker.getByRole("button", { name: "Back", exact: true }).click();
+  await expect(
+    picker.getByRole("button", { name: /example-user/ }).getByRole("img"),
+  ).toHaveAttribute("src", userAvatar);
+});


### PR DESCRIPTION
## What is this contribution about?

Connected GitHub and GitLab accounts displayed provider logos even when the API supplied an organization or user avatar. Restore those avatars in repository settings, the account picker, and its selected-account header using the shared Avatar component. Missing, blank, and broken image URLs fall back to the provider icon.

## How did you verify your code works?

- Five Playwright tests passed, covering account avatars in settings and the picker, missing/broken image fallback, the selected-account header and back navigation, plus existing desktop/mobile repository import flows.
- `bun run test` passed.
- Web type checking, `bun run fmt`, `bun run lint`, and `bun run knip` passed. Lint reports 14 warnings and no errors.
- Inspected the browser screenshots below. The fixtures use synthetic accounts and images; the local GitHub App is unconfigured.

## Screenshots/Demonstration

![Connected account avatars](https://raw.githubusercontent.com/decocms/studio/7bd035c08bc5a2d3c098b3cd71ad3b1d1bbbc67e/connected-account-avatars.png)

![Account picker avatars](https://raw.githubusercontent.com/decocms/studio/7bd035c08bc5a2d3c098b3cd71ad3b1d1bbbc67e/picker-account-avatars.png)

## How to Test

1. Open Settings → Repositories with connected GitHub or GitLab accounts. Organization and user avatars should appear beside their names.
2. Open Add repository or Import repository. Confirm the same avatars appear when choosing an account and in the header after selecting it.
3. Check an account with no avatar or an unavailable image. Its provider icon should remain visible.

No database migration or configuration changes are required.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores connected GitHub and GitLab account avatars in repository settings, the account picker, and the selected-account header. Previously, provider logos were shown even when an avatar was available; now the actual avatar is displayed, with the provider icon as fallback for missing, blank, or broken images.

Adds Playwright tests covering avatar rendering, fallback behavior, and existing import flows. No migration or configuration changes are required.

<sup>Written for commit 227eb90b4bae089861be2351f7aee166880ff140. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

