### PR TITLE
fix(web): stop publish resurrecting/dropping drafts under concurrent release writes

### DIFF
--- a/apps/web/src/components/thread/github/release-edits.test.ts
+++ b/apps/web/src/components/thread/github/release-edits.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import type { Release } from "@decocms/shared/sdk/types";
+import { addRelease, removeRelease, renameReleaseIn } from "./release-edits";
+
+const rel = (branch: string, name = branch): Release => ({
+  branch,
+  name,
+  color: "orange",
+  createdAt: "2026-01-01T00:00:00.000Z",
+});
+
+describe("release-edits", () => {
+  it("addRelease appends a new branch", () => {
+    expect(addRelease([rel("a")], rel("b"))).toEqual([rel("a"), rel("b")]);
+  });
+
+  it("addRelease is idempotent by branch (no duplicate draft)", () => {
+    const current = [rel("a")];
+    expect(addRelease(current, rel("a", "renamed"))).toBe(current);
+  });
+
+  it("removeRelease drops only the matching branch", () => {
+    expect(removeRelease([rel("a"), rel("b")], "a")).toEqual([rel("b")]);
+  });
+
+  it("renameReleaseIn renames only the matching branch", () => {
+    expect(renameReleaseIn([rel("a"), rel("b")], "a", "New")).toEqual([
+      rel("a", "New"),
+      rel("b"),
+    ]);
+  });
+
+  // Serialized publish discard + auto-name landing compose either way.
+  describe("publish landing never resurrects the merged draft", () => {
+    const start = [rel("published")];
+
+    it("discard-then-land", () => {
+      const out = addRelease(removeRelease(start, "published"), rel("fresh"));
+      expect(out).toEqual([rel("fresh")]);
+    });
+
+    it("land-then-discard", () => {
+      const out = removeRelease(addRelease(start, rel("fresh")), "published");
+      expect(out).toEqual([rel("fresh")]);
+    });
+  });
+});

--- a/apps/web/src/components/thread/github/release-edits.ts
+++ b/apps/web/src/components/thread/github/release-edits.ts
@@ -1,0 +1,27 @@
+import type { Release } from "@decocms/shared/sdk/types";
+
+/**
+ * Pure edits to the `metadata.releases` array. Kept separate from
+ * {@link ./use-releases.ts} so they're unit-testable without React/SDK, and so
+ * the read-modify-write serialization there composes over well-defined steps.
+ *
+ * Add is idempotent by branch: a double-fire (two tabs, or the shell's
+ * auto-name effect re-running) can't duplicate a draft.
+ */
+export function addRelease(current: Release[], release: Release): Release[] {
+  return current.some((r) => r.branch === release.branch)
+    ? current
+    : [...current, release];
+}
+
+export function removeRelease(current: Release[], branch: string): Release[] {
+  return current.filter((r) => r.branch !== branch);
+}
+
+export function renameReleaseIn(
+  current: Release[],
+  branch: string,
+  name: string,
+): Release[] {
+  return current.map((r) => (r.branch === branch ? { ...r, name } : r));
+}

--- a/apps/web/src/components/thread/github/use-releases.ts
+++ b/apps/web/src/components/thread/github/use-releases.ts
@@ -1,6 +1,8 @@
 import { useProjectContext, useVirtualMCP, useVirtualMCPActions } from "@/sdk";
 import { useQueryClient } from "@tanstack/react-query";
 import type { Release, VirtualMCPEntity } from "@decocms/shared/sdk/types";
+import { runSerializedTask } from "@/lib/serial-task-queue";
+import { addRelease, removeRelease, renameReleaseIn } from "./release-edits";
 
 /**
  * Dot colors a named release can take, in assignment order. `success` (green) is
@@ -60,43 +62,66 @@ export function useReleases(virtualMcpId: string) {
     queryKey[4] === "VIRTUAL_MCP" &&
     queryKey[5] === virtualMcpId;
 
-  const write = (next: Release[]) => {
-    queryClient.setQueriesData<ItemData>(
-      { predicate: (q) => isItemQuery(q.queryKey) },
-      (old) =>
-        old?.item
-          ? {
-              item: {
-                ...old.item,
-                metadata: { ...old.item.metadata, releases: next },
-              },
-            }
-          : old,
-    );
-    return actions.update
-      .mutateAsync({
-        id: virtualMcpId,
-        data: {
-          metadata: { releases: next } as unknown as NonNullable<
-            VirtualMCPEntity["metadata"]
-          >,
-        },
-      })
-      .catch((err) => {
+  /** Freshest committed list, so a queued edit sees the previous one's result —
+   *  not a stale render snapshot. Falls back to the render value pre-hydration. */
+  const readCacheReleases = (): Release[] => {
+    for (const [, data] of queryClient.getQueriesData<ItemData>({
+      predicate: (q) => isItemQuery(q.queryKey),
+    })) {
+      if (data?.item) return data.item.metadata?.releases ?? [];
+    }
+    return releases;
+  };
+
+  /**
+   * Read-modify-write of the whole `metadata.releases` array. Two writers race
+   * here — the shell auto-names a fresh draft while publish discards the merged
+   * one — and each sends the full array (last write wins), so a naive write
+   * resurrects the just-discarded draft. Serializing per VM (and re-reading the
+   * cache inside the task) makes each edit compose on the previous one's result.
+   */
+  const write = (reduce: (current: Release[]) => Release[]) =>
+    runSerializedTask(`vm-releases:${virtualMcpId}`, async () => {
+      const current = readCacheReleases();
+      const next = reduce(current);
+      if (next === current) return;
+      queryClient.setQueriesData<ItemData>(
+        { predicate: (q) => isItemQuery(q.queryKey) },
+        (old) =>
+          old?.item
+            ? {
+                item: {
+                  ...old.item,
+                  metadata: { ...old.item.metadata, releases: next },
+                },
+              }
+            : old,
+      );
+      try {
+        await actions.update.mutateAsync({
+          id: virtualMcpId,
+          data: {
+            metadata: { releases: next } as unknown as NonNullable<
+              VirtualMCPEntity["metadata"]
+            >,
+          },
+        });
+      } catch (err) {
         queryClient.invalidateQueries({
           predicate: (q) => isItemQuery(q.queryKey),
         });
         throw err;
-      });
-  };
+      }
+    });
 
