### PR TITLE
feat(task-board): push PR checks and preview url from a GitHub webhook

### DIFF
--- a/apps/api/migrations/207-task-board-prs-repo-idx.ts
+++ b/apps/api/migrations/207-task-board-prs-repo-idx.ts
@@ -1,0 +1,22 @@
+/**
+ * Index `task_board_item_prs` by (repo_owner, repo_name, pr_number).
+ *
+ * The GitHub webhook arrives knowing only a repo and a PR number and has to
+ * find the card, if any. The table's only index is (organization_id,
+ * task_board_item_id) and its PK is (task_board_item_id, url), so that lookup
+ * was a full scan — on a path that fires for every check suite and PR comment
+ * across every repo the App is installed on, most of which link to no card.
+ */
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createIndex("task_board_item_prs_repo_idx")
+    .on("task_board_item_prs")
+    .columns(["repo_owner", "repo_name", "pr_number"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("task_board_item_prs_repo_idx").execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -1,3 +1,4 @@
+import * as migration207taskboardprsrepoidx from "./207-task-board-prs-repo-idx";
 import * as migration206repositoryconsumers from "./206-repository-consumers";
 import { type Migration } from "kysely";
 import * as migration001initialschema from "./001-initial-schema.ts";
@@ -446,6 +447,7 @@ const migrations: Record<string, Migration> = {
     migration204gitprovideraccountsandrepositories,
   "205-repository-references": migration205repositoryreferences,
   "206-repository-consumers": migration206repositoryconsumers,
+  "207-task-board-prs-repo-idx": migration207taskboardprsrepoidx,
 };
 
 export default migrations;

--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -114,7 +114,7 @@ import publicConfigRoutes from "./routes/public-config";
 import { createReportPagesRoutes } from "./routes/report-pages";
 import reportsRoutes from "./routes/reports";
 import { stripeWebhookRoutes } from "./routes/stripe-webhook";
-import { githubWebhookRoutes } from "./routes/github-webhook";
+import { createGithubWebhookRoutes } from "./routes/github-webhook";
 import { createJiraAttachmentRoutes } from "./routes/jira-attachments";
 import { createJiraWebhookRoutes } from "./routes/jira-webhook";
 import {
@@ -1499,7 +1499,13 @@ export async function createApp(options: CreateAppOptions = {}) {
   // GitHub push webhook (tenant warm-pool freshness): HMAC-authed, no session.
   // Optional — 503 without GITHUB_WEBHOOK_SECRET, and pools refresh on their
   // own schedule regardless.
-  app.route("/api/_github", githubWebhookRoutes);
+  app.route(
+    "/api/_github",
+    createGithubWebhookRoutes({
+      taskBoard: () => projectorTaskBoard,
+      contextFactory: () => automationContextFactory,
+    }),
+  );
   // Git provider OAuth callbacks: the state, not the URL, carries org+user.
   app.route("/api/_git", gitProviderCallbackRoutes);
 

--- a/apps/api/src/api/routes/github-webhook.test.ts
+++ b/apps/api/src/api/routes/github-webhook.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { verifyGithubSignature } from "./github-webhook";
+import { prRefsFromGithubEvent, verifyGithubSignature } from "./github-webhook";
 
 const SECRET = "s3cret";
 const BODY = JSON.stringify({ ref: "refs/heads/main" });
@@ -25,5 +25,65 @@ describe("verifyGithubSignature", () => {
       verifyGithubSignature(BODY, VALID.slice("sha256=".length), SECRET),
     ).toBe(false);
     expect(verifyGithubSignature(BODY, "sha256=abc", SECRET)).toBe(false);
+  });
+});
+
+describe("prRefsFromGithubEvent", () => {
+  const repository = { name: "storefront", owner: { login: "deco-cx" } };
+
+  it("reads every PR a check suite belongs to, deduped", () => {
+    expect(
+      prRefsFromGithubEvent("check_suite", {
+        action: "completed",
+        repository,
+        check_suite: { pull_requests: [{ number: 7 }, { number: 7 }] },
+      }),
+    ).toEqual([{ repoOwner: "deco-cx", repoName: "storefront", number: 7 }]);
+  });
+
+  it("ignores a check suite that has not finished", () => {
+    // Every refresh is an uncached provider read, and a suite fires on
+    // `requested`/`rerequested` too — both of which only say "pending", which
+    // is already what the card shows.
+    for (const action of ["requested", "rerequested", undefined]) {
+      expect(
+        prRefsFromGithubEvent("check_suite", {
+          action,
+          repository,
+          check_suite: { pull_requests: [{ number: 7 }] },
+        }),
+      ).toEqual([]);
+    }
+  });
+
+  it("reads a PR comment but not an issue comment", () => {
+    const issue = { number: 12, pull_request: { url: "https://api/pulls/12" } };
+    expect(
+      prRefsFromGithubEvent("issue_comment", { repository, issue }),
+    ).toEqual([{ repoOwner: "deco-cx", repoName: "storefront", number: 12 }]);
+    // No `pull_request` key — a comment on a plain issue names no PR.
+    expect(
+      prRefsFromGithubEvent("issue_comment", {
+        repository,
+        issue: { number: 12 },
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns nothing for a push-to-no-PR suite, a wrong shape or another event", () => {
+    expect(
+      prRefsFromGithubEvent("check_suite", {
+        action: "completed",
+        repository,
+        check_suite: { pull_requests: [] },
+      }),
+    ).toEqual([]);
+    expect(
+      prRefsFromGithubEvent("check_suite", {
+        action: "completed",
+        check_suite: {},
+      }),
+    ).toEqual([]);
+    expect(prRefsFromGithubEvent("push", { repository })).toEqual([]);
   });
 });

--- a/apps/api/src/api/routes/github-webhook.ts
+++ b/apps/api/src/api/routes/github-webhook.ts
@@ -1,21 +1,35 @@
 /**
- * POST /api/_github/webhook — GitHub push intake for tenant warm pools.
+ * POST /api/_github/webhook — GitHub event intake.
+ *
+ * Two consumers, one endpoint (GitHub Apps have exactly one webhook url):
+ *  - `push` refreshes tenant warm pools.
+ *  - `check_suite` / `issue_comment` re-read the task board PR cards for the
+ *    PR the event names, so CI results and a deploy bot's preview url reach the
+ *    open dialog in about a second instead of on a poll.
  *
  * OPTIONAL everywhere. Without `GITHUB_WEBHOOK_SECRET` the route answers 503
- * and warm pools still pick up new commits on their periodic refresh — the
- * webhook only makes that immediate. Instance-level (underscore namespace,
- * mounted before the /api/:org catch-all) and outside session auth: the caller
- * is GitHub, authenticated exclusively by the HMAC over the RAW body.
+ * and both consumers still catch up on their own polling. Instance-level
+ * (underscore namespace, mounted before the /api/:org catch-all) and outside
+ * session auth: the caller is GitHub, authenticated exclusively by the HMAC
+ * over the RAW body.
  */
 
 import { timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { getOrInitSharedRunner } from "@/sandbox/lifecycle";
+import type { StudioContextFactory } from "@/automations/fire";
+import type { TaskBoardStorage } from "@/storage/task-board";
+import { refreshItemPrCards } from "@/tools/task-board/prs-get";
 
 // A push event with a large commit list is still small; the route is
 // unauthenticated, so cap the body before buffering it.
 const MAX_BODY_SIZE = 5_242_880; // 5MB
+
+/** Events that can change a PR card. `check_suite` covers third-party checks
+ *  (Cloudflare Pages / Workers Builds) as well as Actions; `issue_comment`
+ *  carries the deploy bots that publish the preview url as a comment. */
+const PR_CARD_EVENTS = new Set(["check_suite", "issue_comment"]);
 
 export function verifyGithubSignature(
   rawBody: string,
@@ -31,49 +45,189 @@ export function verifyGithubSignature(
   return timingSafeEqual(Buffer.from(received), Buffer.from(expected));
 }
 
-export const githubWebhookRoutes = new Hono();
+export interface GithubPrEventRef {
+  repoOwner: string;
+  repoName: string;
+  number: number;
+}
 
-githubWebhookRoutes.post(
-  "/webhook",
-  bodyLimit({
-    maxSize: MAX_BODY_SIZE,
-    onError: (c) => c.json({ error: "payload too large" }, 413),
-  }),
-  async (c) => {
-    const secret = process.env.GITHUB_WEBHOOK_SECRET;
-    if (!secret) return c.json({ error: "github webhook not configured" }, 503);
-
-    // Raw body FIRST — the signature covers the exact bytes.
-    const rawBody = await c.req.text();
-    if (
-      !verifyGithubSignature(
-        rawBody,
-        c.req.header("x-hub-signature-256"),
-        secret,
-      )
-    ) {
-      return c.json({ error: "invalid signature" }, 400);
+/**
+ * Which PRs an event is about. A `check_suite` names them in `pull_requests[]`
+ * (empty for a push to a branch with no PR — nothing to refresh). An
+ * `issue_comment` is about a PR only when the issue carries a `pull_request`
+ * key; a comment on a plain issue is not one.
+ *
+ * `check_suite` is narrowed to `completed`. Every refresh is an UNCACHED
+ * provider read, and a suite fires three times per commit per app
+ * (`requested`, `rerequested`, `completed`) — so honouring the other two would
+ * triple the cost of this path to learn "pending", which is what the card
+ * already shows. Only `completed` changes the verdict.
+ *
+ * Pure, so the payload shapes are unit-tested without a server. Exported for
+ * that test.
+ */
+export function prRefsFromGithubEvent(
+  event: string,
+  payload: unknown,
+): GithubPrEventRef[] {
+  const body = payload as {
+    action?: unknown;
+    repository?: { name?: unknown; owner?: { login?: unknown } };
+    check_suite?: { pull_requests?: unknown };
+    issue?: { number?: unknown; pull_request?: unknown };
+  };
+  const repoName = body?.repository?.name;
+  const repoOwner = body?.repository?.owner?.login;
+  if (typeof repoName !== "string" || typeof repoOwner !== "string") return [];
+  const numbers: number[] = [];
+  if (event === "check_suite") {
+    if (body.action !== "completed") return [];
+    const prs = body.check_suite?.pull_requests;
+    for (const pr of Array.isArray(prs) ? prs : []) {
+      const n = (pr as { number?: unknown })?.number;
+      if (typeof n === "number") numbers.push(n);
     }
+  } else if (event === "issue_comment" && body.issue?.pull_request) {
+    const n = body.issue.number;
+    if (typeof n === "number") numbers.push(n);
+  }
+  return [...new Set(numbers)].map((number) => ({
+    repoOwner,
+    repoName,
+    number,
+  }));
+}
 
-    // 200-and-ignore everything that isn't a push: GitHub retries on non-2xx,
-    // and there is nothing to retry for an event we don't handle.
-    if (c.req.header("x-github-event") !== "push") {
-      return c.json({ ok: true, ignored: "event" });
-    }
+/** Resolved lazily: the route is mounted before the /api/:org catch-all, which
+ *  is earlier than where the storage and the context factory are built. */
+export interface GithubWebhookDeps {
+  taskBoard: () => TaskBoardStorage;
+  contextFactory: () => StudioContextFactory;
+}
 
-    let payload: { ref?: string; repository?: { full_name?: string } };
+export function createGithubWebhookRoutes(deps: GithubWebhookDeps): Hono {
+  const routes = new Hono();
+
+  routes.post(
+    "/webhook",
+    bodyLimit({
+      maxSize: MAX_BODY_SIZE,
+      onError: (c) => c.json({ error: "payload too large" }, 413),
+    }),
+    async (c) => {
+      const secret = process.env.GITHUB_WEBHOOK_SECRET;
+      if (!secret) {
+        return c.json({ error: "github webhook not configured" }, 503);
+      }
+
+      // Raw body FIRST — the signature covers the exact bytes.
+      const rawBody = await c.req.text();
+      if (
+        !verifyGithubSignature(
+          rawBody,
+          c.req.header("x-hub-signature-256"),
+          secret,
+        )
+      ) {
+        return c.json({ error: "invalid signature" }, 400);
+      }
+
+      const event = c.req.header("x-github-event");
+      // 200-and-ignore everything we don't handle: GitHub retries on non-2xx,
+      // and there is nothing to retry for an event nobody consumes.
+      if (event !== "push" && !PR_CARD_EVENTS.has(event ?? "")) {
+        return c.json({ ok: true, ignored: "event" });
+      }
+
+      let payload: {
+        ref?: string;
+        repository?: { full_name?: string };
+      };
+      try {
+        payload = JSON.parse(rawBody);
+      } catch {
+        return c.json({ error: "invalid payload" }, 400);
+      }
+
+      if (event === "push") {
+        const ref = payload.ref;
+        const repo = payload.repository?.full_name;
+        if (!ref || !repo) return c.json({ ok: true, ignored: "shape" });
+        const runner = await getOrInitSharedRunner();
+        // The pool reconciler refreshes on its next tick; nothing waits here.
+        const pools = runner?.markTenantPoolsDirty(repo, ref) ?? [];
+        return c.json({ ok: true, pools });
+      }
+
+      const refs = prRefsFromGithubEvent(event ?? "", payload);
+      // No PR to refresh: a check suite mid-flight, a comment on a plain issue,
+      // or a shape we don't read. Not an error — nothing to retry.
+      if (refs.length === 0) return c.json({ ok: true, ignored: "no-pr" });
+      const refreshed = await refreshPrCardsForRefs(deps, refs);
+      return c.json({ ok: true, refreshed });
+    },
+  );
+
+  return routes;
+}
+
+/**
+ * Refresh every task card linked to any of `refs`. Almost always zero: the App
+ * is installed on far more repos than the board links PRs from, so the indexed
+ * lookup is the whole cost of an event nobody is watching.
+ *
+ * Awaited rather than detached so GitHub's delivery log reflects whether the
+ * work actually happened — the deliveries page is the only debugging surface
+ * this path has.
+ */
+async function refreshPrCardsForRefs(
+  deps: GithubWebhookDeps,
+  refs: GithubPrEventRef[],
+): Promise<number> {
+  let refreshed = 0;
+  for (const ref of refs) {
+    const taskBoard = deps.taskBoard();
+    let links: Awaited<ReturnType<typeof taskBoard.findPrLinks>>;
     try {
-      payload = JSON.parse(rawBody);
-    } catch {
-      return c.json({ error: "invalid payload" }, 400);
+      links = await taskBoard.findPrLinks(ref);
+    } catch (err) {
+      // Same reason `refreshItemPrCards` swallows its own: a 500 here makes
+      // GitHub retry the delivery, and a database blip is not something a
+      // replay fixes. The count in the response is the signal instead.
+      console.error("[github-webhook] pr link lookup failed:", err);
+      continue;
     }
-    const ref = payload.ref;
-    const repo = payload.repository?.full_name;
-    if (!ref || !repo) return c.json({ ok: true, ignored: "shape" });
-
-    const runner = await getOrInitSharedRunner();
-    // The pool reconciler refreshes on its next tick; nothing here waits on it.
-    const pools = runner?.markTenantPoolsDirty(repo, ref) ?? [];
-    return c.json({ ok: true, pools });
-  },
-);
+    for (const link of links) {
+      // Per link, so one card whose owner or context is unreadable doesn't cost
+      // the other cards linked to the same PR their refresh.
+      try {
+        const item = await taskBoard.getById(
+          link.taskBoardItemId,
+          link.organizationId,
+        );
+        // The context is the org's, built from the card's owner: a webhook has
+        // no principal of its own, and the GitHub connection it reads through
+        // is the organization's.
+        const ctx = item
+          ? await deps.contextFactory()(
+              link.organizationId,
+              item.assignedBy ?? item.createdBy,
+            )
+          : null;
+        if (!ctx) continue;
+        const cards = await refreshItemPrCards(
+          ctx,
+          link.organizationId,
+          link.taskBoardItemId,
+        );
+        if (cards !== null) refreshed++;
+      } catch (err) {
+        console.error(
+          `[github-webhook] pr card refresh failed for ${link.taskBoardItemId}:`,
+          err,
+        );
+      }
+    }
+  }
+  return refreshed;
+}

--- a/apps/api/src/git-providers/change-requests.ts
+++ b/apps/api/src/git-providers/change-requests.ts
@@ -117,6 +117,13 @@ export interface ChangeRequest {
   state: ChangeRequestState;
   draft: boolean;
   mergedAt: string | null;
+  /**
+   * When the provider last saw activity on it — a push, a comment, a review.
+   * Bounds how long a reader keeps waiting for something that may never come
+   * (a deploy preview from a repo that publishes none). Null when the read
+   * does not carry it.
+   */
+  updatedAt: string | null;
   /** Branch it targets. */
   base: string;
   /** Branch it proposes. */

--- a/apps/api/src/git-providers/github/change-requests.test.ts
+++ b/apps/api/src/git-providers/github/change-requests.test.ts
@@ -126,6 +126,7 @@ describe("mapPullRequest", () => {
         mergeable: true,
         mergeable_state: "clean",
         changed_files: 3,
+        updated_at: "2026-09-09T10:00:00Z",
         base: { ref: "main" },
         head: {
           ref: "feat/x",
@@ -142,6 +143,7 @@ describe("mapPullRequest", () => {
       state: "open",
       draft: false,
       mergedAt: null,
+      updatedAt: "2026-09-09T10:00:00Z",
       base: "main",
       head: "feat/x",
       headSha: "abc1234",

--- a/apps/api/src/git-providers/github/change-requests.ts
+++ b/apps/api/src/git-providers/github/change-requests.ts
@@ -70,6 +70,7 @@ export interface RawPullRequest {
   draft?: boolean | null;
   merged?: boolean | null;
   merged_at?: string | null;
+  updated_at?: string | null;
   mergeable?: boolean | null;
   mergeable_state?: string | null;
   changed_files?: number | null;
@@ -140,6 +141,7 @@ export function mapPullRequest(pr: RawPullRequest): ChangeRequest {
     state: merged ? "merged" : pr.state === "closed" ? "closed" : "open",
     draft: pr.draft === true,
     mergedAt: pr.merged_at ?? null,
+    updatedAt: pr.updated_at ?? null,
     base: pr.base?.ref ?? "main",
     head: pr.head?.ref ?? "",
     headSha: pr.head?.sha ?? "",
@@ -202,6 +204,7 @@ fragment CrDetail on PullRequest {
   state
   merged
   mergedAt
+  updatedAt
   isDraft
   mergeable
   reviewDecision
@@ -323,6 +326,7 @@ export interface RawGraphqlChangeRequest {
   state?: string | null;
   merged?: boolean | null;
   mergedAt?: string | null;
+  updatedAt?: string | null;
   isDraft?: boolean | null;
   mergeable?: string | null;
   reviewDecision?: string | null;
@@ -437,6 +441,7 @@ export function mapDetail(
     state: merged ? "merged" : pr.state === "OPEN" ? "open" : "closed",
     draft: pr.isDraft === true,
     mergedAt: pr.mergedAt ?? null,
+    updatedAt: pr.updatedAt ?? null,
     base: pr.baseRefName ?? "main",
     head: pr.headRefName ?? "",
     headSha: pr.headRefOid ?? "",
@@ -670,6 +675,7 @@ export class GithubChangeRequestClient implements ChangeRequestClient {
       state: "merged",
       draft: false,
       mergedAt: node.mergedAt ?? null,
+      updatedAt: node.mergedAt ?? null,
       base: node.baseRefName ?? base,
       head: node.headRefName ?? "",
       headSha: node.headRefOid ?? "",

--- a/apps/api/src/git-providers/gitlab/change-requests.ts
+++ b/apps/api/src/git-providers/gitlab/change-requests.ts
@@ -56,6 +56,7 @@ export interface RawMergeRequest {
   draft?: boolean | null;
   work_in_progress?: boolean | null;
   merged_at?: string | null;
+  updated_at?: string | null;
   target_branch?: string | null;
   source_branch?: string | null;
   sha?: string | null;
@@ -322,6 +323,7 @@ export class GitlabChangeRequestClient implements ChangeRequestClient {
       state: mapState(mr.state),
       draft: mr.draft === true || mr.work_in_progress === true,
       mergedAt: mr.merged_at ?? null,
+      updatedAt: mr.updated_at ?? null,
       base: mr.target_branch ?? "main",
       head: mr.source_branch ?? "",
       headSha: mr.sha ?? "",

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1372,6 +1372,28 @@ export class TaskBoardStorage {
       .execute();
   }
 
+  /**
+   * Every card linked to one PR, across all orgs — the GitHub webhook's
+   * reverse lookup, which knows a repo and a number and nothing else. Empty for
+   * the common case: a repo the App is installed on with no card linked to it.
+   */
+  async findPrLinks(pr: {
+    repoOwner: string;
+    repoName: string;
+    number: number;
+  }): Promise<{ taskBoardItemId: string; organizationId: string }[]> {
+    return await this.db
+      .selectFrom("task_board_item_prs")
+      .select([
+        "task_board_item_id as taskBoardItemId",
+        "organization_id as organizationId",
+      ])
+      .where("repo_owner", "=", pr.repoOwner)
+      .where("repo_name", "=", pr.repoName)
+      .where("pr_number", "=", pr.number)
+      .execute();
+  }
+
   /** PRs linked to a task (most-recent first), identity only. */
   async listPrs(
     taskBoardItemId: string,

--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -13,7 +13,6 @@ import { GitProviderError } from "@/git-providers";
 import {
   asHeadSha,
   cardLifecycle,
-  isAwaitingPreview,
   isRateLimitError,
   isTrustedPreviewHost,
   previewMatchesHead,
@@ -397,28 +396,5 @@ describe("previewMatchesHead", () => {
     };
     expect(previewMatchesHead([closed, merged, pr("passing")])).toBe(true);
     expect(previewMatchesHead([])).toBe(true);
-  });
-});
-
-describe("isAwaitingPreview", () => {
-  it("keeps refreshing while CI runs with no preview yet", () => {
-    expect(
-      isAwaitingPreview({ previewUrl: null, checksStatus: "pending" }),
-    ).toBe(true);
-  });
-
-  it("caches normally once either settles", () => {
-    expect(
-      isAwaitingPreview({
-        previewUrl: "https://x.vtex.app",
-        checksStatus: "pending",
-      }),
-    ).toBe(false);
-    expect(
-      isAwaitingPreview({ previewUrl: null, checksStatus: "passing" }),
-    ).toBe(false);
-    expect(isAwaitingPreview({ previewUrl: null, checksStatus: null })).toBe(
-      false,
-    );
   });
 });

--- a/apps/api/src/tools/task-board/pr-cache.ts
+++ b/apps/api/src/tools/task-board/pr-cache.ts
@@ -30,7 +30,7 @@ import { meter } from "../../observability";
 
 const cacheCounter = meter.createCounter("pr_read_cache.fetches", {
   description:
-    "Task board PR cache outcomes (hit, stale, miss, placeholder, error, store_rejected)",
+    "Task board PR cache outcomes (hit, stale, miss, placeholder, refresh, error, store_rejected)",
   unit: "{fetches}",
 });
 
@@ -97,6 +97,10 @@ export interface PrCacheFetch {
   /** Receives the background revalidation so the caller can keep its MCP client
    *  open until it settles. */
   onRevalidation: (promise: Promise<void>) => void;
+  /** Ignore whatever is stored and fetch live, then store it — for a caller the
+   *  provider has just told the value changed, where a cached read is precisely
+   *  what the event supersedes. */
+  fresh?: boolean;
 }
 
 export class JetStreamKVPrCache {
@@ -177,7 +181,7 @@ export class JetStreamKVPrCache {
     }
 
     const key = this.storageKey(namespace, rawKey);
-    const stored = await this.read(key);
+    const stored = params.fresh ? null : await this.read(key);
     const age = stored
       ? this.now() - stored.storedAt
       : Number.POSITIVE_INFINITY;
@@ -268,6 +272,26 @@ export class JetStreamKVPrCache {
     return usable
       ? { value: stored!.value as T, live: true }
       : { value: placeholder, live: false };
+  }
+
+  /**
+   * Fetch live and store, ignoring whatever is cached — the webhook's push
+   * path, where the provider has just told us the value changed. Rejects if the
+   * fetch does, so a failed refresh leaves the previous value in place.
+   */
+  async refresh<T>(params: {
+    namespace: string;
+    key: string;
+    fetchLive: () => Promise<T>;
+  }): Promise<T> {
+    const value = await params.fetchLive();
+    await this.write(
+      this.storageKey(params.namespace, params.key),
+      value,
+      this.config.cache,
+    );
+    cacheCounter.add(1, { cache: this.config.cache, outcome: "refresh" });
+    return value;
   }
 
   private async read(key: string): Promise<StoredRead | null> {

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -13,6 +13,7 @@ import {
 } from "@/git-providers";
 import type { TaskBoardItemPrRef } from "@/storage/types";
 import {
+  isCardNotReady,
   LANES,
   shippedLane,
   SUPER_AGENT_ASSIGNEE_ID,
@@ -20,11 +21,15 @@ import {
 import { repoIdentityKey } from "@decocms/shared/git-providers";
 import { retry, RetryError } from "@decocms/shared/std";
 import { TaskBoardItemPrSchema } from "./schema";
+
+/** One assembled PR card — the tool's output shape, and what the card cache
+ *  stores. */
+export type TaskBoardItemPrCard = z.infer<typeof TaskBoardItemPrSchema>;
 import { cardWorkLanded } from "./archive-merged";
 import { recordTaskActivity } from "./activity";
 import { originOf } from "./change-request-extract";
 import { inReviewPhase, movesForward } from "./lanes";
-import { emitTaskBoardUpdated } from "./run-reactions";
+import { emitTaskBoardPrsUpdated, emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
 import { readPrStateThrottled } from "./dbos-github-read";
@@ -88,20 +93,10 @@ const prLabel = (pr: TaskBoardItemPrRef) =>
 export const readNamespace = (pr: TaskBoardItemPrRef) =>
   repoIdentityKey(originOf(pr).repo);
 
-/**
- * A card that should keep refreshing: CI is still running and no preview URL
- * has been found yet. Once either settles the card caches normally.
- */
-export function isAwaitingPreview(card: {
-  previewUrl: string | null;
-  checksStatus: ChecksSummary;
-}): boolean {
-  return card.previewUrl === null && card.checksStatus === "pending";
-}
-
 /** Hit window for a card still waiting on something. Zero, so the next poll
  *  revalidates (detached, off the request path) instead of serving the
- *  not-ready answer for the full window. */
+ *  not-ready answer for the full window. The reads underneath still cache
+ *  normally, so this costs a reassembly, not a provider call. */
 const NOT_READY_MS = 0;
 
 /**
@@ -119,11 +114,15 @@ async function cachedRead<T>(
   key: string,
   describe: string,
   fetchLive: () => Promise<T>,
+  /** Skip the cache and store what comes back — the provider has just told us
+   *  this value changed, so a cached read is exactly what the event supersedes. */
+  fresh = false,
 ): Promise<T | null> {
   try {
     const raw = await getPrReadCache().fetch({
       namespace,
       key,
+      fresh,
       fetchLive: () =>
         retry(fetchLive, {
           maxAttempts: 3,
@@ -217,12 +216,32 @@ export function previewUrlFromChecks(runs: CheckRun[]): string | null {
     const url = `https://${version}-${worker}.${WORKERS_DEV_SUBDOMAIN}.workers.dev`;
     if (isTrustedPreviewHost(url)) return url;
   }
-  // A successful run's own link, preferred over an in-flight one's.
-  const linked = runs.filter(
-    (run) => run.url !== null && isTrustedPreviewHost(run.url),
+  // Then the generic one: a trusted host anywhere in the run's own link or its
+  // report. Reported alongside the stale-card bug — the deploy bot sometimes
+  // posts no comment at all, and only the check knows the url. Successful runs
+  // win, so a retried deploy does not hand back the broken attempt's.
+  const isSuccess = (run: CheckRun) => run.conclusion === "success";
+  for (const run of [
+    ...runs.filter(isSuccess),
+    ...runs.filter((r) => !isSuccess(r)),
+  ]) {
+    const url =
+      (run.url && isTrustedPreviewHost(run.url) ? run.url : null) ??
+      firstTrustedUrl(run.summary);
+    if (url) return url;
+  }
+  return null;
+}
+
+/** The first url in `text` on a trusted preview host. The character class stops
+ *  at `)`/`]` so a markdown link's url does not absorb its syntax. */
+function firstTrustedUrl(text: unknown): string | null {
+  if (typeof text !== "string") return null;
+  return (
+    (text.match(/https?:\/\/[^\s"'<>)\]]+/g) ?? []).find(
+      isTrustedPreviewHost,
+    ) ?? null
   );
-  const success = linked.find((run) => run.conclusion === "success");
-  return success?.url ?? linked[0]?.url ?? null;
 }
 
 /**
@@ -262,9 +281,7 @@ export function previewUrlFromComments(
     // prefer the branch URL, which stays valid as the branch gets new commits.
     const branch = body.match(/href=['"]([^'"]+)['"][^>]*>\s*Branch Preview/i);
     if (branch?.[1] && isTrustedPreviewHost(branch[1])) return branch[1];
-    const url = (body.match(/https?:\/\/[^\s"'<>)\]]+/g) ?? []).find((u) =>
-      isTrustedPreviewHost(u),
-    );
+    const url = firstTrustedUrl(body);
     if (url) return url;
   }
   return null;
@@ -282,6 +299,8 @@ export function asHeadSha(sha: unknown): string | null {
 type PrLiveState = {
   title: string | null;
   body: string | null;
+  /** The provider's last-activity timestamp — bounds the preview chase. */
+  updatedAt: string | null;
   state: "open" | "closed" | null;
   draft: boolean | null;
   merged: boolean | null;
@@ -308,6 +327,7 @@ export type PrCheck = {
 const NO_LIVE_STATE: PrLiveState = {
   title: null,
   body: null,
+  updatedAt: null,
   state: null,
   draft: null,
   merged: null,
@@ -380,6 +400,7 @@ async function fetchPrLiveState(
   ctx: StudioContext,
   orgId: string,
   pr: TaskBoardItemPrRef,
+  fresh = false,
 ): Promise<PrLiveState> {
   const client = await clientFor(ctx, orgId, pr);
   if (!client) return NO_LIVE_STATE;
@@ -389,6 +410,7 @@ async function fetchPrLiveState(
     `detail:${pr.number}`,
     prLabel(pr),
     () => client.readDetailed({ number: pr.number }),
+    fresh,
   );
   if (!detail) return NO_LIVE_STATE;
 
@@ -399,6 +421,7 @@ async function fetchPrLiveState(
       ...NO_LIVE_STATE,
       title: detail.title,
       body: detail.body,
+      updatedAt: detail.updatedAt,
       state,
       draft: detail.draft,
       merged,
@@ -430,6 +453,7 @@ async function fetchPrLiveState(
   return {
     title: detail.title,
     body: detail.body,
+    updatedAt: detail.updatedAt,
     state,
     draft: detail.draft,
     merged,
@@ -688,6 +712,66 @@ export async function pickActivePr(
   return prs[pickActivePrIndex(states)];
 }
 
+/** One provider round-trip per linked change request, in parallel, each
+ *  best-effort. */
+function assemblePrCards(
+  ctx: StudioContext,
+  orgId: string,
+  linked: TaskBoardItemPrRef[],
+  fresh = false,
+): Promise<TaskBoardItemPrCard[]> {
+  return Promise.all(
+    linked.map(async (pr) => {
+      const live = await fetchPrLiveState(ctx, orgId, pr, fresh);
+      return {
+        url: pr.url,
+        number: pr.number,
+        repoOwner: pr.repoOwner,
+        repoName: pr.repoName,
+        createdAt: pr.createdAt,
+        ...live,
+      };
+    }),
+  );
+}
+
+/**
+ * Re-read a task's PR cards from the provider and push them out — the GitHub
+ * webhook's entry point, where a delivery has just said CI finished or a
+ * deploy bot commented.
+ *
+ * Reads bypass the read cache (`fresh`), because the event IS the invalidation.
+ * The result is written straight into the card cache, so the dialog's next poll
+ * is a hit, and emitted on the org's SSE stream, so a dialog already open
+ * updates without waiting for that poll.
+ *
+ * Best-effort and never throws: a webhook delivery must not be retried because
+ * one org's provider credential is unreachable.
+ */
+export async function refreshItemPrCards(
+  ctx: StudioContext,
+  orgId: string,
+  taskBoardItemId: string,
+): Promise<TaskBoardItemPrCard[] | null> {
+  try {
+    const linked = await ctx.storage.taskBoard.listPrs(taskBoardItemId, orgId);
+    if (linked.length === 0) return null;
+    const prs = await getPrCardCache().refresh({
+      namespace: orgId,
+      key: taskBoardItemId,
+      fetchLive: () => assemblePrCards(ctx, orgId, linked, true),
+    });
+    emitTaskBoardPrsUpdated(orgId, taskBoardItemId, prs);
+    return prs;
+  } catch (err) {
+    console.error(
+      `[task-board] pr card refresh failed for ${taskBoardItemId}:`,
+      err,
+    );
+    return null;
+  }
+}
+
 export const TASK_BOARD_ITEM_PRS_GET = defineTool({
   name: "TASK_BOARD_ITEM_PRS_GET",
   description:
@@ -725,21 +809,7 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
       taskBoardItemId,
       organizationId,
     );
-    // One provider round-trip per linked change request, in parallel, each best-effort.
-    const assemble = () =>
-      Promise.all(
-        linked.map(async (pr) => {
-          const live = await fetchPrLiveState(ctx, organizationId, pr);
-          return {
-            url: pr.url,
-            number: pr.number,
-            repoOwner: pr.repoOwner,
-            repoName: pr.repoName,
-            createdAt: pr.createdAt,
-            ...live,
-          };
-        }),
-      );
+    const assemble = () => assemblePrCards(ctx, organizationId, linked);
 
     /**
      * Serve the assembled card, not the reads it was built from. And on a cold
@@ -753,14 +823,13 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
       key: taskBoardItemId,
       fetchLive: assemble,
       /**
-       * A card whose deploy is still running has no preview yet. At the default
-       * window it is a hit for 30s, so the URL can be a poll or two late even
-       * after the read above refreshes. Go stale immediately instead: the
-       * revalidation is detached, so this costs a background rebuild per poll
-       * on exactly the cards that are still missing something.
+       * A card still waiting on something (CI running, or no preview url yet
+       * and the change request active recently) is never a hit: the
+       * revalidation is detached, so it costs one reassembly per poll from
+       * reads that are themselves cached.
        */
       revalidateAfterMs: (cards) =>
-        cards.some(isAwaitingPreview)
+        cards.some((card) => isCardNotReady(card))
           ? NOT_READY_MS
           : PR_CARDS_CACHE.revalidateAfterMs,
       placeholder: linked.map((pr) => ({

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -42,6 +42,7 @@ import {
   LANES,
   SUPER_AGENT_ASSIGNEE_ID,
   TASK_BOARD_ITEM_DELETED_EVENT,
+  TASK_BOARD_ITEM_PRS_UPDATED_EVENT,
   TASK_BOARD_ITEM_UPDATED_EVENT,
 } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
@@ -77,6 +78,22 @@ export function emitTaskBoardUpdated(orgId: string, item: TaskBoardItem): void {
     source: "task-board",
     subject: item.id,
     data: item,
+    time: new Date().toISOString(),
+  });
+}
+
+/** Push a task's freshly re-read PR cards to every SSE listener on its org. */
+export function emitTaskBoardPrsUpdated(
+  orgId: string,
+  itemId: string,
+  prs: unknown[],
+): void {
+  sseHub.emit(orgId, {
+    id: crypto.randomUUID(),
+    type: TASK_BOARD_ITEM_PRS_UPDATED_EVENT,
+    source: "task-board",
+    subject: itemId,
+    data: { id: itemId, prs },
     time: new Date().toISOString(),
   });
 }

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -112,6 +112,10 @@ export const TaskBoardItemPrSchema = z.object({
   repoOwner: z.string(),
   repoName: z.string(),
   createdAt: z.string(),
+  /** GitHub's `updated_at` for the PR — bumped by a push, a comment or a review.
+   *  Bounds how long a card with no preview url keeps chasing one. `null` when
+   *  GitHub hasn't been read yet or the fetch failed. */
+  updatedAt: z.string().nullable(),
   title: z.string().nullable(),
   body: z.string().nullable(),
   state: z.enum(["open", "closed"]).nullable(),

--- a/apps/web/src/hooks/use-task-board-item-prs-events.ts
+++ b/apps/web/src/hooks/use-task-board-item-prs-events.ts
@@ -1,0 +1,62 @@
+/**
+ * useTaskBoardItemPrsEvents — live PR cards for one open task dialog.
+ *
+ * Subscribes to the shared `/api/:org/watch` connection, filtered to
+ * `task-board.item.prs.updated`, and hands the fresh cards for THIS task to
+ * `onPrs`. The GitHub webhook pushes that event when CI finishes or a deploy
+ * bot posts a preview url, so the dialog's checks and Preview button update
+ * without waiting for its poll.
+ *
+ * Mirrors `useTaskBoardEvents`: useSyncExternalStore for React 19 lifecycle,
+ * callback read from a ref so the connection stays stable across re-renders.
+ */
+
+import type { TaskBoardItemPr } from "@/layouts/task-board/config";
+import { useRef, useSyncExternalStore } from "react";
+import { taskBoardPrsWatchView } from "./watch-sse-pool";
+
+const getSnapshot = () => 0;
+
+export function useTaskBoardItemPrsEvents(options: {
+  orgSlug: string;
+  itemId: string | undefined;
+  onPrs: (prs: TaskBoardItemPr[]) => void;
+}): void {
+  const { orgSlug, itemId, onPrs } = options;
+
+  const onPrsRef = useRef(onPrs);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- callback kept fresh without re-subscribing
+  onPrsRef.current = onPrs;
+
+  const subscribeRef = useRef<
+    ((onStoreChange: () => void) => () => void) | null
+  >(null);
+  const prevKey = useRef<string>("");
+  const key = `${orgSlug}:${itemId ?? ""}`;
+
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- escape hatch for stable subscription identity
+  if (!subscribeRef.current || prevKey.current !== key) {
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- escape hatch for stable subscription identity
+    prevKey.current = key;
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- escape hatch for stable subscription identity
+    subscribeRef.current = (onStoreChange: () => void) => {
+      if (!orgSlug || !itemId) return () => {};
+      const handler = (e: MessageEvent) => {
+        let event: { data?: { id?: string; prs?: TaskBoardItemPr[] } };
+        try {
+          event = JSON.parse(e.data);
+        } catch {
+          return;
+        }
+        // Org-wide stream: every open dialog sees every task's push.
+        if (event.data?.id !== itemId || !Array.isArray(event.data.prs)) return;
+        onPrsRef.current(event.data.prs);
+        onStoreChange();
+      };
+      return taskBoardPrsWatchView.subscribe(orgSlug, handler);
+    };
+  }
+
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- escape hatch for stable subscription identity
+  useSyncExternalStore(subscribeRef.current!, getSnapshot, getSnapshot);
+}

--- a/apps/web/src/hooks/use-task-board-item-prs.ts
+++ b/apps/web/src/hooks/use-task-board-item-prs.ts
@@ -1,8 +1,9 @@
 import { useProjectContext } from "@/sdk";
 import type { TaskBoardItemPr } from "@/layouts/task-board/config";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { KEYS } from "@/lib/query-keys";
 import { useStudioTools } from "@/lib/studio-tools";
+import { useTaskBoardItemPrsEvents } from "./use-task-board-item-prs-events";
 import {
   readCachedTaskPrs,
   writeCachedTaskPrs,
@@ -10,10 +11,12 @@ import {
 
 /** Poll interval for a task's PRs while the dialog is open. The tool fetches
  *  live GitHub state — PR/checks status and the checks→QA hand-off it drives —
- *  so a periodic refresh keeps the review lane moving without a webhook. Kept at
- *  one minute to stay well within GitHub's rate limits, since every poll fans
- *  out to live GitHub PR + checks calls. The query is only active while the
- *  dialog (and thus this hook) is mounted. */
+ *  so a periodic refresh keeps the review lane moving. Kept at one minute to
+ *  stay well within GitHub's rate limits, since every poll can fan out to live
+ *  GitHub PR + checks calls — polling a mid-flight PR any faster is what took
+ *  the App's rate limit out. Freshness comes from the webhook push above; this
+ *  is the fallback for repos the App is not installed on. The query is only
+ *  active while the dialog (and thus this hook) is mounted. */
 const PRS_POLL_INTERVAL_MS = 60_000;
 
 /** While a card is still waiting on GitHub the server answers from the database
@@ -33,8 +36,23 @@ const isUnenriched = (pr: TaskBoardItemPr) => pr.state === null;
  * while the dialog is open, so poll it.
  */
 export function useTaskBoardItemPrs(itemId: string | undefined) {
-  const { locator } = useProjectContext();
+  const { org, locator } = useProjectContext();
   const studio = useStudioTools();
+  const queryClient = useQueryClient();
+
+  // The webhook's push path: fresh cards land here as soon as GitHub reports CI
+  // finished or the deploy bot commented, which is why the poll below can stay
+  // at the idle minute instead of chasing the same states at 10s.
+  useTaskBoardItemPrsEvents({
+    orgSlug: org.slug,
+    itemId,
+    onPrs: (prs) => {
+      queryClient.setQueryData(
+        KEYS.taskBoardItemPrs(locator, itemId ?? ""),
+        prs,
+      );
+    },
+  });
 
   return useQuery({
     queryKey: KEYS.taskBoardItemPrs(locator, itemId ?? ""),

--- a/apps/web/src/hooks/watch-sse-pool.ts
+++ b/apps/web/src/hooks/watch-sse-pool.ts
@@ -7,6 +7,7 @@
 import { ALL_DECOPILOT_EVENT_TYPES } from "@/sdk";
 import {
   TASK_BOARD_ITEM_DELETED_EVENT,
+  TASK_BOARD_ITEM_PRS_UPDATED_EVENT,
   TASK_BOARD_ITEM_UPDATED_EVENT,
 } from "@decocms/shared/task-board";
 import { NOTIFICATION_CREATED_EVENT } from "@decocms/shared/notification-types";
@@ -21,6 +22,7 @@ const WATCH_TYPES = [
   ...ALL_DECOPILOT_EVENT_TYPES,
   TASK_BOARD_ITEM_UPDATED_EVENT,
   TASK_BOARD_ITEM_DELETED_EVENT,
+  TASK_BOARD_ITEM_PRS_UPDATED_EVENT,
   NOTIFICATION_CREATED_EVENT,
 ];
 
@@ -54,6 +56,12 @@ export const taskBoardWatchView: SSESubscription = filterEventTypes(watchSSE, [
   TASK_BOARD_ITEM_UPDATED_EVENT,
   TASK_BOARD_ITEM_DELETED_EVENT,
 ]);
+
+/** A task's PR cards, re-read because a GitHub webhook said they changed. */
+export const taskBoardPrsWatchView: SSESubscription = filterEventTypes(
+  watchSSE,
+  [TASK_BOARD_ITEM_PRS_UPDATED_EVENT],
+);
 
 /** Inbox fan-out (`notification.created`). Org-wide — the consumer matches the
  *  event's `subject` against its own user id. */

--- a/apps/web/src/layouts/task-board/build-task-chat-context.test.ts
+++ b/apps/web/src/layouts/task-board/build-task-chat-context.test.ts
@@ -24,6 +24,7 @@ const pr = (o: Partial<TaskBoardItemPr>): TaskBoardItemPr => ({
   repoOwner: "x",
   repoName: "y",
   createdAt: "",
+  updatedAt: null,
   title: null,
   body: null,
   state: "open",

--- a/apps/web/src/layouts/task-board/pr-card-actions.test.ts
+++ b/apps/web/src/layouts/task-board/pr-card-actions.test.ts
@@ -20,6 +20,7 @@ function pr(overrides: Partial<TaskBoardItemPr> = {}): TaskBoardItemPr {
     repoOwner: "o",
     repoName: "r",
     createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: null,
     title: "A PR",
     body: null,
     state: "open",

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -56,7 +56,7 @@ const jiraStubPort = process.env.JIRA_STUB_PORT || "4103";
 // the config isn't a spec module).
 const vaultServiceToken = "e2e-vault-service-token";
 
-const apiServerCommand = `MCP_CACHE_ENABLED=true VAULT_SERVICE_TOKEN=${vaultServiceToken} REPORTS_INTERNAL_API_URL=${commerceMockOrigin} REPORTS_INTERNAL_API_KEY=${commerceMockKey} GITHUB_API_BASE_URL=${githubStubOrigin} JIRA_ALLOW_LOCAL_SITE_URL=1 BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} RUN_IDLE_TIMEOUT_MS=120000 DEPLOYMENT_ADMIN_EMAILS=deployment-admin@e2e.local,deployment-admin-2@e2e.local bun run dev`;
+const apiServerCommand = `MCP_CACHE_ENABLED=true GITHUB_WEBHOOK_SECRET=e2e-github-webhook-secret VAULT_SERVICE_TOKEN=${vaultServiceToken} REPORTS_INTERNAL_API_URL=${commerceMockOrigin} REPORTS_INTERNAL_API_KEY=${commerceMockKey} GITHUB_API_BASE_URL=${githubStubOrigin} JIRA_ALLOW_LOCAL_SITE_URL=1 BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} RUN_IDLE_TIMEOUT_MS=120000 DEPLOYMENT_ADMIN_EMAILS=deployment-admin@e2e.local,deployment-admin-2@e2e.local bun run dev`;
 // CI serves the PRODUCTION build via `vite preview` (same Node proxy as dev —
 // see apps/web/vite.config.ts): the suite's charter is production-like
 // behavior, and the dev server's on-demand transform inflated browser-heavy

--- a/packages/e2e/tests/task-board-pr-webhook.spec.ts
+++ b/packages/e2e/tests/task-board-pr-webhook.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * `/api/_github/webhook`'s PR-card contract, over the wire.
+ *
+ * A PR card's checks and preview url used to be poll-only, so they landed
+ * minutes after GitHub had them. GitHub now posts `check_suite` /
+ * `issue_comment` here, which re-reads the card and pushes it on the org's
+ * `/watch` stream.
+ *
+ * What this spec covers is the route's own contract: authentication, and which
+ * deliveries are worth a provider read at all. That second half is the one that
+ * costs money — every refresh is an UNCACHED read, and polling this same state
+ * too hard is what took the App's rate limit out (see #7094).
+ *
+ * NOT covered here: the full delivery → reverse lookup → fresh read → SSE →
+ * dialog chain. It needs a stub for the provider read the card path now makes
+ * (a GraphQL detail query through `git-providers`, not the `mcp-github`
+ * connection this spec originally stubbed), which the suite has no fixture for
+ * yet — `github-stub.ts` covers Git Data and pulls only.
+ *
+ * `GITHUB_WEBHOOK_SECRET` is set on the API server by playwright.config.ts;
+ * the literal is duplicated here by hand (the config isn't a spec module),
+ * matching how commerce-diagnostic-share.spec.ts carries the vault token.
+ */
+
+import { createHmac } from "node:crypto";
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../fixtures/test";
+
+const WEBHOOK_SECRET = "e2e-github-webhook-secret";
+
+/** GitHub's own signature scheme: HMAC-SHA256 over the exact request bytes. */
+function sign(body: string): string {
+  return `sha256=${createHmac("sha256", WEBHOOK_SECRET).update(body).digest("hex")}`;
+}
+
+function postWebhook(
+  request: APIRequestContext,
+  event: string,
+  payload: unknown,
+  signature?: string,
+) {
+  const body = JSON.stringify(payload);
+  return request.post("/api/_github/webhook", {
+    data: body,
+    headers: {
+      "content-type": "application/json",
+      "x-github-event": event,
+      "x-hub-signature-256": signature ?? sign(body),
+    },
+  });
+}
+
+test.describe("github webhook → PR card", () => {
+  test("authenticates by HMAC and refreshes nothing it should not", async ({
+    authedPage,
+  }) => {
+    const request = authedPage.page.context().request;
+    const repository = {
+      name: "nobody-links-me",
+      owner: { login: "acme-e2e" },
+    };
+
+    // The route's only authentication is the HMAC — a wrong one is a 400, and
+    // must not be treated as an unsigned-but-harmless ping.
+    const forged = await postWebhook(
+      request,
+      "check_suite",
+      { repository },
+      "sha256=" + "0".repeat(64),
+    );
+    expect(forged.status()).toBe(400);
+
+    // An event nobody consumes is a 200: GitHub retries non-2xx, and there is
+    // nothing here to retry.
+    const unhandled = await postWebhook(request, "star", { repository });
+    expect(unhandled.status()).toBe(200);
+    expect(await unhandled.json()).toMatchObject({ ignored: "event" });
+
+    // A suite that has not finished says only "pending", which the card already
+    // shows — so it must NOT buy an uncached provider read. A suite fires on
+    // `requested` and `rerequested` too, so honouring them would triple this
+    // path's cost for no new information.
+    for (const action of ["requested", "rerequested"]) {
+      const midFlight = await postWebhook(request, "check_suite", {
+        action,
+        repository,
+        check_suite: { pull_requests: [{ number: 1 }] },
+      });
+      expect(midFlight.status()).toBe(200);
+      expect(await midFlight.json()).toMatchObject({ ignored: "no-pr" });
+    }
+
+    // A comment on a plain ISSUE is not a PR event — no `pull_request` key.
+    const onIssue = await postWebhook(request, "issue_comment", {
+      action: "created",
+      repository,
+      issue: { number: 1 },
+    });
+    expect(await onIssue.json()).toMatchObject({ ignored: "no-pr" });
+
+    // A finished suite for a repo no card links: the indexed lookup finds
+    // nothing and the delivery still succeeds. This is the common case in prod,
+    // where the App is installed on far more repos than the board tracks.
+    const unlinked = await postWebhook(request, "check_suite", {
+      action: "completed",
+      repository,
+      check_suite: { pull_requests: [{ number: 1 }] },
+    });
+    expect(await unlinked.json()).toMatchObject({ ok: true, refreshed: 0 });
+  });
+});

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -466,8 +466,49 @@ export const TASK_BOARD_ITEM_UPDATED_EVENT = "task-board.item.updated";
 export const TASK_BOARD_ITEM_DELETED_EVENT = "task-board.item.deleted";
 
 /**
+ * Org-scoped SSE event pushed on `sseHub` whenever a task's linked PR cards are
+ * re-read from GitHub because a webhook said they changed — CI finished, or a
+ * deploy bot commented. Its `data` is `{ id, prs }` (the task id and the fresh
+ * cards); the open task dialog writes them straight into its react-query cache,
+ * so checks and the preview url land without waiting for the next poll.
+ */
+export const TASK_BOARD_ITEM_PRS_UPDATED_EVENT = "task-board.item.prs.updated";
+
+/**
  * Cap on the org's task system prompt. It rides in the system prompt of EVERY
  * task run, so an unbounded textarea is a per-run token bill. Shared so the
  * settings tool rejects what the textarea already refuses.
  */
 export const TASK_SYSTEM_PROMPT_MAX_LENGTH = 4000;
+
+/** Bound on chasing a preview url that may never arrive, from GitHub's
+ *  `updated_at`. */
+const PREVIEW_CHASE_MS = 10 * 60_000;
+
+/**
+ * A PR card waiting on something that ends by itself: never asked GitHub yet,
+ * CI running, or no preview url yet (time-bounded — a repo may publish none,
+ * ever).
+ *
+ * Shared because both sides key off it and must not drift: the server drops the
+ * card cache's hit window to zero, and the dialog polls faster.
+ */
+export function isCardNotReady(
+  card: {
+    checksStatus: string | null;
+    previewUrl: string | null;
+    state: string | null;
+    updatedAt: string | null;
+  },
+  now: number = Date.now(),
+): boolean {
+  // `null` is the placeholder: we have not asked GitHub yet, so it is the least
+  // ready a card can be. Only a state GitHub actually reported as not-open is
+  // settled.
+  if (card.state !== null && card.state !== "open") return false;
+  if (card.state === null) return true;
+  if (card.checksStatus === "pending") return true;
+  if (card.previewUrl !== null) return false;
+  const activeAt = card.updatedAt ? Date.parse(card.updatedAt) : Number.NaN;
+  return Number.isFinite(activeAt) && now - activeAt < PREVIEW_CHASE_MS;
+}

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -626,6 +626,7 @@ export interface StudioToolIO {
         repoOwner: string;
         repoName: string;
         createdAt: string;
+        updatedAt: string | null;
         title: string | null;
         body: string | null;
         state: "open" | "closed" | null;


### PR DESCRIPTION
**Two commits, and the first one is #7094 verbatim** — the rate-limit revert. The
repo only allows `main` as a PR base, so this branch carries both rather than
stacking. Merge #7094 first and this collapses to the second commit; merge this
alone and it does both. **The revert is the incident mitigation and should not
wait on this review.**

**Replaces #7039**, which was written against the pre-#7022 MCP read path and no longer applies.

## The problem

Checks go green and the deploy bot posts a preview url, but the card shows
neither for 1–3 minutes. Every cache layer is one window behind and the windows
stack.

Polling harder is not the fix — it *is* the incident #7094 just reverted. At a
10s poll one open dialog on a mid-flight PR costs ~6 uncached provider reads a
minute, against an App installation floor of 5,000/hr (~83/min).

## The fix: use the events GitHub already sends

Most of this was already built and dormant — `/api/_github/webhook` has been
HMAC-verifying `push` deliveries for tenant warm pools, and the App already
emits `check_suite` (which covers Cloudflare Pages / Workers Builds, unlike
Actions-only `workflow_run`). It just had no PR-card consumer.

1. `check_suite` / `issue_comment` reverse-look-up the PR's cards via a new
   `findPrLinks`, indexed by **migration 207** — the table's only index was
   `(organization_id, task_board_item_id)`, so a repo/number lookup was a full
   scan on a path that fires for every repo the App is installed on.
2. The refresh re-reads the provider **bypassing the read cache** (the event
   *is* the invalidation), writes the card cache, and emits
   `task-board.item.prs.updated` on the org's `/watch` stream.
3. The open dialog writes those cards straight into its query cache.
4. Polling stays the fallback for repos the App is not installed on.

Also: a deploy check that prints its url in its `summary` now counts as a
preview source, so a repo whose bot never comments still gets a Preview button
(reported alongside the stale-card bug).

## Two deliberate changes from #7039

Both about not re-creating the rate limit its predecessor caused:

- **The dialog poll stays at 60s.** #7039 kept a 10s tier for in-flight cards —
  that is what #7094 reverted, and the webhook is the freshness path now.
- **`check_suite` is narrowed to `action: "completed"`.** A suite fires three
  times per commit per app (`requested`, `rerequested`, `completed`) and every
  refresh is an *uncached* provider read. The other two would triple this
  path's cost to learn "pending" — which the card already shows.

## Port notes (what #7022 changed underneath)

- `updatedAt` is now on the neutral `ChangeRequest`, mapped in both the GitHub
  (REST + GraphQL) and GitLab adapters. It bounds `isCardNotReady`'s preview
  chase to 10 min.
- `fresh` is a flag on the read cache rather than #7039's zero-stale-ceiling
  predicate — the per-entry window overrides went away with the MCP read path.
- `commentsRevalidateAfterMs` is obsolete: comments arrive inside `readDetailed`
  now, not a separate `get_comments` read.
- This also settles #7039's own open question — `ciMaxStaleMs` (a rate-limited
  pending read returning `null` → `checksStatus: null` → `prReadyForReview`
  passing → a reviewer handed a PR whose CI is still running) is gone with the
  revert.

## Bounded / reversible

- No `GITHUB_WEBHOOK_SECRET` → the route answers **503** and everything falls
  back to today's polling. Nothing here is load-bearing until it is deployed.
- An event for a repo no card links costs **one indexed lookup**.
- A failed refresh is logged and the delivery still returns 200, so GitHub does
  not retry a database blip; one unreadable card does not cost the others on the
  same PR their refresh.

## Testing

- **Unit** — webhook payload shapes (`check_suite` fan-out + dedupe, the new
  mid-flight guard, PR comment vs plain-issue comment, wrong shape); the
  generalized check-run preview scan; `isCardNotReady`.
  `bun test` on the touched suites: 227 pass, 2 fail — both a pt-BR locale
  assertion in `task-filters-search.test.tsx`, untouched here and failing the
  same way on `main`. The 10 `*.integration.test.ts` task-board failures need a
  live Postgres and also pre-exist.
- `bun run check` clean (bar the pre-existing duplicate-prosemirror errors),
  `bun run lint` 0 errors, `knip` clean, `bun run fmt` applied.
- **E2E is reduced, deliberately.** `packages/e2e/tests/task-board-pr-webhook.spec.ts`
  covers the route's own contract — HMAC rejection, unhandled event, the
  mid-flight guard, plain-issue comment, unlinked PR → `refreshed: 0`. #7039's
  full delivery→SSE→dialog walk is **dropped**: it stubbed GitHub as an
  `mcp-github` connection, which is no longer how the card path reads, and the
  suite has no fixture for the GraphQL detail read that replaced it
  (`github-stub.ts` covers Git Data and pulls only). **So the end-to-end chain
  is not verified by CI** — building that fixture is follow-up work worth doing
  before the secret is deployed.

## Deploy steps (not code)

1. `GITHUB_WEBHOOK_SECRET` into AWS SM `prod/studio/application` (us-west-2);
   ESO syncs into `deco-studio-secrets` within 1h. Confirmed missing today:
   `POST https://studio.decocms.com/api/_github/webhook` → `503`.
2. The same string in the App's *Webhook secret* field, URL at
   `/api/_github/webhook`, subscribed to `check_suite` + `issue_comment`.

Side effect worth knowing: this also switches on the **warm-pool push
acceleration** that has been dormant since it shipped, for the same reason.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
PR cards now refresh from GitHub webhooks instead of polling, so CI results and preview URLs appear in about a second instead of 1–3 minutes. This branch also carries the #7094 rate-limit revert as its first commit — merge that first and this collapses to just the webhook work.

- `check_suite` (`completed` only) and `issue_comment` deliveries on `/api/_github/webhook` reverse-look-up the PR's cards via a new indexed lookup (migration 207) and re-read the provider bypassing the read cache.
- Fresh cards are written to the card cache and pushed to open dialogs over SSE via `task-board.item.prs.updated`; polling stays at 60s as fallback.
- A deploy check printing a trusted URL in its `summary` now counts as a preview source.
- `updatedAt` on the neutral `ChangeRequest` bounds the preview chase to 10 minutes.

**Deploy**
- Set `GITHUB_WEBHOOK_SECRET` in AWS SM `prod/studio/application`; without it the route answers 503 and nothing changes.
- Add the same secret and URL to the GitHub App's webhook config, subscribed to `check_suite` + `issue_comment`.

<sup>Written for commit 3f521b9983423c6a4da68bd2c8954d5b2d5a36ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

