### PR TITLE
fix(settings): batch the coding-agent MCP picker behind one Save

### DIFF
--- a/apps/web/src/components/settings/review-settings.tsx
+++ b/apps/web/src/components/settings/review-settings.tsx
@@ -1,4 +1,6 @@
 import { toast } from "sonner";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import { Switch } from "@decocms/ui/components/switch.tsx";
 import {
   Coins01,
@@ -7,6 +9,7 @@ import {
   GitBranch01,
   GitMerge,
   Rocket01,
+  SearchLg,
   Terminal,
   UserSquare,
 } from "@untitledui/icons";
@@ -22,9 +25,9 @@ import {
   useSetCodingAgentExcludedMcps,
   useSetOrgFlag,
 } from "@/hooks/use-organization-settings";
-import { useConnections } from "@/sdk";
+import { useConnections, useProjectContext, WellKnownOrgMCPId } from "@/sdk";
 import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import type { OrgFlags } from "@decocms/shared/organization/schema";
 import { useT } from "@/i18n/use-t.ts";
 import type { TranslationKey } from "@/i18n/use-t.ts";
@@ -132,56 +135,217 @@ function OrgMcpExclusionsFallback() {
   );
 }
 
+/** Stable identity for a saved id list, so a re-seed can compare by CONTENT.
+ *  The hook returns a fresh `[]` when the setting is unset — comparing by
+ *  reference would re-seed the draft on every render and discard every edit. */
+function idsKey(ids: readonly string[]): string {
+  return [...ids].sort().join("\u0000");
+}
+
+/**
+ * The connections Studio owns rather than the user. Mirrors
+ * `isStudioOwnedConnection` on the dispatch side, which drops them from a run's
+ * `orgMcps` whatever this list says — so a switch for one would be a control
+ * that provably does nothing.
+ */
+function isStudioOwned(orgId: string, connectionId: string): boolean {
+  return [
+    WellKnownOrgMCPId.SELF,
+    WellKnownOrgMCPId.REGISTRY,
+    WellKnownOrgMCPId.COMMUNITY_REGISTRY,
+    WellKnownOrgMCPId.DEV_ASSETS,
+    WellKnownOrgMCPId.COMMERCE_DISCOVERY,
+  ].some((id) => id(orgId) === connectionId);
+}
+
 function OrgMcpExclusionList() {
   const t = useT();
+  const { org } = useProjectContext();
   const connections = useConnections();
-  const excluded = useCodingAgentExcludedMcps();
+  const saved = useCodingAgentExcludedMcps();
   const setExcluded = useSetCodingAgentExcludedMcps();
-  const excludedSet = new Set(excluded);
 
-  const toggle = (id: string, available: boolean) => {
-    const next = available
-      ? excluded.filter((x) => x !== id)
-      : [...new Set([...excluded, id])];
-    setExcluded.mutate(next, {
-      onError: () => toast.error(t("settings.agentTools.orgMcpsPickFailed")),
-    });
+  // Edits are local until Save. One write instead of one per switch: the
+  // mutation invalidates the settings query, so a per-row toggle re-fetched
+  // and re-rendered the whole list under the cursor on every click.
+  const [draft, setDraft] = useState<string[]>(saved);
+  const [syncedWith, setSyncedWith] = useState(idsKey(saved));
+  const [query, setQuery] = useState("");
+  const savedKey = idsKey(saved);
+  if (syncedWith !== savedKey) {
+    setSyncedWith(savedKey);
+    setDraft(saved);
+  }
+
+  const mountable = connections.filter(
+    (connection) => !isStudioOwned(org.id, connection.id),
+  );
+  const needle = query.trim().toLowerCase();
+  const visible = needle
+    ? mountable.filter((connection) =>
+        `${connection.title} ${connection.slug ?? ""}`
+          .toLowerCase()
+          .includes(needle),
+      )
+    : mountable;
+
+  const draftSet = new Set(draft);
+  // Only the ids that still exist: a connection deleted since this was saved
+  // would otherwise sit in the list forever and count as a pending change.
+  const dirty =
+    idsKey(draft.filter((id) => mountable.some((c) => c.id === id))) !==
+    savedKey;
+  const allVisibleOn =
+    visible.length > 0 && visible.every((c) => !draftSet.has(c.id));
+
+  const setAvailable = (ids: readonly string[], available: boolean) => {
+    const touched = new Set(ids);
+    setDraft(
+      available
+        ? draft.filter((id) => !touched.has(id))
+        : [...new Set([...draft, ...ids])],
+    );
   };
+
+  const save = () =>
+    setExcluded.mutate(
+      // Prune ids whose connection is gone, so saving also tidies the list.
+      draft.filter((id) => mountable.some((c) => c.id === id)),
+      {
+        onSuccess: () =>
+          toast.success(t("settings.agentTools.orgMcpsPickSaved")),
+        onError: () => toast.error(t("settings.agentTools.orgMcpsPickFailed")),
+      },
+    );
 
   return (
     <SettingsCardItem
       title={t("settings.agentTools.orgMcpsPickTitle")}
       description={t("settings.agentTools.orgMcpsPickDescription")}
     >
-      <div className="mt-3 flex w-full flex-col divide-y divide-border rounded-xl border border-border">
-        {connections.length === 0 ? (
-          <p className="p-3 text-xs text-muted-foreground">
-            {t("settings.agentTools.orgMcpsPickEmpty")}
-          </p>
-        ) : (
-          connections.map((connection) => {
-            const available = !excludedSet.has(connection.id);
-            const label = connection.title || connection.id;
-            return (
-              <div
-                key={connection.id}
-                className="flex items-center justify-between gap-3 p-3"
-              >
-                <span className="min-w-0 truncate text-sm">{label}</span>
-                <Switch
-                  checked={available}
-                  disabled={setExcluded.isPending}
-                  aria-label={t("settings.agentTools.orgMcpsPickAriaLabel", {
-                    name: label,
-                  })}
-                  onCheckedChange={(checked) => toggle(connection.id, checked)}
-                />
-              </div>
-            );
-          })
-        )}
+      <div className="mt-3 flex w-full flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1">
+            <SearchLg
+              size={14}
+              className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={t("settings.agentTools.orgMcpsPickSearch")}
+              aria-label={t("settings.agentTools.orgMcpsPickSearch")}
+              className="h-8 pl-8 text-xs"
+            />
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            disabled={visible.length === 0}
+            onClick={() =>
+              setAvailable(
+                visible.map((c) => c.id),
+                !allVisibleOn,
+              )
+            }
+          >
+            {allVisibleOn
+              ? t("settings.agentTools.orgMcpsPickDisableAll")
+              : t("settings.agentTools.orgMcpsPickEnableAll")}
+          </Button>
+        </div>
+
+        <div className="max-h-64 overflow-y-auto rounded-xl border border-border divide-y divide-border">
+          {mountable.length === 0 ? (
+            <p className="p-3 text-xs text-muted-foreground">
+              {t("settings.agentTools.orgMcpsPickEmpty")}
+            </p>
+          ) : visible.length === 0 ? (
+            <p className="p-3 text-xs text-muted-foreground">
+              {t("settings.agentTools.orgMcpsPickNoMatch")}
+            </p>
+          ) : (
+            visible.map((connection) => {
+              const label = connection.title || connection.id;
+              return (
+                <div
+                  key={connection.id}
+                  className="flex items-center justify-between gap-3 px-3 py-2"
+                >
+                  <div className="flex min-w-0 items-center gap-2.5">
+                    <McpAvatar icon={connection.icon} title={label} />
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate text-sm leading-tight">
+                        {label}
+                      </span>
+                      {connection.slug && (
+                        <span className="truncate text-xs text-muted-foreground">
+                          {connection.slug}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <Switch
+                    checked={!draftSet.has(connection.id)}
+                    aria-label={t("settings.agentTools.orgMcpsPickAriaLabel", {
+                      name: label,
+                    })}
+                    onCheckedChange={(checked) =>
+                      setAvailable([connection.id], checked)
+                    }
+                  />
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            disabled={!dirty || setExcluded.isPending}
+            onClick={save}
+          >
+            {setExcluded.isPending
+              ? t("settings.agentTools.orgMcpsPickSaving")
+              : t("settings.agentTools.orgMcpsPickSave")}
+          </Button>
+          {dirty && (
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={setExcluded.isPending}
+              onClick={() => setDraft(saved)}
+            >
+              {t("settings.agentTools.orgMcpsPickDiscard")}
+            </Button>
+          )}
+        </div>
       </div>
     </SettingsCardItem>
+  );
+}
+
+/** Small square avatar for a connection, falling back to its initial. */
+function McpAvatar({ icon, title }: { icon: string | null; title: string }) {
+  const [failed, setFailed] = useState(false);
+  return (
+    <div className="flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-muted/20">
+      {icon && !failed ? (
+        <img
+          src={icon}
+          alt=""
+          loading="lazy"
+          className="h-full w-full object-cover"
+          onError={() => setFailed(true)}
+        />
+      ) : (
+        <span className="text-[10px] font-semibold text-muted-foreground">
+          {title.charAt(0).toUpperCase()}
+        </span>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -639,6 +639,15 @@ export const settings = {
     "This organization has no MCP connections yet",
   "settings.agentTools.orgMcpsPickFailed":
     "Could not save which connections runs can reach",
+  "settings.agentTools.orgMcpsPickSearch": "Search connections\u2026",
+  "settings.agentTools.orgMcpsPickEnableAll": "Enable all",
+  "settings.agentTools.orgMcpsPickDisableAll": "Disable all",
+  "settings.agentTools.orgMcpsPickNoMatch": "No connection matches that search",
+  "settings.agentTools.orgMcpsPickSave": "Save",
+  "settings.agentTools.orgMcpsPickSaving": "Saving\u2026",
+  "settings.agentTools.orgMcpsPickDiscard": "Discard",
+  "settings.agentTools.orgMcpsPickSaved":
+    "Saved which connections runs can reach",
   "settings.agentTools.codingAgentsClaudeCodeTitle":
     "Run Code Agent chats with Claude Code",
   "settings.agentTools.codingAgentsClaudeCodeDescription":

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -663,6 +663,16 @@ export const settings = {
     "Esta organiza\u00e7\u00e3o ainda n\u00e3o tem conex\u00f5es MCP",
   "settings.agentTools.orgMcpsPickFailed":
     "N\u00e3o foi poss\u00edvel salvar quais conex\u00f5es os runs alcan\u00e7am",
+  "settings.agentTools.orgMcpsPickSearch": "Buscar conex\u00f5es\u2026",
+  "settings.agentTools.orgMcpsPickEnableAll": "Ligar todas",
+  "settings.agentTools.orgMcpsPickDisableAll": "Desligar todas",
+  "settings.agentTools.orgMcpsPickNoMatch":
+    "Nenhuma conex\u00e3o corresponde a essa busca",
+  "settings.agentTools.orgMcpsPickSave": "Salvar",
+  "settings.agentTools.orgMcpsPickSaving": "Salvando\u2026",
+  "settings.agentTools.orgMcpsPickDiscard": "Descartar",
+  "settings.agentTools.orgMcpsPickSaved":
+    "Conex\u00f5es que os runs alcan\u00e7am salvas",
   "settings.agentTools.codingAgentsClaudeCodeTitle":
     "Rodar chats de Code Agent com o Claude Code",
   "settings.agentTools.codingAgentsClaudeCodeDescription":


### PR DESCRIPTION
The picker shipped in #7140 wrote on **every switch**. Each write invalidates the org-settings query, so the list re-fetched and re-rendered under the cursor on every click — and because each row was a full-width settings row, a couple dozen connections pushed the rest of the page off screen.

Edits are local now and commit on one **Save**.

## What it looks like

![Clean state](https://raw.githubusercontent.com/decocms/studio/ad3b0f890a87bccc11273c36590a09f9d3ded286/clean.png)

Dirty — Save enables and a Discard appears beside it:

![Dirty state](https://raw.githubusercontent.com/decocms/studio/ad3b0f890a87bccc11273c36590a09f9d3ded286/dirty.png)

Search, with enable/disable-all scoped to what's filtered:

![Search](https://raw.githubusercontent.com/decocms/studio/ad3b0f890a87bccc11273c36590a09f9d3ded286/search.png)

## Changes

- **One write.** Toggles mutate local draft state; Save issues the single `ORGANIZATION_SETTINGS_UPDATE`.
- **A scrolling box** (14 rows in 254px) instead of N page-height rows.
- **The connection's own icon**, falling back to its initial.
- **Search** over title and slug.
- **Enable/disable-all over the FILTERED set**, so it composes with the search instead of fighting it — the button label reads the visible rows' state.
- **Save disabled until dirty**, Discard only once it is.

## Two correctness details

Both are about the connection list moving under a stored id list:

- **The draft re-seeds by comparing saved ids by content, not reference.** `useCodingAgentExcludedMcps` returns a fresh `[]` when the setting is unset, so a reference compare re-seeded the draft on every render and discarded every edit. This one would have shipped as "the switches don't move".
- **Ids whose connection no longer exists are pruned on save** and excluded from the dirty check, so a deleted connection can neither sit in the stored list forever nor show a pending change that cannot be cleared.

Studio's own connections (`_self`, the two registries, dev-assets, commerce discovery) are dropped from the list. `isStudioOwnedConnection` already drops them at dispatch whatever this setting says, so a switch for one was a control that provably did nothing.

## Testing

Driven with Playwright against a local org seeded with 14 connections:

| | |
|---|---|
| clean | Save disabled, no Discard |
| 3 toggles | **0** non-GET requests |
| Save | exactly **1** request, Save disabled again |
| after reload | the 2 switched off read off, an untouched one reads on |
| stored value | exactly the 2 excluded ids |

`bun run check`, `lint` (0 errors), `fmt`, `knip` clean. No `useEffect`/`useMemo`/`useCallback` — the draft re-seed uses the `syncedWith` idiom already used by the Jira automation cards. New copy is in `en` + `pt-br`; the compile-time completeness check caught the missing pt-br half on the first pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the coding-agent MCP picker in org settings so toggles are batched behind a single Save instead of writing on every switch, which previously re-fetched and re-rendered the list under the cursor and pushed the page off screen on large connection sets.

- Adds a scrolling list with connection icons, search over title and slug, and enable/disable-all scoped to the filtered set.
- Disables Save until the draft is dirty and shows a Discard button only then.
- Re-seeds the draft by comparing saved ids by content, not reference, so edits are no longer discarded on re-render.
- Prunes ids whose connection no longer exists on save and excludes them from the dirty check.
- Drops Studio-owned connections from the list since they are already filtered out at dispatch.

<sup>Written for commit a3b7e974e898b32513fe15426764b126d977cbb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

