### PR TITLE
fix(dev-agent): don't resolve the Develop/Live toggle to a deleted agent

### DIFF
--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -3,6 +3,7 @@ import {
   agentHasClonableSource,
   agentHasConnectedGithub,
   agentShowsGithubHeaderActions,
+  findDevPartner,
 } from "./agent-capabilities";
 
 describe("agentHasClonableSource", () => {
@@ -160,5 +161,43 @@ describe("agentShowsGithubHeaderActions", () => {
         },
       } as any),
     ).toBe(true);
+  });
+});
+
+describe("findDevPartner", () => {
+  it("returns null for a null/undefined agent", () => {
+    expect(findDevPartner(null, [])).toBeNull();
+    expect(findDevPartner(undefined, [])).toBeNull();
+  });
+
+  it("resolves the dev agent's live counterpart when it's in the list", () => {
+    const dev = { id: "vir_dev", metadata: { liveAgentId: "vir_live" } } as any;
+    const live = { id: "vir_live", metadata: {} } as any;
+    expect(findDevPartner(dev, [dev, live])).toEqual({
+      mode: "dev",
+      targetId: "vir_live",
+    });
+  });
+
+  it("resolves the live agent's dev counterpart via reverse lookup", () => {
+    const dev = { id: "vir_dev", metadata: { liveAgentId: "vir_live" } } as any;
+    const live = { id: "vir_live", metadata: {} } as any;
+    expect(findDevPartner(live, [dev, live])).toEqual({
+      mode: "live",
+      targetId: "vir_dev",
+    });
+  });
+
+  it("returns null when liveAgentId is dangling (the live agent was deleted)", () => {
+    const dev = {
+      id: "vir_dev",
+      metadata: { liveAgentId: "vir_deleted" },
+    } as any;
+    expect(findDevPartner(dev, [dev])).toBeNull();
+  });
+
+  it("returns null for an agent that isn't part of a dev/live pair", () => {
+    const solo = { id: "vir_solo", metadata: {} } as any;
+    expect(findDevPartner(solo, [solo])).toBeNull();
   });
 });

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -74,6 +74,11 @@ export function getDevAgentIds(
  *   the loaded list) — the partner is that dev agent.
  * - `null` when the agent is not part of a dev/live pair.
  * `targetId` is the OTHER agent in the pair — where the toggle navigates.
+ *
+ * Both directions are checked against `agents`: deleting a virtual MCP does
+ * not clear `liveAgentId` on the counterpart it leaves behind, so a dev agent
+ * can carry a `liveAgentId` pointing at an agent that no longer exists. Left
+ * unchecked, the toggle would still render and navigate to a dead id.
  */
 export function findDevPartner(
   agent: VirtualMCPEntity | null | undefined,
@@ -82,7 +87,8 @@ export function findDevPartner(
   if (!agent) return null;
   const liveId = agent.metadata?.liveAgentId;
   if (typeof liveId === "string" && liveId) {
-    return { mode: "dev", targetId: liveId };
+    const liveAgent = (agents ?? []).find((a) => a.id === liveId);
+    return liveAgent ? { mode: "dev", targetId: liveId } : null;
   }
   const devAgent = (agents ?? []).find(
     (a) => a.metadata?.liveAgentId === agent.id,


### PR DESCRIPTION
Follow-up hardening on the dev-agent/virtual-mcp area touched by #7099 (settings-form re-seed fix) and #7096 (Develop/Live label translation).

**The bug:** `COLLECTION_VIRTUAL_MCP_DELETE` (`apps/api/src/tools/virtual/delete.ts`) deletes a virtual MCP without clearing `metadata.liveAgentId` on the dev counterpart it leaves behind — there's no such cleanup step in that handler. `findDevPartner` (`apps/web/src/lib/agent-capabilities.ts`), which drives the header's Develop/Live toggle (`DevAgentControl`), only checked that the dev agent's `liveAgentId` was a non-empty string — it never verified the referenced agent still exists in the loaded list. The reverse direction (`live` → `dev`) already only matches by scanning that same list, so it was already safe; the forward direction wasn't.

**Failure scenario:** link a dev agent to a live agent, then delete the live agent. The dev agent still carries the dangling `liveAgentId`, so its header keeps rendering a "Live" toggle segment. Clicking it calls `goToAgent` with the deleted agent's id, which fails to create a thread against it and then navigates to a dead agent route.

**Fix:** `findDevPartner`'s dev branch now checks that the live agent is present in the loaded `agents` list before returning `mode: "dev"`, mirroring the existing reverse-lookup on the live branch. Added `agent-capabilities.test.ts` cases for: dev with a live partner in the list, live with a dev partner in the list (existing behavior, now explicitly covered), a dangling `liveAgentId` (the new fix), and a solo agent.

Reviewer check: `bun test apps/web/src/lib/agent-capabilities.test.ts`.

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean aside from a pre-existing, unrelated prosemirror version-mismatch error), the targeted test above, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Develop/Live toggle so it no longer resolves to a deleted live agent. The toggle previously rendered and navigated to a dead agent route whenever a dev agent carried a dangling `liveAgentId`; it now verifies the live agent still exists in the loaded list before returning `mode: "dev"`.

**Bug Fixes**
- Mirrors the existing reverse lookup on the live branch, which already scans the loaded list.
- Adds test cases for dev/live pairs, a dangling `liveAgentId`, and a solo agent.

<sup>Written for commit 22e00a101cdd9e8e99e14e8d596ed3502c610d30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

