### PR TITLE
fix(jira): give a Jira-triggered run its own prompt and its own tool grant

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -65,7 +65,7 @@ import { hasAdminRole } from "@decocms/shared/auth/roles";
 import { fetchRolePermissions } from "@/core/context-factory";
 import type { Permission } from "@/storage/types";
 import { connectionGrantsFor, rolesOf } from "@/harnesses/org-mcp-grants";
-import { REVIEW_RUN_TOOL_NAMES } from "@/tools/task-board/task-run-context";
+import { resolveTaskRunToolNames } from "@/tools/task-board/task-run-context";
 import { getPublicUrl } from "@/core/server-constants";
 import { getAgentSandboxProvider } from "@/sandbox/lifecycle";
 import { getSettings } from "@/settings";
@@ -358,12 +358,24 @@ export class SandboxDispatchClient {
       // Studio surface exposes, plus the connections it was given.
       //
       // `self` is the resource key management tools are checked under (see
-      // AccessControl's default `connectionId`); the reviewer superset covers
-      // both run kinds, and which of them a given run can actually call is
-      // already decided by the server it talks to (`toolSubsetMCP`). Each
-      // connection is its own resource key, `"*"` because a run that was given
-      // a connection was given the whole connection.
-      runKeyPermissions({ toolNames: REVIEW_RUN_TOOL_NAMES, grants }),
+      // AccessControl's default `connectionId`). Read from the run THREAD via
+      // the same resolver the endpoint itself uses, so the key and the server
+      // can never name different surfaces. Each connection is its own resource
+      // key, `"*"` because a run that was given a connection was given the
+      // whole connection.
+      //
+      // This was the reviewer list, hardcoded, on the reasoning that it was a
+      // superset of "both run kinds". A third kind (Jira) whose tools are not
+      // in it made that false: its endpoint served `JIRA_COMMENT_ADD` while its
+      // key did not authorize it, so the first production run did the work,
+      // opened its pull request, and got "Access denied to: JIRA_COMMENT_ADD"
+      // on the one call that reports back. Deriving it removes the class.
+      runKeyPermissions({
+        toolNames: resolveTaskRunToolNames(
+          await this.ctx.storage.threads.get(threadId),
+        ),
+        grants,
+      }),
     );
     if (connections.length === 0 || !organization.slug) return { mcp };
     const orgMcps = orgMcpServers({

--- a/apps/api/src/jira/trigger.ts
+++ b/apps/api/src/jira/trigger.ts
@@ -107,16 +107,6 @@ export type TriggerOutcome = "started" | "no_rule" | "duplicate" | "disabled";
 const DEFAULT_JIRA_INSTRUCTION =
   "A Jira issue was moved into a column you are responsible for. Work the issue.";
 
-/** Appended to every Jira-triggered run: the board tools are absent on
- *  purpose, and the issue is the thing to keep up to date. */
-const JIRA_RUN_FOOTER = [
-  "This run was started by a Jira issue, not a board card. Keep the ISSUE up to date, not a Studio card:",
-  "- `JIRA_ISSUE_GET` re-reads the issue (description, comments, attachments).",
-  "- `JIRA_COMMENT_ADD` posts a comment on it (markdown). Leave one when you finish, with what you did and any pull request link.",
-  "- `JIRA_ISSUE_TRANSITION` moves it to another status when your work warrants it.",
-  "- `JIRA_ATTACHMENT_DOWNLOAD` fetches an attachment into the sandbox by its id.",
-].join("\n");
-
 function jiraRunTitle(issue: { key: string; summary: string }): string {
   return `Jira ${issue.key}: ${issue.summary}`;
 }
@@ -239,7 +229,11 @@ async function dispatchJiraRun(
         kind: "jira",
         issueKey: issue.key,
         title: jiraRunTitle(issue),
-        body: `${renderIssueForPrompt(issue)}\n\n${JIRA_RUN_FOOTER}`,
+        // The issue only. How to report back is the prompt builder's job — it
+        // is the half that knows how this harness namespaces the tools, and it
+        // puts the instruction where the model weights it (the end) instead of
+        // in the middle of the issue body.
+        body: renderIssueForPrompt(issue),
       },
     });
   } catch (err) {

--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -30,6 +30,63 @@ describe("buildClaudeCodeTaskPrompt", () => {
     expect(prompt).toContain("acme/web is already cloned");
   });
 
+  // The rule's own prompt was dropped on this path entirely — only the
+  // Decopilot builder read it — so every Jira status rule and every by-hand
+  // test run silently got the generic lead instead, on any org with a repo.
+  test("leads with the caller's instruction when there is one", () => {
+    const prompt = buildClaudeCodeTaskPrompt(task, repo, {
+      instruction: "Reproduce the bug, then fix it.",
+    });
+    expect(prompt.startsWith("Reproduce the bug, then fix it.")).toBe(true);
+    expect(prompt).not.toContain("You've been assigned this task.");
+  });
+
+  test("falls back to the generic lead with no instruction", () => {
+    expect(buildClaudeCodeTaskPrompt(task, repo)).toContain(
+      "You've been assigned this task.",
+    );
+  });
+
+  describe("a Jira-triggered run", () => {
+    const jira = {
+      source: {
+        kind: "jira" as const,
+        issueKey: "ABC-1",
+        title: "Jira ABC-1: x",
+        body: "# ABC-1",
+      },
+    };
+
+    // It has no board tools (`JIRA_RUN_TOOL_NAMES`). Naming them sent the
+    // first production run hunting for `TASK_BOARD_COMMENT_CREATE`, which its
+    // endpoint does not serve.
+    test("is never told to use a board tool", () => {
+      const prompt = buildClaudeCodeTaskPrompt(task, repo, jira);
+      expect(prompt).not.toContain("TASK_BOARD_");
+    });
+
+    // Prefixed the way the sandbox harness actually sees them: bare names cost
+    // the run a tool search before it could report anything.
+    test("is told to report on the issue, with namespaced tool names", () => {
+      const prompt = buildClaudeCodeTaskPrompt(task, repo, jira);
+      expect(prompt).toContain("mcp__studio__JIRA_COMMENT_ADD");
+      expect(prompt).toContain("mcp__studio__JIRA_ISSUE_TRANSITION");
+    });
+
+    // The coding half is unchanged — a Jira run still opens a pull request.
+    test("still opens a pull request from its own branch", () => {
+      const prompt = buildClaudeCodeTaskPrompt(task, repo, jira);
+      expect(prompt).toContain("open a pull request");
+      expect(prompt).toContain("from the branch you were given");
+    });
+  });
+
+  test("a board run keeps its board tools", () => {
+    const prompt = buildClaudeCodeTaskPrompt(task, repo);
+    expect(prompt).toContain("mcp__studio__TASK_BOARD_COMMENT_CREATE");
+    expect(prompt).not.toContain("JIRA_");
+  });
+
   test("omits the description block when there is none", () => {
     const prompt = buildClaudeCodeTaskPrompt(
       { ...task, description: null },

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -30,6 +30,7 @@ import {
 import { SHALLOW_CHECKOUT_NOTE } from "@decocms/shared/task-board";
 import { agentSandboxEnabled } from "@/settings";
 import type { SuperAgentPromptOpts } from "./enqueue-super-agent";
+import { jiraRunFinishInstructions } from "./jira-run-prompt";
 import {
   sandboxUploadHint,
   uploadsAsSandboxPaths,
@@ -191,8 +192,12 @@ export function buildClaudeCodeTaskPrompt(
    * checkout is stated separately — see MIXED_PROVIDER_NOTE.
    */
   const cli = providerCli(repo?.provider ?? "github");
+  // A column rule's own instruction, when the caller passed one. Dropping it
+  // here (the Decopilot builder never did) silently ignored every Jira status
+  // rule's prompt on any org with a repo to work in.
   const lines: string[] = [
-    `You've been assigned this task. Complete it and finish with a ${cli.changeRequest} if it makes sense (like a coding task) or is explicitly requested.`,
+    opts?.instruction?.trim() ||
+      `You've been assigned this task. Complete it and finish with a ${cli.changeRequest} if it makes sense (like a coding task) or is explicitly requested.`,
     "",
     "You are running AUTONOMOUSLY — no human is watching, so drive this to " +
       "completion yourself. Make reasonable decisions and move on; do not stop " +
@@ -271,6 +276,8 @@ export function buildClaudeCodeTaskPrompt(
     );
   }
 
+  const jiraRun = opts?.source?.kind === "jira";
+
   lines.push(
     "How to finish:",
     "- Make the change, commit it, push the branch, and open a pull request" +
@@ -294,6 +301,14 @@ export function buildClaudeCodeTaskPrompt(
     // is open the PR from some other branch. Replaces asking the run to report
     // it, which a run that died right after `gh pr create` could never do.
     `- Open the ${cli.changeRequest} from the branch you were given — the board finds it by that branch. Don't move the work to a differently-named one.`,
+  );
+
+  if (jiraRun) {
+    lines.push(...jiraRunFinishInstructions("mcp__studio__"), "");
+    return lines.join("\n");
+  }
+
+  lines.push(
     // A tool call, NOT a line in the PR body: the first version of this read
     // the body back, and one hand-edited body lost the routes silently.
     `- If your change adds or edits pages a person can open, report their paths with \`mcp__studio__TASK_BOARD_ITEM_UPDATE\` (id "${task.id}", \`previewRoutes: ["/some-page"]\`) — paths only, no host. The card joins them onto the deploy preview so a reviewer opens the page directly. Skip it when the change has no visible route.`,

--- a/apps/api/src/tools/task-board/enqueue-super-agent.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.test.ts
@@ -19,6 +19,26 @@ const CONTINUE_LEAD = "already has an open pull request";
 const OPEN_A_PR = "commit on a new branch, push, and open a pull request";
 
 describe("buildSuperAgentTaskPrompt", () => {
+  // Decopilot registers the issue tools as built-ins, so they are named bare
+  // here and namespaced in the sandbox builder. Same instruction, two spellings
+  // — a run told the wrong one spends a turn searching for the tool.
+  it("a Jira-triggered run is told to report on the issue, unprefixed", () => {
+    const p = buildSuperAgentTaskPrompt(task, {
+      source: {
+        kind: "jira",
+        issueKey: "ABC-1",
+        title: "Jira ABC-1: x",
+        body: "# ABC-1",
+      },
+    });
+    expect(p).toContain("`JIRA_COMMENT_ADD`");
+    expect(p).not.toContain("mcp__studio__");
+  });
+
+  it("a board run is told nothing about Jira", () => {
+    expect(buildSuperAgentTaskPrompt(task)).not.toContain("JIRA_");
+  });
+
   it("a fresh attempt has no lead block, and opens a PR", () => {
     const p = buildSuperAgentTaskPrompt(task);
     expect(p).not.toContain(CONFLICT_LEAD);

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -14,6 +14,7 @@ import { isReportsTask } from "@decocms/shared/task-board";
 import { captureOrgEvent } from "@/posthog";
 import { getSettings } from "@/settings";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
+import { jiraRunFinishInstructions } from "./jira-run-prompt";
 import type { RunClass } from "@/dispatch-queue/run-priority";
 import type { ClaudeCodeModelClass } from "@/harnesses/claude-code-env";
 import { fetchPrHeadRef } from "./prs-get";
@@ -168,6 +169,11 @@ export function buildSuperAgentTaskPrompt(
     "- Change only what the task needs. Don't trace the definition of a pre-existing symbol that's incidental to your change — note it in one line and move on. Prefer one or two broad searches over many narrow retries.",
     "- Only if you hit a genuine blocker a human must clear (see above) may you call `user_ask` — otherwise keep going and finish the task.",
     "",
+    // Bare names: on this path the issue tools are Decopilot built-ins, not
+    // MCP tools behind a namespace.
+    ...(opts?.source?.kind === "jira"
+      ? [...jiraRunFinishInstructions(""), ""]
+      : []),
     `(task id: ${task.id})`,
   ].join("\n");
   // prompt-region:end super-agent

--- a/apps/api/src/tools/task-board/jira-run-prompt.ts
+++ b/apps/api/src/tools/task-board/jira-run-prompt.ts
@@ -1,0 +1,30 @@
+/**
+ * How a Jira-triggered run is told to finish.
+ *
+ * Its card is a hidden anchor nobody reads, so the board's closing
+ * instructions are wrong for it twice over: they point at `TASK_BOARD_*` tools
+ * its endpoint does not serve (`JIRA_RUN_TOOL_NAMES`), and they would have it
+ * record its work where no one looks while the issue stayed untouched. Observed
+ * on the first production run: the model searched for `TASK_BOARD_COMMENT_CREATE`,
+ * found nothing, and fell back to the issue tools on its own.
+ *
+ * `prefix` is the harness's tool namespace. A sandbox-hosted run reaches Studio
+ * over MCP and sees `mcp__studio__JIRA_COMMENT_ADD`; a Decopilot run has the
+ * same tools registered as built-ins under their bare names. Naming them the
+ * way the model will actually see them is the difference between a call and a
+ * tool search.
+ */
+
+export type JiraToolPrefix = "mcp__studio__" | "";
+
+export function jiraRunFinishInstructions(prefix: JiraToolPrefix): string[] {
+  const tool = (name: string) => `\`${prefix}${name}\``;
+  return [
+    "This run was started by a Jira issue, not a board card. Report on the ISSUE — there is no card for anyone to read:",
+    `- ${tool("JIRA_ISSUE_GET")} re-reads the issue (description, comments, attachments).`,
+    `- ${tool("JIRA_COMMENT_ADD")} posts a comment on it (markdown). Leave one when you finish, with what you did and any pull request link. This is the ONLY way your work gets reported — a final message in this run is not a report.`,
+    `- ${tool("JIRA_ISSUE_TRANSITION")} moves it to another status when your work warrants it.`,
+    `- ${tool("JIRA_ATTACHMENT_DOWNLOAD")} fetches an attachment into the sandbox by its id.`,
+    "You have no board tools on this run. Do not look for them.",
+  ];
+}

--- a/apps/api/src/tools/task-board/task-run-context.test.ts
+++ b/apps/api/src/tools/task-board/task-run-context.test.ts
@@ -8,6 +8,7 @@
  * lists are distinguished by the thread title the board itself assigned.
  */
 import { describe, expect, test } from "bun:test";
+import { runKeyPermissions } from "@/mcp-clients/virtual-mcp/mint-endpoint";
 import {
   REVIEW_RUN_TOOL_NAMES,
   JIRA_RUN_TOOL_NAMES,
@@ -89,5 +90,54 @@ describe("resolveTaskRunToolNames", () => {
         metadata: { source: "jira" },
       }),
     ).toEqual(JIRA_RUN_TOOL_NAMES);
+  });
+});
+
+/**
+ * The run's KEY has to authorize everything the run's SERVER serves.
+ *
+ * These are two independent halves and they drifted: the key was minted from a
+ * hardcoded `REVIEW_RUN_TOOL_NAMES` on the reasoning that it was a superset of
+ * every run kind, which stopped being true the moment the Jira kind existed.
+ * The endpoint served `JIRA_COMMENT_ADD`, the key did not authorize it, and the
+ * first production Jira run did all its work and then got
+ * "Access denied to: JIRA_COMMENT_ADD" on the one call that reports back.
+ *
+ * Asserted over every kind rather than for Jira alone, so a FOURTH kind cannot
+ * reintroduce it.
+ */
+describe("a run's key covers the surface its endpoint serves", () => {
+  const threads = {
+    worker: { title: "Super Agent: Add an H1" },
+    reviewer: { title: "Reviewer: Add an H1" },
+    jira: { title: "Jira ABC-1: x", metadata: { source: "jira" as const } },
+  };
+
+  for (const [kind, thread] of Object.entries(threads)) {
+    test(`${kind}`, () => {
+      const served = resolveTaskRunToolNames(thread);
+      const authorized = runKeyPermissions({
+        toolNames: served,
+        grants: {},
+      }).self;
+      for (const tool of served) expect(authorized).toContain(tool);
+    });
+  }
+
+  // The half that actually broke, stated on its own so the reason survives.
+  test("a Jira run may comment on its issue", () => {
+    expect(
+      runKeyPermissions({
+        toolNames: resolveTaskRunToolNames(threads.jira),
+        grants: {},
+      }).self,
+    ).toContain("JIRA_COMMENT_ADD");
+  });
+
+  // Inverted: the reviewer list is no longer a superset of every kind, so
+  // nothing may mint a key from it again.
+  test("the reviewer list does not cover a Jira run", () => {
+    expect(REVIEW_RUN_TOOL_NAMES).not.toContain("JIRA_COMMENT_ADD");
+    expect(JIRA_RUN_TOOL_NAMES).toContain("JIRA_COMMENT_ADD");
   });
 });


### PR DESCRIPTION
Follow-up to #7126, from its first real run. The run did the work correctly and reported **nothing** on the issue. Two independent causes, both on the sandbox-hosted path — the one any org with a repo takes.

## 1. The run's key did not authorize the tools its own server served

`mcpForRun` minted the per-run key from a hardcoded `REVIEW_RUN_TOOL_NAMES`, with this reasoning in the comment:

> the reviewer superset covers both run kinds

That was true while worker and reviewer were the only kinds. The Jira kind's tools are not in it, so:

- the endpoint **served** `JIRA_COMMENT_ADD` (`resolveTaskRunToolNames` — correct),
- the key **did not grant** it,
- and the run's one call that reports back failed with `Error: Access denied to: JIRA_COMMENT_ADD`.

Exactly the class of bug `runKeyPermissions`' own docstring warns about ("Both halves are load-bearing and the connection half was missed once"). The key is now derived from the run thread with the same resolver the endpoint uses, so the two halves cannot name different surfaces — and a fourth run kind is covered without editing this call site.

## 2. `buildClaudeCodeTaskPrompt` ignored both `instruction` and `source`

**It never read `opts.instruction`.** Every Jira status rule's prompt was silently dropped and replaced with the generic lead. This is not specific to runs started by hand — it broke column rules generally. The Decopilot builder honored it all along, so the bug was invisible on repo-less orgs.

**Its closing instructions were board-flavored.** They named \`TASK_BOARD_ITEM_UPDATE\`, \`TASK_BOARD_COMMENT_CREATE\` (twice) and \`TASK_BOARD_COMMENT_LIST\`, none of which a Jira run's endpoint serves, and told it to "move it to done" on a card that is a hidden anchor. The observed run searched for \`TASK_BOARD_COMMENT_CREATE\`, got nothing back, and fell back to the issue tools on its own — so the model behaved better than the prompt did.

The issue tools were only ever named in a footer buried **mid-prompt** inside the rendered issue body, with bare names the sandbox harness does not use. That footer is gone. \`jiraRunFinishInstructions(prefix)\` now emits them at the end, where the model weights them, spelled the way each harness actually sees them: \`mcp__studio__JIRA_COMMENT_ADD\` for the sandbox, the bare name for Decopilot's built-ins.

The coding half is unchanged — a Jira run still opens a pull request from the branch it was given.

## Testing

- The key/server invariant is asserted **for every run kind**, not for Jira alone, so a fourth kind cannot reintroduce it.
- The "reviewer list is a superset" assumption is **inverted** into a test, so nothing mints a key from it again.
- Prompt tests cover the instruction lead (present and absent), both tool spellings, and that a board run is unchanged.
- \`bun test apps/api/src/tools/task-board apps/api/src/harnesses apps/api/src/mcp-clients apps/api/src/jira\` — 1286 pass, 0 fail (real-Postgres suites included). \`bun run check\`, \`lint\`, \`fmt\`, \`knip\` clean.

## Known, not fixed here

A reviewer run is still enqueued for a Jira-triggered task once it has a PR, and it records its verdict and comment on the **hidden anchor card** — where nobody reads it — leaving nothing on the issue. Its own key and surface agree, so it does not error; the outcome is just invisible to whoever opened the issue. Worth deciding separately: either give the reviewer the issue tools too, or don't review an anchor-only card.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two defects on the sandbox-hosted path that made the first Jira-triggered run do its work and then report nothing on the issue.

- The run's key is now derived from the run thread with the same resolver the endpoint uses, so it grants `JIRA_COMMENT_ADD`; previously it was minted from the reviewer tool list, which doesn't cover Jira, and the report-back call failed with "Access denied".
- `buildClaudeCodeTaskPrompt` now leads with the rule's `instruction` when present and gives Jira runs finish instructions naming only issue tools, spelled the way each harness sees them (`mcp__studio__JIRA_COMMENT_ADD` for the sandbox, bare names for Decopilot) via a shared `jiraRunFinishInstructions`.
- The issue-tools footer is gone from the rendered issue body, and Jira runs are told explicitly they have no board tools.
- Tests assert the key/server invariant for every run kind so a fourth kind can't reintroduce the drift.

Known, not fixed: a Jira-triggered task still enqueues a reviewer run once it has a PR, and the reviewer's verdict lands on the hidden anchor card rather than the issue.

<sup>Written for commit efa2aab8fb9dd780856340a82492089831ab8266. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

