### PR TITLE
fix(git-providers): drain discarded response bodies in GitHub GraphQL transport

### DIFF
--- a/apps/api/src/git-providers/github/graphql.ts
+++ b/apps/api/src/git-providers/github/graphql.ts
@@ -158,7 +158,10 @@ export async function githubGraphqlRequest<T>(
     if (!refreshed) throw new Error(args.missingTokenMessage);
     res = await postWithRetry(refreshed);
     spentToken = refreshed;
-    if (res.status === 401) throw new Error(args.missingTokenMessage);
+    if (res.status === 401) {
+      await res.body?.cancel().catch(() => {});
+      throw new Error(args.missingTokenMessage);
+    }
   }
 
   const installation = budgetOwnerFor(spentToken);
@@ -179,6 +182,7 @@ export async function githubGraphqlRequest<T>(
       kind,
     });
     const waitMs = githubRetryAfterMs(res.headers);
+    await res.body?.cancel().catch(() => {});
     throw new Error(
       `GitHub ${kind} rate limit reached${
         waitMs === null ? "" : `; retry in ${Math.ceil(waitMs / 1000)}s`
@@ -187,6 +191,7 @@ export async function githubGraphqlRequest<T>(
   }
 
   if (!res.ok) {
+    await res.body?.cancel().catch(() => {});
     throw new Error(`GitHub GraphQL ${args.label} failed: ${res.status}`);
   }
 


### PR DESCRIPTION
**Source**: bug found while auditing recently-touched GitHub-provider files (C3, established "drain a discarded body before discarding/retrying" lane — see #6887, #7067, #7091, #7104, #7109, #7112, #7113).

**Payoff**: `githubGraphqlRequest` (`apps/api/src/git-providers/github/graphql.ts`) already drains the *first* 401's body before refreshing the token, but three sibling discard points in the same function throw straight past an unread body: the second 401 (after the one refresh attempt), the rate-limit refusal, and the final `!res.ok` fallback. On Node/undici, not consuming a response body keeps its socket held instead of released back to the connection pool — the same class of leak this codebase has fixed repeatedly for GitHub/GitLab/sandbox HTTP clients (`client.ts`, `http.ts`, `content.ts`). This transport backs every GraphQL-driven git-provider read (PR/change-request lookups etc.), so a string of rate-limited or expired-token calls would leak a connection each time.

**Fix**: add `await res.body?.cancel().catch(() => {})` at each of the three throw sites, matching the pattern already used one line above for the first 401 and matching every other GitHub transport in the repo. No behavior change on the happy path.

**Verify**: `cd apps/api && bunx tsc --noEmit` — green. `bun test apps/api/src/git-providers/github/graphql.test.ts` (existing 12 tests) — green; no new test added because `githubGraphqlRequest` isn't unit-testable without mocking global `fetch`, which belongs in e2e per this repo's testing tiers, and no e2e harness runs GraphQL against a real GitHub token in CI. `bunx oxlint apps/api/src/git-providers/github/graphql.ts` — 0 warnings/errors. Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drains discarded response bodies in the GitHub GraphQL transport before throwing on a second 401, a rate-limit refusal, or a non-2xx fallback. Previously these three paths left the body unread, keeping the undici connection out of the pool and leaking a connection per call under rate limits or expired tokens; the first 401 already drained the body. No behavior change on the happy path.

<sup>Written for commit d2579b9a09fd541b321ebc99fd44f294d4627a54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

