### PR TITLE
feat(jira): report on the issue like a person does, and let an org narrow a run's MCPs

### DIFF
--- a/apps/api/migrations/212-coding-agent-mcp-excluded.ts
+++ b/apps/api/migrations/212-coding-agent-mcp-excluded.ts
@@ -1,0 +1,28 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Which of the org's MCP connections a coding-agent run must NOT mount.
+ *
+ * `coding_agent_org_mcps` is all-or-nothing: on, a run mounts every active
+ * connection the dispatching user can reach. Some of them are the wrong tool
+ * for a coding run even so — an org whose Jira is also connected as an MCP
+ * would hand a Jira-triggered run two ways to reach the same issue, one of
+ * which bypasses the vault-held credential the run tools exist to keep out of
+ * the sandbox.
+ *
+ * A list, not a boolean, so it is its own column rather than a key in the
+ * `flags` bag — same shape and storage as `enabled_plugins` (JSON in text).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("organization_settings")
+    .addColumn("coding_agent_mcp_excluded", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("organization_settings")
+    .dropColumn("coding_agent_mcp_excluded")
+    .execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -1,5 +1,6 @@
 import * as migration211userfsorg from "./211-user-fs-org";
 import * as migration210githubrepositoryauthorization from "./210-github-repository-authorization";
+import * as migration212codingagentmcpexcluded from "./212-coding-agent-mcp-excluded";
 import * as migration209githubinstallationauthorization from "./209-github-installation-authorization";
 import * as migration208githubconnectflows from "./208-github-connect-flows";
 import * as migration207taskboardprsrepoidx from "./207-task-board-prs-repo-idx";
@@ -458,6 +459,7 @@ const migrations: Record<string, Migration> = {
   "210-github-repository-authorization":
     migration210githubrepositoryauthorization,
   "211-user-fs-org": migration211userfsorg,
+  "212-coding-agent-mcp-excluded": migration212codingagentmcpexcluded,
 };
 
 export default migrations;

--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -103,6 +103,48 @@ describe("selectRunConnections", () => {
       }).map((c) => c.id),
     ).toEqual(["conn_github", "conn_vtex"]);
   });
+
+  // The point of the exclusion list: the org-wide opt-in is all-or-nothing,
+  // and some connections are the wrong tool for a coding run even so.
+  test("an excluded connection is not mounted under the org-wide flag", () => {
+    expect(
+      selectRunConnections({
+        organizationId,
+        orgWide: true,
+        ownIds: new Set<string>(),
+        excludedIds: new Set(["conn_vtex"]),
+        connections,
+      }).map((c) => c.id),
+    ).toEqual(["conn_github"]);
+  });
+
+  // An exclusion someone set explicitly must not be silently reinstated
+  // because the connection also happens to be aggregated on the agent.
+  test("an exclusion outranks the agent's own aggregation", () => {
+    expect(
+      selectRunConnections({
+        organizationId,
+        orgWide: false,
+        ownIds: new Set(["conn_github", "conn_vtex"]),
+        excludedIds: new Set(["conn_github"]),
+        connections,
+      }).map((c) => c.id),
+    ).toEqual(["conn_vtex"]);
+  });
+
+  test("an empty or absent exclusion list changes nothing", () => {
+    for (const excludedIds of [undefined, new Set<string>()]) {
+      expect(
+        selectRunConnections({
+          organizationId,
+          orgWide: true,
+          ownIds: new Set<string>(),
+          excludedIds,
+          connections,
+        }).map((c) => c.id),
+      ).toEqual(["conn_github", "conn_vtex"]);
+    }
+  });
 });
 
 describe("harnessRunsInSandbox", () => {

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -475,6 +475,7 @@ export class SandboxDispatchClient {
       organizationId: organization.id,
       orgWide,
       ownIds,
+      excludedIds: new Set(settings?.coding_agent_mcp_excluded ?? []),
       connections: items,
     });
   }
@@ -1200,11 +1201,20 @@ export function selectRunConnections<
   orgWide: boolean;
   /** Connections aggregated on the agent itself; always mounted. */
   ownIds: ReadonlySet<string>;
