### PR TITLE
fix(decofile): stop a save re-reading every block from GitHub

### DIFF
--- a/apps/api/src/decofile/commit-coalescer.test.ts
+++ b/apps/api/src/decofile/commit-coalescer.test.ts
@@ -1,0 +1,245 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { RepoRef } from "@decocms/shared/git-providers";
+import type {
+  BranchPage,
+  FileChange,
+  RepoContentClient,
+  TreeEntry,
+} from "@/git-providers";
+import { RepoWriteConflict } from "@/git-providers";
+import { enqueueDecofilePatch } from "./commit-coalescer";
+import { resolveBlockContents } from "./read-decofile";
+
+/**
+ * These cover the blob-read cost of a decofile save. Regenerating the tracked
+ * `.deco/blocks.gen.json` artifact touches EVERY block, so an uncached or
+ * unbounded read there is a whole-repo blob fetch per save — which spent an
+ * entire GitHub App installation's hourly REST budget in production.
+ *
+ * The disk blob cache is switched off here (`FAST_PREVIEW_CACHE_DIR=""`), so
+ * these assert the two protections that survive without it: per-sha dedup +
+ * the in-memory memo threaded across CAS attempts, and the concurrency bound.
+ */
+beforeAll(() => {
+  process.env.FAST_PREVIEW_CACHE_DIR = "";
+});
+
+const REPO: RepoRef = {
+  provider: "github",
+  host: "github.com",
+  path: "acme/site",
+};
+
+interface FakeOpts {
+  /** Block stems present in the tree at HEAD. */
+  stems: string[];
+  /** Whether the repo tracks the merged `.deco/blocks.gen.json` artifact. */
+  tracksGen: boolean;
+  /** Reject this many `commitFiles` calls with a conflict before accepting. */
+  conflicts?: number;
+}
+
+function fakeClient(opts: FakeOpts) {
+  const readBlobCalls: string[] = [];
+  let inFlight = 0;
+  let maxInFlight = 0;
+  let commitAttempts = 0;
+  let committed: FileChange[] = [];
+
+  const treeEntries = (): TreeEntry[] => [
+    ...opts.stems.map(
+      (s): TreeEntry => ({
+        path: `.deco/blocks/${s}.json`,
+        type: "blob",
+        sha: `sha-${s}`,
+      }),
+    ),
+    ...(opts.tracksGen
+      ? [
+          {
+            path: ".deco/blocks.gen.json",
+            type: "blob" as const,
+            sha: "sha-gen",
+          },
+        ]
+      : []),
+  ];
+
+  const client: RepoContentClient = {
+    repo: REPO,
+    getDefaultBranch: async () => "main",
+    getBranch: async () => ({ sha: "head1", committedAt: "2026-01-01" }),
+    searchBranches: async (): Promise<BranchPage> => ({
+      branches: [],
+      totalCount: 0,
+      nextCursor: null,
+    }),
+    getArchive: async () => null,
+    listDecofileEntries: async () => treeEntries(),
+    getEntriesAtPaths: async () => new Map(),
+    readBlob: async (sha: string) => {
+      readBlobCalls.push(sha);
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      // Yield so concurrent callers actually overlap.
+      await new Promise((r) => setTimeout(r, 1));
+      inFlight--;
+      const stem = sha.replace(/^sha-/, "");
+      return JSON.stringify({ __resolveType: stem });
+    },
+    readFileAtRef: async () => null,
+    commitFiles: async ({ changes }: { changes: FileChange[] }) => {
+      commitAttempts++;
+      if (commitAttempts <= (opts.conflicts ?? 0)) {
+        throw new RepoWriteConflict("head moved");
+      }
+      committed = changes;
+      return { sha: `commit${commitAttempts}` };
+    },
+    createBranch: async () => {},
+    forceBranchHead: async () => {},
+    mergeBranches: async () => true,
+    compare: async () => ({ ahead: 0, behind: 0 }),
+  } as unknown as RepoContentClient;
+
+  return {
+    client,
+    readBlobCalls,
+    get maxInFlight() {
+      return maxInFlight;
+    },
+    get commitAttempts() {
+      return commitAttempts;
+    },
+    get committed() {
+      return committed;
+    },
+  };
+}
+
+describe("resolveBlockContents", () => {
+  it("passes through in-hand content without a fetch", async () => {
+    const f = fakeClient({ stems: [], tracksGen: false });
+    const out = await resolveBlockContents(f.client, [
+      { stem: "A", content: "a" },
+      { stem: "B", content: "b" },
+    ]);
+    expect(out).toEqual([
+      { stem: "A", content: "a" },
+      { stem: "B", content: "b" },
+    ]);
+    expect(f.readBlobCalls).toEqual([]);
+  });
+
+  it("fetches each distinct sha exactly once, preserving input order", async () => {
+    const f = fakeClient({ stems: [], tracksGen: false });
+    const out = await resolveBlockContents(f.client, [
+      { stem: "A", sha: "sha-A" },
+      { stem: "B", sha: "sha-B" },
+      // Same blob reached by a second stem: one fetch, both resolved.
+      { stem: "B-alias", sha: "sha-B" },
+    ]);
+    expect(out.map((o) => o.stem)).toEqual(["A", "B", "B-alias"]);
+    expect(out[1]?.content).toBe(out[2]?.content);
+    expect(f.readBlobCalls.sort()).toEqual(["sha-A", "sha-B"]);
+  });
+
+  it("reuses a caller-provided memo instead of refetching", async () => {
+    const f = fakeClient({ stems: [], tracksGen: false });
+    const memo = new Map<string, string>();
+    const blocks = [{ stem: "A", sha: "sha-A" }];
+
+    await resolveBlockContents(f.client, blocks, memo);
+    expect(f.readBlobCalls).toEqual(["sha-A"]);
+
+    await resolveBlockContents(f.client, blocks, memo);
+    expect(f.readBlobCalls).toEqual(["sha-A"]); // no second read
+  });
+
+  it("bounds concurrency rather than fanning out over every block", async () => {
+    const f = fakeClient({ stems: [], tracksGen: false });
+    const blocks = Array.from({ length: 200 }, (_, i) => ({
+      stem: `B${i}`,
+      sha: `sha-B${i}`,
+    }));
+    await resolveBlockContents(f.client, blocks);
+    expect(f.readBlobCalls).toHaveLength(200);
+    // The whole point: NOT 200 concurrent requests.
+    expect(f.maxInFlight).toBeLessThanOrEqual(12);
+  });
+});
+
+describe("enqueueDecofilePatch blob cost", () => {
+  const stems = Array.from({ length: 50 }, (_, i) => `Block${i}`);
+
+  it("reads no blobs at all when the repo does not track blocks.gen.json", async () => {
+    const f = fakeClient({ stems, tracksGen: false });
+    await enqueueDecofilePatch(
+      `q-untracked-${Date.now()}`,
+      {
+        client: f.client,
+        branch: "feature",
+        packagePath: null,
+      },
+      { set: { Block0: { __resolveType: "Block0" } } },
+    );
+
+    expect(f.readBlobCalls).toEqual([]);
+  });
+
+  it("reads each other block once when regenerating blocks.gen.json", async () => {
+    const f = fakeClient({ stems, tracksGen: true });
+    await enqueueDecofilePatch(
+      `q-tracked-${Date.now()}`,
+      {
+        client: f.client,
+        branch: "feature",
+        packagePath: null,
+      },
+      { set: { Block0: { __resolveType: "Block0" } } },
+    );
+
+    // The written block comes from the patch, not GitHub; the other 49 are read.
+    expect(f.readBlobCalls).toHaveLength(stems.length - 1);
+    expect(new Set(f.readBlobCalls).size).toBe(stems.length - 1);
+    expect(f.readBlobCalls).not.toContain("sha-Block0");
+    expect(f.maxInFlight).toBeLessThanOrEqual(12);
+  });
+
+  it("a CAS retry re-reads nothing it already resolved", async () => {
+    const f = fakeClient({ stems, tracksGen: true, conflicts: 1 });
+    await enqueueDecofilePatch(
+      `q-retry-${Date.now()}`,
+      {
+        client: f.client,
+        branch: "feature",
+        packagePath: null,
+      },
+      { set: { Block0: { __resolveType: "Block0" } } },
+    );
+
+    expect(f.commitAttempts).toBe(2);
+    // Was 2x the tree before the memo was hoisted out of the attempt loop.
+    expect(f.readBlobCalls).toHaveLength(stems.length - 1);
+  });
+
+  it("still regenerates the artifact over every block", async () => {
+    const f = fakeClient({ stems, tracksGen: true });
+    await enqueueDecofilePatch(
+      `q-gen-${Date.now()}`,
+      {
+        client: f.client,
+        branch: "feature",
+        packagePath: null,
+      },
+      { set: { Block0: { __resolveType: "Block0" } } },
+    );
+
+    const gen = f.committed.find((c) => c.path === ".deco/blocks.gen.json");
+    expect(gen).toBeDefined();
+    const doc = JSON.parse(
+      (gen as { path: string; content: string }).content,
+    ) as Record<string, unknown>;
+    expect(Object.keys(doc)).toHaveLength(stems.length);
+  });
+});

