### PR TITLE
feat(content-sidebar): group advanced collections under an "Advanced" dropdown

### DIFF
--- a/apps/web/src/components/sandbox/content/collections-sidebar.tsx
+++ b/apps/web/src/components/sandbox/content/collections-sidebar.tsx
@@ -2,6 +2,7 @@ import {
   BookOpen01,
   Calendar,
   CalendarDate,
+  ChevronDown,
   CornerUpRight,
   Database01,
   File02,
@@ -9,14 +10,23 @@ import {
   Grid01,
   LayoutAlt01,
   Settings01,
+  Sliders02,
   Tag01,
   CreditCardSearch,
   Users01,
   Zap,
 } from "@untitledui/icons";
+import { useState } from "react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@decocms/ui/components/collapsible.tsx";
 import { cn } from "@decocms/ui/lib/utils.ts";
 import { useT } from "@/i18n/use-t.ts";
 import type { CollectionCounts, CollectionId } from "./content-browser";
+
+const ADVANCED_IDS = ["sections", "apps", "loaders", "actions"] as const;
 
 export function CollectionsSidebar({
   active,
@@ -47,22 +57,6 @@ export function CollectionsSidebar({
           onSelect={onSelect}
         />
         <CollectionRow
-          id="sections"
-          icon={Globe02}
-          label={t("sandbox.collectionsSidebar.sections")}
-          count={counts.sections}
-          active={active === "sections"}
-          onSelect={onSelect}
-        />
-        <CollectionRow
-          id="apps"
-          icon={Grid01}
-          label={t("sandbox.collectionsSidebar.apps")}
-          count={counts.apps}
-          active={active === "apps"}
-          onSelect={onSelect}
-        />
-        <CollectionRow
           id="redirects"
           icon={CornerUpRight}
           label={t("sandbox.collectionsSidebar.redirects")}
@@ -70,22 +64,7 @@ export function CollectionsSidebar({
           active={active === "redirects"}
           onSelect={onSelect}
         />
-        <CollectionRow
-          id="loaders"
-          icon={Database01}
-          label={t("sandbox.collectionsSidebar.loaders")}
-          count={counts.loaders}
-          active={active === "loaders"}
-          onSelect={onSelect}
-        />
-        <CollectionRow
-          id="actions"
-          icon={Zap}
-          label={t("sandbox.collectionsSidebar.actions")}
-          count={counts.actions}
-          active={active === "actions"}
-          onSelect={onSelect}
-        />
+        <AdvancedGroup active={active} counts={counts} onSelect={onSelect} />
         <CollectionRow
           id="site"
           icon={Settings01}
@@ -151,6 +130,82 @@ export function CollectionsSidebar({
   );
 }
 
+function AdvancedGroup({
+  active,
+  counts,
+  onSelect,
+}: {
+  active: CollectionId;
+  counts: CollectionCounts;
+  onSelect: (id: CollectionId) => void;
+}) {
+  const t = useT();
+  const activeIsAdvanced = (ADVANCED_IDS as readonly string[]).includes(active);
+  const [userOpen, setUserOpen] = useState(false);
+  // Stay open while an item inside is active, so the active row is never hidden.
+  const open = userOpen || activeIsAdvanced;
+  return (
+    <Collapsible open={open} onOpenChange={setUserOpen}>
+      <CollapsibleTrigger
+        className={cn(
+          "flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors cursor-pointer",
+          "text-muted-foreground hover:bg-muted hover:text-foreground",
+        )}
+      >
+        <Sliders02 size={16} className="shrink-0" />
+        <span className="flex-1 truncate">
+          {t("sandbox.collectionsSidebar.advanced")}
+        </span>
+        <ChevronDown
+          size={16}
+          className={cn(
+            "shrink-0 text-muted-foreground/70 transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="flex flex-col gap-0.5 pt-0.5">
+        <CollectionRow
+          id="sections"
+          icon={Globe02}
+          label={t("sandbox.collectionsSidebar.sections")}
+          count={counts.sections}
+          active={active === "sections"}
+          onSelect={onSelect}
+          indent
+        />
+        <CollectionRow
+          id="apps"
+          icon={Grid01}
+          label={t("sandbox.collectionsSidebar.apps")}
+          count={counts.apps}
+          active={active === "apps"}
+          onSelect={onSelect}
+          indent
+        />
+        <CollectionRow
+          id="loaders"
+          icon={Database01}
+          label={t("sandbox.collectionsSidebar.loaders")}
+          count={counts.loaders}
+          active={active === "loaders"}
+          onSelect={onSelect}
+          indent
+        />
+        <CollectionRow
+          id="actions"
+          icon={Zap}
+          label={t("sandbox.collectionsSidebar.actions")}
+          count={counts.actions}
+          active={active === "actions"}
+          onSelect={onSelect}
+          indent
+        />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
 function CollectionRow({
   id,
   icon: Icon,
@@ -158,6 +213,7 @@ function CollectionRow({
   count,
   active,
   onSelect,
+  indent,
 }: {
   id: CollectionId;
   icon: React.ComponentType<{ size?: number; className?: string }>;
@@ -165,6 +221,7 @@ function CollectionRow({
   count?: number;
   active: boolean;
   onSelect: (id: CollectionId) => void;
+  indent?: boolean;
 }) {
   return (
     <button
@@ -172,6 +229,7 @@ function CollectionRow({
       onClick={() => onSelect(id)}
       className={cn(
         "flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors cursor-pointer",
+        indent && "pl-6",
         active
           ? "bg-accent text-accent-foreground"
           : "text-muted-foreground hover:bg-muted hover:text-foreground",

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -81,6 +81,7 @@ export const sandbox = {
   "sandbox.categoryEditor.untitledCategory": "Untitled category",
   "sandbox.categoryEditor.untitledPost": "Untitled post",
   "sandbox.collectionsSidebar.actions": "Actions",
+  "sandbox.collectionsSidebar.advanced": "Advanced",
   "sandbox.collectionsSidebar.apps": "Apps",
   "sandbox.collectionsSidebar.authors": "Authors",
   "sandbox.collectionsSidebar.blog": "Blog",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -86,6 +86,7 @@ export const sandbox = {
   "sandbox.categoryEditor.untitledCategory": "Categoria sem título",
   "sandbox.categoryEditor.untitledPost": "Post sem título",
   "sandbox.collectionsSidebar.actions": "Ações",
+  "sandbox.collectionsSidebar.advanced": "Avançado",
   "sandbox.collectionsSidebar.apps": "Apps",
   "sandbox.collectionsSidebar.authors": "Autores",
   "sandbox.collectionsSidebar.blog": "Blog",


### PR DESCRIPTION
## Summary

Groups **Sections, Apps, Loaders, and Actions** into a collapsible **"Advanced"** dropdown in the Content sidebar, decluttering the top level.

New order: Pages → Redirects → **Advanced ▸** (Sections, Apps, Loaders, Actions) → Site → SEO → Calendar → Blog.

## Behavior

- The dropdown is **closed by default**.
- It **auto-opens when one of its items is the active collection** (`open = userOpen || activeIsAdvanced`), so the active row is never hidden — no `useEffect` needed. Users can also toggle it manually.
- Built on the shared `Collapsible` UI primitive, with a `Sliders02` icon and a chevron that rotates when open.
- Inner rows reuse `CollectionRow` with a new optional `indent` prop for nesting; counts and active state are unchanged.

## i18n

Added `sandbox.collectionsSidebar.advanced` to `en` ("Advanced") and `pt-br` ("Avançado").

## Testing

- `bun run fmt` — clean
- `bun run --cwd=apps/web check` — tsc passes
- `bun run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups Sections, Apps, Loaders, and Actions under a collapsible "Advanced" dropdown in the Content sidebar, decluttering the top level. The dropdown is closed by default and auto-opens when one of its items is the active collection, so the active row is never hidden; users can also toggle it manually.

- New sidebar order: Pages → Redirects → Advanced (Sections, Apps, Loaders, Actions) → Site → SEO → Calendar → Blog.
- Built on the shared `Collapsible` primitive with a `Sliders02` icon and a chevron that rotates when open.
- `CollectionRow` gains an optional `indent` prop for nested rows; counts and active state are unchanged.
- Adds `sandbox.collectionsSidebar.advanced` translations for English ("Advanced") and Brazilian Portuguese ("Avançado").

<sup>Written for commit f64d73bd6fffc8092c21600f86382bac641d9522. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

