### PR TITLE
feat(observability): label GitHub rate-limit metrics with whose budget was spent

### DIFF
--- a/apps/api/src/git-providers/github/app-auth.ts
+++ b/apps/api/src/git-providers/github/app-auth.ts
@@ -16,6 +16,7 @@ import {
   isPermissionRejected,
   OPTIONAL_MINT_PERMISSIONS,
 } from "@decocms/shared/github-repo-scope";
+import { APP_BUDGET_OWNER, rememberBudgetOwner } from "./budget-owner";
 import { type GithubAppConfig, readGithubAppConfig } from "./env";
 import type { GitProviderCapability } from "../types";
 import { GitProviderError } from "../types";
@@ -234,6 +235,11 @@ export class GithubAppAuth {
       nowSeconds: now,
     });
     this.jwt = { value, exp: now + JWT_TTL_SECONDS };
+    rememberBudgetOwner(
+      value,
+      APP_BUDGET_OWNER,
+      (now + JWT_TTL_SECONDS) * 1000,
+    );
     return value;
   }
 
@@ -262,6 +268,11 @@ export class GithubAppAuth {
     const mint = this.mint(installationId, opts)
       .then((token) => {
         this.cache.set(key, token);
+        rememberBudgetOwner(
+          token.token,
+          String(installationId),
+          token.expiresAt.getTime(),
+        );
         pruneExpiredTokens(this.cache, Date.now());
         return token;
       })

--- a/apps/api/src/git-providers/github/budget-owner.test.ts
+++ b/apps/api/src/git-providers/github/budget-owner.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import {
+  APP_BUDGET_OWNER,
+  budgetOwnerFor,
+  rememberBudgetOwner,
+} from "./budget-owner";
+
+describe("budgetOwnerFor", () => {
+  const now = 1_000_000;
+
+  it("returns the owner registered for a token", () => {
+    rememberBudgetOwner("tok-a", "12345", now + 3600_000, now);
+    expect(budgetOwnerFor("tok-a", now)).toBe("12345");
+  });
+
+  it("keeps two installations apart", () => {
+    rememberBudgetOwner("tok-b", "111", now + 3600_000, now);
+    rememberBudgetOwner("tok-c", "222", now + 3600_000, now);
+    expect(budgetOwnerFor("tok-b", now)).toBe("111");
+    expect(budgetOwnerFor("tok-c", now)).toBe("222");
+  });
+
+  it("is unknown for a token nobody registered", () => {
+    expect(budgetOwnerFor("never-seen", now)).toBe("unknown");
+  });
+
+  it("is unknown once the token has expired", () => {
+    rememberBudgetOwner("tok-d", "333", now + 1000, now);
+    expect(budgetOwnerFor("tok-d", now + 1001)).toBe("unknown");
+  });
+
+  it("tags the App's own JWT window", () => {
+    rememberBudgetOwner("jwt", APP_BUDGET_OWNER, now + 600_000, now);
+    expect(budgetOwnerFor("jwt", now)).toBe(APP_BUDGET_OWNER);
+  });
+
+  it("does not grow without bound as tokens rotate", () => {
+    for (let i = 0; i < 2000; i++) {
+      rememberBudgetOwner(`rot-${i}`, String(i), now + 1000, now + 2000);
+    }
+    expect(budgetOwnerFor("rot-0", now + 2000)).toBe("unknown");
+  });
+});

--- a/apps/api/src/git-providers/github/budget-owner.ts
+++ b/apps/api/src/git-providers/github/budget-owner.ts
@@ -1,0 +1,71 @@
+/**
+ * Which GitHub rate-limit window a token spends.
+ *
+ * GitHub meters per credential, not per app: every App installation gets its
+ * own hourly window, the App's JWT another, each user OAuth grant another.
+ * `github_rate_limit_remaining` without that distinction is one series fed by
+ * every window in turn, so it reports whichever caller answered last — a `min()`
+ * over it cannot say which tenant is out of budget, which is what an operator
+ * needs before deciding whom to throttle.
+ *
+ * The label has to be resolvable from the token because the two biggest
+ * spenders — `GithubChangeRequestClient` and the decofile content client —
+ * hold only a `TokenSource` and never see an installation id. So the owner is
+ * registered where the credential is minted and looked up by the token here.
+ * Keyed by a hash: a live credential is not something to hold as a map key.
+ */
+
+/** Owner of the window when the token is not one we minted (a PAT, say). */
+const UNKNOWN_BUDGET_OWNER = "unknown";
+
+/** The App's own JWT window, which `POST /app/installations/…` spends. */
+export const APP_BUDGET_OWNER = "app";
+
+/** A user OAuth grant's own 5,000/hr window, separate from any installation's. */
+export const USER_BUDGET_OWNER = "user";
+
+/** Bounds the map if a caller ever registers without expiry churn reclaiming it. */
+const MAX_ENTRIES = 512;
+
+const owners = new Map<string, { owner: string; expiresAt: number }>();
+
+function hashKey(token: string): string {
+  return Bun.hash(token).toString(36);
+}
+
+function prune(now: number): void {
+  for (const [key, entry] of owners) {
+    if (entry.expiresAt <= now) owners.delete(key);
+  }
+  while (owners.size >= MAX_ENTRIES) {
+    const oldest = owners.keys().next();
+    if (oldest.done) break;
+    owners.delete(oldest.value);
+  }
+}
+
+/** Record that `token` spends `owner`'s window until `expiresAt` (epoch ms). */
+export function rememberBudgetOwner(
+  token: string,
+  owner: string,
+  expiresAt: number,
+  now: number = Date.now(),
+): void {
+  prune(now);
+  owners.set(hashKey(token), { owner, expiresAt });
+}
+
+/** The metric label for `token`, or `unknown` when we did not mint it. */
+export function budgetOwnerFor(
+  token: string,
+  now: number = Date.now(),
+): string {
+  const key = hashKey(token);
+  const entry = owners.get(key);
+  if (!entry) return UNKNOWN_BUDGET_OWNER;
+  if (entry.expiresAt <= now) {
+    owners.delete(key);
+    return UNKNOWN_BUDGET_OWNER;
+  }
+  return entry.owner;
+}

--- a/apps/api/src/git-providers/github/content.ts
+++ b/apps/api/src/git-providers/github/content.ts
@@ -19,6 +19,7 @@ import {
   isGithubRateLimited,
   recordGithubRateLimit,
 } from "@/observability/github-rate-limit";
+import { budgetOwnerFor } from "./budget-owner";
 import { githubGraphqlRequest } from "./graphql";
 import { githubApiBaseUrl } from "./http";
 import type { TokenSource } from "../types";
@@ -400,7 +401,12 @@ export class GithubContentClient implements RepoContentClient {
       body: body !== undefined ? JSON.stringify(body) : undefined,
       signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
     });
