### PR TITLE
fix(git): guide GitHub setup and show who connected each account

### DIFF
--- a/apps/api/migrations/208-github-connect-flows.ts
+++ b/apps/api/migrations/208-github-connect-flows.ts
@@ -1,0 +1,19 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE github_connect_flows (
+      id text PRIMARY KEY,
+      organization_id text NOT NULL REFERENCES organization(id) ON DELETE CASCADE,
+      user_id text NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+      encrypted_access_token text NOT NULL,
+      expires_at timestamptz NOT NULL
+    );
+    CREATE UNIQUE INDEX github_connect_flows_owner ON github_connect_flows(organization_id, user_id);
+    CREATE INDEX github_connect_flows_expiry ON github_connect_flows(expires_at);
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("github_connect_flows").execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -1,3 +1,4 @@
+import * as migration208githubconnectflows from "./208-github-connect-flows";
 import * as migration207taskboardprsrepoidx from "./207-task-board-prs-repo-idx";
 import * as migration206repositoryconsumers from "./206-repository-consumers";
 import { type Migration } from "kysely";
@@ -448,6 +449,7 @@ const migrations: Record<string, Migration> = {
   "205-repository-references": migration205repositoryreferences,
   "206-repository-consumers": migration206repositoryconsumers,
   "207-task-board-prs-repo-idx": migration207taskboardprsrepoidx,
+  "208-github-connect-flows": migration208githubconnectflows,
 };
 
 export default migrations;

--- a/apps/api/src/api/routes/git-providers.test.ts
+++ b/apps/api/src/api/routes/git-providers.test.ts
@@ -26,5 +26,8 @@ describe("sanitizeReturnTo", () => {
     expect(sanitizeReturnTo("\\\\evil.example")).toBe("/");
     expect(sanitizeReturnTo("javascript:alert(1)")).toBe("/");
     expect(sanitizeReturnTo("acme/settings")).toBe("/");
+    for (const control of ["\r", "\n", "\t"]) {
+      expect(sanitizeReturnTo(`/${control}/evil.example/steal`)).toBe("/");
+    }
   });
 });

--- a/apps/api/src/api/routes/git-providers.ts
+++ b/apps/api/src/api/routes/git-providers.ts
@@ -12,9 +12,9 @@
  *   and the callback insists the session user is the state's user.
  *
  * GitHub: user-to-server OAuth is used ONLY to prove which App installations
- * the user can see (`GET /user/installations`); one account row is upserted per
- * installation and the user token is then discarded. Everything afterwards is
- * minted from the App private key.
+ * the user can see (`GET /user/installations`). An encrypted, ten-minute grant
+ * lets the user select an installation or install the App in another tab. The
+ * grant is deleted after selection; saved accounts use the App private key.
  *
  * GitLab: standard OAuth with a refreshable grant stored on the account.
  *
@@ -23,6 +23,7 @@
  */
 
 import { Hono } from "hono";
+import { z } from "zod";
 import { ContextFactory } from "@/core/context-factory";
 import type { StudioContext } from "@/core/studio-context";
 import { getPublicUrl } from "@/core/server-constants";
