### PR TITLE
feat(admin): badge archived orgs in deployment-admin list

### DIFF
--- a/apps/api/src/api/routes/admin.ts
+++ b/apps/api/src/api/routes/admin.ts
@@ -28,6 +28,7 @@ import { OrganizationSettingsStorage } from "@/storage/organization-settings";
 import { OrganizationNoticeStorage } from "@/storage/organization-notices";
 import { OrgSiteConflictError, OrgSiteStorage } from "@/storage/org-sites";
 import { OrgNoticeInputSchema } from "@decocms/shared/organization/notice";
+import { isOrgArchived } from "@decocms/shared/organization/org-archived";
 import { invalidateOrgNoticeCache } from "@/core/org-notice-gate";
 import { isValidSiteSlug } from "@decocms/shared/site-slug";
 import {
@@ -320,6 +321,8 @@ export function createAdminRoutes(): Hono<Env> {
         "organization.name as name",
         "organization.slug as slug",
         "organization.createdAt as createdAt",
+        // Soft-delete lives in metadata.archived — surface it to badge the row.
+        "organization.metadata as metadata",
       ])
       .select((eb) => eb.fn.count<string>("member.id").as("memberCount"));
 
@@ -339,6 +342,7 @@ export function createAdminRoutes(): Hono<Env> {
         "organization.name",
         "organization.slug",
         "organization.createdAt",
+        "organization.metadata",
       ])
       .orderBy("organization.createdAt", "desc")
       .limit(limit)
@@ -351,10 +355,11 @@ export function createAdminRoutes(): Hono<Env> {
     );
 
     return c.json({
-      organizations: rows.map((row) => ({
+      organizations: rows.map(({ metadata, ...row }) => ({
         ...row,
         memberCount: Number(row.memberCount || 0),
         notice: notices.get(row.id) ?? null,
+        archived: isOrgArchived({ metadata }),
       })),
     });
   });

--- a/apps/web/src/i18n/en/admin.ts
+++ b/apps/web/src/i18n/en/admin.ts
@@ -9,6 +9,7 @@ export const admin = {
   "admin.layout.restrictedToDashboard":
     "This dashboard is restricted to deployment admins.",
   "admin.layout.usersTab": "Users",
+  "admin.orgs.archived": "Archived",
   "admin.orgs.notice": "Notice",
   "admin.orgs.noticeFor": "Billing notice for {org}",
   "admin.orgs.noticeDescription":

--- a/apps/web/src/i18n/pt-br/admin.ts
+++ b/apps/web/src/i18n/pt-br/admin.ts
@@ -11,6 +11,7 @@ export const admin = {
   "admin.layout.restrictedToDashboard":
     "Este painel é restrito a administradores de implantação.",
   "admin.layout.usersTab": "Usuários",
+  "admin.orgs.archived": "Arquivada",
   "admin.orgs.notice": "Aviso",
   "admin.orgs.noticeFor": "Aviso de cobrança de {org}",
   "admin.orgs.noticeDescription":

--- a/apps/web/src/routes/admin/orgs.tsx
+++ b/apps/web/src/routes/admin/orgs.tsx
@@ -58,6 +58,8 @@ interface DeploymentAdminOrg {
   memberCount: number;
   /** The org's live billing notice, or null — see `organization_notices`. */
   notice: AdminOrgNotice | null;
+  /** True when the org is soft-deleted (`metadata.archived`). */
+  archived: boolean;
 }
 
 interface FlagsResponse {
@@ -1047,8 +1049,15 @@ export default function AdminOrgsPage() {
       header: t("admin.orgs.organization"),
       render: (org) => (
         <div className="min-w-0">
-          <div className="text-sm font-medium text-foreground truncate">
-            {org.name}
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-foreground truncate">
+              {org.name}
+            </span>
+            {org.archived ? (
+              <Badge variant="outline" className="shrink-0">
+                {t("admin.orgs.archived")}
+              </Badge>
+            ) : null}
           </div>
           <div className="text-sm text-muted-foreground truncate">
             {org.slug}


### PR DESCRIPTION
## Summary

The deployment-admin Organizations list (`/_admin/orgs`) was the one surface that showed **soft-deleted (archived) orgs indistinguishable from live ones**. Org deletion is a soft-delete — `ORGANIZATION_DELETE` sets `metadata.archived = true` (no `deleted_at` column) — and every user-facing surface filters archived orgs via `isOrgArchived`, but the admin list's query never selected `metadata` or applied the check.

Per request, this **badges** archived orgs rather than hiding them — an operator wants to see all orgs on this screen, just visually distinguished.

## Changes

- **`apps/api/src/api/routes/admin.ts`** (`GET /api/_admin/orgs`): select `organization.metadata` (+ add to `groupBy`), and return `archived: isOrgArchived({ metadata })` per row. Raw `metadata` is destructured out — only the boolean crosses the wire.
- **`apps/web/src/routes/admin/orgs.tsx`**: `DeploymentAdminOrg.archived: boolean`; render an `Archived` badge next to the org name when set.
- **i18n**: new `admin.orgs.archived` key in `en` ("Archived") and `pt-br` ("Arquivada").

## Testing

- `bun run fmt`, `bun run check` (api + web) pass.
- No new automated test; happy to add an e2e asserting an archived org returns `archived: true` from this endpoint if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Badges soft-deleted (archived) organizations in the deployment-admin org list so they are distinguishable from live ones.

**Changes**
- The admin org API now returns an `archived` boolean derived from `metadata.archived` per organization.
- The admin org list UI shows an "Archived" badge next to the org name when `archived` is true, with translations for English and Brazilian Portuguese.

<sup>Written for commit eb51648ec1ab38bd96c5b38f2b312c9ed795fd08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

