### PR TITLE
fix(file-storage): drain the response body on tarball fetch errors

### DIFF
--- a/apps/api/src/file-storage/skill-set-sync.test.ts
+++ b/apps/api/src/file-storage/skill-set-sync.test.ts
@@ -199,6 +199,14 @@ describe("tarballRequestFor", () => {
   });
 });
 
+describe("TarballHttpError", () => {
+  it("captures the HTTP status for classification", () => {
+    const err = new TarballHttpError(404, "not found");
+    expect(err.status).toBe(404);
+    expect(err.message).toBe("not found");
+  });
+});
+
 describe("isRetriableTarballError", () => {
   it("retries codeload 5xx and 429", () => {
     expect(isRetriableTarballError(new TarballHttpError(503, "x"))).toBe(true);

--- a/apps/api/src/file-storage/skill-set-sync.ts
+++ b/apps/api/src/file-storage/skill-set-sync.ts
@@ -256,6 +256,7 @@ async function fetchRepoFiles(
       signal: AbortSignal.timeout(60_000),
     });
     if (!res.ok) {
+      await res.body?.cancel().catch(() => {});
       throw new TarballHttpError(
         res.status,
         `tarball fetch failed for ${label}: HTTP ${res.status}`,


### PR DESCRIPTION
When a non-2xx response occurs in fetchRepoFiles, the response body is not consumed before throwing a TarballHttpError. This can leave HTTP/2 connections in a bad state and prevent reuse or proper closure.

This fix follows the pattern from #7091 (which drained response bodies in git-providers for 404 responses) and extends it to all error statuses in the tarball sync path. The drain call uses `.catch(() => {})` to handle edge cases where the stream is already cancelled.

**Why this matters:** Skill set syncs over HTTP/2 require proper connection cleanup. A leaked connection reduces throughput for subsequent syncs and can cause transient 5xx errors when the connection pool is exhausted.

**Testing:** All existing tests pass. The fix is minimal (1 line) and matches the established pattern from #7091.

**Verification:** `bun test apps/api/src/file-storage/skill-set-sync.test.ts` (22 tests pass); `bunx tsc --noEmit` in apps/api; `bunx oxlint` on changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drains the response body when `fetchRepoFiles` gets a non-2xx response, preventing HTTP/2 connections from being left in a bad state during skill set syncs.

<sup>Written for commit b78bcd56c7c0d25a94c81968372b85ea96971d4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

