### PR TITLE
feat(jira): run the agent on one issue from Settings, without a rule

### DIFF
--- a/apps/api/src/jira/issue-key.test.ts
+++ b/apps/api/src/jira/issue-key.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { parseIssueKey } from "./issue-key";
+
+describe("parseIssueKey", () => {
+  it("takes a key as typed, uppercased", () => {
+    expect(parseIssueKey("ABC-123")).toBe("ABC-123");
+    expect(parseIssueKey("  abc-123  ")).toBe("ABC-123");
+    expect(parseIssueKey("A1_B-7")).toBe("A1_B-7");
+  });
+
+  it("takes the key out of a pasted link", () => {
+    expect(parseIssueKey("https://x.atlassian.net/browse/ABC-123")).toBe(
+      "ABC-123",
+    );
+    expect(
+      parseIssueKey(
+        "https://x.atlassian.net/browse/ABC-123?focusedCommentId=99",
+      ),
+    ).toBe("ABC-123");
+    expect(
+      parseIssueKey(
+        "https://x.atlassian.net/jira/software/projects/ABC/boards/1?selectedIssue=ABC-45",
+      ),
+    ).toBe("ABC-45");
+  });
+
+  /** Never hand Jira something that is not a key — the 404 it answers with
+   *  reads like the integration is broken. */
+  it("rejects anything that is not a key", () => {
+    for (const bad of [
+      "",
+      "   ",
+      "ABC",
+      "123",
+      "-123",
+      "ABC-",
+      "1ABC-2",
+      "ABC 123",
+      "ABC-12x",
+      "https://x.atlassian.net/",
+    ]) {
+      expect(parseIssueKey(bad)).toBeNull();
+    }
+  });
+});