@@ -45,7 +46,12 @@ import type { Env } from "../hono-env";
 /** Only a same-origin path is an acceptable post-flow destination. */
 export function sanitizeReturnTo(raw: string | undefined | null): string {
   if (!raw) return "/";
-  if (!raw.startsWith("/") || raw.startsWith("//") || raw.includes("\\")) {
+  if (
+    !raw.startsWith("/") ||
+    raw.startsWith("//") ||
+    raw.includes("\\") ||
+    /[\r\n\t]/.test(raw)
+  ) {
     return "/";
   }
   return raw;
@@ -58,6 +64,7 @@ function callbackUrl(provider: "github" | "gitlab"): string {
 /** Where the browser lands after the flow, with an optional error code. */
 function finish(returnTo: string, error?: string): string {
   const url = new URL(returnTo, getPublicUrl());
+  url.searchParams.delete("git_error");
   if (error) url.searchParams.set("git_error", error);
   return url.toString();
 }
@@ -83,10 +90,11 @@ async function mintState(
 export const createGitProviderRoutes = () => {
   const app = new Hono<Env>();
 
-  /** Prove installation access via user OAuth, then record each installation. */
+  /** Prove installation access via user OAuth, then let the user choose one. */
   app.get("/git-providers/github/connect", async (c) => {
     const ctx = c.get("studioContext");
     if (!ctx.auth.user) return c.json({ error: "Unauthorized" }, 401);
+    await ctx.access.check("GIT_ACCOUNT_CONNECT_TOKEN");
     const config = readGithubAppConfig();
     if (!config) {
       return c.json({ error: "GitHub App is not configured" }, 503);
@@ -114,6 +122,7 @@ export const createGitProviderRoutes = () => {
   app.get("/git-providers/github/install", async (c) => {
     const ctx = c.get("studioContext");
     if (!ctx.auth.user) return c.json({ error: "Unauthorized" }, 401);
+    await ctx.access.check("GIT_ACCOUNT_CONNECT_TOKEN");
     const config = readGithubAppConfig();
     if (!config) {
       return c.json({ error: "GitHub App is not configured" }, 503);
@@ -128,6 +137,120 @@ export const createGitProviderRoutes = () => {
     );
     url.searchParams.set("state", state);
     return c.redirect(url.toString());
+  });
+
+  app.get("/git-providers/github/flows/:id", async (c) => {
+    const ctx = c.get("studioContext");
+    if (!ctx.auth.user || !ctx.organization)
+      return c.json({ error: "Unauthorized" }, 401);
+    await ctx.access.check("GIT_ACCOUNT_CONNECT_TOKEN");
+    c.header("Cache-Control", "no-store");
+    const owner = {
+      organizationId: ctx.organization.id,
+      userId: ctx.auth.user.id,
+    };
+    const flow = await ctx.storage.githubConnectFlows.get(
+      c.req.param("id"),
+      owner,
+    );
+    if (!flow) return c.json({ error: "flow_expired" }, 410);
+    const appAuth = getGithubAppAuth();
+    if (!appAuth) return c.json({ error: "not_configured" }, 503);
+    try {
+      const installations = await appAuth.listUserInstallations(
+        await ctx.vault.decrypt(flow.encrypted_access_token),
+      );
+      return c.json({ installations, expiresAt: flow.expires_at });
+    } catch {
+      return c.json({ error: "github_unavailable" }, 502);
+    }
+  });
+
+  app.post("/git-providers/github/flows/:id", async (c) => {
+    const ctx = c.get("studioContext");
+    if (!ctx.auth.user || !ctx.organization)
+      return c.json({ error: "Unauthorized" }, 401);
+    await ctx.access.check("GIT_ACCOUNT_CONNECT_TOKEN");
+    c.header("Cache-Control", "no-store");
+    if (!c.req.header("Content-Type")?.startsWith("application/json"))
+      return c.json({ error: "Invalid content type" }, 415);
+    const input = z
+      .object({ installationId: z.number().int().positive().safe() })
+      .safeParse(await c.req.json().catch(() => null));
+    if (!input.success) return c.json({ error: "Invalid installation" }, 400);
+    const owner = {
+      organizationId: ctx.organization.id,
+      userId: ctx.auth.user.id,
+    };
+    const flow = await ctx.storage.githubConnectFlows.get(
+      c.req.param("id"),
+      owner,
+    );
+    if (!flow) return c.json({ error: "flow_expired" }, 410);
+    const appAuth = getGithubAppAuth();
+    if (!appAuth) return c.json({ error: "not_configured" }, 503);
+    let installations;
+    try {
+      installations = await appAuth.listUserInstallations(
+        await ctx.vault.decrypt(flow.encrypted_access_token),
+      );
+    } catch {
+      return c.json({ error: "github_unavailable" }, 502);
+    }
+    const installation = installations.find(
+      (item) => item.installationId === input.data.installationId,
+    );
+    if (!installation) return c.json({ error: "installation_forbidden" }, 403);
+    const account = await ctx.storage.githubConnectFlows.connect(
+      c.req.param("id"),
+      owner,
+      {
+        organizationId: owner.organizationId,
+        type: "github",
+        host: "github.com",
+        authKind: "github_app",
+        externalAccountId: String(installation.installationId),
+        login: installation.login,
+        avatarUrl: installation.avatarUrl,
+        installationId: installation.installationId,
+      },
+    );
+    if (!account) return c.json({ error: "flow_expired" }, 410);
+    return c.json({ account: { id: account.id, login: account.login } });
+  });
+
+  app.delete("/git-providers/github/flows/:id", async (c) => {
+    const ctx = c.get("studioContext");
+    if (!ctx.auth.user || !ctx.organization)
+      return c.json({ error: "Unauthorized" }, 401);
+    await ctx.access.check("GIT_ACCOUNT_CONNECT_TOKEN");
+    await ctx.storage.githubConnectFlows.cancel(c.req.param("id"), {
+      organizationId: ctx.organization.id,
+      userId: ctx.auth.user.id,
+    });
+    return c.body(null, 204);
+  });
+
+  app.get("/git-providers/github/accounts/:id/manage", async (c) => {
+    const ctx = c.get("studioContext");
+    if (!ctx.auth.user || !ctx.organization)
+      return c.json({ error: "Unauthorized" }, 401);
+    await ctx.access.check("GIT_ACCOUNT_CONNECT_TOKEN");
+    const account = await ctx.storage.gitProviderAccounts.get(
+      c.req.param("id"),
+      ctx.organization.id,
+    );
+    if (!account || account.type !== "github" || !account.installationId)
+      return c.json({ error: "Account not found" }, 404);
+    const appAuth = getGithubAppAuth();
+    if (!appAuth) return c.json({ error: "not_configured" }, 503);
+    const installation = await appAuth.getInstallation(account.installationId);
+    if (!installation) return c.json({ error: "Installation not found" }, 404);
+    const path =
+      installation.accountType === "Organization"
+        ? `/organizations/${encodeURIComponent(installation.login)}/settings/installations/${installation.installationId}`
+        : `/settings/installations/${installation.installationId}`;
+    return c.redirect(`https://github.com${path}`);
   });
 
   app.get("/git-providers/gitlab/connect", async (c) => {
@@ -212,28 +335,25 @@ gitProviderCallbackRoutes.get("/github/callback", async (c) => {
       code,
       redirectUri: callbackUrl("github"),
     });
-    const installations = await appAuth.listUserInstallations(
-      grant.accessToken,
-    );
-    for (const installation of installations) {
-      await ctx.storage.gitProviderAccounts.upsert({
-        organizationId: state.organizationId,
-        type: "github",
-        host: "github.com",
-        authKind: "github_app",
-        externalAccountId: String(installation.installationId),
-        login: installation.login,
-        avatarUrl: installation.avatarUrl,
-        installationId: installation.installationId,
-        createdBy: state.userId,
-      });
-    }
-    return c.redirect(
-      finish(
-        returnTo,
-        installations.length === 0 ? "no_installations" : undefined,
-      ),
-    );
+    const owner = {
+      organizationId: state.organizationId,
+      userId: state.userId,
+    };
+    const destination = new URL(returnTo, getPublicUrl());
+    const previous = destination.searchParams.get("git_flow");
+    const encryptedToken = await ctx.vault.encrypt(grant.accessToken);
+    const flowId =
+      previous &&
+      (await ctx.storage.githubConnectFlows.refresh(
+        previous,
+        owner,
+        encryptedToken,
+      ))
+        ? previous
+        : await ctx.storage.githubConnectFlows.create(owner, encryptedToken);
+    destination.searchParams.delete("git_error");
+    destination.searchParams.set("git_flow", flowId);
+    return c.redirect(destination.toString());
   } catch (error) {
     console.error("[git-providers] github callback failed", {
       message: error instanceof Error ? error.message : String(error),
@@ -245,7 +365,7 @@ gitProviderCallbackRoutes.get("/github/callback", async (c) => {
 /**
  * GitHub App "Setup URL": reached after the user installs/updates the App.
  * The installation id in the query is unauthenticated, so it is NOT trusted —
- * we bounce straight into the OAuth proof, which records whatever
+ * we bounce straight into the OAuth proof, which lists only
  * installations the user can actually see.
  */
 gitProviderCallbackRoutes.get("/github/setup", async (c) => {

--- a/apps/api/src/core/context-factory.ts
+++ b/apps/api/src/core/context-factory.ts
@@ -532,6 +532,7 @@ import { OrgRepoSyncStorage } from "@/storage/org-repo-syncs";
 import { GitProviderAccountStorage } from "@/storage/git-provider-accounts";
 import { GitProviderAccountCredentialStorage } from "@/storage/git-provider-account-credentials";
 import { RepositoryStorage } from "@/storage/repositories";
+import { GithubConnectFlowStorage } from "@/storage/github-connect-flows";
 import { GitProviderOAuthStateStorage } from "@/storage/git-provider-oauth-states";
 import { JiraIntegrationStorage } from "@/storage/jira-integrations";
 import { ColumnAutomationStorage } from "@/storage/task-board-column-automations";
@@ -1479,6 +1480,7 @@ export async function createStudioContextFactory(
       vault,
     ),
     gitProviderOAuthStates: new GitProviderOAuthStateStorage(config.db),
+    githubConnectFlows: new GithubConnectFlowStorage(config.db),
     repositories: new RepositoryStorage(config.db),
     jiraIntegrations: new JiraIntegrationStorage(config.db, vault),
     taskBoard: new TaskBoardStorage(config.db),

--- a/apps/api/src/core/studio-context.test.ts
+++ b/apps/api/src/core/studio-context.test.ts
@@ -26,6 +26,7 @@ const createMockContext = (
     gitProviderAccounts: null as never,
     gitProviderAccountCredentials: null as never,
     gitProviderOAuthStates: null as never,
+    githubConnectFlows: null as never,
     repositories: null as never,
     userModelPreferences: null as never,
     monitoring: null as never,

--- a/apps/api/src/core/studio-context.ts
+++ b/apps/api/src/core/studio-context.ts
@@ -309,6 +309,7 @@ import { OrgRepoSyncStorage } from "@/storage/org-repo-syncs";
 import type { GitProviderAccountStorage } from "@/storage/git-provider-accounts";
 import type { GitProviderAccountCredentialStorage } from "@/storage/git-provider-account-credentials";
 import type { RepositoryStorage } from "@/storage/repositories";
+import type { GithubConnectFlowStorage } from "@/storage/github-connect-flows";
 import type { GitProviderOAuthStateStorage } from "@/storage/git-provider-oauth-states";
 import { JiraIntegrationStorage } from "@/storage/jira-integrations";
 import { ColumnAutomationStorage } from "@/storage/task-board-column-automations";
@@ -359,6 +360,7 @@ export interface StudioStorage {
   gitProviderAccounts: GitProviderAccountStorage;
   gitProviderAccountCredentials: GitProviderAccountCredentialStorage;
   gitProviderOAuthStates: GitProviderOAuthStateStorage;
+  githubConnectFlows: GithubConnectFlowStorage;
   repositories: RepositoryStorage;
   jiraIntegrations: JiraIntegrationStorage;
   taskBoard: TaskBoardStorage;

--- a/apps/api/src/git-providers/github/app-auth.ts
+++ b/apps/api/src/git-providers/github/app-auth.ts
@@ -21,6 +21,7 @@ import { type GithubAppConfig, readGithubAppConfig } from "./env";
 import type { GitProviderCapability } from "../types";
 import { GitProviderError } from "../types";
 import {
+  githubApiBaseUrl,
   githubErrorMessage,
   githubFailure,
   githubFailureFromBody,
@@ -416,7 +417,11 @@ export function getGithubAppAuth(): GithubAppAuth | null {
   if (appAuthSingleton === undefined) {
     const config = readGithubAppConfig();
     appAuthSingleton =
-      config && usableAppKey(config) ? new GithubAppAuth(config) : null;
+      config && usableAppKey(config)
+        ? new GithubAppAuth(config, {
+            apiBaseUrl: githubApiBaseUrl("github.com"),
+          })
+        : null;
   }
   return appAuthSingleton;
 }

--- a/apps/api/src/git-providers/github/oauth.ts
+++ b/apps/api/src/git-providers/github/oauth.ts
@@ -106,7 +106,10 @@ export async function exchangeGithubCode(params: {
 }): Promise<GithubOAuthTokens> {
   let res: Response;
   try {
-    res = await fetch(GITHUB_OAUTH_TOKEN_URL, {
+    // Keep the code exchange on the external HTTP fixture in end-to-end tests.
+    const tokenUrl =
+      process.env.GITHUB_OAUTH_TOKEN_URL ?? GITHUB_OAUTH_TOKEN_URL;
+    res = await fetch(tokenUrl, {
       method: "POST",
       headers: {
         Accept: "application/json",

--- a/apps/api/src/storage/git-provider-accounts.ts
+++ b/apps/api/src/storage/git-provider-accounts.ts
@@ -29,6 +29,7 @@ type Row = {
   credential_connection_id: string | null;
   status: "active" | "revoked";
   created_by: string | null;
+  connected_by_name?: string | null;
   created_at: Date | string;
   updated_at: Date | string;
 };
@@ -36,6 +37,7 @@ type Row = {
 /** Entity plus the server-only bridge to a legacy `mcp-github` connection. */
 export interface GitProviderAccountRecord extends GitProviderAccount {
   credentialConnectionId: string | null;
+  connectedBy: { name: string } | null;
 }
 
 function toEntity(row: Row): GitProviderAccountRecord {
@@ -55,6 +57,7 @@ function toEntity(row: Row): GitProviderAccountRecord {
     installationId: Number.isFinite(installationId) ? installationId : null,
     status: row.status,
     credentialConnectionId: row.credential_connection_id,
+    connectedBy: row.connected_by_name ? { name: row.connected_by_name } : null,
     createdAt: toIso(row.created_at),
     updatedAt: toIso(row.updated_at),
   };
@@ -145,11 +148,17 @@ export class GitProviderAccountStorage {
   async listByOrg(organizationId: string): Promise<GitProviderAccountRecord[]> {
     const rows = await this.db
       .selectFrom("git_provider_accounts")
-      .selectAll()
-      .where("organization_id", "=", organizationId)
-      .orderBy("created_at", "asc")
+      .leftJoin(
+        "user as connector",
+        "connector.id",
+        "git_provider_accounts.created_by",
+      )
+      .selectAll("git_provider_accounts")
+      .select("connector.name as connected_by_name")
+      .where("git_provider_accounts.organization_id", "=", organizationId)
+      .orderBy("git_provider_accounts.created_at", "asc")
       .execute();
-    return (rows as Row[]).map(toEntity);
+    return rows.map(toEntity);
   }
 
   async findByExternalId(params: {

--- a/apps/api/src/storage/github-connect-flows.ts
+++ b/apps/api/src/storage/github-connect-flows.ts
@@ -1,0 +1,108 @@
+import type { Kysely } from "kysely";
+import type { Database } from "./types";
+import {
+  GitProviderAccountStorage,
+  type UpsertGitProviderAccountParams,
+} from "./git-provider-accounts";
+
+type FlowOwner = { organizationId: string; userId: string };
+
+/** Short-lived, encrypted user grants used only while choosing an installation. */
+export class GithubConnectFlowStorage {
+  constructor(private readonly db: Kysely<Database>) {}
+
+  async create(
+    owner: FlowOwner,
+    encryptedAccessToken: string,
+  ): Promise<string> {
+    await this.db
+      .deleteFrom("github_connect_flows")
+      .where("expires_at", "<=", new Date())
+      .execute();
+    // Keep at most one pending flow per user/workspace, including abandoned tabs.
+    return this.db.transaction().execute(async (trx) => {
+      await trx
+        .selectFrom("organization")
+        .select("id")
+        .where("id", "=", owner.organizationId)
+        .forUpdate()
+        .executeTakeFirstOrThrow();
+      await trx
+        .deleteFrom("github_connect_flows")
+        .where("organization_id", "=", owner.organizationId)
+        .where("user_id", "=", owner.userId)
+        .execute();
+      const id = crypto.randomUUID();
+      await trx
+        .insertInto("github_connect_flows")
+        .values({
+          id,
+          organization_id: owner.organizationId,
+          user_id: owner.userId,
+          encrypted_access_token: encryptedAccessToken,
+          expires_at: new Date(Date.now() + 10 * 60_000),
+        })
+        .execute();
+      return id;
+    });
+  }
+
+  async get(id: string, owner: FlowOwner) {
+    return this.db
+      .selectFrom("github_connect_flows")
+      .selectAll()
+      .where("id", "=", id)
+      .where("organization_id", "=", owner.organizationId)
+      .where("user_id", "=", owner.userId)
+      .where("expires_at", ">", new Date())
+      .executeTakeFirst();
+  }
+
+  async refresh(
+    id: string,
+    owner: FlowOwner,
+    encryptedAccessToken: string,
+  ): Promise<boolean> {
+    const result = await this.db
+      .updateTable("github_connect_flows")
+      .set({ encrypted_access_token: encryptedAccessToken })
+      .where("id", "=", id)
+      .where("organization_id", "=", owner.organizationId)
+      .where("user_id", "=", owner.userId)
+      .where("expires_at", ">", new Date())
+      .executeTakeFirst();
+    return result.numUpdatedRows > 0n;
+  }
+
+  async cancel(id: string, owner: FlowOwner) {
+    await this.db
+      .deleteFrom("github_connect_flows")
+      .where("id", "=", id)
+      .where("organization_id", "=", owner.organizationId)
+      .where("user_id", "=", owner.userId)
+      .execute();
+  }
+
+  async connect(
+    id: string,
+    owner: FlowOwner,
+    account: UpsertGitProviderAccountParams,
+  ) {
+    return this.db.transaction().execute(async (trx) => {
+      const flow = await trx
+        .deleteFrom("github_connect_flows")
+        .where("id", "=", id)
+        .where("organization_id", "=", owner.organizationId)
+        .where("user_id", "=", owner.userId)
+        .where("expires_at", ">", new Date())
+        .returning("id")
+        .executeTakeFirst();
+      if (!flow) return null;
+      return new GitProviderAccountStorage(trx).upsert({
+        ...account,
+        organizationId: owner.organizationId,
+        createdBy: owner.userId,
+      });
+    });
+  }
+}

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -2421,6 +2421,13 @@ export interface Database extends PrivateRegistryDatabase {
   git_provider_accounts: GitProviderAccountTable;
   git_provider_account_credentials: GitProviderAccountCredentialTable;
   git_provider_oauth_states: GitProviderOAuthStateTable;
+  github_connect_flows: {
+    id: string;
+    organization_id: string;
+    user_id: string;
+    encrypted_access_token: string;
+    expires_at: ColumnType<Date, Date, never>;
+  };
   repositories: RepositoryTable;
   task_board_items: TaskBoardItemTable;
   task_board_column_automations: TaskBoardColumnAutomationTable;

--- a/apps/api/src/tools/connection/connection-tools.integration.test.ts
+++ b/apps/api/src/tools/connection/connection-tools.integration.test.ts
@@ -117,6 +117,7 @@ describe("Connection Tools", () => {
         orgRepoSyncs: null as never,
         gitProviderAccounts: null as never,
         gitProviderAccountCredentials: null as never,
+        githubConnectFlows: null as never,
         gitProviderOAuthStates: null as never,
         repositories: null as never,
         jiraIntegrations: null as never,

--- a/apps/api/src/tools/git/index.ts
+++ b/apps/api/src/tools/git/index.ts
@@ -47,6 +47,7 @@ const RepoSummarySchema = z.object({
 const AccountOutputSchema = GitProviderAccountSchema.extend({
   /** False for a backfilled GitHub account this deployment cannot mint for yet. */
   servable: z.boolean(),
+  connectedBy: z.object({ name: z.string() }).nullable(),
 });
 
 function toAccountOutput(

--- a/apps/web/src/components/git-account-connect.tsx
+++ b/apps/web/src/components/git-account-connect.tsx
@@ -247,7 +247,7 @@ function ConnectActions({
     >
       <ConnectAction
         layout={layout}
-        label={t("settings.repositories.connectGithub")}
+        label={t("settings.repositories.addGithubAccount")}
         description={t(
           githubConfigured
             ? "settings.repositories.browseAccount"
@@ -257,16 +257,6 @@ function ConnectActions({
         href={github?.connectPath ? connectUrl(github.connectPath) : undefined}
         disabled={disabled || !githubConfigured || !github?.connectPath}
       />
-      {githubConfigured && github?.installPath && (
-        <ConnectAction
-          layout={layout}
-          label={t("settings.repositories.manageGithub")}
-          description={t("settings.repositories.manageGithubHint")}
-          icon={<GitHubIcon size={16} />}
-          href={connectUrl(github.installPath)}
-          disabled={disabled}
-        />
-      )}
       {gitlabConfigured && gitlab?.connectPath && (
         <ConnectAction
           layout={layout}

--- a/apps/web/src/components/github-connect-dialog.tsx
+++ b/apps/web/src/components/github-connect-dialog.tsx
@@ -1,0 +1,250 @@
+import { useSyncExternalStore } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
+import { ArrowRight, LinkExternal01, RefreshCw01 } from "@untitledui/icons";
+import { toast } from "sonner";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@decocms/ui/components/dialog.tsx";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
+import { GitHubIcon } from "@/components/icons/github-icon";
+import { useGitProviderCapabilities } from "@/hooks/use-git-providers";
+import { KEYS } from "@/lib/query-keys";
+import { useProjectContext } from "@/sdk";
+import { useT } from "@/i18n/use-t";
+
+const flowSchema = z.object({
+  installations: z.array(
+    z.object({
+      installationId: z.number(),
+      login: z.string(),
+      avatarUrl: z.string().nullable(),
+    }),
+  ),
+});
+
+class FlowError extends Error {
+  constructor(readonly status: number) {
+    super("GitHub connection request failed");
+  }
+}
+
+async function requestFlow(url: string, init?: RequestInit) {
+  const response = await fetch(url, init);
+  if (!response.ok) throw new FlowError(response.status);
+  return response;
+}
+
+const getSnapshot = () => null;
+
+function broadcast(name: string, message: string) {
+  const channel = new BroadcastChannel(name);
+  channel.postMessage(message);
+  channel.close();
+}
+
+export function GithubConnectDialog({
+  flowId,
+  returning,
+  onClose,
+}: {
+  flowId: string;
+  returning: boolean;
+  onClose: () => void;
+}) {
+  const t = useT();
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+  const capabilities = useGitProviderCapabilities();
+  const path = `/api/${encodeURIComponent(org.slug)}/git-providers/github/flows/${encodeURIComponent(flowId)}`;
+  const channelName = `github-connect:${org.id}:${flowId}`;
+  const flow = useQuery({
+    queryKey: KEYS.githubConnectFlow(org.id, flowId),
+    queryFn: async () =>
+      flowSchema.parse(await (await requestFlow(path)).json()),
+    retry: false,
+    gcTime: 0,
+    refetchOnWindowFocus: "always",
+  });
+
+  function finish() {
+    void queryClient.invalidateQueries({ queryKey: KEYS.gitAccounts(org.id) });
+    void queryClient.invalidateQueries({ queryKey: KEYS.repositories(org.id) });
+    onClose();
+  }
+
+  // The setup tab announces its return. Only close it after the original tab
+  // acknowledges receipt; a standalone return still has a usable picker.
+  useSyncExternalStore(
+    () => {
+      const channel = new BroadcastChannel(channelName);
+      // Separate GitHub windows can leave this document visible while unfocused.
+      const refresh = () => {
+        if (!returning) void flow.refetch({ cancelRefetch: false });
+      };
+      window.addEventListener("focus", refresh);
+      channel.onmessage = (event: MessageEvent<unknown>) => {
+        if (event.data === "refresh" && !returning) {
+          void flow.refetch();
+          channel.postMessage("ack");
+        } else if (event.data === "ack" && returning) {
+          window.close();
+        } else if (event.data === "complete") {
+          finish();
+        }
+      };
+      if (returning) channel.postMessage("refresh");
+      return () => {
+        window.removeEventListener("focus", refresh);
+        channel.close();
+      };
+    },
+    getSnapshot,
+    getSnapshot,
+  );
+
+  const connect = useMutation({
+    mutationFn: async (installationId: number) =>
+      requestFlow(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ installationId }),
+      }),
+    onSuccess: () => {
+      broadcast(channelName, "complete");
+      toast.success(t("settings.repositories.githubConnected"));
+      finish();
+    },
+    onError: () => {
+      void flow.refetch();
+      toast.error(t("settings.repositories.oauthFailed"));
+    },
+  });
+  const cancel = useMutation({
+    mutationFn: () => requestFlow(path, { method: "DELETE" }),
+    onSuccess: onClose,
+    onError: () => toast.error(t("settings.repositories.failed")),
+  });
+  const returnTo = `/${org.slug}/settings/repositories?git_flow=${flowId}&git_return=true`;
+  const installPath = capabilities.data?.github.installPath;
+  const installUrl = installPath
+    ? `${installPath}?returnTo=${encodeURIComponent(returnTo)}`
+    : undefined;
+  const connectPath = capabilities.data?.github.connectPath;
+  const restartUrl = connectPath
+    ? `${connectPath}?returnTo=${encodeURIComponent(`/${org.slug}/settings/repositories`)}`
+    : undefined;
+  const expired = flow.error instanceof FlowError && flow.error.status === 410;
+  const busy = connect.isPending || cancel.isPending;
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && !busy) cancel.mutate();
+      }}
+    >
+      <DialogContent className="sm:max-w-lg p-0 gap-0 overflow-hidden">
+        <DialogHeader className="px-4 py-4 border-b border-border">
+          <DialogTitle>
+            {t("settings.repositories.addGithubAccount")}
+          </DialogTitle>
+          <DialogDescription>
+            {t("settings.repositories.githubShareHint", {
+              organization: org.name,
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-80 overflow-y-auto">
+          {flow.isPending ? (
+            <div className="p-4">
+              <Skeleton className="h-20 w-full" />
+            </div>
+          ) : flow.isError ? (
+            <p role="alert" className="p-4 text-sm text-destructive">
+              {t(
+                expired
+                  ? "settings.repositories.oauthExpired"
+                  : "settings.repositories.githubRefreshFailed",
+              )}
+            </p>
+          ) : flow.data.installations.length === 0 ? (
+            <div className="px-4 py-6 text-sm text-muted-foreground">
+              {t("settings.repositories.githubInstallHint")}
+            </div>
+          ) : (
+            flow.data.installations.map((installation) => (
+              <Button
+                key={installation.installationId}
+                variant="ghost"
+                disabled={busy || flow.isFetching}
+                className="w-full h-auto rounded-none justify-start gap-3 px-4 py-3"
+                onClick={() => connect.mutate(installation.installationId)}
+              >
+                <Avatar
+                  url={installation.avatarUrl ?? undefined}
+                  fallback={<GitHubIcon size={16} />}
+                  size="sm"
+                  shape="circle"
+                  muted
+                />
+                <span className="flex-1 text-left truncate">
+                  {installation.login}
+                </span>
+                <ArrowRight size={16} />
+              </Button>
+            ))
+          )}
+        </div>
+        <div className="border-t border-border px-4 py-3 flex flex-wrap gap-2">
+          {!expired && installUrl && (
+            <Button variant="outline" size="sm" asChild disabled={busy}>
+              <a
+                href={busy ? undefined : installUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-disabled={busy}
+              >
+                <LinkExternal01 size={14} />
+                {t("settings.repositories.installGithubAccount")}
+              </a>
+            </Button>
+          )}
+          {!expired && (
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={busy || flow.isFetching}
+              onClick={() => void flow.refetch()}
+            >
+              <RefreshCw01 size={14} />
+              {t("settings.repositories.checkGithubAccess")}
+            </Button>
+          )}
+          {restartUrl && (
+            <Button variant="ghost" size="sm" asChild disabled={busy}>
+              <a href={busy ? undefined : restartUrl} aria-disabled={busy}>
+                {t(
+                  expired
+                    ? "settings.repositories.tryAgain"
+                    : "settings.repositories.switchGithubUser",
+                )}
+              </a>
+            </Button>
+          )}
+        </div>
+        {!expired && (
+          <p className="px-4 pb-4 text-xs text-muted-foreground">
+            {t("settings.repositories.githubReturnHint")}
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -115,12 +115,28 @@ export const settings = {
   "settings.repositories.browseAccount": "Browse repositories in your account.",
   "settings.repositories.gitlabTokenHint":
     "Use a personal, project or group access token.",
-  "settings.repositories.connectGithub": "Connect GitHub",
-  "settings.repositories.manageGithub": "Manage GitHub access",
-  "settings.repositories.manageGithubHint":
-    "Install or configure the app on your GitHub accounts and organizations.",
+  "settings.repositories.addGithubAccount":
+    "Add GitHub account or organization",
+  "settings.repositories.githubShareHint":
+    "Choose an account to share with {organization}. Members with repository permissions in Studio can use this connection.",
+  "settings.repositories.githubInstallHint":
+    "No accounts are available yet. Install the GitHub App on your account or organization, or ask an organization owner to approve access.",
+  "settings.repositories.installGithubAccount": "Install on another account",
+  "settings.repositories.checkGithubAccess": "Check access",
+  "settings.repositories.switchGithubUser": "Use another GitHub login",
+  "settings.repositories.githubReturnHint":
+    "GitHub opens in a new tab. After saving access, return here to choose the account. If it does not appear, use Check access.",
+  "settings.repositories.githubRefreshFailed":
+    "Could not check GitHub access. Try again without leaving this dialog.",
+  "settings.repositories.githubConnected": "GitHub account connected",
+  "settings.repositories.manageRepositoryAccess": "Manage repository access",
+  "settings.repositories.connectedBy": "Connected by {name}",
+  "settings.repositories.connectedByUnknown":
+    "Connected by an unavailable user",
+  "settings.repositories.dismiss": "Dismiss",
+  "settings.repositories.tryAgain": "Try again",
   "settings.repositories.oauthNoInstallations":
-    "GitHub authorization succeeded, but no app installations are available to this user. Use Manage GitHub access to install the app or request access from an organization owner, then connect again.",
+    "GitHub authorization succeeded, but no app installations are available to this user. Add a GitHub account or organization to finish setup.",
   "settings.repositories.oauthDenied":
     "Authorization was cancelled. Connect again when you are ready.",
   "settings.repositories.oauthExpired":

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -120,12 +120,29 @@ export const settings = {
   "settings.repositories.browseAccount": "Busque repositórios da sua conta.",
   "settings.repositories.gitlabTokenHint":
     "Use um token de acesso pessoal, de projeto ou de grupo.",
-  "settings.repositories.connectGithub": "Conectar GitHub",
-  "settings.repositories.manageGithub": "Gerenciar acesso no GitHub",
-  "settings.repositories.manageGithubHint":
-    "Instale ou configure o app nas suas contas e organizações do GitHub.",
+  "settings.repositories.addGithubAccount":
+    "Adicionar conta ou organização do GitHub",
+  "settings.repositories.githubShareHint":
+    "Escolha uma conta para compartilhar com {organization}. Membros com permissão para repositórios no Studio podem usar esta conexão.",
+  "settings.repositories.githubInstallHint":
+    "Nenhuma conta disponível ainda. Instale o app do GitHub na sua conta ou organização, ou peça a um administrador da organização para aprovar o acesso.",
+  "settings.repositories.installGithubAccount": "Instalar em outra conta",
+  "settings.repositories.checkGithubAccess": "Verificar acesso",
+  "settings.repositories.switchGithubUser": "Usar outro login do GitHub",
+  "settings.repositories.githubReturnHint":
+    "O GitHub abre em uma nova aba. Depois de salvar o acesso, volte aqui para escolher a conta. Se ela não aparecer, use Verificar acesso.",
+  "settings.repositories.githubRefreshFailed":
+    "Não foi possível verificar o acesso no GitHub. Tente novamente sem sair desta janela.",
+  "settings.repositories.githubConnected": "Conta do GitHub conectada",
+  "settings.repositories.manageRepositoryAccess":
+    "Gerenciar acesso aos repositórios",
+  "settings.repositories.connectedBy": "Conectado por {name}",
+  "settings.repositories.connectedByUnknown":
+    "Conectado por um usuário indisponível",
+  "settings.repositories.dismiss": "Dispensar",
+  "settings.repositories.tryAgain": "Tentar novamente",
   "settings.repositories.oauthNoInstallations":
-    "A autorização no GitHub foi concluída, mas nenhuma instalação do app está disponível para este usuário. Use Gerenciar acesso no GitHub para instalar o app ou solicitar acesso a um administrador da organização. Depois, conecte novamente.",
+    "A autorização no GitHub foi concluída, mas nenhuma instalação do app está disponível para este usuário. Adicione uma conta ou organização do GitHub para concluir a configuração.",
   "settings.repositories.oauthDenied":
     "A autorização foi cancelada. Conecte novamente quando quiser.",
   "settings.repositories.oauthExpired":

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -562,6 +562,8 @@ export const KEYS = {
   // First-class git repositories (Settings → Repositories)
   gitProviderCapabilities: (orgId: string) =>
     ["git-provider-capabilities", orgId] as const,
+  githubConnectFlow: (orgId: string, flowId: string) =>
+    ["github-connect-flow", orgId, flowId] as const,
   gitAccounts: (orgId: string) => ["git-accounts", orgId] as const,
   /** Omit `accountId` for the whole org's list — that key is also the prefix a
    *  mutation invalidates to refresh every per-account listing with it. */

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -917,6 +917,8 @@ const settingsRepositoriesRoute = createRoute({
   path: "/repositories",
   validateSearch: z.object({
     git_error: z.string().optional().catch(undefined),
+    git_flow: z.string().uuid().optional().catch(undefined),
+    git_return: z.boolean().optional().catch(undefined),
   }),
   pendingComponent: settingsGroupPendingComponent("repositories"),
   component: lazyRouteComponent(

--- a/apps/web/src/views/settings/repositories.tsx
+++ b/apps/web/src/views/settings/repositories.tsx
@@ -9,10 +9,14 @@
  */
 
 import { GitAccountConnect } from "@/components/git-account-connect";
+import { GithubConnectDialog } from "@/components/github-connect-dialog";
+import { useProjectContext } from "@/sdk";
 import { RepositoryPicker } from "@/components/repository-picker";
 
+import { useQueryClient } from "@tanstack/react-query";
+import { KEYS } from "@/lib/query-keys";
 import { useState } from "react";
-import { useSearch } from "@tanstack/react-router";
+import { useSearch, useNavigate } from "@tanstack/react-router";
 import { GitBranch01, LinkExternal01, Plus } from "@untitledui/icons";
 import { toast } from "sonner";
 import {
@@ -102,9 +106,11 @@ function AccountRow({
   onDisconnect: () => void;
 }) {
   const t = useT();
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
   const needsReconnect = account.status === "revoked" || !account.servable;
   return (
-    <div className="flex items-center justify-between gap-4 py-3 border-b border-border/60 last:border-b-0">
+    <div className="flex flex-wrap items-center justify-between gap-4 py-3 border-b border-border/60 last:border-b-0">
       <div className="flex items-start gap-3 min-w-0">
         <Avatar
           url={account.avatarUrl?.trim() || undefined}
@@ -128,6 +134,13 @@ function AccountRow({
           <p className="text-xs text-muted-foreground mt-0.5 truncate">
             {account.host} · {authKindLabel(account, t)}
           </p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {account.connectedBy
+              ? t("settings.repositories.connectedBy", {
+                  name: account.connectedBy.name,
+                })
+              : t("settings.repositories.connectedByUnknown")}
+          </p>
           {needsReconnect && (
             <p className="text-xs text-muted-foreground mt-0.5">
               {t("settings.repositories.needsReconnectHint")}
@@ -135,9 +148,35 @@ function AccountRow({
           )}
         </div>
       </div>
-      <Button variant="outline" size="sm" onClick={onDisconnect}>
-        {t("settings.repositories.disconnect")}
-      </Button>
+      <div className="flex flex-wrap justify-end gap-2 max-w-full">
+        {account.type === "github" &&
+          account.installationId &&
+          account.servable && (
+            <Button variant="outline" size="sm" asChild>
+              <a
+                href={`/api/${encodeURIComponent(org.slug)}/git-providers/github/accounts/${encodeURIComponent(account.id)}/manage`}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => {
+                  void queryClient.invalidateQueries({
+                    queryKey: KEYS.providerRepoSearch(
+                      org.id,
+                      account.id,
+                      "",
+                    ).slice(0, 3),
+                    refetchType: "none",
+                  });
+                }}
+              >
+                <LinkExternal01 size={14} />
+                {t("settings.repositories.manageRepositoryAccess")}
+              </a>
+            </Button>
+          )}
+        <Button variant="outline" size="sm" onClick={onDisconnect}>
+          {t("settings.repositories.disconnect")}
+        </Button>
+      </div>
     </div>
   );
 }
@@ -221,6 +260,7 @@ function AccountsSection({
   return (
     <SettingsSection
       title={t("settings.repositories.accountsTitle")}
+      headerClassName="flex-col items-start 2xl:flex-row 2xl:items-center [&>div]:max-w-full"
       description={t("settings.repositories.accountsDescription")}
       actions={rows.length > 0 ? <GitAccountConnect /> : null}
     >
@@ -340,11 +380,18 @@ function RepositoriesSection({
 
 function ConnectError() {
   const t = useT();
+  const navigate = useNavigate();
+  const accounts = useGitAccounts();
   const error = useSearch({
     strict: false,
     select: (search) => search.git_error,
   });
-  if (!error) return null;
+  if (
+    !error ||
+    (error === "no_installations" &&
+      accounts.data?.some((account) => account.type === "github"))
+  )
+    return null;
 
   let message: string;
   switch (error) {
@@ -368,13 +415,28 @@ function ConnectError() {
   }
   return (
     <Alert variant={error === "no_installations" ? "info" : "destructive"}>
-      <AlertDescription>{message}</AlertDescription>
+      <AlertDescription className="flex-1">{message}</AlertDescription>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() =>
+          void navigate({
+            to: ".",
+            search: (prev) => ({ ...prev, git_error: undefined }),
+            replace: true,
+          })
+        }
+      >
+        {t("settings.repositories.dismiss")}
+      </Button>
     </Alert>
   );
 }
 
 function RepositoriesContent() {
   const t = useT();
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false });
   const deleteAccount = useDeleteGitAccount();
   const deleteRepository = useDeleteRepository();
 
@@ -410,7 +472,25 @@ function RepositoriesContent() {
         {t("settings.repositories.pageDescription")}
       </p>
 
-      <ConnectError />
+      {!search.git_flow && <ConnectError />}
+      {search.git_flow && (
+        <GithubConnectDialog
+          flowId={search.git_flow}
+          returning={search.git_return === true}
+          onClose={() =>
+            void navigate({
+              to: ".",
+              search: (prev) => ({
+                ...prev,
+                git_flow: undefined,
+                git_return: undefined,
+                git_error: undefined,
+              }),
+              replace: true,
+            })
+          }
+        />
+      )}
 
       <AccountsSection onDisconnect={setPendingAccount} />
 

--- a/packages/e2e/fixtures/github-stub.ts
+++ b/packages/e2e/fixtures/github-stub.ts
@@ -900,12 +900,85 @@ async function handleRepos(
   notFound(res);
 }
 
+interface UserInstallation {
+  id: number;
+  account: {
+    id: number;
+    login: string;
+    avatar_url: string | null;
+    type: "Organization" | "User";
+  };
+}
+
 export function createGithubStubServer(): Server {
+  const users = new Map<string, UserInstallation[]>();
+  const codes = new Map<string, string>();
   return createServer((req, res) => {
     const url = new URL(req.url ?? "/", "http://localhost");
     const dispatch = async (): Promise<void> => {
       if (req.method === "GET" && url.pathname === "/health") {
         json(res, 200, { ok: true });
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/__admin/github-users") {
+        const body = JSON.parse(await readBody(req)) as {
+          token: string;
+          installations: UserInstallation[];
+        };
+        users.set(body.token, body.installations);
+        json(res, 200, { ok: true });
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/__admin/github-codes") {
+        const body = JSON.parse(await readBody(req)) as {
+          code: string;
+          token: string;
+        };
+        codes.set(body.code, body.token);
+        json(res, 200, { ok: true });
+        return;
+      }
+      if (
+        req.method === "POST" &&
+        url.pathname === "/login/oauth/access_token"
+      ) {
+        const body = JSON.parse(await readBody(req)) as { code: string };
+        const token = codes.get(body.code);
+        codes.delete(body.code);
+        json(
+          res,
+          200,
+          token
+            ? { access_token: token, token_type: "bearer", expires_in: 28800 }
+            : { error: "bad_verification_code" },
+        );
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/user/installations") {
+        const installations = users.get(
+          req.headers.authorization?.replace(/^Bearer /, "") ?? "",
+        );
+        if (!installations) {
+          json(res, 401, { message: "Bad credentials" });
+          return;
+        }
+        const page = Number(url.searchParams.get("page") ?? 1);
+        json(res, 200, {
+          installations: installations.slice((page - 1) * 100, page * 100),
+          total_count: installations.length,
+        });
+        return;
+      }
+      if (
+        req.method === "GET" &&
+        url.pathname.startsWith("/app/installations/")
+      ) {
+        const id = Number(url.pathname.split("/").at(-1));
+        const installation = [...users.values()]
+          .flat()
+          .find((item) => item.id === id);
+        if (installation) json(res, 200, installation);
+        else notFound(res);
         return;
       }
       if (url.pathname.startsWith("/__admin/")) {

--- a/packages/e2e/playwright.github-connect.config.ts
+++ b/packages/e2e/playwright.github-connect.config.ts
@@ -2,8 +2,8 @@ import { generateKeyPairSync } from "node:crypto";
 import { defineConfig } from "@playwright/test";
 import base from "./playwright.config";
 
-// This key belongs to no registered app. These tests stop at redirects and
-// never exchange codes or mint installation tokens with GitHub.
+// This key belongs to no registered app. GitHub API requests go to the local
+// fixture; OAuth redirects are checked without authorizing a real account.
 const privateKey = generateKeyPairSync("rsa", {
   modulusLength: 2048,
   privateKeyEncoding: { type: "pkcs8", format: "pem" },
@@ -28,6 +28,8 @@ export default defineConfig({
       ...server.env,
       ...(server.cwd === "../../apps/api"
         ? {
+            ENCRYPTION_KEY: "github-connect-e2e-encryption-key",
+            GITHUB_OAUTH_TOKEN_URL: `http://localhost:${process.env.GITHUB_STUB_PORT ?? "4102"}/login/oauth/access_token`,
             GITHUB_APP_ID: "1",
             GITHUB_APP_SLUG: "studio-e2e",
             GITHUB_APP_CLIENT_ID: "Iv1.studio-e2e",

--- a/packages/e2e/tests/git-account-avatars.spec.ts
+++ b/packages/e2e/tests/git-account-avatars.spec.ts
@@ -7,7 +7,7 @@ const organizationAvatar = `data:image/svg+xml,${encodeURIComponent('<svg xmlns=
 const userAvatar = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" fill="#047857"/><circle cx="32" cy="24" r="11" fill="white"/><path d="M12 60v-6a20 20 0 0 1 40 0v6" fill="white"/></svg>')}`;
 
 test("account avatars appear in settings and the picker, with fallbacks for missing and broken images", async ({
-  authedPage: { page, orgSlug },
+  authedPage: { page, orgSlug, user },
 }, testInfo) => {
   const orgId = await findOrgId(page.request, orgSlug);
   const db = await connectDevDb();
@@ -28,8 +28,8 @@ test("account avatars appear in settings and the picker, with fallbacks for miss
     ]) {
       await db.query(
         `INSERT INTO git_provider_accounts
-          (organization_id, type, host, auth_kind, external_account_id, login, avatar_url, installation_id)
-         VALUES ($1, $2, $3, $4, $5, $5, $6, $7)`,
+          (organization_id, type, host, auth_kind, external_account_id, login, avatar_url, installation_id, created_by)
+         VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8)`,
         [
           orgId,
           account.provider,
@@ -38,6 +38,7 @@ test("account avatars appear in settings and the picker, with fallbacks for miss
           account.login,
           account.avatar,
           account.provider === "github" ? 123 : null,
+          account.login.startsWith("example-") ? user.userId : null,
         ],
       );
     }
@@ -50,6 +51,12 @@ test("account avatars appear in settings and the picker, with fallbacks for miss
   await expect(accounts.getByText("example-user", { exact: true })).toBeVisible(
     { timeout: 15000 },
   );
+  await expect(
+    accounts.getByText(`Connected by ${user.name}`, { exact: true }),
+  ).toHaveCount(2);
+  await expect(
+    accounts.getByText("Connected by an unavailable user", { exact: true }),
+  ).toHaveCount(2);
   await expect(accounts.getByRole("img")).toHaveCount(2);
   await expect(accounts.locator("img").nth(0)).toHaveAttribute(
     "src",

--- a/packages/e2e/tests/github-connect.spec.ts
+++ b/packages/e2e/tests/github-connect.spec.ts
@@ -1,44 +1,370 @@
-import { expect, test } from "../fixtures/test";
+import {
+  createCipheriv,
+  createHash,
+  randomBytes,
+  randomUUID,
+} from "node:crypto";
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test, newApiContext, type AuthedPage } from "../fixtures/test";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { connectDevDb } from "../fixtures/db";
 
-test("an account with no GitHub installations can open installation settings from settings and the picker", async ({
-  authedPage: { page, orgSlug },
+const fixtureOrigin = `http://localhost:${process.env.GITHUB_STUB_PORT ?? "4102"}`;
+type Installation = {
+  id: number;
+  account: {
+    id: number;
+    login: string;
+    type: "Organization" | "User";
+    avatar_url: string | null;
+  };
+};
+function installation(
+  login: string,
+  type: "Organization" | "User" = "Organization",
+): Installation {
+  return {
+    id: Math.floor(Math.random() * 1_000_000_000) + 1,
+    account: {
+      id: Math.floor(Math.random() * 1_000_000_000) + 1,
+      login,
+      type,
+      avatar_url: null,
+    },
+  };
+}
+async function grantAccess(
+  request: APIRequestContext,
+  token: string,
+  installations: Installation[],
+) {
+  const result = await request.post(`${fixtureOrigin}/__admin/github-users`, {
+    data: { token, installations },
+  });
+  expect(result.ok()).toBe(true);
+}
+async function seedFlow(
+  { page, orgSlug, user }: AuthedPage,
+  installations: Installation[] = [],
+  expired = false,
+) {
+  const db = await connectDevDb();
+  try {
+    const {
+      rows: [org],
+    } = await db.query<{ id: string }>(
+      "SELECT id FROM organization WHERE slug=$1",
+      [orgSlug],
+    );
+    const id = randomUUID();
+    const token = `synthetic-${randomUUID()}`;
+    // Persist the public storage contract using the dedicated server's synthetic vault key.
+    const key = createHash("sha256")
+      .update("github-connect-e2e-encryption-key")
+      .digest();
+    const iv = randomBytes(16);
+    const cipher = createCipheriv("aes-256-gcm", key, iv);
+    const ciphertext = Buffer.concat([cipher.update(token), cipher.final()]);
+    const encrypted = Buffer.concat([
+      iv,
+      cipher.getAuthTag(),
+      ciphertext,
+    ]).toString("base64");
+    await db.query(
+      "INSERT INTO github_connect_flows (id, organization_id, user_id, encrypted_access_token, expires_at) VALUES ($1,$2,$3,$4,$5)",
+      [
+        id,
+        org!.id,
+        user.userId,
+        encrypted,
+        new Date(Date.now() + (expired ? -60_000 : 600_000)),
+      ],
+    );
+    await grantAccess(page.request, token, installations);
+    return {
+      id,
+      token,
+      orgId: org!.id,
+      path: `/api/${orgSlug}/git-providers/github/flows/${id}`,
+      url: `/${orgSlug}/settings/repositories?git_flow=${id}`,
+    };
+  } finally {
+    await db.end();
+  }
+}
+
+test("choose one account, show its Studio connector, and manage that installation in a new tab", async ({
+  authedPage,
 }, testInfo) => {
-  const returnTo = `/${orgSlug}/settings/repositories`;
-  await page.goto(`${returnTo}?git_error=no_installations`);
-  await expect(page.getByRole("alert")).toContainText(
-    "GitHub authorization succeeded",
+  const { page, user } = authedPage;
+  const selected = installation("acme-studio");
+  selected.account.avatar_url = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48"><rect width="48" height="48" fill="#143630"/><text x="24" y="33" text-anchor="middle" fill="white" font-family="sans-serif" font-size="30">a</text></svg>')}`;
+  const unselected = installation("personal-projects", "User");
+  const flow = await seedFlow(authedPage, [selected, unselected]);
+  await page.goto(flow.url);
+  const dialog = page.getByRole("dialog");
+  await expect(
+    dialog.getByRole("button", { name: selected.account.login }),
+  ).toBeVisible();
+  await expect(dialog).toContainText("Members with repository permissions");
+  await expect(dialog.locator("img")).toHaveAttribute(
+    "src",
+    selected.account.avatar_url,
   );
+  await page.screenshot({
+    path: testInfo.outputPath("github-account-chooser.png"),
+    animations: "disabled",
+  });
+  await dialog.getByRole("button", { name: selected.account.login }).click();
+  await expect(dialog).toHaveCount(0);
+  await expect(
+    page.getByText(`Connected by ${user.name}`, { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(unselected.account.login, { exact: true }),
+  ).toHaveCount(0);
   const manage = page.getByRole("link", {
-    name: "Manage GitHub access",
+    name: "Manage repository access",
     exact: true,
   });
-  await expect(manage).toBeVisible();
-  const href = await manage.getAttribute("href");
-  expect(href).toBe(
-    `/api/${orgSlug}/git-providers/github/install?returnTo=${encodeURIComponent(returnTo)}`,
+  await expect(manage).toHaveAttribute("target", "_blank");
+  const response = await page.request.get(
+    (await manage.getAttribute("href"))!,
+    { maxRedirects: 0 },
   );
-  const response = await page.request.get(href!, { maxRedirects: 0 });
   expect(response.status()).toBe(302);
-  const destination = new URL(response.headers().location!);
-  expect(destination.origin).toBe("https://github.com");
-  expect(destination.pathname).toBe("/apps/studio-e2e/installations/new");
-  expect(destination.searchParams.get("state")).toBeTruthy();
+  expect(response.headers().location).toBe(
+    `https://github.com/organizations/acme-studio/settings/installations/${selected.id}`,
+  );
+  const db = await connectDevDb();
+  try {
+    const saved = await db.query(
+      "SELECT installation_id, created_by FROM git_provider_accounts WHERE organization_id=$1",
+      [flow.orgId],
+    );
+    expect(saved.rows).toEqual([
+      { installation_id: String(selected.id), created_by: user.userId },
+    ]);
+    expect(
+      (
+        await db.query(
+          "SELECT id FROM github_connect_flows WHERE organization_id=$1 AND id=$2",
+          [flow.orgId, flow.id],
+        )
+      ).rows,
+    ).toEqual([]);
+  } finally {
+    await db.end();
+  }
+  expect((await page.request.get(flow.path)).status()).toBe(410);
   await page.screenshot({
-    path: testInfo.outputPath("github-installation-required.png"),
+    path: testInfo.outputPath("github-connected-account.png"),
     animations: "disabled",
   });
-  await page
-    .getByRole("button", { name: "Add repository", exact: true })
-    .click();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(manage).toBeVisible();
+  const bounds = await manage.boundingBox();
+  expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(390);
   await expect(
-    page
-      .getByRole("dialog")
-      .getByRole("link", { name: "Manage GitHub access", exact: true }),
+    page.getByRole("heading", { name: "Connected accounts" }),
   ).toBeVisible();
   await page.screenshot({
-    path: testInfo.outputPath("github-picker-access.png"),
+    path: testInfo.outputPath("github-connected-account-mobile.png"),
     animations: "disabled",
   });
+});
+
+test("installation in another tab refreshes the original chooser and closes the returned tab", async ({
+  authedPage,
+}, testInfo) => {
+  const { page } = authedPage;
+  const flow = await seedFlow(authedPage);
+  await page.goto(`${flow.url}&git_error=no_installations`);
+  const dialog = page.getByRole("dialog");
+  const install = dialog.getByRole("link", {
+    name: "Install on another account",
+  });
+  await expect(install).toHaveAttribute("target", "_blank");
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  const href = (await install.getAttribute("href"))!;
+  expect(new URL(href, page.url()).searchParams.get("returnTo")).toContain(
+    `git_flow=${flow.id}&git_return=true`,
+  );
+  const start = await page.request.get(href, { maxRedirects: 0 });
+  expect(new URL(start.headers().location!).pathname).toBe(
+    "/apps/studio-e2e/installations/new",
+  );
+  await page.screenshot({
+    path: testInfo.outputPath("github-installation-step.png"),
+    animations: "disabled",
+  });
+  const account = installation("new-organization");
+  await grantAccess(page.request, flow.token, [account]);
+  await page
+    .context()
+    .route("https://github.com/apps/studio-e2e/installations/new?*", (route) =>
+      route.fulfill({
+        contentType: "text/html",
+        body: "GitHub installation configured",
+      }),
+    );
+  const popup = page.waitForEvent("popup");
+  await install.click();
+  const returned = await popup;
+  await returned.waitForLoadState();
+  const closed = returned.waitForEvent("close");
+  await returned.goto(`${flow.url}&git_return=true`).catch((error: Error) => {
+    if (!error.message.includes("closed")) throw error;
+  });
+  await closed;
+  await expect(
+    dialog.getByRole("button", { name: account.account.login }),
+  ).toBeVisible();
+  await dialog.getByRole("button", { name: account.account.login }).click();
+  await expect(dialog).toHaveCount(0);
+});
+
+test("check access recovers when GitHub stays on its settings page", async ({
+  authedPage,
+}) => {
+  const { page } = authedPage;
+  const flow = await seedFlow(authedPage);
+  await page.goto(flow.url);
+  await expect(
+    page.getByRole("link", { name: "Install on another account" }),
+  ).toBeVisible();
+  const account = installation("manual-return", "User");
+  await grantAccess(page.request, flow.token, [account]);
+  await page.getByRole("button", { name: "Check access", exact: true }).click();
+  await page
+    .getByRole("button", { name: account.account.login, exact: true })
+    .click();
+  const manage = page.getByRole("link", { name: "Manage repository access" });
+  await expect(manage).toBeVisible();
+  const response = await page.request.get(
+    (await manage.getAttribute("href"))!,
+    { maxRedirects: 0 },
+  );
+  expect(response.headers().location).toBe(
+    `https://github.com/settings/installations/${account.id}`,
+  );
+});
+
+test("flow ownership, expiry, validation, and concurrent completion protect the saved account", async ({
+  authedPage,
+  playwright,
+}) => {
+  const { page, orgSlug } = authedPage;
+  const account = installation("owned-organization");
+  const flow = await seedFlow(authedPage, [account]);
+  const outsider = await newApiContext(playwright);
+  const db = await connectDevDb();
+  try {
+    const other = await signUpViaApi(outsider);
+    // A second admin in this same Studio workspace still cannot consume this user's grant.
+    await db.query(
+      'INSERT INTO member (id, "organizationId", "userId", role, "createdAt") VALUES ($1,$2,$3,$4,now())',
+      [randomUUID(), flow.orgId, other.userId, "owner"],
+    );
+    for (const path of [
+      flow.path,
+      `/api/${other.orgSlug}/git-providers/github/flows/${flow.id}`,
+    ]) {
+      expect((await outsider.get(path)).status()).toBe(410);
+      expect(
+        (
+          await outsider.post(path, { data: { installationId: account.id } })
+        ).status(),
+      ).toBe(410);
+      expect((await outsider.delete(path)).status()).toBe(204);
+    }
+    expect(
+      (
+        await page.request.post(flow.path, {
+          data: { installationId: account.id + 1 },
+        })
+      ).status(),
+    ).toBe(403);
+    expect(
+      (
+        await page.request.post(flow.path, { data: { installationId: "1" } })
+      ).status(),
+    ).toBe(400);
+    expect(
+      (
+        await page.request.post(flow.path, {
+          data: "installationId=1",
+          headers: { "Content-Type": "text/plain" },
+        })
+      ).status(),
+    ).toBe(415);
+    const listed = await page.request.get(flow.path);
+    expect(listed.headers()["cache-control"]).toBe("no-store");
+    expect(await listed.text()).not.toContain(flow.token);
+    const results = await Promise.all(
+      [1, 2].map(() =>
+        page.request.post(flow.path, { data: { installationId: account.id } }),
+      ),
+    );
+    expect(results.map((r) => r.status()).sort()).toEqual([200, 410]);
+    expect(
+      (
+        await db.query(
+          "SELECT id FROM git_provider_accounts WHERE organization_id=$1",
+          [flow.orgId],
+        )
+      ).rows,
+    ).toHaveLength(1);
+    // A later teammate reconnect does not rewrite the original connector.
+    const teammate = await seedFlow({ page, user: other, orgSlug }, [account]);
+    expect(
+      (
+        await outsider.post(teammate.path, {
+          data: { installationId: account.id },
+        })
+      ).status(),
+    ).toBe(200);
+    expect(
+      (
+        await db.query(
+          "SELECT created_by FROM git_provider_accounts WHERE organization_id=$1",
+          [flow.orgId],
+        )
+      ).rows[0].created_by,
+    ).toBe(authedPage.user.userId);
+  } finally {
+    await outsider.dispose();
+    await db.end();
+  }
+  const expired = await seedFlow(authedPage, [account], true);
+  expect(
+    (
+      await page.request.post(expired.path, {
+        data: { installationId: account.id },
+      })
+    ).status(),
+  ).toBe(410);
+  await page.goto(expired.url);
+  await expect(page.getByRole("dialog").getByRole("alert")).toContainText(
+    "expired",
+  );
+  await expect(
+    page.getByRole("link", { name: "Try again", exact: true }),
+  ).toBeVisible();
+});
+
+test("closing the chooser deletes the grant and a standalone return remains usable", async ({
+  authedPage,
+}) => {
+  const { page } = authedPage;
+  const flow = await seedFlow(authedPage, [installation("standalone-return")]);
+  await page.goto(`${flow.url}&git_return=true`);
+  await expect(
+    page.getByRole("button", { name: "standalone-return", exact: true }),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  expect((await page.request.get(flow.path)).status()).toBe(410);
 });
 
 test("reconnect asks which GitHub user to authorize and cancellation is visible", async ({
@@ -62,7 +388,10 @@ test("reconnect asks which GitHub user to authorize and cancellation is visible"
     "Authorization was cancelled",
   );
   await expect(
-    page.getByRole("link", { name: "Manage GitHub access", exact: true }),
+    page.getByRole("link", {
+      name: "Add GitHub account or organization",
+      exact: true,
+    }),
   ).toBeVisible();
 });
 
@@ -102,4 +431,151 @@ test("unknown callback errors show a safe message and a successful return clears
   );
   await page.goto(returnTo);
   await expect(page.getByRole("alert")).toHaveCount(0);
+});
+
+test("OAuth creates an encrypted chooser grant, setup refreshes it, and restarting replaces abandoned flows", async ({
+  authedPage,
+}) => {
+  const { page, orgSlug, user } = authedPage;
+  const db = await connectDevDb();
+  const account = installation("oauth-organization");
+  const token = `synthetic-${randomUUID()}`;
+  await grantAccess(page.request, token, [account]);
+  async function exchange(state: string) {
+    const code = randomUUID();
+    expect(
+      (
+        await page.request.post(`${fixtureOrigin}/__admin/github-codes`, {
+          data: { code, token },
+        })
+      ).ok(),
+    ).toBe(true);
+    const result = await page.request.get(
+      `/api/_git/github/callback?state=${state}&code=${code}`,
+      { maxRedirects: 0 },
+    );
+    expect(result.status()).toBe(302);
+    const destination = new URL(result.headers().location!);
+    expect(destination.searchParams.has("git_error")).toBe(false);
+    expect(destination.searchParams.get("git_flow")).toBeTruthy();
+    return destination;
+  }
+  async function start(returnTo: string) {
+    const result = await page.request.get(
+      `/api/${orgSlug}/git-providers/github/connect?returnTo=${encodeURIComponent(returnTo)}`,
+      { maxRedirects: 0 },
+    );
+    return new URL(result.headers().location!).searchParams.get("state")!;
+  }
+  try {
+    const {
+      rows: [org],
+    } = await db.query<{ id: string }>(
+      "SELECT id FROM organization WHERE slug=$1",
+      [orgSlug],
+    );
+    const destination = await exchange(
+      await start(
+        `/${orgSlug}/settings/repositories?git_error=no_installations`,
+      ),
+    );
+    const id = destination.searchParams.get("git_flow")!;
+    const before = await db.query(
+      "SELECT * FROM github_connect_flows WHERE id=$1 AND organization_id=$2",
+      [id, org!.id],
+    );
+    expect(before.rows).toHaveLength(1);
+    expect(before.rows[0].user_id).toBe(user.userId);
+    expect(before.rows[0].encrypted_access_token).not.toContain(token);
+    const expiry = new Date(before.rows[0].expires_at).getTime();
+    expect(expiry).toBeGreaterThan(Date.now());
+    expect(expiry).toBeLessThanOrEqual(Date.now() + 600_000);
+    expect(
+      (
+        await db.query(
+          "SELECT id FROM git_provider_accounts WHERE organization_id=$1",
+          [org!.id],
+        )
+      ).rows,
+    ).toEqual([]);
+    destination.searchParams.set("git_return", "true");
+    const install = await page.request.get(
+      `/api/${orgSlug}/git-providers/github/install?returnTo=${encodeURIComponent(destination.pathname + destination.search)}`,
+      { maxRedirects: 0 },
+    );
+    const installState = new URL(install.headers().location!).searchParams.get(
+      "state",
+    )!;
+    const setup = await page.request.get(
+      `/api/_git/github/setup?state=${installState}&installation_id=${account.id}`,
+      { maxRedirects: 0 },
+    );
+    const setupState = new URL(setup.headers().location!).searchParams.get(
+      "state",
+    )!;
+    const returned = await exchange(setupState);
+    expect(returned.searchParams.get("git_flow")).toBe(id);
+    expect(returned.searchParams.get("git_return")).toBe("true");
+    const refreshed = await db.query(
+      "SELECT encrypted_access_token, expires_at FROM github_connect_flows WHERE id=$1 AND organization_id=$2",
+      [id, org!.id],
+    );
+    expect(new Date(refreshed.rows[0].expires_at).getTime()).toBe(expiry);
+    expect(refreshed.rows[0].encrypted_access_token).not.toBe(
+      before.rows[0].encrypted_access_token,
+    );
+    const again = await exchange(
+      await start(`/${orgSlug}/settings/repositories`),
+    );
+    const nextId = again.searchParams.get("git_flow")!;
+    expect(nextId).not.toBe(id);
+    expect(
+      (
+        await db.query(
+          "SELECT id FROM github_connect_flows WHERE organization_id=$1 AND user_id=$2",
+          [org!.id, user.userId],
+        )
+      ).rows,
+    ).toEqual([{ id: nextId }]);
+    expect(
+      (
+        await page.request.get(
+          `/api/${orgSlug}/git-providers/github/flows/${id}`,
+        )
+      ).status(),
+    ).toBe(410);
+    await page.goto(again.toString());
+    await page
+      .getByRole("button", { name: account.account.login, exact: true })
+      .click();
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(
+      page.getByText(`Connected by ${user.name}`, { exact: true }),
+    ).toBeVisible();
+  } finally {
+    await db.end();
+  }
+});
+
+test("returning focus discovers new installation access without a callback or another authorization", async ({
+  authedPage,
+}) => {
+  const { page } = authedPage;
+  const flow = await seedFlow(authedPage);
+  await page.goto(flow.url);
+  await expect(
+    page.getByRole("link", { name: "Install on another account" }),
+  ).toBeVisible();
+  const githubTab = await page.context().newPage();
+  await githubTab.goto("about:blank");
+  await githubTab.bringToFront();
+  const account = installation("focus-return");
+  await grantAccess(page.request, flow.token, [account]);
+  await page.bringToFront();
+  // Headless Chromium keeps both documents visible; deliver the browser focus event.
+  await page.evaluate(() => window.dispatchEvent(new Event("focus")));
+  await expect(
+    page.getByRole("button", { name: account.account.login, exact: true }),
+  ).toBeVisible();
+  await githubTab.close();
 });

--- a/packages/e2e/tests/repository-picker.spec.ts
+++ b/packages/e2e/tests/repository-picker.spec.ts
@@ -18,7 +18,7 @@ for (const width of [1280, 390]) {
       }),
     ).toBeVisible();
     await expect(
-      dialog.getByText("Connect GitHub", { exact: true }),
+      dialog.getByText("Add GitHub account or organization", { exact: true }),
     ).toBeVisible();
     await expect(dialog.getByLabel("Repository URL")).toHaveCount(0);
     await page.screenshot({

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -7593,6 +7593,7 @@ export interface StudioToolIO {
         createdAt: string;
         updatedAt: string;
         servable: boolean;
+        connectedBy: { name: string } | null;
       }[];
     };
   };
@@ -7613,6 +7614,7 @@ export interface StudioToolIO {
         createdAt: string;
         updatedAt: string;
         servable: boolean;
+        connectedBy: { name: string } | null;
       };
     };
   };


### PR DESCRIPTION
Connecting GitHub could leave Studio showing an old warning after installation access changed, and the global management action did not identify which account it managed. Authorization now opens a chooser: select the GitHub account or organization to share with the Studio workspace.

- Install on another account opens GitHub in a new tab. The chooser refreshes on return or focus, with a Check access fallback. A returned setup tab closes after the original tab acknowledges it.
- Each connected GitHub account has its own Manage repository access link, opening the correct organization or personal installation settings in a new tab.
- Every GitHub/GitLab account row shows Connected by using the original Studio connector's name. Reconnecting preserves that attribution; missing historical authors have an explicit fallback. Account avatars are preserved, and actions wrap on mobile.

Migration 208 adds one encrypted, ten-minute authorization grant per Studio user/workspace. Selecting an installation rechecks GitHub access and atomically saves the account while consuming the grant. Cancel, expiry, replacement, tenant/user ownership, and concurrent completion are covered. Saved accounts continue using GitHub App installation credentials.

Validation: `bun run fmt`, `bun run lint`, `bun run check`, and `bun run knip` pass. `bun run test`: 8,554 passing tests. Playwright: 10 guided GitHub flow tests and 17 existing provider/picker/avatar tests pass against real Postgres and synthetic external providers. The OAuth code exchange is exercised against the local HTTP fixture; these tests do not authorize a real GitHub account.

<details>
<summary>Desktop and mobile screenshots</summary>

Account chooser:

![GitHub account chooser](https://raw.githubusercontent.com/decocms/studio/80839a4a170f4313711a8d99b0453863ffbbf00f/github-account-chooser.png)

Connected account with Studio attribution and account-specific management:

![Connected account](https://raw.githubusercontent.com/decocms/studio/80839a4a170f4313711a8d99b0453863ffbbf00f/github-connected-account.png)

Mobile:

<img src="https://raw.githubusercontent.com/decocms/studio/80839a4a170f4313711a8d99b0453863ffbbf00f/github-connected-account-mobile.png" alt="Connected account on mobile" width="390" />

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guides GitHub setup with an account chooser and shows who connected each GitHub/GitLab account in Studio settings.

Connecting GitHub previously saved every installation the authorized user could see and could leave stale warnings after access changed. Now users authorize once and pick the specific account or organization to share; only that installation is saved. Each connected account row shows `Connected by` using the original Studio connector's name, and GitHub accounts get their own Manage repository access link that opens the correct installation settings in a new tab. Installing on another account opens GitHub in a new tab; the chooser refreshes on return or focus, with a Check access fallback, and a returned setup tab closes once the original tab acknowledges it. The post-flow `returnTo` URL is also hardened against control characters.

**Migration**
- Adds `github_connect_flows`, one encrypted ten-minute grant per Studio user/workspace; connecting consumes the grant and saves the account atomically.
- Cancel, expiry, replacement, and concurrent completion are covered; saved accounts keep using GitHub App installation credentials.
- Reconnecting preserves the original connector attribution; missing historical authors show an explicit fallback.

<sup>Written for commit 46c49b1b09a484e6eaedaf8133691f9367087c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

