### PR TITLE
fix(virtual-mcp): re-seed the settings form when switching agents

### DIFF
--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -1540,7 +1540,8 @@ export function VirtualMcpDetailView({
 
   return (
     <VirtualMcpDetailViewWithData
-      key={getActiveGithubRepo(virtualMcp)?.connectionId ?? ""}
+      // Re-seed the form on agent switch, not just on GitHub-repo change.
+      key={`${virtualMcp.id}:${getActiveGithubRepo(virtualMcp)?.connectionId ?? ""}`}
       virtualMcp={virtualMcp}
       hideOwnTitle={hideOwnTitle}
     />


### PR DESCRIPTION
**Source**: a bug found while auditing `apps/web/src/views/virtual-mcp/index.tsx` for the Virtual MCP integration lane.

**The bug**: `VirtualMcpDetailView` renders `VirtualMcpDetailViewWithData` keyed only by `getActiveGithubRepo(virtualMcp)?.connectionId ?? ""` (added in #3095 to reset the form when a GitHub repo gets connected/disconnected on the *same* agent). No ancestor in the render tree (`SettingsTab`, `MainPanelContent`) keys on `virtualMcpId`, so navigating from one agent's Settings tab to a *different* agent's Settings tab — while both lack a connected GitHub repo, so the key stays `""` — reuses the same component instance instead of remounting.

`useForm({ defaultValues })` (react-hook-form) only applies `defaultValues` on the initial mount. So after switching agents, the form kept showing the previous agent's title/instructions/connections instead of the new agent's data. Worse: `handleAutoSave` posts `form.getValues()` against `virtualMcp.id`, so saving from that stale state would silently write agent A's field values onto agent B's record — a cross-record data-integrity bug, not just a display glitch.

**Fix**: fold `virtualMcp.id` into the existing remount key, so any agent switch re-seeds the form, while preserving the original GitHub-repo-change reset behavior for the same agent.

**To confirm**: open two agents that neither has a connected GitHub repo, view agent A's Settings tab, switch (without a full page reload) to agent B's Settings tab, and check the title/instructions field reflects agent B, not agent A.

**Checks run locally**: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (no new errors — the one pre-existing error is an unrelated prosemirror version-skew issue), `bunx oxlint apps/web/src/views/virtual-mcp/index.tsx` (0 warnings/errors). No isolable unit-test target for this fix (it's a React remount/key bug in a heavily-hooked component); full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Virtual MCP settings form so it loads the correct agent's data when you switch between agents. Previously, switching from an agent without a connected GitHub repo to another agent that also lacks one reused the same form instance, leaving the previous agent's title and instructions visible — and saving could write that stale data onto the new agent's record. Now the form resets on any agent switch, and the existing reset-on-GitHub-repo-change behavior still works.

<sup>Written for commit 108cee7eacbd5de6c9fac5649941b48b302a905a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

