### PR TITLE
fix(ai-providers): cap AI_PROVIDER_KEY_CREATE/UPDATE apiKey length

### DIFF
--- a/apps/api/src/tools/ai-providers/key-create.ts
+++ b/apps/api/src/tools/ai-providers/key-create.ts
@@ -19,7 +19,7 @@ export const AI_PROVIDER_KEY_CREATE = defineTool({
   inputSchema: z.object({
     providerId: z.enum(HOSTED_PROVIDER_IDS),
     label: z.string().min(1).max(100),
-    apiKey: z.string().min(1),
+    apiKey: z.string().min(1).max(4096),
     presetId: z.string().min(1).max(64).optional(),
   }),
   outputSchema: providerKeyOutputSchema,

--- a/apps/api/src/tools/ai-providers/key-length-bound.test.ts
+++ b/apps/api/src/tools/ai-providers/key-length-bound.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { AI_PROVIDER_KEY_CREATE } from "./key-create";
+import { AI_PROVIDER_KEY_UPDATE } from "./key-update";
+
+describe("AI provider key apiKey length bound", () => {
+  test("AI_PROVIDER_KEY_CREATE rejects an oversized apiKey", () => {
+    expect(
+      AI_PROVIDER_KEY_CREATE.inputSchema.safeParse({
+        providerId: "deco",
+        label: "Provider key",
+        apiKey: "a".repeat(4097),
+      }).success,
+    ).toBeFalse();
+  });
+
+  test("AI_PROVIDER_KEY_CREATE accepts a key at the bound", () => {
+    expect(
+      AI_PROVIDER_KEY_CREATE.inputSchema.safeParse({
+        providerId: "deco",
+        label: "Provider key",
+        apiKey: "a".repeat(4096),
+      }).success,
+    ).toBeTrue();
+  });
+
+  test("AI_PROVIDER_KEY_UPDATE rejects an oversized apiKey", () => {
+    expect(
+      AI_PROVIDER_KEY_UPDATE.inputSchema.safeParse({
+        keyId: "key_1",
+        apiKey: "a".repeat(4097),
+      }).success,
+    ).toBeFalse();
+  });
+});

--- a/apps/api/src/tools/ai-providers/key-update.ts
+++ b/apps/api/src/tools/ai-providers/key-update.ts
@@ -10,7 +10,7 @@ export const AI_PROVIDER_KEY_UPDATE = defineTool({
   inputSchema: z.object({
     keyId: z.string(),
     label: z.string().min(1).max(100).optional(),
-    apiKey: z.string().min(1).optional(),
+    apiKey: z.string().min(1).max(4096).optional(),
   }),
   outputSchema: providerKeyOutputSchema,
   handler: async (input, ctx) => {


### PR DESCRIPTION
Reduction/hardening: none of AI_PROVIDER_KEY_CREATE or AI_PROVIDER_KEY_UPDATE bounded the length of the `apiKey` field before it's hashed (SHA-256) and encrypted (AES-256-GCM) into the vault and stored in Postgres — every other string field on these tools (`label`, `presetId`) has a `.max()`, but `apiKey` had none.

Why it matters: an authenticated org member could submit an arbitrarily large string as an "API key" (megabytes), and it would be hashed, encrypted, and persisted as a DB row with no bound — a resource/DoS gap of the same shape as the other attacker-controlled-string-length caps already fixed in this codebase (see the `apiKeys`/`registry` tool schemas, which do cap their key/secret fields).

Fix: added `.max(4096)` to `apiKey` in both `AI_PROVIDER_KEY_CREATE` and `AI_PROVIDER_KEY_UPDATE` input schemas — generous enough for any real provider API key/token (these are typically well under 200 characters) while closing the unbounded-write gap. Pure input-validation tightening; no behavior change for any legitimate caller.

Regression test: `apps/api/src/tools/ai-providers/key-length-bound.test.ts` asserts a 4097-char key is rejected on both tools and a 4096-char key is accepted.

To verify: `bun test apps/api/src/tools/ai-providers/key-length-bound.test.ts apps/api/src/tools/ai-providers/key-create.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above (16 pass), and `bunx oxlint` on the three changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the `apiKey` length on the AI provider key create and update tools to prevent unbounded string writes. Previously any length was accepted; now keys over 4096 characters are rejected.

- Adds a regression test covering the new limit on both tools.

<sup>Written for commit 1cd9f5a213042298eaeab4e356eeabe2127d2b60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

