### PR TITLE
fix(task-board): expose expand state on the PR card's checks toggle

### DIFF
--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -1996,6 +1996,7 @@ function PrCard({
           <button
             type="button"
             disabled={!expandable}
+            aria-expanded={expandable ? checksOpen : undefined}
             onClick={() => setChecksOpen((o) => !o)}
             className="flex w-full items-center gap-1.5 font-medium disabled:cursor-default"
           >


### PR DESCRIPTION
The PR card's CI-checks disclosure button (in `task-dialog.tsx`'s `PrCard`) toggles a `checksOpen` state that conditionally renders the check-run list, driven by a chevron icon that rotates — the standard disclosure-widget pattern used ~15 other places in this codebase (`collapsible-highlight.tsx`, `checks-tab.tsx`, `object-field.tsx`, etc.), all of which set `aria-expanded`. This one button was the outlier missing it, so a screen reader user gets no indication the button opens/closes a panel or what its current state is.

Fix: add `aria-expanded={expandable ? checksOpen : undefined}` (undefined when the button has nothing to expand and is disabled, matching the existing `disabled={!expandable}` guard).

Reviewer check: open a task with a linked PR that has CI checks, inspect the checks-toggle button's accessibility tree (or just read the diff) — `aria-expanded` should track the open/closed chevron state.

Verified locally: `bun run fmt` (clean) and `bunx oxlint apps/web/src/layouts/task-board/task-dialog.tsx` (0 warnings/errors) on the touched file. Skipped a targeted `tsc --noEmit` run — it surfaces only a pre-existing, unrelated duplicate-dependency-version error in `mention-suggestion.tsx` from a stale lockfile in this worktree, not from this change. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `aria-expanded` to the PR card's CI-checks toggle so screen reader users can tell when the checks panel is open. The attribute is only set when the button has expandable content, matching the existing disabled state.

<sup>Written for commit cfc5d8f3b4e27d386057687cbb5a1df47031dc23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

