### PR TITLE
feat(repositories): search all installed repos server-side in the grant picker

### DIFF
--- a/apps/api/src/api/routes/git-providers.ts
+++ b/apps/api/src/api/routes/git-providers.ts
@@ -193,6 +193,7 @@ export const createGitProviderRoutes = () => {
       .object({
         installationId: z.coerce.number().int().positive().safe(),
         page: z.coerce.number().int().positive().safe().default(1),
+        query: z.string().trim().max(256).optional(),
       })
       .safeParse(c.req.query());
     if (!input.success) return c.json({ error: "Invalid installation" }, 400);
@@ -222,6 +223,7 @@ export const createGitProviderRoutes = () => {
         userToken,
         installation,
         input.data.page,
+        input.data.query,
       );
       const account = await ctx.storage.gitProviderAccounts.findByExternalId({
         organizationId: owner.organizationId,

--- a/apps/api/src/git-providers/github/app-auth.ts
+++ b/apps/api/src/git-providers/github/app-auth.ts
@@ -22,6 +22,7 @@ import { APP_BUDGET_OWNER, rememberBudgetOwner } from "./budget-owner";
 import { type GithubAppConfig, readGithubAppConfig } from "./env";
 import type { GitProviderCapability } from "../types";
 import { GitProviderError } from "../types";
+import { matchesRepoQuery } from "./client";
 import {
   githubApiBaseUrl,
   githubErrorMessage,
@@ -531,11 +532,18 @@ export class GithubAppAuth {
     };
   }
 
-  /** Repository choices use the temporary user grant, never an installation token. */
+  /**
+   * Repository choices use the temporary user grant, never an installation
+   * token. An optional `query` narrows by `owner/name` substring server-side so
+   * the picker searches every installed repository, not only the pages the
+   * client happens to have loaded. `hasMore` reflects the raw page length, so
+   * the query filter never hides the remaining provider pages.
+   */
   async listRepositoryChoices(
     userToken: string,
     installation: AuthorizedInstallation,
     page: number,
+    query?: string,
   ) {
     const result = z
       .object({
@@ -561,6 +569,7 @@ export class GithubAppAuth {
             installation.repositoryIds === null ||
             repo.permissions?.admin === true,
         )
+        .filter((repo) => matchesRepoQuery(repo.full_name, query))
         .map((repo) => ({ id: repo.id, name: repo.full_name })),
       hasMore: result.repositories.length === 100,
     };

--- a/apps/web/src/components/github-connect-dialog.tsx
+++ b/apps/web/src/components/github-connect-dialog.tsx
@@ -21,6 +21,7 @@ import { Checkbox } from "@decocms/ui/components/checkbox.tsx";
 import { Input } from "@decocms/ui/components/input.tsx";
 import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
 import { GitHubIcon } from "@/components/icons/github-icon";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { useGitProviderCapabilities } from "@/hooks/use-git-providers";
 import { KEYS } from "@/lib/query-keys";
 import { useProjectContext } from "@/sdk";
@@ -345,14 +346,20 @@ function RepositoryGrantPicker({
   const t = useT();
   const [selected, setSelected] = useState<number[]>([]);
   const [query, setQuery] = useState("");
+  const debouncedQuery = useDebouncedValue(query.trim(), 300);
   const repositories = useInfiniteQuery({
-    queryKey: KEYS.githubConnectRepositories(orgId, flowId, installationId),
+    queryKey: KEYS.githubConnectRepositories(
+      orgId,
+      flowId,
+      installationId,
+      debouncedQuery,
+    ),
     initialPageParam: 1,
     queryFn: async ({ pageParam }) =>
       repositoryPageSchema.parse(
         await (
           await requestFlow(
-            `${path}/repositories?installationId=${installationId}&page=${pageParam}`,
+            `${path}/repositories?installationId=${installationId}&page=${pageParam}${debouncedQuery ? `&query=${encodeURIComponent(debouncedQuery)}` : ""}`,
           )
         ).json(),
       ),
@@ -390,35 +397,37 @@ function RepositoryGrantPicker({
         <Skeleton className="h-20 w-full" />
       ) : (
         <div className="max-h-64 overflow-y-auto space-y-2">
-          {choices
-            .filter((repo) =>
-              repo.name.toLowerCase().includes(query.trim().toLowerCase()),
-            )
-            .map((repo) => (
-              <label
-                key={repo.id}
-                className="flex items-center gap-2 text-sm py-1"
-              >
-                <Checkbox
-                  checked={selected.includes(repo.id)}
-                  disabled={
-                    busy ||
-                    (!selected.includes(repo.id) && selected.length >= 500)
-                  }
-                  onCheckedChange={(checked) =>
-                    setSelected((current) =>
-                      checked === true
-                        ? [...current, repo.id]
-                        : current.filter((id) => id !== repo.id),
-                    )
-                  }
-                />
-                <span className="break-all">{repo.name}</span>
-              </label>
-            ))}
+          {choices.map((repo) => (
+            <label
+              key={repo.id}
+              className="flex items-center gap-2 text-sm py-1"
+            >
+              <Checkbox
+                checked={selected.includes(repo.id)}
+                disabled={
+                  busy ||
+                  (!selected.includes(repo.id) && selected.length >= 500)
+                }
+                onCheckedChange={(checked) =>
+                  setSelected((current) =>
+                    checked === true
+                      ? [...current, repo.id]
+                      : current.filter((id) => id !== repo.id),
+                  )
+                }
+              />
+              <span className="break-all">{repo.name}</span>
+            </label>
+          ))}
           {choices.length === 0 && (
             <p className="text-sm text-muted-foreground">
-              {t("settings.repositories.githubNoRepos")}
+              {t(
+                repositories.hasNextPage
+                  ? "settings.repositories.githubSearchMore"
+                  : debouncedQuery
+                    ? "settings.repositories.githubSearchNoMatches"
+                    : "settings.repositories.githubNoRepos",
+              )}
             </p>
           )}
         </div>

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -139,9 +139,13 @@ export const settings = {
     "Choose up to 500 repositories for this workspace.",
   "settings.repositories.githubReplaceHint":
     "Saving replaces this account’s existing workspace access with your selection. Removed repositories stop receiving new credentials. Previously issued credentials may work until they expire.",
-  "settings.repositories.githubFilterRepos": "Filter loaded repositories",
+  "settings.repositories.githubFilterRepos": "Search repositories",
   "settings.repositories.githubNoRepos":
     "No repositories available to authorize.",
+  "settings.repositories.githubSearchNoMatches":
+    "No repositories match your search.",
+  "settings.repositories.githubSearchMore":
+    "Load more to keep searching your repositories.",
   "settings.repositories.githubAccessChanged":
     "Someone changed this account’s access. Go back and review the repositories again before saving.",
   "settings.repositories.githubMoreRepos": "Load more repositories",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -144,9 +144,13 @@ export const settings = {
     "Escolha até 500 repositórios para este workspace.",
   "settings.repositories.githubReplaceHint":
     "Salvar substitui o acesso atual desta conta no workspace pela sua seleção. Repositórios removidos deixam de receber novas credenciais. Credenciais já emitidas podem funcionar até expirarem.",
-  "settings.repositories.githubFilterRepos": "Filtrar repositórios carregados",
+  "settings.repositories.githubFilterRepos": "Buscar repositórios",
   "settings.repositories.githubNoRepos":
     "Nenhum repositório disponível para autorizar.",
+  "settings.repositories.githubSearchNoMatches":
+    "Nenhum repositório corresponde à sua busca.",
+  "settings.repositories.githubSearchMore":
+    "Carregue mais para continuar buscando nos seus repositórios.",
   "settings.repositories.githubAccessChanged":
     "Alguém alterou o acesso desta conta. Volte e revise os repositórios antes de salvar.",
   "settings.repositories.githubMoreRepos": "Carregar mais repositórios",

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -574,7 +574,15 @@ export const KEYS = {
     orgId: string,
     flowId: string,
     installationId: number,
-  ) => ["github-connect-repositories", orgId, flowId, installationId] as const,
+    query: string,
+  ) =>
+    [
+      "github-connect-repositories",
+      orgId,
+      flowId,
+      installationId,
+      query,
+    ] as const,
   gitAccounts: (orgId: string) => ["git-accounts", orgId] as const,
   /** Omit `accountId` for the whole org's list — that key is also the prefix a
    *  mutation invalidates to refresh every per-account listing with it. */


### PR DESCRIPTION
## Summary

The GitHub connect **grant picker** ("Choose up to 500 repositories for this workspace") only filtered the repositories already paged into the client. A repo on a not-yet-loaded page was invisible to the search box, and the empty state misleadingly said there were no repositories.

This threads the query to the backend so the search runs server-side across every installed repository — matching the pattern the `REPOSITORY_SEARCH` picker already uses.

## Changes

**Backend**
- `app-auth.ts`: `listRepositoryChoices` takes an optional `query`, filtering `owner/name` per page via the existing (already-tested) `matchesRepoQuery`. `hasMore` stays on the raw page length, so the filter never hides later provider pages. `canAuthorizeRepositories` still calls it without a query (no regression).
- `git-providers.ts`: `GET .../flows/:id/repositories` accepts an optional `query` (trimmed, max 256) and passes it through.

**Frontend (`github-connect-dialog.tsx`)**
- Debounces the query (300ms), threads it into the fetch URL + query key, and drops the client-side `.filter()`.
- Empty state now distinguishes "load more to keep searching" / "no matches" / "no repositories".
- Placeholder copy: "Filter loaded repositories" → "Search repositories" (en + pt-br).

## Known limitation

GitHub's installation-repositories endpoint has no native text search, so results are still filtered per page — a match deep in the pages may need "Load more". The fix is that search now works *across* pages instead of only over what was already loaded.

## Testing
- `tsc --noEmit` clean in `apps/api` and `apps/web`.
- `bun run lint`: 0 errors, no warnings in changed files.
- `bun run fmt` applied.
- The pure `matchesRepoQuery` semantics this relies on are fully covered in `client.test.ts` (substring, case-insensitive, empty/blank → match-all). The route/hook wiring is e2e territory (needs a live GitHub App) with no existing coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The GitHub connect grant picker now searches all installed repositories server-side, so a repo on a page the client hasn't loaded yet shows up in search instead of appearing missing.

- `listRepositoryChoices` and the `/repositories` route take an optional `query` filtered with the existing `matchesRepoQuery`; `hasMore` still tracks the raw page length so the filter never hides later provider pages.
- The picker debounces the query 300ms, includes it in the fetch URL and query key, and drops the client-side filter.
- The empty state now distinguishes "no repositories", "no matches", and "load more to keep searching"; the placeholder is now "Search repositories" in en and pt-br.
- GitHub's installation endpoint has no native search, so matching stays per page and a deep match may still need "Load more".

<sup>Written for commit 2eb1fec52b7adbbe7581a11063e267042996f256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

