### PR TITLE
fix(file-storage): enforce the tarball size cap on chunked codeload responses

### DIFF
--- a/apps/api/src/file-storage/skill-set-sync.test.ts
+++ b/apps/api/src/file-storage/skill-set-sync.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { GitProviderError } from "../git-providers/types";
 import {
+  assertWithinByteCap,
   isRetriableTarballError,
   isUpToDate,
   parseTar,
@@ -160,6 +161,20 @@ describe("isUpToDate", () => {
   it("rewrites on a content change", () => {
     expect(isUpToDate({ ...args, manifestHash: "old" })).toBe(false);
     expect(isUpToDate({ ...args, manifestHash: null })).toBe(false);
+  });
+});
+
+describe("assertWithinByteCap", () => {
+  it("allows a length at or under the cap", () => {
+    expect(() => assertWithinByteCap(100, 100, "x")).not.toThrow();
+    expect(() => assertWithinByteCap(99, 100, "x")).not.toThrow();
+  });
+
+  it("throws once the length exceeds the cap", () => {
+    // Regression: a chunked (no Content-Length) codeload response used to skip this check.
+    expect(() => assertWithinByteCap(101, 100, "x")).toThrow(
+      "tarball for x exceeds 100 bytes",
+    );
   });
 });
 

--- a/apps/api/src/file-storage/skill-set-sync.ts
+++ b/apps/api/src/file-storage/skill-set-sync.ts
@@ -162,6 +162,17 @@ function filesFromTarball(
   return files;
 }
 
+/** Throws once `length` exceeds `cap` — shared by every tarball size guard. */
+export function assertWithinByteCap(
+  length: number,
+  cap: number,
+  label: string,
+): void {
+  if (length > cap) {
+    throw new Error(`tarball for ${label} exceeds ${cap} bytes`);
+  }
+}
+
 /** Buffer a tarball stream, refusing to grow past the download cap. */
 async function readTarballStream(
   stream: ReadableStream<Uint8Array>,
@@ -175,11 +186,7 @@ async function readTarballStream(
       const { done, value } = await reader.read();
       if (done) break;
       total += value.length;
-      if (total > MAX_TARBALL_BYTES) {
-        throw new Error(
-          `tarball for ${label} exceeds ${MAX_TARBALL_BYTES} bytes`,
-        );
-      }
+      assertWithinByteCap(total, MAX_TARBALL_BYTES, label);
       chunks.push(value);
     }
   } finally {
@@ -254,14 +261,16 @@ async function fetchRepoFiles(
         `tarball fetch failed for ${label}: HTTP ${res.status}`,
       );
     }
-    // Refuse before buffering when the server declares the size; the post-download check backstops chunked responses.
+    // Refuse before buffering when the server declares the size; the post-download check backstops chunked responses (no Content-Length).
     const declared = Number(res.headers.get("content-length") ?? 0);
     if (declared > MAX_TARBALL_BYTES) {
       throw new Error(
         `tarball for ${label} declares ${declared} bytes (cap ${MAX_TARBALL_BYTES})`,
       );
     }
-    return new Uint8Array(await res.arrayBuffer());
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    assertWithinByteCap(bytes.length, MAX_TARBALL_BYTES, label);
+    return bytes;
   };
   try {
     const gz = await retry(attempt, {


### PR DESCRIPTION
**Source:** bug found reading `apps/api/src/file-storage/skill-set-sync.ts` (skill-set sync backend focus area) — a real DoS/resource-bound gap, not from an open issue.

**Payoff:** the sync's whole reason for `MAX_TARBALL_BYTES` (200MB) is to refuse an oversized/malicious tarball before it OOMs the process, but the codeload fetch path only enforced that cap via the `Content-Length` header. A response using chunked transfer-encoding (no `Content-Length`) skipped the check entirely and `res.arrayBuffer()` buffered the whole body with no bound — the exact gap the sibling `readTarballStream` streaming path (used for first-class-repo tarballs) already guards against with a running-total check. The comment on the header-only check even claimed "the post-download check backstops chunked responses", which wasn't true for this path.

**Fix:** extracted the size check into an exported `assertWithinByteCap(length, cap, label)` helper, applied it to the buffered bytes right after `res.arrayBuffer()` in `fetchRepoFiles`, and reused it in `readTarballStream` for consistency. Added a unit test (`skill-set-sync.test.ts`) covering the boundary and the regression case directly (no fetch mocking needed since the check is a pure function of length vs cap).

**Reviewer check:** `bun test apps/api/src/file-storage/skill-set-sync.test.ts`

**Verified locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/file-storage/skill-set-sync.test.ts` (21 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI suite (e2e/integration) not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the 200MB tarball size cap on chunked codeload responses so an oversized response can't bypass the limit and exhaust memory.

- Extracts the size check into an exported `assertWithinByteCap` helper used by both the streaming and buffered paths.
- Adds unit tests covering the boundary and the regression case.

<sup>Written for commit 89bec5c682f7dd35240acb3aa9353ed0c92b2d35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

