### PR TITLE
feat(api): add organization notices service API

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -110,6 +110,10 @@ import openaiCompatRoutes from "./routes/openai-compat";
 import { createProxyRoutes } from "./routes/proxy";
 import { createTriggerCallbackRoutes } from "./routes/trigger-callback";
 import { createEditorResolveRoutes } from "./routes/editor-resolve";
+import {
+  FINANCE_API_PREFIX,
+  createFinanceSiteResolutionRoutes,
+} from "./routes/finance-notice";
 import publicConfigRoutes from "./routes/public-config";
 import { createReportPagesRoutes } from "./routes/report-pages";
 import reportsRoutes from "./routes/reports";
@@ -2333,6 +2337,10 @@ export async function createApp(options: CreateAppOptions = {}) {
   // admin surface. The `_` prefix just keeps well-behaved slugs from ever
   // wanting the name (a bare `admin` is a legal, live slug).
   app.route(ADMIN_API_PREFIX, createAdminRoutes());
+
+  // deCommand's cross-org site ownership lookup. Dedicated service token,
+  // static prefix, and registered before the /api/:org catch-all.
+  app.route(FINANCE_API_PREFIX, createFinanceSiteResolutionRoutes());
 
   // Storefront "." shortcut: resolve (site, domain) → editor. Instance-level (org from org_sites), so it must win over `:org` below.
   app.route("/api/_editor-resolve", createEditorResolveRoutes());

--- a/apps/api/src/api/middleware/resolve-org-from-path.test.ts
+++ b/apps/api/src/api/middleware/resolve-org-from-path.test.ts
@@ -17,6 +17,7 @@ describe("isServiceTokenPath", () => {
         "/api/org_1/internal/commerce-diagnostic/share-invite",
       ),
     ).toBe(true);
+    expect(isServiceTokenPath("/api/org_1/internal/finance/notice")).toBe(true);
   });
 
   it("rejects everything else", () => {

--- a/apps/api/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/api/src/api/middleware/resolve-org-from-path.ts
@@ -67,6 +67,7 @@ const SERVICE_TOKEN_ROUTES: readonly (readonly string[])[] = [
   ["vault", "connections", "*", "configuration"],
   ["internal", "task-board", "import"],
   ["internal", "commerce-diagnostic", "share-invite"],
+  ["internal", "finance", "notice"],
 ];
 
 /**

--- a/apps/api/src/api/routes/finance-notice.test.ts
+++ b/apps/api/src/api/routes/finance-notice.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  financeSiteResolutionBodySchema,
+  isFinanceServiceToken,
+} from "./finance-notice";
+
+const original = process.env.FINANCE_SERVICE_TOKEN;
+
+afterEach(() => {
+  if (original === undefined) delete process.env.FINANCE_SERVICE_TOKEN;
+  else process.env.FINANCE_SERVICE_TOKEN = original;
+});
+
+describe("isFinanceServiceToken", () => {
+  it("fails closed when the service token is not configured", () => {
+    delete process.env.FINANCE_SERVICE_TOKEN;
+    expect(isFinanceServiceToken("anything")).toBe(false);
+  });
+
+  it("accepts only the configured finance token", () => {
+    process.env.FINANCE_SERVICE_TOKEN = "finance-secret";
+    expect(isFinanceServiceToken("finance-secret")).toBe(true);
+    expect(isFinanceServiceToken("wrong-secret")).toBe(false);
+  });
+});
+
+describe("financeSiteResolutionBodySchema", () => {
+  it("normalizes and deduplicates valid site slugs", () => {
+    expect(
+      financeSiteResolutionBodySchema.parse({
+        siteSlugs: [" Store-One ", "store-one", "store-two"],
+      }),
+    ).toEqual({ siteSlugs: ["store-one", "store-two"] });
+  });
+
+  it("rejects empty, malformed, and oversized site lists", () => {
+    expect(
+      financeSiteResolutionBodySchema.safeParse({ siteSlugs: [] }).success,
+    ).toBe(false);
+    expect(
+      financeSiteResolutionBodySchema.safeParse({ siteSlugs: ["not/a/site"] })
+        .success,
+    ).toBe(false);
+    expect(
+      financeSiteResolutionBodySchema.safeParse({
+        siteSlugs: Array.from({ length: 501 }, (_, index) => `site-${index}`),
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/api/routes/finance-notice.ts
+++ b/apps/api/src/api/routes/finance-notice.ts
@@ -1,0 +1,259 @@
+import { Hono, type Context, type Next } from "hono";
+import { z } from "zod";
+import { OrgNoticeInputSchema } from "@decocms/shared/organization/notice";
+import { isOrgArchived } from "@decocms/shared/organization/org-archived";
+import { isValidSiteSlug } from "@decocms/shared/site-slug";
+import type { StudioContext } from "@/core/studio-context";
+import { invalidateOrgNoticeCache } from "@/core/org-notice-gate";
+import { posthog } from "@/posthog";
+import { OrganizationNoticeStorage } from "@/storage/organization-notices";
+import { bearerToken, safeEqual } from "./credential-vault";
+
+const FINANCE_NOTICE_SOURCE = "finance_ar";
+const FINANCE_NOTICE_ACTOR = "service:decommand-center";
+export const FINANCE_API_PREFIX = "/api/_finance";
+
+type Variables = {
+  studioContext: StudioContext;
+};
+
+/** A dedicated token keeps finance notice access separate from credential vault access. */
+export function isFinanceServiceToken(token: string): boolean {
+  const expected = process.env.FINANCE_SERVICE_TOKEN;
+  return !!expected && safeEqual(token, expected);
+}
+
+export const financeSiteResolutionBodySchema = z.object({
+  siteSlugs: z
+    .array(z.string().trim().toLowerCase())
+    .min(1)
+    .max(500)
+    .transform((items) => [...new Set(items)])
+    .refine((items) => items.every(isValidSiteSlug), {
+      message: "Every site slug must be a valid Studio site slug",
+    }),
+});
+
+async function requireFinanceServiceToken(
+  c: Context<{ Variables: Variables }>,
+  next: Next,
+) {
+  const token = bearerToken(c.req.header("authorization"));
+  if (!token || !isFinanceServiceToken(token)) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  return next();
+}
+
+function auditFinanceNotice(
+  action: "set" | "resolve" | "refused",
+  props: Record<string, unknown>,
+) {
+  console.log("finance_ar_notice_action", { action, ...props });
+}
+
+/**
+ * Service-to-service control for the same organization notice rendered by the
+ * Studio shell. The source is fixed server-side: deCommand can update or clear
+ * only notices it created and can never overwrite a deployment-admin notice.
+ */
+export const createFinanceNoticeRoutes = () => {
+  const app = new Hono<{ Variables: Variables }>();
+
+  app.use("/internal/finance/notice", async (c, next) => {
+    const token = bearerToken(c.req.header("authorization"));
+    if (!token || !isFinanceServiceToken(token)) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    return next();
+  });
+
+  app.get("/internal/finance/notice", async (c) => {
+    const ctx = c.get("studioContext");
+    const organizationId = ctx.organization?.id;
+    if (!organizationId) {
+      return c.json({ error: "Organization context required" }, 403);
+    }
+    const notice = await new OrganizationNoticeStorage(ctx.db).getActive(
+      organizationId,
+    );
+    return c.json({ notice });
+  });
+
+  app.put("/internal/finance/notice", async (c) => {
+    const parsed = OrgNoticeInputSchema.safeParse(
+      await c.req.json().catch(() => null),
+    );
+    if (!parsed.success) {
+      return c.json(
+        { error: "Invalid notice", issues: parsed.error.issues },
+        400,
+      );
+    }
+
+    const ctx = c.get("studioContext");
+    const organizationId = ctx.organization?.id;
+    if (!organizationId) {
+      return c.json({ error: "Organization context required" }, 403);
+    }
+
+    const storage = new OrganizationNoticeStorage(ctx.db);
+    const notice = await storage.setActiveForSource({
+      organizationId,
+      notice: parsed.data,
+      source: FINANCE_NOTICE_SOURCE,
+      by: FINANCE_NOTICE_ACTOR,
+    });
+    if (!notice) {
+      const active = await storage.getActive(organizationId);
+      auditFinanceNotice("refused", {
+        organization_id: organizationId,
+        requested_severity: parsed.data.severity,
+        active_source: active?.source ?? null,
+        reason: "active_notice_owned_by_another_source",
+      });
+      return c.json(
+        {
+          error:
+            "An active notice from another source must be cleared by a deployment admin",
+          notice: active,
+        },
+        409,
+      );
+    }
+
+    invalidateOrgNoticeCache(organizationId);
+    auditFinanceNotice("set", {
+      organization_id: organizationId,
+      severity: notice.severity,
+      source: FINANCE_NOTICE_SOURCE,
+    });
+    posthog.capture({
+      distinctId: FINANCE_NOTICE_ACTOR,
+      event: "finance_ar_org_notice_set",
+      groups: { organization: organizationId },
+      properties: {
+        organization_id: organizationId,
+        severity: notice.severity,
+        source: FINANCE_NOTICE_SOURCE,
+      },
+    });
+    return c.json({ notice });
+  });
+
+  app.delete("/internal/finance/notice", async (c) => {
+    const ctx = c.get("studioContext");
+    const organizationId = ctx.organization?.id;
+    if (!organizationId) {
+      return c.json({ error: "Organization context required" }, 403);
+    }
+
+    const storage = new OrganizationNoticeStorage(ctx.db);
+    const active = await storage.getActive(organizationId);
+    if (!active) {
+      return c.json({ error: "No active notice for this organization" }, 404);
+    }
+    if (active.source !== FINANCE_NOTICE_SOURCE) {
+      auditFinanceNotice("refused", {
+        organization_id: organizationId,
+        active_source: active.source,
+        reason: "active_notice_owned_by_another_source",
+      });
+      return c.json(
+        {
+          error:
+            "This notice belongs to another source and cannot be resolved by finance",
+          notice: active,
+        },
+        409,
+      );
+    }
+
+    const resolved = await storage.resolveActiveForSource({
+      organizationId,
+      source: FINANCE_NOTICE_SOURCE,
+      by: FINANCE_NOTICE_ACTOR,
+    });
+    if (!resolved) {
+      return c.json(
+        { error: "The active notice changed before it could be resolved" },
+        409,
+      );
+    }
+
+    invalidateOrgNoticeCache(organizationId);
+    auditFinanceNotice("resolve", {
+      organization_id: organizationId,
+      source: FINANCE_NOTICE_SOURCE,
+    });
+    posthog.capture({
+      distinctId: FINANCE_NOTICE_ACTOR,
+      event: "finance_ar_org_notice_resolved",
+      groups: { organization: organizationId },
+      properties: {
+        organization_id: organizationId,
+        source: FINANCE_NOTICE_SOURCE,
+      },
+    });
+    return c.json({ ok: true });
+  });
+
+  return app;
+};
+
+/**
+ * Cross-organization read used to map deCommand subscription repositories to
+ * their Studio organizations in one request. `org_sites` is the ownership
+ * source of truth; the dedicated finance token is the only principal allowed.
+ */
+export const createFinanceSiteResolutionRoutes = () => {
+  const app = new Hono<{ Variables: Variables }>();
+  app.use("*", requireFinanceServiceToken);
+
+  app.post("/site-organizations", async (c) => {
+    const parsed = financeSiteResolutionBodySchema.safeParse(
+      await c.req.json().catch(() => null),
+    );
+    if (!parsed.success) {
+      return c.json(
+        { error: "Invalid site list", issues: parsed.error.issues },
+        400,
+      );
+    }
+
+    const ctx = c.get("studioContext");
+    const rows = await ctx.db
+      .selectFrom("org_sites")
+      .innerJoin("organization", "organization.id", "org_sites.organization_id")
+      .select([
+        "org_sites.slug as siteSlug",
+        "organization.id as organizationId",
+        "organization.slug as organizationSlug",
+        "organization.name as organizationName",
+        "organization.metadata as organizationMetadata",
+      ])
+      .where("org_sites.slug", "in", parsed.data.siteSlugs)
+      .execute();
+
+    const activeRows = rows.filter(
+      (row) =>
+        row.organizationSlug &&
+        !isOrgArchived({ metadata: row.organizationMetadata }),
+    );
+    const notices = await new OrganizationNoticeStorage(
+      ctx.db,
+    ).getActiveForOrgs(activeRows.map((row) => row.organizationId));
+
+    return c.json({
+      sites: activeRows.map((row) => ({
+        siteSlug: row.siteSlug,
+        organizationId: row.organizationId,
+        organizationSlug: row.organizationSlug,
+        organizationName: row.organizationName,
+        notice: notices.get(row.organizationId) ?? null,
+      })),
+    });
+  });
+
+  return app;
+};

--- a/apps/api/src/api/routes/org-scoped.ts
+++ b/apps/api/src/api/routes/org-scoped.ts
@@ -31,6 +31,7 @@ import { createSelfRoutes } from "./self";
 import { createTaskRunMcpRoutes } from "./task-run-mcp";
 import { createHomeNextActionsRoutes } from "./home-next-actions";
 import { createCommerceDiagnosticShareRoutes } from "./commerce-diagnostic-share";
+import { createFinanceNoticeRoutes } from "./finance-notice";
 import { createTaskBoardImportRoutes } from "./task-board-import";
 import { createObjectStorageRoutes } from "./object-storage";
 import { createThreadOutputsRoutes } from "./thread-outputs";
@@ -99,6 +100,7 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   app.route("/", createCredentialVaultRoutes()); // /api/:org/vault/connections/:connectionId/access-token
   app.route("/", createTaskBoardImportRoutes()); // /api/:org/internal/task-board/import — service-token batch import
   app.route("/", createCommerceDiagnosticShareRoutes()); // /api/:org/internal/commerce-diagnostic/share-invite — service-token share invite
+  app.route("/", createFinanceNoticeRoutes()); // /api/:org/internal/finance/notice — deCommand-owned billing notice
   app.route("/", createThreadOutputsRoutes()); // /api/:org/threads/:threadId/outputs
   app.route("/tools", createToolsRestRoutes()); // /api/:org/tools[/:toolName] — REST builtin-tool dispatch
   app.route("/", createObjectStorageRoutes()); // /api/:org/object-storage/*

--- a/apps/api/src/core/org-notice-gate.test.ts
+++ b/apps/api/src/core/org-notice-gate.test.ts
@@ -56,6 +56,21 @@ describe("isBlockableOrgRequest", () => {
     ).toBe(false);
   });
 
+  it("lets finance reactivate only through its exact notice route", () => {
+    expect(
+      isBlockableOrgRequest("DELETE", "/api/acme/internal/finance/notice"),
+    ).toBe(false);
+    expect(
+      isBlockableOrgRequest(
+        "POST",
+        "/api/acme/internal/finance/notice/anything",
+      ),
+    ).toBe(true);
+    expect(
+      isBlockableOrgRequest("POST", "/api/acme/internal/anything-else"),
+    ).toBe(true);
+  });
+
   it("ignores a path with no route under the org segment", () => {
     expect(isBlockableOrgRequest("POST", "/api/acme")).toBe(false);
     expect(isBlockableOrgRequest("POST", "/api/acme/")).toBe(false);

--- a/apps/api/src/core/org-notice-gate.ts
+++ b/apps/api/src/core/org-notice-gate.ts
@@ -126,6 +126,16 @@ export function isBlockableOrgRequest(method: string, path: string): boolean {
     return false;
   }
   const segments = path.split("/").filter(Boolean);
+  // The finance service must be able to lift the restriction it owns. Keep
+  // this exemption exact: every other /internal write remains control plane.
+  if (
+    segments.length === 5 &&
+    segments[2] === "internal" &&
+    segments[3] === "finance" &&
+    segments[4] === "notice"
+  ) {
+    return false;
+  }
   // ["api", "<org>", "<first>", ...] — anything shorter has no route to block.
   const first = segments[2];
   if (!first) return false;

--- a/apps/api/src/storage/organization-notices.ts
+++ b/apps/api/src/storage/organization-notices.ts
@@ -126,6 +126,63 @@ export class OrganizationNoticeStorage {
     return toEntity(row);
   }
 
+  /**
+   * Set a live notice only when the current notice belongs to the same source.
+   *
+   * Machine integrations use this instead of `setActive`: a finance sync may
+   * refresh its own warning or escalate it to a block, but it must never replace
+   * text an operator pinned manually. The conflict predicate makes that
+   * ownership check atomic, including when a manual write races this one.
+   * Returns null when another source owns the active notice.
+   */
+  async setActiveForSource(params: {
+    organizationId: string;
+    notice: OrgNoticeInput;
+    source: string;
+    by: string;
+  }): Promise<OrganizationNotice | null> {
+    const now = new Date();
+    const { notice, source } = params;
+    const row = await this.db
+      .insertInto("organization_notices")
+      .values({
+        id: randomUUID(),
+        organization_id: params.organizationId,
+        severity: notice.severity,
+        title: notice.title,
+        message: notice.message,
+        cta_label: notice.ctaLabel || null,
+        cta_url: notice.ctaUrl || null,
+        source,
+        resolved_at: null,
+        resolved_by: null,
+        created_by: params.by,
+        created_at: now,
+        updated_by: params.by,
+        updated_at: now,
+      })
+      .onConflict((oc) =>
+        oc
+          .column("organization_id")
+          .where("resolved_at", "is", null)
+          .doUpdateSet({
+            severity: notice.severity,
+            title: notice.title,
+            message: notice.message,
+            cta_label: notice.ctaLabel || null,
+            cta_url: notice.ctaUrl || null,
+            source,
+            updated_by: params.by,
+            updated_at: now,
+          })
+          .where("organization_notices.source", "=", source),
+      )
+      .returningAll()
+      .executeTakeFirst();
+
+    return row ? toEntity(row) : null;
+  }
+
   /** Resolve the org's live notice. False when there was nothing pinned. */
   async resolveActive(params: {
     organizationId: string;
@@ -141,6 +198,28 @@ export class OrganizationNoticeStorage {
         updated_at: now,
       })
       .where("organization_id", "=", params.organizationId)
+      .where("resolved_at", "is", null)
+      .executeTakeFirst();
+    return Number(res.numUpdatedRows ?? 0n) > 0;
+  }
+
+  /** Resolve only a notice owned by `source`. */
+  async resolveActiveForSource(params: {
+    organizationId: string;
+    source: string;
+    by: string;
+  }): Promise<boolean> {
+    const now = new Date();
+    const res = await this.db
+      .updateTable("organization_notices")
+      .set({
+        resolved_at: now,
+        resolved_by: params.by,
+        updated_by: params.by,
+        updated_at: now,
+      })
+      .where("organization_id", "=", params.organizationId)
+      .where("source", "=", params.source)
       .where("resolved_at", "is", null)
       .executeTakeFirst();
     return Number(res.numUpdatedRows ?? 0n) > 0;

--- a/deploy/helm/studio/templates/secret.yaml
+++ b/deploy/helm/studio/templates/secret.yaml
@@ -18,6 +18,9 @@ type: Opaque
 stringData:
   BETTER_AUTH_SECRET: {{ .Values.secret.BETTER_AUTH_SECRET | quote }}
   ENCRYPTION_KEY: {{ .Values.secret.ENCRYPTION_KEY | default "" | quote }}
+  {{- with .Values.secret.FINANCE_SERVICE_TOKEN }}
+  FINANCE_SERVICE_TOKEN: {{ . | quote }}
+  {{- end }}
   {{- with .Values.secret.NATS_CLUSTER_CREDS }}
   NATS_CLUSTER_CREDS: |-
     {{- . | nindent 4 }}

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -401,6 +401,9 @@ secret:
   # If omitted, the server auto-generates a random key on each boot (breaks across restarts).
   # Generate with: openssl rand -base64 32
   ENCRYPTION_KEY: ""
+  # Dedicated bearer for deCommand's finance-owned organization notices.
+  # Leave unset to disable the internal finance notice API.
+  # FINANCE_SERVICE_TOKEN: ""
   # Optional internal NATS credentials. Prefer secret.secretName or
   # externalSecret for production GitOps so credentials are not stored in
   # plain values files.

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -55,8 +55,9 @@ const jiraStubPort = process.env.JIRA_STUB_PORT || "4103";
 // hand with the literal in commerce-diagnostic-share.spec.ts (no shared import:
 // the config isn't a spec module).
 const vaultServiceToken = "e2e-vault-service-token";
+const financeServiceToken = "e2e-finance-service-token";
 
-const apiServerCommand = `MCP_CACHE_ENABLED=true GITHUB_WEBHOOK_SECRET=e2e-github-webhook-secret VAULT_SERVICE_TOKEN=${vaultServiceToken} REPORTS_INTERNAL_API_URL=${commerceMockOrigin} REPORTS_INTERNAL_API_KEY=${commerceMockKey} GITHUB_API_BASE_URL=${githubStubOrigin} JIRA_ALLOW_LOCAL_SITE_URL=1 BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} RUN_IDLE_TIMEOUT_MS=120000 DEPLOYMENT_ADMIN_EMAILS=deployment-admin@e2e.local,deployment-admin-2@e2e.local bun run dev`;
+const apiServerCommand = `MCP_CACHE_ENABLED=true GITHUB_WEBHOOK_SECRET=e2e-github-webhook-secret VAULT_SERVICE_TOKEN=${vaultServiceToken} FINANCE_SERVICE_TOKEN=${financeServiceToken} REPORTS_INTERNAL_API_URL=${commerceMockOrigin} REPORTS_INTERNAL_API_KEY=${commerceMockKey} GITHUB_API_BASE_URL=${githubStubOrigin} JIRA_ALLOW_LOCAL_SITE_URL=1 BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} RUN_IDLE_TIMEOUT_MS=120000 DEPLOYMENT_ADMIN_EMAILS=deployment-admin@e2e.local,deployment-admin-2@e2e.local bun run dev`;
 // CI serves the PRODUCTION build via `vite preview` (same Node proxy as dev —
 // see apps/web/vite.config.ts): the suite's charter is production-like
 // behavior, and the dev server's on-demand transform inflated browser-heavy

--- a/packages/e2e/tests/deployment-admin.spec.ts
+++ b/packages/e2e/tests/deployment-admin.spec.ts
@@ -38,6 +38,9 @@ const DEPLOYMENT_ADMIN_EMAIL_2 = "deployment-admin-2@e2e.local";
 // The sign-in fallback below must use the same password sign-up used when an
 // earlier `reuseExistingServer` run created the identity.
 const DEPLOYMENT_ADMIN_PASSWORD = TEST_PASSWORD;
+const FINANCE_SERVICE_HEADERS = {
+  Authorization: "Bearer e2e-finance-service-token",
+};
 
 /** Idempotent: signs up the reserved admin identity, or signs in if a prior
  *  `reuseExistingServer` run already created it. */
@@ -1146,6 +1149,150 @@ test.describe("/api/_admin/*", () => {
 
     await adminCtx.dispose();
     await ownerCtx.dispose();
+  });
+
+  test("finance notice service owns its lifecycle without replacing admin notices", async ({
+    playwright,
+  }) => {
+    const adminCtx = await newApiContext(playwright);
+    const admin = await ensureDeploymentAdmin(adminCtx);
+    await verifyDeploymentAdmin(db, admin.userId);
+
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const serviceCtx = await newApiContext(playwright);
+    const organization = (
+      await db.query<{ id: string; name: string }>(
+        `SELECT id, name FROM "organization" WHERE slug = $1`,
+        [owner.orgSlug],
+      )
+    ).rows[0];
+    if (!organization) throw new Error("Org not found after signup");
+
+    const siteSlug = `finance-notice-${crypto.randomUUID().slice(0, 8)}`;
+    expect(
+      (
+        await adminCtx.post(`/api/_admin/orgs/${organization.id}/sites`, {
+          data: { slug: siteSlug },
+        })
+      ).status(),
+    ).toBe(200);
+
+    const unauthorized = await serviceCtx.post(
+      "/api/_finance/site-organizations",
+      { data: { siteSlugs: [siteSlug] } },
+    );
+    expect(unauthorized.status()).toBe(401);
+
+    const mapped = await serviceCtx.post("/api/_finance/site-organizations", {
+      headers: FINANCE_SERVICE_HEADERS,
+      data: { siteSlugs: [siteSlug, siteSlug] },
+    });
+    expect(mapped.status()).toBe(200);
+    expect(await mapped.json()).toEqual({
+      sites: [
+        {
+          siteSlug,
+          organizationId: organization.id,
+          organizationSlug: owner.orgSlug,
+          organizationName: organization.name,
+          notice: null,
+        },
+      ],
+    });
+
+    const warning = await serviceCtx.put(
+      `/api/${owner.orgSlug}/internal/finance/notice`,
+      {
+        headers: FINANCE_SERVICE_HEADERS,
+        data: {
+          severity: "warn",
+          title: "Payment overdue",
+          message: "Review billing to avoid an interruption.",
+        },
+      },
+    );
+    expect(warning.status()).toBe(200);
+    expect(
+      (await warning.json()) as {
+        notice: { severity: string; source: string };
+      },
+    ).toMatchObject({
+      notice: { severity: "warn", source: "finance_ar" },
+    });
+
+    const block = await serviceCtx.put(
+      `/api/${owner.orgSlug}/internal/finance/notice`,
+      {
+        headers: FINANCE_SERVICE_HEADERS,
+        data: {
+          severity: "block",
+          title: "Workspace access restricted",
+          message: "Settle the outstanding balance to restore access.",
+        },
+      },
+    );
+    expect(block.status()).toBe(200);
+    const stored = await db.query<{ severity: string; source: string }>(
+      `SELECT severity, source FROM organization_notices
+       WHERE organization_id = $1 AND resolved_at IS NULL`,
+      [organization.id],
+    );
+    expect(stored.rows).toEqual([{ severity: "block", source: "finance_ar" }]);
+
+    // The same service route remains available after its block takes effect.
+    expect(
+      (
+        await serviceCtx.delete(
+          `/api/${owner.orgSlug}/internal/finance/notice`,
+          { headers: FINANCE_SERVICE_HEADERS },
+        )
+      ).status(),
+    ).toBe(200);
+
+    expect(
+      (
+        await adminCtx.put(`/api/_admin/orgs/${organization.id}/notice`, {
+          data: {
+            severity: "warn",
+            title: "Manual review",
+            message: "Contact support.",
+          },
+        })
+      ).status(),
+    ).toBe(200);
+
+    expect(
+      (
+        await serviceCtx.put(`/api/${owner.orgSlug}/internal/finance/notice`, {
+          headers: FINANCE_SERVICE_HEADERS,
+          data: {
+            severity: "block",
+            title: "Workspace access restricted",
+            message: "Settle the outstanding balance to restore access.",
+          },
+        })
+      ).status(),
+    ).toBe(409);
+    expect(
+      (
+        await serviceCtx.delete(
+          `/api/${owner.orgSlug}/internal/finance/notice`,
+          { headers: FINANCE_SERVICE_HEADERS },
+        )
+      ).status(),
+    ).toBe(409);
+
+    const manualStored = await db.query<{ severity: string; source: string }>(
+      `SELECT severity, source FROM organization_notices
+       WHERE organization_id = $1 AND resolved_at IS NULL`,
+      [organization.id],
+    );
+    expect(manualStored.rows).toEqual([{ severity: "warn", source: "manual" }]);
+
+    await adminCtx.dispose();
+    await ownerCtx.dispose();
+    await serviceCtx.dispose();
   });
 
   test("notice: PUT rejects a bad severity, empty text, a half CTA and a non-http link", async ({


### PR DESCRIPTION
## Summary

Adds an internal service API for managing Studio organization notices.

This allows an external system, such as deCommand Center, to resolve Studio sites to their organizations and push warning, blocking, or reactivation states into Studio.

## What changed

- Added a bearer-authenticated API for organization notices.
- Added batch resolution from site slugs to Studio organizations.
- Added endpoints to read, create, update, and resolve notices.
- Added support for the `ORGANIZATION_NOTICES_API_KEY` secret.
- Added audit logs and PostHog events for notice lifecycle operations.
- Added cache invalidation so notice changes take effect immediately.
- Allowed the exact reactivation endpoint to remain available while an organization is blocked.

## API

- `POST /api/_organization-notices/site-organizations`
- `GET /api/:org/internal/organization-notices`
- `PUT /api/:org/internal/organization-notices`
- `DELETE /api/:org/internal/organization-notices`

## Safety

- Requests fail closed when `ORGANIZATION_NOTICES_API_KEY` is not configured.
- The API uses constant-time bearer-token comparison.
- deCommand notices use the server-controlled `decommand_ar` source.
- The service can update or resolve only notices it owns.
- Notices created manually by deployment admins cannot be overwritten or removed by the service.
- Site resolution ignores archived organizations.

## Deployment

The production Studio secret must expose:

`ORGANIZATION_NOTICES_API_KEY`

Deploy this PR before enabling the dependent deCommand Center integration. The same key must also be configured in deCommand Center.

## Testing

- Unit tests for authentication and site-slug validation.
- Route-resolution and blocked-organization gate tests.
- Full workspace typecheck.
- Lint with zero errors.
- Formatting check.
- Unused-code analysis.
- Postgres-backed HTTP E2E covering:
  - site-to-organization resolution;
  - warning creation;
  - escalation to blocking;
  - reactivation after blocking;
  - protection of deployment-admin notices.