### PR TITLE
fix(sections-editor): resolve deeply-nested fields so the Content form panel stops blanking

### DIFF
--- a/apps/web/src/components/sections-editor/resolve-schema.test.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.test.ts
@@ -762,6 +762,86 @@ describe("resolveSchema – plainSchema on block-ref", () => {
     expect(image?.plainSchema?.format).toBe("image-uri");
   });
 
+  test("resolves the deepest leaf of a mega-menu of Resolvable-wrapped arrays", () => {
+    // A real storefront's header (zeedog): departmentMenus → menu → submenuColumns → submenuGroups → submenuGroupItems, five nested arrays each emitted as `anyOf: [Resolvable loader, array]` with no `__resolveType` boundary to reset depth. The old structural cap (8) nulled `items`/`properties` a couple levels in, so drilling to the deepest item rendered a blank form panel.
+    const loaderBranch = (rt: string) => ({
+      type: "object",
+      properties: {
+        __resolveType: { type: "string", enum: [rt], default: rt },
+      },
+    });
+    // A navigation array as deco emits it: pick a loader, or inline the array.
+    const wrappedArray = (
+      itemsSchema: Record<string, unknown>,
+      rt: string,
+    ) => ({
+      anyOf: [loaderBranch(rt), { type: "array", items: itemsSchema }],
+    });
+
+    const menuItem = {
+      type: "object",
+      title: "IMenuItem",
+      properties: {
+        text: { type: "string", title: "Text" },
+        url: { type: "string", title: "URL" },
+        imgsrc: {
+          type: "object",
+          properties: { desktop: { type: "string", format: "image-uri" } },
+        },
+      },
+    };
+    const submenuGroup = {
+      type: "object",
+      properties: {
+        submenuGroupItems: wrappedArray(menuItem, "site/loaders/items.ts"),
+      },
+    };
+    const submenuColumn = {
+      type: "object",
+      properties: {
+        submenuGroups: wrappedArray(submenuGroup, "site/loaders/groups.ts"),
+      },
+    };
+    const menu = {
+      type: "object",
+      properties: {
+        submenuColumns: wrappedArray(submenuColumn, "site/loaders/columns.ts"),
+      },
+    };
+    const departmentMenu = {
+      type: "object",
+      properties: { menu: wrappedArray(menu, "site/loaders/menu.ts") },
+    };
+    const meta = metaWithSchema({
+      type: "object",
+      properties: {
+        departmentMenus: wrappedArray(
+          departmentMenu,
+          "site/loaders/departments.ts",
+        ),
+      },
+    });
+
+    // A Resolvable-wrapped array resolves to an `array` field (loader branch dropped) — or a block-ref carrying the array as `plainSchema`; accept either.
+    const arrayItems = (field: SchemaProperty | undefined) =>
+      field?.items ?? field?.plainSchema?.items;
+
+    const resolved = resolveSchema("site/sections/Test.tsx", meta);
+    const departmentMenu2 = arrayItems(resolved?.properties?.departmentMenus);
+    const menu2 = arrayItems(departmentMenu2?.properties?.menu);
+    const submenuColumn2 = arrayItems(menu2?.properties?.submenuColumns);
+    const submenuGroup2 = arrayItems(submenuColumn2?.properties?.submenuGroups);
+    const menuItem2 = arrayItems(submenuGroup2?.properties?.submenuGroupItems);
+
+    // The leaf (IMenuItem) and its fields resolve — no blank panel.
+    expect(menuItem2?.type).toBe("object");
+    expect(menuItem2?.properties?.text?.type).toBe("string");
+    expect(menuItem2?.properties?.url?.type).toBe("string");
+    expect(menuItem2?.properties?.imgsrc?.properties?.desktop?.format).toBe(
+      "image-uri",
+    );
+  });
+
   test("plainSchema is undefined when all branches are loaders", () => {
     const meta = metaWithSchema({
       type: "object",

--- a/apps/web/src/components/sections-editor/resolve-schema.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.ts
@@ -92,8 +92,28 @@ type RawSchema = Record<string, unknown>;
 /** Max `$ref` / `allOf` hops while flattening top-level properties. */
 const MAX_COLLECT_PROPS_DEPTH = 12;
 
-/** Max recursion while building nested field schemas. */
+/**
+ * Max recursion while eagerly materializing a multi-branch union's nested
+ * branch schemas ({@link eagerBranchSchema}). Kept low because that path is the
+ * combinatorial one: a `__SECTION_REF__` selector lists every section, many of
+ * which point back at the same union, so materializing each branch's subtree at
+ * depth explodes. The cycle guard (`seen`) and {@link MAX_ANYOF_EAGER_SCHEMA_BRANCHES}
+ * bound the width; this bounds the depth.
+ */
 const MAX_BUILD_PROPERTY_DEPTH = 8;
+
+/**
+ * Max recursion for plain structural descent — an object's `properties`, an
+ * array's `items`, and inline plain-data unions (`A | B`). Unlike union-branch
+ * materialization above, this path is cycle-free (a `$ref` cycle is caught by
+ * `seen` regardless of depth; inline nesting is a finite tree) and linear in the
+ * schema's node count, so it gets a far higher cap. Without it, deeply-nested
+ * data structures — e.g. a mega-menu of `departmentMenus → menu → submenuColumns
+ * → submenuGroups → submenuGroupItems`, ~5 nested arrays with no `__resolveType`
+ * boundary to reset depth — resolve their leaf `items`/`properties` to
+ * `undefined` past depth 8, and the Content editor renders a blank form panel.
+ */
+const MAX_STRUCTURE_DEPTH = 32;
 
 /**
  * Above this branch count, a block-ref union (e.g. the `__SECTION_REF__`
@@ -842,8 +862,7 @@ export function resolveSchema(
         };
         // allOf is merged as an object earlier, so this block only sees choice unions.
         const isPlainDataUnion =
-          depth < MAX_BUILD_PROPERTY_DEPTH &&
-          nonNull.every(branchIsPlainDataObject);
+          depth < MAX_STRUCTURE_DEPTH && nonNull.every(branchIsPlainDataObject);
 
         // All branches are $refs to block/loader defs
         const allRefs = nonNull.every((a) => typeof a.$ref === "string");
@@ -1003,12 +1022,10 @@ export function resolveSchema(
       type = "object";
     }
 
-    // Nested properties for object types. Bumped past depth 3 because real
-    // deco sections nest images at depth 4+ (`images[].desktop.src`); the
-    // old cap left those leaves un-resolved and stripped their `format`.
+    // Nested properties for object types (see MAX_STRUCTURE_DEPTH).
     let nestedProperties: Record<string, SchemaProperty> | undefined;
     let requiredKeys: string[] | undefined;
-    if (depth < MAX_BUILD_PROPERTY_DEPTH) {
+    if (depth < MAX_STRUCTURE_DEPTH) {
       const nestedRaw = collectProps(resolved);
       const nestedRequired = asStringArray(nestedRaw.__required);
       if (nestedRequired.length > 0) requiredKeys = nestedRequired;
@@ -1031,7 +1048,7 @@ export function resolveSchema(
     let itemsSchema: SchemaProperty | undefined;
     if (
       (type === "array" || resolved.type === "array") &&
-      depth < MAX_BUILD_PROPERTY_DEPTH
+      depth < MAX_STRUCTURE_DEPTH
     ) {
       let rawItems = resolved.items as RawSchema | undefined;
       if (rawItems) {


### PR DESCRIPTION
## Summary

Deeply-nested fields in the **Content** editor (e.g. a mega-menu like zeedog's header) let you drill the breadcrumb all the way down, but the form panel rendered **blank** at the deepest level.

Root cause: the schema resolver (`apps/web/src/components/sections-editor/resolve-schema.ts`) capped **all** recursion at `MAX_BUILD_PROPERTY_DEPTH = 8` — including plain structural descent (an object's `properties`, an array's `items`, inline plain-data unions). Past depth 8 those leaves resolved to `undefined`, so a structure like `departmentMenus → menu → submenuColumns → submenuGroups → submenuGroupItems` (~5 nested arrays, each emitted as `anyOf: [Resolvable, array]` with no `__resolveType` boundary to reset the depth counter) blew past the cap a few levels in and left `SchemaFormPanel` with no schema to render.

## Fix

Split the single cap into two:

- **`MAX_BUILD_PROPERTY_DEPTH = 8`** — kept only on the genuinely combinatorial path: eager multi-branch union materialization (`eagerBranchSchema`, e.g. the `__SECTION_REF__` "pick any section" selector that lists every section, many pointing back at the same union).
- **`MAX_STRUCTURE_DEPTH = 32`** (new) — plain structural descent. This path is cycle-free (a `$ref` cycle is still caught by the `seen` guard regardless of depth; inline nesting is a finite tree) and linear in node count, so a much higher cap is both safe and cheap.

This is a pure client-side schema-resolution fix — no wire/storage/hot-path change; it strictly makes *more* schemas editable. No flag warranted.

## Testing

- Added a `resolve-schema` test reproducing the 5-level Resolvable-wrapped-array mega-menu. Verified it resolves the leaf's fields with the fix, and yields `undefined` (the blank panel) when the cap is reverted to 8.
- `bun test apps/web/src/components/sections-editor/` — 748 pass.
- `bun run --cwd=apps/web check`, `bun run fmt`, `bun run lint` — clean (lint warnings are pre-existing, unrelated files).

## Affected areas

Content editor schema resolution for deeply-nested inline data (menus, nested banner/card structures). No change to shallow schemas or to union/section-picker resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Content editor rendering a blank form panel for deeply-nested fields (e.g., a mega-menu's `departmentMenus → menu → submenuColumns → submenuGroups → submenuGroupItems`). The schema resolver capped all recursion at depth 8, so past that leaves resolved to `undefined`; the fix splits the cap — the combinatorial union path keeps its low bound, while plain structural descent (object `properties`, array `items`, inline plain-data unions) gets a new depth 32 cap, which is cycle-free and linear.

**Bug Fixes**
- Kept `MAX_BUILD_PROPERTY_DEPTH = 8` only for eager multi-branch union materialization; added `MAX_STRUCTURE_DEPTH = 32` for structural descent.
- Added a `resolve-schema` test reproducing the 5-level Resolvable-wrapped-array mega-menu; it resolves the leaf's fields with the fix and yields `undefined` at cap 8.
- Pure client-side schema-resolution change — no wire/storage/hot-path impact; makes more schemas editable, no flag needed.

<sup>Written for commit e65a67f4668022e104364e21291733edcedd1dc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

