### PR TITLE
fix(git): share a GitHub installation by repository, not only by ownership

### DIFF
--- a/apps/api/migrations/210-github-repository-authorization.ts
+++ b/apps/api/migrations/210-github-repository-authorization.ts
@@ -1,0 +1,22 @@
+import type { Kysely } from "kysely";
+
+/**
+ * The repositories of a GitHub installation an organization was granted.
+ *
+ * Null keeps the meaning `209` gave the account: the installation's own owner
+ * authorized it, whole. A list is the narrower grant somebody who only
+ * administers part of the account can hand over.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("git_provider_accounts")
+    .addColumn("installation_repository_ids", "jsonb")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("git_provider_accounts")
+    .dropColumn("installation_repository_ids")
+    .execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -1,3 +1,4 @@
+import * as migration210githubrepositoryauthorization from "./210-github-repository-authorization";
 import * as migration209githubinstallationauthorization from "./209-github-installation-authorization";
 import * as migration208githubconnectflows from "./208-github-connect-flows";
 import * as migration207taskboardprsrepoidx from "./207-task-board-prs-repo-idx";
@@ -453,6 +454,8 @@ const migrations: Record<string, Migration> = {
   "208-github-connect-flows": migration208githubconnectflows,
   "209-github-installation-authorization":
     migration209githubinstallationauthorization,
+  "210-github-repository-authorization":
+    migration210githubrepositoryauthorization,
 };
 
 export default migrations;

--- a/apps/api/src/api/routes/git-providers.ts
+++ b/apps/api/src/api/routes/git-providers.ts
@@ -158,10 +158,20 @@ export const createGitProviderRoutes = () => {
     const appAuth = getGithubAppAuth();
     if (!appAuth) return c.json({ error: "not_configured" }, 503);
     try {
-      const { installations } = await appAuth.listOwnedInstallations(
+      const { installations } = await appAuth.listAuthorizedInstallations(
         await ctx.vault.decrypt(flow.encrypted_access_token),
       );
-      return c.json({ installations, expiresAt: flow.expires_at });
+      // The ids themselves are Studio's business; the chooser only needs to
+      // say whether the account comes whole or as a slice of its repositories.
+      return c.json({
+        installations: installations.map(
+          ({ repositoryIds, ...installation }) => ({
+            ...installation,
+            repositoryCount: repositoryIds?.length ?? null,
+          }),
+        ),
+        expiresAt: flow.expires_at,
+      });
     } catch {
       return c.json({ error: "github_unavailable" }, 502);
     }
@@ -192,7 +202,7 @@ export const createGitProviderRoutes = () => {
     if (!appAuth) return c.json({ error: "not_configured" }, 503);
     let access;
     try {
-      access = await appAuth.listOwnedInstallations(
+      access = await appAuth.listAuthorizedInstallations(
         await ctx.vault.decrypt(flow.encrypted_access_token),
       );
     } catch {
@@ -215,6 +225,7 @@ export const createGitProviderRoutes = () => {
         avatarUrl: installation.avatarUrl,
         installationId: installation.installationId,
         installationAuthorizedBy: access.userId,
+        installationRepositoryIds: installation.repositoryIds,
       },
     );
     if (!account) return c.json({ error: "flow_expired" }, 410);

--- a/apps/api/src/git-providers/credentials.ts
+++ b/apps/api/src/git-providers/credentials.ts
@@ -86,8 +86,10 @@ function grantKind(
 }
 
 /**
- * Whether Studio itself can produce credentials for this account. A GitHub installation
- * must have an owner authorization recorded before Studio can mint for it.
+ * Whether Studio itself can produce credentials for this account. A GitHub
+ * installation must carry an authorization before Studio can mint for it, and
+ * that authorization must still cover something: a partial grant emptied of
+ * every repository is an account nobody may use.
  */
 export function accountIsServable(account: GitProviderAccountRecord): boolean {
   if (account.status !== "active") return false;
@@ -95,7 +97,8 @@ export function accountIsServable(account: GitProviderAccountRecord): boolean {
     return (
       getGithubAppAuth() !== null &&
       account.installationId !== null &&
-      !!account.installationAuthorizedBy
+      !!account.installationAuthorizedBy &&
+      account.installationRepositoryIds?.length !== 0
     );
   }
   return true;
@@ -113,12 +116,16 @@ export function clientForAccount(
         "This git account was revoked. Reconnect it before accessing repositories.",
     });
   }
-  if (account.authKind === "github_app" && !account.installationAuthorizedBy) {
+  if (
+    account.authKind === "github_app" &&
+    (!account.installationAuthorizedBy ||
+      account.installationRepositoryIds?.length === 0)
+  ) {
     throw new GitProviderError({
       provider: account.type,
       status: 403,
       message:
-        "Reconnect this git account. A GitHub installation must be authorized by its personal account owner or an organization owner.",
+        "Reconnect this git account. A GitHub installation must be authorized by its account owner or by someone who administers repositories in it.",
     });
   }
   const credentials = new GitProviderAccountCredentialStorage(
@@ -140,6 +147,7 @@ export function clientForAccount(
         return new GithubProviderClient({
           host: account.host,
           installationId: account.installationId,
+          repositoryIds: account.installationRepositoryIds,
           appAuth,
         });
       }

--- a/apps/api/src/git-providers/github/app-auth.test.ts
+++ b/apps/api/src/git-providers/github/app-auth.test.ts
@@ -8,7 +8,9 @@ import {
   buildAppJwt,
   installationCacheKey,
   type InstallationToken,
+  invalidTokenScope,
   mapInstallation,
+  MAX_TOKEN_REPOSITORIES,
   nextPermissionSet,
   pruneExpiredTokens,
   usableAppKey,
@@ -210,6 +212,53 @@ describe("installationCacheKey", () => {
       }),
     ).not.toBe(base);
     expect(installationCacheKey(1, {})).not.toBe(base);
+  });
+
+  test("separates a scope by id from the same numbers spelled as names", () => {
+    const byId = installationCacheKey(1, { repositoryIds: [7] });
+    expect(byId).not.toBe(installationCacheKey(1, { repositories: ["7"] }));
+    expect(byId).not.toBe(installationCacheKey(1, {}));
+    expect(installationCacheKey(1, { repositoryIds: [9, 7] })).toBe(
+      installationCacheKey(1, { repositoryIds: [7, 9] }),
+    );
+    expect(installationCacheKey(1, { repositoryIds: [7, 9] })).not.toBe(byId);
+  });
+});
+
+describe("invalidTokenScope", () => {
+  test("accepts an unrestricted scope and either restricted spelling", () => {
+    expect(invalidTokenScope({})).toBeNull();
+    expect(invalidTokenScope({ repositories: ["alpha"] })).toBeNull();
+    expect(invalidTokenScope({ repositoryIds: [1] })).toBeNull();
+  });
+
+  test("rejects an empty scope, which GitHub would read as every repo", () => {
+    expect(invalidTokenScope({ repositories: [] })).toContain("1 to");
+    expect(invalidTokenScope({ repositoryIds: [] })).toContain("1 to");
+  });
+
+  test("rejects more repositories than GitHub mints for", () => {
+    const ids = Array.from(
+      { length: MAX_TOKEN_REPOSITORIES + 1 },
+      (_, i) => i + 1,
+    );
+    expect(invalidTokenScope({ repositoryIds: ids })).toContain("1 to");
+    expect(invalidTokenScope({ repositoryIds: ids.slice(1) })).toBeNull();
+  });
+
+  test("rejects the two spellings together and non-identifier ids", () => {
+    expect(
+      invalidTokenScope({ repositories: ["alpha"], repositoryIds: [1] }),
+    ).toContain("never both");
+    expect(invalidTokenScope({ repositoryIds: [0] })).toContain(
+      "positive integer",
+    );
+    expect(invalidTokenScope({ repositoryIds: [1, 1.5] })).toContain(
+      "positive integer",
+    );
+    expect(invalidTokenScope({ repositoryIds: [Number.MAX_VALUE] })).toContain(
+      "positive integer",
+    );
   });
 });
 

