### PR TITLE
fix(sandbox): drain discarded GitHub response bodies in runtime detection

### DIFF
--- a/apps/api/src/shared/github-runtime-detect.ts
+++ b/apps/api/src/shared/github-runtime-detect.ts
@@ -130,7 +130,10 @@ async function fetchGithubFile(
       headers,
       signal: AbortSignal.timeout(5_000),
     });
-    if (!res.ok) return null;
+    if (!res.ok) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
     const body = (await res.json()) as {
       content?: string;
       encoding?: string;


### PR DESCRIPTION
Follows #7109/#7087/#7104, which fixed the same undrained-body class in the GitHub provider client, `GITHUB_LIST_USER_ORGS`, and the file-storage tarball fetch. `github-runtime-detect.ts`'s `fetchGithubFile` had the identical gap.

`probeRuntime` (called from `SANDBOX_START`'s runtime detection) fires up to 8 parallel GitHub Contents API requests per repo — one per candidate lockfile path (`deno.json`, `bun.lock`, `pnpm-lock.yaml`, `package.json`, etc.) plus the port-source files. Only one of those paths actually exists in a given repo, so on every other one GitHub answers 404 and `fetchGithubFile` returned `null` immediately without draining `res.body`. Because `probeRuntime` runs the fetches with `Promise.all`, this leaves several unread response bodies per sandbox start, holding the underlying connections open longer than necessary under Bun's fetch implementation — the same connection-hygiene issue the sibling PRs fixed.

**Fix**: drain the body (`await res.body?.cancel().catch(() => {})`) before returning `null` on the `!res.ok` path, matching the pattern already used everywhere else in `apps/api/src/git-providers/github/`.

Behavior is unchanged — same early return, same fallback to clone-only on any non-2xx response — this only ensures the body is released.

**Verify**: `cd apps/api && bunx tsc --noEmit` (clean) and `bunx oxlint apps/api/src/shared/github-runtime-detect.ts` (0 warnings/errors). No test added — this is a pure resource-drain fix with no behavior change, same as #7109/#7087/#7104 which also shipped without new tests; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drains discarded GitHub response bodies during sandbox runtime detection so unread 404 bodies don't hold connections open. `fetchGithubFile` now cancels the body before returning `null` on non-OK responses, matching the pattern used elsewhere in the GitHub provider. Behavior is unchanged: failed probes still fall back to clone-only.

<sup>Written for commit 3e2928b07ab00a872d4525256e7e43e04fe9edad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

