### PR TITLE
fix(git): require owner authorization for GitHub installations

### DIFF
--- a/apps/api/migrations/209-github-installation-authorization.ts
+++ b/apps/api/migrations/209-github-installation-authorization.ts
@@ -1,0 +1,17 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Historical connections only proved repository access, not installation ownership.
+  // Leave them unverified so reconnect performs the new ownership check.
+  await db.schema
+    .alterTable("git_provider_accounts")
+    .addColumn("installation_authorized_by", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("git_provider_accounts")
+    .dropColumn("installation_authorized_by")
+    .execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -1,3 +1,4 @@
+import * as migration209githubinstallationauthorization from "./209-github-installation-authorization";
 import * as migration208githubconnectflows from "./208-github-connect-flows";
 import * as migration207taskboardprsrepoidx from "./207-task-board-prs-repo-idx";
 import * as migration206repositoryconsumers from "./206-repository-consumers";
@@ -450,6 +451,8 @@ const migrations: Record<string, Migration> = {
   "206-repository-consumers": migration206repositoryconsumers,
   "207-task-board-prs-repo-idx": migration207taskboardprsrepoidx,
   "208-github-connect-flows": migration208githubconnectflows,
+  "209-github-installation-authorization":
+    migration209githubinstallationauthorization,
 };
 
 export default migrations;

--- a/apps/api/src/api/routes/git-providers.ts
+++ b/apps/api/src/api/routes/git-providers.ts
@@ -12,7 +12,8 @@
  *   and the callback insists the session user is the state's user.
  *
  * GitHub: user-to-server OAuth is used ONLY to prove which App installations
- * the user can see (`GET /user/installations`). An encrypted, ten-minute grant
+ * the user owns or administers. Repository collaborators cannot share an
+ * installation. An encrypted, ten-minute grant
  * lets the user select an installation or install the App in another tab. The
  * grant is deleted after selection; saved accounts use the App private key.
  *
@@ -157,7 +158,7 @@ export const createGitProviderRoutes = () => {
     const appAuth = getGithubAppAuth();
     if (!appAuth) return c.json({ error: "not_configured" }, 503);
     try {
-      const installations = await appAuth.listUserInstallations(
+      const { installations } = await appAuth.listOwnedInstallations(
         await ctx.vault.decrypt(flow.encrypted_access_token),
       );
       return c.json({ installations, expiresAt: flow.expires_at });
@@ -189,15 +190,15 @@ export const createGitProviderRoutes = () => {
     if (!flow) return c.json({ error: "flow_expired" }, 410);
     const appAuth = getGithubAppAuth();
     if (!appAuth) return c.json({ error: "not_configured" }, 503);
-    let installations;
+    let access;
     try {
-      installations = await appAuth.listUserInstallations(
+      access = await appAuth.listOwnedInstallations(
         await ctx.vault.decrypt(flow.encrypted_access_token),
       );
     } catch {
       return c.json({ error: "github_unavailable" }, 502);
     }
-    const installation = installations.find(
+    const installation = access.installations.find(
       (item) => item.installationId === input.data.installationId,
     );
     if (!installation) return c.json({ error: "installation_forbidden" }, 403);
@@ -213,6 +214,7 @@ export const createGitProviderRoutes = () => {
         login: installation.login,
         avatarUrl: installation.avatarUrl,
         installationId: installation.installationId,
+        installationAuthorizedBy: access.userId,
       },
     );
     if (!account) return c.json({ error: "flow_expired" }, 410);

--- a/apps/api/src/git-providers/credentials.ts
+++ b/apps/api/src/git-providers/credentials.ts
@@ -86,14 +86,17 @@ function grantKind(
 }
 
 /**
- * Whether Studio itself can produce credentials for this account. False only
- * for a backfilled GitHub App account on a deployment without the App keys —
- * those still clone through their legacy `mcp-github` connection.
+ * Whether Studio itself can produce credentials for this account. A GitHub installation
+ * must have an owner authorization recorded before Studio can mint for it.
  */
 export function accountIsServable(account: GitProviderAccountRecord): boolean {
   if (account.status !== "active") return false;
   if (account.type === "github" && account.authKind === "github_app") {
-    return getGithubAppAuth() !== null && account.installationId !== null;
+    return (
+      getGithubAppAuth() !== null &&
+      account.installationId !== null &&
+      !!account.installationAuthorizedBy
+    );
   }
   return true;
 }
@@ -102,6 +105,22 @@ export function clientForAccount(
   deps: GitProviderDeps,
   account: GitProviderAccountRecord,
 ): GitProviderClient {
+  if (account.status !== "active") {
+    throw new GitProviderError({
+      provider: account.type,
+      status: 403,
+      message:
+        "This git account was revoked. Reconnect it before accessing repositories.",
+    });
+  }
+  if (account.authKind === "github_app" && !account.installationAuthorizedBy) {
+    throw new GitProviderError({
+      provider: account.type,
+      status: 403,
+      message:
+        "Reconnect this git account. A GitHub installation must be authorized by its personal account owner or an organization owner.",
+    });
+  }
   const credentials = new GitProviderAccountCredentialStorage(
     deps.db,
     deps.vault,

--- a/apps/api/src/git-providers/github/app-auth.ts
+++ b/apps/api/src/git-providers/github/app-auth.ts
@@ -12,6 +12,7 @@
  */
 
 import { createPrivateKey, sign } from "node:crypto";
+import { z } from "zod";
 import {
   isPermissionRejected,
   OPTIONAL_MINT_PERMISSIONS,
@@ -370,11 +371,73 @@ export class GithubAppAuth {
     return mapped;
   }
 
+  /** Repository collaboration does not authorize sharing an entire installation. */
+  async listOwnedInstallations(userToken: string): Promise<{
+    userId: string;
+    installations: GithubInstallation[];
+  }> {
+    const user = z
+      .object({ id: z.number().int().positive().safe() })
+      .parse(await this.userGet("/user", userToken, "get_connecting_user"));
+    const installations = await this.listUserInstallations(userToken);
+    const ownedOrganizations = new Set<string>();
+    if (installations.some((item) => item.accountType === "Organization")) {
+      for (let page = 1; ; page++) {
+        // Unlike the per-org membership endpoint, this requires no extra App permissions.
+        const memberships = z
+          .array(
+            z.object({
+              state: z.string(),
+              role: z.string(),
+              organization: z.object({
+                id: z.number().int().positive().safe(),
+              }),
+            }),
+          )
+          .parse(
+            await this.userGet(
+              `/user/memberships/orgs?state=active&per_page=100&page=${page}`,
+              userToken,
+              "list_connecting_user_memberships",
+            ),
+          );
+        for (const membership of memberships) {
+          if (membership.state === "active" && membership.role === "admin") {
+            ownedOrganizations.add(String(membership.organization.id));
+          }
+        }
+        if (memberships.length < 100) break;
+      }
+    }
+    return {
+      userId: String(user.id),
+      installations: installations.filter((item) =>
+        item.accountType === "User"
+          ? item.externalAccountId === String(user.id)
+          : item.accountType === "Organization" &&
+            ownedOrganizations.has(item.externalAccountId),
+      ),
+    };
+  }
+
+  private async userGet(
+    path: string,
+    token: string,
+    operation: string,
+  ): Promise<unknown> {
+    const response = await githubFetch(`${this.apiBaseUrl}${path}`, {
+      token,
+      operation,
+    });
+    if (!response.ok) throw await githubFailure(response, operation);
+    return githubJson<unknown>(response, operation);
+  }
+
   /**
    * Every installation of this App the user can access, via their
    * user-to-server token: `GET /user/installations`, paginated.
    */
-  async listUserInstallations(
+  private async listUserInstallations(
     userToken: string,
   ): Promise<GithubInstallation[]> {
     const operation = "list_user_installations";

--- a/apps/api/src/storage/git-provider-accounts.ts
+++ b/apps/api/src/storage/git-provider-accounts.ts
@@ -26,6 +26,7 @@ type Row = {
   login: string;
   avatar_url: string | null;
   installation_id: string | number | null;
+  installation_authorized_by: string | null;
   credential_connection_id: string | null;
   status: "active" | "revoked";
   created_by: string | null;
@@ -38,6 +39,7 @@ type Row = {
 export interface GitProviderAccountRecord extends GitProviderAccount {
   credentialConnectionId: string | null;
   connectedBy: { name: string } | null;
+  installationAuthorizedBy: string | null;
 }
 
 function toEntity(row: Row): GitProviderAccountRecord {
@@ -56,6 +58,7 @@ function toEntity(row: Row): GitProviderAccountRecord {
     avatarUrl: row.avatar_url,
     installationId: Number.isFinite(installationId) ? installationId : null,
     status: row.status,
+    installationAuthorizedBy: row.installation_authorized_by ?? null,
     credentialConnectionId: row.credential_connection_id,
     connectedBy: row.connected_by_name ? { name: row.connected_by_name } : null,
     createdAt: toIso(row.created_at),
@@ -72,6 +75,7 @@ export interface UpsertGitProviderAccountParams {
   login: string;
   avatarUrl?: string | null;
   installationId?: number | null;
+  installationAuthorizedBy?: string | null;
   createdBy?: string | null;
 }
 
@@ -99,6 +103,7 @@ export class GitProviderAccountStorage {
         login: params.login,
         avatar_url: params.avatarUrl ?? null,
         installation_id: params.installationId ?? null,
+        installation_authorized_by: params.installationAuthorizedBy ?? null,
         credential_connection_id: null,
         status: "active",
         created_by: params.createdBy ?? null,
@@ -112,6 +117,7 @@ export class GitProviderAccountStorage {
             login: params.login,
             avatar_url: params.avatarUrl ?? null,
             installation_id: params.installationId ?? null,
+            installation_authorized_by: params.installationAuthorizedBy ?? null,
             credential_connection_id: null,
             status: "active",
             updated_at: now,

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -2253,6 +2253,11 @@ export type GitAuthKindColumn = "github_app" | "oauth" | "token";
 export type GitAccountStatusColumn = "active" | "revoked";
 
 export interface GitProviderAccountTable {
+  installation_authorized_by: ColumnType<
+    string | null,
+    string | null | undefined,
+    string | null
+  >;
   id: ColumnType<string, string | undefined, never>;
   organization_id: string;
   type: GitProviderKindColumn;

--- a/apps/api/src/tools/git/index.ts
+++ b/apps/api/src/tools/git/index.ts
@@ -53,7 +53,11 @@ const AccountOutputSchema = GitProviderAccountSchema.extend({
 function toAccountOutput(
   account: GitProviderAccountRecord,
 ): z.infer<typeof AccountOutputSchema> {
-  const { credentialConnectionId: _bridge, ...entity } = account;
+  const {
+    credentialConnectionId: _bridge,
+    installationAuthorizedBy: _authorization,
+    ...entity
+  } = account;
   return { ...entity, servable: accountIsServable(account) };
 }
 

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -118,9 +118,9 @@ export const settings = {
   "settings.repositories.addGithubAccount":
     "Add GitHub account or organization",
   "settings.repositories.githubShareHint":
-    "Choose an account to share with {organization}. Members with repository permissions in Studio can use this connection.",
+    "Choose your personal GitHub account or an organization you own to share with {organization}. Members with repository permissions in Studio can use this connection.",
   "settings.repositories.githubInstallHint":
-    "No accounts are available yet. Install the GitHub App on your account or organization, or ask an organization owner to approve access.",
+    "No accounts you own are available. Install the GitHub App on your personal account or an organization you own, or ask its owner to connect it to Studio. Access to an individual repository does not allow sharing its entire account.",
   "settings.repositories.installGithubAccount": "Install on another account",
   "settings.repositories.checkGithubAccess": "Check access",
   "settings.repositories.switchGithubUser": "Use another GitHub login",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -123,9 +123,9 @@ export const settings = {
   "settings.repositories.addGithubAccount":
     "Adicionar conta ou organização do GitHub",
   "settings.repositories.githubShareHint":
-    "Escolha uma conta para compartilhar com {organization}. Membros com permissão para repositórios no Studio podem usar esta conexão.",
+    "Escolha sua conta pessoal do GitHub ou uma organização da qual você é dono para compartilhar com {organization}. Membros com permissão para repositórios no Studio podem usar esta conexão.",
   "settings.repositories.githubInstallHint":
-    "Nenhuma conta disponível ainda. Instale o app do GitHub na sua conta ou organização, ou peça a um administrador da organização para aprovar o acesso.",
+    "Nenhuma conta da qual você é dono está disponível. Instale o app do GitHub na sua conta pessoal ou organização, ou peça ao dono para conectá-la ao Studio. Ter acesso a um repositório não permite compartilhar a conta inteira.",
   "settings.repositories.installGithubAccount": "Instalar em outra conta",
   "settings.repositories.checkGithubAccess": "Verificar acesso",
   "settings.repositories.switchGithubUser": "Usar outro login do GitHub",

--- a/packages/e2e/fixtures/github-stub.ts
+++ b/packages/e2e/fixtures/github-stub.ts
@@ -911,7 +911,20 @@ interface UserInstallation {
 }
 
 export function createGithubStubServer(): Server {
-  const users = new Map<string, UserInstallation[]>();
+  const users = new Map<
+    string,
+    {
+      installations: UserInstallation[];
+      user: { id: number; login: string };
+      memberships: Array<{
+        state: string;
+        role: string;
+        organization: { id: number };
+      }>;
+      identityStatus?: number;
+      membershipsStatus?: number;
+    }
+  >();
   const codes = new Map<string, string>();
   return createServer((req, res) => {
     const url = new URL(req.url ?? "/", "http://localhost");
@@ -924,8 +937,16 @@ export function createGithubStubServer(): Server {
         const body = JSON.parse(await readBody(req)) as {
           token: string;
           installations: UserInstallation[];
+          user: { id: number; login: string };
+          memberships: Array<{
+            state: string;
+            role: string;
+            organization: { id: number };
+          }>;
+          identityStatus?: number;
+          membershipsStatus?: number;
         };
-        users.set(body.token, body.installations);
+        users.set(body.token, body);
         json(res, 200, { ok: true });
         return;
       }
@@ -954,10 +975,39 @@ export function createGithubStubServer(): Server {
         );
         return;
       }
+      if (
+        req.method === "GET" &&
+        (url.pathname === "/user" || url.pathname === "/user/memberships/orgs")
+      ) {
+        const user = users.get(
+          req.headers.authorization?.replace(/^Bearer /, "") ?? "",
+        );
+        if (!user) {
+          json(res, 401, { message: "Bad credentials" });
+          return;
+        }
+        if (url.pathname === "/user") {
+          json(
+            res,
+            user.identityStatus ?? 200,
+            user.identityStatus ? { message: "Denied" } : user.user,
+          );
+        } else {
+          const page = Number(url.searchParams.get("page") ?? 1);
+          json(
+            res,
+            user.membershipsStatus ?? 200,
+            user.membershipsStatus
+              ? { message: "Denied" }
+              : user.memberships.slice((page - 1) * 100, page * 100),
+          );
+        }
+        return;
+      }
       if (req.method === "GET" && url.pathname === "/user/installations") {
         const installations = users.get(
           req.headers.authorization?.replace(/^Bearer /, "") ?? "",
-        );
+        )?.installations;
         if (!installations) {
           json(res, 401, { message: "Bad credentials" });
           return;
@@ -975,7 +1025,7 @@ export function createGithubStubServer(): Server {
       ) {
         const id = Number(url.pathname.split("/").at(-1));
         const installation = [...users.values()]
-          .flat()
+          .flatMap((user) => user.installations)
           .find((item) => item.id === id);
         if (installation) json(res, 200, installation);
         else notFound(res);

--- a/packages/e2e/tests/github-connect.spec.ts
+++ b/packages/e2e/tests/github-connect.spec.ts
@@ -8,6 +8,7 @@ import type { APIRequestContext } from "@playwright/test";
 import { expect, test, newApiContext, type AuthedPage } from "../fixtures/test";
 import { signUpViaApi } from "../fixtures/auth-api";
 import { connectDevDb } from "../fixtures/db";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
 
 const fixtureOrigin = `http://localhost:${process.env.GITHUB_STUB_PORT ?? "4102"}`;
 type Installation = {
@@ -26,7 +27,8 @@ function installation(
   return {
     id: Math.floor(Math.random() * 1_000_000_000) + 1,
     account: {
-      id: Math.floor(Math.random() * 1_000_000_000) + 1,
+      id:
+        type === "User" ? 1001 : Math.floor(Math.random() * 1_000_000_000) + 1,
       login,
       type,
       avatar_url: null,
@@ -37,9 +39,34 @@ async function grantAccess(
   request: APIRequestContext,
   token: string,
   installations: Installation[],
+  identity?: {
+    id?: number;
+    memberships?: Array<{
+      state: string;
+      role: string;
+      organization: { id: number };
+    }>;
+    identityStatus?: number;
+    membershipsStatus?: number;
+  },
 ) {
   const result = await request.post(`${fixtureOrigin}/__admin/github-users`, {
-    data: { token, installations },
+    data: {
+      token,
+      installations,
+      user: { id: identity?.id ?? 1001, login: "connecting-user" },
+      memberships:
+        identity?.memberships ??
+        installations
+          .filter((item) => item.account.type === "Organization")
+          .map((item) => ({
+            state: "active",
+            role: "admin",
+            organization: { id: item.account.id },
+          })),
+      identityStatus: identity?.identityStatus,
+      membershipsStatus: identity?.membershipsStatus,
+    },
   });
   expect(result.ok()).toBe(true);
 }
@@ -578,4 +605,223 @@ test("returning focus discovers new installation access without a callback or an
     page.getByRole("button", { name: account.account.login, exact: true }),
   ).toBeVisible();
   await githubTab.close();
+});
+
+test("access to a collaborator's personal installation does not authorize sharing that entire account", async ({
+  authedPage,
+}, testInfo) => {
+  const ownOrg = installation("my-organization");
+  // GitHub may list a personal installation because the user collaborates on
+  // one repository. That is not authority over its owner's other repositories.
+  const collaborator = installation("another-person", "User");
+  collaborator.account.id = 2002;
+  const flow = await seedFlow(authedPage, [ownOrg, collaborator]);
+  const response = await authedPage.page.request.get(flow.path);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(
+    body.installations.map((item: { login: string }) => item.login),
+  ).not.toContain(collaborator.account.login);
+  const connected = await authedPage.page.request.post(flow.path, {
+    data: { installationId: collaborator.id },
+  });
+  expect(connected.status()).toBe(403);
+  await authedPage.page.addInitScript(() =>
+    localStorage.setItem(
+      "studio:user:preferences",
+      JSON.stringify({ language: "pt-BR" }),
+    ),
+  );
+  await authedPage.page.goto(flow.url);
+  const dialog = authedPage.page.getByRole("dialog");
+  await expect(
+    dialog.getByRole("button", { name: ownOrg.account.login, exact: true }),
+  ).toBeVisible();
+  await expect(
+    dialog.getByText(collaborator.account.login, { exact: true }),
+  ).toHaveCount(0);
+  await authedPage.page.screenshot({
+    path: testInfo.outputPath("github-owner-chooser.png"),
+    animations: "disabled",
+  });
+});
+
+test("organization membership is not ownership and the check runs again when connecting", async ({
+  authedPage,
+}) => {
+  const { page } = authedPage;
+  const owned = installation("owned-organization");
+  const member = installation("member-organization");
+  const pending = installation("pending-owner-organization");
+  const external = installation("external-organization");
+  const personal = installation("my-personal-account", "User");
+  const installations = [owned, member, pending, external, personal];
+  const flow = await seedFlow(authedPage, installations);
+  const memberships = [
+    { state: "active", role: "admin", organization: { id: owned.account.id } },
+    {
+      state: "active",
+      role: "member",
+      organization: { id: member.account.id },
+    },
+    {
+      state: "pending",
+      role: "admin",
+      organization: { id: pending.account.id },
+    },
+  ];
+  await grantAccess(page.request, flow.token, installations, { memberships });
+  const listed = await (await page.request.get(flow.path)).json();
+  expect(
+    listed.installations.map((item: { login: string }) => item.login),
+  ).toEqual([owned.account.login, personal.account.login]);
+  for (const installation of [member, pending, external]) {
+    expect(
+      (
+        await page.request.post(flow.path, {
+          data: { installationId: installation.id },
+        })
+      ).status(),
+    ).toBe(403);
+  }
+  await grantAccess(page.request, flow.token, installations, {
+    memberships: [],
+  });
+  expect(
+    (
+      await page.request.post(flow.path, { data: { installationId: owned.id } })
+    ).status(),
+  ).toBe(403);
+  expect(
+    (
+      await page.request.post(flow.path, {
+        data: { installationId: personal.id },
+      })
+    ).status(),
+  ).toBe(200);
+});
+
+test("owner lookup handles membership pagination and fails closed on GitHub errors", async ({
+  authedPage,
+}) => {
+  const { page } = authedPage;
+  const owned = installation("organization-after-page-one");
+  const flow = await seedFlow(authedPage, [owned]);
+  const memberships = Array.from({ length: 100 }, (_, i) => ({
+    state: "active",
+    role: "member",
+    organization: { id: i + 1 },
+  }));
+  memberships.push({
+    state: "active",
+    role: "admin",
+    organization: { id: owned.account.id },
+  });
+  await grantAccess(page.request, flow.token, [owned], { memberships });
+  expect(
+    (await (await page.request.get(flow.path)).json()).installations,
+  ).toHaveLength(1);
+  for (const failure of [{ identityStatus: 403 }, { membershipsStatus: 403 }]) {
+    await grantAccess(page.request, flow.token, [owned], failure);
+    expect((await page.request.get(flow.path)).status()).toBe(502);
+    expect(
+      (
+        await page.request.post(flow.path, {
+          data: { installationId: owned.id },
+        })
+      ).status(),
+    ).toBe(502);
+  }
+  const accounts = await callSelfMcpTool<{ accounts: unknown[] }>(
+    page.request,
+    authedPage.orgSlug,
+    "GIT_ACCOUNT_LIST",
+    {},
+  );
+  expect(accounts.accounts).toEqual([]);
+});
+
+test("historical accounts cannot mint credentials until an owner reconnects, and revoked accounts stay blocked", async ({
+  authedPage,
+}) => {
+  const { page, orgSlug, user } = authedPage;
+  const owned = installation("previously-connected");
+  const flow = await seedFlow(authedPage, [owned]);
+  const db = await connectDevDb();
+  try {
+    const saved = await db.query<{ id: string }>(
+      `INSERT INTO git_provider_accounts (organization_id,type,host,auth_kind,external_account_id,login,installation_id,created_by) VALUES ($1,'github','github.com','github_app',$2,$3,$4,$5) RETURNING id`,
+      [
+        flow.orgId,
+        String(owned.id),
+        owned.account.login,
+        owned.id,
+        user.userId,
+      ],
+    );
+    const accountId = saved.rows[0]!.id;
+    const list = () =>
+      callSelfMcpTool<{ accounts: Array<{ id: string; servable: boolean }> }>(
+        page.request,
+        orgSlug,
+        "GIT_ACCOUNT_LIST",
+        {},
+      );
+    expect((await list()).accounts[0]?.servable).toBe(false);
+    const linked = await db.query<{ id: string }>(
+      `INSERT INTO repositories (organization_id,account_id,provider,host,path,web_url,visibility) VALUES ($1,$2,'github','github.com','previously-connected/private-project','https://github.com/previously-connected/private-project','private') RETURNING id`,
+      [flow.orgId, accountId],
+    );
+    const repositoryId = linked.rows[0]!.id;
+    const repositories = await callSelfMcpTool<{
+      repositories: Array<{ id: string; usable: boolean }>;
+    }>(page.request, orgSlug, "REPOSITORY_LIST", {});
+    expect(repositories.repositories).toMatchObject([
+      { id: repositoryId, usable: false },
+    ]);
+    await expect(
+      callSelfMcpTool(page.request, orgSlug, "REPOSITORY_SEARCH_BRANCHES", {
+        repositoryId,
+        query: "",
+      }),
+    ).rejects.toThrow(/reconnect/i);
+    await expect(
+      callSelfMcpTool(page.request, orgSlug, "REPOSITORY_SEARCH", {
+        accountId,
+      }),
+    ).rejects.toThrow("Reconnect this git account");
+    await expect(
+      callSelfMcpTool(page.request, orgSlug, "REPOSITORY_LINK", {
+        accountId,
+        url: "https://github.com/previously-connected/private-project",
+      }),
+    ).rejects.toThrow("Reconnect this git account");
+    expect(
+      (
+        await page.request.post(flow.path, {
+          data: { installationId: owned.id },
+        })
+      ).status(),
+    ).toBe(200);
+    expect((await list()).accounts).toMatchObject([
+      { id: accountId, servable: true },
+    ]);
+    const proof = await db.query(
+      "SELECT installation_authorized_by FROM git_provider_accounts WHERE id=$1 AND organization_id=$2",
+      [accountId, flow.orgId],
+    );
+    expect(proof.rows[0].installation_authorized_by).toBe("1001");
+    await db.query(
+      "UPDATE git_provider_accounts SET status='revoked' WHERE id=$1 AND organization_id=$2",
+      [accountId, flow.orgId],
+    );
+    expect((await list()).accounts[0]?.servable).toBe(false);
+    await expect(
+      callSelfMcpTool(page.request, orgSlug, "REPOSITORY_SEARCH", {
+        accountId,
+      }),
+    ).rejects.toThrow("revoked");
+  } finally {
+    await db.end();
+  }
 });


### PR DESCRIPTION
GitHub installation visibility can come from collaboration on an individual repository. Studio treated that visibility as authorization to share the entire installation with a workspace, then used the broader GitHub App credentials. This change requires installation ownership before creating that shared connection.

The chooser and its confirmation endpoint both verify the authenticated GitHub user. Personal installations must belong to that user; organization installations require an active owner membership. Memberships are paginated and matched by immutable account IDs. GitHub errors fail closed, and confirmation checks ownership again. The membership-list endpoint supports GitHub App user tokens without adding App permissions ([GitHub documentation](https://docs.github.com/en/rest/orgs/members#list-organization-memberships-for-the-authenticated-user)).

Migration 209 records the verified GitHub user's ID on the account. Existing GitHub App connections have no ownership proof and require an owner to reconnect before Studio can mint new credentials. The shared credential factory also rejects revoked accounts, so direct repository operations cannot bypass the picker. EN/PT-BR copy explains who may share a connection.

Deployment impact: existing GitHub App connections need reconnection by the personal account owner or a GitHub organization owner. The migration preserves account and repository records. It blocks new Studio-issued credentials; it does not revoke previously issued installation tokens or stop running sandboxes. No environment was changed while preparing this PR.

Validation:

- Reproduced the collaborator-account bug with a failing browser/API test before the fix.
- 14 GitHub connection E2E tests pass, including personal collaborators, organization members, pending owners, outside collaborators, role changes before confirmation, membership pagination, provider failures, and historical/revoked connections. Existing linked repositories are unusable until their owner reconnects.
- 17 provider, repository-picker, and avatar regression tests pass.
- 8,554 unit tests pass. `bun run fmt`, `bun run lint`, `bun run check`, and `bun run knip` pass.
- E2E uses real Postgres and synthetic external GitHub responses; no real customer data is in fixtures.

![Chooser only offers accounts the connecting GitHub user owns](https://raw.githubusercontent.com/decocms/studio/c8cdaffa0980a1267813fbc898a0881064f73c8a/github-owner-chooser.png)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub installation sharing so repository collaboration no longer grants access to an entire installation. The chooser and confirmation now verify the connecting GitHub user owns the personal installation or is an admin owner of an organization installation, and credential minting refuses accounts without ownership proof.

**Migration**
- Existing GitHub App connections have no ownership proof and require the owner to reconnect before Studio can issue new credentials.
- Migration 209 preserves account and repository records and only blocks new credentials; it does not revoke previously issued tokens or stop running sandboxes.

<sup>Written for commit 9a65a0ad92354fbe6dd66374af4ceac8db67c835. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

