### PR TITLE
fix(sections-editor): render selected page variant in preview on load

### DIFF
--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -536,6 +536,28 @@ export function SectionsEditor({
     onVariantPreviewOverride(params.length > 0 ? params : null);
   };
 
+  // Seed the override on page load so the iframe opens on the selected variant.
+  const pageVariantSeedKey =
+    onVariantPreviewOverride &&
+    activePageKey &&
+    pageIsMultivariate &&
+    hasMultipleVariants &&
+    !decofileLoading &&
+    !metaLoading
+      ? activePageKey
+      : null;
+  const [prevPageVariantSeedKey, setPrevPageVariantSeedKey] = useState<
+    string | null
+  >(null);
+  if (pageVariantSeedKey !== prevPageVariantSeedKey) {
+    setPrevPageVariantSeedKey(pageVariantSeedKey);
+    if (pageVariantSeedKey) {
+      const seedVariants = pageVariants.map((v) => ({ rule: v.rule }));
+      const seedIndex = safeVariantIndex;
+      queueMicrotask(() => emitPageVariantOverride(seedVariants, seedIndex));
+    }
+  }
+
   const syncVariantPreviewOverride = (
     mvObj: Record<string, unknown> | null,
     sectionIndex: number,


### PR DESCRIPTION
## Summary

When entering the site editor on a page that has variants, the preview iframe did **not** carry the selected variant — it fell back to the deco runtime matcher (date/audience), which could disagree with the variant row highlighted in the "Variantes" list. The `x-deco-matchers-override` param was only emitted **after** the user clicked a variant row.

This seeds the override on page load so the iframe opens on the **selected** variant (index 0 / the highlighted row), keeping the list selection and the iframe in agreement from the first render.

## Implementation

`apps/web/src/components/sections-editor/sections-editor.tsx`:
- Reuses the existing `emitPageVariantOverride` (same path as a variant-row click).
- No `useEffect` — follows the file's prev-state-during-render pattern (`prevPageVariantSeedKey`).
- Keyed on `activePageKey` + a `decofileLoading`/`metaLoading` ready-gate (saved-matcher ids need decofile/meta); re-seeds on page change, and a background decofile refetch does not re-trigger it.
- Emit is deferred via `queueMicrotask` so it never dispatches to the parent workspace reducer mid-render.

## Testing

- `bun run --cwd=apps/web check` ✅
- `bun run lint` ✅ (0 errors)
- `bun run fmt` ✅

Manual check recommended: open the editor on a home page with date-range variants and confirm the iframe opens on the highlighted variant without a click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sections editor so the preview iframe opens on the selected page variant on load instead of falling back to the deco runtime matcher, keeping the Variantes list and the iframe in sync from first render.

**Bug Fixes**
- Seeds the override on multivariate pages only after the decofile and meta finish loading.
- Re-seeds on page change but not on background decofile refetches; the emit is deferred so it never fires mid-render.

<sup>Written for commit 4e8b1bbcdc892acbfe4b7bdf0c93ac639bfed986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

