### PR TITLE
fix(github): recover authorization without app installations

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,6 +105,8 @@ jobs:
       # signups per run; without this they get 429s and only pass on retry,
       # which masks real regressions as "flaky".
       DISABLE_RATE_LIMIT: "true"
+      # Both test runs use the same DB; persisted JWKS need the same auth secret.
+      BETTER_AUTH_SECRET: "studio-e2e-synthetic-auth-secret-for-tests"
       # MinIO, started below — makes the app resolve OBJECT_STORAGE to the real
       # S3Service path (not the DevObjectStorage filesystem fallback) so the
       # object-storage e2e exercises production code end-to-end.
@@ -235,6 +237,14 @@ jobs:
         env:
           E2E_SKIP_WEB_BUILD: ${{ steps.cache-web-dist.outputs.cache-hit == 'true' && '1' || '' }}
         run: bun run test:e2e --shard=${{ matrix.shard }}/2
+
+      - name: Run GitHub connect tests
+        if: matrix.shard == 1
+        working-directory: packages/e2e
+        env:
+          # The main suite above has already built the same web source.
+          E2E_SKIP_WEB_BUILD: "1"
+        run: bun run test:e2e:github-connect
 
   # Aggregator carrying the required-check name: branch protection requires a
   # check called "e2e", and matrix jobs report as "e2e-shard (1)"/"(2)" — a

--- a/apps/api/src/api/routes/git-providers.ts
+++ b/apps/api/src/api/routes/git-providers.ts
@@ -101,6 +101,7 @@ export const createGitProviderRoutes = () => {
         clientId: config.clientId,
         redirectUri: callbackUrl("github"),
         state,
+        selectAccount: true,
       }),
     );
   });

