### PR TITLE
refactor(router): drop the redundant as-cast on the agents route search

### DIFF
--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -536,7 +536,7 @@ const agentsRoute = createRoute({
   beforeLoad: ({ params, search }) => {
     const segment = params.panel;
     if (!segment || isKnownPanelSegment(segment)) return;
-    if ((search as { virtualmcpid?: string }).virtualmcpid) return;
+    if (search.virtualmcpid) return;
     throw redirect({
       to: "/$org/agents/{-$panel}",
       params: { org: params.org, panel: undefined },


### PR DESCRIPTION
**Source**: C-DEBT (type-safety) hunt over `apps/web/src/router.tsx`, this worker's assigned focus area (web-router-audit).

**What/why**: `agentsRoute`'s `beforeLoad` read `(search as { virtualmcpid?: string }).virtualmcpid`, but the route's own `validateSearch` already declares `virtualmcpid: z.string().optional()` on the same object literal — TanStack's route typing already infers that shape for the `search` param `beforeLoad` receives. The cast was dead weight papering over a type TypeScript can already prove; if a future edit ever renamed or dropped `virtualmcpid` from `validateSearch`, the cast would keep compiling and silently mask the mismatch instead of surfacing it as a type error at the `beforeLoad` call site (this route's legacy-project-id redirect logic depends on reading that field correctly).

**Change**: replace `(search as { virtualmcpid?: string }).virtualmcpid` with plain `search.virtualmcpid` — no behavior change, same runtime value, just lets the compiler check it.

**Verification**:
- `cd apps/web && bunx tsc --noEmit` — no new errors (confirmed identical output with and without the cast; the file's own type-check is clean either way)
- `cd apps/web && bunx oxlint src/router.tsx` — 0 warnings/errors
- `bun run fmt` — no changes needed

No test added: this is a compile-time-only narrowing with no behavior change, so there's nothing new for a runtime test to assert (the existing route logic, and its behavior, is untouched).

Full CI (`bun run check`, lint, e2e) validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the redundant cast from the agents route’s `search.virtualmcpid` access, letting the inferred route type check the field directly without changing redirect behavior.

- TypeScript now catches mismatches between `beforeLoad` and `validateSearch`.
- Verified with `bunx tsc --noEmit` and `bunx oxlint src/router.tsx`.

<sup>Written for commit b3afa9d66276a04882b704df246d54f31523ae31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

