### PR TITLE
fix(git-providers): drain discarded GitHub response bodies

### DIFF
--- a/apps/api/src/git-providers/github/client.ts
+++ b/apps/api/src/git-providers/github/client.ts
@@ -214,7 +214,10 @@ export class GithubProviderClient implements GitProviderClient {
       `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`,
       { operation },
     );
-    if (res.status === 404) return null;
+    if (res.status === 404) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
     if (!res.ok) throw await githubFailure(res, operation);
     return mapGithubRepo(
       await githubJson<GithubRepoJson>(res, operation),
@@ -276,7 +279,10 @@ export class GithubProviderClient implements GitProviderClient {
       `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/contents/${encodePath(path)}${query}`,
       { operation, accept: RAW_CONTENT_ACCEPT },
     );
-    if (res.status === 404) return null;
+    if (res.status === 404) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
     if (!res.ok) throw await githubFailure(res, operation);
     return res.text();
   }
@@ -302,7 +308,10 @@ export class GithubProviderClient implements GitProviderClient {
         timeoutMs: ARCHIVE_TIMEOUT_MS,
       });
     }
-    if (res.status === 404) return null;
+    if (res.status === 404) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
     if (!res.ok) throw await githubFailure(res, operation);
     return res.body;
   }
@@ -329,6 +338,7 @@ export class GithubProviderClient implements GitProviderClient {
     const first = await this.accountToken();
     const res = await githubFetch(url, { ...init, token: first.token });
     if (res.status !== 401) return res;
+    await res.body?.cancel().catch(() => {});
     const refreshed = await this.accountToken({ forceRefresh: true });
     return githubFetch(url, { ...init, token: refreshed.token });
   }


### PR DESCRIPTION
Follows #7091 (GitLab client) — same leak class in the GitHub provider client that #7091's PR body called out as a pattern worth checking elsewhere.

`GithubProviderClient.getRepo`, `.readFile`, and `.archiveTarball` all return `null` on a 404 by short-circuiting on `res.status === 404` without ever reading the response body, and the private `request()` helper's 401-retry path discarded the first response the same way before firing the refreshed-token retry. An unread `Response` body keeps its underlying connection from being released back to Bun's fetch keep-alive pool, and `archiveTarball` already knew this for its own 401 branch (`await res.body?.cancel().catch(() => {})`) — the 404 branches right next to it just never got the same treatment.

Fix: drain (`res.body?.cancel().catch(() => {})`) before returning/retrying at all four sites, matching the existing pattern in this same file and in `#7091`/`#7087`/`#7104`.

Failure scenario: a caller repeatedly probing for a file/repo that doesn't exist (e.g. checking for an optional config file across many repos) leaks one unread body per miss, exhausting the connection pool under load instead of reusing connections.

Behavior-preserving: return values and control flow are unchanged, only the body-draining side effect is added.

Reviewer check: `cd apps/api && bunx tsc --noEmit && bun test src/git-providers/github/client.test.ts` (16/16 pass).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bun test apps/api/src/git-providers/github/client.test.ts` (16 pass), `bunx oxlint apps/api/src/git-providers/github/client.ts` (0 warnings/errors). Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `GithubProviderClient` leaking connections when it discards response bodies. The client now drains the body before returning `null` on a 404 in `getRepo`, `readFile`, and `archiveTarball`, and before retrying after a 401.

- An unread body keeps its connection out of Bun's fetch keep-alive pool, so repeated probes for missing files or repos could exhaust the pool.
- Behavior-preserving: return values and control flow are unchanged.

<sup>Written for commit 915d83b1959eeb6e98385f7e4f437c5ae6d5682d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

