### PR TITLE
fix(preview): stop redundant iframe reload after instant preview render

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -688,11 +688,15 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   if (!inPlaceRenderActive) {
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- track the live draft URL while not editing in place; pin it while editing
     pinnedDraftUrlRef.current = draftPreviewUrl;
+  } else if (pinnedDraftUrlRef.current === null && draftPreviewUrl !== null) {
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- latch the first draft URL once (panel opened before the grant loaded), then freeze: re-tracking would reload the frame on every save's new @sha
+    pinnedDraftUrlRef.current = draftPreviewUrl;
   }
-  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read the value pinned during this same render (written just above when inactive)
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read the value pinned/latched during this same render (written just above)
   const pinnedDraftUrl = pinnedDraftUrlRef.current;
+  // Frozen while editing in place (no live fallback), so autosave version bumps don't reload the frame; a null pin keeps iframeSrc on the base URL until the latch above.
   const effectiveDraftPreviewUrl = inPlaceRenderActive
-    ? (pinnedDraftUrl ?? draftPreviewUrl)
+    ? pinnedDraftUrl
     : draftPreviewUrl;
 
   const iframeSrc = withDecoFBT(

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -685,15 +685,15 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     blocksEditingEnabled &&
     editingMode === "blocks";
   const pinnedDraftUrlRef = useRef<string | null>(null);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read the value pinned/latched last render before deciding whether to re-pin
+  let pinnedDraftUrl = pinnedDraftUrlRef.current;
   if (!inPlaceRenderActive) {
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- track the live draft URL while not editing in place; pin it while editing
     pinnedDraftUrlRef.current = draftPreviewUrl;
-  } else if (pinnedDraftUrlRef.current === null && draftPreviewUrl !== null) {
+  } else if (pinnedDraftUrl === null && draftPreviewUrl !== null) {
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- latch the first draft URL once (panel opened before the grant loaded), then freeze: re-tracking would reload the frame on every save's new @sha
-    pinnedDraftUrlRef.current = draftPreviewUrl;
+    pinnedDraftUrl = pinnedDraftUrlRef.current = draftPreviewUrl;
   }
-  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read the value pinned/latched during this same render (written just above)
-  const pinnedDraftUrl = pinnedDraftUrlRef.current;
   // Frozen while editing in place (no live fallback), so autosave version bumps don't reload the frame; a null pin keeps iframeSrc on the base URL until the latch above.
   const effectiveDraftPreviewUrl = inPlaceRenderActive
     ? pinnedDraftUrl


### PR DESCRIPTION
## Summary

Instant preview (in-place render) fetches `/live/previews` and swaps the iframe's body in place — no navigation. But users saw a **redundant full iframe reload right after each in-place swap**.

**Cause:** the `?__draft=` pointer ends in `@<branch-head-sha>` ([`section-preview-url.ts`](https://github.com/decocms/studio/blob/main/apps/web/src/components/sections-editor/section-preview-url.ts)), so every autosave bumps the sha and changes `draftPreviewUrl`. The pin meant to freeze the frame's URL during in-place editing fell back to the live URL (`pinnedDraftUrl ?? draftPreviewUrl`) whenever the pin was `null`. `pinnedDraftUrl` is only captured while **not** editing in place, so when the Blocks panel opens before the draft grant loads (the common case) it stays `null` forever — the fallback tracks the live URL, `iframeSrc` changes on every save, and both the `src={iframeSrc}` binding and the cross-origin navigation effect reload the frame.

## Fix

`apps/web/src/components/sandbox/preview/preview.tsx` — latch the first non-null draft URL once (so the frame still carries any existing draft), then **freeze** it with no live fallback. Version bumps during in-place editing no longer change `iframeSrc`, so the frame is not reloaded mid-edit. On leaving in-place mode the pin re-tracks live, as before.

## Testing

- `bun run fmt` and `bun run --cwd=apps/web check` pass.
- Manual verification of the live editing loop still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the preview iframe from reloading after an in-place render during live editing. The draft URL pin now latches the first non-null value and freezes while editing in place, so autosave `@<sha>` bumps no longer change `iframeSrc`; leaving in-place mode re-tracks the live URL as before.

<sup>Written for commit 5178c78873ebeb92543d305e96f513a1433ba089. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