-  const createRelease = (release: Release) => write([...releases, release]);
+  const createRelease = (release: Release) =>
+    write((current) => addRelease(current, release));
 
   const renameRelease = (branch: string, name: string) =>
-    write(releases.map((r) => (r.branch === branch ? { ...r, name } : r)));
+    write((current) => renameReleaseIn(current, branch, name));
 
   const deleteRelease = (branch: string) =>
-    write(releases.filter((r) => r.branch !== branch));
+    write((current) => removeRelease(current, branch));
 
   return { releases, createRelease, renameRelease, deleteRelease };
 }


### PR DESCRIPTION
## Summary

The version/drafts switcher (`Rascunho N`) is backed by a `metadata.releases`
array on the VirtualMCP. Publishing fires **two** writes to that whole array at
the same time:

- the shell (`agent-shell-layout`) auto-names the **fresh landing branch** the
  publish switches you to, and
- publish completion **discards the merged draft** (`deleteRelease`).

Both send the full array with **last-writer-wins** semantics, so they race:

- when the auto-name write lands last, it **resurrects the just-published
  draft** → drafts pile up in the dropdown (the reported "20 rascunhos" and
  "publiquei e ficaram");
- when the discard lands last, the **fresh landing draft fails to persist** →
  it shows as an unnamed transient "Rascunho" until a page refresh re-persists
  and renames it (e.g. `Rascunho 4` published → briefly unnamed → `Rascunho 2`
  after refresh).

## Fix

- Serialize release writes **per VM** through the existing
  `runSerializedTask` queue and **re-read the freshest list from the query
  cache inside each task**, so discard and auto-name compose on each other's
  result instead of clobbering. The outcome is now order-independent.
- `addRelease` is **idempotent by branch**, so a double-fire (two tabs, effect
  re-run) can't duplicate a draft.
- Pure array edits (`addRelease` / `removeRelease` / `renameReleaseIn`)
  extracted to `release-edits.ts` for unit testing without React/SDK.

## Out of scope (deliberately — separate follow-ups)

- Publish still lands you on a fresh editable draft (by design). Whether
  publishing should spawn a draft at all is a product decision.
- Draft **numbering** still derives from the current max (`nextDraftName`), so
  deleting a high number reuses it (`4` deleted → next is `2`, not `5`).
- The underlying **git branch is never deleted on GitHub** (`deleteRelease`
  only drops the switcher entry; the GitHub content provider has no
  `deleteBranch`, only GitLab does).

## Testing

- `bun test apps/web/src/components/thread/github/release-edits.test.ts` — 6
  tests, covering both publish interleavings (discard-then-land, land-then-discard)
  proving the merged draft never resurrects.
- `bun test apps/web/src/components/thread/github/ apps/web/src/lib/serial-task-queue.test.ts` — 313 pass.
- `bun run check` (typecheck), `bun run lint` (0 errors), `bun run fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition where publishing a draft fires two concurrent writes to the `metadata.releases` array — the shell auto-names the fresh landing branch while publish discards the merged draft. Depending on which write lands last, the just-published draft resurrects in the dropdown or the fresh landing draft fails to persist until a page refresh renames it.

The fix serializes release writes per VM through the existing `runSerializedTask` queue and re-reads the freshest list from the query cache inside each task, so the two writes compose on each other's result instead of clobbering. `addRelease` is idempotent by branch so a double-fire can't duplicate a draft; pure array edits were extracted to `release-edits.ts` for unit testing without React/SDK.

**Out of scope**
- Publishing still lands on a fresh editable draft by design; whether it should spawn one is a product decision.
- Draft numbering still derives from the current max, so deleting a high number reuses it.
- The underlying git branch is never deleted on GitHub; `deleteRelease` only drops the switcher entry, since the GitHub content provider has no `deleteBranch`.

<sup>Written for commit a41d983d59661048214c8c04f0b1563d2ef9aee2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

