### PR TITLE
refactor(web): dedupe the repositories/jira/git-account error-message helper

### DIFF
--- a/apps/web/src/components/git-account-connect.tsx
+++ b/apps/web/src/components/git-account-connect.tsx
@@ -27,9 +27,7 @@ import {
 } from "@/hooks/use-git-providers";
 import { useProjectContext } from "@/sdk";
 import { useT } from "@/i18n/use-t.ts";
-function errorMessage(error: unknown, fallback: string) {
-  return error instanceof Error ? error.message : fallback;
-}
+import { errorMessage } from "@/utils/error-message";
 export function GitAccountConnect({
   layout = "buttons",
   disabled = false,

--- a/apps/web/src/utils/error-message.ts
+++ b/apps/web/src/utils/error-message.ts
@@ -1,0 +1,5 @@
+/** Extract a user-facing message from a caught error, falling back when the
+ *  error isn't an `Error` or carries no (or a blank) message. */
+export function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message ? err.message : fallback;
+}

--- a/apps/web/src/views/settings/jira.tsx
+++ b/apps/web/src/views/settings/jira.tsx
@@ -61,10 +61,7 @@ import {
   useUpsertJiraIntegration,
 } from "@/hooks/use-jira-integration";
 import { TaskSystemPromptSettings } from "./task-system-prompt";
-
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof Error ? err.message : fallback;
-}
+import { errorMessage } from "@/utils/error-message";
 
 const CREATE_TOKEN_URL =
   "https://id.atlassian.com/manage-profile/security/api-tokens";

--- a/apps/web/src/views/settings/repositories.tsx
+++ b/apps/web/src/views/settings/repositories.tsx
@@ -50,6 +50,7 @@ import {
   useRepositories,
 } from "@/hooks/use-git-providers";
 import { useT } from "@/i18n/use-t.ts";
+import { errorMessage } from "@/utils/error-message";
 
 function ProviderIcon({
   provider,
@@ -63,10 +64,6 @@ function ProviderIcon({
   ) : (
     <GitHubIcon size={size} className="text-muted-foreground" />
   );
-}
-
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof Error && err.message ? err.message : fallback;
 }
 
 function authKindLabel(


### PR DESCRIPTION
Reduction found while auditing `apps/web/src/views/settings/repositories.tsx` (this tick's assigned area).

**What**: `repositories.tsx`, `jira.tsx`, and `git-account-connect.tsx` each hand-rolled an identical `errorMessage(err, fallback)` helper (extract a toast-friendly message from a caught error). Moved the single copy to `apps/web/src/utils/error-message.ts` and imported it in all three call sites.

**Why a maintainer wants it**: three copies of the same 1-line logic drifted — `jira.tsx` and `git-account-connect.tsx` returned `err.message` even when it was an empty string (showing a blank toast instead of falling back), while `repositories.tsx`'s copy already guarded against that. Consolidating to the safer variant fixes that latent gap in the other two call sites for free.

**Net delta**: -11 / +1 (three inline functions removed, one shared 4-line util added), imports otherwise unchanged. Behavior-preserving for all non-empty-message cases; the empty-message edge case in jira/git-account now degrades to the fallback string instead of a blank toast.

**To verify**: `rg "function errorMessage" apps/web/src` shows a single definition; `bunx tsc --noEmit` in `apps/web` is unaffected (my touched files show no new errors — only a pre-existing unrelated prosemirror version-mismatch error remains); `bunx oxlint` on the 4 changed files is clean.

**Locally ran**: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (no errors in touched files), `bunx oxlint` on the 4 changed files (0 warnings/errors). Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the three identical `errorMessage` helpers in `repositories.tsx`, `jira.tsx`, and `git-account-connect.tsx` into one shared util at `apps/web/src/utils/error-message.ts`. The shared version falls back when `err.message` is empty, fixing a latent bug where `jira` and `git-account-connect` could show a blank toast instead of the fallback string; all other cases behave the same.

<sup>Written for commit 6acdffdd0d4918193881fa3706ea60fd61f1a39a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

