### PR TITLE
fix(git-providers): degrade a malformed GitLab JSON body, not a raw SyntaxError

### DIFF
--- a/apps/api/src/git-providers/gitlab/client.ts
+++ b/apps/api/src/git-providers/gitlab/client.ts
@@ -24,7 +24,7 @@ import {
   type TokenOptions,
   type TokenSource,
 } from "../types";
-import { gitlabFailure, gitlabFetch } from "./http";
+import { gitlabFailure, gitlabFetch, gitlabJson } from "./http";
 
 /** A whole-repo archive is a download, not a REST call — it needs room to stream. */
 const ARCHIVE_TIMEOUT_MS = 60_000;
@@ -156,7 +156,7 @@ async function fetchGitlabUser(
       message: "GitLab did not recognise the authenticated user",
     });
   }
-  return GitlabUserSchema.parse(await res.json());
+  return GitlabUserSchema.parse(await gitlabJson(res, "get_user"));
 }
 
 /**
@@ -209,7 +209,7 @@ export class GitlabProviderClient implements GitProviderClient {
   async getRepo(repo: RepoRef): Promise<RepoSummary | null> {
     const res = await this.get(`/projects/${encodeProjectPath(repo.path)}`);
     if (!res) return null;
-    return mapGitlabProject(await res.json(), this.host);
+    return mapGitlabProject(await gitlabJson(res, "get_repo"), this.host);
   }
 
   async listRepos(
@@ -231,7 +231,7 @@ export class GitlabProviderClient implements GitProviderClient {
     if (query) params.set("search", query);
     const res = await this.get(`/projects?${params}`);
     if (!res) return { repositories: [], hasMore: false };
-    const json = await res.json();
+    const json = await gitlabJson(res, "list_repos");
     if (!Array.isArray(json)) {
       throw new GitProviderError({
         provider: "gitlab",
@@ -286,7 +286,7 @@ export class GitlabProviderClient implements GitProviderClient {
   async identity(): Promise<GitIdentity | null> {
     const res = await this.authedFetch(`${this.apiBase}/user`);
     if (!res.ok) throw await gitlabFailure(res);
-    const user = GitlabUserSchema.parse(await res.json());
+    const user = GitlabUserSchema.parse(await gitlabJson(res, "identity"));
     return {
       name: user.name || user.username,
       email:

--- a/apps/api/src/git-providers/gitlab/http.test.ts
+++ b/apps/api/src/git-providers/gitlab/http.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { GitProviderError } from "../types";
+import { gitlabJson } from "./http";
+
+describe("gitlabJson", () => {
+  test("parses a well-formed 2xx body", async () => {
+    const res = new Response(JSON.stringify({ id: 1 }), { status: 200 });
+    await expect(gitlabJson(res, "get_repo")).resolves.toEqual({ id: 1 });
+  });
+
+  test("degrades a malformed 2xx body into a GitProviderError instead of a raw SyntaxError", async () => {
+    const res = new Response("<html>Not JSON</html>", { status: 200 });
+    await expect(gitlabJson(res, "get_repo")).rejects.toBeInstanceOf(
+      GitProviderError,
+    );
+  });
+});

--- a/apps/api/src/git-providers/gitlab/http.ts
+++ b/apps/api/src/git-providers/gitlab/http.ts
@@ -68,6 +68,28 @@ export async function gitlabFailure(res: Response): Promise<GitProviderError> {
   });
 }
 
+/**
+ * Parse a response body as JSON, degrading a malformed 2xx body into a
+ * `GitProviderError` instead of letting a raw `SyntaxError` escape — mirrors
+ * `github/http.ts`'s `githubJson`.
+ */
+export async function gitlabJson<T>(
+  res: Response,
+  operation: string,
+): Promise<T> {
+  const text = await res.text();
+  try {
+    return JSON.parse(text) as T;
+  } catch (cause) {
+    throw new GitProviderError({
+      provider: "gitlab",
+      status: res.status,
+      message: `GitLab ${operation} returned invalid JSON: ${text.slice(0, 300)}`,
+      cause,
+    });
+  }
+}
+
 export interface GitlabFetchInit {
   method?: "GET" | "POST" | "PUT" | "DELETE";
   body?: unknown;


### PR DESCRIPTION
**Source:** bug, found while auditing `apps/api/src/git-providers/` for resilience gaps. `github/client.ts` was already hardened for this exact case via `githubJson()` (`github/http.ts:159`), which catches a JSON parse failure and turns it into a `GitProviderError`. `gitlab/client.ts` never got the equivalent — every read path (`fetchGitlabUser`, `getRepo`, `listRepos`, `identity`) called `res.json()` directly.

**Payoff:** a GitLab instance (self-hosted proxy, maintenance page, misconfigured LB) returning a 2xx with an HTML/empty body currently throws a raw `SyntaxError` out of these calls instead of the typed `GitProviderError` every other GitLab failure path produces — callers checking `instanceof GitProviderError` (route error mapping, retry logic) miss it entirely.

**Failure scenario:** GitLab self-hosted returns `200 OK` with an HTML error page (e.g. behind a proxy) instead of the expected JSON project/user payload — `GitlabUserSchema.parse(await res.json())` throws an unhandled `SyntaxError` instead of a well-typed `GitProviderError`.

**Fix:** added `gitlabJson()` to `gitlab/http.ts`, mirroring `github/http.ts`'s `githubJson()` — parses the body text and wraps a parse failure in `GitProviderError`. Wired it into the four `.json()` call sites in `gitlab/client.ts`. Net: -5/+27 (mostly the new helper + its test).

**Regression test:** `apps/api/src/git-providers/gitlab/http.test.ts` — asserts a well-formed body still parses, and a malformed 2xx body rejects with `GitProviderError` (not a raw `SyntaxError`).

**To verify:** `bun test apps/api/src/git-providers/gitlab/http.test.ts apps/api/src/git-providers/gitlab/client.test.ts`

**Locally ran:** `bun run fmt`, `bunx tsc --noEmit` (apps/api), the two test files above, and `bunx oxlint` on the three changed/added files — all clean. Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitLab client read paths so a 2xx response with a malformed body (e.g. an HTML error page from a proxy) throws a typed `GitProviderError` instead of a raw `SyntaxError`, matching the existing `githubJson()` behavior. Callers checking `instanceof GitProviderError` (route error mapping, retry logic) now catch these failures.

- Adds `gitlabJson()` to `gitlab/http.ts` and uses it at all four `.json()` call sites in `gitlab/client.ts`.
- Adds tests for `gitlabJson()` covering well-formed and malformed 2xx bodies.

<sup>Written for commit 9af857cd895ba01b56f3b6fd6b98ea572d77c56f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

