### PR TITLE
fix(dev-agent): translate the Develop/Live toggle labels

### DIFF
--- a/apps/web/src/components/dev-agent/dev-agent-control.tsx
+++ b/apps/web/src/components/dev-agent/dev-agent-control.tsx
@@ -14,12 +14,14 @@ import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
 import { useChatNavigation } from "@/components/chat/hooks/use-chat-navigation";
 import { useThreadActions } from "@/components/chat/store/hooks";
 import { findDevPartner } from "@/lib/agent-capabilities";
+import { useT } from "@/i18n/use-t.ts";
 
 export function DevAgentControl({
   virtualMcp,
 }: {
   virtualMcp: VirtualMCPEntity;
 }) {
+  const t = useT();
   const allAgents = useVirtualMCPs();
   const { navigateToTask } = useChatNavigation();
   const { create } = useThreadActions();
@@ -72,8 +74,8 @@ export function DevAgentControl({
 
   return (
     <div className="inline-flex items-center rounded-lg border border-border bg-muted p-0.5 text-xs font-medium">
-      {segment("Develop", isDev, Code01)}
-      {segment("Live", !isDev, Globe01)}
+      {segment(t("devAgent.devAgentControl.develop"), isDev, Code01)}
+      {segment(t("devAgent.devAgentControl.live"), !isDev, Globe01)}
     </div>
   );
 }

--- a/apps/web/src/i18n/en/dev-agent.ts
+++ b/apps/web/src/i18n/en/dev-agent.ts
@@ -9,4 +9,6 @@ export const devAgent = {
     "Or link an existing dev project…",
   "devAgent.devAgentSetup.title": "Development project",
   "devAgent.devAgentSetup.unlinkButton": "Unlink",
+  "devAgent.devAgentControl.develop": "Develop",
+  "devAgent.devAgentControl.live": "Live",
 } as const;

--- a/apps/web/src/i18n/pt-br/dev-agent.ts
+++ b/apps/web/src/i18n/pt-br/dev-agent.ts
@@ -12,4 +12,6 @@ export const devAgent = {
     "Ou vincule um projeto de desenvolvimento existente…",
   "devAgent.devAgentSetup.title": "Projeto de desenvolvimento",
   "devAgent.devAgentSetup.unlinkButton": "Desvincular",
+  "devAgent.devAgentControl.develop": "Desenvolver",
+  "devAgent.devAgentControl.live": "Ao vivo",
 } satisfies Record<keyof typeof devAgentEn, string>;


### PR DESCRIPTION
**Source:** i18n gap in `apps/web/src/components/dev-agent/dev-agent-control.tsx` — the Develop/Live toggle rendered in the agent shell header hardcoded `"Develop"` / `"Live"` as JSX text, `aria-label`, and native `title` tooltip, bypassing the repo's `useT()` i18n module entirely (every other user-facing string in this component tree already goes through it, including its sibling `dev-agent-setup.tsx`).

**Payoff:** a pt-br user sees the rest of the agent shell header translated except this one control, which stays in English — a visible, easily-fixed inconsistency.

**Change:** added `devAgent.devAgentControl.develop` / `.live` keys to `i18n/en/dev-agent.ts` and their pt-br translations (`Desenvolver` / `Ao vivo`), and swapped the two hardcoded strings in `dev-agent-control.tsx` for `t(...)` calls. No behavior change — same labels in English, now sourced from the dictionary.

**Reviewer check:** switch language to pt-br in Preferences and open an agent that has a linked dev/live pair — the header toggle now reads "Desenvolver" / "Ao vivo".

**Verified locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/web — no new errors, one pre-existing unrelated prosemirror-version error untouched by this diff), `bunx oxlint` on the three changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Develop/Live toggle now uses the i18n dictionary instead of hardcoded labels. English remains unchanged, while pt-BR users see “Desenvolver” and “Ao vivo” in the visible label, accessibility label, and tooltip.

<sup>Written for commit 250d78349b261504a09f558769f47e44094b9af2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