+  /**
+   * Connections the org excluded from coding-agent runs
+   * (`coding_agent_mcp_excluded`). Wins over BOTH other reasons to mount one:
+   * the org-wide opt-in is what it exists to narrow, and an exclusion someone
+   * set explicitly must not be silently reinstated because the connection also
+   * happens to be aggregated on the agent.
+   */
+  excludedIds?: ReadonlySet<string>;
   connections: readonly T[];
 }): T[] {
   return args.connections.filter(
     (connection) =>
       (args.orgWide || args.ownIds.has(connection.id)) &&
+      !args.excludedIds?.has(connection.id) &&
       // A connection Studio already knows is erroring only costs the session
       // a failed connect at startup.
       connection.status === "active" &&

--- a/apps/api/src/jira/client.test.ts
+++ b/apps/api/src/jira/client.test.ts
@@ -7,6 +7,7 @@ import {
   textToAdf,
   JiraClient,
   JiraUserDirectory,
+  mediaUuidFromLocation,
 } from "./client";
 
 describe("normalizeSiteUrl", () => {
@@ -944,5 +945,39 @@ describe("JiraClient issue reads", () => {
         expect(calls.at(-1)).toContain("nextPageToken=tok-2");
       },
     );
+  });
+});
+
+/**
+ * An ADF `media` node addresses the media-services uuid, NOT the numeric
+ * attachment id — Jira answers a comment carrying the id with
+ * `ATTACHMENT_VALIDATION_ERROR`. The uuid is only available as the last path
+ * segment of the 303 the content endpoint answers with, so this parse is the
+ * single point where an inline screenshot is won or lost.
+ */
+describe("mediaUuidFromLocation", () => {
+  const uuid = "509aa4a2-390d-4c7a-bfac-aeab2f6a596b";
+
+  it("reads the uuid out of the media CDN redirect", () => {
+    expect(
+      mediaUuidFromLocation(
+        `https://api.media.atlassian.com/file/${uuid}/binary?token=x`,
+      ),
+    ).toBe(uuid);
+    expect(mediaUuidFromLocation(`https://cdn.example/file/${uuid}`)).toBe(
+      uuid,
+    );
+  });
+
+  it("is null when there is no redirect or no uuid in it", () => {
+    for (const location of [
+      null,
+      "",
+      "https://example.com/file/not-a-uuid/binary",
+      "https://example.com/",
+      "509aa4a2390d4c7abfacaeab2f6a596b",
+    ]) {
+      expect(mediaUuidFromLocation(location)).toBeNull();
+    }
   });
 });

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -217,7 +217,12 @@ export class JiraClient {
         headers: {
           Authorization: this.authHeader,
           Accept: "application/json",
-          ...(init?.body ? { "Content-Type": "application/json" } : {}),
+          // Only a string body is JSON. A FormData body must keep the boundary
+          // `fetch` computes for it — naming the type here truncates the upload.
+          ...(typeof init?.body === "string"
+            ? { "Content-Type": "application/json" }
+            : {}),
+          ...(init?.headers as Record<string, string> | undefined),
         },
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
@@ -562,6 +567,93 @@ export class JiraClient {
       console.warn(`[jira] comment rejected as ADF, posting flat: ${err}`);
       return post(textToAdf(header ? `${header}\n${markdown}` : markdown));
     }
+  }
+
+  /**
+   * Upload one file to the issue.
+   *
+   * `X-Atlassian-Token: no-check` is required — Jira rejects a multipart
+   * attachment POST without it as XSRF, whatever the credential.
+   */
+  async uploadAttachment(
+    issueIdOrKey: string,
+    filename: string,
+    bytes: Uint8Array,
+    contentType = "application/octet-stream",
+  ): Promise<JiraAttachment> {
+    const form = new FormData();
+    form.append(
+      "file",
+      new Blob([bytes as BlobPart], { type: contentType }),
+      filename,
+    );
+    const created = await this.request<JiraAttachment[]>(
+      `/rest/api/3/issue/${encodeURIComponent(issueIdOrKey)}/attachments`,
+      {
+        method: "POST",
+        body: form,
+        headers: { "X-Atlassian-Token": "no-check" },
+      },
+      // A retried upload would leave a duplicate attachment on the issue.
+      { idempotent: false },
+    );
+    const attachment = created[0];
+    if (!attachment) {
+      throw new Error(
+        `Jira accepted the upload of ${filename} but named no attachment`,
+      );
+    }
+    return attachment;
+  }
+
+  /**
+   * The media-services uuid of an attachment — what an ADF `media` node
+   * addresses. The numeric attachment id is NOT it; Jira answers a comment
+   * carrying one with `ATTACHMENT_VALIDATION_ERROR`.
+   *
+   * The content endpoint answers 303 to the media CDN and the uuid is the last
+   * path segment of that `Location`. Read WITHOUT following the redirect: the
+   * hop is a file download, and the platform drops Authorization across it
+   * anyway (see `downloadAttachment`).
+   */
+  async attachmentMediaUuid(attachmentId: string): Promise<string | null> {
+    const response = await fetch(
+      `${this.baseUrl}/rest/api/3/attachment/content/${encodeURIComponent(attachmentId)}`,
+      {
+        headers: { Authorization: this.authHeader },
+        redirect: "manual",
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      },
+    );
+    return mediaUuidFromLocation(response.headers.get("location"));
+  }
+
+  /**
+   * A remote link on the issue — how a pull request and a deploy preview get
+   * onto the card as links a person can click, rather than buried in a comment.
+   *
+   * `globalId` makes it idempotent: posting the same one twice updates that
+   * link instead of adding a second.
+   */
+  async addRemoteLink(
+    issueIdOrKey: string,
+    link: { url: string; title: string; summary?: string; globalId?: string },
+  ): Promise<{ id: number }> {
+    return this.request<{ id: number }>(
+      `/rest/api/3/issue/${encodeURIComponent(issueIdOrKey)}/remotelink`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          ...(link.globalId ? { globalId: link.globalId } : {}),
+          object: {
+            url: link.url,
+            title: link.title,
+            ...(link.summary ? { summary: link.summary } : {}),
+          },
+        }),
+      },
+      { idempotent: false },
+    );
   }
 
   /** Attachments on the issue. */
@@ -919,4 +1011,20 @@ export class JiraUserDirectory {
     }
     return resolved;
   }
+}
+
+/**
+ * The media uuid out of the `Location` the attachment-content endpoint
+ * redirects to, or null when the header is absent or shaped differently.
+ *
+ * Pure, so the parse is unit-tested: the uuid is what an ADF `media` node
+ * addresses, and getting it wrong makes Jira reject the whole comment.
+ */
+export function mediaUuidFromLocation(location: string | null): string | null {
+  if (!location) return null;
+  const match =
+    /\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[/?]|$)/i.exec(
+      location,
+    );
+  return match?.[1] ?? null;
 }

--- a/apps/api/src/jira/comment-images.test.ts
+++ b/apps/api/src/jira/comment-images.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Which markdown image refs become Jira attachments.
+ *
+ * Only the run's own `org/output/…` outputs are ours to upload; anything else
+ * is somebody's URL and stays a link. The traversal guard matters because the
+ * subpath is joined onto the run's thread prefix — `..` would read another
+ * run's screenshots onto this customer's issue.
+ */
+import { describe, expect, it } from "bun:test";
+import { attachmentNameFor, outputSubpath } from "./comment-images";
+
+describe("outputSubpath", () => {
+  it("takes the subpath of an org/output ref", () => {
+    expect(outputSubpath("org/output/qa/before.png")).toBe("qa/before.png");
+    expect(outputSubpath("org/output/a.png")).toBe("a.png");
+  });
+
+  it("refuses anything that is not ours to upload", () => {
+    for (const target of [
+      "https://example.com/a.png",
+      "/api/acme/fs/outputs/read?path=x",
+      "output/a.png",
+      "org/outputs/a.png",
+      "org/output/",
+      "org/output/   ",
+    ]) {
+      expect(outputSubpath(target)).toBeNull();
+    }
+  });
+
+  // The subpath is joined onto `<threadId>/`, so traversal would reach another
+  // run's outputs — and put them on a customer's issue.
+  it("refuses traversal out of the run's own prefix", () => {
+    expect(outputSubpath("org/output/../../secrets.png")).toBeNull();
+    expect(outputSubpath("org/output/qa/../../../x.png")).toBeNull();
+  });
+});
+
+describe("attachmentNameFor", () => {
+  it("flattens a subpath into one safe filename", () => {
+    expect(attachmentNameFor("qa/before-desktop.png")).toBe(
+      "qa-before-desktop.png",
+    );
+    expect(attachmentNameFor("a b/c.png")).toBe("a-b-c.png");
+  });
+
+  it("never yields an empty name", () => {
+    expect(attachmentNameFor("///")).toBe("image");
+  });
+});

