### PR TITLE
fix(sandbox): confine the daemon's /read route to app root for absolute paths

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/fs.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs.go
@@ -61,13 +61,6 @@ func decodeBody(r *http.Request, out any) error {
 	return nil
 }
 
-func resolveReadPath(appRoot, repoDir, userPath string) (string, bool) {
-	if filepath.IsAbs(userPath) {
-		return userPath, true
-	}
-	return paths.SafePath(appRoot, repoDir, userPath)
-}
-
 // sniffImageMediaType reports the media type only for the formats /read is
 // willing to return inline; anything else reads as text or binary.
 func sniffImageMediaType(probe []byte) string {
@@ -91,9 +84,9 @@ func Read(deps FsDeps) http.HandlerFunc {
 			httpx.Error(w, 400, err.Error())
 			return
 		}
-		filePath, ok := resolveReadPath(deps.AppRoot, deps.RepoDir, body.Path)
+		filePath, ok := paths.SafePath(deps.AppRoot, deps.RepoDir, body.Path)
 		if !ok {
-			httpx.Error(w, 400, "Path escapes project root")
+			httpx.Error(w, 400, deps.escapesRoot())
 			return
 		}
 		stat, err := os.Stat(filePath)
@@ -106,10 +99,9 @@ func Read(deps FsDeps) http.HandlerFunc {
 			// the decofile is consumed as one blob and the client's line-number
 			// strip is a no-op on content that lacks the `^\d+\t` prefix.
 			//
-			// Only for relative paths: those are SafePath-confined to appRoot by
-			// resolveReadPath, so the sibling `blocks` dir can't escape the
-			// project. An absolute `body.Path` bypasses SafePath, so refuse to
-			// turn it into a directory glob (the CMS only ever sends relative).
+			// Only for relative paths: an absolute `body.Path` that reaches here
+			// is already SafePath-confined to appRoot, but still refuse to turn
+			// it into a directory glob (the CMS only ever sends relative).
 			if !filepath.IsAbs(body.Path) && filepath.Base(filePath) == decofile.GenBasename {
 				blocksDir := filepath.Join(filepath.Dir(filePath), decofile.BlocksDirname)
 				if merged, ok := decofile.GenerateFromBlocksDeduped(blocksDir); ok {

--- a/packages/sandbox/daemon-go/internal/routes/fs_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs_test.go
@@ -187,6 +187,33 @@ func TestReadDecofileFallbackRefusesAbsolute(t *testing.T) {
 	}
 }
 
+// /read must reject an absolute path outside AppRoot with the same
+// containment SafePath already gives Write/Mkdir/etc — an agent-controlled
+// path crossing the daemon's HTTP boundary must not be able to read arbitrary
+// files on the pod (e.g. `/etc/passwd`, another repo's secrets) just by
+// spelling an absolute path.
+func TestReadRefusesAbsolutePathOutsideRoot(t *testing.T) {
+	deps := seedBlocks(t)
+	// os.MkdirTemp (not t.TempDir) so this lands in its own OS-level temp root,
+	// not nested under deps.AppRoot the way a second t.TempDir() call would be.
+	secretDir, err := os.MkdirTemp("", "fs-read-escape")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(secretDir) })
+	secret := filepath.Join(secretDir, "secret.txt")
+	if err := os.WriteFile(secret, []byte("top-secret"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	rec := readReq(t, deps, secret)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (path escapes root); body = %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "top-secret") {
+		t.Fatalf("response leaked file content outside AppRoot: %s", rec.Body.String())
+	}
+}
+
 // The 400 an out-of-root write returns must name the root it wants. A model
 // that guessed `/tmp` (writable from its own bash tool, not from here) has to
 // be able to correct itself from the message alone — prod thread 38147122


### PR DESCRIPTION
Found while hunting the `studio-fs-abstraction` focus area (the fs abstraction itself, `packages/sandbox/daemon-go/internal/routes/fs.go`, is the real implementation of issue #2884 — the frontend `apps/web/src/lib/filesystem.ts` hinted at doesn't exist and a prior audit confirmed the abstraction is already mature). Reading the route while auditing that area surfaced a real trust-boundary gap.

**The bug:** every fs mutation route (`/write`, `/edit`, `/mkdir`, `/rename`, `/delete`) confines a caller-supplied path via `paths.SafePath(appRoot, repoDir, path)`, which checks even an absolute path is inside `appRoot`. `/read` had its own `resolveReadPath` wrapper that special-cased absolute paths to skip that check entirely and pass them straight to `os.Stat`/read. A `path` in a `/read` request crosses a real trust boundary — it comes from the agent's tool call over the daemon's HTTP API — so an absolute path let a run read any file the daemon process can see (secrets, other repos on the same pod, etc.), not just files under the sandbox's app root.

**Failure scenario:** POST `/read` with `{"path": "/etc/passwd"}` (or any absolute path outside `appRoot`) returned 200 with the file's content instead of the 400 every other fs route already gives for the same shape of request.

**Fix:** deleted `resolveReadPath`'s bypass and route `/read` through the same `paths.SafePath` call the write-side routes use. Net: -13/+... a small deletion, no new abstraction.

**Regression test:** `TestReadRefusesAbsolutePathOutsideRoot` in `fs_test.go` — writes a secret file outside `appRoot` (via `os.MkdirTemp`, not `t.TempDir()`, so it's genuinely outside the shared per-test temp root) and asserts `/read` now 400s and never echoes the content. Confirmed it fails against the pre-fix code (200 + leaked content) and passes after.

A reviewer can confirm with:
```
cd packages/sandbox/daemon-go && go test ./internal/routes/ -run TestRead -v
```

Locally ran: `go build ./...`, `go vet ./internal/routes/...`, `gofmt -l` (clean), and the full `internal/routes` package test suite (all pass, 2 skipped for missing local `rg`). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a path traversal in the daemon's `/read` route so an absolute path can no longer read files outside the sandbox's app root. Previously `/read` special-cased absolute paths and passed them straight to `os.Stat`, while every other fs route already confined them with `paths.SafePath`.

- `/read` now runs through the same `paths.SafePath` containment as the write-side routes and returns 400 for out-of-root paths.
- Adds a regression test that writes a secret file outside `appRoot` and asserts `/read` returns 400 without leaking its content.

<sup>Written for commit 9dea9f587bab80191cf2a47af293f69058e991a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

