### PR TITLE
perf(connections): skip secret decryption in COLLECTION_CONNECTIONS_CREATE's existence checks

### DIFF
--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -335,6 +335,31 @@ export class ConnectionStorage implements ConnectionStoragePort {
     return row ? this.deserializeConnection(row as RawConnectionRow) : null;
   }
 
+  /**
+   * Organization id for an existence/ownership check — skips findById()'s
+   * secret decryption, which callers checking only `organization_id` don't need.
+   */
+  async findOrganizationIdById(id: string): Promise<string | null> {
+    const row = await this.db
+      .selectFrom("connections")
+      .select("organization_id")
+      .where("id", "=", id)
+      .executeTakeFirst();
+    return row?.organization_id ?? null;
+  }
+
+  /** Boolean form of `findBySanitizedId`, for callers that only need the collision check. */
+  async sanitizedIdCollisionExists(id: string): Promise<boolean> {
+    const sanitized = id.replace(/-/g, "_");
+    const row = await this.db
+      .selectFrom("connections")
+      .select("id")
+      .where(sql<string>`replace(id, '-', '_')`, "=", sanitized)
+      .where("id", "!=", id)
+      .executeTakeFirst();
+    return row !== undefined;
+  }
+
   async list(
     organizationId: string,
     options?: {

--- a/apps/api/src/storage/ports.ts
+++ b/apps/api/src/storage/ports.ts
@@ -308,6 +308,10 @@ export interface ConnectionStoragePort {
   findById(id: string): Promise<ConnectionEntity | null>;
   /** See `ConnectionStorage.findBySanitizedId`. */
   findBySanitizedId(id: string): Promise<ConnectionEntity | null>;
+  /** See `ConnectionStorage.findOrganizationIdById`. */
+  findOrganizationIdById(id: string): Promise<string | null>;
+  /** See `ConnectionStorage.sanitizedIdCollisionExists`. */
+  sanitizedIdCollisionExists(id: string): Promise<boolean>;
   list(
     organizationId: string,
     options?: {

--- a/apps/api/src/tools/connection/create.ts
+++ b/apps/api/src/tools/connection/create.ts
@@ -78,16 +78,17 @@ export const COLLECTION_CONNECTIONS_CREATE = defineTool({
     };
 
     if (connectionData.id) {
-      const existing = await ctx.storage.connections.findById(
-        connectionData.id,
-      );
-      if (existing?.organization_id === organization.id) {
+      // Existence/organization checks only — skip findById()'s secret decryption.
+      const existingOrgId =
+        await ctx.storage.connections.findOrganizationIdById(connectionData.id);
+      if (existingOrgId === organization.id) {
         throw new Error("Connection already exists in organization");
       }
       // Would collide with another connection's DATABASES_RUN_SQL schema/role — see findBySanitizedId.
-      const collision = await ctx.storage.connections.findBySanitizedId(
-        connectionData.id,
-      );
+      const collision =
+        await ctx.storage.connections.sanitizedIdCollisionExists(
+          connectionData.id,
+        );
       if (collision) {
         throw new Error(
           "Connection id conflicts with an existing connection's isolated database schema",


### PR DESCRIPTION
Reduction/optimization, not tied to a specific issue.

Why: `COLLECTION_CONNECTIONS_CREATE`'s explicit-id path calls `findById()` and `findBySanitizedId()` purely to check `organization_id` / existence — both go through `deserializeConnection()`, which vault-decrypts `connection_token`, `oauth_config`, `configuration_state`, and any STDIO `envVars` on every call. This is the exact pattern `ConnectionStorage.create()` itself already avoids one path down (see its own `// Skip findById() here` comment) and `update()` avoids for its slug merge — the tool handler just hadn't picked it up.

Change: added two non-decrypting lookups to `ConnectionStorage` (`findOrganizationIdById`, `sanitizedIdCollisionExists`) mirroring the existing lightweight query already inlined in `create()`, and switched the tool handler to use them instead of the full decrypting reads. Behavior is unchanged — both checks only ever read `organization_id`/existence from the result, never any decrypted field.

How a reviewer confirms: `cd apps/api && bunx tsc --noEmit` (green), `bunx oxlint` on the 3 touched files (0 warnings/errors), and a diff read confirming `existing?.organization_id` / `collision` truthiness are preserved 1:1.

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint` on the touched files. This path is covered by `connection-tools.integration.test.ts` / `connection.integration.test.ts`, which need real Postgres — not runnable in this sandbox; full CI validates them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up `COLLECTION_CONNECTIONS_CREATE`'s explicit-id path by skipping secret decryption in its ownership and collision checks.

- Replaces `findById()` and `findBySanitizedId()` calls with the new `findOrganizationIdById` and `sanitizedIdCollisionExists` lookups, which only read `organization_id` and existence.
- Adds both methods to `ConnectionStoragePort`; they mirror the minimal query `create()` already inlines.
- Behavior is unchanged — the checks never read decrypted fields, and the new methods return the same values.

<sup>Written for commit da9d38d0ba44fe61ae48a49fb0c114e2f88c654a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

