### PR TITLE
fix(git-providers): fall back to the page length when GitLab omits x-total

### DIFF
--- a/apps/api/src/git-providers/gitlab/content.test.ts
+++ b/apps/api/src/git-providers/gitlab/content.test.ts
@@ -11,6 +11,7 @@ import {
   mapMergeRequest,
   mapMergeRequestState,
   pooledMap,
+  totalCountFromHeader,
   type ResolvedChange,
 } from "./content";
 import { gitlabErrorMessage } from "./http";
@@ -467,5 +468,19 @@ describe("isProtectedBranch", () => {
       isProtectedBranch("The file has changed since you started editing it: a"),
     ).toBe(false);
     expect(isProtectedBranch("404 Project Not Found")).toBe(false);
+  });
+});
+
+describe("totalCountFromHeader", () => {
+  test("uses the header when GitLab sent one", () => {
+    expect(totalCountFromHeader("42", 3)).toBe(42);
+  });
+
+  test("falls back to the page length when the header is absent, not 0", () => {
+    expect(totalCountFromHeader(null, 3)).toBe(3);
+  });
+
+  test("falls back when the header is present but unparseable", () => {
+    expect(totalCountFromHeader("not-a-number", 3)).toBe(3);
   });
 });

--- a/apps/api/src/git-providers/gitlab/content.ts
+++ b/apps/api/src/git-providers/gitlab/content.ts
@@ -209,6 +209,22 @@ export function mapMergeRequest(mr: GitlabMergeRequestRow): ChangeRequestInfo {
   };
 }
 
+/**
+ * GitLab's `x-total` header as a count, or `fallback` when the header is
+ * absent (a very large project, where GitLab stops counting) or unparseable.
+ * `Number(null)` is `0`, so a missing header must be distinguished from a
+ * present-and-zero one before falling back — otherwise a listing with no
+ * `x-total` reads as "0 results" even when it returned matches.
+ */
+export function totalCountFromHeader(
+  headerValue: string | null,
+  fallback: number,
+): number {
+  if (headerValue === null) return fallback;
+  const total = Number(headerValue);
+  return Number.isFinite(total) ? total : fallback;
+}
+
 /** Repo-relative directory of `path`; `""` for a file at the repo root. */
 export function directoryOf(path: string): string {
   const normalized = path.replace(/^\/+/, "");
@@ -405,11 +421,13 @@ export class GitlabContentClient implements RepoContentClient {
         ? [{ name: row.name, author: row.commit?.author_name ?? null }]
         : [],
     );
-    const total = Number(res.headers.get("x-total"));
     const nextPage = res.headers.get("x-next-page");
     return {
       branches,
-      totalCount: Number.isFinite(total) ? total : branches.length,
+      totalCount: totalCountFromHeader(
+        res.headers.get("x-total"),
+        branches.length,
+      ),
       nextCursor: nextPage ? nextPage : null,
     };
   }


### PR DESCRIPTION
Bug found while hardening `apps/api/src/git-providers/gitlab/*` (GitLab provider client area).

**Payoff:** `GitlabContentClient.searchBranches` powers the branch picker (`apps/web/src/components/thread/github/use-branches.ts`) via `totalCount`. On a self-hosted or very large GitLab project, GitLab omits the `x-total` header (documented in this function's own comment as a known case), and the returned page's length is meant to be the fallback. But `Number(res.headers.get("x-total"))` on a missing header is `Number(null)` = `0`, not `NaN` — so `Number.isFinite(total)` was `true` and the function reported a real total of `0` while still returning actual branches, exactly backwards from the documented intent.

**Failure scenario:** searching branches on a project large enough that GitLab stops counting matches renders as "0 results" in the branch picker even though branches were returned.

**Fix:** extracted the header parsing into a small pure `totalCountFromHeader(headerValue, fallback)` helper that distinguishes an absent header from a present-and-zero one, and unit-tested it directly (matching this file's existing pattern of testable pure helpers like `mapCompareDiff`/`parseChangesCount`).

**Verify:** `bun test apps/api/src/git-providers/gitlab/content.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above (51 pass), `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitLab branch picker showing 0 results on large projects by correctly falling back to the page length when GitLab omits the `x-total` header. Previously a missing header was read as 0 (via `Number(null)`), so `searchBranches` reported a total of 0 while still returning branches; now an absent or unparseable header uses the returned branches' length.

- Extracts the header parsing into a small `totalCountFromHeader` helper and adds unit tests for it.

<sup>Written for commit b7263f7e44373ffd4ac2aa1d0e65f164faf71b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

