### PR TITLE
fix(git-providers): drain a GitLab 404 body before discarding in content.ts

### DIFF
--- a/apps/api/src/git-providers/gitlab/content.ts
+++ b/apps/api/src/git-providers/gitlab/content.ts
@@ -1146,7 +1146,10 @@ export class GitlabContentClient implements RepoContentClient {
         cause,
       });
     }
-    if (res.status === 404) return null;
+    if (res.status === 404) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
     if (!res.ok) throw await gitlabFailure(res);
     return res;
   }


### PR DESCRIPTION
Follows #7091/#7109 (drain-discarded-body hardening for GitLab client.ts and GitHub) — this PR closes the same gap in `GitlabContentClient`'s private `call()` helper in `apps/api/src/git-providers/gitlab/content.ts`, which was missed by #7091.

**The gap**: `GitlabProviderClient.get()` in `client.ts` and `GitlabChangeRequestsClient`'s `call()` in `change-requests.ts` both drain the response body (`await res.body?.cancel().catch(() => {})`) before returning `null` on a 404. `GitlabContentClient`'s `call()` — the shared plumbing behind `searchBranches`, `readBlob`, `readFileAtRef`, `listTree`, and every other content read — did not, leaking the connection's readable stream on every 404 (a routine, expected response for "file/branch does not exist at this ref"). Under load this holds sockets open longer than necessary against GitLab, same failure class as the two prior PRs.

**Fix**: drain the body before returning `null`, matching the sibling clients exactly.

**Verify**: `bun test apps/api/src/git-providers/gitlab/content.test.ts` (48 pass, unchanged — this is a body-draining side effect, not a behavior change: every caller already treats a `null` return as "not found" and never reads the body afterward).

Checks run locally: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/git-providers/gitlab/content.ts` (0 errors/warnings), targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drains the GitLab 404 response body before discarding in `GitlabContentClient.call()`, so content reads no longer leak the connection's readable stream on routine "not found" responses. Sibling clients (`GitlabProviderClient.get()` and `GitlabChangeRequestsClient.call()`) already do this; behavior is unchanged since callers treat a `null` return as not found and never read the body afterward.

**Verification**
- `bun test apps/api/src/git-providers/gitlab/content.test.ts` passes (48 tests).
- `bun run fmt`, `bunx tsc --noEmit` in `apps/api`, and `bunx oxlint` on the changed file report no issues.

<sup>Written for commit c4ee822ca4e0228055fd7e8f25f40363ef729b1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

