### PR TITLE
fix(inbox): better hierarchy in the inbox row, and a bell for the trigger

### DIFF
--- a/apps/web/src/components/sidebar/footer/inbox-task-item.tsx
+++ b/apps/web/src/components/sidebar/footer/inbox-task-item.tsx
@@ -1,19 +1,32 @@
-/**
- * One unread task update in the inbox: who did what, on which card, when.
- *
- * Deliberately terser than the task dialog's timeline — the dialog renders
- * chips inside a sentence, this is a scannable row whose only job is to get you
- * to the card.
- */
+/** One inbox row: the card, what changed on it, and when. */
 
-import { ChevronRight } from "@untitledui/icons";
 import { Avatar } from "@decocms/ui/components/avatar.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { SuperAgentIcon } from "@/components/super-agent-icon";
 import { getInitials } from "@/lib/get-initials";
 import { formatTimeAgo } from "@/lib/format-time";
 import { taskKey } from "@decocms/shared/task-key";
 import { useT } from "@/i18n/use-t.ts";
 import type { InboxTaskUpdate } from "@/hooks/use-inbox-feed";
+
+/**
+ * The few actions worth a color: the two that need you and the one that is
+ * simply good news. Everything else stays muted, or nothing stands out.
+ */
+function tone(action: InboxTaskUpdate["action"]): string {
+  switch (action) {
+    case "mentioned":
+    case "review_requested":
+      return "font-medium text-foreground";
+    case "merge_failed":
+    case "review_changes_requested":
+      return "font-medium text-destructive";
+    case "review_approved":
+      return "font-medium text-success";
+    default:
+      return "";
+  }
+}
 
 /** What changed, in a few words. The card itself carries the detail. */
 function summarize(
@@ -63,33 +76,43 @@ export function InboxTaskItem({
     <button
       type="button"
       onClick={onSelect}
-      className="flex w-full items-center gap-3 border-b border-border px-4 py-3 text-left transition-colors last:border-0 hover:bg-muted/25"
+      className="flex w-full items-start gap-3 border-b border-border px-4 py-3 text-left transition-colors last:border-0 hover:bg-muted/25"
     >
-      {isAgent ? (
-        <SuperAgentIcon size={24} className="shrink-0" />
-      ) : (
-        <Avatar
-          url={update.actorImage ?? undefined}
-          fallback={getInitials(update.actorName ?? undefined)}
-          shape="circle"
-          // 24px, matching SuperAgentIcon above — `sm` is 32 and read bigger.
-          size="xs"
-          className="shrink-0"
-        />
-      )}
+      <span className="mt-0.5 shrink-0">
+        {isAgent ? (
+          <SuperAgentIcon size={24} />
+        ) : (
+          <Avatar
+            url={update.actorImage ?? undefined}
+            fallback={getInitials(update.actorName ?? undefined)}
+            shape="circle"
+            // 24px, matching SuperAgentIcon above — `sm` is 32 and read bigger.
+            size="xs"
+          />
+        )}
+      </span>
       <div className="min-w-0 flex-1">
-        <p className="truncate text-xs text-muted-foreground">
-          {key ? `${key} · ` : ""}
-          {update.taskTitle}
-        </p>
-        <p className="truncate text-sm font-medium text-foreground">
-          {summarize(update, t)}
+        {/* Title and age share a line so the row has a right column to scan. */}
+        <div className="flex items-baseline gap-2">
+          <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+            {update.taskTitle}
+          </p>
+          <span className="shrink-0 text-xs text-muted-foreground/70">
+            {formatTimeAgo(new Date(update.occurredAt))}
+          </span>
+        </div>
+        <p className="mt-0.5 truncate text-xs text-muted-foreground">
+          {key && (
+            <>
+              <span className="font-medium">{key}</span>
+              {" · "}
+            </>
+          )}
+          <span className={cn(tone(update.action))}>
+            {summarize(update, t)}
+          </span>
         </p>
       </div>
-      <span className="shrink-0 text-xs text-muted-foreground">
-        {formatTimeAgo(new Date(update.occurredAt))}
-      </span>
-      <ChevronRight size={16} className="shrink-0 text-muted-foreground" />
     </button>
   );
 }

--- a/apps/web/src/components/sidebar/footer/inbox.tsx
+++ b/apps/web/src/components/sidebar/footer/inbox.tsx
@@ -7,7 +7,7 @@
  */
 
 import { type ReactNode, useState } from "react";
-import { Inbox01 } from "@untitledui/icons";
+import { Bell01 } from "@untitledui/icons";
 import {
   Popover,
   PopoverContent,
@@ -67,7 +67,7 @@ function InboxPanel({ onClose }: { onClose: () => void }) {
       </div>
       {updates.length === 0 ? (
         <div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 py-10 text-center">
-          <Inbox01 size={24} className="text-muted-foreground/50" />
+          <Bell01 size={24} className="text-muted-foreground/50" />
           <p className="text-sm font-medium text-foreground">
             {t("sidebar.inbox.emptyTitle")}
           </p>
@@ -116,19 +116,18 @@ function InboxDot() {
 function InboxPopover({
   open,
   onOpenChange,
-  side,
   children,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  side: "right" | "top";
   children: ReactNode;
 }) {
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       {children}
       <PopoverContent
-        side={side}
+        // Beside the sidebar: `top` covered the nav the trigger sits in.
+        side="right"
         align="end"
         sideOffset={12}
         collisionPadding={16}
@@ -145,14 +144,14 @@ export function InboxIconButton() {
   const t = useT();
   const [open, setOpen] = useState(false);
   return (
-    <InboxPopover open={open} onOpenChange={setOpen} side="top">
+    <InboxPopover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
           type="button"
           aria-label={t("sidebar.inbox.title")}
           className="relative flex size-7 shrink-0 items-center justify-center rounded-md text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
         >
-          <Inbox01 size={15} />
+          <Bell01 size={15} />
           <InboxDot />
         </button>
       </PopoverTrigger>
@@ -166,13 +165,13 @@ export function InboxFullButton() {
   const [open, setOpen] = useState(false);
   const collapsed = useSidebarCollapsed();
   return (
-    <InboxPopover open={open} onOpenChange={setOpen} side="right">
+    <InboxPopover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <SidebarMenuButton
           tooltip={collapsed ? t("sidebar.inbox.title") : undefined}
           className="relative"
         >
-          <Inbox01 />
+          <Bell01 />
           {/* Before the label: the collapsed rail hides `span:last-child`. */}
           <InboxDot />
           <span className="truncate">{t("sidebar.inbox.title")}</span>


### PR DESCRIPTION
## What is this contribution about?
Design-only pass on the inbox row, which put the key, the title, the action and the age at the same visual weight so nothing led. The card title now leads on its own line, the age moved to a right-hand column aligned to its baseline, and the key plus the action form the meta line under it, with color only on the actions that need you (mention, review requested, changes requested, merge failed) or are plainly good news (approved). The trigger is also a bell rather than an inbox tray, and the panel opens beside the sidebar instead of over the nav its trigger sits in (`side="top"` covered it).

## How did you verify your code works?
No behavior changed, so no new tests: `bun run --cwd=apps/web check`, `bun run lint` (0 errors) and `bun run fmt` all pass. Seeded a local org with 13 prod-shaped notifications (a burst on one card, an agent actor, a recent mention, a failed merge, a 4-day-old card) and read the popover: title first, `RAFA-259 · Review approved` in green, `RAFA-258 · Couldn't be merged` in red, ages right-aligned, panel opening to the right of the sidebar.

## Screenshots/Demonstration
Screenshot attached in the PR conversation.

## How to Test
1. Run `bun run dev` and open the bell in the sidebar footer (it replaces the inbox tray icon).
2. Have a teammate comment on, approve or request review on a task you follow.
3. Expected: rows read title, then `KEY · action` with the action tinted for the ones above, age on the right, and the panel opens beside the sidebar rather than covering the nav.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)