--- a/apps/api/src/jira/comment-images.ts
+++ b/apps/api/src/jira/comment-images.ts
@@ -1,0 +1,97 @@
+/**
+ * Screenshots in a Jira comment.
+ *
+ * A run writes images to `org/output/…` in its pod — the idiom the board's QA
+ * reviewer already uses (`embedOrgOutputImages`) — and references them as
+ * markdown images. That mount materializes into the org-fs `outputs` volume
+ * under the run's thread id, so the bytes are readable here.
+ *
+ * Jira needs three steps per image: upload it to the issue, resolve the
+ * media-services uuid (the numeric attachment id is rejected), then address it
+ * from an ADF `media` node. `markdownToAdf` already takes that map — this is
+ * the half that fills it.
+ */
+
+import type { OrgFs } from "@/file-storage/org-fs";
+import type { JiraClient } from "./client";
+import { collectImageTargets, type AdfMedia } from "./markdown-adf";
+
+/** The volume `org/output/…` materializes into. */
+const OUTPUTS_VOLUME = "outputs";
+
+/** Only this prefix is ours to upload — an external URL stays a link. */
+const ORG_OUTPUT_PREFIX = "org/output/";
+
+const CONTENT_TYPES: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+};
+
+function contentTypeFor(path: string): string {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  return CONTENT_TYPES[ext] ?? "application/octet-stream";
+}
+
+/** `org/output/qa/before.png` → `qa/before.png`, or null when not ours. */
+export function outputSubpath(target: string): string | null {
+  if (!target.startsWith(ORG_OUTPUT_PREFIX)) return null;
+  const subpath = target.slice(ORG_OUTPUT_PREFIX.length).trim();
+  // No traversal out of the run's own prefix, and no empty ref.
+  if (subpath === "" || subpath.includes("..")) return null;
+  return subpath;
+}
+
+/** A flat, filesystem-safe name for the attachment on the issue. */
+export function attachmentNameFor(subpath: string): string {
+  return subpath.replace(/[^\w.-]+/g, "-").replace(/^-+|-+$/g, "") || "image";
+}
+
+/**
+ * Upload every `org/output/…` image the comment references and return the map
+ * `markdownToAdf` wants, keyed by the target exactly as written.
+ *
+ * Best-effort per image: one unreadable file or one refused upload leaves that
+ * ref as a link and still posts the comment. Losing the whole report because a
+ * screenshot went missing is the worse failure — the text is the point, the
+ * images are evidence for it.
+ */
+export async function uploadCommentImages(args: {
+  client: JiraClient;
+  orgFs: OrgFs | null;
+  issueIdOrKey: string;
+  threadId: string | null;
+  markdown: string;
+}): Promise<Map<string, AdfMedia>> {
+  const media = new Map<string, AdfMedia>();
+  const { orgFs, threadId } = args;
+  if (!orgFs || !threadId) return media;
+
+  // Deduped: the same screenshot referenced twice (a before/after table and a
+  // paragraph) must not become two attachments on the customer's issue.
+  const targets = [...new Set(collectImageTargets(args.markdown))];
+  for (const target of targets) {
+    const subpath = outputSubpath(target);
+    if (!subpath) continue;
+    try {
+      const bytes = await orgFs.read(OUTPUTS_VOLUME, `${threadId}/${subpath}`);
+      const attachment = await args.client.uploadAttachment(
+        args.issueIdOrKey,
+        attachmentNameFor(subpath),
+        bytes,
+        contentTypeFor(subpath),
+      );
+      const uuid = await args.client.attachmentMediaUuid(attachment.id);
+      if (uuid) media.set(target, { id: uuid });
+    } catch (err) {
+      console.warn(
+        `[jira] could not embed ${target} in the comment: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  return media;
+}

--- a/apps/api/src/storage/organization-settings.ts
+++ b/apps/api/src/storage/organization-settings.ts
@@ -40,6 +40,9 @@ export class OrganizationSettingsStorage
       enabled_plugins: parseJsonColumn<OrganizationSettings["enabled_plugins"]>(
         record.enabled_plugins,
       ),
+      coding_agent_mcp_excluded: parseJsonColumn<
+        OrganizationSettings["coding_agent_mcp_excluded"]
+      >(record.coding_agent_mcp_excluded),
       registry_config: parseJsonColumn<OrganizationSettings["registry_config"]>(
         record.registry_config,
       ),
@@ -62,6 +65,7 @@ export class OrganizationSettingsStorage
         OrganizationSettings,
         | "sidebar_items"
         | "enabled_plugins"
+        | "coding_agent_mcp_excluded"
         | "registry_config"
         | "simple_mode"
         | "default_home_agents"
@@ -73,6 +77,7 @@ export class OrganizationSettingsStorage
     const json = {
       sidebar_items: toJsonColumn(data?.sidebar_items),
       enabled_plugins: toJsonColumn(data?.enabled_plugins),
+      coding_agent_mcp_excluded: toJsonColumn(data?.coding_agent_mcp_excluded),
       registry_config: toJsonColumn(data?.registry_config),
       simple_mode: toJsonColumn(data?.simple_mode),
       default_home_agents: toJsonColumn(data?.default_home_agents),
@@ -90,6 +95,8 @@ export class OrganizationSettingsStorage
         oc.column("organizationId").doUpdateSet({
           sidebar_items: json.sidebar_items ?? undefined,
           enabled_plugins: json.enabled_plugins ?? undefined,
+          coding_agent_mcp_excluded:
+            json.coding_agent_mcp_excluded ?? undefined,
           registry_config: json.registry_config ?? undefined,
           simple_mode: json.simple_mode ?? undefined,
           default_home_agents: json.default_home_agents ?? undefined,
@@ -113,6 +120,7 @@ export class OrganizationSettingsStorage
         organizationId,
         sidebar_items: data?.sidebar_items ?? null,
         enabled_plugins: data?.enabled_plugins ?? null,
+        coding_agent_mcp_excluded: data?.coding_agent_mcp_excluded ?? null,
         registry_config: data?.registry_config ?? null,
         simple_mode: data?.simple_mode ?? null,
         default_home_agents: data?.default_home_agents ?? null,

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -181,6 +181,9 @@ export interface OrganizationSettingsTable {
   organizationId: string;
   sidebar_items: JsonArray<SidebarItem[]> | null;
   enabled_plugins: JsonArray<string[]> | null;
+  // Connection ids a coding-agent run must not mount, even with
+  // `coding_agent_org_mcps` on. See migration 212.
+  coding_agent_mcp_excluded: JsonArray<string[]> | null;
   registry_config: JsonObject<RegistryConfig> | null;
   simple_mode: JsonObject<SimpleModeConfig> | null;
   default_home_agents: JsonObject<DefaultHomeAgentsConfig> | null;
@@ -196,6 +199,7 @@ export interface OrganizationSettings {
   organizationId: string;
   sidebar_items: SidebarItem[] | null;
   enabled_plugins: string[] | null;
+  coding_agent_mcp_excluded: string[] | null;
   registry_config: RegistryConfig | null;
   simple_mode: SimpleModeConfig | null;
   default_home_agents: DefaultHomeAgentsConfig | null;

--- a/apps/api/src/tools/index.ts
+++ b/apps/api/src/tools/index.ts
@@ -242,6 +242,7 @@ export const CORE_TOOLS = [
   JiraTools.JIRA_COMMENT_ADD,
   JiraTools.JIRA_ISSUE_TRANSITION,
   JiraTools.JIRA_ATTACHMENT_DOWNLOAD,
+  JiraTools.JIRA_REMOTE_LINK_ADD,
 
   // Object Storage tools
   ObjectStorageTools.LIST_OBJECTS,

--- a/apps/api/src/tools/jira/index.ts
+++ b/apps/api/src/tools/jira/index.ts
@@ -248,4 +248,5 @@ export {
   JIRA_COMMENT_ADD,
   JIRA_ISSUE_GET,
   JIRA_ISSUE_TRANSITION,
+  JIRA_REMOTE_LINK_ADD,
 } from "./run-tools";

--- a/apps/api/src/tools/jira/run-tools.ts
+++ b/apps/api/src/tools/jira/run-tools.ts
@@ -17,8 +17,12 @@ import {
   mintAttachmentToken,
 } from "@/jira/attachment-token";
 import { JiraClient } from "@/jira/client";
+import { uploadCommentImages } from "@/jira/comment-images";
 import { loadIssueForPrompt, renderIssueForPrompt } from "@/jira/issue-prompt";
-import { requireTaskRunContext } from "@/tools/task-board/task-run-context";
+import {
+  requireTaskRunContext,
+  taskRunContextStore,
+} from "@/tools/task-board/task-run-context";
 import type { OrgJiraIntegration } from "@/storage/types";
 
 const MAX_COMMENT_LENGTH = 50_000;
@@ -104,17 +108,72 @@ export const JIRA_COMMENT_ADD = defineTool({
   name: "JIRA_COMMENT_ADD",
   description:
     "Post a comment on the Jira issue this run is working on. Markdown is " +
-    "rendered as Jira rich text. Leave one when you finish: what you did, " +
-    "and any pull request link.",
+    "rendered as Jira rich text, tables included. Leave one when you finish: " +
+    "what you did, and any pull request link. To show evidence, write the " +
+    "image to `org/output/<name>.png` in your working pod and reference it as " +
+    "`![what it shows](org/output/<name>.png)` — it is uploaded to the issue " +
+    "and rendered inline. Any other URL stays a plain link.",
   inputSchema: z.object({
     body: z.string().min(1).max(MAX_COMMENT_LENGTH),
   }),
-  outputSchema: z.object({ commentId: z.string() }),
+  outputSchema: z.object({
+    commentId: z.string(),
+    /** Screenshots that made it onto the issue, by markdown target. */
+    embeddedImages: z.array(z.string()),
+  }),
   handler: async (input, ctx) => {
     await ctx.access.check();
     const { client, issueId } = await resolveRunIssue(ctx);
-    const { id } = await client.addComment(issueId, input.body);
-    return { commentId: id };
+    const media = await uploadCommentImages({
+      client,
+      orgFs: ctx.orgFs,
+      issueIdOrKey: issueId,
+      threadId: taskRunContextStore.getStore()?.threadId ?? null,
+      markdown: input.body,
+    });
+    const { id } = await client.addComment(issueId, input.body, { media });
+    return { commentId: id, embeddedImages: [...media.keys()] };
+  },
+});
+
+export const JIRA_REMOTE_LINK_ADD = defineTool({
+  name: "JIRA_REMOTE_LINK_ADD",
+  description:
+    "Put a link on the Jira issue this run is working on — its pull request, " +
+    "its deploy preview. A link on the card is what a person clicks; the same " +
+    "URL inside a comment is not. Posting the same `key` again updates that " +
+    "link instead of adding a second.",
+  inputSchema: z.object({
+    url: z.string().min(1),
+    title: z.string().min(1).max(255),
+    summary: z.string().max(1000).optional(),
+    key: z
+      .string()
+      .max(255)
+      .optional()
+      .describe("Stable id for this link, e.g. `pull-request` or `preview`."),
+  }),
+  outputSchema: z.object({ linkId: z.number() }),
+  handler: async (input, ctx) => {
+    await ctx.access.check();
+    const { client, issueId, issueKey } = await resolveRunIssue(ctx);
+    let url: URL;
+    try {
+      url = new URL(input.url);
+    } catch {
+      throw new Error(`"${input.url}" is not an absolute URL`);
+    }
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      throw new Error(`${url.protocol} is not a linkable scheme`);
+    }
+    const { id } = await client.addRemoteLink(issueId, {
+      url: url.toString(),
+      title: input.title,
+      ...(input.summary ? { summary: input.summary } : {}),
+      // Scoped to the issue so two issues' "preview" links never collide.
+      ...(input.key ? { globalId: `studio-${issueKey}-${input.key}` } : {}),
+    });
+    return { linkId: id };
   },
 });
 

--- a/apps/api/src/tools/organization/settings-update.ts
+++ b/apps/api/src/tools/organization/settings-update.ts
@@ -14,6 +14,7 @@ const MAX_SIDEBAR_ITEMS = 50;
 const MAX_BLOCKED_MCPS = 500;
 const MAX_DEFAULT_HOME_AGENTS = 100;
 const MAX_ENABLED_PLUGINS = 200;
+const MAX_EXCLUDED_MCPS = 500;
 const MAX_REGISTRIES = 200;
 const MAX_STRING_LENGTH = 500;
 
@@ -35,6 +36,13 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
       .array(z.string().max(MAX_STRING_LENGTH))
       .max(MAX_ENABLED_PLUGINS)
       .optional(),
+    coding_agent_mcp_excluded: z
+      .array(z.string().max(MAX_STRING_LENGTH))
+      .max(MAX_EXCLUDED_MCPS)
+      .optional()
+      .describe(
+        "Connection ids a coding-agent run must not mount, even with `coding_agent_org_mcps` on. Replaces the stored list; pass [] to clear it.",
+      ),
     registry_config: RegistryConfigSchema.extend({
       registries: z
         .record(
@@ -68,6 +76,7 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
     organizationId: z.string(),
     sidebar_items: z.array(SidebarItemSchema).nullable().optional(),
     enabled_plugins: z.array(z.string()).nullable().optional(),
+    coding_agent_mcp_excluded: z.array(z.string()).nullable().optional(),
     registry_config: RegistryConfigSchema.nullable().optional(),
     simple_mode: SimpleModeConfigSchema.nullable().optional(),
     default_home_agents: DefaultHomeAgentsConfigSchema.nullable().optional(),
@@ -94,6 +103,7 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
       {
         sidebar_items: input.sidebar_items,
         enabled_plugins: input.enabled_plugins,
+        coding_agent_mcp_excluded: input.coding_agent_mcp_excluded,
         registry_config: input.registry_config,
         simple_mode: input.simple_mode,
         default_home_agents: input.default_home_agents,

--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -79,12 +79,47 @@ describe("buildClaudeCodeTaskPrompt", () => {
       expect(prompt).toContain("open a pull request");
       expect(prompt).toContain("from the branch you were given");
     });
+
+    // Inverted from the board rule. A Jira run's reviewer writes its verdict to
+    // the hidden anchor card, so "a reviewer checks the preview after you hand
+    // over" reports to nobody — this run is the only one that can check it.
+    test("is told to verify on the deploy preview, not only locally", () => {
+      const prompt = buildClaudeCodeTaskPrompt(task, repo, jira);
+      expect(prompt).toContain("DEPLOY PREVIEW");
+      expect(prompt).not.toContain("Do NOT wait for, or verify against");
+    });
+
+    test("is told how to get evidence onto the issue", () => {
+      const prompt = buildClaudeCodeTaskPrompt(task, repo, jira);
+      expect(prompt).toContain("org/output/");
+      expect(prompt).toContain("mcp__studio__JIRA_REMOTE_LINK_ADD");
+      expect(prompt).toContain("qa-screenshot");
+    });
+
+    // With no rule prompt the board's "you've been assigned this task" lead is
+    // wrong: there is no task, there is an issue.
+    test("leads with the Jira default when the rule has no prompt", () => {
+      const prompt = buildClaudeCodeTaskPrompt(task, repo, jira);
+      expect(prompt.startsWith("A Jira issue was moved into a column")).toBe(
+        true,
+      );
+    });
+
+    test("a rule's own prompt still wins over that default", () => {
+      const prompt = buildClaudeCodeTaskPrompt(task, repo, {
+        ...jira,
+        instruction: "Only review, do not change code.",
+      });
+      expect(prompt.startsWith("Only review, do not change code.")).toBe(true);
+    });
   });
 
-  test("a board run keeps its board tools", () => {
+  test("a board run keeps its board tools and its local-only verification", () => {
     const prompt = buildClaudeCodeTaskPrompt(task, repo);
     expect(prompt).toContain("mcp__studio__TASK_BOARD_COMMENT_CREATE");
     expect(prompt).not.toContain("JIRA_");
+    expect(prompt).toContain("Do NOT wait for, or verify against");
+    expect(prompt).not.toContain("DEPLOY PREVIEW");
   });
 
   test("omits the description block when there is none", () => {

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -30,7 +30,11 @@ import {
 import { SHALLOW_CHECKOUT_NOTE } from "@decocms/shared/task-board";
 import { agentSandboxEnabled } from "@/settings";
 import type { SuperAgentPromptOpts } from "./enqueue-super-agent";
-import { jiraRunFinishInstructions } from "./jira-run-prompt";
+import {
+  JIRA_DEFAULT_LEAD,
+  jiraRunFinishInstructions,
+  jiraRunVerifyInstructions,
+} from "./jira-run-prompt";
 import {
   sandboxUploadHint,
   uploadsAsSandboxPaths,
@@ -195,9 +199,12 @@ export function buildClaudeCodeTaskPrompt(
   // A column rule's own instruction, when the caller passed one. Dropping it
   // here (the Decopilot builder never did) silently ignored every Jira status
   // rule's prompt on any org with a repo to work in.
+  const jiraRun = opts?.source?.kind === "jira";
   const lines: string[] = [
     opts?.instruction?.trim() ||
-      `You've been assigned this task. Complete it and finish with a ${cli.changeRequest} if it makes sense (like a coding task) or is explicitly requested.`,
+      (jiraRun
+        ? JIRA_DEFAULT_LEAD
+        : `You've been assigned this task. Complete it and finish with a ${cli.changeRequest} if it makes sense (like a coding task) or is explicitly requested.`),
     "",
     "You are running AUTONOMOUSLY — no human is watching, so drive this to " +
       "completion yourself. Make reasonable decisions and move on; do not stop " +
@@ -276,8 +283,6 @@ export function buildClaudeCodeTaskPrompt(
     );
   }
 
-  const jiraRun = opts?.source?.kind === "jira";
-
   lines.push(
     "How to finish:",
     "- Make the change, commit it, push the branch, and open a pull request" +
@@ -290,7 +295,14 @@ export function buildClaudeCodeTaskPrompt(
     // Deliberately LOCAL-only. Verifying on the deploy preview means waiting
     // for a deploy that may not exist yet, and that is the reviewer's job
     // (`enqueue-reviewer.ts`) — this run implements and hands over.
-    `- Before handing over, VERIFY the task's outcome LOCALLY, in the sandbox: exercise the affected code path and confirm the behaviour actually happens. A green test suite is not the bar. Do NOT wait for, or verify against, the PR's deploy preview — a reviewer checks that after you hand over.`,
+    // A Jira run is the only one that CAN check the preview: the reviewer of
+    // one writes its verdict to the hidden anchor card, so handing over
+    // "for a reviewer to check" reports to nobody.
+    ...(jiraRun
+      ? jiraRunVerifyInstructions()
+      : [
+          `- Before handing over, VERIFY the task's outcome LOCALLY, in the sandbox: exercise the affected code path and confirm the behaviour actually happens. A green test suite is not the bar. Do NOT wait for, or verify against, the PR's deploy preview — a reviewer checks that after you hand over.`,
+        ]),
     // The sandbox's state — installed or not, dev server or not — is NOT
     // stated here. It is decided by the claim, minutes after this string is
     // built, and `sandboxStateInstruction` (sandbox-dispatch-client.ts) appends

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -14,7 +14,10 @@ import { isReportsTask } from "@decocms/shared/task-board";
 import { captureOrgEvent } from "@/posthog";
 import { getSettings } from "@/settings";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
-import { jiraRunFinishInstructions } from "./jira-run-prompt";
+import {
+  JIRA_DEFAULT_LEAD,
+  jiraRunFinishInstructions,
+} from "./jira-run-prompt";
 import type { RunClass } from "@/dispatch-queue/run-priority";
 import type { ClaudeCodeModelClass } from "@/harnesses/claude-code-env";
 import { fetchPrHeadRef } from "./prs-get";
@@ -108,7 +111,10 @@ export function buildSuperAgentTaskPrompt(
   return [
     // A column's rule supplies its own instruction; without one this is the
     // Super Agent's, which is what every run used before rules existed.
-    opts?.instruction?.trim() || "You've been assigned this task. Complete it.",
+    opts?.instruction?.trim() ||
+      (opts?.source?.kind === "jira"
+        ? JIRA_DEFAULT_LEAD
+        : "You've been assigned this task. Complete it."),
     "",
     "You are running AUTONOMOUSLY — no human is watching this run, so drive it " +
       "to completion on your own. Use `user_ask` ONLY for a genuine, " +

--- a/apps/api/src/tools/task-board/jira-run-prompt.ts
+++ b/apps/api/src/tools/task-board/jira-run-prompt.ts
@@ -1,5 +1,5 @@
 /**
- * How a Jira-triggered run is told to finish.
+ * How a Jira-triggered run is told to work and to finish.
  *
  * Its card is a hidden anchor nobody reads, so the board's closing
  * instructions are wrong for it twice over: they point at `TASK_BOARD_*` tools
@@ -7,6 +7,11 @@
  * record its work where no one looks while the issue stayed untouched. Observed
  * on the first production run: the model searched for `TASK_BOARD_COMMENT_CREATE`,
  * found nothing, and fell back to the issue tools on its own.
+ *
+ * The bar is what a person doing this by hand produces on the card: the PR and
+ * the preview as links, before/after screenshots taken on the deployed preview,
+ * a report that says what was measured rather than what was intended, and the
+ * issue moved on. Everything below exists because a compared run was missing it.
  *
  * `prefix` is the harness's tool namespace. A sandbox-hosted run reaches Studio
  * over MCP and sees `mcp__studio__JIRA_COMMENT_ADD`; a Decopilot run has the
@@ -17,14 +22,40 @@
 
 export type JiraToolPrefix = "mcp__studio__" | "";
 
+/** The lead a Jira run opens with when its rule supplies no instruction of
+ *  its own. Replaces the board's "you've been assigned this task". */
+export const JIRA_DEFAULT_LEAD =
+  "A Jira issue was moved into a column you are responsible for. Work the " +
+  "issue: implement what it asks, verify it, and report back on the issue.";
+
+/**
+ * Verification, for a run whose work reaches a deploy preview.
+ *
+ * The board's rule is the opposite of this ("do not verify against the
+ * preview — a reviewer checks it after you hand over") and it does not hold
+ * here: the reviewer of a Jira run writes its verdict to the hidden anchor
+ * card, so nobody checks the preview and nobody reports it. This run is the
+ * only one that can.
+ */
+export function jiraRunVerifyInstructions(): string[] {
+  return [
+    "- Verify on the DEPLOY PREVIEW, not only locally. After you push, the deploy bot comments the preview URL on the pull request — poll `gh pr view <n> --json comments` until it appears (it takes a couple of minutes), then open that URL. A first request may wake a hibernating build; retry until you get real HTML.",
+    "- Exercise the actual behaviour on that preview and MEASURE it. Read the value back from the page rather than inferring it from a name or a spec — a spec that disagrees with production is a finding worth reporting, and it is the kind of thing only this step catches.",
+    "- Capture before/after evidence with `qa-screenshot <url> <path>.png [--mobile]`, on desktop AND mobile, and `Read` each file — a screenshot you never opened is not verification.",
+  ];
+}
+
+/** How the run reports back: on the ISSUE, with the tools its endpoint serves. */
 export function jiraRunFinishInstructions(prefix: JiraToolPrefix): string[] {
   const tool = (name: string) => `\`${prefix}${name}\``;
   return [
-    "This run was started by a Jira issue, not a board card. Report on the ISSUE — there is no card for anyone to read:",
-    `- ${tool("JIRA_ISSUE_GET")} re-reads the issue (description, comments, attachments).`,
-    `- ${tool("JIRA_COMMENT_ADD")} posts a comment on it (markdown). Leave one when you finish, with what you did and any pull request link. This is the ONLY way your work gets reported — a final message in this run is not a report.`,
-    `- ${tool("JIRA_ISSUE_TRANSITION")} moves it to another status when your work warrants it.`,
-    `- ${tool("JIRA_ATTACHMENT_DOWNLOAD")} fetches an attachment into the sandbox by its id.`,
+    "This run was started by a Jira issue, not a board card. Report on the ISSUE — there is no card for anyone to read, and no reviewer will report for you:",
+    `- ${tool("JIRA_REMOTE_LINK_ADD")} puts the pull request on the issue as a link (\`key: "pull-request"\`), and the deploy preview as another (\`key: "preview"\`). Do both — a URL buried in a comment is not something a person clicks.`,
+    `- ${tool("JIRA_COMMENT_ADD")} posts your report (markdown, tables included). This is the ONLY way your work gets reported — a final message in this run is not a report. Say what you changed, what you MEASURED on the preview, and what you deliberately left alone. Name anything the issue asked for that you did not do.`,
+    "- To show evidence, write each screenshot to `org/output/<name>.png` and reference it in that comment as `![what it shows](org/output/<name>.png)` — it is uploaded to the issue and rendered inline. A before/after markdown table of two images reads best.",
+    `- ${tool("JIRA_ISSUE_GET")} re-reads the issue — worth doing before you report, since a person may have edited the card while you worked.`,
+    `- ${tool("JIRA_ISSUE_TRANSITION")} moves the issue on when your work warrants it. Do this last, after the links and the comment are on the card.`,
+    `- ${tool("JIRA_ATTACHMENT_DOWNLOAD")} fetches an attachment of the issue into the pod by its id, when the card carries a mockup or a log you need.`,
     "You have no board tools on this run. Do not look for them.",
   ];
 }

--- a/apps/api/src/tools/task-board/task-run-context.ts
+++ b/apps/api/src/tools/task-board/task-run-context.ts
@@ -91,6 +91,7 @@ export const JIRA_RUN_TOOL_NAMES: readonly ToolName[] = [
   "JIRA_COMMENT_ADD",
   "JIRA_ISSUE_TRANSITION",
   "JIRA_ATTACHMENT_DOWNLOAD",
+  "JIRA_REMOTE_LINK_ADD",
 ];
 
 /**

--- a/apps/web/src/components/settings/review-settings.tsx
+++ b/apps/web/src/components/settings/review-settings.tsx
@@ -17,9 +17,14 @@ import {
 } from "@/components/settings/settings-section";
 import {
   useAutoResolveConflicts,
+  useCodingAgentExcludedMcps,
   useOrgFlag,
+  useSetCodingAgentExcludedMcps,
   useSetOrgFlag,
 } from "@/hooks/use-organization-settings";
+import { useConnections } from "@/sdk";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
+import { Suspense } from "react";
 import type { OrgFlags } from "@decocms/shared/organization/schema";
 import { useT } from "@/i18n/use-t.ts";
 import type { TranslationKey } from "@/i18n/use-t.ts";
@@ -92,8 +97,91 @@ export function AgentToolsSettings() {
           titleKey="settings.agentTools.orgMcpsTitle"
           descriptionKey="settings.agentTools.orgMcpsDescription"
         />
+        <OrgMcpExclusions />
       </SettingsCard>
     </SettingsSection>
+  );
+}
+
+/**
+ * Which of the org's connections a run may mount, once the toggle above is on.
+ *
+ * Only shown when it IS on: with it off nothing is mounted anyway, and a list
+ * of switches that change nothing reads as broken. Stored as the EXCLUDED ids
+ * (`coding_agent_mcp_excluded`) but rendered as "available to runs", because
+ * the answer people want to read off the row is what a run can reach — and
+ * because a connection added after this was configured should default to
+ * available, which an exclusion list gives for free and an allowlist would not.
+ */
+function OrgMcpExclusions() {
+  const enabled = useOrgFlag("coding_agent_org_mcps");
+  if (!enabled) return null;
+  return (
+    <Suspense fallback={<OrgMcpExclusionsFallback />}>
+      <OrgMcpExclusionList />
+    </Suspense>
+  );
+}
+
+function OrgMcpExclusionsFallback() {
+  const t = useT();
+  return (
+    <SettingsCardItem title={t("settings.agentTools.orgMcpsPickTitle")}>
+      <Skeleton className="mt-3 h-24 w-full" />
+    </SettingsCardItem>
+  );
+}
+
+function OrgMcpExclusionList() {
+  const t = useT();
+  const connections = useConnections();
+  const excluded = useCodingAgentExcludedMcps();
+  const setExcluded = useSetCodingAgentExcludedMcps();
+  const excludedSet = new Set(excluded);
+
+  const toggle = (id: string, available: boolean) => {
+    const next = available
+      ? excluded.filter((x) => x !== id)
+      : [...new Set([...excluded, id])];
+    setExcluded.mutate(next, {
+      onError: () => toast.error(t("settings.agentTools.orgMcpsPickFailed")),
+    });
+  };
+
+  return (
+    <SettingsCardItem
+      title={t("settings.agentTools.orgMcpsPickTitle")}
+      description={t("settings.agentTools.orgMcpsPickDescription")}
+    >
+      <div className="mt-3 flex w-full flex-col divide-y divide-border rounded-xl border border-border">
+        {connections.length === 0 ? (
+          <p className="p-3 text-xs text-muted-foreground">
+            {t("settings.agentTools.orgMcpsPickEmpty")}
+          </p>
+        ) : (
+          connections.map((connection) => {
+            const available = !excludedSet.has(connection.id);
+            const label = connection.title || connection.id;
+            return (
+              <div
+                key={connection.id}
+                className="flex items-center justify-between gap-3 p-3"
+              >
+                <span className="min-w-0 truncate text-sm">{label}</span>
+                <Switch
+                  checked={available}
+                  disabled={setExcluded.isPending}
+                  aria-label={t("settings.agentTools.orgMcpsPickAriaLabel", {
+                    name: label,
+                  })}
+                  onCheckedChange={(checked) => toggle(connection.id, checked)}
+                />
+              </div>
+            );
+          })
+        )}
+      </div>
+    </SettingsCardItem>
   );
 }
 

--- a/apps/web/src/hooks/use-organization-settings.ts
+++ b/apps/web/src/hooks/use-organization-settings.ts
@@ -48,6 +48,7 @@ export interface OrganizationSettings {
   organizationId: string;
   sidebar_items: unknown[] | null;
   enabled_plugins: string[] | null;
+  coding_agent_mcp_excluded: string[] | null;
   registry_config: RegistryConfig | null;
   simple_mode: SimpleModeConfig | null;
   default_home_agents: DefaultHomeAgentsConfig | null;
@@ -60,6 +61,7 @@ const EMPTY_SETTINGS: OrganizationSettings = {
   organizationId: "",
   sidebar_items: null,
   enabled_plugins: null,
+  coding_agent_mcp_excluded: null,
   registry_config: null,
   simple_mode: null,
   default_home_agents: null,
@@ -143,6 +145,7 @@ type OrgSettingsUpdateInput = Partial<
     OrganizationSettings,
     | "sidebar_items"
     | "enabled_plugins"
+    | "coding_agent_mcp_excluded"
     | "registry_config"
     | "simple_mode"
     | "default_home_agents"
@@ -359,6 +362,24 @@ export function useSetOrgFlag() {
       value: boolean,
       options?: OrgSettingsMutateOptions,
     ) => mutation.mutateAsync({ flags: { [flag]: value } }, options),
+  };
+}
+
+/**
+ * Connections a coding-agent run must not mount, even with
+ * `coding_agent_org_mcps` on. The full list is stored, so a write replaces it.
+ */
+export function useCodingAgentExcludedMcps(): string[] {
+  const { data } = useOrganizationSettings((s) => s.coding_agent_mcp_excluded);
+  return data ?? [];
+}
+
+export function useSetCodingAgentExcludedMcps() {
+  const mutation = useUpdateOrganizationSettings();
+  return {
+    ...mutation,
+    mutate: (ids: string[], options?: OrgSettingsMutateOptions) =>
+      mutation.mutate({ coding_agent_mcp_excluded: ids }, options),
   };
 }
 

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -631,6 +631,14 @@ export const settings = {
   "settings.agentTools.orgMcpsTitle": "Give runs this org's MCP connections",
   "settings.agentTools.orgMcpsDescription":
     "Every MCP you have connected becomes available to the Super Agent and the reviewers, on top of the task tools they always get. Tools load only when the agent looks for one, so connecting more does not crowd its context.",
+  "settings.agentTools.orgMcpsPickTitle": "Connections runs can reach",
+  "settings.agentTools.orgMcpsPickDescription":
+    "Turn one off to keep it away from coding-agent runs. Useful for a connection that duplicates a tool a run already has \u2014 an MCP for the same tracker the run reports to, say. A newly connected MCP starts on.",
+  "settings.agentTools.orgMcpsPickAriaLabel": "Let runs reach {name}",
+  "settings.agentTools.orgMcpsPickEmpty":
+    "This organization has no MCP connections yet",
+  "settings.agentTools.orgMcpsPickFailed":
+    "Could not save which connections runs can reach",
   "settings.agentTools.codingAgentsClaudeCodeTitle":
     "Run Code Agent chats with Claude Code",
   "settings.agentTools.codingAgentsClaudeCodeDescription":

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -653,6 +653,16 @@ export const settings = {
     "Dar aos runs as conex\u00f5es MCP desta organiza\u00e7\u00e3o",
   "settings.agentTools.orgMcpsDescription":
     "Cada MCP conectado fica dispon\u00edvel para o Super Agent e para os revisores, al\u00e9m das ferramentas de tarefa que eles sempre recebem. As ferramentas carregam s\u00f3 quando o agente procura por uma, ent\u00e3o conectar mais n\u00e3o ocupa o contexto dele.",
+  "settings.agentTools.orgMcpsPickTitle":
+    "Conex\u00f5es que os runs alcan\u00e7am",
+  "settings.agentTools.orgMcpsPickDescription":
+    "Desligue uma para mant\u00ea-la fora dos runs de coding agent. \u00datil para uma conex\u00e3o que duplica uma ferramenta que o run j\u00e1 tem \u2014 um MCP do mesmo tracker em que o run reporta, por exemplo. Um MCP conectado depois come\u00e7a ligado.",
+  "settings.agentTools.orgMcpsPickAriaLabel":
+    "Deixar os runs alcan\u00e7arem {name}",
+  "settings.agentTools.orgMcpsPickEmpty":
+    "Esta organiza\u00e7\u00e3o ainda n\u00e3o tem conex\u00f5es MCP",
+  "settings.agentTools.orgMcpsPickFailed":
+    "N\u00e3o foi poss\u00edvel salvar quais conex\u00f5es os runs alcan\u00e7am",
   "settings.agentTools.codingAgentsClaudeCodeTitle":
     "Rodar chats de Code Agent com o Claude Code",
   "settings.agentTools.codingAgentsClaudeCodeDescription":

--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -203,6 +203,7 @@ const ALL_TOOL_NAMES = [
   "JIRA_COMMENT_ADD",
   "JIRA_ISSUE_TRANSITION",
   "JIRA_ATTACHMENT_DOWNLOAD",
+  "JIRA_REMOTE_LINK_ADD",
 
   // Object Storage tools
   "LIST_OBJECTS",
@@ -980,6 +981,12 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     name: "JIRA_ATTACHMENT_DOWNLOAD",
     description:
       "Get a short-lived download URL for an attachment of the run's Jira issue",
+    category: "Jira",
+  },
+  {
+    name: "JIRA_REMOTE_LINK_ADD",
+    description:
+      "Link a pull request or deploy preview on the run's Jira issue",
     category: "Jira",
   },
   {

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -150,6 +150,7 @@ export interface StudioToolIO {
         | { title: string; url: string; icon: string }[]
         | undefined;
       enabled_plugins?: string[] | undefined;
+      coding_agent_mcp_excluded?: string[] | undefined;
       registry_config?:
         | {
             registries: Record<string, { enabled: boolean }>;
@@ -224,6 +225,7 @@ export interface StudioToolIO {
         | null
         | undefined;
       enabled_plugins?: string[] | null | undefined;
+      coding_agent_mcp_excluded?: string[] | null | undefined;
       registry_config?:
         | {
             registries: Record<string, { enabled: boolean }>;
@@ -5462,7 +5464,10 @@ export interface StudioToolIO {
     input: { [x: string]: never };
     output: { key: string; url: string; status: string; markdown: string };
   };
-  JIRA_COMMENT_ADD: { input: { body: string }; output: { commentId: string } };
+  JIRA_COMMENT_ADD: {
+    input: { body: string };
+    output: { commentId: string; embeddedImages: string[] };
+  };
   JIRA_ISSUE_TRANSITION: {
     input: { toStatus: string };
     output: { status: string };
@@ -5475,6 +5480,15 @@ export interface StudioToolIO {
       expiresAt: string;
       command: string;
     };
+  };
+  JIRA_REMOTE_LINK_ADD: {
+    input: {
+      url: string;
+      title: string;
+      summary?: string | undefined;
+      key?: string | undefined;
+    };
+    output: { linkId: number };
   };
   LIST_OBJECTS: {
     input: {


### PR DESCRIPTION
Follow-up to #7126 / #7137, from comparing a Studio Jira run against the same work done by hand.

The gaps were **not** in the coding — the run implemented the issue and opened its pull request. They were in what it could reach and what it was told to do with it.

## 1. The report

Done by hand, a card gets: the PR and the deploy preview as clickable links, before/after screenshots taken on the **deployed preview**, and a comment saying what was *measured* rather than what was intended. (That measuring step is how the hand-run caught two wrong values in a design spec before they shipped.) A Studio run could post markdown and nothing else.

- **`JIRA_REMOTE_LINK_ADD`** — the PR and the preview as links on the issue. `globalId` is scoped per issue, so re-posting a link updates it instead of stacking duplicates.
- **`JIRA_COMMENT_ADD` now embeds screenshots.** The run writes them to `org/output/…` — the idiom the board's QA reviewer already uses — and references them as markdown images; each is uploaded to the issue and addressed from an ADF `media` node.

  The ADF half already existed and was **dormant**: `collectImageTargets` had no caller and `addComment`'s `media` option was never passed by anyone. This PR wires the upload half to it (`uploadAttachment`, `attachmentMediaUuid`, `comment-images.ts`).
- Per image it's best-effort: an unreadable file leaves that ref as a plain link and still posts the comment. The text is the report; the images are evidence for it, and losing the whole report over one missing screenshot is the worse failure.

## 2. The instructions

`buildClaudeCodeTaskPrompt` told a Jira run to verify locally and **not** against the deploy preview, because *"a reviewer checks that after you hand over."*

That doesn't hold for a Jira run: its reviewer writes the verdict to the **hidden anchor card**, so nobody checks the preview and nobody reports it. A Jira run now gets the opposite instruction — poll the PR for the deploy bot's URL, exercise the behaviour there, measure it, capture desktop and mobile evidence. **The board's rule is unchanged** (asserted in both directions).

A Jira run with no rule prompt also led with the board's *"you've been assigned this task"*, naming a task nobody reads. It now leads with the issue.

## 3. Narrowing a run's MCPs

`coding_agent_org_mcps` is all-or-nothing, which made it unusable for an org whose tracker is *also* connected as an MCP: turning it on hands a Jira-triggered run a second path to the same issue — one that bypasses the vault-held credential the run tools exist to keep out of the sandbox.

`coding_agent_mcp_excluded` (migration 212 — its own column, since it's a list and not a flag) excludes specific connections, surfaced in Settings → Agent tools as *"connections runs can reach"*.

- Excluding **wins over both** reasons to mount a connection, so an explicit exclusion is never silently reinstated because the connection also happens to be aggregated on the agent.
- Stored as exclusions rather than an allowlist, so a newly connected MCP defaults to available.

## Testing

- **Real Postgres** round trip for the new column: `upsert` writes through a column whitelist on *both* the INSERT and the ON CONFLICT branch, and a miss is silently dropped — an in-memory store would accept the write and hand the value back from memory.
- Exclusion precedence (org-wide, agent-aggregated, empty/absent list).
- The `org/output/` ref guard, including traversal out of the run's own thread prefix — the subpath is joined onto `<threadId>/`, so `..` would put another run's screenshots on a customer's issue.
- The media-uuid parse: an ADF `media` node needs the media-services uuid, and Jira rejects the numeric attachment id with `ATTACHMENT_VALIDATION_ERROR`. It's only available as a path segment of the 303 the content endpoint answers with.
- Prompt branches: Jira lead vs board lead, rule prompt overriding both, preview-vs-local verification each way.
- `bun test apps/api/src`: **51 failures before, 51 after, zero new** — all pre-existing local-env failures (MinIO and NATS aren't running here). `check`, `lint`, `fmt:check`, `knip` clean.

## Still open, not in here

The reviewer of a Jira-anchored task still records its verdict and comment on the hidden anchor card, so the review is invisible on the issue. Needs a product call: give the reviewer `JIRA_COMMENT_ADD` too, or don't review an anchor-only card.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Jira-triggered runs now report on the issue like a person would — pull request and deploy preview as clickable links, screenshots embedded in the comment — instead of plain markdown. Also lets an org exclude specific MCP connections from coding-agent runs instead of the org-wide flag being all-or-nothing.

**Jira run reporting**
- New `JIRA_REMOTE_LINK_ADD` tool puts the pull request and deploy preview on the issue; re-posting the same `key` updates the link instead of duplicating it.
- `JIRA_COMMENT_ADD` uploads images referenced from `org/output/...` and embeds them inline; a missing or unreadable image leaves that ref as a plain link and still posts the comment.
- Jira runs are now told to verify on the deploy preview — polling the PR for the deploy bot's URL — and capture desktop and mobile evidence, instead of verifying locally only.

**MCP exclusions**
- New `coding_agent_mcp_excluded` setting (migration 212) keeps specific connections out of coding-agent runs; an exclusion wins over both the org-wide flag and agent aggregation.
- Settings → Agent tools shows "connections runs can reach" switches when the org-wide flag is on; newly connected MCPs default to available.

<sup>Written for commit ec2f6022e65b366c30b14b0c1599b032c2e715a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

