### PR TITLE
fix(file-storage): drain the tarball body when declared size exceeds the cap

### DIFF
--- a/apps/api/src/file-storage/skill-set-sync.ts
+++ b/apps/api/src/file-storage/skill-set-sync.ts
@@ -265,6 +265,7 @@ async function fetchRepoFiles(
     // Refuse before buffering when the server declares the size; the post-download check backstops chunked responses (no Content-Length).
     const declared = Number(res.headers.get("content-length") ?? 0);
     if (declared > MAX_TARBALL_BYTES) {
+      await res.body?.cancel().catch(() => {});
       throw new Error(
         `tarball for ${label} declares ${declared} bytes (cap ${MAX_TARBALL_BYTES})`,
       );


### PR DESCRIPTION
Follows the same-file hardening in #7104/#7098 (skill-set-sync.ts tarball fetch).

`fetchRepoFiles`'s `attempt()` already drains the response body before throwing on a non-2xx status (`await res.body?.cancel()`), but the sibling `declared > MAX_TARBALL_BYTES` branch (a repo whose `Content-Length` header already exceeds the 200MB cap) threw without draining. An undrained body leaves the underlying connection un-reusable/un-closed until GC — the exact defect class fixed for the non-2xx path one PR earlier, and matches the repo's established "drain a discarded/non-2xx response body before discarding" lane (#6887, #7067, #7091, #7104, #7109, #7112, #7113).

Failure scenario: a public-skill-set or org-repo sync hits a repo whose tarball declares an oversized `Content-Length` (misconfigured or malicious upstream); the sync throws (correctly refuses the tarball) but leaks the fetch's socket every time this path is hit, same as the pre-#7104 non-ok-status case did.

Fix: `await res.body?.cancel().catch(() => {})` before throwing, mirroring the `!res.ok` branch two lines above.

Net diff: +1/-0, behavior-preserving (the thrown error and its message/classification are unchanged — only the body is now drained first).

Reviewer check: `bun test apps/api/src/file-storage/skill-set-sync.test.ts` (22 pass, unchanged — this branch has no existing test, matching #7104's own precedent which also shipped without a fetch-mock test for the same cancel() call).

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/file-storage/skill-set-sync.test.ts` (22/22 pass), `bunx oxlint apps/api/src/file-storage/skill-set-sync.ts` (0 warnings/errors). Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drains the tarball response body before throwing when the declared `Content-Length` exceeds the cap, preventing a socket leak on misconfigured or malicious upstream repos. The error thrown is unchanged; only the body is now cancelled first, mirroring the existing non-2xx status handling.

<sup>Written for commit 85abb5d9d80069651a42f30ca5cd501888fb4ce5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