-    recordGithubRateLimit(res.headers, { lane: "rest", operation: method });
+    const installation = budgetOwnerFor(accessToken);
+    recordGithubRateLimit(res.headers, {
+      lane: "rest",
+      operation: method,
+      installation,
+    });
 
     if (conditional && res.status === 304) {
       return { status: 200, json: conditional.body as T };
@@ -408,7 +414,12 @@ export class GithubContentClient implements RepoContentClient {
     if (isGithubRateLimited(res)) {
       const kind =
         res.headers.get("retry-after") !== null ? "secondary" : "primary";
-      countGithubRateLimited({ lane: "rest", operation: method, kind });
+      countGithubRateLimited({
+        lane: "rest",
+        operation: method,
+        installation,
+        kind,
+      });
       await res.body?.cancel().catch(() => {});
       throw new GitHubRateLimitError(
         res.status,

--- a/apps/api/src/git-providers/github/graphql.ts
+++ b/apps/api/src/git-providers/github/graphql.ts
@@ -21,6 +21,7 @@ import {
   isGithubRateLimited,
   recordGithubRateLimit,
 } from "@/observability/github-rate-limit";
+import { budgetOwnerFor } from "./budget-owner";
 
 /** e2e seam, mirroring `git-providers/content/github.ts`. Read per call site so a
  *  long-lived dev server and a test webServer agree on one value. */
@@ -143,6 +144,7 @@ export async function githubGraphqlRequest<T>(
   };
 
   let res = await postWithRetry(accessToken);
+  let spentToken = accessToken;
 
   // Token revoked/rotated behind our clock: one refresh + retry, then give up.
   if (res.status === 401) {
@@ -155,12 +157,15 @@ export async function githubGraphqlRequest<T>(
     const refreshed = await args.getToken(true);
     if (!refreshed) throw new Error(args.missingTokenMessage);
     res = await postWithRetry(refreshed);
+    spentToken = refreshed;
     if (res.status === 401) throw new Error(args.missingTokenMessage);
   }
 
+  const installation = budgetOwnerFor(spentToken);
   recordGithubRateLimit(res.headers, {
     lane: "graphql",
     operation: args.operation,
+    installation,
   });
 
   // Never retried here: retrying a secondary limit IS the burst being limited.
@@ -170,6 +175,7 @@ export async function githubGraphqlRequest<T>(
     countGithubRateLimited({
       lane: "graphql",
       operation: args.operation,
+      installation,
       kind,
     });
     const waitMs = githubRetryAfterMs(res.headers);

--- a/apps/api/src/git-providers/github/http.ts
+++ b/apps/api/src/git-providers/github/http.ts
@@ -15,6 +15,7 @@ import {
   isGithubRateLimited,
   recordGithubRateLimit,
 } from "@/observability/github-rate-limit";
+import { budgetOwnerFor } from "./budget-owner";
 import { GitProviderError } from "../types";
 
 const GITHUB_API_VERSION = "2022-11-28";
@@ -82,9 +83,11 @@ export async function githubFetch(
     });
   }
 
+  const installation = budgetOwnerFor(init.token);
   recordGithubRateLimit(res.headers, {
     lane: "rest",
     operation: init.operation,
+    installation,
   });
 
   if (isGithubRateLimited(res)) {
@@ -92,7 +95,12 @@ export async function githubFetch(
     await res.body?.cancel().catch(() => {});
     const kind =
       res.headers.get("retry-after") !== null ? "secondary" : "primary";
-    countGithubRateLimited({ lane: "rest", operation: init.operation, kind });
+    countGithubRateLimited({
+      lane: "rest",
+      operation: init.operation,
+      installation,
+      kind,
+    });
     const retryAfterMs = githubRetryAfterMs(res.headers);
     throw new GitProviderError({
       provider: "github",

--- a/apps/api/src/observability/github-rate-limit.ts
+++ b/apps/api/src/observability/github-rate-limit.ts
@@ -1,14 +1,16 @@
 /**
  * GitHub rate-limit telemetry. Every path that talks to api.github.com competes
- * for ONE budget per installation token; `dbos-github-read.ts` records that
- * budget shutting for 17 hours, and the ceiling it added was sized against an
- * estimate because nothing measured the real thing.
+ * for one budget per credential; `dbos-github-read.ts` records that budget
+ * shutting for 17 hours, and the ceiling it added was sized against an estimate
+ * because nothing measured the real thing.
  *
- * `lane` tags the transport, not the caller: the question to answer is which of
- * our ways of reaching GitHub spends the budget. `resource` stays an attribute
- * rather than being collapsed — REST and GraphQL are metered separately
- * (requests/hour vs points/hour) through these same headers, so a remaining
- * count means nothing without knowing which pool it drained.
+ * Three attributes, three different questions. `installation` is WHOSE window a
+ * call spent (`git-providers/github/budget-owner.ts`) — the one an operator
+ * needs before deciding whom to throttle. `lane` is the transport, not the
+ * caller: which of our ways of reaching GitHub spends the budget. `resource`
+ * stays separate rather than being collapsed — REST and GraphQL are metered
+ * differently (requests/hour vs points/hour) through these same headers, so a
+ * remaining count means nothing without knowing which pool it drained.
  */
 
 import type { Counter, Gauge } from "@opentelemetry/api";
@@ -95,34 +97,33 @@ let limitedCounter: Counter | null = null;
  */
 export function recordGithubRateLimit(
   headers: Headers,
-  attrs: { lane: GithubLane; operation: string },
+  attrs: { lane: GithubLane; operation: string; installation: string },
 ): GithubRateLimitSnapshot {
   const snapshot = readGithubRateLimit(headers);
-  const labels = {
-    lane: attrs.lane,
-    operation: attrs.operation,
-    resource: snapshot.resource ?? "unknown",
-  };
+  const resource = snapshot.resource ?? "unknown";
+  // A budget belongs to (installation, resource) — `operation` on a gauge only made it report whichever call touched it last.
+  const budget = { installation: attrs.installation, resource };
+  const call = { ...budget, lane: attrs.lane, operation: attrs.operation };
 
   callCounter ??= meter.createCounter("github_api_calls", {
     description: "Calls to the GitHub API, by transport and operation",
     unit: "{calls}",
   });
-  callCounter.add(1, labels);
+  callCounter.add(1, call);
 
   if (snapshot.remaining !== null) {
     remainingGauge ??= meter.createGauge("github_rate_limit_remaining", {
       description: "Requests (REST) or points (GraphQL) left in the window",
       unit: "{requests}",
     });
-    remainingGauge.record(snapshot.remaining, labels);
+    remainingGauge.record(snapshot.remaining, budget);
   }
   if (snapshot.used !== null) {
     usedGauge ??= meter.createGauge("github_rate_limit_used", {
       description: "Requests (REST) or points (GraphQL) spent in the window",
       unit: "{requests}",
     });
-    usedGauge.record(snapshot.used, labels);
+    usedGauge.record(snapshot.used, budget);
   }
 
   return snapshot;
@@ -135,6 +136,8 @@ export function recordGithubRateLimit(
 export function countGithubRateLimited(attrs: {
   lane: GithubLane;
   operation: string;
+  /** Whose window was exhausted — see `git-providers/github/budget-owner.ts`. */
+  installation: string;
   /** "primary" when the window is exhausted, "secondary" for a burst refusal. */
   kind: "primary" | "secondary";
 }): void {

--- a/apps/api/src/tools/github/list-user-orgs.ts
+++ b/apps/api/src/tools/github/list-user-orgs.ts
@@ -14,6 +14,7 @@ import {
   isGithubRateLimited,
   recordGithubRateLimit,
 } from "@/observability/github-rate-limit";
+import { USER_BUDGET_OWNER } from "@/git-providers/github/budget-owner";
 
 const GITHUB_API = "https://api.github.com";
 /** Matches the content client's per-attempt timeout in `git-providers/content/github.ts`. */
@@ -169,6 +170,7 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
       recordGithubRateLimit(res.headers, {
         lane: "rest",
         operation: "list_user_installations",
+        installation: USER_BUDGET_OWNER,
       });
 
       if (isGithubRateLimited(res)) {
@@ -177,6 +179,7 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
         countGithubRateLimited({
           lane: "rest",
           operation: "list_user_installations",
+          installation: USER_BUDGET_OWNER,
           kind,
         });
         const waitMs = githubRetryAfterMs(res.headers);


### PR DESCRIPTION
## The gap

Today's incident (#7101, #7094) was diagnosed by reading traces, not metrics — because the metrics can't answer the operative question.

GitHub meters **per credential**, not per app: every App installation gets its own hourly window, the App's JWT another, each user OAuth grant another. `github_rate_limit_remaining` carried `{lane, operation, resource}` and no owner, so all of those windows land in one series that reports whichever caller answered last. `min by (resource)` tells you *someone* is at zero. It cannot tell you who — which is what you need before you can throttle anybody.

Confirmed against prod while writing this (VictoriaMetrics `P4169E866C3094E38`):

```
min by (resource) (min_over_time(github_rate_limit_remaining[24h]))
  core     0        ← the incident
  graphql  4925
sum by (kind) (increase(github_rate_limited_total[24h]))
  primary    13129
  secondary  14400
```

## The change

An `installation` attribute on all four metrics: `github_rate_limit_remaining`, `_used`, `github_api_calls`, `github_rate_limited`.

The label has to be resolvable **from the token**. The two biggest spenders — `GithubChangeRequestClient` (`change_request_read`/`_detail`, ~1.6k calls/hr) and the decofile content client (the path #7101 just fixed) — are constructed with a `TokenSource` and never see an installation id; threading one in means touching a dozen constructors and still missing whatever lane gets added next.

So `budget-owner.ts` registers the owner at the one place each credential is created (`GithubAppAuth.installationToken` → the installation id, `appJwt()` → `"app"`) and `budgetOwnerFor(token)` reads it back at the four `recordGithubRateLimit` call sites. `list_user_installations` passes `"user"` directly, since it knows. Anything else reads `"unknown"`.

Keyed by `Bun.hash(token)`, not the token — per CLAUDE.md gotcha #8, a live credential is not something to hold as a map key. Entries expire with the token and the map is pruned on write, with a 512-entry backstop.

**Also drops `operation` from the two gauges.** A remaining count is a property of `(installation, resource)`, not of the call that observed it — with `operation` in the label set, each operation kept its own series reporting the budget as of whenever that operation last ran, and `min by (resource)` picked whichever straggler was most stale. Removing it roughly offsets the cardinality the new label adds.

## What this does not do

No gate, no ceiling, no behavior change. Deliberately: a limiter without attribution can only be global, which is the blunt instrument `dbos-github-read.ts` already applies to the review sweep. This is the prerequisite. Once it is deployed, `min by (installation, resource) (github_rate_limit_remaining) < 1000` is an alert, and a per-installation gate has an id to key on.

## Testing

- `apps/api/src/git-providers/github/budget-owner.test.ts` — 6 tests: resolution, two installations kept apart, unknown token, expiry, the App JWT owner, and that 2000 rotations don't grow the map.
- `bun test apps/api/src/git-providers/github/ apps/api/src/observability/` → **131 pass, 0 fail**.
- `bun run --cwd=apps/api check` clean · `bun run lint` 0 errors · `bun run fmt` applied · `bunx knip` flags nothing new.

## Verifying after deploy

`sum by (installation) (increase(github_api_calls_total[1h]))` should split today's flat ~3.5k/hr `GET` into per-tenant series, and `installation="app"` should account for the ~1k/hr `installation_access_token` calls that spend the App's own window rather than any tenant's.

## Follow-ups (not in scope)

From #7101's own list, still open: no shared per-installation ceiling on the content/decofile lane; `CHANGE_REQUEST_STATE` polls GraphQL every 60s uncached; the `gh` CLI inside sandboxes spends the same budget with no telemetry at all.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GitHub rate-limit metrics now identify whose credential budget was spent with an `installation` label, instead of merging installation, app JWT, and user OAuth windows into one series. This makes per-installation exhaustion visible without changing request handling or adding a limiter; the remaining and used gauges now omit `operation` and are keyed by installation and resource.

- Registers owners when app JWTs and installation tokens are created; user-installation requests use `user`.
- Resolves owners from hashed, expiring token entries, with unrecognized credentials labeled `unknown`.
- Applies attribution to REST, GraphQL, API call, and rate-limited metrics.
- Tests cover owner separation, expiry, app JWTs, unknown tokens, and bounded token rotation.

<sup>Written for commit b97d87220e212052704ae04bb612b757e650da03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

