### PR TITLE
fix(jira): take the Jira integration off the board's reactions

### DIFF
--- a/apps/api/src/storage/task-board-advance-review.integration.test.ts
+++ b/apps/api/src/storage/task-board-advance-review.integration.test.ts
@@ -40,11 +40,12 @@ describe("advanceToReviewIfInProgress (real Postgres)", () => {
   let threads: SqlThreadStorage;
 
   /** A card In Progress with one finished, message-carrying run linked. */
-  const cardWithFinishedRun = async (title: string) => {
+  const cardWithFinishedRun = async (title: string, source?: "jira") => {
     const task = await taskBoard.create({
       organizationId: ORG,
       title,
       status: "in_progress",
+      ...(source ? { source } : {}),
       by: USER,
     });
     const thread = await threads.create({
@@ -312,6 +313,48 @@ describe("advanceToReviewIfInProgress (real Postgres)", () => {
     const after = await taskBoard.getById(task.id, ORG);
     expect(after?.status).toBe("in_progress");
     expect(after?.reviewCycleStartedAt).not.toBeNull();
+  });
+
+  /**
+   * A Jira run's anchor is not a card the board manages: advancing it to In
+   * Review is what enqueues a reviewer, and that reviewer rules on a card
+   * nobody reads. Observed doing worse than nothing — it read a pull request
+   * from a PRIOR run of the same issue, requested changes because that one was
+   * closed, and unassigned the agent.
+   */
+  it("never advances an item the board does not manage, PR or not", async () => {
+    const { task, thread } = await cardWithFinishedRun("jira anchor", "jira");
+    await taskBoard.linkPr({
+      taskBoardItemId: task.id,
+      organizationId: ORG,
+      url: "https://github.com/acme/site/pull/9",
+      prNumber: 9,
+      repo: { provider: "github", host: "github.com", path: "acme/site" },
+    });
+
+    const moved = await taskBoard.advanceLinkedTasksToReviewOnThreadFinish(
+      thread.id,
+      ORG,
+    );
+
+    expect(moved.map((m) => m.id)).not.toContain(task.id);
+    const after = await taskBoard.getById(task.id, ORG);
+    expect(after?.status).toBe("in_progress");
+    // No cycle opened either — that is the other half of what a reviewer reads.
+    expect(after?.reviewCycleStartedAt).toBeNull();
+  });
+
+  it("boardManagedIds keeps ordinary cards and drops sourced anchors", async () => {
+    const card = await cardWithFinishedRun("ordinary");
+    const anchor = await cardWithFinishedRun("anchored", "jira");
+    expect(
+      await taskBoard.boardManagedIds([anchor.task.id, card.task.id], ORG),
+    ).toEqual([card.task.id]);
+    // Order is the caller's, and another org sees neither.
+    expect(
+      await taskBoard.boardManagedIds([card.task.id], "org_other"),
+    ).toEqual([]);
+    expect(await taskBoard.boardManagedIds([], ORG)).toEqual([]);
   });
 
   // The backstop must never move a card that is already mid-review, whatever

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1316,6 +1316,38 @@ export class TaskBoardStorage {
     return rows.map((r) => r.threadId);
   }
 
+  /**
+   * Of `ids`, the ones the BOARD manages — the ones with no `source`.
+   *
+   * An item WITH a source (today, a Jira issue's) is a run handle, not a card:
+   * it is hidden from the board, its lanes and review cycle are read by nobody,
+   * and the issue is where its run reports. So no board reaction may move it,
+   * link a pull request to it, or hand it to a reviewer. One query rather than
+   * a `getById` per id, so the reaction path stays a single round trip.
+   *
+   * Deliberately NOT a filter inside `linkedTaskIds`: that one answers "which
+   * items is this thread linked to", and the Jira run tools ask it to find the
+   * issue their run is bound to (`resolveRunIssue`). Filtering there would take
+   * every Jira tool offline.
+   */
+  async boardManagedIds(
+    ids: readonly string[],
+    organizationId: string,
+  ): Promise<string[]> {
+    if (ids.length === 0) return [];
+    const rows = await this.db
+      .selectFrom("task_board_items")
+      .select("id")
+      .where("id", "in", [...ids])
+      .where("organization_id", "=", organizationId)
+      .where("source", "is", null)
+      .execute();
+    const managed = new Set(rows.map((row) => row.id));
+    // Caller order preserved: `resolveAdvanceTargets` puts the run's own item
+    // first and callers act on that order.
+    return ids.filter((id) => managed.has(id));
+  }
+
   async linkedTaskIds(
     threadId: string,
     organizationId: string,
@@ -1449,6 +1481,12 @@ export class TaskBoardStorage {
     for (const taskId of await this.linkedTaskIds(threadId, organizationId)) {
       const item = await this.getById(taskId, organizationId);
       if (!item) continue;
+      // Not a card the board manages (a Jira issue's anchor): advancing it to
+      // In Review is what enqueues a reviewer, and a reviewer on such an item
+      // rules on a hidden card nobody reads. Observed doing worse than nothing
+      // — it read a pull request from a PRIOR run of the same issue, requested
+      // changes because that one was closed, and unassigned the agent.
+      if (item.source) continue;
       // A LINKED PR is the whole test. It used to be `item.repo != null && …`,
       // as a cheap way to skip the query for a card that could not have one —
       // but `repo` is only stamped on a card created against a repository, and

--- a/apps/api/src/tools/task-board/pr-open-board-reaction.ts
+++ b/apps/api/src/tools/task-board/pr-open-board-reaction.ts
@@ -27,7 +27,7 @@ import {
   findChangeRequestIn,
 } from "./change-request-extract";
 import { invalidatePrCards } from "./prs-get";
-import { resolveRunTaskTargets, emitTaskBoardUpdated } from "./run-reactions";
+import { resolveRunLinkedTaskIds, emitTaskBoardUpdated } from "./run-reactions";
 
 // Cap on cards sent to the LLM prompt, so a large backlog doesn't inflate cost per PR-open.
 const MAX_OPEN_CARDS_FOR_DECISION = 50;
@@ -235,7 +235,11 @@ export async function reactToPrOpenedForBoard(
   const userId = ctx.auth?.user?.id;
   if (!orgId || !userId || !threadId) return;
   try {
-    const alreadyLinked = await resolveRunTaskTargets(ctx, orgId, threadId);
+    // The UNFILTERED links on purpose: a Jira run's anchor is not a card the
+    // board manages, but its work IS tracked (on the issue). Asking the
+    // filtered question here would read as "nothing tracks this" and open a
+    // visible card for every Jira run's pull request.
+    const alreadyLinked = await resolveRunLinkedTaskIds(ctx, orgId, threadId);
     if (alreadyLinked.length > 0) return;
 
     const pr = findChangeRequestIn(source);

--- a/apps/api/src/tools/task-board/run-reactions.test.ts
+++ b/apps/api/src/tools/task-board/run-reactions.test.ts
@@ -25,6 +25,9 @@ function makeCtx(opts: {
   orgId?: string;
   metadataItemId?: string;
   linked?: string[];
+  /** Ids the board manages. Omitted means "all of them" — the ordinary card
+   *  case. Set it to exclude an anchor the board does not manage (Jira's). */
+  boardManaged?: string[];
 }) {
   const linkPrCalls: LinkPrCall[] = [];
   const ctx = {
@@ -38,12 +41,22 @@ function makeCtx(opts: {
           linkPrCalls.push(p);
         },
         linkedTaskIds: async () => opts.linked ?? [],
+        boardManagedIds: async (ids: readonly string[]) =>
+          opts.boardManaged
+            ? ids.filter((id) => opts.boardManaged?.includes(id))
+            : [...ids],
       },
     },
   } as never;
   return { ctx, linkPrCalls };
 }
 
+/**
+ * The PR link is what a later reviewer reads. On a Jira run's anchor it pointed
+ * at a hidden card, and a reviewer picked up a PR from a PRIOR run of the same
+ * issue, requested changes because that one was closed, and unassigned the
+ * agent. The Jira run puts its PR on the ISSUE instead.
+ */
 const MCP_RESULT = {
   structuredContent: { id: 1, url: "https://github.com/acme/site/pull/42" },
 };
@@ -114,6 +127,27 @@ describe("capturePrForRun", () => {
     const { ctx, linkPrCalls } = makeCtx({ orgId: "org-1", linked: [] });
     await capturePrForRun(ctx, MCP_RESULT, null, "thr-x");
     expect(linkPrCalls).toEqual([]);
+  });
+  // The disconnect: an anchor the board does not manage gets no PR link, so no
+  // later reviewer can read one off it.
+  it("links nothing for a run whose only task is not board-managed", async () => {
+    const { ctx, linkPrCalls } = makeCtx({
+      orgId: "org-1",
+      linked: ["anchor-jira"],
+      boardManaged: [],
+    });
+    await capturePrForRun(ctx, MCP_RESULT, null, "thr-1");
+    expect(linkPrCalls).toHaveLength(0);
+  });
+
+  it("still links for an ordinary card alongside one that is not managed", async () => {
+    const { ctx, linkPrCalls } = makeCtx({
+      orgId: "org-1",
+      linked: ["anchor-jira", "card-1"],
+      boardManaged: ["card-1"],
+    });
+    await capturePrForRun(ctx, MCP_RESULT, null, "thr-1");
+    expect(linkPrCalls.map((c) => c.taskBoardItemId)).toEqual(["card-1"]);
   });
 });
 

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -132,7 +132,14 @@ export function resolveAdvanceTargets(
  * Shared by the advance-status and PR-capture reactions so both resolve a
  * subtask-opened action the same way.
  */
-export async function resolveRunTaskTargets(
+/**
+ * Every task the run is linked to, board-managed or not.
+ *
+ * This is the "is this run's work already tracked?" question, and a Jira run's
+ * anchor is a yes — its work is tracked, on the issue. Use
+ * `resolveRunTaskTargets` for the other question ("which cards may I move").
+ */
+export async function resolveRunLinkedTaskIds(
   ctx: StudioContext,
   orgId: string,
   threadId?: string,
@@ -143,6 +150,27 @@ export async function resolveRunTaskTargets(
       ? await ctx.storage.taskBoard.linkedTaskIds(threadId, orgId)
       : [];
   return resolveAdvanceTargets(metadataItemId, linkedIds);
+}
+
+/**
+ * The tasks a board reaction may ACT on: the run's links, minus the items the
+ * board does not manage (`boardManagedIds`).
+ *
+ * A run started by the Jira integration hangs off a hidden anchor, so every
+ * reaction that moves a lane, opens a review cycle or links a pull request
+ * would be writing where nobody reads — and the pull-request link in
+ * particular is what let a later reviewer rule on a stale PR. The Jira run
+ * reports on the issue itself instead.
+ */
+async function resolveRunTaskTargets(
+  ctx: StudioContext,
+  orgId: string,
+  threadId?: string,
+): Promise<string[]> {
+  return ctx.storage.taskBoard.boardManagedIds(
+    await resolveRunLinkedTaskIds(ctx, orgId, threadId),
+    orgId,
+  );
 }
 
 /**
@@ -390,6 +418,8 @@ export async function reactToFailedTaskRun(
     for (const itemId of await taskBoard.linkedTaskIds(threadId, orgId)) {
       const item = await taskBoard.getById(itemId, orgId);
       if (!item) continue;
+      // Not a card the board manages — see `boardManagedIds`.
+      if (item.source) continue;
       // The run moved the card itself and only THEN lost its stream. By rank, so
       // a card the merged-PR reconcile pushed further still counts as delivered
       // — as does one still In Progress with a review cycle open, which since
@@ -503,6 +533,8 @@ export async function refundUnproductiveTaskClaims(
     for (const taskId of await taskBoard.linkedTaskIds(threadId, orgId)) {
       const item = await taskBoard.getById(taskId, orgId);
       if (!item) continue;
+      // Not a card the board manages — see `boardManagedIds`.
+      if (item.source) continue;
       if (cardDelivered(item)) continue;
       const stillRunning = item.threads.some(
         (t) =>


### PR DESCRIPTION
A run the Jira integration starts hangs off a **hidden anchor** item — a handle for quota, dispatch and rerun, not a card. The board's reactions didn't know that and kept writing to it: moving invisible lanes, opening review cycles nobody reads, linking its pull request, and enqueueing a reviewer.

## The reviewer did worse than nothing

Observed on OS-\<n\> today. The reviewer for one issue picked up the pull request linked by a **prior run of the same issue**, found it closed, and recorded `review_changes_requested`:

> *"PR #\<prior\> was CLOSED (not merged) by a human … I cannot exercise a live preview against a closed PR"*

That flipped the card to In Review and **unassigned the agent** as "review is single-pass". None of it was visible on the issue, where the run had already posted a full report with embedded screenshots and moved it to `Teste`.

The PR link that misled it was put there by `capturePrForRun` — a board reaction on an anchor that has no business carrying one, since the run now publishes its PR to the issue with `JIRA_REMOTE_LINK_ADD`.

## The change

Board reactions act only on items the board manages (`source` null):

- **`boardManagedIds`** filters an id list in one query; `resolveRunTaskTargets` runs the run's links through it. Covers the lane advance, the review-cycle open, and the PR link.
- **`advanceLinkedTasksToReviewOnThreadFinish`** skips a sourced item. This is the reviewer's actual trigger and it resolves targets in storage rather than through that funnel, so it needs its own skip — the "one funnel" reading of this code is wrong.
- **`reactToFailedTaskRun`** and **`refundUnproductiveTaskClaims`** skip one too. Both already load the item, and leaving them connected keeps mutating and parking a card no one reads.

## Two things deliberately NOT filtered

Both would have broken, and neither is obvious:

- **`linkedTaskIds` stays unfiltered.** The Jira run tools ask it which issue their run is bound to (`resolveRunIssue`). Filtering there takes every Jira tool offline.
- **`reactToPrOpenedForBoard` now asks the unfiltered question** via `resolveRunLinkedTaskIds`. It uses the answer as *"is this work already tracked?"*, and a Jira anchor is a **yes** — its work is tracked, on the issue. Handed the filtered list it would read "nothing tracks this" and open a visible board card for every Jira run's pull request.

That's why this is two functions and not one filter: the codebase asks two different questions of the same link table.

## What this gives up, on purpose

No reviewer on Jira-driven work. That is a real loss — an earlier run's reviewer found and fixed a `deno check` failure the implementer missed. The trade was made knowingly: a second opinion that sometimes rules on the wrong artifact and hijacks the card is worse than none, and if we want it back it should be a second run **in Jira mode** that comments on the issue, not a board reviewer writing to a hidden card. Quota refunds and failed-run handling for Jira anchors are also given up.

## Testing

- **Real Postgres:** a sourced anchor is never advanced and gets no review cycle even with a PR linked; `boardManagedIds` preserves caller order, is org-scoped, and handles the empty list.
- **Unit:** `capturePrForRun` links nothing for an unmanaged anchor, and still links an ordinary card sitting beside one.
- 974 pass / 0 fail across `tools/task-board`, `storage`, `tools/jira`, `jira`. `check`, `lint` (0 errors), `fmt` clean.
- `knip` flagged `resolveRunTaskTargets` once its only external caller moved; it is module-private now.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops board reactions from writing to the hidden anchor items Jira runs hang off of. Previously they advanced invisible lanes, opened review cycles, linked pull requests, and enqueued a reviewer - one of whom picked up a stale PR from a prior run of the same issue, requested changes, and unassigned the agent.

**What changed**

- `boardManagedIds` filters an id list to board-managed items (`source` null) in one query; `resolveRunTaskTargets` runs the run's links through it.
- `advanceLinkedTasksToReviewOnThreadFinish`, `reactToFailedTaskRun`, and `refundUnproductiveTaskClaims` skip sourced items where they load them.
- `linkedTaskIds` stays unfiltered - Jira tools use it to find the issue their run is bound to.
- `reactToPrOpenedForBoard` asks the unfiltered question, since a Jira anchor's work is already tracked on the issue; filtering would open a visible card for every Jira run's PR.

**Trade-offs**

- Jira-driven work loses the board reviewer. A prior run's reviewer once caught a `deno check` failure, but a second opinion that rules on the wrong artifact and hijacks the card is worse than none; review should come from a second run in Jira mode commenting on the issue.
- Quota refunds and failed-run handling also no longer apply to Jira anchors.

<sup>Written for commit 62d1cc217d53f90cd397a0e6a2e7c491b825c99a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

