### PR TITLE
fix(core): cap the org-notice cache in org-notice-gate.ts

### DIFF
--- a/apps/api/src/core/org-notice-gate.cache.test.ts
+++ b/apps/api/src/core/org-notice-gate.cache.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit test for the org-notice cache's eviction: without a bound, every org
+ * id ever seen stays in the map forever (a stale entry is only ever
+ * overwritten on its own next lookup, never dropped otherwise).
+ */
+import { describe, expect, it } from "bun:test";
+import {
+  evictExpiredOrgNoticeEntries,
+  refreshOrgNoticeCacheEntry,
+} from "./org-notice-gate";
+
+describe("evictExpiredOrgNoticeEntries", () => {
+  it("leaves the cache untouched when under the cap", () => {
+    const cache = new Map([["org_1", { notice: null, at: Date.now() }]]);
+    evictExpiredOrgNoticeEntries(cache, 10, 60_000);
+    expect(cache.size).toBe(1);
+  });
+
+  it("drops expired entries first when over the cap", () => {
+    const now = Date.now();
+    const cache = new Map([
+      ["org_stale", { notice: null, at: now - 120_000 }],
+      ["org_fresh", { notice: null, at: now }],
+    ]);
+    evictExpiredOrgNoticeEntries(cache, 1, 60_000);
+    expect(cache.has("org_stale")).toBe(false);
+    expect(cache.has("org_fresh")).toBe(true);
+  });
+
+  it("trims the oldest entries when still over the cap after expiry", () => {
+    const now = Date.now();
+    const cache = new Map([
+      ["org_a", { notice: null, at: now }],
+      ["org_b", { notice: null, at: now }],
+      ["org_c", { notice: null, at: now }],
+    ]);
+    evictExpiredOrgNoticeEntries(cache, 1, 60_000);
+    expect(cache.size).toBe(1);
+    expect(cache.has("org_c")).toBe(true);
+  });
+});
+
+describe("refreshOrgNoticeCacheEntry", () => {
+  it("moves a re-looked-up org past older untouched ones, so a hot org isn't the first evicted", () => {
+    const cache = new Map<string, { notice: null; at: number }>();
+    refreshOrgNoticeCacheEntry(cache, "org_a", null);
+    refreshOrgNoticeCacheEntry(cache, "org_b", null);
+    refreshOrgNoticeCacheEntry(cache, "org_c", null);
+    // org_a is looked up again — same key, but it's the hot one now.
+    refreshOrgNoticeCacheEntry(cache, "org_a", null);
+
+    evictExpiredOrgNoticeEntries(cache, 2, 60_000);
+
+    expect(cache.has("org_b")).toBe(false);
+    expect(cache.has("org_a")).toBe(true);
+    expect(cache.has("org_c")).toBe(true);
+  });
+});

--- a/apps/api/src/core/org-notice-gate.ts
+++ b/apps/api/src/core/org-notice-gate.ts
@@ -27,11 +27,49 @@ import type { Database, OrganizationNotice } from "../storage/types";
  * window matter only for other pods in a multi-instance deployment.
  */
 const ORG_NOTICE_CACHE_TTL_MS = 5 * 60_000;
+// Cap: entries are only ever overwritten on their own next lookup, never dropped otherwise.
+const ORG_NOTICE_CACHE_MAX_SIZE = 10_000;
 
 const orgNoticeCache = new Map<
   string,
   { notice: OrganizationNotice | null; at: number }
 >();
+
+/** Write (or refresh) a cache entry, moving it to the most-recently-set
+ *  position — `Map.set` on an existing key keeps its original iteration
+ *  order, which would leave a hot org first in line for eviction. Exported
+ *  for unit testing. */
+export function refreshOrgNoticeCacheEntry(
+  cache: Map<string, { notice: OrganizationNotice | null; at: number }>,
+  organizationId: string,
+  notice: OrganizationNotice | null,
+): void {
+  cache.delete(organizationId);
+  cache.set(organizationId, { notice, at: Date.now() });
+}
+
+/** Exported for unit testing. */
+export function evictExpiredOrgNoticeEntries(
+  cache: Map<string, { notice: OrganizationNotice | null; at: number }>,
+  maxSize: number,
+  ttlMs: number,
+): void {
+  if (cache.size <= maxSize) return;
+  const now = Date.now();
+  for (const [key, entry] of cache) {
+    if (now - entry.at >= ttlMs) cache.delete(key);
+  }
+  // Trims oldest first (Map iteration order = insertion order).
+  if (cache.size > maxSize) {
+    const excess = cache.size - maxSize;
+    let removed = 0;
+    for (const key of cache.keys()) {
+      if (removed >= excess) break;
+      cache.delete(key);
+      removed++;
+    }
+  }
+}
 
 /** Thrown when a blocked org's control plane is touched. Serialized as 403. */
 export class OrgBlockedError extends ForbiddenError {
@@ -56,7 +94,12 @@ export async function getActiveOrgNoticeCached(
   const notice = await new OrganizationNoticeStorage(db).getActive(
     organizationId,
   );
-  orgNoticeCache.set(organizationId, { notice, at: Date.now() });
+  refreshOrgNoticeCacheEntry(orgNoticeCache, organizationId, notice);
+  evictExpiredOrgNoticeEntries(
+    orgNoticeCache,
+    ORG_NOTICE_CACHE_MAX_SIZE,
+    ORG_NOTICE_CACHE_TTL_MS,
+  );
   return notice;
 }
 


### PR DESCRIPTION
Follows #7083/#7093 (same unbounded-cache class, fixed in context-factory.ts's orgArchivedCache).

`orgNoticeCache` in `apps/api/src/core/org-notice-gate.ts` backs `isOrgBlocked`, which every `defineTool` execution and every non-GET org-scoped route checks (per the file's own docblock: cached because it sits on the request hot path). The cache only ever grows: an entry is overwritten on its own next lookup, but nothing ever removes one otherwise. Every organization id this pod has ever served a request for stays in memory for the process's lifetime — an unbounded map on a hot path, exactly the bug #7083 fixed for the sibling `orgArchivedCache`.

Fix mirrors that PR's shape: a `ORG_NOTICE_CACHE_MAX_SIZE` cap, an `evictExpiredOrgNoticeEntries` helper that drops expired entries first and then trims oldest-by-insertion-order, and a `refreshOrgNoticeCacheEntry` helper that deletes-then-sets so a repeatedly-looked-up (hot) org moves to the newest iteration position instead of staying first in line for eviction (`Map.set` on an existing key does not move its position).

Behavior for callers is unchanged — same TTL, same values returned; only the cache's memory bound changes. Net effect: bounded memory instead of unbounded growth, with hot orgs never evicted ahead of a genuinely stale one.

Reviewer check: `bun test apps/api/src/core/org-notice-gate.cache.test.ts apps/api/src/core/org-notice-gate.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the two test files above (12/12 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the `orgNoticeCache` in `apps/api/src/core/org-notice-gate.ts` so it no longer grows without bound. Previously every org ID ever seen stayed in memory for the process lifetime; now the cache is capped at 10,000 entries, with expired entries evicted first and the oldest untouched entries trimmed next. Caller behavior is unchanged—same TTL and values—only the memory bound changes.

- Adds `ORG_NOTICE_CACHE_MAX_SIZE` and two exported helpers for eviction and refresh (refresh moves a hot org to the newest position so it isn't the first evicted).
- Adds unit tests covering eviction under/over cap, expiry-first trimming, and hot-org refresh ordering.

<sup>Written for commit c23082704b613b8e526df8b7a2e412d436deeb12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

