### PR TITLE
fix(github): speed up organization permission checks

### DIFF
--- a/apps/api/src/api/routes/git-providers.ts
+++ b/apps/api/src/api/routes/git-providers.ts
@@ -204,6 +204,7 @@ export const createGitProviderRoutes = () => {
     try {
       access = await appAuth.listAuthorizedInstallations(
         await ctx.vault.decrypt(flow.encrypted_access_token),
+        input.data.installationId,
       );
     } catch {
       return c.json({ error: "github_unavailable" }, 502);

--- a/apps/api/src/decofile/git-compat.ts
+++ b/apps/api/src/decofile/git-compat.ts
@@ -22,7 +22,8 @@ import {
   type RepoContentClient,
   type TreeEntry,
 } from "@/git-providers";
-import { mapBounded, resolveOrCreateHead } from "./read-decofile";
+import { mapBounded } from "@decocms/shared/std";
+import { resolveOrCreateHead } from "./read-decofile";
 
 const DIFF_MAX_FILES = 200;
 const DIFF_FETCH_CONCURRENCY = 12;

--- a/apps/api/src/decofile/read-decofile.ts
+++ b/apps/api/src/decofile/read-decofile.ts
@@ -1,3 +1,4 @@
+import { mapBounded } from "@decocms/shared/std";
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import {
@@ -113,27 +114,6 @@ function countSkippedBlocks(n: number): void {
     unit: "{blocks}",
   });
   skippedBlocksCounter.add(n);
-}
-
-export async function mapBounded<T, R>(
-  items: T[],
-  limit: number,
-  fn: (item: T) => Promise<R>,
-): Promise<R[]> {
-  const out = new Array<R>(items.length);
-  let next = 0;
-  const workers = Array.from(
-    { length: Math.min(limit, items.length) },
-    async () => {
-      for (;;) {
-        const i = next++;
-        if (i >= items.length) return;
-        out[i] = await fn(items[i] as T);
-      }
-    },
-  );
-  await Promise.all(workers);
-  return out;
 }
 
 /** Repo-relative directory holding block sources for a (possibly nested) project. */

--- a/apps/api/src/git-providers/github/app-auth.ts
+++ b/apps/api/src/git-providers/github/app-auth.ts
@@ -13,6 +13,7 @@
 
 import { createPrivateKey, sign } from "node:crypto";
 import { z } from "zod";
+import { mapBounded } from "@decocms/shared/std";
 import {
   isPermissionRejected,
   OPTIONAL_MINT_PERMISSIONS,
@@ -462,14 +463,21 @@ export class GithubAppAuth {
    *
    * An installation where none of that holds is left out entirely.
    */
-  async listAuthorizedInstallations(userToken: string): Promise<{
+  async listAuthorizedInstallations(
+    userToken: string,
+    installationId?: number,
+  ): Promise<{
     userId: string;
     installations: AuthorizedInstallation[];
   }> {
     const user = z
       .object({ id: z.number().int().positive().safe() })
       .parse(await this.userGet("/user", userToken, "get_connecting_user"));
-    const installations = await this.listUserInstallations(userToken);
+    // A connect revalidates only the selected installation, using fresh user access.
+    const installations = (await this.listUserInstallations(userToken)).filter(
+      (item) =>
+        installationId === undefined || item.installationId === installationId,
+    );
     const ownedOrganizations = new Set<string>();
     if (installations.some((item) => item.accountType === "Organization")) {
       for (let page = 1; ; page++) {
@@ -499,25 +507,29 @@ export class GithubAppAuth {
         if (memberships.length < 100) break;
       }
     }
-    const authorized: AuthorizedInstallation[] = [];
-    for (const item of installations) {
-      if (item.accountType === "User") {
-        if (item.externalAccountId === String(user.id)) {
-          authorized.push({ ...item, repositoryIds: null });
+    const authorized = await mapBounded(
+      installations,
+      4,
+      async (item): Promise<AuthorizedInstallation | null> => {
+        if (item.accountType === "User") {
+          return item.externalAccountId === String(user.id)
+            ? { ...item, repositoryIds: null }
+            : null;
         }
-        continue;
-      }
-      if (ownedOrganizations.has(item.externalAccountId)) {
-        authorized.push({ ...item, repositoryIds: null });
-        continue;
-      }
-      const repositoryIds = await this.administeredRepositories(
-        userToken,
-        item.installationId,
-      );
-      if (repositoryIds.length > 0) authorized.push({ ...item, repositoryIds });
-    }
-    return { userId: String(user.id), installations: authorized };
+        if (ownedOrganizations.has(item.externalAccountId)) {
+          return { ...item, repositoryIds: null };
+        }
+        const repositoryIds = await this.administeredRepositories(
+          userToken,
+          item.installationId,
+        );
+        return repositoryIds.length > 0 ? { ...item, repositoryIds } : null;
+      },
+    );
+    return {
+      userId: String(user.id),
+      installations: authorized.filter((item) => item !== null),
+    };
   }
 
   /**

--- a/packages/e2e/fixtures/github-stub.ts
+++ b/packages/e2e/fixtures/github-stub.ts
@@ -53,6 +53,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { sleep } from "@decocms/shared/std";
 import {
   createServer,
   type IncomingMessage,
@@ -952,6 +953,10 @@ interface UserInstallation {
 }
 
 export function createGithubStubServer(): Server {
+  const userRequests = new Map<
+    string,
+    { paths: string[]; active: number; peak: number }
+  >();
   const users = new Map<
     string,
     {
@@ -964,12 +969,40 @@ export function createGithubStubServer(): Server {
       }>;
       identityStatus?: number;
       membershipsStatus?: number;
+      repositoryDelayMs?: number;
     }
   >();
   const codes = new Map<string, string>();
   return createServer((req, res) => {
     const url = new URL(req.url ?? "/", "http://localhost");
     const dispatch = async (): Promise<void> => {
+      const userToken =
+        req.headers.authorization?.replace(/^Bearer /, "") ?? "";
+      if (
+        req.method === "GET" &&
+        url.pathname === "/__admin/github-user-requests"
+      ) {
+        json(
+          res,
+          200,
+          userRequests.get(userToken) ?? { paths: [], active: 0, peak: 0 },
+        );
+        return;
+      }
+      if (req.method === "GET" && url.pathname.startsWith("/user")) {
+        let requests = userRequests.get(userToken);
+        if (!requests) {
+          requests = { paths: [], active: 0, peak: 0 };
+          userRequests.set(userToken, requests);
+        }
+        requests.paths.push(url.pathname + url.search);
+        if (/^\/user\/installations\/\d+\/repositories$/.test(url.pathname)) {
+          requests.active++;
+          requests.peak = Math.max(requests.peak, requests.active);
+          await sleep(users.get(userToken)?.repositoryDelayMs ?? 0);
+          requests.active--;
+        }
+      }
       if (req.method === "GET" && url.pathname === "/health") {
         json(res, 200, { ok: true });
         return;

--- a/packages/e2e/tests/github-connect.spec.ts
+++ b/packages/e2e/tests/github-connect.spec.ts
@@ -52,6 +52,7 @@ async function grantAccess(
     }>;
     identityStatus?: number;
     membershipsStatus?: number;
+    repositoryDelayMs?: number;
   },
 ) {
   const result = await request.post(`${fixtureOrigin}/__admin/github-users`, {
@@ -70,6 +71,7 @@ async function grantAccess(
           })),
       identityStatus: identity?.identityStatus,
       membershipsStatus: identity?.membershipsStatus,
+      repositoryDelayMs: identity?.repositoryDelayMs,
     },
   });
   expect(result.ok()).toBe(true);
@@ -728,6 +730,69 @@ test("an organization member shares only the repositories they administer", asyn
   } finally {
     await db.end();
   }
+});
+
+test("organization permission checks overlap with bounded concurrency", async ({
+  authedPage,
+}) => {
+  const { page } = authedPage;
+  const installations = Array.from({ length: 9 }, (_, index) =>
+    installation(`member-org-${index}`, "Organization", [
+      { id: 8000 + index, permissions: { admin: true } },
+    ]),
+  );
+  const flow = await seedFlow(authedPage, installations);
+  await grantAccess(page.request, flow.token, installations, {
+    memberships: [],
+    repositoryDelayMs: 100,
+  });
+  const response = await page.request.get(flow.path);
+  expect(response.status()).toBe(200);
+  expect(
+    (await response.json()).installations.map(
+      (item: { login: string }) => item.login,
+    ),
+  ).toEqual(installations.map((item) => item.account.login));
+  const stats = await (
+    await page.request.get(`${fixtureOrigin}/__admin/github-user-requests`, {
+      headers: { Authorization: `Bearer ${flow.token}` },
+    })
+  ).json();
+  expect(stats.peak).toBeGreaterThan(1);
+  expect(stats.peak).toBeLessThanOrEqual(4);
+});
+
+test("connecting checks repositories only for the selected organization", async ({
+  authedPage,
+}) => {
+  const { page } = authedPage;
+  const installations = Array.from({ length: 6 }, (_, index) =>
+    installation(`connect-org-${index}`, "Organization", [
+      { id: 9000 + index, permissions: { admin: true } },
+    ]),
+  );
+  const flow = await seedFlow(authedPage, installations);
+  await grantAccess(page.request, flow.token, installations, {
+    memberships: [],
+  });
+  const selected = installations[3]!;
+  expect(
+    (
+      await page.request.post(flow.path, {
+        data: { installationId: selected.id },
+      })
+    ).status(),
+  ).toBe(200);
+  const stats = await (
+    await page.request.get(`${fixtureOrigin}/__admin/github-user-requests`, {
+      headers: { Authorization: `Bearer ${flow.token}` },
+    })
+  ).json();
+  expect(
+    stats.paths.filter((path: string) => path.includes("/repositories?")),
+  ).toEqual([
+    `/user/installations/${selected.id}/repositories?per_page=100&page=1`,
+  ]);
 });
 
 test("grants add up between connectors and an owner widens them to the whole installation", async ({

--- a/packages/shared/src/std/index.ts
+++ b/packages/shared/src/std/index.ts
@@ -10,3 +10,5 @@ export { exponentialBackoffWithJitter } from "./backoff";
 // just `delay`. Prefer this over `Bun.sleep` (Bun-only) or a hand-rolled
 // `new Promise(r => setTimeout(r, ms))`.
 export { delay as sleep } from "./delay";
+
+export { mapBounded } from "./map-bounded";

--- a/packages/shared/src/std/map-bounded.ts
+++ b/packages/shared/src/std/map-bounded.ts
@@ -1,0 +1,20 @@
+export async function mapBounded<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const out = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      for (;;) {
+        const i = next++;
+        if (i >= items.length) return;
+        out[i] = await fn(items[i] as T);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return out;
+}


### PR DESCRIPTION
## What is this contribution about?

The GitHub connection chooser checked repository admin permissions one organization at a time. Selecting an organization then repeated those checks for every available installation.

Run the chooser checks with a concurrency limit of four and revalidate only the selected installation when connecting. Permission checks remain fresh, paginated, and scoped to the connecting user's access. Listing still requires repository requests for each organization the user does not own.

Move the existing `mapBounded` helper into `@decocms/shared/std` so GitHub auth and the existing decofile callers share it.

## How did you verify your code works?

- GitHub connection Playwright suite: all 18 tests passed against an isolated Postgres database and the HTTP GitHub fixture. Local execution used an installed Chromium executable through a temporary config override.
- Added two regressions that failed before the fix: organization checks must overlap without exceeding four concurrent requests; connecting must query repositories only for the selected installation.
- `bun test apps/api/src/git-providers/github apps/api/src/decofile packages/shared/src/std`: 232 passed.
- `bun run fmt`, `bun run lint`, `bun run check`, and `bun run knip` passed. Lint reports 14 warnings; knip reports two package-entry configuration hints.

## Screenshots/Demonstration

With nine organizations and 100 ms of simulated latency per repository request, the chooser API took 933 ms before and 323 ms after. No visual changes.

## How to Test

1. Run `bun run --cwd=packages/e2e test:e2e:github-connect` with a test `DATABASE_URL`, `DISABLE_RATE_LIMIT=true`, and a stable test `BETTER_AUTH_SECRET`.
2. Open the GitHub connection chooser with access to several organizations where you administer repositories but are not an organization owner. The checks should overlap, with at most four repository requests in flight per listing.
3. Select an organization. Only that installation's repository permissions should be rechecked. Existing tests cover revoked ownership, partial repository grants, pagination, and GitHub errors.

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up GitHub organization permission checks by running them with bounded concurrency and revalidating only the selected installation when connecting.

- Organization permission checks now run with a concurrency limit of four.
- Connecting to an installation rechecks only that installation's permissions instead of all available ones.
- Moved the `mapBounded` helper into `@decocms/shared/std` so GitHub auth and decofile callers share it.
- Added regression tests for bounded concurrency and selective revalidation.

<sup>Written for commit 7d6789a52a78cc96a6fef9ab1ef1bcbb8d6f91fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

