### PR TITLE
fix(blog): stop overlapping autosaves from dropping the penultimate edit

### DIFF
--- a/apps/web/src/components/sandbox/content/blog/category-editor.tsx
+++ b/apps/web/src/components/sandbox/content/blog/category-editor.tsx
@@ -87,12 +87,16 @@ export function CategoryEditor({
   const draftPointer = useDraftPointer({ orgSlug, virtualMcpId, branch });
   const initial = getBlogPayload(block, "categories");
 
-  const [category, setCategory, syncCategory] = useAutosave(initial, (next) => {
-    save.mutate({
-      blockKey,
-      data: buildBlogBlock(blockKey, "categories", next),
-    });
-  });
+  const [category, setCategory, syncCategory] = useAutosave(
+    initial,
+    (next) => {
+      save.mutate({
+        blockKey,
+        data: buildBlogBlock(blockKey, "categories", next),
+      });
+    },
+    { isSaving: save.isPending },
+  );
 
   const setField = (key: string, value: unknown) =>
     setCategory({ ...category, [key]: value });

--- a/apps/web/src/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/web/src/components/sandbox/content/blog/post-editor.tsx
@@ -100,12 +100,16 @@ export function PostEditor({
   const draftPointer = useDraftPointer({ orgSlug, virtualMcpId, branch });
   const initial = getBlogPayload(block, "posts");
 
-  const [post, setPost] = useAutosave(initial, (next) => {
-    save.mutate({
-      blockKey,
-      data: buildBlogBlock(blockKey, "posts", stampPostModified(next)),
-    });
-  });
+  const [post, setPost] = useAutosave(
+    initial,
+    (next) => {
+      save.mutate({
+        blockKey,
+        data: buildBlogBlock(blockKey, "posts", stampPostModified(next)),
+      });
+    },
+    { isSaving: save.isPending },
+  );
 
   const setField = (key: string, value: unknown) =>
     setPost({ ...post, [key]: value });

--- a/apps/web/src/components/sandbox/content/blog/record-editor.tsx
+++ b/apps/web/src/components/sandbox/content/blog/record-editor.tsx
@@ -90,9 +90,13 @@ export function RecordEditor({
   const save = useSaveBlock({ orgSlug, virtualMcpId, branch });
   const initial = getBlogPayload(block, kind);
 
-  const [payload, setPayload] = useAutosave(initial, (next) => {
-    save.mutate({ blockKey, data: buildBlogBlock(blockKey, kind, next) });
-  });
+  const [payload, setPayload] = useAutosave(
+    initial,
+    (next) => {
+      save.mutate({ blockKey, data: buildBlogBlock(blockKey, kind, next) });
+    },
+    { isSaving: save.isPending },
+  );
 
   const setField = (key: string, value: unknown) =>
     setPayload({ ...payload, [key]: value });

--- a/apps/web/src/components/sandbox/content/blog/use-autosave.test.tsx
+++ b/apps/web/src/components/sandbox/content/blog/use-autosave.test.tsx
@@ -1,0 +1,88 @@
+import { setupComponentTest } from "../../../../../test/setup";
+setupComponentTest();
+import { describe, expect, it } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+import { useAutosave } from "./use-autosave";
+
+type Doc = { v: string };
+
+/**
+ * Drives useAutosave with controllable `initial` and `isSaving` props so the
+ * external re-seed path can be exercised without real timers or a network.
+ */
+function renderAutosave(initialProps: { initial: Doc; isSaving: boolean }) {
+  return renderHook(
+    ({ initial, isSaving }: { initial: Doc; isSaving: boolean }) =>
+      useAutosave<Doc>(initial, () => {}, { delay: 10_000, isSaving }),
+    { initialProps },
+  );
+}
+
+describe("useAutosave re-seed guard", () => {
+  it("re-seeds the draft from an external `initial` change once edits are settled", () => {
+    const a = { v: "a" };
+    const b = { v: "b" };
+    const { result, rerender } = renderAutosave({
+      initial: a,
+      isSaving: false,
+    });
+
+    expect(result.current[0]).toEqual(a);
+
+    rerender({ initial: b, isSaving: false });
+
+    expect(result.current[0]).toEqual(b);
+  });
+
+  it("does NOT re-seed while a save is in flight, so a slow save's older echo can't revert a newer edit", () => {
+    const a = { v: "a" };
+    const b = { v: "b" };
+    const c = { v: "c" };
+    const { result, rerender } = renderAutosave({
+      initial: a,
+      isSaving: false,
+    });
+
+    // The newer edit `c` lives only in the local draft while save #1 runs.
+    act(() => result.current[1](c));
+    expect(result.current[0]).toEqual(c);
+
+    // Save #1's older echo (`b`) lands while still in flight; draft must hold `c`.
+    rerender({ initial: b, isSaving: true });
+    expect(result.current[0]).toEqual(c);
+  });
+
+  it("does NOT re-seed while a debounced edit is pending", () => {
+    const a = { v: "a" };
+    const b = { v: "b" };
+    const local = { v: "local" };
+    const { result, rerender } = renderAutosave({
+      initial: a,
+      isSaving: false,
+    });
+
+    // A local edit schedules a (far-off) save, so `pending` is now true.
+    act(() => result.current[1](local));
+    expect(result.current[0]).toEqual(local);
+
+    rerender({ initial: b, isSaving: false });
+    expect(result.current[0]).toEqual(local);
+  });
+
+  it("`sync` clears the pending timer so a later settled re-seed applies", () => {
+    const a = { v: "a" };
+    const b = { v: "b" };
+    const synced = { v: "synced" };
+    const { result, rerender } = renderAutosave({
+      initial: a,
+      isSaving: false,
+    });
+
+    act(() => result.current[1]({ v: "typing" }));
+    act(() => result.current[2](synced));
+    expect(result.current[0]).toEqual(synced);
+
+    rerender({ initial: b, isSaving: false });
+    expect(result.current[0]).toEqual(b);
+  });
+});

--- a/apps/web/src/components/sandbox/content/blog/use-autosave.ts
+++ b/apps/web/src/components/sandbox/content/blog/use-autosave.ts
@@ -9,7 +9,7 @@ const AUTOSAVE_DELAY = 700;
  *
  * External re-seeding: when `initial` changes by reference (e.g. a batch
  * mutation patched this block's payload in the shared cache while it's open),
- * the draft re-seeds from it — but only when there's no pending local edit, so
+ * the draft re-seeds from it — but only once edits settle (no timer pending and no save in flight), so
  * we never clobber what the user is currently typing. This is the "adjust
  * state during render" pattern, same as the collection-switch reset upstream.
  *
@@ -21,8 +21,10 @@ const AUTOSAVE_DELAY = 700;
 export function useAutosave<T>(
   initial: T,
   save: (value: T) => void,
-  delay = AUTOSAVE_DELAY,
+  opts?: { delay?: number; isSaving?: boolean },
 ): readonly [T, (next: T) => void, (next: T) => void] {
+  const delay = opts?.delay ?? AUTOSAVE_DELAY;
+  const isSaving = opts?.isSaving ?? false;
   const [draft, setDraft] = useState<T>(initial);
   const [seeded, setSeeded] = useState<T>(initial);
   // `pending` mirrors "a debounced save is scheduled" as state so the re-seed
@@ -31,10 +33,10 @@ export function useAutosave<T>(
   const [pending, setPending] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Re-seed from an external change to `initial` when no local edit is pending.
+  // Re-seed from external `initial` only once edits settle — not while a save is in flight, whose older echo would revert a newer edit.
   if (initial !== seeded) {
     setSeeded(initial);
-    if (!pending) setDraft(initial);
+    if (!pending && !isSaving) setDraft(initial);
   }
 
   const update = (next: T) => {

--- a/apps/web/src/components/sandbox/content/redirect-editor.tsx
+++ b/apps/web/src/components/sandbox/content/redirect-editor.tsx
@@ -48,9 +48,13 @@ export function RedirectEditor({
   const save = useSaveBlock({ orgSlug, virtualMcpId, branch });
   const initial = getRedirectPayload(block);
 
-  const [payload, setPayload] = useAutosave(initial, (next) => {
-    save.mutate({ blockKey, data: buildRedirectBlock(next) });
-  });
+  const [payload, setPayload] = useAutosave(
+    initial,
+    (next) => {
+      save.mutate({ blockKey, data: buildRedirectBlock(next) });
+    },
+    { isSaving: save.isPending },
+  );
 
   const setField = (patch: Partial<RedirectPayload>) =>
     setPayload({ ...payload, ...patch });

--- a/apps/web/src/components/sections-editor/use-save-block.ts
+++ b/apps/web/src/components/sections-editor/use-save-block.ts
@@ -41,6 +41,10 @@ export function useSaveBlock({
 
   return useMutation({
     mutationKey: decofileWriteMutationKey(orgSlug, virtualMcpId, branch),
+    // Serialize a branch's writes so overlapping autosaves can't land an older payload last, dropping a newer edit.
+    scope: {
+      id: decofileWriteMutationKey(orgSlug, virtualMcpId, branch).join(":"),
+    },
     mutationFn: async ({
       blockKey,
       data,


### PR DESCRIPTION
## Summary

Fixes a data-loss bug reported by a content team: while uploading content in the blog editors, editing rapidly (an edit every ~1–2s) would intermittently **lose the penultimate edit**, which then had to be redone. The workaround was waiting 3–4s between edits.

The block editors autosave with a **700ms debounce**, but the write lands in **~2s** (network + coalesced commit), so consecutive edits produce **overlapping** saves. Two concurrency gaps combined to drop an earlier edit:

1. **Writes weren't serialized** (`use-save-block.ts`). Overlapping saves raced their optimistic `onMutate`/`onSuccess` writes into the shared decofile cache, and an earlier save finishing **last** re-applied its **older** payload over a newer one — permanent loss when responses land out of order. (In cms/FastPreview mode `patchDecofile` returns only the draft pointer, so the content cache is driven purely by these optimistic writes.)
2. **The `useAutosave` re-seed guard was too narrow** (`use-autosave.ts`). It was `if (!pending)` — only the debounce-timer window. During the ~2s save-in-flight window `pending` is false, so a slow earlier save's echo (older payload landing back in the cache) did `setDraft(older)`, reverting the draft; the user's next edit then built on the reverted draft, omitting the penultimate edit permanently.

## Changes

- **Serialize a branch's writes** with TanStack v5 `scope: { id }` in `useSaveBlock`, so saves run one at a time in edit order — payloads stack and the last write always wins. Backend commits already coalesce per branch, so no correctness cost.
- **Widen the re-seed guard**: `useAutosave` signature `(initial, save, delay?)` → `(initial, save, opts?: { delay?, isSaving? })`; re-seed is now `if (!pending && !isSaving)`. All four editors (post/record/category/redirect) pass `{ isSaving: save.isPending }`. `isPending` stays true across a serialized burst until the last save settles, so the draft can't be transiently reverted mid-burst.

## Testing

- New `use-autosave.test.tsx` (renderHook) covering the in-flight-echo guard, the pending guard, settled re-seed, and `sync`.
- `bun test` blog suite (213 tests) ✅, `bun run check` (typecheck) ✅, `bun run lint` (0 errors) ✅, `bun run fmt` ✅.

## Affected areas

Blog block editors (post, category, author/record, redirect) — the manual content-editing flow. No schema/API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the blog editors silently dropping the penultimate edit when typing every 1–2 seconds, caused by overlapping autosaves where a slower earlier save could land after a newer one and overwrite it.

**Bug Fixes**
- Serializes a branch's block writes via TanStack `scope: { id }` in `useSaveBlock` so saves apply in edit order.
- Guards `useAutosave`'s re-seed on in-flight saves in addition to the debounce timer, so a slow save's older echo can't revert the draft mid-edit; all four editors pass `save.isPending` as `isSaving`.
- Adds `use-autosave.test.tsx` covering the in-flight echo, pending, settled re-seed, and sync paths.

<sup>Written for commit 5a75b20d11135ede79518d70eda5c5e9cf152fa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

