### PR TITLE
refactor(sandbox): dedupe studio-repository resolution in SANDBOX_START

### DIFF
--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -364,6 +364,28 @@ type StartParams = {
 };
 
 /**
+ * The `repository` row to clone through Studio-owned credentials, or null to
+ * fall back to the legacy connection path — either because it's a bare
+ * credentialless legacy binding (no account, no connection at all) or because
+ * its account is actually servable by Studio.
+ */
+async function resolveStudioRepository(
+  ctx: StudioContext,
+  repository: RepositoryRecord | null,
+  rawConnectionId: string | undefined,
+): Promise<RepositoryRecord | null> {
+  if (!repository) return null;
+  const credentialless =
+    repository.accountId === null &&
+    !rawConnectionId &&
+    !repository.legacyConnectionId;
+  if (credentialless) return repository;
+  return (await repositoryUsesStudioCredentials(ctx.storage, repository))
+    ? repository
+    : null;
+}
+
+/**
  * `EnsureRepo` entries for a thread's secondary checkouts.
  *
  * Skips the primary when it turns up in the list, so a repo cannot be cloned
@@ -400,14 +422,11 @@ async function buildExtraRepoOpts(args: {
         args.orgId,
         repo,
       );
-      const studioRepository =
-        repository &&
-        ((repository.accountId === null &&
-          !repo.connectionId &&
-          !repository.legacyConnectionId) ||
-          (await repositoryUsesStudioCredentials(args.ctx.storage, repository)))
-          ? repository
-          : null;
+      const studioRepository = await resolveStudioRepository(
+        args.ctx,
+        repository,
+        repo.connectionId,
+      );
       const connectionId = repo.connectionId ?? repository?.legacyConnectionId;
       if (!studioRepository && !connectionId) continue;
       const { cloneUrl } = studioRepository
@@ -506,14 +525,11 @@ async function provisionSandbox(params: StartParams): Promise<{
       orgId,
       githubRepo,
     );
-    const studioRepository =
-      repository &&
-      ((repository.accountId === null &&
-        !githubRepo.connectionId &&
-        !repository.legacyConnectionId) ||
-        (await repositoryUsesStudioCredentials(ctx.storage, repository)))
-        ? repository
-        : null;
+    const studioRepository = await resolveStudioRepository(
+      ctx,
+      repository,
+      githubRepo.connectionId,
+    );
 
     const connectionId =
       githubRepo.connectionId ?? repository?.legacyConnectionId ?? undefined;


### PR DESCRIPTION
Follows #7057 (`fix(repositories): unify provider selection and repository consumers`), which introduced the same 6-line `studioRepository` resolution block — "credentialless legacy binding OR account is Studio-servable" — copy-pasted verbatim into both `buildExtraRepoOpts` (secondary repos) and `provisionSandbox` (primary repo) in `apps/api/src/tools/sandbox/start.ts`.

Extracts the shared logic into one `resolveStudioRepository(ctx, repository, rawConnectionId)` helper and calls it from both sites — same conditions, same order of evaluation, no behavior change.

**Net delta:** the file grows by 16 lines only because the extracted helper carries its own doc comment; the two call sites shrink from 7 lines each to 4-5, and the boolean logic itself is written once instead of twice.

**How I confirmed behavior is unchanged:** the two blocks were textually identical (`repository.accountId === null && !<connectionId> && !repository.legacyConnectionId) || await repositoryUsesStudioCredentials(...)`), so extracting them into a shared function called with each site's own `repository`/`connectionId` inputs is a pure relocation. `apps/api/src/tools/sandbox/start.test.ts` (21 tests, covering primary + secondary repo provisioning, studio vs. legacy-connection paths, and dangling-connection healing) passes unchanged.

**Reviewer check:** `bun test apps/api/src/tools/sandbox/start.test.ts`

**Local checks run:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean on this file), `bunx oxlint apps/api/src/tools/sandbox/start.ts` (0 warnings/errors), targeted test file above. Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts the duplicated `studioRepository` resolution logic into a shared `resolveStudioRepository` helper and calls it from both the primary and secondary repo paths. No behavior change; the same conditions and evaluation order are preserved.

<sup>Written for commit 24f56f8b05f41efda17a206784fe7787ffc0a167. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