--- a/apps/api/src/git-providers/github/oauth.test.ts
+++ b/apps/api/src/git-providers/github/oauth.test.ts
@@ -7,6 +7,18 @@ import {
 } from "./oauth";
 
 describe("githubAuthorizeUrl", () => {
+  test("explicit reconnect shows the GitHub account chooser", () => {
+    const url = new URL(
+      githubAuthorizeUrl({
+        clientId: "Iv1.abc",
+        redirectUri: "https://studio.example/api/_git/github/callback",
+        state: "opaque-state",
+        selectAccount: true,
+      }),
+    );
+    expect(url.searchParams.get("prompt")).toBe("select_account");
+  });
+
   test("targets github.com's authorize endpoint with the three parameters", () => {
     const url = new URL(
       githubAuthorizeUrl({

--- a/apps/api/src/git-providers/github/oauth.ts
+++ b/apps/api/src/git-providers/github/oauth.ts
@@ -20,11 +20,13 @@ export function githubAuthorizeUrl(params: {
   clientId: string;
   redirectUri: string;
   state: string;
+  selectAccount?: boolean;
 }): string {
   const url = new URL(GITHUB_OAUTH_AUTHORIZE_URL);
   url.searchParams.set("client_id", params.clientId);
   url.searchParams.set("redirect_uri", params.redirectUri);
   url.searchParams.set("state", params.state);
+  if (params.selectAccount) url.searchParams.set("prompt", "select_account");
   return url.toString();
 }
 

--- a/apps/web/src/components/git-account-connect.tsx
+++ b/apps/web/src/components/git-account-connect.tsx
@@ -22,7 +22,6 @@ import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
 import { GitHubIcon } from "@/components/icons/github-icon";
 import { GitLabIcon } from "@/components/icons/gitlab-icon";
 import {
-  useGitAccounts,
   useGitProviderCapabilities,
   useConnectGitAccountToken,
 } from "@/hooks/use-git-providers";
@@ -39,16 +38,12 @@ export function GitAccountConnect({
   disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
-  const accounts = useGitAccounts();
   return (
     <>
       <ConnectActions
         layout={layout}
         disabled={disabled}
         onTokenDialog={() => setOpen(true)}
-        hasGithubAccount={(accounts.data ?? []).some(
-          (a) => a.type === "github",
-        )}
       />
       {open && <TokenConnectDialog open onOpenChange={setOpen} />}
     </>
@@ -216,12 +211,10 @@ function ConnectActions({
   layout,
   disabled,
   onTokenDialog,
-  hasGithubAccount,
 }: {
   layout: "buttons" | "picker";
   disabled: boolean;
   onTokenDialog: () => void;
-  hasGithubAccount: boolean;
 }) {
   const t = useT();
   const capabilities = useGitProviderCapabilities();
@@ -264,11 +257,11 @@ function ConnectActions({
         href={github?.connectPath ? connectUrl(github.connectPath) : undefined}
         disabled={disabled || !githubConfigured || !github?.connectPath}
       />
-      {githubConfigured && hasGithubAccount && github?.installPath && (
+      {githubConfigured && github?.installPath && (
         <ConnectAction
           layout={layout}
-          label={t("settings.repositories.installGithub")}
-          description={t("settings.repositories.browseAccount")}
+          label={t("settings.repositories.manageGithub")}
+          description={t("settings.repositories.manageGithubHint")}
           icon={<GitHubIcon size={16} />}
           href={connectUrl(github.installPath)}
           disabled={disabled}

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -116,7 +116,19 @@ export const settings = {
   "settings.repositories.gitlabTokenHint":
     "Use a personal, project or group access token.",
   "settings.repositories.connectGithub": "Connect GitHub",
-  "settings.repositories.installGithub": "Install on another account",
+  "settings.repositories.manageGithub": "Manage GitHub access",
+  "settings.repositories.manageGithubHint":
+    "Install or configure the app on your GitHub accounts and organizations.",
+  "settings.repositories.oauthNoInstallations":
+    "GitHub authorization succeeded, but no app installations are available to this user. Use Manage GitHub access to install the app or request access from an organization owner, then connect again.",
+  "settings.repositories.oauthDenied":
+    "Authorization was cancelled. Connect again when you are ready.",
+  "settings.repositories.oauthExpired":
+    "This connection attempt expired or belongs to another session. Start again from this page.",
+  "settings.repositories.oauthNotConfigured":
+    "This git provider is not configured. Ask an administrator to enable it.",
+  "settings.repositories.oauthFailed":
+    "Could not connect your git account. Try again. If it keeps failing, contact an administrator.",
   "settings.repositories.connectGitlab": "Connect GitLab",
   "settings.repositories.connectGitlabToken": "Connect GitLab with a token",
   "settings.repositories.authKindGithubApp": "GitHub App",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -121,7 +121,19 @@ export const settings = {
   "settings.repositories.gitlabTokenHint":
     "Use um token de acesso pessoal, de projeto ou de grupo.",
   "settings.repositories.connectGithub": "Conectar GitHub",
-  "settings.repositories.installGithub": "Instalar em outra conta",
+  "settings.repositories.manageGithub": "Gerenciar acesso no GitHub",
+  "settings.repositories.manageGithubHint":
+    "Instale ou configure o app nas suas contas e organizações do GitHub.",
+  "settings.repositories.oauthNoInstallations":
+    "A autorização no GitHub foi concluída, mas nenhuma instalação do app está disponível para este usuário. Use Gerenciar acesso no GitHub para instalar o app ou solicitar acesso a um administrador da organização. Depois, conecte novamente.",
+  "settings.repositories.oauthDenied":
+    "A autorização foi cancelada. Conecte novamente quando quiser.",
+  "settings.repositories.oauthExpired":
+    "Esta tentativa de conexão expirou ou pertence a outra sessão. Comece novamente por esta página.",
+  "settings.repositories.oauthNotConfigured":
+    "Este provedor git não está configurado. Peça a um administrador para habilitá-lo.",
+  "settings.repositories.oauthFailed":
+    "Não foi possível conectar sua conta git. Tente novamente. Se o erro persistir, entre em contato com um administrador.",
   "settings.repositories.connectGitlab": "Conectar GitLab",
   "settings.repositories.connectGitlabToken": "Conectar GitLab com um token",
   "settings.repositories.authKindGithubApp": "GitHub App",

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -915,6 +915,9 @@ const settingsBucketsRoute = createRoute({
 const settingsRepositoriesRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/repositories",
+  validateSearch: z.object({
+    git_error: z.string().optional().catch(undefined),
+  }),
   pendingComponent: settingsGroupPendingComponent("repositories"),
   component: lazyRouteComponent(
     () => import("./routes/orgs/settings/repositories.tsx"),

--- a/apps/web/src/views/settings/repositories.tsx
+++ b/apps/web/src/views/settings/repositories.tsx
@@ -12,6 +12,7 @@ import { GitAccountConnect } from "@/components/git-account-connect";
 import { RepositoryPicker } from "@/components/repository-picker";
 
 import { useState } from "react";
+import { useSearch } from "@tanstack/react-router";
 import { GitBranch01, LinkExternal01, Plus } from "@untitledui/icons";
 import { toast } from "sonner";
 import {
@@ -27,6 +28,7 @@ import {
 import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import { Badge } from "@decocms/ui/components/badge.tsx";
 import { Button } from "@decocms/ui/components/button.tsx";
+import { Alert, AlertDescription } from "@decocms/ui/components/alert.tsx";
 
 import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
 
@@ -336,6 +338,41 @@ function RepositoriesSection({
   );
 }
 
+function ConnectError() {
+  const t = useT();
+  const error = useSearch({
+    strict: false,
+    select: (search) => search.git_error,
+  });
+  if (!error) return null;
+
+  let message: string;
+  switch (error) {
+    case "no_installations":
+      message = t("settings.repositories.oauthNoInstallations");
+      break;
+    case "denied":
+    case "access_denied":
+      message = t("settings.repositories.oauthDenied");
+      break;
+    case "missing_state":
+    case "invalid_state":
+    case "session_mismatch":
+      message = t("settings.repositories.oauthExpired");
+      break;
+    case "not_configured":
+      message = t("settings.repositories.oauthNotConfigured");
+      break;
+    default:
+      message = t("settings.repositories.oauthFailed");
+  }
+  return (
+    <Alert variant={error === "no_installations" ? "info" : "destructive"}>
+      <AlertDescription>{message}</AlertDescription>
+    </Alert>
+  );
+}
+
 function RepositoriesContent() {
   const t = useT();
   const deleteAccount = useDeleteGitAccount();
@@ -372,6 +409,8 @@ function RepositoriesContent() {
       <p className="text-sm text-muted-foreground">
         {t("settings.repositories.pageDescription")}
       </p>
+
+      <ConnectError />
 
       <AccountsSection onDisconnect={setPendingAccount} />
 

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -51,6 +51,18 @@ Studio services. Tests that require production-style object storage also need
 the `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY_ID`, and
 `S3_SECRET_ACCESS_KEY` variables; they skip when S3 is unavailable.
 
+GitHub reconnect tests run separately with a synthetic GitHub App:
+
+```bash
+bun run --cwd=packages/e2e test:e2e:github-connect
+```
+
+The main suite excludes this spec because enabling an App changes credential
+resolution for its legacy GitHub fixtures. The dedicated configuration starts
+fresh API and web servers on ports 3001 and 4001. Set the same
+`BETTER_AUTH_SECRET` for both runs when reusing a database, so the second server
+can decrypt persisted authentication keys. CI runs both suites.
+
 ## Architecture
 
 `playwright.config.ts` runs the commerce-upgrade mock, `apps/api`, and

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "check": "tsc --noEmit",
     "test:e2e": "playwright test",
+    "test:e2e:github-connect": "PORT=3001 VITE_PORT=4001 BASE_URL=http://localhost:4001 playwright test --config=playwright.github-connect.config.ts",
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -1,4 +1,13 @@
 import { defineConfig, devices } from "@playwright/test";
+import { generateKeyPairSync } from "node:crypto";
+
+// Synthetic GitHub App credentials exercise connect/setup redirects locally.
+// Tests stop before GitHub; this key belongs to no registered application.
+const githubTestKey = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+}).privateKey;
 
 const serverPort = process.env.PORT || "3000";
 const appPort = process.env.VITE_PORT || "4000";
@@ -141,6 +150,13 @@ export default defineConfig({
     },
     {
       command: apiServerCommand,
+      env: {
+        GITHUB_APP_ID: "1",
+        GITHUB_APP_SLUG: "studio-e2e",
+        GITHUB_APP_CLIENT_ID: "Iv1.studio-e2e",
+        GITHUB_APP_CLIENT_SECRET: "synthetic-e2e-secret",
+        GITHUB_APP_PRIVATE_KEY: githubTestKey,
+      },
       // The API and web apps are launched as separate processes. These cwd
       // entries are the suite's ONLY ties to app implementation, and both stay
       // behind process + HTTP boundaries so the black-box contract holds.

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -1,13 +1,4 @@
 import { defineConfig, devices } from "@playwright/test";
-import { generateKeyPairSync } from "node:crypto";
-
-// Synthetic GitHub App credentials exercise connect/setup redirects locally.
-// Tests stop before GitHub; this key belongs to no registered application.
-const githubTestKey = generateKeyPairSync("rsa", {
-  modulusLength: 2048,
-  privateKeyEncoding: { type: "pkcs8", format: "pem" },
-  publicKeyEncoding: { type: "spki", format: "pem" },
-}).privateKey;
 
 const serverPort = process.env.PORT || "3000";
 const appPort = process.env.VITE_PORT || "4000";
@@ -84,6 +75,9 @@ const webServerCommand = process.env.CI
 
 export default defineConfig({
   testDir: "./tests",
+  // Uses a separate server with a synthetic GitHub App. Enabling that app
+  // here changes credential resolution for the CMS suite's legacy fixtures.
+  testIgnore: "**/github-connect.spec.ts",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   // Whole-suite backstop: even if a single spec wedges (a dangling fetch /
@@ -150,13 +144,6 @@ export default defineConfig({
     },
     {
       command: apiServerCommand,
-      env: {
-        GITHUB_APP_ID: "1",
-        GITHUB_APP_SLUG: "studio-e2e",
-        GITHUB_APP_CLIENT_ID: "Iv1.studio-e2e",
-        GITHUB_APP_CLIENT_SECRET: "synthetic-e2e-secret",
-        GITHUB_APP_PRIVATE_KEY: githubTestKey,
-      },
       // The API and web apps are launched as separate processes. These cwd
       // entries are the suite's ONLY ties to app implementation, and both stay
       // behind process + HTTP boundaries so the black-box contract holds.

--- a/packages/e2e/playwright.github-connect.config.ts
+++ b/packages/e2e/playwright.github-connect.config.ts
@@ -1,0 +1,40 @@
+import { generateKeyPairSync } from "node:crypto";
+import { defineConfig } from "@playwright/test";
+import base from "./playwright.config";
+
+// This key belongs to no registered app. These tests stop at redirects and
+// never exchange codes or mint installation tokens with GitHub.
+const privateKey = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+}).privateKey;
+
+const servers = Array.isArray(base.webServer) ? base.webServer : [];
+
+export default defineConfig({
+  ...base,
+  testIgnore: [],
+  testMatch: "**/github-connect.spec.ts",
+  outputDir: "./test-results/github-connect",
+  webServer: servers.map((server) => ({
+    ...server,
+    // Reusing a developer's server could exercise a different App configuration.
+    reuseExistingServer:
+      server.cwd === "../../apps/api" || server.cwd === "../../apps/web"
+        ? false
+        : server.reuseExistingServer,
+    env: {
+      ...server.env,
+      ...(server.cwd === "../../apps/api"
+        ? {
+            GITHUB_APP_ID: "1",
+            GITHUB_APP_SLUG: "studio-e2e",
+            GITHUB_APP_CLIENT_ID: "Iv1.studio-e2e",
+            GITHUB_APP_CLIENT_SECRET: "synthetic-e2e-secret",
+            GITHUB_APP_PRIVATE_KEY: privateKey,
+          }
+        : {}),
+    },
+  })),
+});

--- a/packages/e2e/tests/github-connect.spec.ts
+++ b/packages/e2e/tests/github-connect.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "../fixtures/test";
+
+test("an account with no GitHub installations can open installation settings from settings and the picker", async ({
+  authedPage: { page, orgSlug },
+}, testInfo) => {
+  const returnTo = `/${orgSlug}/settings/repositories`;
+  await page.goto(`${returnTo}?git_error=no_installations`);
+  await expect(page.getByRole("alert")).toContainText(
+    "GitHub authorization succeeded",
+  );
+  const manage = page.getByRole("link", {
+    name: "Manage GitHub access",
+    exact: true,
+  });
+  await expect(manage).toBeVisible();
+  const href = await manage.getAttribute("href");
+  expect(href).toBe(
+    `/api/${orgSlug}/git-providers/github/install?returnTo=${encodeURIComponent(returnTo)}`,
+  );
+  const response = await page.request.get(href!, { maxRedirects: 0 });
+  expect(response.status()).toBe(302);
+  const destination = new URL(response.headers().location!);
+  expect(destination.origin).toBe("https://github.com");
+  expect(destination.pathname).toBe("/apps/studio-e2e/installations/new");
+  expect(destination.searchParams.get("state")).toBeTruthy();
+  await page.screenshot({
+    path: testInfo.outputPath("github-installation-required.png"),
+    animations: "disabled",
+  });
+  await page
+    .getByRole("button", { name: "Add repository", exact: true })
+    .click();
+  await expect(
+    page
+      .getByRole("dialog")
+      .getByRole("link", { name: "Manage GitHub access", exact: true }),
+  ).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath("github-picker-access.png"),
+    animations: "disabled",
+  });
+});
+
+test("reconnect asks which GitHub user to authorize and cancellation is visible", async ({
+  authedPage: { page, orgSlug },
+}) => {
+  const returnTo = `/${orgSlug}/settings/repositories`;
+  const response = await page.request.get(
+    `/api/${orgSlug}/git-providers/github/connect?returnTo=${encodeURIComponent(returnTo)}`,
+    { maxRedirects: 0 },
+  );
+  expect(response.status()).toBe(302);
+  const destination = new URL(response.headers().location!);
+  expect(destination.origin).toBe("https://github.com");
+  expect(destination.searchParams.get("prompt")).toBe("select_account");
+  const state = destination.searchParams.get("state");
+  expect(state).toBeTruthy();
+  await page.goto(
+    `/api/_git/github/callback?state=${state}&error=access_denied`,
+  );
+  await expect(page.getByRole("alert")).toContainText(
+    "Authorization was cancelled",
+  );
+  await expect(
+    page.getByRole("link", { name: "Manage GitHub access", exact: true }),
+  ).toBeVisible();
+});
+
+test("installation setup continues authorization with a fresh single-use state", async ({
+  authedPage: { page, orgSlug },
+}) => {
+  const returnTo = `/${orgSlug}/settings/repositories`;
+  const install = await page.request.get(
+    `/api/${orgSlug}/git-providers/github/install?returnTo=${encodeURIComponent(returnTo)}`,
+    { maxRedirects: 0 },
+  );
+  const state = new URL(install.headers().location!).searchParams.get("state");
+  const setup = `/api/_git/github/setup?state=${state}&installation_id=123`;
+  const response = await page.request.get(setup, { maxRedirects: 0 });
+  expect(response.status()).toBe(302);
+  const destination = new URL(response.headers().location!);
+  expect(destination.pathname).toBe("/login/oauth/authorize");
+  expect(destination.searchParams.has("prompt")).toBe(false);
+  expect(destination.searchParams.get("state")).toBeTruthy();
+  expect(destination.searchParams.get("state")).not.toBe(state);
+  const replay = await page.request.get(setup, { maxRedirects: 0 });
+  expect(
+    new URL(replay.headers().location!).searchParams.get("git_error"),
+  ).toBe("invalid_state");
+});
+
+test("unknown callback errors show a safe message and a successful return clears it", async ({
+  authedPage: { page, orgSlug },
+}) => {
+  const returnTo = `/${orgSlug}/settings/repositories`;
+  await page.goto(`${returnTo}?git_error=untrusted-provider-text`);
+  await expect(page.getByRole("alert")).toContainText(
+    "Could not connect your git account",
+  );
+  await expect(page.getByRole("alert")).not.toContainText(
+    "untrusted-provider-text",
+  );
+  await page.goto(returnTo);
+  await expect(page.getByRole("alert")).toHaveCount(0);
+});


### PR DESCRIPTION
GitHub authorization can succeed while the app has no installations. Studio returned to Repositories with an invisible `no_installations` error and hid the installation link until a GitHub account already existed, leaving first-time users and users who disconnected all accounts stuck.

Show “Manage GitHub access” in settings and the shared picker whenever GitHub is configured. Display translated callback errors with an actionable installation message. Explicit connects request GitHub’s account chooser; the post-install setup callback continues OAuth without another chooser.

Validation: 21 Playwright tests passed against real local Postgres and authentication, including connect/setup redirects, single-use state, callback messages, picker behavior, and account avatars. The GitHub App credentials are synthetic and the redirect tests stop before GitHub. These four tests run in a dedicated Playwright configuration and CI step because enabling an App for the shared suite changes credential resolution for its legacy CMS fixtures. After isolating that configuration, all 23 tests in the affected CMS files and all four reconnect tests pass locally. All 8,533 unit tests, API/web/e2e type checks, formatting, lint, and knip passed. Desktop and mobile screenshots inspected.

GitHub documents the account-chooser parameter [here](https://github.blog/changelog/2024-06-07-account-picker-updates-for-oauth-and-github-app-sign-in/).

![Installation required](https://github.com/decocms/studio/blob/69689749c6b6d672c79c1ac744bf49a6ed727eee/github-installation-required.png?raw=true)
![Repository picker](https://github.com/decocms/studio/blob/69689749c6b6d672c79c1ac744bf49a6ed727eee/github-picker-access.png?raw=true)
<details><summary>Mobile picker</summary>

![Mobile picker](https://github.com/decocms/studio/blob/69689749c6b6d672c79c1ac744bf49a6ed727eee/github-picker-mobile.png?raw=true)

</details>
