### PR TITLE
fix(task-board): stop a stale revalidation clobbering a fresher PR cache write

### DIFF
--- a/apps/api/src/tools/task-board/pr-cache.test.ts
+++ b/apps/api/src/tools/task-board/pr-cache.test.ts
@@ -87,6 +87,49 @@ describe("JetStreamKVPrCache", () => {
     expect(await read()).toEqual({ ok: true });
   });
 
+  test("a slow background revalidation cannot clobber a fresher write that lands first", async () => {
+    // A webhook refresh() lands while an older, slower background revalidation is still pending.
+    const clock = { now: 0 };
+    const cache = await cacheAt(clock);
+    const key = JSON.stringify({ name: "pull_request_read", number: 7 });
+    let releaseStale: ((v: { n: number }) => void) | undefined;
+
+    await cache.fetch({
+      namespace: "conn_1",
+      key,
+      fetchLive: async () => ({ n: 0 }),
+      onRevalidation: () => {},
+    });
+    clock.now = 60_000;
+    const pending: Promise<void>[] = [];
+    await cache.fetch({
+      namespace: "conn_1",
+      key,
+      fetchLive: () => new Promise((r) => (releaseStale = r)),
+      onRevalidation: (p) => pending.push(p),
+    });
+    expect(pending).toHaveLength(1);
+
+    clock.now = 60_001;
+    await cache.refresh({
+      namespace: "conn_1",
+      key,
+      fetchLive: async () => ({ n: 2 }),
+    });
+
+    releaseStale?.({ n: 1 });
+    await Promise.all(pending);
+
+    expect(
+      await cache.fetch({
+        namespace: "conn_1",
+        key,
+        fetchLive: async () => ({ n: -1 }),
+        onRevalidation: () => {},
+      }),
+    ).toEqual({ n: 2 });
+  });
+
   test("invalidate drops the connection's reads", async () => {
     const clock = { now: 0 };
     const cache = await cacheAt(clock);
@@ -219,8 +262,7 @@ describe("fetchOrPlaceholder", () => {
     expect(first).toEqual({ value: "from-db", live: false });
 
     release("from-github");
-    await Promise.resolve();
-    await Promise.resolve();
+    await Bun.sleep(0);
 
     expect(
       await cache.fetchOrPlaceholder({

--- a/apps/api/src/tools/task-board/pr-cache.ts
+++ b/apps/api/src/tools/task-board/pr-cache.ts
@@ -187,17 +187,19 @@ export class JetStreamKVPrCache {
       : Number.POSITIVE_INFINITY;
     if (!stored || age > maxStaleMs) {
       cacheCounter.add(1, { cache, outcome: "miss" });
+      const fetchStartedAt = this.now();
       const value = await fetchLive();
-      await this.write(key, value, cache);
+      await this.write(key, value, cache, fetchStartedAt);
       return value;
     }
 
     if (age > revalidateAfterMs && !this.revalidating.has(key)) {
       cacheCounter.add(1, { cache, outcome: "stale" });
       this.revalidating.add(key);
+      const fetchStartedAt = this.now();
       onRevalidation(
         fetchLive()
-          .then((value) => this.write(key, value, cache))
+          .then((value) => this.write(key, value, cache, fetchStartedAt))
           .catch(() => {
             // Best-effort: keep serving the stored value until maxStaleMs.
             cacheCounter.add(1, { cache, outcome: "error" });
@@ -259,10 +261,11 @@ export class JetStreamKVPrCache {
     });
     if (!this.revalidating.has(key)) {
       this.revalidating.add(key);
+      const fetchStartedAt = this.now();
       // Detached: the wait is the thing being removed. The result lands in KV
       // for the next poll, which is seconds away while the card is unenriched.
       void fetchLive()
-        .then((value) => this.write(key, value, cache))
+        .then((value) => this.write(key, value, cache, fetchStartedAt))
         .catch(() => {
           cacheCounter.add(1, { cache, outcome: "error" });
         })
@@ -284,11 +287,13 @@ export class JetStreamKVPrCache {
     key: string;
     fetchLive: () => Promise<T>;
   }): Promise<T> {
+    const fetchStartedAt = this.now();
     const value = await params.fetchLive();
     await this.write(
       this.storageKey(params.namespace, params.key),
       value,
       this.config.cache,
+      fetchStartedAt,
     );
     cacheCounter.add(1, { cache: this.config.cache, outcome: "refresh" });
     return value;
@@ -306,11 +311,23 @@ export class JetStreamKVPrCache {
     }
   }
 
+  /**
+   * @param notBefore The fetch's own start time. If a fresher write (its own
+   *   fetch started later) already landed by the time this one is ready to
+   *   store, this write is dropped instead of clobbering it — otherwise a
+   *   slow background revalidation that started before a webhook push can
+   *   still finish after it and overwrite the fresher card with stale data.
+   */
   private async write(
     key: string,
     value: unknown,
     cache: string,
+    notBefore?: number,
   ): Promise<void> {
+    if (notBefore !== undefined) {
+      const current = await this.read(key);
+      if (current && current.storedAt > notBefore) return;
+    }
     if (!this.kv) {
       // Evict the oldest entry (insertion order) once past the cap.
       if (


### PR DESCRIPTION
A real race in `JetStreamKVPrCache` (`apps/api/src/tools/task-board/pr-cache.ts`), introduced by the recent webhook push-cache work (#7100): `fetch()`/`fetchOrPlaceholder()`'s background revalidation and the webhook's `refresh()` can both target the same cache key concurrently, and whichever fetch resolves *last* wins the write regardless of which one *started* first. So a slow, poll-triggered revalidation that began before a webhook delivery can still finish after it and overwrite the fresher, webhook-pushed card with stale data — silently, until the next poll's revalidate window passes.

A maintainer wants this because it's exactly the class of bug #7100 was built to fix ("checks go green ... but the card shows neither for 1-3 minutes") — this closes the one gap left where the fix could still lose a fresh write to a slower stale one.

**Failure scenario:** a task dialog poll sees a stale card and kicks off a background revalidation (slow provider read). Before it resolves, a GitHub webhook fires (CI just finished), calls `refresh()`, which fetches fast and writes the fresh card. The dialog's earlier revalidation then finally resolves and overwrites the just-pushed fresh card with its own older answer — the SSE push the user just saw gets silently reverted until the next poll ages it out again.

**Fix:** `write()` now takes the writer's own fetch-*start* time (`notBefore`) and skips the write if the currently stored value was written after that time — so only a write whose fetch started later than what's currently stored can land. Added a regression test in `pr-cache.test.ts` that reproduces the race (a revalidation started before a `refresh()` push, but resolving after it) and asserts the fresher value survives.

**To verify:** `bun test apps/api/src/tools/task-board/pr-cache.test.ts`

**Checks run locally:** `bun test apps/api/src/tools/task-board/pr-cache.test.ts` (12 pass, including the new case), `bun test apps/api/src/tools/task-board/checks-status.test.ts` (unaffected, 33 pass), `bunx tsc --noEmit` in `apps/api`, `bunx oxlint` on both touched files, `bun run fmt`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the task-board PR cache where a slow background revalidation could overwrite a fresher webhook-pushed card after the webhook write had already landed. `write()` now records each fetch's start time and skips the write if a newer value is already stored, so only a fetch that started later can replace the cached card.

**Bug Fixes**
- Adds a regression test that reproduces the race and verifies the fresher value survives.

<sup>Written for commit e1f9ac1415e396e3cd157e20cc7130530c74fb1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

