### PR TITLE
feat(web): rebuild project settings as a grouped index of views

### DIFF
--- a/apps/web/src/components/settings/settings-section.tsx
+++ b/apps/web/src/components/settings/settings-section.tsx
@@ -144,6 +144,20 @@ export function SettingsCardItem({
   );
 }
 
+interface SettingsCardRowProps {
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * A card row for content that already owns its label, description and control
+ * — the `*Field` components bound to a form. Same padding as
+ * `SettingsCardItem`, so a card can mix the two and still read as one list.
+ */
+export function SettingsCardRow({ className, children }: SettingsCardRowProps) {
+  return <div className={cn("px-4 py-4", className)}>{children}</div>;
+}
+
 interface SettingsCardActionsProps {
   children: ReactNode;
   className?: string;

--- a/apps/web/src/i18n/en/virtual-mcp.ts
+++ b/apps/web/src/i18n/en/virtual-mcp.ts
@@ -106,8 +106,6 @@ export const virtualMcp = {
   "virtualMcp.filesSection.selectSkill": "Select skill",
   "virtualMcp.filesSection.uploadFile": "Upload file",
   "virtualMcp.layoutTabContent.noMainView": "No main view",
-  "virtualMcp.layoutTabContent.addConnectionMessage":
-    "Add a connection above to configure app views.",
   "virtualMcp.layoutTabContent.automations": "Automations",
   "virtualMcp.layoutTabContent.chatAlwaysShown":
     "Chat is always shown when it is the default view",
@@ -115,16 +113,32 @@ export const virtualMcp = {
   "virtualMcp.layoutTabContent.mainView": "Main view",
   "virtualMcp.layoutTabContent.mainViewDescription":
     "What users see when they first open this project.",
-  "virtualMcp.layoutTabContent.noInteractiveTools":
-    "None of the connected servers expose interactive tools.",
-  "virtualMcp.layoutTabContent.sidebarViews": "Sidebar views",
-  "virtualMcp.layoutTabContent.sidebarViewsDescription":
-    "Choose which available views appear in this project's sidebar.",
   "virtualMcp.layoutTabContent.settings": "Settings",
   "virtualMcp.layoutTabContent.showChat": "Show chat",
   "virtualMcp.layoutTabContent.showChatDescription":
     "Display Chat in the side panel alongside the main view.",
   "virtualMcp.layoutTabContent.siteEditor": "Site Editor",
+  "virtualMcp.settings.general.title": "General",
+  "virtualMcp.settings.general.description":
+    "Instructions, attached files and who this project may delegate to.",
+  "virtualMcp.settings.site.title": "Site and sandbox",
+  "virtualMcp.settings.site.description":
+    "How edits reach the live site, and the repository it runs from.",
+  "virtualMcp.settings.backToSettings": "Settings",
+  "virtualMcp.settings.groups.advanced": "Advanced",
+  "virtualMcp.settings.connections.title": "Connections",
+  "virtualMcp.settings.connections.description":
+    "The MCP servers this project brings together.",
+  "virtualMcp.settings.views.projectViews": "Views",
+  "virtualMcp.settings.views.open": "Open",
+  "virtualMcp.settings.views.pin": "Pin to sidebar",
+  "virtualMcp.settings.views.unpin": "Remove from sidebar",
+  "virtualMcp.settings.views.setMainView": "Set as main view",
+  "virtualMcp.settings.views.rowActions": "View options",
+  "virtualMcp.settings.value.notLinked": "Not linked",
+  "virtualMcp.settings.value.connectionOne": "1 connection",
+  "virtualMcp.settings.value.connectionMany": "{count} connections",
+  "virtualMcp.settings.value.inSidebar": "{count} in sidebar",
   "virtualMcp.subAgentsSection.addSubAgent": "Add sub-project",
   "virtualMcp.subAgentsSection.anyAgent": "Any project",
   "virtualMcp.subAgentsSection.canDelegateToAnyAgent":

--- a/apps/web/src/i18n/pt-br/virtual-mcp.ts
+++ b/apps/web/src/i18n/pt-br/virtual-mcp.ts
@@ -109,8 +109,6 @@ export const virtualMcp = {
   "virtualMcp.filesSection.selectSkill": "Selecionar skill",
   "virtualMcp.filesSection.uploadFile": "Enviar arquivo",
   "virtualMcp.layoutTabContent.noMainView": "Sem visão principal",
-  "virtualMcp.layoutTabContent.addConnectionMessage":
-    "Adicione uma conexão acima para configurar visualizações de apps.",
   "virtualMcp.layoutTabContent.automations": "Automações",
   "virtualMcp.layoutTabContent.chatAlwaysShown":
     "O Chat sempre aparece quando é a visualização padrão",
@@ -118,16 +116,33 @@ export const virtualMcp = {
   "virtualMcp.layoutTabContent.mainView": "Visualização principal",
   "virtualMcp.layoutTabContent.mainViewDescription":
     "O que os usuários veem quando abrem este projeto pela primeira vez.",
-  "virtualMcp.layoutTabContent.noInteractiveTools":
-    "Nenhum dos servidores conectados expõe ferramentas interativas.",
-  "virtualMcp.layoutTabContent.sidebarViews": "Visualizações da barra lateral",
-  "virtualMcp.layoutTabContent.sidebarViewsDescription":
-    "Escolha quais visualizações disponíveis aparecem na barra lateral deste projeto.",
   "virtualMcp.layoutTabContent.settings": "Configurações",
   "virtualMcp.layoutTabContent.showChat": "Mostrar chat",
   "virtualMcp.layoutTabContent.showChatDescription":
     "Exibir Chat no painel lateral junto com a visualização principal.",
   "virtualMcp.layoutTabContent.siteEditor": "Editor do site",
+  "virtualMcp.settings.general.title": "Geral",
+  "virtualMcp.settings.general.description":
+    "Instruções, arquivos anexados e para quem este projeto pode delegar.",
+  "virtualMcp.settings.site.title": "Site e sandbox",
+  "virtualMcp.settings.site.description":
+    "Como as edições chegam ao site e o repositório de onde ele roda.",
+  "virtualMcp.settings.backToSettings": "Configurações",
+  "virtualMcp.settings.groups.advanced": "Avançado",
+  "virtualMcp.settings.connections.title": "Conexões",
+  "virtualMcp.settings.connections.description":
+    "Os servidores MCP que este projeto reúne.",
+  "virtualMcp.settings.views.projectViews": "Visualizações",
+  "virtualMcp.settings.views.open": "Abrir",
+  "virtualMcp.settings.views.pin": "Fixar na barra lateral",
+  "virtualMcp.settings.views.unpin": "Remover da barra lateral",
+  "virtualMcp.settings.views.setMainView":
+    "Definir como visualização principal",
+  "virtualMcp.settings.views.rowActions": "Opções da visualização",
+  "virtualMcp.settings.value.notLinked": "Sem repositório",
+  "virtualMcp.settings.value.connectionOne": "1 conexão",
+  "virtualMcp.settings.value.connectionMany": "{count} conexões",
+  "virtualMcp.settings.value.inSidebar": "{count} na barra lateral",
   "virtualMcp.subAgentsSection.addSubAgent": "Adicionar sub-projeto",
   "virtualMcp.subAgentsSection.anyAgent": "Qualquer projeto",
   "virtualMcp.subAgentsSection.canDelegateToAnyAgent":

--- a/apps/web/src/layouts/main-panel-tabs/panel-route.ts
+++ b/apps/web/src/layouts/main-panel-tabs/panel-route.ts
@@ -58,6 +58,8 @@ export interface PanelPayload {
   /** `site-editor` — {@link CONTENT_MAIN} while the surface is on Content;
    *  absent for the plain preview. */
   main?: string;
+  /** `settings` — the open settings section (absent = its index). */
+  section?: string;
 }
 
 /** Every payload key, so a writer can clear the ones it does not use. */
@@ -70,6 +72,7 @@ export const PANEL_PAYLOAD_KEYS = [
   "tool",
   "automation",
   "main",
+  "section",
 ] as const satisfies ReadonlyArray<keyof PanelPayload>;
 
 /**

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -557,6 +557,8 @@ const agentsRoute = createRoute({
     connection: z.string().optional(),
     tool: z.string().optional(),
     automation: z.string().optional(),
+    /** Settings' open section (see `views/virtual-mcp/settings/sections.ts`). */
+    section: z.string().optional(),
     /** Library file-preview overlay ("<volume>/<path…>"), set by org-file refs. */
     preview: z.string().optional(),
     autosend: z.string().optional(),

--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -15,7 +15,7 @@ import { EmptyState } from "@/components/empty-state.tsx";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { usePanelActions } from "@/layouts/shell-layout";
 import { User } from "@/components/user/user";
-import { useT } from "@/i18n/use-t.ts";
+import { useT, type TranslationKey } from "@/i18n/use-t.ts";
 import { useDateFnsLocale } from "@/hooks/use-date-fns-locale.ts";
 
 import { authenticateMcp, isConnectionAuthenticated } from "@/lib/mcp-oauth";
@@ -38,7 +38,6 @@ import {
   DialogTitle,
 } from "@decocms/ui/components/dialog.tsx";
 import { Button } from "@decocms/ui/components/button.tsx";
-import { Card, CardContent } from "@decocms/ui/components/card.tsx";
 import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import {
   Tooltip,
@@ -58,8 +57,18 @@ import {
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { Maximize01, Play, Plus, Stars01, Trash01 } from "@untitledui/icons";
+import {
+  Cube01,
+  Maximize01,
+  MessageTextSquare01,
+  Play,
+  PuzzlePiece01,
+  Plus,
+  Stars01,
+  Trash01,
+} from "@untitledui/icons";
 import { Suspense, useEffect, useReducer, useState } from "react";
+import type { ReactNode } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useDebouncedAutosave } from "@/hooks/use-debounced-autosave.ts";
 import { toast } from "sonner";
@@ -71,7 +80,23 @@ import { SubAgentsSection } from "./sub-agents-section";
 import { track } from "@/lib/posthog-client";
 import { DependencySelectionDialog } from "./dependency-selection-dialog";
 import { ConnectionItem, ConnectionItemSkeleton } from "./connection-item";
-import { LayoutTabContent } from "./layout-tab-content";
+import { ProjectViewsSection } from "./settings/views-section";
+import { useProjectViews } from "./settings/use-project-views";
+import {
+  ProjectSettingsIndex,
+  type ProjectSettingsGroupDef,
+} from "./settings/settings-index";
+import { ProjectSettingsDetail } from "./settings/settings-detail";
+import {
+  PROJECT_SETTINGS_SECTIONS,
+  type ProjectSettingsSectionKey,
+} from "./settings/sections";
+import {
+  SettingsCard,
+  SettingsCardRow,
+  SettingsSection,
+} from "@/components/settings/settings-section";
+import { useProjectSettingsSection } from "./settings/use-settings-section";
 import { ALL_ITEMS_SELECTED } from "./selection-utils";
 import { VirtualMcpFormSchema, type VirtualMcpFormData } from "./types";
 import { VirtualMCPShareModal } from "./virtual-mcp-share-modal";
@@ -918,6 +943,12 @@ function VirtualMcpDetailViewWithData({
   };
 
   const addedConnectionIds = new Set(connections.map((c) => c.connection_id));
+  const { section, openSection } = useProjectSettingsSection();
+  const views = useProjectViews({
+    virtualMcpId: virtualMcp.id,
+    form,
+    flushAndSave,
+  });
   const navigate = useNavigate();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
@@ -937,6 +968,101 @@ function VirtualMcpDetailViewWithData({
       // Error toast handled by mutation
     }
   };
+
+  /** Right-hand summaries: what each row currently answers. */
+  const countValue = (
+    count: number,
+    one: TranslationKey,
+    many: TranslationKey,
+  ) => (count === 1 ? t(one) : t(many, { count: String(count) }));
+  const settingsGroups: ProjectSettingsGroupDef[] = [
+    {
+      key: "project",
+      rows: [
+        {
+          key: "general",
+          icon: <MessageTextSquare01 size={16} />,
+          title: t(PROJECT_SETTINGS_SECTIONS.general.titleKey),
+          description: t(PROJECT_SETTINGS_SECTIONS.general.descriptionKey),
+          onClick: () => openSection("general"),
+        },
+        {
+          key: "connections",
+          icon: <PuzzlePiece01 size={16} />,
+          title: t(PROJECT_SETTINGS_SECTIONS.connections.titleKey),
+          description: t(PROJECT_SETTINGS_SECTIONS.connections.descriptionKey),
+          value: countValue(
+            connections.length,
+            "virtualMcp.settings.value.connectionOne",
+            "virtualMcp.settings.value.connectionMany",
+          ),
+          onClick: () => openSection("connections"),
+        },
+        {
+          key: "site",
+          icon: <Cube01 size={16} />,
+          title: t(PROJECT_SETTINGS_SECTIONS.site.titleKey),
+          description: t(PROJECT_SETTINGS_SECTIONS.site.descriptionKey),
+          value: runtimeCardRepo
+            ? `${runtimeCardRepo.owner}/${runtimeCardRepo.name}`
+            : t("virtualMcp.settings.value.notLinked"),
+          onClick: () => openSection("site"),
+        },
+      ],
+    },
+    {
+      /** The views are the index's own list: opening one is the point, and a
+       *  drill-in would have hidden ten destinations behind one row. */
+      key: "views",
+      content: <ProjectViewsSection views={views} />,
+    },
+    {
+      key: "danger",
+      title: t("virtualMcp.settings.groups.advanced"),
+      rows: [
+        {
+          key: "delete",
+          icon: <Trash01 size={16} />,
+          title: t("virtualMcp.virtualMcp.deleteAgent"),
+          description: t("virtualMcp.virtualMcp.deleteAgentDescription"),
+          destructive: true,
+          onClick: () => setDeleteDialogOpen(true),
+        },
+      ],
+    },
+  ];
+
+  /** Connections owns its whole page, so its action rides in the page header;
+   *  the instructions buttons sit beside their own heading inside General. */
+  const sectionActions: Partial<Record<ProjectSettingsSectionKey, ReactNode>> =
+    {
+      connections:
+        connections.length > 0 ? (
+          <Button variant="outline" size="sm" onClick={handleOpenAddDialog}>
+            <Plus size={14} />
+            {t("virtualMcp.virtualMcp.addConnection")}
+          </Button>
+        ) : undefined,
+    };
+
+  const sectionInstructionsActions = (
+    <div className="flex items-center gap-2">
+      {!form.watch("metadata.instructions")?.trim() && (
+        <Button variant="outline" size="sm" onClick={handleInsertTemplate}>
+          {t("virtualMcp.virtualMcp.promptTemplate")}
+        </Button>
+      )}
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={isImproving || !form.watch("metadata.instructions")?.trim()}
+        onClick={handleImprovePrompt}
+      >
+        <Stars01 size={13} />
+        {t("virtualMcp.virtualMcp.improve")}
+      </Button>
+    </div>
+  );
 
   return (
     <Page>
@@ -970,434 +1096,389 @@ function VirtualMcpDetailViewWithData({
               </Page.Title>
             )}
 
-            {/* Agent identity header */}
-            <div className="flex items-center gap-3">
-              <Controller
-                name="icon"
-                control={form.control}
-                render={({ field }) => (
-                  <IconPicker
-                    value={field.value ?? null}
-                    onChange={(icon) => {
-                      field.onChange(icon);
-                      flushAndSave();
-                    }}
-                    onColorChange={(color) => {
-                      form.setValue("metadata.ui.themeColor", color, {
-                        shouldDirty: true,
-                      });
-                      flushAndSave();
-                    }}
-                    name={
-                      form.watch("title") ||
-                      t("virtualMcp.virtualMcp.agentNameFallback")
-                    }
-                    size="md"
-                    className="shrink-0"
-                    avatarClassName="[&_svg]:w-1/2 [&_svg]:h-1/2"
+            {section === null ? (
+              <>
+                {/* Agent identity header */}
+                <div className="flex items-center gap-3">
+                  <Controller
+                    name="icon"
+                    control={form.control}
+                    render={({ field }) => (
+                      <IconPicker
+                        value={field.value ?? null}
+                        onChange={(icon) => {
+                          field.onChange(icon);
+                          flushAndSave();
+                        }}
+                        onColorChange={(color) => {
+                          form.setValue("metadata.ui.themeColor", color, {
+                            shouldDirty: true,
+                          });
+                          flushAndSave();
+                        }}
+                        name={
+                          form.watch("title") ||
+                          t("virtualMcp.virtualMcp.agentNameFallback")
+                        }
+                        size="md"
+                        className="shrink-0"
+                        avatarClassName="[&_svg]:w-1/2 [&_svg]:h-1/2"
+                      />
+                    )}
                   />
-                )}
-              />
-              <div className="flex flex-col flex-1 min-w-0">
-                <Controller
-                  name="title"
-                  control={form.control}
-                  render={({ field }) => (
-                    <input
-                      {...field}
-                      type="text"
-                      value={field.value ?? ""}
-                      onChange={(e) => {
-                        field.onChange(e);
-                      }}
-                      onBlur={() => {
-                        field.onBlur();
-                        flushAndSave();
-                      }}
-                      placeholder={t(
-                        "virtualMcp.virtualMcp.agentNamePlaceholder",
-                      )}
-                      className="text-lg font-medium leading-tight text-foreground bg-transparent border-none outline-none px-1 -mx-1 rounded hover:bg-input/25 focus:bg-input/25 transition-colors w-full truncate"
-                    />
-                  )}
-                />
-                <Controller
-                  name="description"
-                  control={form.control}
-                  render={({ field }) => (
-                    <input
-                      {...field}
-                      type="text"
-                      value={field.value ?? ""}
-                      onChange={(e) => {
-                        field.onChange(e);
-                      }}
-                      onBlur={() => {
-                        field.onBlur();
-                        flushAndSave();
-                      }}
-                      placeholder={t(
-                        "virtualMcp.virtualMcp.descriptionPlaceholder",
-                      )}
-                      className="text-sm text-muted-foreground bg-transparent border-none outline-none px-1 -mx-1 rounded hover:bg-input/25 focus:bg-input/25 transition-colors w-full truncate"
-                    />
-                  )}
-                />
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                className="shrink-0"
-                onClick={() => {
-                  track("agent_connect_modal_opened", {
-                    agent_id: virtualMcp.id,
-                  });
-                  dispatch({
-                    type: "SET_SHARE_DIALOG_OPEN",
-                    payload: true,
-                  });
-                }}
-              >
-                <span className="flex items-center -space-x-1.5 mr-0.5">
-                  <span className="inline-flex items-center justify-center size-4 rounded-full bg-black ring-1 ring-white/20 shrink-0">
-                    <img
-                      src="/logos/cursor.svg"
-                      alt="Cursor"
-                      className="size-2.5 brightness-0 invert"
-                    />
-                  </span>
-                  <span
-                    className="relative z-10 inline-flex items-center justify-center size-4 rounded-full ring-1 ring-background shrink-0"
-                    style={{ backgroundColor: "#D97757" }}
-                  >
-                    <img
-                      src="/logos/Claude Code.svg"
-                      alt="Claude"
-                      className="size-2.5 brightness-0 invert"
-                    />
-                  </span>
-                </span>
-                {t("virtualMcp.virtualMcp.connect")}
-              </Button>
-            </div>
-
-            {/* Creator metadata */}
-            <div className="flex items-center gap-2 -mt-6 text-sm text-muted-foreground">
-              <User
-                id={virtualMcp.created_by}
-                size="2xs"
-                className="text-sm text-muted-foreground"
-              />
-              <span className="text-muted-foreground/50">·</span>
-              <span>
-                {t("virtualMcp.virtualMcp.created")}{" "}
-                {format(new Date(virtualMcp.created_at), "PP", { locale })}
-              </span>
-              <span className="text-muted-foreground/50">·</span>
-              <span>
-                {lastUsedAt
-                  ? t("virtualMcp.virtualMcp.lastUsed", {
-                      time: formatDistanceToNow(new Date(lastUsedAt), {
-                        addSuffix: true,
-                        locale,
-                      }),
-                    })
-                  : t("virtualMcp.virtualMcp.neverUsed")}
-              </span>
-            </div>
-
-            {/* Connections section */}
-            <section className="flex flex-col gap-3">
-              <div className="flex items-center justify-between gap-3">
-                <h2 className="text-sm font-medium text-foreground">
-                  {t("virtualMcp.virtualMcp.connections")}
-                </h2>
-                {connections.length > 0 && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleOpenAddDialog}
-                  >
-                    <Plus size={14} />
-                    {t("virtualMcp.virtualMcp.addConnection")}
-                  </Button>
-                )}
-              </div>
-              <div className="flex flex-col gap-2">
-                {connections.length === 0 ? (
-                  <button
-                    type="button"
-                    onClick={handleOpenAddDialog}
-                    className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-dashed border-border hover:bg-accent/50 transition-colors w-full text-left cursor-pointer"
-                  >
-                    <div className="flex items-center justify-center size-8 rounded-md text-muted-foreground/75 border border-dashed border-border shrink-0">
-                      <Plus size={16} />
-                    </div>
-                    <span className="text-sm text-muted-foreground">
-                      {t("virtualMcp.virtualMcp.noConnectionsYet")}
-                    </span>
-                  </button>
-                ) : (
-                  connections.map((conn) => (
-                    <ErrorBoundary
-                      key={conn.connection_id}
-                      fallback={() => null}
-                    >
-                      <Suspense fallback={<ConnectionItemSkeleton />}>
-                        <ConnectionItem
-                          connection_id={conn.connection_id}
-                          usedConnectionIds={addedConnectionIds}
-                          onOpenSettings={() =>
-                            handleOpenSettings(conn.connection_id)
-                          }
-                          onRemove={() =>
-                            handleRemoveConnection(conn.connection_id)
-                          }
-                          onAuthenticate={handleAuthenticate}
-                          onSwitchInstance={handleSwitchInstance}
-                          onNewInstance={() =>
-                            handleNewInstance(conn.connection_id)
-                          }
+                  <div className="flex flex-col flex-1 min-w-0">
+                    <Controller
+                      name="title"
+                      control={form.control}
+                      render={({ field }) => (
+                        <input
+                          {...field}
+                          type="text"
+                          value={field.value ?? ""}
+                          onChange={(e) => {
+                            field.onChange(e);
+                          }}
+                          onBlur={() => {
+                            field.onBlur();
+                            flushAndSave();
+                          }}
+                          placeholder={t(
+                            "virtualMcp.virtualMcp.agentNamePlaceholder",
+                          )}
+                          className="text-lg font-medium leading-tight text-foreground bg-transparent border-none outline-none px-1 -mx-1 rounded hover:bg-input/25 focus:bg-input/25 transition-colors w-full truncate"
                         />
-                      </Suspense>
-                    </ErrorBoundary>
-                  ))
-                )}
-              </div>
-            </section>
-
-            {/* Instructions section */}
-            <section className="flex flex-col gap-3">
-              <div className="flex items-center justify-between gap-3">
-                <h2 className="text-sm font-medium text-foreground">
-                  {t("virtualMcp.virtualMcp.instructions")}
-                </h2>
-                <div className="flex items-center gap-2">
-                  {!form.watch("metadata.instructions")?.trim() && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={handleInsertTemplate}
-                    >
-                      {t("virtualMcp.virtualMcp.promptTemplate")}
-                    </Button>
-                  )}
+                      )}
+                    />
+                    <Controller
+                      name="description"
+                      control={form.control}
+                      render={({ field }) => (
+                        <input
+                          {...field}
+                          type="text"
+                          value={field.value ?? ""}
+                          onChange={(e) => {
+                            field.onChange(e);
+                          }}
+                          onBlur={() => {
+                            field.onBlur();
+                            flushAndSave();
+                          }}
+                          placeholder={t(
+                            "virtualMcp.virtualMcp.descriptionPlaceholder",
+                          )}
+                          className="text-sm text-muted-foreground bg-transparent border-none outline-none px-1 -mx-1 rounded hover:bg-input/25 focus:bg-input/25 transition-colors w-full truncate"
+                        />
+                      )}
+                    />
+                  </div>
                   <Button
                     variant="outline"
                     size="sm"
-                    disabled={
-                      isImproving ||
-                      !form.watch("metadata.instructions")?.trim()
-                    }
-                    onClick={handleImprovePrompt}
+                    className="shrink-0"
+                    onClick={() => {
+                      track("agent_connect_modal_opened", {
+                        agent_id: virtualMcp.id,
+                      });
+                      dispatch({
+                        type: "SET_SHARE_DIALOG_OPEN",
+                        payload: true,
+                      });
+                    }}
                   >
-                    <Stars01 size={13} />
-                    {t("virtualMcp.virtualMcp.improve")}
+                    <span className="flex items-center -space-x-1.5 mr-0.5">
+                      <span className="inline-flex items-center justify-center size-4 rounded-full bg-black ring-1 ring-white/20 shrink-0">
+                        <img
+                          src="/logos/cursor.svg"
+                          alt="Cursor"
+                          className="size-2.5 brightness-0 invert"
+                        />
+                      </span>
+                      <span
+                        className="relative z-10 inline-flex items-center justify-center size-4 rounded-full ring-1 ring-background shrink-0"
+                        style={{ backgroundColor: "#D97757" }}
+                      >
+                        <img
+                          src="/logos/Claude Code.svg"
+                          alt="Claude"
+                          className="size-2.5 brightness-0 invert"
+                        />
+                      </span>
+                    </span>
+                    {t("virtualMcp.virtualMcp.connect")}
                   </Button>
                 </div>
-              </div>
-              <Controller
-                name="metadata.instructions"
-                control={form.control}
-                render={({ field }) => (
-                  <div className="relative rounded-xl card-shadow bg-card focus-within:ring-1 focus-within:ring-ring">
-                    <Textarea
-                      {...field}
-                      value={field.value ?? ""}
-                      onChange={(e) => {
-                        field.onChange(e);
-                      }}
-                      onBlur={() => {
-                        field.onBlur();
-                        flushAndSave();
-                      }}
-                      placeholder={t(
-                        "virtualMcp.virtualMcp.instructionsPlaceholder",
-                      )}
-                      className="min-h-[200px] max-h-[360px] overflow-auto resize-none text-base text-muted-foreground placeholder:text-muted-foreground/40 leading-relaxed border-0 shadow-none px-4 py-3 pr-11 focus-visible:ring-0 focus-visible:ring-offset-0 bg-transparent"
-                      style={{ boxShadow: "none" }}
-                    />
-                    <Tooltip delayDuration={0}>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="absolute top-2 right-2 h-7 w-7 text-muted-foreground"
-                          onClick={() => setInstructionsFullscreen(true)}
-                          aria-label={t(
-                            "virtualMcp.virtualMcp.openFullscreenEditor",
-                          )}
-                        >
-                          <Maximize01 size={14} />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="left">
-                        {t("virtualMcp.virtualMcp.fullscreen")}
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                )}
-              />
-            </section>
 
-            {/* Files section — files attached to the agent as reference */}
-            <FilesSection form={form} />
+                {/* Creator metadata */}
+                <div className="flex items-center gap-2 -mt-6 text-sm text-muted-foreground">
+                  <User
+                    id={virtualMcp.created_by}
+                    size="2xs"
+                    className="text-sm text-muted-foreground"
+                  />
+                  <span className="text-muted-foreground/50">·</span>
+                  <span>
+                    {t("virtualMcp.virtualMcp.created")}{" "}
+                    {format(new Date(virtualMcp.created_at), "PP", { locale })}
+                  </span>
+                  <span className="text-muted-foreground/50">·</span>
+                  <span>
+                    {lastUsedAt
+                      ? t("virtualMcp.virtualMcp.lastUsed", {
+                          time: formatDistanceToNow(new Date(lastUsedAt), {
+                            addSuffix: true,
+                            locale,
+                          }),
+                        })
+                      : t("virtualMcp.virtualMcp.neverUsed")}
+                  </span>
+                </div>
 
-            {/* Sub-agents section — delegation allowlist for the subtask tool */}
-            <ErrorBoundary fallback={() => null}>
-              <Suspense
-                fallback={
-                  <section className="flex flex-col gap-3">
-                    <h2 className="text-sm font-medium text-foreground">
-                      {t("virtualMcp.virtualMcp.subAgents")}
-                    </h2>
-                    <div className="h-16 rounded-lg border border-dashed border-border animate-pulse" />
-                  </section>
-                }
+                <ProjectSettingsIndex groups={settingsGroups} />
+              </>
+            ) : (
+              <ProjectSettingsDetail
+                title={t(PROJECT_SETTINGS_SECTIONS[section].titleKey)}
+                backLabel={t("virtualMcp.settings.backToSettings")}
+                onBack={() => openSection(null)}
+                actions={sectionActions[section]}
               >
-                <SubAgentsSection form={form} currentAgentId={virtualMcp.id} />
-              </Suspense>
-            </ErrorBoundary>
-
-            {/* Layout section */}
-            <LayoutTabContent
-              virtualMcpId={virtualMcp.id}
-              form={form}
-              flushAndSave={flushAndSave}
-            />
-
-            {/* Development agent section (link a dev counterpart) */}
-            <DevAgentSetup virtualMcp={virtualMcp} />
-
-            {/* CMS section — Fast Preview + Publishing (how CMS/code changes
-                reach the live site). Publishing is code-agent only. */}
-            <div className="flex flex-col gap-3">
-              <div className="flex items-center justify-between gap-3">
-                <h2 className="text-sm font-medium text-foreground">
-                  {t("sandbox.cmsSettings.title")}
-                </h2>
-              </div>
-              <Card className="p-6 gap-5">
-                {/* Content editing — whether this agent has a CMS at all, and
-                    where the preview lands when it does. Reads first: the rest
-                    of the card configures what this turns on. */}
-                {hasClonableSource && (
-                  <>
-                    <CardContent className="p-0 space-y-5">
-                      <ContentEditingField
-                        control={form.control}
-                        onCommit={flushAndSave}
-                      />
-                      <DraftsModeField
-                        control={form.control}
-                        onCommit={flushAndSave}
-                        onEnable={() =>
-                          draftsTaskCtx?.setCurrentTaskBranch(
-                            generateBranchName(
-                              branchUserLabel(draftsSession?.user),
-                            ),
-                          )
-                        }
-                      />
-                      {/* Blocks-form preference — nothing to tune with the CMS off. */}
-                      {!cmsOff && (
-                        <FieldDescriptionTooltipsField control={form.control} />
+                {section === "connections" && (
+                  <section className="flex flex-col gap-3">
+                    <div className="flex flex-col gap-2">
+                      {connections.length === 0 ? (
+                        <button
+                          type="button"
+                          onClick={handleOpenAddDialog}
+                          className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-dashed border-border hover:bg-accent/50 transition-colors w-full text-left cursor-pointer"
+                        >
+                          <div className="flex items-center justify-center size-8 rounded-md text-muted-foreground/75 border border-dashed border-border shrink-0">
+                            <Plus size={16} />
+                          </div>
+                          <span className="text-sm text-muted-foreground">
+                            {t("virtualMcp.virtualMcp.noConnectionsYet")}
+                          </span>
+                        </button>
+                      ) : (
+                        connections.map((conn) => (
+                          <ErrorBoundary
+                            key={conn.connection_id}
+                            fallback={() => null}
+                          >
+                            <Suspense fallback={<ConnectionItemSkeleton />}>
+                              <ConnectionItem
+                                connection_id={conn.connection_id}
+                                usedConnectionIds={addedConnectionIds}
+                                onOpenSettings={() =>
+                                  handleOpenSettings(conn.connection_id)
+                                }
+                                onRemove={() =>
+                                  handleRemoveConnection(conn.connection_id)
+                                }
+                                onAuthenticate={handleAuthenticate}
+                                onSwitchInstance={handleSwitchInstance}
+                                onNewInstance={() =>
+                                  handleNewInstance(conn.connection_id)
+                                }
+                              />
+                            </Suspense>
+                          </ErrorBoundary>
+                        ))
                       )}
-                    </CardContent>
-                    {!cmsOff && (
-                      <div className="border-t border-border -mx-6" />
-                    )}
-                  </>
+                    </div>
+                  </section>
                 )}
-                {!cmsOff && (
-                  <>
-                    {/* Preview — preview URL + the Fast Preview switch it gates
-                        (a URL is required for Fast Preview to take effect). */}
-                    <CardContent className="p-0 space-y-5">
-                      <div className="flex flex-col gap-1">
-                        <h3 className="text-sm font-medium text-foreground">
-                          {t("sandbox.cmsSettings.preview.title")}
-                        </h3>
-                        <p className="text-sm text-muted-foreground">
-                          {t("sandbox.cmsSettings.preview.description")}
-                        </p>
-                      </div>
-                      <PreviewServerUrlField control={form.control} />
-                      <FastPreviewField
-                        control={form.control}
-                        previewServerUrl={form.watch(
-                          "metadata.previewServerUrl",
-                        )}
-                      />
-                      <InPlaceRenderField
-                        control={form.control}
-                        fastPreview={form.watch("metadata.fastPreview")}
-                      />
-                    </CardContent>
 
-                    {hasGithubRepo && (
-                      <>
-                        <div className="border-t border-border -mx-6" />
-                        <CardContent className="p-0 space-y-5">
+                {/* Instructions section */}
+                {section === "general" && (
+                  <section className="flex flex-col gap-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <h2 className="text-sm font-medium text-foreground">
+                        {t("virtualMcp.virtualMcp.instructions")}
+                      </h2>
+                      {sectionInstructionsActions}
+                    </div>
+                    <Controller
+                      name="metadata.instructions"
+                      control={form.control}
+                      render={({ field }) => (
+                        <div className="relative rounded-xl card-shadow bg-card focus-within:ring-1 focus-within:ring-ring">
+                          <Textarea
+                            {...field}
+                            value={field.value ?? ""}
+                            onChange={(e) => {
+                              field.onChange(e);
+                            }}
+                            onBlur={() => {
+                              field.onBlur();
+                              flushAndSave();
+                            }}
+                            placeholder={t(
+                              "virtualMcp.virtualMcp.instructionsPlaceholder",
+                            )}
+                            className="min-h-[200px] max-h-[360px] overflow-auto resize-none text-base text-muted-foreground placeholder:text-muted-foreground/40 leading-relaxed border-0 shadow-none px-4 py-3 pr-11 focus-visible:ring-0 focus-visible:ring-offset-0 bg-transparent"
+                            style={{ boxShadow: "none" }}
+                          />
+                          <Tooltip delayDuration={0}>
+                            <TooltipTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                className="absolute top-2 right-2 h-7 w-7 text-muted-foreground"
+                                onClick={() => setInstructionsFullscreen(true)}
+                                aria-label={t(
+                                  "virtualMcp.virtualMcp.openFullscreenEditor",
+                                )}
+                              >
+                                <Maximize01 size={14} />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side="left">
+                              {t("virtualMcp.virtualMcp.fullscreen")}
+                            </TooltipContent>
+                          </Tooltip>
+                        </div>
+                      )}
+                    />
+                  </section>
+                )}
+
+                {/* Files section — files attached to the agent as reference */}
+                {section === "general" && <FilesSection form={form} />}
+
+                {/* Sub-agents section — delegation allowlist for the subtask tool */}
+                {section === "general" && (
+                  <ErrorBoundary fallback={() => null}>
+                    <Suspense
+                      fallback={
+                        <section className="flex flex-col gap-3">
+                          <h2 className="text-sm font-medium text-foreground">
+                            {t("virtualMcp.virtualMcp.subAgents")}
+                          </h2>
+                          <div className="h-16 rounded-lg border border-dashed border-border animate-pulse" />
+                        </section>
+                      }
+                    >
+                      <SubAgentsSection
+                        form={form}
+                        currentAgentId={virtualMcp.id}
+                      />
+                    </Suspense>
+                  </ErrorBoundary>
+                )}
+
+                {/* Layout section */}
+                {/* Development agent section (link a dev counterpart) */}
+                {section === "site" && (
+                  <DevAgentSetup virtualMcp={virtualMcp} />
+                )}
+
+                {/* CMS — content editing, then how changes reach the live
+                site. Publishing is code-agent only. */}
+                {section === "site" && hasClonableSource && (
+                  <SettingsSection title={t("sandbox.cmsSettings.title")}>
+                    <SettingsCard>
+                      <SettingsCardRow>
+                        <ContentEditingField
+                          control={form.control}
+                          onCommit={flushAndSave}
+                        />
+                      </SettingsCardRow>
+                      <SettingsCardRow>
+                        <DraftsModeField
+                          control={form.control}
+                          onCommit={flushAndSave}
+                          onEnable={() =>
+                            draftsTaskCtx?.setCurrentTaskBranch(
+                              generateBranchName(
+                                branchUserLabel(draftsSession?.user),
+                              ),
+                            )
+                          }
+                        />
+                      </SettingsCardRow>
+                      {/* Nothing to tune in the blocks form with the CMS off. */}
+                      {!cmsOff && (
+                        <SettingsCardRow>
+                          <FieldDescriptionTooltipsField
+                            control={form.control}
+                          />
+                        </SettingsCardRow>
+                      )}
+                      {!cmsOff && hasGithubRepo && (
+                        <SettingsCardRow>
                           <PublishPolicyField
                             control={form.control}
                             onCommit={flushAndSave}
                           />
-                        </CardContent>
-                      </>
-                    )}
-                  </>
+                        </SettingsCardRow>
+                      )}
+                    </SettingsCard>
+                  </SettingsSection>
                 )}
-              </Card>
-            </div>
 
-            {/* Sandbox section */}
-            <div className="flex flex-col gap-3">
-              <div className="flex items-center justify-between gap-3">
-                <h2 className="text-sm font-medium text-foreground">
-                  {t("virtualMcp.virtualMcp.sandbox")}
-                </h2>
-              </div>
-              <Card className="p-6 gap-5">
-                <CardContent className="p-0 space-y-5">
-                  <RepoRow repo={runtimeCardRepo} />
-                  <RuntimeFields control={form.control} />
-                  <EnvVarsField
-                    control={form.control}
-                    form={form}
-                    virtualMcpId={virtualMcp.id}
-                    orgSlug={org.slug}
-                    sandboxMap={virtualMcp.metadata.sandboxMap}
-                  />
-                  <SubmoduleCredentialsField
-                    control={form.control}
-                    form={form}
-                  />
-                </CardContent>
-              </Card>
-            </div>
+                {/* Preview — the URL, and the Fast Preview switch it gates
+                (Fast Preview renders against that URL, so it needs one). */}
+                {section === "site" && !cmsOff && (
+                  <SettingsSection
+                    title={t("sandbox.cmsSettings.preview.title")}
+                    description={t("sandbox.cmsSettings.preview.description")}
+                  >
+                    <SettingsCard>
+                      <SettingsCardRow>
+                        <PreviewServerUrlField control={form.control} />
+                      </SettingsCardRow>
+                      <SettingsCardRow>
+                        <FastPreviewField
+                          control={form.control}
+                          previewServerUrl={form.watch(
+                            "metadata.previewServerUrl",
+                          )}
+                        />
+                      </SettingsCardRow>
+                      {form.watch("metadata.fastPreview") && (
+                        <SettingsCardRow>
+                          <InPlaceRenderField
+                            control={form.control}
+                            fastPreview={form.watch("metadata.fastPreview")}
+                          />
+                        </SettingsCardRow>
+                      )}
+                    </SettingsCard>
+                  </SettingsSection>
+                )}
 
-            {/* Danger zone */}
-            <section className="flex items-center justify-between border-t border-border pt-6">
-              <div>
-                <p className="text-sm font-medium">
-                  {t("virtualMcp.virtualMcp.deleteAgent")}
-                </p>
-                <p className="text-sm text-muted-foreground">
-                  {t("virtualMcp.virtualMcp.deleteAgentDescription")}
-                </p>
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                className="text-destructive border-destructive/40 hover:bg-destructive/10 hover:text-destructive shrink-0"
-                onClick={() => setDeleteDialogOpen(true)}
-              >
-                <Trash01 size={14} />
-                {t("virtualMcp.virtualMcp.deleteAgent")}
-              </Button>
-            </section>
+                {/* Sandbox — the repo it clones and what it runs there. */}
+                {section === "site" && (
+                  <SettingsSection title={t("virtualMcp.virtualMcp.sandbox")}>
+                    <SettingsCard>
+                      <SettingsCardRow>
+                        <RepoRow repo={runtimeCardRepo} />
+                      </SettingsCardRow>
+                      <SettingsCardRow>
+                        <RuntimeFields control={form.control} />
+                      </SettingsCardRow>
+                      <SettingsCardRow>
+                        <EnvVarsField
+                          control={form.control}
+                          form={form}
+                          virtualMcpId={virtualMcp.id}
+                          orgSlug={org.slug}
+                          sandboxMap={virtualMcp.metadata.sandboxMap}
+                        />
+                      </SettingsCardRow>
+                      <SettingsCardRow>
+                        <SubmoduleCredentialsField
+                          control={form.control}
+                          form={form}
+                        />
+                      </SettingsCardRow>
+                    </SettingsCard>
+                  </SettingsSection>
+                )}
+              </ProjectSettingsDetail>
+            )}
           </div>
         </Page.Body>
       </Page.Content>

--- a/apps/web/src/views/virtual-mcp/settings/sections.test.ts
+++ b/apps/web/src/views/virtual-mcp/settings/sections.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { PANEL_PAYLOAD_KEYS } from "@/layouts/main-panel-tabs/panel-route";
+import {
+  isProjectSettingsSectionKey,
+  PROJECT_SETTINGS_SECTION_KEYS,
+  PROJECT_SETTINGS_SECTIONS,
+} from "./sections";
+
+describe("project settings sections", () => {
+  test("every key has a title and a description", () => {
+    for (const key of PROJECT_SETTINGS_SECTION_KEYS) {
+      expect(PROJECT_SETTINGS_SECTIONS[key].titleKey).toBeString();
+      expect(PROJECT_SETTINGS_SECTIONS[key].descriptionKey).toBeString();
+    }
+  });
+
+  test("an unknown or absent value lands on the index, not a blank page", () => {
+    expect(isProjectSettingsSectionKey(undefined)).toBe(false);
+    expect(isProjectSettingsSectionKey("")).toBe(false);
+    expect(isProjectSettingsSectionKey("layout")).toBe(false);
+    /** The views are listed on the index, so `views` is not a section. */
+    expect(isProjectSettingsSectionKey("views")).toBe(false);
+    expect(isProjectSettingsSectionKey("general")).toBe(true);
+  });
+
+  test("`section` is a registered panel payload key, so leaving Settings drops it", () => {
+    expect(PANEL_PAYLOAD_KEYS).toContain("section");
+  });
+});

--- a/apps/web/src/views/virtual-mcp/settings/sections.ts
+++ b/apps/web/src/views/virtual-mcp/settings/sections.ts
@@ -1,0 +1,58 @@
+/**
+ * Project settings, as a few places rather than one long page.
+ *
+ * Settings used to be a single scroll: identity, connections, instructions,
+ * files, sub-projects, layout, CMS, sandbox and the delete button, stacked. It
+ * read as a wall, and the things people actually come here for (the views, the
+ * instructions) were the furthest down.
+ *
+ * So it is an index of SECTIONS, each with its own address — `?section=<key>`
+ * on the settings panel. A section is a HANDFUL of related concerns, not one
+ * field each: splitting per concern only moved the wall into the index.
+ * The key is the URL's, so a section is linkable and Back returns to the index.
+ */
+
+import type { TranslationKey } from "@/i18n/use-t.ts";
+
+export const PROJECT_SETTINGS_SECTION_KEYS = [
+  "general",
+  "connections",
+  "site",
+] as const;
+
+export type ProjectSettingsSectionKey =
+  (typeof PROJECT_SETTINGS_SECTION_KEYS)[number];
+
+export interface ProjectSettingsSectionDef {
+  titleKey: TranslationKey;
+  descriptionKey: TranslationKey;
+}
+
+/** Title and description, in ONE place: the index row and the section's own
+ *  header read the same words, so a row can never promise a different page. */
+export const PROJECT_SETTINGS_SECTIONS: Record<
+  ProjectSettingsSectionKey,
+  ProjectSettingsSectionDef
+> = {
+  general: {
+    titleKey: "virtualMcp.settings.general.title",
+    descriptionKey: "virtualMcp.settings.general.description",
+  },
+  connections: {
+    titleKey: "virtualMcp.settings.connections.title",
+    descriptionKey: "virtualMcp.settings.connections.description",
+  },
+  site: {
+    titleKey: "virtualMcp.settings.site.title",
+    descriptionKey: "virtualMcp.settings.site.description",
+  },
+};
+
+export function isProjectSettingsSectionKey(
+  value: string | undefined | null,
+): value is ProjectSettingsSectionKey {
+  return (
+    !!value &&
+    (PROJECT_SETTINGS_SECTION_KEYS as readonly string[]).includes(value)
+  );
+}

--- a/apps/web/src/views/virtual-mcp/settings/settings-detail.tsx
+++ b/apps/web/src/views/virtual-mcp/settings/settings-detail.tsx
@@ -1,0 +1,63 @@
+/**
+ * One settings section, opened from the index.
+ *
+ * The header is the task page's breadcrumb, same primitives and same sizing:
+ * the trail's leaf names the section, so it also serves as the title, and the
+ * parent crumb is the way back. A section has no sibling tabs, so the trail is
+ * always two deep — and no blurb, since the fields below say what they are;
+ * the one-line summary belongs on the index row that promises the page.
+ */
+
+import type { ReactNode } from "react";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@decocms/ui/components/breadcrumb.tsx";
+
+export function ProjectSettingsDetail({
+  title,
+  backLabel,
+  onBack,
+  actions,
+  children,
+}: {
+  title: string;
+  backLabel: string;
+  onBack: () => void;
+  actions?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="flex items-center justify-between gap-4">
+        <Breadcrumb className="-ml-2 min-w-0">
+          <BreadcrumbList className="text-[15px]">
+            <BreadcrumbItem>
+              {/** A button, not an anchor: the index is a search param away,
+               *  not a document to link to. */}
+              <BreadcrumbLink
+                asChild
+                className="rounded-md px-2 py-1 text-muted-foreground hover:bg-accent"
+              >
+                <button type="button" onClick={onBack}>
+                  {backLabel}
+                </button>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage className="px-2 py-1">{title}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+        {actions && <div className="shrink-0">{actions}</div>}
+      </div>
+      {/** Sections breathe like the /settings pages (`SettingsPage`) do. */}
+      <div className="flex flex-col gap-10">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/views/virtual-mcp/settings/settings-index.tsx
+++ b/apps/web/src/views/virtual-mcp/settings/settings-index.tsx
@@ -1,0 +1,94 @@
+/**
+ * The settings index: grouped rows that drill into one section each.
+ *
+ * Presentation only — every row's availability, summary and handler is decided
+ * by the caller, which is the one place that has the project's data. Built on
+ * the org settings kit (`components/settings/settings-section.tsx`) so project
+ * settings and `/settings` are the same screen twice, not two designs.
+ */
+
+import { ChevronRight } from "@untitledui/icons";
+import type { ReactNode } from "react";
+import {
+  SettingsCard,
+  SettingsCardItem,
+  SettingsPage,
+  SettingsSection,
+} from "@/components/settings/settings-section";
+import { cn } from "@decocms/ui/lib/utils.ts";
+
+export interface ProjectSettingsRowDef {
+  key: string;
+  icon: ReactNode;
+  title: string;
+  description: string;
+  /** The row's current answer, right-aligned: "3 connections", "Off". */
+  value?: string;
+  onClick: () => void;
+  destructive?: boolean;
+}
+
+export interface ProjectSettingsGroupDef {
+  key: string;
+  /** Absent for the first card, which needs no heading to be understood. */
+  title?: string;
+  rows?: ProjectSettingsRowDef[];
+  /** A group that renders its own lists instead of drill-in rows. */
+  content?: ReactNode;
+}
+
+export function ProjectSettingsIndex({
+  header,
+  groups,
+}: {
+  header?: ReactNode;
+  groups: ProjectSettingsGroupDef[];
+}) {
+  return (
+    <SettingsPage>
+      {header}
+      {groups
+        .filter((group) => group.content || group.rows?.length)
+        .map((group) =>
+          group.content ? (
+            <div key={group.key}>{group.content}</div>
+          ) : (
+            <SettingsSection key={group.key} title={group.title}>
+              <SettingsCard>
+                {(group.rows ?? []).map((row) => (
+                  <SettingsCardItem
+                    key={row.key}
+                    onClick={row.onClick}
+                    icon={row.icon}
+                    title={
+                      <span
+                        className={cn(row.destructive && "text-destructive")}
+                      >
+                        {row.title}
+                      </span>
+                    }
+                    description={row.description}
+                    action={
+                      <div className="flex items-center gap-2 text-muted-foreground">
+                        {/** The action slot stops propagation for the controls
+                         *  inside it, so the row's own affordance re-arms it. */}
+                        <span
+                          onClick={row.onClick}
+                          className="flex cursor-pointer items-center gap-2"
+                        >
+                          {row.value && (
+                            <span className="text-sm">{row.value}</span>
+                          )}
+                          <ChevronRight size={16} />
+                        </span>
+                      </div>
+                    }
+                  />
+                ))}
+              </SettingsCard>
+            </SettingsSection>
+          ),
+        )}
+    </SettingsPage>
+  );
+}

--- a/apps/web/src/views/virtual-mcp/settings/use-project-views.ts
+++ b/apps/web/src/views/virtual-mcp/settings/use-project-views.ts
@@ -1,5 +1,13 @@
+/**
+ * Everything the project's views need, once.
+ *
+ * State and writers for the Views card: which views this project can open,
+ * which are pinned, and where it lands. The renderer stays dumb, and the hook
+ * is called ONCE by the settings view — two copies would each stage their own
+ * optimistic revision.
+ */
+
 import { getUIResourceUri } from "@decocms/shared/mcp-apps/types";
-import { IntegrationIcon } from "@/components/integration-icon.tsx";
 import { toTitleCase } from "@/components/chat/message/parts/tool-call-part/utils";
 import { agentHasClonableSource } from "@/lib/agent-capabilities";
 import { KEYS } from "@/lib/query-keys";
@@ -10,39 +18,11 @@ import {
   normalizePanelSegment,
 } from "@/layouts/main-panel-tabs/tab-id";
 import { useT } from "@/i18n/use-t.ts";
-import { Card, CardContent } from "@decocms/ui/components/card.tsx";
-import { Input } from "@decocms/ui/components/input.tsx";
-import { Label } from "@decocms/ui/components/label.tsx";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@decocms/ui/components/select.tsx";
-import { Switch } from "@decocms/ui/components/switch.tsx";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@decocms/ui/components/tooltip.tsx";
-import { cn } from "@decocms/ui/lib/utils.ts";
 import { useVirtualMCP } from "@/sdk";
 import { useQuery } from "@tanstack/react-query";
 import { useRef } from "react";
-import {
-  BarChartSquare02,
-  CheckDone01,
-  Columns03,
-  Globe02,
-  Home02,
-  Image01,
-  Lightning01,
-  Monitor01,
-  Server01,
-} from "@untitledui/icons";
-import { SimpleIconPicker } from "../../components/simple-icon-picker";
-import type { VirtualMcpFormReturn } from "./types";
+import type { VirtualMcpFormReturn } from "../types";
+import { usePanelNavigate } from "@/layouts/main-panel-tabs/use-panel-navigate";
 import { useProjectNativeViewPresence } from "@/layouts/main-panel-tabs/use-project-native-view-presence";
 import {
   availableProjectSidebarViews,
@@ -77,14 +57,14 @@ interface UITool {
   resourceUri: string;
 }
 
-interface PinnedView {
+export interface PinnedView {
   connectionId: string;
   toolName: string;
   label: string;
   icon?: string | null;
 }
 
-interface ConnectionWithTools {
+export interface ConnectionWithTools {
   fetchOk: boolean;
   id: string;
   title: string;
@@ -92,20 +72,9 @@ interface ConnectionWithTools {
   uiTools: UITool[];
 }
 
-function SidebarViewIcon({ viewId }: { viewId: ProjectSidebarViewId }) {
-  if (viewId === "overview") return <Home02 size={16} />;
-  if (viewId === "reports") return <BarChartSquare02 size={16} />;
-  if (viewId === "board") return <Columns03 size={16} />;
-  if (viewId === "site-editor") return <Monitor01 size={16} />;
-  if (viewId === "assets") return <Image01 size={16} />;
-  if (viewId === "hosting") return <Server01 size={16} />;
-  if (viewId === "e2e") return <CheckDone01 size={16} />;
-  if (viewId === "analytics") return <BarChartSquare02 size={16} />;
-  if (viewId === "cdn") return <Globe02 size={16} />;
-  return <Lightning01 size={16} />;
-}
+export type ProjectViews = ReturnType<typeof useProjectViews>;
 
-export function LayoutTabContent({
+export function useProjectViews({
   virtualMcpId,
   form,
   flushAndSave,
@@ -116,6 +85,7 @@ export function LayoutTabContent({
 }) {
   const t = useT();
   const studio = useStudioTools();
+  const { openPanel } = usePanelNavigate();
 
   const virtualMcp = useVirtualMCP(virtualMcpId);
   const nativeViews = useProjectNativeViewPresence(virtualMcp);
@@ -183,9 +153,11 @@ export function LayoutTabContent({
     ...DESTINATION_MAIN_VIEWS,
   ]);
 
-  // Layout state lives in the parent form under metadata.ui.{pinnedViews, layout}.
-  // form.watch subscribes the component to changes from any source — direct user
-  // edits, the orphan-pin reconciliation below, or a server refetch.
+  /**
+   * Layout state lives in the parent form under metadata.ui.{pinnedViews, layout}.
+   * form.watch subscribes the component to changes from any source — direct user
+   * edits, the orphan-pin reconciliation below, or a server refetch.
+   */
   const pinnedViews = form.watch("metadata.ui.pinnedViews") ?? [];
   const layoutMeta = form.watch("metadata.ui.layout") ?? null;
   const currentDefaultMain = layoutMeta?.defaultMainView ?? null;
@@ -197,9 +169,11 @@ export function LayoutTabContent({
     }),
     form.watch("metadata.sidebarViewsVersion"),
   );
-  // A Settings panel can remount while its previous instance is still saving.
-  // Pending edits and the item cache outlive that form, so they remain the
-  // switch authority instead of stale remounted defaults.
+  /**
+   * A Settings panel can remount while its previous instance is still saving.
+   * Pending edits and the item cache outlive that form, so they remain the
+   * switch authority instead of stale remounted defaults.
+   */
   const sidebarViews =
     pendingSidebarViews ??
     (virtualMcp
@@ -210,8 +184,10 @@ export function LayoutTabContent({
       : formSidebarViews);
   /** No main view: the chat is the whole workspace, so its switch is forced on
    *  and locked. This was the old `chat` main view, which no longer exists. */
-  // Convert the stored {type, id, toolName} object into the string composite
-  // key used by the <Select> UI. Legacy tab types fold into "settings".
+  /**
+   * Convert the stored {type, id, toolName} object into the string composite
+   * key used by the <Select> UI. Legacy tab types fold into "settings".
+   */
   const defaultMainView = (() => {
     /** Chat is retired as a main view. An agent still stored on it — or on
      *  nothing — selects no option, so the trigger shows its placeholder rather
@@ -265,10 +241,12 @@ export function LayoutTabContent({
     );
   };
 
-  // Reconcile orphaned pinned views once tool data is available.
-  // Drop pins whose connection is detached from the agent, or which fetched
-  // OK but no longer expose the pinned tool. Pins for attached connections
-  // that failed to fetch are kept to survive transient errors.
+  /**
+   * Reconcile orphaned pinned views once tool data is available.
+   * Drop pins whose connection is detached from the agent, or which fetched
+   * OK but no longer expose the pinned tool. Pins for attached connections
+   * that failed to fetch are kept to survive transient errors.
+   */
   const reconciledRef = useRef(false);
   if (
     connectionsWithTools &&
@@ -297,8 +275,10 @@ export function LayoutTabContent({
     if (validPinned.length !== pinnedViews.length) {
       writePinned(validPinned);
 
-      // If the default view was an ext-app that got removed, use the permanent
-      // Settings view instead.
+      /**
+       * If the default view was an ext-app that got removed, use the permanent
+       * Settings view instead.
+       */
       if (
         currentDefaultMain?.type === "ext-apps" &&
         !validPinned.some(
@@ -404,18 +384,18 @@ export function LayoutTabContent({
     if (nextDefaultMain !== currentDefaultMain) {
       writeLayout({ defaultMainView: nextDefaultMain });
     }
-    // The parent form subscription coalesces rapid adjacent switch changes and
-    // flushes the latest value on unmount. Starting a full metadata write for
-    // every click would let out-of-order responses revert the newest choice.
+    /**
+     * The parent form subscription coalesces rapid adjacent switch changes and
+     * flushes the latest value on unmount. Starting a full metadata write for
+     * every click would let out-of-order responses revert the newest choice.
+     */
   };
 
-  const noConnections = connectionIds.length === 0;
-  const noInteractiveTools =
-    connectionsWithTools && connectionsData.length === 0;
-
-  // Preview is available whenever the agent has a clonable source —
-  // either a Start Website template or a connected GitHub repo — matching
-  // the gating in `use-main-panel-tabs.ts`.
+  /**
+   * Preview is available whenever the agent has a clonable source —
+   * either a Start Website template or a connected GitHub repo — matching
+   * the gating in `use-main-panel-tabs.ts`.
+   */
   const hasClonableSource = agentHasClonableSource(virtualMcp?.metadata);
   const sidebarViewPresence = projectSidebarViewPresence(
     hasClonableSource,
@@ -449,8 +429,10 @@ export function LayoutTabContent({
    */
   const defaultMainOptions: { value: string; label: string }[] = [];
   for (const viewId of enabledSidebarViews) {
-    // Pinned app rows sit before Automations in the actual sidebar, so append
-    // that final project row after the pinned-view loop below.
+    /**
+     * Pinned app rows sit before Automations in the actual sidebar, so append
+     * that final project row after the pinned-view loop below.
+     */
     if (viewId === "automations") continue;
     defaultMainOptions.push({
       value: viewId,
@@ -474,229 +456,32 @@ export function LayoutTabContent({
     label: t("virtualMcp.layoutTabContent.settings"),
   });
 
-  const hasSidebarContent =
-    availableSidebarViews.length > 0 ||
-    connectionsData.length > 0 ||
-    noConnections ||
-    noInteractiveTools;
+  const openView = (tabId: string) =>
+    openPanel(tabId, { virtualmcpid: virtualMcpId });
 
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-center justify-between gap-3">
-        <h2 className="text-sm font-medium text-foreground">
-          {t("virtualMcp.layoutTabContent.layout")}
-        </h2>
-      </div>
-      <Card className="p-6 gap-5">
-        <CardContent className="p-0 space-y-5">
-          <div className="flex items-center justify-between gap-4">
-            <div className="space-y-0.5 min-w-0">
-              <Label className="font-normal text-foreground">
-                {t("virtualMcp.layoutTabContent.mainView")}
-              </Label>
-              <p className="text-xs text-muted-foreground">
-                {t("virtualMcp.layoutTabContent.mainViewDescription")}
-              </p>
-            </div>
-            <Select
-              value={defaultMainView}
-              onValueChange={handleDefaultMainViewChange}
-            >
-              <SelectTrigger className="w-44 h-8 text-sm capitalize shrink-0">
-                <SelectValue
-                  placeholder={t("virtualMcp.layoutTabContent.noMainView")}
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {defaultMainOptions.map((opt) => (
-                  <SelectItem
-                    key={opt.value}
-                    value={opt.value}
-                    className="capitalize"
-                  >
-                    {opt.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="space-y-0.5 min-w-0">
-              <Label className="font-normal text-foreground">
-                {t("virtualMcp.layoutTabContent.showChat")}
-              </Label>
-              <p className="text-xs text-muted-foreground">
-                {t("virtualMcp.layoutTabContent.showChatDescription")}
-              </p>
-            </div>
-            <Tooltip delayDuration={0}>
-              <TooltipTrigger asChild>
-                <span className="shrink-0">
-                  <Switch
-                    checked={noMainView ? true : chatDefaultOpen}
-                    disabled={noMainView}
-                    onCheckedChange={(checked) => {
-                      writeLayout({ chatDefaultOpen: checked });
-                      flushAndSave();
-                    }}
-                  />
-                </span>
-              </TooltipTrigger>
-              {noMainView && (
-                <TooltipContent side="top">
-                  {t("virtualMcp.layoutTabContent.chatAlwaysShown")}
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </div>
-        </CardContent>
-
-        {hasSidebarContent && (
-          <>
-            <div className="border-t border-border -mx-6" />
-            <CardContent className="p-0 space-y-3">
-              <div className="flex items-center justify-between gap-4">
-                <div className="space-y-0.5 min-w-0">
-                  <Label className="font-normal text-foreground">
-                    {t("virtualMcp.layoutTabContent.sidebarViews")}
-                  </Label>
-                  <p className="text-xs text-muted-foreground">
-                    {t("virtualMcp.layoutTabContent.sidebarViewsDescription")}
-                  </p>
-                </div>
-              </div>
-              {availableSidebarViews.length > 0 && (
-                <div className="space-y-1.5 pt-1">
-                  {availableSidebarViews.map((viewId) => {
-                    const switchId = `sidebar-view-${viewId}`;
-                    return (
-                      <div
-                        key={viewId}
-                        className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg border border-border"
-                      >
-                        <Label
-                          htmlFor={switchId}
-                          className="min-w-0 flex flex-1 items-center gap-2 font-normal text-foreground"
-                        >
-                          <SidebarViewIcon viewId={viewId} />
-                          <span className="truncate">
-                            {sidebarViewLabels[viewId]}
-                          </span>
-                        </Label>
-                        <Switch
-                          id={switchId}
-                          checked={sidebarViews.includes(viewId)}
-                          onCheckedChange={(enabled) =>
-                            handleSidebarViewChange(viewId, enabled)
-                          }
-                        />
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-              {availableSidebarViews.length > 0 &&
-                (noConnections ||
-                  noInteractiveTools ||
-                  connectionsData.length > 0) && (
-                  <div className="border-t border-border -mx-6" />
-                )}
-              {noConnections && (
-                <p className="text-xs text-muted-foreground">
-                  {t("virtualMcp.layoutTabContent.addConnectionMessage")}
-                </p>
-              )}
-              {noInteractiveTools && !noConnections && (
-                <p className="text-xs text-muted-foreground">
-                  {t("virtualMcp.layoutTabContent.noInteractiveTools")}
-                </p>
-              )}
-              {connectionsData.length > 0 && (
-                <div className="space-y-4 pt-1">
-                  {connectionsData.map((conn, connIdx) => (
-                    <div key={conn.id}>
-                      {connIdx > 0 && (
-                        <div className="border-t border-border -mx-6 mb-4" />
-                      )}
-                      <div className="flex items-center gap-2 mb-2.5">
-                        <IntegrationIcon
-                          icon={conn.icon}
-                          name={conn.title}
-                          size="xs"
-                          className="shrink-0"
-                        />
-                        <span className="text-xs font-medium text-muted-foreground">
-                          {conn.title}
-                        </span>
-                      </div>
-                      <div className="space-y-1.5">
-                        {conn.uiTools.map((tool) => {
-                          const pinned = pinnedViews.some(
-                            (v) =>
-                              v.connectionId === conn.id &&
-                              v.toolName === tool.name,
-                          );
-                          const pinnedView = pinnedViews.find(
-                            (v) =>
-                              v.connectionId === conn.id &&
-                              v.toolName === tool.name,
-                          );
-                          return (
-                            <div
-                              key={tool.name}
-                              className={cn(
-                                "flex items-center justify-between gap-3 px-3 py-2 rounded-lg border transition-colors",
-                                pinned
-                                  ? "bg-accent/40 border-border"
-                                  : "bg-transparent border-border",
-                              )}
-                            >
-                              <div className="min-w-0 flex-1 flex items-center gap-2">
-                                <SimpleIconPicker
-                                  value={pinnedView?.icon ?? null}
-                                  onChange={(icon) =>
-                                    handleIconChange(conn.id, tool.name, icon)
-                                  }
-                                  disabled={!pinned}
-                                />
-                                <Input
-                                  value={
-                                    pinned && pinnedView
-                                      ? pinnedView.label
-                                      : (tool.title ?? toTitleCase(tool.name))
-                                  }
-                                  onChange={(e) =>
-                                    handleLabelChange(
-                                      conn.id,
-                                      tool.name,
-                                      e.target.value,
-                                    )
-                                  }
-                                  onBlur={handleLabelBlur}
-                                  className="h-7 text-sm w-40"
-                                  disabled={!pinned}
-                                  readOnly={!pinned}
-                                />
-                              </div>
-                              <Switch
-                                checked={pinned}
-                                onCheckedChange={() =>
-                                  handleTogglePin(conn.id, tool.name)
-                                }
-                              />
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </CardContent>
-          </>
-        )}
-      </Card>
-    </div>
-  );
+  return {
+    /** Every view this project can open, in sidebar order. */
+    projectViews: availableSidebarViews,
+    labels: sidebarViewLabels,
+    pinned: (viewId: ProjectSidebarViewId) => sidebarViews.includes(viewId),
+    isMainView: (value: string) => defaultMainView === value,
+    defaultMainView,
+    defaultMainOptions,
+    noMainView,
+    chatDefaultOpen,
+    connectionsData,
+    pinnedAppViews: pinnedViews,
+    openView,
+    togglePin: (viewId: ProjectSidebarViewId, next: boolean) =>
+      handleSidebarViewChange(viewId, next),
+    setMainView: handleDefaultMainViewChange,
+    setChatDefaultOpen: (checked: boolean) => {
+      writeLayout({ chatDefaultOpen: checked });
+      flushAndSave();
+    },
+    toggleAppViewPin: handleTogglePin,
+    setAppViewIcon: handleIconChange,
+    setAppViewLabel: handleLabelChange,
+    commitAppViewLabel: handleLabelBlur,
+  };
 }

--- a/apps/web/src/views/virtual-mcp/settings/use-settings-section.ts
+++ b/apps/web/src/views/virtual-mcp/settings/use-settings-section.ts
@@ -1,0 +1,39 @@
+/**
+ * The open settings section, as a URL parameter.
+ *
+ * `?section=` is the settings panel's payload, the same way `?main=content` is
+ * the Site Editor's (see `panel-route.ts`) — WHICH view is the segment, and the
+ * place inside it is search. It is registered in `PANEL_PAYLOAD_KEYS`, so
+ * switching to any other view clears it; opening Settings from the sidebar
+ * therefore always lands on the index.
+ *
+ * Drilling in is a real navigation (not `replace`), so Back returns to the
+ * index instead of leaving the panel.
+ */
+
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import {
+  isProjectSettingsSectionKey,
+  type ProjectSettingsSectionKey,
+} from "./sections";
+
+export function useProjectSettingsSection(): {
+  section: ProjectSettingsSectionKey | null;
+  openSection: (section: ProjectSettingsSectionKey | null) => void;
+} {
+  const navigate = useNavigate();
+  const raw = (useSearch({ strict: false }) as { section?: string }).section;
+  const section = isProjectSettingsSectionKey(raw) ? raw : null;
+
+  return {
+    section,
+    openSection: (next) =>
+      navigate({
+        to: ".",
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          section: next ?? undefined,
+        }),
+      }),
+  };
+}

--- a/apps/web/src/views/virtual-mcp/settings/view-row-actions.tsx
+++ b/apps/web/src/views/virtual-mcp/settings/view-row-actions.tsx
@@ -1,0 +1,130 @@
+/**
+ * The two presentational bits both view lists share: a view's glyph, and the
+ * row's trailing controls (pin state + menu).
+ */
+
+import {
+  ArrowUpRight,
+  BarChartSquare02,
+  CheckDone01,
+  Columns03,
+  DotsVertical,
+  Globe02,
+  Home02,
+  Image01,
+  Lightning01,
+  Monitor01,
+  Pin01,
+  Server01,
+} from "@untitledui/icons";
+import { Button } from "@decocms/ui/components/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@decocms/ui/components/dropdown-menu.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@decocms/ui/components/tooltip.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { useT } from "@/i18n/use-t.ts";
+import type { ProjectSidebarViewId } from "@/layouts/main-panel-tabs/project-sidebar-views";
+
+export function SidebarViewIcon({ viewId }: { viewId: ProjectSidebarViewId }) {
+  if (viewId === "overview") return <Home02 size={16} />;
+  if (viewId === "reports") return <BarChartSquare02 size={16} />;
+  if (viewId === "board") return <Columns03 size={16} />;
+  if (viewId === "site-editor") return <Monitor01 size={16} />;
+  if (viewId === "assets") return <Image01 size={16} />;
+  if (viewId === "hosting") return <Server01 size={16} />;
+  if (viewId === "e2e") return <CheckDone01 size={16} />;
+  if (viewId === "analytics") return <BarChartSquare02 size={16} />;
+  if (viewId === "cdn") return <Globe02 size={16} />;
+  return <Lightning01 size={16} />;
+}
+
+/**
+ * A view's row actions: the pin state as a glyph, and the menu that changes it.
+ *
+ * Pinning used to be a switch, which made the sidebar the only way IN to a
+ * view — turn it off and the view was unreachable. Opening is the row itself
+ * now, so the sidebar is a shortcut you grant, not the door.
+ */
+export function ViewRowActions({
+  pinned,
+  canSetMainView,
+  onOpen,
+  onTogglePin,
+  onSetMainView,
+}: {
+  pinned: boolean;
+  canSetMainView: boolean;
+  onOpen: () => void;
+  onTogglePin: () => void;
+  onSetMainView: () => void;
+}) {
+  const t = useT();
+  return (
+    <div className="flex items-center gap-1">
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn(
+              "size-7",
+              pinned ? "text-foreground" : "text-muted-foreground/40",
+            )}
+            aria-label={
+              pinned
+                ? t("virtualMcp.settings.views.unpin")
+                : t("virtualMcp.settings.views.pin")
+            }
+            aria-pressed={pinned}
+            onClick={onTogglePin}
+          >
+            <Pin01 size={16} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          {pinned
+            ? t("virtualMcp.settings.views.unpin")
+            : t("virtualMcp.settings.views.pin")}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7 text-muted-foreground"
+            aria-label={t("virtualMcp.settings.views.rowActions")}
+          >
+            <DotsVertical size={16} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={onOpen}>
+            <ArrowUpRight size={14} />
+            {t("virtualMcp.settings.views.open")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={onTogglePin}>
+            <Pin01 size={14} />
+            {pinned
+              ? t("virtualMcp.settings.views.unpin")
+              : t("virtualMcp.settings.views.pin")}
+          </DropdownMenuItem>
+          {canSetMainView && (
+            <DropdownMenuItem onClick={onSetMainView}>
+              <Home02 size={14} />
+              {t("virtualMcp.settings.views.setMainView")}
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/apps/web/src/views/virtual-mcp/settings/views-section.tsx
+++ b/apps/web/src/views/virtual-mcp/settings/views-section.tsx
@@ -1,0 +1,221 @@
+/**
+ * The Views card on the settings index: every view this project can open, in
+ * sidebar order, plus the two settings that say where it lands.
+ *
+ * One card, not one per source: a view from a connected app is the same kind of
+ * thing as a native one, so the app's rows sit under a labelled divider inside
+ * the same list instead of in a section of their own.
+ *
+ * State and writers come from `useProjectViews`, called once by the settings
+ * view — this file only renders.
+ */
+
+import { IntegrationIcon } from "@/components/integration-icon.tsx";
+import { toTitleCase } from "@/components/chat/message/parts/tool-call-part/utils";
+import { useT } from "@/i18n/use-t.ts";
+import { formatPinnedViewTabId } from "@/layouts/main-panel-tabs/tab-id";
+import { Input } from "@decocms/ui/components/input.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@decocms/ui/components/select.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@decocms/ui/components/tooltip.tsx";
+import { ChevronRight, Lightning01 } from "@untitledui/icons";
+import { SimpleIconPicker } from "@/components/simple-icon-picker";
+import {
+  SettingsCard,
+  SettingsCardItem,
+  SettingsSection,
+} from "@/components/settings/settings-section";
+import { SidebarViewIcon, ViewRowActions } from "./view-row-actions";
+import type { ProjectViews } from "./use-project-views";
+
+/** Clicking a control inside a row must not also open the row's view. */
+const stopRowClick = (event: { stopPropagation: () => void }) =>
+  event.stopPropagation();
+
+/** The row that names the app a group of views comes from. */
+function AppHeaderRow({ icon, title }: { icon: string | null; title: string }) {
+  return (
+    <div className="flex items-center gap-2 px-4 py-2.5 bg-muted/30">
+      <IntegrationIcon
+        icon={icon}
+        name={title}
+        size="xs"
+        className="shrink-0"
+      />
+      <span className="text-xs text-muted-foreground">{title}</span>
+    </div>
+  );
+}
+
+export function ProjectViewsSection({ views }: { views: ProjectViews }) {
+  const t = useT();
+  return (
+    <SettingsSection title={t("virtualMcp.settings.views.projectViews")}>
+      <SettingsCard>
+        {views.projectViews.map((viewId) => {
+          const pinned = views.pinned(viewId);
+          return (
+            <SettingsCardItem
+              key={viewId}
+              icon={<SidebarViewIcon viewId={viewId} />}
+              title={views.labels[viewId]}
+              onClick={() => views.openView(viewId)}
+              action={
+                <div className="flex items-center gap-1">
+                  <ViewRowActions
+                    pinned={pinned}
+                    canSetMainView={pinned && !views.isMainView(viewId)}
+                    onOpen={() => views.openView(viewId)}
+                    onTogglePin={() => views.togglePin(viewId, !pinned)}
+                    onSetMainView={() => views.setMainView(viewId)}
+                  />
+                  <span
+                    onClick={() => views.openView(viewId)}
+                    className="flex cursor-pointer items-center text-muted-foreground"
+                  >
+                    <ChevronRight size={16} />
+                  </span>
+                </div>
+              }
+            />
+          );
+        })}
+
+        {/** App views, each group behind the divider that names its app. */}
+        {views.connectionsData.flatMap((conn) => [
+          <AppHeaderRow
+            key={`${conn.id}:header`}
+            icon={conn.icon}
+            title={conn.title}
+          />,
+          ...conn.uiTools.map((tool) => {
+            const pinnedView = views.pinnedAppViews.find(
+              (v) => v.connectionId === conn.id && v.toolName === tool.name,
+            );
+            const pinned = !!pinnedView;
+            const tabId = formatPinnedViewTabId(conn.id, tool.name);
+            const mainViewValue = `ext-apps:${conn.id}:${tool.name}`;
+            return (
+              <SettingsCardItem
+                key={`${conn.id}:${tool.name}`}
+                onClick={() => views.openView(tabId)}
+                icon={
+                  pinned ? (
+                    // A control, not the row: it must not also open.
+                    <span onClick={stopRowClick}>
+                      <SimpleIconPicker
+                        value={pinnedView.icon ?? null}
+                        onChange={(icon) =>
+                          views.setAppViewIcon(conn.id, tool.name, icon)
+                        }
+                      />
+                    </span>
+                  ) : (
+                    <Lightning01 size={16} />
+                  )
+                }
+                title={
+                  pinned ? (
+                    <span onClick={stopRowClick}>
+                      <Input
+                        value={pinnedView.label}
+                        onChange={(e) =>
+                          views.setAppViewLabel(
+                            conn.id,
+                            tool.name,
+                            e.target.value,
+                          )
+                        }
+                        onBlur={views.commitAppViewLabel}
+                        className="h-7 w-52 text-sm"
+                      />
+                    </span>
+                  ) : (
+                    (tool.title ?? toTitleCase(tool.name))
+                  )
+                }
+                action={
+                  <div className="flex items-center gap-1">
+                    <ViewRowActions
+                      pinned={pinned}
+                      canSetMainView={
+                        pinned && !views.isMainView(mainViewValue)
+                      }
+                      onOpen={() => views.openView(tabId)}
+                      onTogglePin={() =>
+                        views.toggleAppViewPin(conn.id, tool.name)
+                      }
+                      onSetMainView={() => views.setMainView(mainViewValue)}
+                    />
+                    <span
+                      onClick={() => views.openView(tabId)}
+                      className="flex cursor-pointer items-center text-muted-foreground"
+                    >
+                      <ChevronRight size={16} />
+                    </span>
+                  </div>
+                }
+              />
+            );
+          }),
+        ])}
+
+        <SettingsCardItem
+          title={t("virtualMcp.layoutTabContent.mainView")}
+          description={t("virtualMcp.layoutTabContent.mainViewDescription")}
+          action={
+            <Select
+              value={views.defaultMainView}
+              onValueChange={views.setMainView}
+            >
+              <SelectTrigger className="w-44 h-8 text-sm shrink-0">
+                <SelectValue
+                  placeholder={t("virtualMcp.layoutTabContent.noMainView")}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {views.defaultMainOptions.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          }
+        />
+        <SettingsCardItem
+          title={t("virtualMcp.layoutTabContent.showChat")}
+          description={t("virtualMcp.layoutTabContent.showChatDescription")}
+          action={
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <span className="shrink-0">
+                  <Switch
+                    checked={views.noMainView ? true : views.chatDefaultOpen}
+                    disabled={views.noMainView}
+                    onCheckedChange={views.setChatDefaultOpen}
+                  />
+                </span>
+              </TooltipTrigger>
+              {views.noMainView && (
+                <TooltipContent side="top">
+                  {t("virtualMcp.layoutTabContent.chatAlwaysShown")}
+                </TooltipContent>
+              )}
+            </Tooltip>
+          }
+        />
+      </SettingsCard>
+    </SettingsSection>
+  );
+}


### PR DESCRIPTION
## What

Project settings was one long page — instructions, connections, sandbox, CMS and the views list in a single scroll — and pinning a view to the sidebar was the only way to reach it at all.

It is now an **index of rows**, each drilling into one section, built on the org settings kit (`components/settings/settings-section.tsx`) so project settings and `/settings` are the same screen twice:

- **General** — instructions, attached files, sub-projects
- **Connections**
- **Site and sandbox** — CMS, Preview and Sandbox as cards of hairline-separated rows instead of three field stacks in one box

The open section lives in `?section=`, a new `PanelPayload` key (so it survives a reload and a tab restore).

**Views** is one card listing every view the project can open, in sidebar order: the native ones (Home, Reports, Tasks, Site editor, Assets, Hosting, E2E, Deco Analytics, Monitor, Automations) and the ones a connected MCP app brings, the latter behind a divider naming their app. Clicking a row opens the view, which changes what the pin means: it is a shortcut you grant, not the door. So it is a pin icon plus a row menu (open / pin / set as main view) rather than a switch that hid the view when off.

`views/virtual-mcp/layout-tab-content.tsx` is deleted. Its state moved to `settings/use-project-views.ts` — called **once** by the settings view, since two copies would each stage their own optimistic sidebar revision — and its markup to the dumb renderers beside it.

## Screenshots

**The index** — three drill-in rows, then the Views card.

<img width="1456" height="833" alt="Settings index" src="https://github.com/user-attachments/assets/f078bcc8-3404-4da2-a8e3-6a280f7cdea5" />

**The rest of the Views card** — the site's surfaces are ordinary rows now, the app's views sit behind a divider naming the app, and where the project lands closes the list.

<img width="1456" height="833" alt="Views card with app views" src="https://github.com/user-attachments/assets/d3306fdd-175d-49c5-abe9-6bd92f07e7ac" />

**Site and sandbox** — CMS, Preview and Sandbox, each a card of rows.

<img width="1456" height="833" alt="Site and sandbox" src="https://github.com/user-attachments/assets/24293a75-66c3-43a8-8701-10173641e598" />

**General** — breadcrumb back to the index, same as a task page.

<img width="1456" height="833" alt="General" src="https://github.com/user-attachments/assets/fb82bd8f-b3ea-4b24-becf-33d4f7f6236f" />

The app views in the shots come from a local MCP server built as a dev fixture (not in this PR) — three of its tools carry a `ui://` resource, one deliberately does not, so the list proves it only picks up the tools that have a view.

## Notes

- `SettingsCardRow` is new in the settings kit: a card row for content that already owns its label, description and control (the `*Field` components bound to the form). No field component changed.
- The in-place-render row is now gated by the parent on `metadata.fastPreview` as well as inside the component — otherwise `SettingsCard` drew a hairline for an empty row.
- Dead code removed in the same pass: the `siteView.*` and `views.appViews*` i18n keys (both languages), the already-orphaned `layoutTabContent.sidebarViews*`, `noInteractiveTools`, and the `trailing` slot on `ProjectSettingsRowDef`.
- No `apps/api` changes.

## Testing

- `bun run --cwd apps/web check`, `bun run lint` (0 errors), `bun test apps/web/src/views/virtual-mcp` (7 pass) — plus a new `sections.test.ts` covering the section registry and the `?section=` payload key.
- Walked it locally against a seeded project: every drill-in row, the chevron, the pin/menu on native and app views, and an MCP app view opening and rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
