### PR TITLE
fix(github): surface GitHub's real error body in GITHUB_LIST_USER_ORGS

### DIFF
--- a/apps/api/src/tools/github/list-user-orgs.ts
+++ b/apps/api/src/tools/github/list-user-orgs.ts
@@ -15,6 +15,7 @@ import {
   recordGithubRateLimit,
 } from "@/observability/github-rate-limit";
 import { USER_BUDGET_OWNER } from "@/git-providers/github/budget-owner";
+import { githubFailure } from "@/git-providers/github/http";
 
 const GITHUB_API = "https://api.github.com";
 /** Matches the content client's per-attempt timeout in `git-providers/content/github.ts`. */
@@ -193,8 +194,7 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
       }
 
       if (!res.ok) {
-        await res.body?.cancel().catch(() => {});
-        throw new Error(`GitHub /user/installations failed: ${res.status}`);
+        throw await githubFailure(res, "list_user_installations");
       }
 
       const data = parseInstallationsBody(await res.text());


### PR DESCRIPTION
**Source**: bug found while auditing recently-touched GitHub-provider files (C3, dropped error detail at a trust boundary).

**Payoff**: `GITHUB_LIST_USER_ORGS`'s installations-listing loop hand-rolled its own `!res.ok` branch: it drained the response body with `res.body?.cancel()` and threw a bare `GitHub /user/installations failed: <status>`, discarding whatever detail GitHub actually sent — e.g. the real reason on a 403 (suspended installation, insufficient scope) or 422. Every other GitHub caller in this codebase (`git-providers/github/client.ts`, `github/http.ts`) already goes through the shared `githubFailure(res, operation)` helper, which reads the body and folds GitHub's own `message` field into the thrown error. This tool was the one holdout with a weaker, duplicate copy.

**Fix**: replace the ad-hoc cancel+generic-throw with `throw await githubFailure(res, "list_user_installations")` — same behavior on success, but a real 403/422/5xx now carries GitHub's actual error text instead of just a status code, which is what a support engineer needs when a user reports "listing my GitHub orgs failed."

**Verify**: `bun test apps/api/src/tools/github/list-user-orgs.test.ts` (existing 3 tests, none assert the old message string, so nothing to invert) plus `cd apps/api && bunx tsc --noEmit` — both green locally. `bunx oxlint apps/api/src/tools/github/list-user-orgs.ts` — 0 warnings/errors. Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces GitHub's actual error message in `GITHUB_LIST_USER_ORGS` failures instead of a bare status code.

**Bug Fixes**
- Replaces the hand-rolled `!res.ok` branch with the shared `githubFailure` helper, matching every other GitHub caller.
- 403/422 and 5xx responses now carry GitHub's reason text (e.g., suspended installation, insufficient scope) in the thrown error.

<sup>Written for commit b9e1a63cc335289bd1badca2b03df37c12e3a2ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