--- a/apps/api/src/decofile/commit-coalescer.ts
+++ b/apps/api/src/decofile/commit-coalescer.ts
@@ -15,6 +15,7 @@ import {
   blockEntriesInTree,
   blocksDirPath,
   primeBlobCache,
+  resolveBlockContents,
   resolveOrCreateHead,
 } from "./read-decofile";
 
@@ -124,6 +125,10 @@ async function runQueue(queueKey: string, state: QueueState): Promise<void> {
 
 async function commitBatch(batch: Batch): Promise<string> {
   const { client, branch, packagePath } = batch.deps;
+  /** blob sha -> text, shared across CAS attempts. A blob sha is immutable, so
+   *  a retry that rebuilds on a fresh head re-reads only blocks it has not
+   *  already resolved instead of the whole tree again. */
+  const blobMemo = new Map<string, string>();
   for (let attempt = 0; ; attempt++) {
     // Writes are session-only, so first-touch of a thread-minted branch may
     // materialize it here (a save can race ahead of the editor's first read).
@@ -175,11 +180,10 @@ async function commitBatch(batch: Batch): Promise<string> {
       ? `${packagePath}/.deco/blocks.gen.json`
       : ".deco/blocks.gen.json";
     if (tree.some((e) => e.type === "blob" && e.path === genPath)) {
-      const files = await Promise.all(
-        [...nextBlocks.values()].map(async (b) => ({
-          stem: b.stem,
-          content: "content" in b ? b.content : await client.readBlob(b.sha),
-        })),
+      const files = await resolveBlockContents(
+        client,
+        nextBlocks.values(),
+        blobMemo,
       );
       const { decofile: genContent, skipped } = mergeBlocks(files);
       if (skipped.length > 0) {

--- a/apps/api/src/decofile/read-decofile.ts
+++ b/apps/api/src/decofile/read-decofile.ts
@@ -208,6 +208,61 @@ export function primeBlobCache(repo: RepoRef, content: string): Promise<void> {
   return putBlob(...cacheScope(repo), gitBlobSha(content), content);
 }
 
+/** A block source that is either already in hand or still addressed by sha. */
+export type BlockSource = { stem: string } & (
+  | { sha: string }
+  | { content: string }
+);
+
+/**
+ * Resolve every block's text, reading only what the disk cache is missing and
+ * bounding the fetches — the same two protections {@link resolveSnapshot} has.
+ *
+ * The write path needs this as badly as the read path: regenerating the merged
+ * artifact touches EVERY block, so an uncached unbounded fan-out there is a
+ * whole-repo blob read per save. That burst spent an entire installation's
+ * hourly REST budget in production (~850 blocks x an unbounded `Promise.all`),
+ * which is exactly the failure `BLOB_FETCH_CONCURRENCY` documents.
+ *
+ * `memo` is keyed by blob sha, which is immutable, so a caller may thread one
+ * map through a compare-and-swap retry loop and never re-read a blob it has
+ * already resolved on an earlier attempt.
+ */
+export async function resolveBlockContents(
+  client: RepoContentClient,
+  blocks: Iterable<BlockSource>,
+  memo: Map<string, string> = new Map(),
+): Promise<Array<{ stem: string; content: string }>> {
+  const [owner, repo] = cacheScope(client.repo);
+  const all = [...blocks];
+  const missing = [
+    ...new Set(
+      all.flatMap((b) => ("content" in b || memo.has(b.sha) ? [] : [b.sha])),
+    ),
+  ];
+  await mapBounded(missing, BLOB_FETCH_CONCURRENCY, async (sha) => {
+    const hit = await getBlob(owner, repo, sha);
+    if (hit !== null) {
+      memo.set(sha, hit);
+      return;
+    }
+    const content = await client.readBlob(sha);
+    await putBlob(owner, repo, sha, content);
+    memo.set(sha, content);
+  });
+  return all.map((b) => {
+    if ("content" in b) return { stem: b.stem, content: b.content };
+    const content = memo.get(b.sha);
+    // Unreachable: every sha not already memoized was just fetched, and a
+    // fetch failure throws. Explicit so a regression is not a silent empty
+    // block in the merged document.
+    if (content === undefined) {
+      throw new Error(`decofile: unresolved block blob ${b.sha}`);
+    }
+    return { stem: b.stem, content };
+  });
+}
+
 export interface DecofileSnapshot {
   /** Branch head commit sha — the version everywhere (ETag, __draft, response). */
   sha: string;


### PR DESCRIPTION
## What is this contribution about?

Production was returning 502s because the GitHub App installation's REST budget was exhausted (`x-ratelimit-remaining: 0` against a 12,500/hr ceiling, ~2k refusals/hr). Traces pinned it to one path: regenerating the tracked `.deco/blocks.gen.json` artifact in `commit-coalescer.ts` read **every** block's blob through an uncached, unbounded `Promise.all`, inside the CAS retry loop — **1,698 blob GETs per `PATCH /api/:org/decofile/...`**, so nine saves on a single branch spent the whole org's hourly budget and every other GitHub-backed path started failing. This routes those reads through a new `resolveBlockContents` helper that applies the two protections the read path already had and this path skipped — the content-addressed disk blob cache (`getBlob`/`putBlob`) and `BLOB_FETCH_CONCURRENCY` via `mapBounded`, whose own comment documents that an unbounded fan-out over ~700 blobs trips GitHub's secondary limit (which is why secondary refusals outnumbered primary ones). The memo is keyed by the immutable blob sha and hoisted out of the attempt loop, so a conflict retry no longer doubles the cost; a warm save now costs ~0 GitHub calls instead of ~850, and the regenerated document is byte-identical.

## How did you verify your code works?

Added `apps/api/src/decofile/commit-coalescer.test.ts` (8 tests, all passing) driving the real coalescer via `enqueueDecofilePatch` with a counting fake `RepoContentClient`: a save on an untracked repo reads **0** blobs; on a tracked repo it reads each *other* block exactly once (never the block supplied by the patch); `maxInFlight` stays ≤ 12 across 200 blocks (asserting the bound, not just the count); a forced `RepoWriteConflict` retry re-reads **nothing** already resolved (this was 2× the tree before the hoist); and the regenerated artifact still contains every block. `bun run --cwd=apps/api check` is clean, `bun run lint` reports 0 errors, and `bunx knip` flags nothing new. Full suite is 3750 pass / 247 fail — I verified the 247 are pre-existing by stashing my changes and re-running (identical 247 on a clean tree); my change adds 8 passing tests and zero failures.

## Screenshots/Demonstration

No UI changes.

## How to Test

1. Use an org whose repo **tracks** `.deco/blocks.gen.json` (e.g. `deco-sites/montecarlo-tanstack`) — gitignored repos never hit this branch and were never affected.
2. Edit a block in the CMS to trigger `PATCH /api/:org/decofile/:project/:branch`.
3. Expected: the save issues ~0 `GET /repos/:owner/:repo/git/blobs/:sha` calls on a warm cache (was ~850 per save, ~1,698 with a retry), and the resulting `.deco/blocks.gen.json` is unchanged.
4. Confirm in production telemetry — `min(github_rate_limit_remaining{resource="core"})` should stop pinning at 0 and `sum(rate(github_rate_limited_total[30m]))*3600` should fall to ~0.

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

---

**Follow-ups deliberately left out of scope** (found while auditing every GitHub call site, happy to file as issues): `CHANGE_REQUEST_STATE` polls GraphQL every 60s with **no** server-side cache (GraphQL has 4,993/5,000 points remaining, so it is not implicated here, but it is the next thing to bite); there is no shared per-installation ceiling on the content/decofile lane (`dbos-github-read.ts` throttles only the review sweep, and its comment notes everything else is unthrottled); the `gh` CLI inside sandboxes spends the same budget with no telemetry, cache, or ceiling; and PR #7039 — cited in the `6d8c9ca6d` revert as the webhook replacement for poll-driven CI freshness — has not landed, leaving `/api/_github/webhook` handling `push` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes decofile saves exhausting the GitHub API rate limit by caching and bounding block reads.

- Regenerating the tracked `.deco/blocks.gen.json` now goes through `resolveBlockContents`, which uses the disk blob cache and limits concurrency to `BLOB_FETCH_CONCURRENCY`.
- A memo keyed by blob sha is hoisted out of the retry loop, so a conflict retry doesn't re-read blobs already resolved.
- Saves on repos that don't track the artifact read no blobs at all.
- Added tests covering dedup, concurrency bound, retry reuse, and unchanged artifact.

<sup>Written for commit ede0b3b70c41e586923415f80d7b1496a349324a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