--- a/apps/api/src/git-providers/github/app-auth.ts
+++ b/apps/api/src/git-providers/github/app-auth.ts
@@ -90,9 +90,17 @@ export function nextPermissionSet(
   return rest;
 }
 
+/** GitHub mints an installation token for at most this many repositories. */
+export const MAX_TOKEN_REPOSITORIES = 500;
+
 export interface InstallationTokenOptions {
   /** Repository names (without owner) the token is restricted to. Omit for every repo. */
   repositories?: string[];
+  /**
+   * Repository ids the token is restricted to, for a scope that has to survive
+   * a rename. Mutually exclusive with `repositories`; omit both for every repo.
+   */
+  repositoryIds?: number[];
   /** Permissions to request; omit for everything the installation grants. */
   permissions?: Record<string, string>;
   /** Re-mint when less than this many ms of life remain. */
@@ -109,13 +117,45 @@ export interface InstallationToken {
 }
 
 /**
+ * Why this token scope cannot be minted, or null when it can.
+ *
+ * The empty list is the dangerous case. GitHub reads it as "no restriction"
+ * and answers with a token for every repository of the installation, so a
+ * caller whose scope computed down to nothing must fail rather than be
+ * silently widened past what it asked for.
+ */
+export function invalidTokenScope(
+  opts: Pick<InstallationTokenOptions, "repositories" | "repositoryIds">,
+): string | null {
+  const { repositories, repositoryIds } = opts;
+  if (repositories && repositoryIds) {
+    return "A GitHub installation token is scoped by repository name or by id, never both";
+  }
+  const size = repositories?.length ?? repositoryIds?.length;
+  if (size !== undefined && (size === 0 || size > MAX_TOKEN_REPOSITORIES)) {
+    return `A GitHub installation token covers 1 to ${MAX_TOKEN_REPOSITORIES} repositories, not ${size}`;
+  }
+  if (repositoryIds?.some((id) => !Number.isSafeInteger(id) || id <= 0)) {
+    return "A GitHub repository id must be a positive integer";
+  }
+  return null;
+}
+
+/**
  * Cache key for an installation token request. Order-insensitive: the same
  * set of repositories and permissions must hit the same entry however the
  * caller spelled them. GitHub matches repository names case-insensitively.
+ *
+ * A scope by id is a different token from the same scope spelled as names, and
+ * both differ from the unrestricted one, so the ids get their own segment with
+ * a marker for "no id restriction".
  */
 export function installationCacheKey(
   installationId: number,
-  opts: Pick<InstallationTokenOptions, "repositories" | "permissions">,
+  opts: Pick<
+    InstallationTokenOptions,
+    "repositories" | "repositoryIds" | "permissions"
+  >,
 ): string {
   const repositories = (opts.repositories ?? [])
     .map((r) => r.toLowerCase())
@@ -123,7 +163,10 @@ export function installationCacheKey(
   const permissions = Object.entries(opts.permissions ?? {})
     .map(([k, v]) => `${k}=${v}`)
     .sort();
-  return `${installationId}|${repositories.join(",")}|${permissions.join(",")}`;
+  const ids = opts.repositoryIds
+    ? `ids:${[...opts.repositoryIds].sort((a, b) => a - b).join(",")}`
+    : "all";
+  return `${installationId}|${repositories.join(",")}|${ids}|${permissions.join(",")}`;
 }
 
 /**
@@ -154,6 +197,27 @@ export interface GithubInstallation {
   /** "User" or "Organization". */
   accountType: string;
 }
+
+/**
+ * An installation a user may connect, with how much of it they authorized.
+ *
+ * `repositoryIds: null` is the whole installation — the account's own owner
+ * connected it. A list is the subset of repositories the connecting user
+ * administers, which is all Studio may ever mint a token for on that account.
+ */
+export interface AuthorizedInstallation extends GithubInstallation {
+  repositoryIds: number[] | null;
+}
+
+/** `GET /user/installations/{id}/repositories`, as the grant walk reads it. */
+const InstallationRepositoriesSchema = z.object({
+  repositories: z.array(
+    z.object({
+      id: z.number().int().positive().safe(),
+      permissions: z.object({ admin: z.boolean().optional() }).optional(),
+    }),
+  ),
+});
 
 interface InstallationJson {
   id?: unknown;
@@ -255,6 +319,16 @@ export class GithubAppAuth {
     installationId: number,
     opts: InstallationTokenOptions = {},
   ): Promise<InstallationToken> {
+    const invalidScope = invalidTokenScope(opts);
+    if (invalidScope) {
+      return Promise.reject(
+        new GitProviderError({
+          provider: "github",
+          status: 403,
+          message: invalidScope,
+        }),
+      );
+    }
     const key = installationCacheKey(installationId, opts);
     const bufferMs = opts.bufferMs ?? DEFAULT_TOKEN_BUFFER_MS;
 
@@ -308,6 +382,7 @@ export class GithubAppAuth {
         token: this.appJwt(),
         body: {
           ...(repositories && { repositories }),
+          ...(opts.repositoryIds && { repository_ids: opts.repositoryIds }),
           ...(permissions && { permissions }),
         },
         operation,
@@ -371,10 +446,25 @@ export class GithubAppAuth {
     return mapped;
   }
 
-  /** Repository collaboration does not authorize sharing an entire installation. */
-  async listOwnedInstallations(userToken: string): Promise<{
+  /**
+   * The installations this user may hand to a Studio organization, and how
+   * much of each one they may hand over.
+   *
+   * GitHub lists an installation whenever the user can see a single repository
+   * in it, and seeing a repository is not authority over the rest of the
+   * account. So the answer is narrowed to what the user can actually authorize:
+   *
+   * - their own personal account, whole (`repositoryIds: null`);
+   * - an organization they own, whole — an owner can install the App on any of
+   *   its repositories anyway;
+   * - otherwise, only the repositories of that installation they administer,
+   *   which is exactly the set GitHub would let them install the App on.
+   *
+   * An installation where none of that holds is left out entirely.
+   */
+  async listAuthorizedInstallations(userToken: string): Promise<{
     userId: string;
-    installations: GithubInstallation[];
+    installations: AuthorizedInstallation[];
   }> {
     const user = z
       .object({ id: z.number().int().positive().safe() })
@@ -409,15 +499,56 @@ export class GithubAppAuth {
         if (memberships.length < 100) break;
       }
     }
-    return {
-      userId: String(user.id),
-      installations: installations.filter((item) =>
-        item.accountType === "User"
-          ? item.externalAccountId === String(user.id)
-          : item.accountType === "Organization" &&
-            ownedOrganizations.has(item.externalAccountId),
-      ),
-    };
+    const authorized: AuthorizedInstallation[] = [];
+    for (const item of installations) {
+      if (item.accountType === "User") {
+        if (item.externalAccountId === String(user.id)) {
+          authorized.push({ ...item, repositoryIds: null });
+        }
+        continue;
+      }
+      if (ownedOrganizations.has(item.externalAccountId)) {
+        authorized.push({ ...item, repositoryIds: null });
+        continue;
+      }
+      const repositoryIds = await this.administeredRepositories(
+        userToken,
+        item.installationId,
+      );
+      if (repositoryIds.length > 0) authorized.push({ ...item, repositoryIds });
+    }
+    return { userId: String(user.id), installations: authorized };
+  }
+
+  /**
+   * The repositories of one installation the user administers, by id.
+   *
+   * Ids rather than names because the grant outlives a rename. The walk stops
+   * at `MAX_TOKEN_REPOSITORIES`: a token cannot be minted for more than that
+   * anyway, and somebody who administers 500 repositories of an organization
+   * is better served by its owner connecting the whole installation.
+   */
+  private async administeredRepositories(
+    userToken: string,
+    installationId: number,
+  ): Promise<number[]> {
+    const perPage = 100;
+    const administered: number[] = [];
+    for (let page = 1; ; page++) {
+      const { repositories } = InstallationRepositoriesSchema.parse(
+        await this.userGet(
+          `/user/installations/${installationId}/repositories?per_page=${perPage}&page=${page}`,
+          userToken,
+          "list_connecting_user_repositories",
+        ),
+      );
+      for (const repository of repositories) {
+        if (repository.permissions?.admin !== true) continue;
+        administered.push(repository.id);
+        if (administered.length === MAX_TOKEN_REPOSITORIES) return administered;
+      }
+      if (repositories.length < perPage) return administered;
+    }
   }
 
   private async userGet(

--- a/apps/api/src/git-providers/github/client.ts
+++ b/apps/api/src/git-providers/github/client.ts
@@ -4,13 +4,14 @@
  * Two modes, picked by the options union:
  * - installation: Studio's GitHub App is installed on the account and tokens
  *   are minted per call through `GithubAppAuth` — repo-scoped for pushes,
- *   read-only account-wide for listing and reading.
+ *   read-only account-wide for listing and reading. When the account carries a
+ *   partial grant (`repositoryIds`), account-wide means grant-wide: every
+ *   token, and so every listing and read, stops at those repositories.
  * - token: a user OAuth grant or personal access token supplied by a
  *   `TokenSource`; the same token serves every call.
  */
 
 import {
-  apiBaseUrlFor,
   type RepoRef,
   repoName,
   splitOwnerName,
@@ -29,6 +30,7 @@ import {
 } from "../types";
 import type { GithubAppAuth } from "./app-auth";
 import {
+  githubApiBaseUrl,
   type GithubFetchInit,
   githubFailure,
   githubFetch,
@@ -36,7 +38,16 @@ import {
 } from "./http";
 
 export type GithubProviderClientOptions =
-  | { host: string; installationId: number; appAuth: GithubAppAuth }
+  | {
+      host: string;
+      installationId: number;
+      /**
+       * The repositories of the installation this Studio organization was
+       * granted, by id. Null is the whole installation.
+       */
+      repositoryIds?: number[] | null;
+      appAuth: GithubAppAuth;
+    }
   | { host: string; tokenSource: TokenSource };
 
 /** Enough to list, inspect and read files in every repository of the installation. */
@@ -141,11 +152,15 @@ export class GithubProviderClient implements GitProviderClient {
   readonly host: string;
   private readonly apiBaseUrl: string;
   private readonly options: GithubProviderClientOptions;
+  /** Repository path → id, for the grant check. Per client, so per request. */
+  private readonly grantedIds = new Map<string, number>();
 
   constructor(options: GithubProviderClientOptions) {
     this.options = options;
     this.host = options.host.toLowerCase();
-    this.apiBaseUrl = apiBaseUrlFor("github", options.host);
+    // `githubApiBaseUrl`, not the bare host mapping: it is the one that honours
+    // `GITHUB_API_BASE_URL`, which is how e2e keeps this client off github.com.
+    this.apiBaseUrl = githubApiBaseUrl(options.host);
   }
 
   async tokenForRepo(
@@ -154,10 +169,18 @@ export class GithubProviderClient implements GitProviderClient {
   ): Promise<GitAccessToken> {
     const options = this.options;
     if ("appAuth" in options) {
+      const granted = options.repositoryIds ?? null;
       const minted = await options.appAuth.installationToken(
         options.installationId,
         {
-          repositories: [repoName(repo)],
+          // A name is enough when the whole installation is Studio's to use.
+          // Under a partial grant it is not: the installation may well cover
+          // repositories nobody here administers, and GitHub would mint for
+          // them just as readily. So the repository is resolved through the
+          // grant first and the token asks for that id and no other.
+          ...(granted
+            ? { repositoryIds: [await this.grantedRepositoryId(repo, granted)] }
+            : { repositories: [repoName(repo)] }),
           permissions: GITHUB_SCOPED_PERMISSIONS,
           bufferMs: opts.bufferMs,
           forceRefresh: opts.forceRefresh,
@@ -178,6 +201,9 @@ export class GithubProviderClient implements GitProviderClient {
       const minted = await options.appAuth.installationToken(
         options.installationId,
         {
+          ...(options.repositoryIds
+            ? { repositoryIds: options.repositoryIds }
+            : {}),
           permissions: ACCOUNT_READ_PERMISSIONS,
           bufferMs: opts.bufferMs,
           forceRefresh: opts.forceRefresh,
@@ -190,6 +216,33 @@ export class GithubProviderClient implements GitProviderClient {
       };
     }
     return this.sourceToken(options.tokenSource, opts);
+  }
+
+  /**
+   * The id of `repo` within a partial grant, or a 403.
+   *
+   * The lookup runs on the account token, which is itself minted for the
+   * granted ids, so a repository outside the grant answers 404 here and never
+   * reaches the mint. The id is memoized: `archiveTarball` asks twice when its
+   * first token turns out to be dead.
+   */
+  private async grantedRepositoryId(
+    repo: RepoRef,
+    granted: number[],
+  ): Promise<number> {
+    const key = repo.path.toLowerCase();
+    const memoized = this.grantedIds.get(key);
+    if (memoized !== undefined) return memoized;
+    const id = Number((await this.getRepo(repo))?.externalId);
+    if (!Number.isSafeInteger(id) || !granted.includes(id)) {
+      throw new GitProviderError({
+        provider: "github",
+        status: 403,
+        message: `${repo.path} is outside what this GitHub account authorized for Studio. Ask someone who administers it to connect it.`,
+      });
+    }
+    this.grantedIds.set(key, id);
+    return id;
   }
 
   private async sourceToken(

--- a/apps/api/src/storage/git-provider-accounts.ts
+++ b/apps/api/src/storage/git-provider-accounts.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 import type {
   GitAuthKind,
   GitProviderAccount,
@@ -27,6 +27,7 @@ type Row = {
   avatar_url: string | null;
   installation_id: string | number | null;
   installation_authorized_by: string | null;
+  installation_repository_ids: number[] | null;
   credential_connection_id: string | null;
   status: "active" | "revoked";
   created_by: string | null;
@@ -40,6 +41,8 @@ export interface GitProviderAccountRecord extends GitProviderAccount {
   credentialConnectionId: string | null;
   connectedBy: { name: string } | null;
   installationAuthorizedBy: string | null;
+  /** Null grants the whole installation; a list grants only those repositories. */
+  installationRepositoryIds: number[] | null;
 }
 
 function toEntity(row: Row): GitProviderAccountRecord {
@@ -59,6 +62,7 @@ function toEntity(row: Row): GitProviderAccountRecord {
     installationId: Number.isFinite(installationId) ? installationId : null,
     status: row.status,
     installationAuthorizedBy: row.installation_authorized_by ?? null,
+    installationRepositoryIds: row.installation_repository_ids ?? null,
     credentialConnectionId: row.credential_connection_id,
     connectedBy: row.connected_by_name ? { name: row.connected_by_name } : null,
     createdAt: toIso(row.created_at),
@@ -76,6 +80,7 @@ export interface UpsertGitProviderAccountParams {
   avatarUrl?: string | null;
   installationId?: number | null;
   installationAuthorizedBy?: string | null;
+  installationRepositoryIds?: number[] | null;
   createdBy?: string | null;
 }
 
@@ -104,6 +109,9 @@ export class GitProviderAccountStorage {
         avatar_url: params.avatarUrl ?? null,
         installation_id: params.installationId ?? null,
         installation_authorized_by: params.installationAuthorizedBy ?? null,
+        installation_repository_ids: params.installationRepositoryIds
+          ? JSON.stringify(params.installationRepositoryIds)
+          : null,
         credential_connection_id: null,
         status: "active",
         created_by: params.createdBy ?? null,
@@ -118,6 +126,20 @@ export class GitProviderAccountStorage {
             avatar_url: params.avatarUrl ?? null,
             installation_id: params.installationId ?? null,
             installation_authorized_by: params.installationAuthorizedBy ?? null,
+            // Grants add up: a second person who administers other
+            // repositories widens what this organization can reach, and an
+            // owner connecting the account widens it to everything. A row
+            // that was revoked or never authorized starts over from the
+            // incoming grant instead of reviving the old one.
+            installation_repository_ids: sql<string | null>`CASE
+              WHEN git_provider_accounts.status != 'active'
+                OR git_provider_accounts.installation_authorized_by IS NULL
+                THEN excluded.installation_repository_ids
+              WHEN excluded.installation_repository_ids IS NULL
+                OR git_provider_accounts.installation_repository_ids IS NULL THEN NULL
+              ELSE (SELECT jsonb_agg(DISTINCT value) FROM jsonb_array_elements(
+                git_provider_accounts.installation_repository_ids || excluded.installation_repository_ids
+              )) END`,
             credential_connection_id: null,
             status: "active",
             updated_at: now,

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -2253,6 +2253,15 @@ export type GitAuthKindColumn = "github_app" | "oauth" | "token";
 export type GitAccountStatusColumn = "active" | "revoked";
 
 export interface GitProviderAccountTable {
+  /**
+   * The granted repositories of the installation, by id. Null is the whole
+   * installation; an empty list would grant nothing and is never written.
+   */
+  installation_repository_ids: ColumnType<
+    number[] | null,
+    string | null | undefined,
+    string | null
+  >;
   installation_authorized_by: ColumnType<
     string | null,
     string | null | undefined,

--- a/apps/api/src/tools/git/index.ts
+++ b/apps/api/src/tools/git/index.ts
@@ -56,6 +56,7 @@ function toAccountOutput(
   const {
     credentialConnectionId: _bridge,
     installationAuthorizedBy: _authorization,
+    installationRepositoryIds: _repositoryScope,
     ...entity
   } = account;
   return { ...entity, servable: accountIsServable(account) };

--- a/apps/web/src/components/github-connect-dialog.tsx
+++ b/apps/web/src/components/github-connect-dialog.tsx
@@ -25,6 +25,8 @@ const flowSchema = z.object({
       installationId: z.number(),
       login: z.string(),
       avatarUrl: z.string().nullable(),
+      /** Null when the whole account is on offer, a count when only part is. */
+      repositoryCount: z.number().nullable(),
     }),
   ),
 });
@@ -194,8 +196,18 @@ export function GithubConnectDialog({
                   shape="circle"
                   muted
                 />
-                <span className="flex-1 text-left truncate">
-                  {installation.login}
+                <span className="flex-1 min-w-0 text-left">
+                  <span className="block truncate">{installation.login}</span>
+                  {installation.repositoryCount !== null && (
+                    <span className="block truncate text-xs text-muted-foreground font-normal">
+                      {t(
+                        installation.repositoryCount === 1
+                          ? "settings.repositories.githubAdministeredOne"
+                          : "settings.repositories.githubAdministered",
+                        { count: String(installation.repositoryCount) },
+                      )}
+                    </span>
+                  )}
                 </span>
                 <ArrowRight size={16} />
               </Button>

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -133,9 +133,12 @@ export const settings = {
   "settings.repositories.addGithubAccount":
     "Add GitHub account or organization",
   "settings.repositories.githubShareHint":
-    "Choose your personal GitHub account or an organization you own to share with {organization}. Members with repository permissions in Studio can use this connection.",
+    "Choose your personal GitHub account, or an organization where you administer repositories, to share with {organization}. Members with repository permissions in Studio can use this connection.",
   "settings.repositories.githubInstallHint":
-    "No accounts you own are available. Install the GitHub App on your personal account or an organization you own, or ask its owner to connect it to Studio. Access to an individual repository does not allow sharing its entire account.",
+    "Nothing here is yours to share yet. Install the GitHub App on your personal account or on repositories you administer, or ask an account owner to connect it to Studio. A repository you only collaborate on is not yours to share.",
+  "settings.repositories.githubAdministered":
+    "{count} repositories you administer",
+  "settings.repositories.githubAdministeredOne": "1 repository you administer",
   "settings.repositories.installGithubAccount": "Install on another account",
   "settings.repositories.checkGithubAccess": "Check access",
   "settings.repositories.switchGithubUser": "Use another GitHub login",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -138,9 +138,13 @@ export const settings = {
   "settings.repositories.addGithubAccount":
     "Adicionar conta ou organização do GitHub",
   "settings.repositories.githubShareHint":
-    "Escolha sua conta pessoal do GitHub ou uma organização da qual você é dono para compartilhar com {organization}. Membros com permissão para repositórios no Studio podem usar esta conexão.",
+    "Escolha sua conta pessoal do GitHub, ou uma organização onde você administra repositórios, para compartilhar com {organization}. Membros com permissão para repositórios no Studio podem usar esta conexão.",
   "settings.repositories.githubInstallHint":
-    "Nenhuma conta da qual você é dono está disponível. Instale o app do GitHub na sua conta pessoal ou organização, ou peça ao dono para conectá-la ao Studio. Ter acesso a um repositório não permite compartilhar a conta inteira.",
+    "Ainda não há nada seu para compartilhar. Instale o app do GitHub na sua conta pessoal ou nos repositórios que você administra, ou peça ao dono da conta para conectá-la ao Studio. Um repositório em que você só colabora não é seu para compartilhar.",
+  "settings.repositories.githubAdministered":
+    "{count} repositórios que você administra",
+  "settings.repositories.githubAdministeredOne":
+    "1 repositório que você administra",
   "settings.repositories.installGithubAccount": "Instalar em outra conta",
   "settings.repositories.checkGithubAccess": "Verificar acesso",
   "settings.repositories.switchGithubUser": "Usar outro login do GitHub",

--- a/packages/e2e/fixtures/github-stub.ts
+++ b/packages/e2e/fixtures/github-stub.ts
@@ -19,7 +19,7 @@
  *   - refs:    `branch -> commitSha`
  *
  * GitHub-shaped endpoints (only what the decofile client calls):
- *   GET   /repos/{o}/{r}                              -> { default_branch }
+ *   GET   /repos/{o}/{r}                              -> { id, full_name, private, html_url, default_branch }
  *   GET   /repos/{o}/{r}/git/ref/heads/{branch}       -> { object: { sha } }
  *   GET   /repos/{o}/{r}/git/commits/{sha}            -> { tree: { sha }, parents }
  *   GET   /repos/{o}/{r}/git/trees/{sha}[?recursive=1] -> { tree: [...], truncated } (non-recursive = direct children + subtree shas)
@@ -33,6 +33,17 @@
  *   GET   /repos/{o}/{r}/pulls?state&base&head        -> [ { number, html_url } ]
  *   POST  /repos/{o}/{r}/pulls                        -> { number, html_url }
  *   GET   /repos/{o}/{r}/compare/{base}...{head}      -> { ahead_by, behind_by, merge_base_commit, files, commits }
+ *
+ * GitHub App endpoints (the git-provider account suite):
+ *   GET   /user/installations                          -> { installations }
+ *   GET   /user/installations/{id}/repositories        -> { repositories }
+ *   POST  /app/installations/{id}/access_tokens        -> { token, expires_at }
+ *
+ * A minted token carries its own scope (`ghs-inst-{id}-all` or
+ * `ghs-inst-{id}-ids-{a}.{b}`), and `/repos/{o}/{r}` answers 404 for a
+ * repository outside it — the same wall GitHub puts up, so a test can prove
+ * Studio never widens a partial grant. Any other Authorization value is taken
+ * as an unrestricted legacy token, which is what the decofile suite sends.
  *
  * Test-only admin endpoints (no auth):
  *   GET  /health
@@ -76,6 +87,8 @@ interface PullRecord {
 }
 
 interface RepoState {
+  /** GitHub's numeric repository id, which is what a token scope names. */
+  id: number;
   owner: string;
   name: string;
   defaultBranch: string;
@@ -102,6 +115,8 @@ interface RepoState {
 interface SeedRepoBody {
   owner: string;
   repo: string;
+  /** Numeric id, for tests that pin it to an installation grant. */
+  id?: number;
   defaultBranch?: string;
   /**
    * Per-branch file map (`path -> content`). The default branch becomes a root
@@ -120,6 +135,21 @@ interface SeedRepoBody {
 }
 
 const repos = new Map<string, RepoState>();
+let repoIdSequence = 1_000_000;
+function nextRepoId(): number {
+  return ++repoIdSequence;
+}
+
+/**
+ * The repository ids an Authorization header may reach, or null for every one.
+ *
+ * Only tokens this stub minted carry a scope; anything else is treated as
+ * unrestricted so the suites that send a static token are unaffected.
+ */
+function tokenScope(authorization: string | undefined): number[] | null {
+  const scope = /^Bearer ghs-inst-\d+-ids-([\d.]+)$/.exec(authorization ?? "");
+  return scope?.[1] ? scope[1].split(".").map(Number) : null;
+}
 let commitCounter = 0;
 
 function sha1(input: string): string {
@@ -234,6 +264,7 @@ function mergeBaseOf(repo: RepoState, a: string, b: string): string | null {
 function seedRepo(body: SeedRepoBody): RepoState {
   const defaultBranch = body.defaultBranch ?? "main";
   const repo: RepoState = {
+    id: body.id ?? nextRepoId(),
     owner: body.owner,
     name: body.repo,
     defaultBranch,
@@ -405,7 +436,9 @@ async function handleRepos(
   const owner = segments[1];
   const name = segments[2];
   const repo = owner && name ? repos.get(repoKey(owner, name)) : undefined;
-  if (!repo) {
+  const scope = tokenScope(req.headers.authorization);
+  // Out of scope reads as absent, exactly as it does on github.com.
+  if (!repo || (scope && !scope.includes(repo.id))) {
     notFound(res);
     return;
   }
@@ -414,8 +447,11 @@ async function handleRepos(
   // GET /repos/{o}/{r}
   if (req.method === "GET" && rest.length === 0) {
     json(res, 200, {
+      id: repo.id,
       name: repo.name,
       full_name: repoKey(repo.owner, repo.name),
+      private: true,
+      html_url: `https://github.com/${repoKey(repo.owner, repo.name)}`,
       default_branch: repo.defaultBranch,
       owner: { login: repo.owner },
     });
@@ -908,6 +944,11 @@ interface UserInstallation {
     avatar_url: string | null;
     type: "Organization" | "User";
   };
+  /**
+   * What `GET /user/installations/{id}/repositories` answers for this user.
+   * `admin` is GitHub's "can this person install the App here" signal.
+   */
+  repositories?: Array<{ id: number; permissions?: { admin?: boolean } }>;
 }
 
 export function createGithubStubServer(): Server {
@@ -1004,7 +1045,12 @@ export function createGithubStubServer(): Server {
         }
         return;
       }
-      if (req.method === "GET" && url.pathname === "/user/installations") {
+      const installationRepositories =
+        /^\/user\/installations\/(\d+)\/repositories$/.exec(url.pathname);
+      if (
+        req.method === "GET" &&
+        (url.pathname === "/user/installations" || installationRepositories)
+      ) {
         const installations = users.get(
           req.headers.authorization?.replace(/^Bearer /, "") ?? "",
         )?.installations;
@@ -1013,9 +1059,46 @@ export function createGithubStubServer(): Server {
           return;
         }
         const page = Number(url.searchParams.get("page") ?? 1);
+        const perPage = Number(url.searchParams.get("per_page") ?? 100);
+        const slice = <T>(items: T[]) =>
+          items.slice((page - 1) * perPage, page * perPage);
+        if (url.pathname === "/user/installations") {
+          json(res, 200, {
+            installations: slice(installations),
+            total_count: installations.length,
+          });
+          return;
+        }
+        const id = Number(installationRepositories?.[1]);
+        const installation = installations.find((item) => item.id === id);
+        if (!installation) {
+          notFound(res);
+          return;
+        }
+        const repositories = installation.repositories ?? [];
         json(res, 200, {
-          installations: installations.slice((page - 1) * 100, page * 100),
-          total_count: installations.length,
+          repositories: slice(repositories),
+          total_count: repositories.length,
+        });
+        return;
+      }
+      if (
+        req.method === "POST" &&
+        /^\/app\/installations\/\d+\/access_tokens$/.test(url.pathname)
+      ) {
+        const installationId = url.pathname.split("/")[3];
+        const body = JSON.parse((await readBody(req)) || "{}") as {
+          repository_ids?: number[];
+          permissions?: Record<string, string>;
+        };
+        // The scope travels in the token, so a later read can be judged by it.
+        const scope = body.repository_ids?.length
+          ? `ids-${body.repository_ids.join(".")}`
+          : "all";
+        json(res, 201, {
+          token: `ghs-inst-${installationId}-${scope}`,
+          expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+          permissions: body.permissions ?? {},
         });
         return;
       }

--- a/packages/e2e/tests/github-connect.spec.ts
+++ b/packages/e2e/tests/github-connect.spec.ts
@@ -19,10 +19,13 @@ type Installation = {
     type: "Organization" | "User";
     avatar_url: string | null;
   };
+  /** What the connecting user sees in the installation, and may install on. */
+  repositories?: Array<{ id: number; permissions?: { admin?: boolean } }>;
 };
 function installation(
   login: string,
   type: "Organization" | "User" = "Organization",
+  repositories?: Installation["repositories"],
 ): Installation {
   return {
     id: Math.floor(Math.random() * 1_000_000_000) + 1,
@@ -33,6 +36,7 @@ function installation(
       type,
       avatar_url: null,
     },
+    ...(repositories && { repositories }),
   };
 }
 async function grantAccess(
@@ -646,15 +650,25 @@ test("access to a collaborator's personal installation does not authorize sharin
   });
 });
 
-test("organization membership is not ownership and the check runs again when connecting", async ({
+test("an organization member shares only the repositories they administer", async ({
   authedPage,
 }) => {
   const { page } = authedPage;
   const owned = installation("owned-organization");
-  const member = installation("member-organization");
-  const pending = installation("pending-owner-organization");
+  // Administering a repository is exactly what GitHub asks for to install the
+  // App on it, so it is enough to hand that repository to Studio — and only it.
+  const member = installation("member-organization", "Organization", [
+    { id: 5001, permissions: { admin: true } },
+    { id: 5002, permissions: { admin: false } },
+    { id: 5003, permissions: { admin: true } },
+  ]);
+  const pending = installation("pending-owner-organization", "Organization", [
+    { id: 5004, permissions: { admin: false } },
+  ]);
   const external = installation("external-organization");
-  const personal = installation("my-personal-account", "User");
+  const personal = installation("my-personal-account", "User", [
+    { id: 5005, permissions: { admin: true } },
+  ]);
   const installations = [owned, member, pending, external, personal];
   const flow = await seedFlow(authedPage, installations);
   const memberships = [
@@ -672,18 +686,22 @@ test("organization membership is not ownership and the check runs again when con
   ];
   await grantAccess(page.request, flow.token, installations, { memberships });
   const listed = await (await page.request.get(flow.path)).json();
-  expect(
-    listed.installations.map((item: { login: string }) => item.login),
-  ).toEqual([owned.account.login, personal.account.login]);
-  for (const installation of [member, pending, external]) {
+  expect(listed.installations).toMatchObject([
+    { login: owned.account.login, repositoryCount: null },
+    { login: member.account.login, repositoryCount: 2 },
+    { login: personal.account.login, repositoryCount: null },
+  ]);
+  for (const forbidden of [pending, external]) {
     expect(
       (
         await page.request.post(flow.path, {
-          data: { installationId: installation.id },
+          data: { installationId: forbidden.id },
         })
       ).status(),
     ).toBe(403);
   }
+  // The check runs again at connect time, against fresh GitHub state: the
+  // organization offered whole a moment ago is now not offered at all.
   await grantAccess(page.request, flow.token, installations, {
     memberships: [],
   });
@@ -692,13 +710,153 @@ test("organization membership is not ownership and the check runs again when con
       await page.request.post(flow.path, { data: { installationId: owned.id } })
     ).status(),
   ).toBe(403);
+  // Losing the membership costs them nothing they administer, though.
   expect(
     (
       await page.request.post(flow.path, {
-        data: { installationId: personal.id },
+        data: { installationId: member.id },
       })
     ).status(),
   ).toBe(200);
+  const db = await connectDevDb();
+  try {
+    const saved = await db.query<{ installation_repository_ids: number[] }>(
+      "SELECT installation_repository_ids FROM git_provider_accounts WHERE organization_id=$1 AND external_account_id=$2",
+      [flow.orgId, String(member.id)],
+    );
+    expect(saved.rows[0]?.installation_repository_ids).toEqual([5001, 5003]);
+  } finally {
+    await db.end();
+  }
+});
+
+test("grants add up between connectors and an owner widens them to the whole installation", async ({
+  authedPage,
+}) => {
+  const { page, orgSlug } = authedPage;
+  const org = installation("shared-organization", "Organization", [
+    { id: 6001, permissions: { admin: true } },
+    { id: 6002, permissions: { admin: false } },
+  ]);
+  const memberOnly = [
+    { state: "active", role: "member", organization: { id: org.account.id } },
+  ];
+  const first = await seedFlow(authedPage, [org]);
+  await grantAccess(page.request, first.token, [org], {
+    memberships: memberOnly,
+  });
+  expect(
+    (
+      await page.request.post(first.path, { data: { installationId: org.id } })
+    ).status(),
+  ).toBe(200);
+
+  const grant = async () => {
+    const db = await connectDevDb();
+    try {
+      const row = await db.query<{ installation_repository_ids: number[] }>(
+        "SELECT installation_repository_ids FROM git_provider_accounts WHERE organization_id=$1 AND external_account_id=$2",
+        [first.orgId, String(org.id)],
+      );
+      return row.rows[0]?.installation_repository_ids ?? null;
+    } finally {
+      await db.end();
+    }
+  };
+  expect(await grant()).toEqual([6001]);
+
+  // A second person, administering the repository the first one could not.
+  const second = await seedFlow(authedPage, []);
+  await grantAccess(
+    page.request,
+    second.token,
+    [
+      {
+        ...org,
+        repositories: [{ id: 6002, permissions: { admin: true } }],
+      },
+    ],
+    { id: 2002, memberships: memberOnly },
+  );
+  expect(
+    (
+      await page.request.post(second.path, { data: { installationId: org.id } })
+    ).status(),
+  ).toBe(200);
+  expect((await grant())?.slice().sort()).toEqual([6001, 6002]);
+
+  // An owner authorizes the account itself, which is every repository in it.
+  const third = await seedFlow(authedPage, []);
+  await grantAccess(page.request, third.token, [org], {
+    memberships: [
+      { state: "active", role: "admin", organization: { id: org.account.id } },
+    ],
+  });
+  expect(
+    (
+      await page.request.post(third.path, { data: { installationId: org.id } })
+    ).status(),
+  ).toBe(200);
+  expect(await grant()).toBeNull();
+  const accounts = await callSelfMcpTool<{
+    accounts: Array<{ login: string; servable: boolean }>;
+  }>(page.request, orgSlug, "GIT_ACCOUNT_LIST", {});
+  expect(accounts.accounts).toMatchObject([
+    { login: org.account.login, servable: true },
+  ]);
+});
+
+test("a partial grant reaches its repositories and nothing else in the installation", async ({
+  authedPage,
+}) => {
+  const { page, orgSlug } = authedPage;
+  const inside = { id: 7001, path: "grant-organization/administered" };
+  const outside = { id: 7002, path: "grant-organization/not-administered" };
+  for (const repo of [inside, outside]) {
+    const [owner, name] = repo.path.split("/");
+    const seeded = await page.request.post(`${fixtureOrigin}/__admin/repos`, {
+      data: {
+        owner,
+        repo: name,
+        id: repo.id,
+        branches: { main: { files: { "README.md": repo.path } } },
+      },
+    });
+    expect(seeded.ok()).toBe(true);
+  }
+  // Both repositories are in the installation; only one is theirs to authorize.
+  const org = installation("grant-organization", "Organization", [
+    { id: inside.id, permissions: { admin: true } },
+    { id: outside.id, permissions: { admin: false } },
+  ]);
+  const flow = await seedFlow(authedPage, [org]);
+  await grantAccess(page.request, flow.token, [org], {
+    memberships: [
+      { state: "active", role: "member", organization: { id: org.account.id } },
+    ],
+  });
+  const connected = await page.request.post(flow.path, {
+    data: { installationId: org.id },
+  });
+  expect(connected.status()).toBe(200);
+  const { account } = (await connected.json()) as { account: { id: string } };
+
+  const linked = await callSelfMcpTool<{
+    repository: { path: string; externalId: string | null };
+  }>(page.request, orgSlug, "REPOSITORY_LINK", {
+    accountId: account.id,
+    url: `https://github.com/${inside.path}`,
+  });
+  expect(linked.repository).toMatchObject({
+    path: inside.path,
+    externalId: String(inside.id),
+  });
+  await expect(
+    callSelfMcpTool(page.request, orgSlug, "REPOSITORY_LINK", {
+      accountId: account.id,
+      url: `https://github.com/${outside.path}`,
+    }),
+  ).rejects.toThrow(/was not found|cannot access/);
 });
 
 test("owner lookup handles membership pagination and fails closed on GitHub errors", async ({


### PR DESCRIPTION
Follow-up to #7125.

#7125 closed a real hole — GitHub lists an installation whenever you can see a single repository in it, and that visibility was being read as authority over the whole account. But requiring **organization ownership** closed it too far. The person who administers the repositories a team actually works on is exactly who GitHub lets install the App on them, and they could not hand any of it to Studio.

## What changes

The connect flow now answers **how much** of an installation the user may authorize, not just whether they may:

| account | offered |
| --- | --- |
| their personal account | whole, owner only (unchanged) |
| an organization they own | whole (unchanged) |
| any other installation | only the repositories in it they administer |

Repository admins come from `GET /user/installations/{id}/repositories` (`permissions.admin`), which is the same signal GitHub uses to decide who may install an App. An installation where none of the three holds is still left out entirely.

The grant lands on the account row as `installation_repository_ids` (migration `210`) — `null` keeps `209`'s meaning, "the owner authorized it whole".

## Keeping the grant honest

A stored grant is only worth what the tokens respect:

- `accountToken` mints with `repository_ids`, so `/installation/repositories`, `getRepo` and every read stop at the grant. Out of scope reads as 404, which is also what makes `REPOSITORY_LINK` refuse a repository nobody here administers.
- `tokenForRepo` no longer asks by name under a partial grant. A name would let GitHub mint for any repository of the installation, including ones nobody here administers, so the repository is resolved through the grant-scoped account token first and the token asks for that id and no other.
- An empty scope is rejected at the mint: GitHub reads `[]` as "no restriction" and would answer with a token for everything.
- Grants add up between connectors — a second person widens the account by what they administer — and an owner connecting it replaces them with the whole installation. A revoked or never-authorized row starts over from the incoming grant instead of reviving the old one.

## Drive-by, and load-bearing

`GithubProviderClient` built its API base from the bare host mapping instead of `githubApiBaseUrl`, unlike every other GitHub module, so it ignored `GITHUB_API_BASE_URL` and talked to github.com even under test. Fixed — without it none of the above is reachable from e2e.

## UI

The chooser says when an account comes as a slice rather than whole ("2 repositories you administer"), and the ownership copy is now about administering repositories. en + pt-BR.

## Testing

- `bun test apps/api/src/git-providers apps/api/src/storage` — 583 pass. New unit coverage for the token-scope guard (empty, over-cap, both spellings, non-identifier ids) and for the cache key separating an id scope from the same numbers spelled as names.
- `bun run --cwd=packages/e2e test:e2e:github-connect` — 16 pass, including three rewritten/new cases: who may share what and at what scope, grants merging across connectors up to an owner widening them, and a partially granted account linking the repository it was given but not the one beside it. The stub now mints scope-carrying installation tokens and 404s a repository outside them, so that last one is a real wall, not an assertion about our own code.
- The stub's other consumers (`decofile-api`, `fast-preview-git-sync`, `task-board-pr-webhook`) — 22 pass; they send static tokens, which stay unrestricted.
- `bun run fmt`, `bun run check`, `bun run lint`, `knip` clean.

## Note for rollout

Accounts connected before #7125 still need a reconnect; that is unchanged. Accounts connected under #7125 keep working — they were owner-authorized, so their grant is `null`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets GitHub repository admins share an installation with Studio by the repositories they administer, instead of requiring ownership of the whole account. #7125 closed an authorization hole but locked out the admins GitHub itself lets install the App; now they can connect only the repositories they administer.

**Bug Fixes**
- Personal accounts and owned organizations are still offered whole; other installations are offered as a repository slice, and installations with nothing to administer stay hidden.
- Stores partial grants in migration `210`; `null` still means the owner authorized the whole installation.
- Scopes every minted token to the granted repositories, so account reads, listings, and `REPOSITORY_LINK` stop at the grant and out-of-scope reads return 404.
- Resolves repository tokens through the grant before minting, so GitHub cannot mint for repositories outside the grant; empty token scopes are rejected.
- Grants merge across connectors, and an owner reconnecting widens the account to the whole installation.
- Connect chooser labels partial accounts with how many repositories are included.
- Fixes `GithubProviderClient` to honor `GITHUB_API_BASE_URL`, which also lets e2e cover this flow.
- Accounts connected before #7125 still need to reconnect; accounts connected under #7125 stay valid.

<sup>Written for commit d1bb9daf79c0627c22339e0077ccdaaec203377f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