--- a/apps/api/src/jira/issue-key.ts
+++ b/apps/api/src/jira/issue-key.ts
@@ -1,0 +1,25 @@
+/**
+ * The issue key out of whatever a person has in hand.
+ *
+ * They are as likely to paste the browser's URL as to type `ABC-123`, and Jira
+ * keys are uppercase while nobody types them that way, so normalizing here
+ * keeps every caller from guessing. Anything that is not a key is rejected
+ * rather than passed to Jira as a search term.
+ */
+
+/** `PROJ-123` — a project key (letters/digits/underscore, starting with a
+ *  letter) then a number. */
+const ISSUE_KEY = /^([A-Za-z][A-Za-z0-9_]*-\d+)$/;
+
+export function parseIssueKey(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  // A pasted link: .../browse/ABC-123, or a board URL with ?selectedIssue=ABC-123.
+  const fromUrl =
+    /(?:\/(?:browse|issues)\/|[?&]selectedIssue=)([A-Za-z][A-Za-z0-9_]*-\d+)/.exec(
+      trimmed,
+    );
+  const candidate = fromUrl?.[1] ?? trimmed.split(/[?#]/)[0] ?? "";
+  const match = ISSUE_KEY.exec(candidate);
+  return match?.[1] ? match[1].toUpperCase() : null;
+}

--- a/apps/api/src/jira/issue-prompt.test.ts
+++ b/apps/api/src/jira/issue-prompt.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { type IssueForPrompt, renderIssueForPrompt } from "./issue-prompt";
 
 const base: IssueForPrompt = {
+  id: "10012",
   key: "EX-12",
   url: "https://example.atlassian.net/browse/EX-12",
   summary: "Fix the checkout button",

--- a/apps/api/src/jira/issue-prompt.ts
+++ b/apps/api/src/jira/issue-prompt.ts
@@ -16,6 +16,9 @@ import {
 } from "./client";
 
 export interface IssueForPrompt {
+  /** Jira's own issue id. The stable identity a link is keyed by — an issue's
+   *  KEY changes when it moves project, its id does not. */
+  id: string;
   key: string;
   url: string;
   summary: string;
@@ -33,15 +36,20 @@ export function issueUrl(siteUrl: string, key: string): string {
   return `${siteUrl.replace(/\/+$/, "")}/browse/${encodeURIComponent(key)}`;
 }
 
-/** Read everything the prompt shows, resolving mentions to names once. */
+/**
+ * Read everything the prompt shows, resolving mentions to names once.
+ *
+ * `issueIdOrKey` is either, as Jira's own endpoint takes either: the trigger
+ * knows the id from the changelog, a person firing a run by hand knows the key.
+ */
 export async function loadIssueForPrompt(
   client: JiraClient,
   siteUrl: string,
-  issueId: string,
+  issueIdOrKey: string,
 ): Promise<IssueForPrompt> {
   const [issue, comments] = await Promise.all([
-    client.getIssue(issueId),
-    client.listComments(issueId),
+    client.getIssue(issueIdOrKey),
+    client.listComments(issueIdOrKey),
   ]);
   const users = new JiraUserDirectory(client);
   const names = await users.resolve([
@@ -49,6 +57,7 @@ export async function loadIssueForPrompt(
     ...comments.flatMap((c) => collectMentionAccountIds(c.body)),
   ]);
   return {
+    id: issue.id,
     key: issue.key,
     url: issueUrl(siteUrl, issue.key),
     summary: issue.fields.summary,

--- a/apps/api/src/jira/trigger.ts
+++ b/apps/api/src/jira/trigger.ts
@@ -12,12 +12,16 @@
  * same entry dispatches nothing, while the issue entering the column again
  * later is a new run. The claim is taken right before dispatch, after the
  * anchor item exists, so a lost claim never leaves an item with no run.
+ *
+ * `startJiraRunForIssue` is the same run without any of that gating — a person
+ * asking for one issue, which is how a rule gets tried before it is turned on.
  */
 
 import { LANES, SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import type { StudioContext } from "@/core/studio-context";
 import type { OrgJiraIntegration, TaskBoardItem } from "@/storage/types";
 import { enqueueSuperAgentForTask } from "@/tools/task-board/enqueue-super-agent";
+import { supersedeLiveRuns } from "@/tools/task-board/rerun";
 import { JiraClient, type JiraChangelogHistory } from "./client";
 import {
   type IssueForPrompt,
@@ -117,6 +121,14 @@ function jiraRunTitle(issue: { key: string; summary: string }): string {
   return `Jira ${issue.key}: ${issue.summary}`;
 }
 
+function jiraClientFor(integration: OrgJiraIntegration): JiraClient {
+  return new JiraClient(
+    integration.siteUrl,
+    integration.email,
+    integration.apiToken,
+  );
+}
+
 /**
  * Dispatch a run for `transition` if the org has a rule for its status and
  * nothing dispatched this transition already.
@@ -134,17 +146,17 @@ export async function triggerRunForTransition(
   );
   if (!rule) return "no_rule";
 
-  const client = new JiraClient(
-    integration.siteUrl,
-    integration.email,
-    integration.apiToken,
-  );
   const issue = await loadIssueForPrompt(
-    client,
+    jiraClientFor(integration),
     integration.siteUrl,
     transition.issueId,
   );
-  const item = await ensureAnchorItem(ctx, integration, transition, issue);
+  const item = await ensureAnchorItem(
+    ctx,
+    integration,
+    issue,
+    integration.createdBy,
+  );
 
   const claimed = await ctx.storage.jiraIntegrations.claimTrigger(
     orgId,
@@ -153,18 +165,76 @@ export async function triggerRunForTransition(
   );
   if (!claimed) return "duplicate";
 
+  // A dispatch failure past here leaves the claim standing: the transition is spent.
+  await dispatchJiraRun(ctx, integration, item, issue, {
+    instruction: rule.prompt,
+    actorId: integration.createdBy,
+  });
+  return "started";
+}
+
+/**
+ * Run the agent on ONE issue because a person asked for it — how a status rule
+ * gets tried before it is switched on for every issue that enters a column.
+ *
+ * Deliberately not the trigger: no rule has to exist, the integration does not
+ * have to be enabled, and there is no transition to fence, so the same issue
+ * can be re-run as many times as the prompt needs rewording without anyone
+ * dragging a card around a real board. Everything downstream is identical, so
+ * what you watch here is what a rule will do — including that the agent works
+ * on the real issue and comments on it.
+ */
+export async function startJiraRunForIssue(
+  ctx: StudioContext,
+  integration: OrgJiraIntegration,
+  issueKey: string,
+  opts: { instruction: string | null; actorId: string },
+): Promise<{
+  item: TaskBoardItem;
+  issue: IssueForPrompt;
+  /** Runs that were failed and stopped to make room for this one. */
+  supersededThreadIds: string[];
+}> {
+  const issue = await loadIssueForPrompt(
+    jiraClientFor(integration),
+    integration.siteUrl,
+    issueKey,
+  );
+  const item = await ensureAnchorItem(ctx, integration, issue, opts.actorId);
+  // Two agents on one issue would each comment and open their own pull request.
+  const supersededThreadIds = await supersedeLiveRuns(ctx, item);
+  await dispatchJiraRun(ctx, integration, item, issue, {
+    instruction: opts.instruction,
+    actorId: opts.actorId,
+    // A person asked for this run, like a card's Re-run.
+    userInitiated: true,
+  });
+  return { item, issue, supersededThreadIds };
+}
+
+/** Hand the anchor to the Super Agent and enqueue its run. */
+async function dispatchJiraRun(
+  ctx: StudioContext,
+  integration: OrgJiraIntegration,
+  item: TaskBoardItem,
+  issue: IssueForPrompt,
+  opts: {
+    instruction: string | null;
+    actorId: string;
+    userInitiated?: boolean;
+  },
+): Promise<void> {
+  const orgId = integration.organizationId;
   const delegated = await ctx.storage.taskBoard.update(
     item.id,
     orgId,
-    {
-      assigneeId: SUPER_AGENT_ASSIGNEE_ID,
-      assignedBy: integration.createdBy,
-    },
-    integration.createdBy,
+    { assigneeId: SUPER_AGENT_ASSIGNEE_ID, assignedBy: opts.actorId },
+    opts.actorId,
   );
   try {
     await enqueueSuperAgentForTask(ctx, delegated, {
-      instruction: rule.prompt ?? DEFAULT_JIRA_INSTRUCTION,
+      instruction: opts.instruction ?? DEFAULT_JIRA_INSTRUCTION,
+      ...(opts.userInitiated ? { userInitiated: true } : {}),
       source: {
         kind: "jira",
         issueKey: issue.key,
@@ -173,45 +243,37 @@ export async function triggerRunForTransition(
       },
     });
   } catch (err) {
-    // Nothing dispatched: leave the anchor unowned rather than assigned to an
-    // agent that will never run. The claim stands — the transition is spent,
-    // and the caller's log is the record of why.
+    // Nothing dispatched: leave the anchor unowned, not owned by a phantom run.
     await ctx.storage.taskBoard
-      .unassignSuperAgent(item.id, orgId, integration.createdBy)
+      .unassignSuperAgent(item.id, orgId, opts.actorId)
       .catch(() => {});
     throw err;
   }
-  return "started";
 }
 
 /**
  * The board item a Jira issue's runs hang off. One per issue, created the
- * first time a rule fires for it and reused after; hidden from the board by
+ * first time a run fires for it and reused after; hidden from the board by
  * `source`, titled by the issue so the monitoring history reads.
  */
 async function ensureAnchorItem(
   ctx: StudioContext,
   integration: OrgJiraIntegration,
-  transition: IssueTransition,
   issue: IssueForPrompt,
+  actorId: string,
 ): Promise<TaskBoardItem> {
   const orgId = integration.organizationId;
   const title = `${issue.key}: ${issue.summary}`;
   const linked = await ctx.storage.jiraIntegrations.getLinkByIssueId(
     orgId,
-    transition.issueId,
+    issue.id,
   );
   if (linked) {
     const existing = await ctx.storage.taskBoard.getById(linked.itemId, orgId);
     if (existing) {
       return existing.title === title
         ? existing
-        : ctx.storage.taskBoard.update(
-            existing.id,
-            orgId,
-            { title },
-            integration.createdBy,
-          );
+        : ctx.storage.taskBoard.update(existing.id, orgId, { title }, actorId);
     }
   }
   const created = await ctx.storage.taskBoard.create({
@@ -221,12 +283,12 @@ async function ensureAnchorItem(
     source: "jira",
     externalKey: issue.key,
     externalUrl: issueUrl(integration.siteUrl, issue.key),
-    by: integration.createdBy,
+    by: actorId,
   });
   await ctx.storage.jiraIntegrations.createLink({
     itemId: created.id,
     organizationId: orgId,
-    jiraIssueId: transition.issueId,
+    jiraIssueId: issue.id,
     jiraIssueKey: issue.key,
   });
   return created;

--- a/apps/api/src/tools/index.ts
+++ b/apps/api/src/tools/index.ts
@@ -235,6 +235,7 @@ export const CORE_TOOLS = [
   JiraTools.JIRA_AUTOMATION_LIST,
   JiraTools.JIRA_AUTOMATION_UPSERT,
   JiraTools.JIRA_AUTOMATION_DELETE,
+  JiraTools.JIRA_RUN_START,
   // Served only on a Jira-triggered run's MCP endpoint (task-run-context.ts)
   JiraTools.JIRA_ISSUE_GET,
   JiraTools.JIRA_COMMENT_ADD,

--- a/apps/api/src/tools/jira/index.ts
+++ b/apps/api/src/tools/jira/index.ts
@@ -242,6 +242,7 @@ export {
   JIRA_AUTOMATION_LIST,
   JIRA_AUTOMATION_UPSERT,
 } from "./automations";
+export { JIRA_RUN_START } from "./run-start";
 export {
   JIRA_ATTACHMENT_DOWNLOAD,
   JIRA_COMMENT_ADD,

--- a/apps/api/src/tools/jira/run-start.ts
+++ b/apps/api/src/tools/jira/run-start.ts
@@ -1,0 +1,98 @@
+/**
+ * JIRA_RUN_START — run the agent on one Jira issue, now.
+ *
+ * How a status rule gets tried before it is switched on for every issue that
+ * enters a column: name an issue, give the prompt you are about to save, watch
+ * the run. No rule has to exist and the integration can be disabled, so
+ * nothing has to be dragged around a real board to see what the agent does.
+ *
+ * The run is the real one, not a simulation — it reads and comments on the
+ * actual issue. Firing it again takes over any run still working that issue,
+ * the same way a card's Re-run does.
+ */
+
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import {
+  getUserId,
+  requireAuth,
+  requireOrganization,
+} from "@/core/studio-context";
+import { parseIssueKey } from "@/jira/issue-key";
+import { startJiraRunForIssue } from "@/jira/trigger";
+import { MAX_AUTOMATION_PROMPT_LENGTH } from "@/tools/task-board/schema";
+
+/** Generous — the input also accepts a pasted issue URL. */
+const MAX_ISSUE_INPUT_LENGTH = 500;
+
+export const JIRA_RUN_START = defineTool({
+  name: "JIRA_RUN_START",
+  description:
+    "Run the agent on ONE Jira issue right now — how a status rule is tried " +
+    "out before it runs on every issue entering that status. Needs no rule " +
+    "for the issue's status and works with the integration disabled. " +
+    "`prompt` is the instruction to try; omit it for the agent's own. The " +
+    "issue itself is always in the run's message. This is a real run on the " +
+    "real issue, and it takes over any run still working that issue.",
+  inputSchema: z.object({
+    issueKey: z
+      .string()
+      .min(1)
+      .max(MAX_ISSUE_INPUT_LENGTH)
+      .describe("An issue key (ABC-123) or a pasted link to the issue."),
+    prompt: z
+      .string()
+      .max(MAX_AUTOMATION_PROMPT_LENGTH)
+      .nullable()
+      .optional()
+      .describe("What to do with the issue; null for the agent's default."),
+  }),
+  outputSchema: z.object({
+    issueKey: z.string(),
+    issueUrl: z.string(),
+    /** The hidden board item the run hangs off — its id in the monitoring
+     *  history, not a card anyone sees. */
+    itemId: z.string(),
+    supersededThreadIds: z
+      .array(z.string())
+      .describe("Runs that were stopped to make room for this one."),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const organization = requireOrganization(ctx);
+    const userId = getUserId(ctx);
+    if (!userId) throw new Error("User ID required");
+
+    const issueKey = parseIssueKey(input.issueKey);
+    if (!issueKey) {
+      throw new Error(
+        `"${input.issueKey}" is not a Jira issue key — expected something like ABC-123, or a link to the issue`,
+      );
+    }
+    const integration = await ctx.storage.jiraIntegrations.getByOrg(
+      organization.id,
+    );
+    if (!integration) {
+      throw new Error(
+        "Jira is not connected — save credentials with JIRA_INTEGRATION_UPSERT first",
+      );
+    }
+
+    const { item, issue, supersededThreadIds } = await startJiraRunForIssue(
+      ctx,
+      integration,
+      issueKey,
+      {
+        instruction: input.prompt?.trim() ? input.prompt.trim() : null,
+        actorId: userId,
+      },
+    );
+    return {
+      issueKey: issue.key,
+      issueUrl: issue.url,
+      itemId: item.id,
+      supersededThreadIds,
+    };
+  },
+});

--- a/apps/api/src/tools/task-board/rerun.ts
+++ b/apps/api/src/tools/task-board/rerun.ts
@@ -44,6 +44,7 @@ import {
   SUPER_AGENT_ASSIGNEE_ID,
 } from "@decocms/shared/task-board";
 import { TERMINAL_THREAD_STATUSES } from "@/storage/task-board";
+import type { TaskBoardItem } from "@/storage/types";
 import { inReviewPhase } from "./lanes";
 import { broadcastRunCancel } from "@/api/routes/decopilot/cancel-registry";
 import { cancelHostedHarness } from "@/dispatch-queue";
@@ -283,6 +284,43 @@ export async function refuseIfMergePending(
   );
 }
 
+/**
+ * Take over `item`: fail every run still holding it open, so the fresh run
+ * about to be queued is the only one working it.
+ *
+ * `failIfNotTerminal` rather than `markRunFailed` because a `requires_action`
+ * thread has to be closed out too — it is non-terminal to
+ * `shouldAdvanceToReview`, so leaving one behind means this task can never
+ * auto-advance again however many later runs succeed. Still a conditional
+ * UPDATE, so a thread that settles in the gap between the caller's read and
+ * this write keeps its real terminal state (and is then absent from the
+ * returned list).
+ *
+ * Shared with the Jira trigger's by-hand run (`startJiraRunForIssue`), which is
+ * the same act on an issue's anchor item and has the same two-agents-one-task
+ * hazard `stopSupersededRun` documents.
+ *
+ * Returns the threads this call really took over.
+ */
+export async function supersedeLiveRuns(
+  ctx: StudioContext,
+  item: TaskBoardItem,
+): Promise<string[]> {
+  const supersededThreadIds: string[] = [];
+  for (const threadId of threadsToSupersede(item)) {
+    const marked = await ctx.storage.threads.failIfNotTerminal(
+      threadId,
+      SUPERSEDED_FAILURE_REASON,
+      "superseded",
+    );
+    if (!marked) continue;
+    supersededThreadIds.push(threadId);
+    // Skipped for a thread that settled on its own: it would stamp over a real terminal.
+    await stopSupersededRun(ctx, threadId, item.organizationId);
+  }
+  return supersededThreadIds;
+}
+
 export const TASK_BOARD_ITEM_RERUN = defineTool({
   name: "TASK_BOARD_ITEM_RERUN",
   description:
@@ -344,27 +382,7 @@ export const TASK_BOARD_ITEM_RERUN = defineTool({
     // Paywall before any write: a refused re-run must leave the card untouched.
     await ensureTaskExecutionAllowed(ctx, item, userInitiatedTaskQuotaConfig());
 
-    // Take over: fail every thread still holding the task open. `failIfNotTerminal`
-    // rather than `markRunFailed` because a `requires_action` thread has to be
-    // closed out too — it is non-terminal to `shouldAdvanceToReview`, so leaving
-    // one behind means this task can never auto-advance again however many later
-    // runs succeed. Still a conditional UPDATE, so a thread that settles in the
-    // gap between the read above and this write keeps its real terminal state
-    // (and is then absent from the returned list).
-    const supersededThreadIds: string[] = [];
-    for (const threadId of threadsToSupersede(item)) {
-      const marked = await ctx.storage.threads.failIfNotTerminal(
-        threadId,
-        SUPERSEDED_FAILURE_REASON,
-        "superseded",
-      );
-      if (!marked) continue;
-      supersededThreadIds.push(threadId);
-      // Only for a thread this call really took over: a run that settled on its
-      // own in the gap above is already finished, and cancelling it would stamp
-      // a cancel over a real terminal.
-      await stopSupersededRun(ctx, threadId, organizationId);
-    }
+    const supersededThreadIds = await supersedeLiveRuns(ctx, item);
 
     // Whatever a reviewer decided was about the pre-rerun work — same reasoning as `reopenLinkedTasksOnThreadRun`.
     await ctx.storage.taskBoard.closeReviewCycle(id, organizationId);

--- a/apps/web/src/hooks/use-jira-integration.ts
+++ b/apps/web/src/hooks/use-jira-integration.ts
@@ -117,3 +117,16 @@ export function useSetJiraAutomation() {
       queryClient.invalidateQueries({ queryKey: KEYS.jiraAutomations(org.id) }),
   });
 }
+
+/**
+ * Run the agent on one issue, now — the way a rule is tried before it is
+ * turned on for a whole column. Needs no rule and works with the integration
+ * disabled, so nothing has to move on the real board to see what it does.
+ */
+export function useStartJiraRun() {
+  const studio = useStudioTools();
+  return useMutation({
+    mutationFn: (input: StudioToolIO["JIRA_RUN_START"]["input"]) =>
+      studio.call("JIRA_RUN_START", input),
+  });
+}

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -76,6 +76,21 @@ export const settings = {
   "settings.jira.removeAriaLabel": "Stop running the agent on {status}",
   "settings.jira.noColumnsYet": "No columns on this board yet",
   "settings.jira.columnsFailed": "Could not load this board's columns",
+  "settings.jira.testRunLabel": "Try it on one issue",
+  "settings.jira.testRunDescription":
+    "Run the agent on a single issue now, without a rule and without enabling the integration \u2014 so you can see what a prompt does before it runs on every issue entering a status.",
+  "settings.jira.testRunIssuePlaceholder": "ABC-123 or a link",
+  "settings.jira.testRunIssueAriaLabel": "Jira issue key or link",
+  "settings.jira.testRunPromptAriaLabel": "Instruction for this test run",
+  "settings.jira.testRun": "Run agent",
+  "settings.jira.testRunRunning": "Starting\u2026",
+  "settings.jira.testRunStarted": "Agent started on {issueKey}",
+  "settings.jira.testRunTookOver":
+    "Agent restarted on {issueKey} \u2014 the run already working it was stopped",
+  "settings.jira.testRunFailed": "Could not start the run",
+  "settings.jira.testRunHelp":
+    "This is a real run: the agent reads the actual issue, comments on it, and may move it. Running it again stops whatever run is still working that issue. Leave the instruction empty to use the agent's own.",
+  "settings.jira.testRunWatch": "Watch runs in Monitor",
   "settings.syncedRepos.pageDescription":
     "Git repositories mirrored into read-only library folders and kept in sync every few minutes. Great for a shared skills repo.",
   "settings.syncedRepos.addRepo": "Add repo",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -81,6 +81,21 @@ export const settings = {
   "settings.jira.noColumnsYet": "Este board ainda não tem colunas",
   "settings.jira.columnsFailed":
     "Não foi possível carregar as colunas do board",
+  "settings.jira.testRunLabel": "Testar em uma issue",
+  "settings.jira.testRunDescription":
+    "Rode o agente em uma única issue agora, sem regra e sem habilitar a integração \u2014 assim você vê o que um prompt faz antes que ele rode em toda issue que entra em um status.",
+  "settings.jira.testRunIssuePlaceholder": "ABC-123 ou um link",
+  "settings.jira.testRunIssueAriaLabel": "Chave ou link da issue do Jira",
+  "settings.jira.testRunPromptAriaLabel": "Instrução para este teste",
+  "settings.jira.testRun": "Rodar agente",
+  "settings.jira.testRunRunning": "Iniciando\u2026",
+  "settings.jira.testRunStarted": "Agente iniciado em {issueKey}",
+  "settings.jira.testRunTookOver":
+    "Agente reiniciado em {issueKey} \u2014 o run que já estava nela foi interrompido",
+  "settings.jira.testRunFailed": "Não foi possível iniciar o run",
+  "settings.jira.testRunHelp":
+    "Este é um run de verdade: o agente lê a issue real, comenta nela e pode movê-la. Rodar de novo interrompe o run que ainda estiver trabalhando nessa issue. Deixe a instrução vazia para usar a do próprio agente.",
+  "settings.jira.testRunWatch": "Ver os runs no Monitor",
   "settings.syncedRepos.pageDescription":
     "Repositórios Git espelhados em pastas somente leitura da biblioteca, sincronizados a cada poucos minutos. Ótimo para um repo de skills compartilhado.",
   "settings.syncedRepos.addRepo": "Adicionar repo",

--- a/apps/web/src/views/settings/jira.tsx
+++ b/apps/web/src/views/settings/jira.tsx
@@ -1,11 +1,12 @@
 /**
  * Settings → Tasks → "Jira integration" section — connect a Jira Cloud site
  * (email + API token), pick the board Studio watches, choose which statuses
- * start an agent run, and wire the webhook that tells it the moment an issue
- * moves.
+ * start an agent run, try a rule on a single issue before switching it on, and
+ * wire the webhook that tells it the moment an issue moves.
  */
 
 import { type ReactNode, useState } from "react";
+import { Link } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { Button } from "@decocms/ui/components/button.tsx";
 import { Input } from "@decocms/ui/components/input.tsx";
@@ -13,6 +14,7 @@ import {
   ArrowUpRight,
   Check,
   ChevronSelectorVertical,
+  Play,
   Plus,
   Trash01,
 } from "@untitledui/icons";
@@ -58,8 +60,10 @@ import {
   useJiraBoards,
   useJiraIntegration,
   useSetJiraAutomation,
+  useStartJiraRun,
   useUpsertJiraIntegration,
 } from "@/hooks/use-jira-integration";
+import { useProjectContext } from "@/sdk";
 import { TaskSystemPromptSettings } from "./task-system-prompt";
 
 function errorMessage(err: unknown, fallback: string): string {
@@ -453,6 +457,102 @@ function StatusAutomationCard({
   );
 }
 
+/**
+ * Run the agent on one issue, by hand — the answer to "will this prompt do the
+ * right thing?" without turning a rule on for every card that lands in a
+ * column.
+ *
+ * Deliberately independent of the rules above: no rule has to exist, the
+ * integration can be off, and the same issue can be re-run while the prompt is
+ * reworded, none of which is true of waiting for a real transition. It is a
+ * real run on the real issue, which is why the copy says so.
+ */
+function TestRunRow() {
+  const t = useT();
+  const { org } = useProjectContext();
+  const start = useStartJiraRun();
+  const [issueKey, setIssueKey] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const canRun = issueKey.trim() !== "" && !start.isPending;
+
+  const run = () => {
+    if (!canRun) return;
+    start.mutate(
+      {
+        issueKey: issueKey.trim(),
+        prompt: prompt.trim() === "" ? null : prompt.trim(),
+      },
+      {
+        onSuccess: (result) =>
+          toast.success(
+            result.supersededThreadIds.length > 0
+              ? t("settings.jira.testRunTookOver", {
+                  issueKey: result.issueKey,
+                })
+              : t("settings.jira.testRunStarted", {
+                  issueKey: result.issueKey,
+                }),
+          ),
+        onError: (err) =>
+          toast.error(errorMessage(err, t("settings.jira.testRunFailed"))),
+      },
+    );
+  };
+
+  return (
+    <SettingsCardItem
+      title={t("settings.jira.testRunLabel")}
+      description={t("settings.jira.testRunDescription")}
+    >
+      <div className="mt-3 flex w-full flex-col gap-3">
+        <div className="flex items-start gap-2">
+          <Input
+            value={issueKey}
+            onChange={(e) => setIssueKey(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") run();
+            }}
+            placeholder={t("settings.jira.testRunIssuePlaceholder")}
+            aria-label={t("settings.jira.testRunIssueAriaLabel")}
+            className="max-w-56 font-mono text-xs"
+            autoComplete="off"
+          />
+          <Button
+            size="sm"
+            className="shrink-0"
+            disabled={!canRun}
+            onClick={run}
+          >
+            <Play size={14} />
+            {start.isPending
+              ? t("settings.jira.testRunRunning")
+              : t("settings.jira.testRun")}
+          </Button>
+        </div>
+        <Textarea
+          value={prompt}
+          rows={2}
+          placeholder={t("settings.jira.promptPlaceholder")}
+          aria-label={t("settings.jira.testRunPromptAriaLabel")}
+          onChange={(e) => setPrompt(e.target.value)}
+        />
+        <p className="text-xs text-muted-foreground">
+          {t("settings.jira.testRunHelp")}
+        </p>
+        <Link
+          to="/$org/settings/monitor"
+          params={{ org: org.slug }}
+          search={{ tab: "threads" }}
+          className="flex w-fit items-center gap-1 text-xs text-muted-foreground underline hover:text-foreground"
+        >
+          {t("settings.jira.testRunWatch")}
+          <ArrowUpRight size={12} />
+        </Link>
+      </div>
+    </SettingsCardItem>
+  );
+}
+
 function EnabledRow({ integration }: { integration: JiraIntegration }) {
   const t = useT();
   const upsert = useUpsertJiraIntegration();
@@ -555,6 +655,7 @@ function JiraContent() {
       <ConnectionRow integration={data} />
       <BoardRow integration={data} />
       {data.boardId && <AutomationsRow boardId={data.boardId} />}
+      <TestRunRow />
       <EnabledRow integration={data} />
       <WebhookRow integration={data} />
     </SettingsCard>

--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -197,6 +197,7 @@ const ALL_TOOL_NAMES = [
   "JIRA_AUTOMATION_LIST",
   "JIRA_AUTOMATION_UPSERT",
   "JIRA_AUTOMATION_DELETE",
+  "JIRA_RUN_START",
   "JIRA_ISSUE_GET",
   "JIRA_COMMENT_ADD",
   "JIRA_ISSUE_TRANSITION",
@@ -955,6 +956,11 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     category: "Jira",
   },
   {
+    name: "JIRA_RUN_START",
+    description: "Run the agent on one Jira issue now, to try a rule out",
+    category: "Jira",
+  },
+  {
     name: "JIRA_ISSUE_GET",
     description: "Re-read the Jira issue a run is working on",
     category: "Jira",
@@ -1613,6 +1619,7 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "JIRA_AUTOMATION_LIST",
       "JIRA_AUTOMATION_UPSERT",
       "JIRA_AUTOMATION_DELETE",
+      "JIRA_RUN_START",
     ],
   },
   {

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -5445,6 +5445,15 @@ export interface StudioToolIO {
     input: { jiraStatus: string };
     output: { removed: boolean };
   };
+  JIRA_RUN_START: {
+    input: { issueKey: string; prompt?: string | null | undefined };
+    output: {
+      issueKey: string;
+      issueUrl: string;
+      itemId: string;
+      supersededThreadIds: string[];
+    };
+  };
   JIRA_ISSUE_GET: {
     input: { [x: string]: never };
     output: { key: string; url: string; status: string; markdown: string };


### PR DESCRIPTION
## Why

Trying out a Jira status rule meant turning it on for **every** issue that enters that status, then dragging a card around a real board to see what the agent does.

Re-testing was worse. The trigger fence is per `(issue, changelog entry)`, so rewording a prompt and running it against the same issue was impossible without producing a fresh transition in Jira.

## What

**Settings → Tasks → Jira integration → "Try it on one issue"**: an issue key (or a pasted issue link), an optional instruction, and a Run agent button. No rule needs to exist for the issue's status, and the integration can be disabled — so nothing has to move in Jira to see what a prompt will do.

![The new row, filled in](https://raw.githubusercontent.com/decocms/studio/df436a8dfab7e5cf7e3f974357b70d4788d360e1/jira-test-row.png)

It sits immediately above the Enabled switch, which is the order of operations: test one issue, then turn it on.

![Where it sits in the card](https://raw.githubusercontent.com/decocms/studio/df436a8dfab7e5cf7e3f974357b70d4788d360e1/jira-placement.png)

## How

`JIRA_RUN_START` shares the trigger's dispatch path via `startJiraRunForIssue` — same anchor item, same prompt assembly, same Jira run tools — so what you watch is what a rule will do. It skips only the rule lookup and the per-transition claim, neither of which applies to a run a person asked for.

**Firing again takes over rather than adding a second run.** Two Super Agent runs on one issue each comment on it, each push, and each open their own pull request — the production failure documented on `stopSupersededRun`. The board's existing takeover is extracted as `supersedeLiveRuns` and now shared by `JIRA_RUN_START` and `TASK_BOARD_ITEM_RERUN`. The toast says so when it happened.

`IssueForPrompt` now carries Jira's issue id, so the anchor link keys off the id instead of needing a transition to supply it — that is what lets the manual path work from a key alone.

Issue-key parsing is a pure module (`apps/api/src/jira/issue-key.ts`): accepts `ABC-123`, a lowercase key, or a pasted browse/board URL, and rejects anything else rather than handing Jira a non-key and getting back a 404 that reads like a broken integration.

## Testing

- `bun test apps/api/src/jira apps/api/src/tools/task-board` — 597 pass. New unit tests for `parseIssueKey`; the existing rerun and review-cycle tests cover the extracted takeover (its step sequence is unchanged).
- `bun run check`, `bun run lint`, `bun run fmt`, `knip` — clean.
- Screenshots above are from a local instance with a synthetic integration (`example.atlassian.net`, unreachable), driven through the real UI.

## Follow-up

The webhook-triggered path can also re-fire on an issue that already has a live run — rarer, since the transition fence covers redelivery. Deliberately left alone here rather than changing shipped automation behavior in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Try it on one issue" row to Settings → Tasks → Jira integration, so a status rule can be tested on a single issue without enabling the rule or moving a card in Jira.

- Accepts an issue key or pasted link, plus an optional prompt, and runs the real agent on that issue.
- Re-running the same issue takes over any live run instead of adding a second one; the takeover logic is now shared with the card's Re-run.
- The anchor link now keys off Jira's issue id, which lets the manual path work from a key alone.
- A new pure `parseIssueKey` module rejects anything that isn't a key, so a bad input never surfaces as a Jira 404.
- The webhook-triggered path can still re-fire on an issue with a live run; that behavior is unchanged.

<sup>Written for commit 8d003d204d49007dd5016de789c8e7ea1c0c762c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

