### PR TITLE
fix(task-board): stop the card's run action from colliding with the title

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -439,23 +439,41 @@ function FooterDueDate({
   );
 }
 
-/** The card's one run action, as a written footer button. Revealed on hover; its collapsed width keeps the resting footer uncluttered. */
-function CardActionGlyph({
+/**
+ * The card's one run action, floating in the title's top-right corner.
+ *
+ * Nothing else on the card can host it. The footer can't: every glyph there
+ * (type, due date, priority, assignee) is a control you reach by hovering, so
+ * covering one on hover removes the very affordance the hover grants. A row of
+ * its own costs every actionable card that height, forever, for a button you
+ * only want while pointing at the card.
+ *
+ * What made the corner unreadable was the hard edge, not the overlap — the
+ * title ran straight into the button mid-word. So the title fades out under it
+ * (`fade-text-end`) and reads as trailing off instead.
+ */
+function CardAction({
   action,
 }: {
   action: { icon: typeof RefreshCw01; label: string; onClick: () => void };
 }) {
   return (
     <Button
-      variant="ghost"
+      variant="outline"
       size="sm"
-      aria-label={action.label}
       onClick={(e) => {
         e.stopPropagation();
         action.onClick();
       }}
       onPointerDown={(e) => e.stopPropagation()}
-      className="-my-1.5 h-7 gap-1.5 px-2 text-xs font-medium pointer-events-none opacity-0 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
+      // The fade has to end where this button starts, and how wide it is depends on the label — i.e. on the language.
+      ref={(node) =>
+        node?.parentElement?.style.setProperty(
+          "--fade-text-end",
+          `${node.offsetWidth}px`,
+        )
+      }
+      className="absolute -top-0.5 right-0 h-6 gap-1.5 rounded-full px-2 text-xs font-medium shadow-sm pointer-events-none opacity-0 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
     >
       <action.icon className={PROPERTY_GLYPH_CLASS} />
       {action.label}
@@ -478,11 +496,9 @@ function CardFooter({
   onPriorityChange,
   onTypeChange,
   onDueDateChange,
-  action,
 }: {
   item: TaskBoardItem;
   checks: { summary: ChecksSummary; enabled: ReviewerKind[] } | null;
-  action?: { icon: typeof RefreshCw01; label: string; onClick: () => void };
   assignee?: Member;
   assignedBy?: Member;
   members?: Member[];
@@ -509,7 +525,6 @@ function CardFooter({
         )}
       </span>
       <span className="flex shrink-0 items-center gap-2">
-        {action && <CardActionGlyph action={action} />}
         {(item.priority !== "none" || onPriorityChange) && (
           <PriorityIcon priority={item.priority} onChange={onPriorityChange} />
         )}
@@ -2543,6 +2558,20 @@ function TaskCard({
     item.assigneeId === SUPER_AGENT_ASSIGNEE_ID &&
     item.status !== "done";
 
+  const action = showAutoFix
+    ? {
+        icon: Lightning01,
+        label: t("taskBoard.taskBoard.autoFix"),
+        onClick: onAutoFix,
+      }
+    : showRerun
+      ? {
+          icon: RefreshCw01,
+          label: t("taskBoard.taskBoard.rerun"),
+          onClick: onRerun,
+        }
+      : null;
+
   return (
     <button
       type="button"
@@ -2569,9 +2598,17 @@ function TaskCard({
     >
       <div className="flex items-start gap-2">
         {/* 14px: one step over the design system's `text-sm`, which is 13 here, not Tailwind's 14. */}
-        <span className="min-w-0 flex-1 text-[14px] font-[450] leading-snug text-foreground line-clamp-2">
-          {item.title}
-        </span>
+        <div className="relative min-w-0 flex-1 text-[14px] font-[450] leading-snug">
+          <span
+            className={cn(
+              "block text-foreground line-clamp-2",
+              action && "group-hover:fade-text-end",
+            )}
+          >
+            {item.title}
+          </span>
+          {action && <CardAction action={action} />}
+        </div>
         {attentionLabel && <span className="sr-only">{attentionLabel}</span>}
         {runState && <AgentRunIndicator state={runState} />}
       </div>
@@ -2597,21 +2634,6 @@ function TaskCard({
         onPriorityChange={onPriorityChange}
         onTypeChange={onTypeChange}
         onDueDateChange={onDueDateChange}
-        action={
-          showAutoFix
-            ? {
-                icon: Lightning01,
-                label: t("taskBoard.taskBoard.autoFix"),
-                onClick: onAutoFix,
-              }
-            : showRerun
-              ? {
-                  icon: RefreshCw01,
-                  label: t("taskBoard.taskBoard.rerun"),
-                  onClick: onRerun,
-                }
-              : undefined
-        }
       />
     </button>
   );

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -46,6 +46,17 @@
   box-shadow: var(--card-shadow);
 }
 
+/* Fades text out over its last `--fade-text-end`, for a control floating in that
+   corner. Masking the text beats painting a gradient over it — a mask needs to
+   know nothing about the background it sits on. */
+@utility fade-text-end {
+  mask-image: linear-gradient(
+    to right,
+    #000 calc(100% - var(--fade-text-end, 6rem) - 5rem),
+    transparent calc(100% - var(--fade-text-end, 6rem))
+  );
+}
+
 /* Recolour a card's ring, keeping the drop shadow under it — the ring IS the card's border, drawn as a shadow. */
 @utility card-ring-destructive {
   --card-shadow:


### PR DESCRIPTION
## Problem

The card's run action (`Auto-fix` / `Executar de novo`) was hidden with `opacity-0`, which still reserves its width. Its comment claimed *"its collapsed width keeps the resting footer uncluttered"* — nothing in the class list implemented that. So the button occupied the footer's layout at all times, pushed the row past the card, and the task key and due date spilled out under it. Invisible at rest, plainly broken on hover:


## Fix

The button leaves the footer entirely. It can't live there: **every glyph in the footer (type, due date, priority, assignee) is a control you reach by hovering**, so a button that covers one on hover removes the very affordance the hover grants. Shrinking it to an icon was rejected — the label is load-bearing.

It now floats in the title's top-right corner, and the title fades out beneath it.

Three details that had to be right:

- **A mask on the text, not a gradient painted over it.** The card's background varies across four states (`bg-card`, hover, `bg-warning/10`, selected), so a coloured gradient would be wrong in three of them. A mask needs to know nothing about what's behind it.
- **The fade ends where the button starts**, measured from the rendered button in a `ref`. `Executar` and `Executar de novo` are not the same width, and neither matches their English counterparts — any constant in `rem` would be wrong in some locale.
- **The hard edge was the actual problem**, not the overlap. The title used to run straight into the button mid-word; now it trails off.

No height cost, no reserved empty row, no neighbouring card moved, footer untouched, label intact.

The new `fade-text-end` utility lives in `packages/ui/src/styles/global.css` and is generic to any control floating at the end of text.

## Testing

- `bun run fmt`, `bun run check`, `bun run lint` pass.
- `bun test apps/web/src/layouts/task-board/` — 146 pass, 2 fail; the same 2 fail on a clean tree (cross-file interference in `task-filters-search.test.tsx`, which passes in isolation). Not from this change.
- Verified by hand on the real board at `/:org/tasks`: two-line title, one-line title, rest and hover states, and the footer's assignee picker still opening with the button visible.
- **Not verified visually:** the `Executar de novo` variant. Reaching it means assigning a card to the Super Agent, which opens the "Conectar GitHub" dialog on a local org without a GitHub connection. Its width is handled by the measured fade rather than a constant, but that isn't the same as having seen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the task card's run action colliding with the footer: the `Auto-fix` / `Executar de novo` button was hidden but still reserved footer width, pushing the task key and due date out of the card. It now floats in the title's top-right corner, and the title fades out beneath it.

The fade is a mask on the text, not a painted gradient, so it works over all four card backgrounds. The fade end is measured from the rendered button, so it adapts to localized labels with different widths.

<sup>Written for commit 67cc35181aa544a4296b4186664c05031eeddc62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

