### PR TITLE
fix(blog): enable "See preview" when the blog app omits pageSlug

### DIFF
--- a/apps/web/src/components/sandbox/content/blog/blog-preview-url.test.ts
+++ b/apps/web/src/components/sandbox/content/blog/blog-preview-url.test.ts
@@ -39,6 +39,53 @@ describe("findBlogPageSlug", () => {
     };
     expect(findBlogPageSlug(decofile)).toBeNull();
   });
+
+  it("falls back to the blog post Page block when the app omits pageSlug", () => {
+    // Bagaggio shape: app block has no route props; the route is a Page block.
+    const decofile = {
+      "deco-blog": { __resolveType: "site/apps/deco/blog.ts" },
+      "pages-blog-slug-66284": {
+        __resolveType: "website/pages/Page.tsx",
+        name: "Blog Post",
+        path: "/blog/:slug",
+        sections: [
+          { __resolveType: "site/sections/Blog/BlogPostPage.tsx" },
+          { __resolveType: "blog/loaders/BlogPostItem.ts" },
+        ],
+      },
+    };
+    expect(findBlogPageSlug(decofile)).toBe("/blog/:slug");
+  });
+
+  it("prefers the app's pageSlug over the Page block fallback", () => {
+    const decofile = {
+      blog: {
+        __resolveType: "site/apps/deco/blog.ts",
+        pageSlug: "/blogteste/:slug",
+      },
+      "pages-blog-slug-66284": {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/blog/:slug",
+        sections: [{ __resolveType: "site/sections/Blog/BlogPostPage.tsx" }],
+      },
+    };
+    expect(findBlogPageSlug(decofile)).toBe("/blogteste/:slug");
+  });
+
+  it("does not treat the category page as the post page", () => {
+    const decofile = {
+      "deco-blog": { __resolveType: "site/apps/deco/blog.ts" },
+      "pages-Blog Categoria-929386": {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/blog/categoria/:categoria",
+        sections: [
+          { __resolveType: "site/sections/Blog/BlogCategoryPage.tsx" },
+          { __resolveType: "site/sections/Blog/BlogCategoryHeader.tsx" },
+        ],
+      },
+    };
+    expect(findBlogPageSlug(decofile)).toBeNull();
+  });
 });
 
 describe("findBlogCategorySlug", () => {
@@ -62,6 +109,27 @@ describe("findBlogCategorySlug", () => {
     };
     expect(findBlogCategorySlug(decofile)).toBeNull();
   });
+
+  it("falls back to the category Page block, skipping the paginated variant", () => {
+    const decofile = {
+      "deco-blog": { __resolveType: "site/apps/deco/blog.ts" },
+      "pages-Blog Categoria-929386": {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/blog/categoria/:categoria",
+        sections: [
+          { __resolveType: "site/sections/Blog/BlogCategoryPage.tsx" },
+        ],
+      },
+      "pages-Blog Categoria Paginada-803419": {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/blog/categoria/:categoria/page/:page",
+        sections: [
+          { __resolveType: "site/sections/Blog/BlogCategoryPage.tsx" },
+        ],
+      },
+    };
+    expect(findBlogCategorySlug(decofile)).toBe("/blog/categoria/:categoria");
+  });
 });
 
 describe("applyBlogCategorySlug", () => {
@@ -75,6 +143,12 @@ describe("applyBlogCategorySlug", () => {
     );
     expect(applyBlogCategorySlug("/blog/:categorySlug?", "news")).toBe(
       "/blog/news",
+    );
+  });
+
+  it("substitutes the pt-BR :categoria param", () => {
+    expect(applyBlogCategorySlug("/blog/categoria/:categoria", "moda")).toBe(
+      "/blog/categoria/moda",
     );
   });
 
@@ -254,6 +328,25 @@ describe("buildBlogPostPreviewUrl", () => {
         previewBaseUrl: "https://abc.preview.example.com",
       }),
     ).toBeNull();
+  });
+
+  it("builds the url from the Page block when the app omits pageSlug", () => {
+    expect(
+      buildBlogPostPreviewUrl({
+        decofile: {
+          "deco-blog": { __resolveType: "site/apps/deco/blog.ts" },
+          "pages-blog-slug-66284": {
+            __resolveType: "website/pages/Page.tsx",
+            path: "/blog/:slug",
+            sections: [
+              { __resolveType: "site/sections/Blog/BlogPostPage.tsx" },
+            ],
+          },
+        },
+        post: { slug: "my-post", categories: [] },
+        previewBaseUrl: "https://abc.preview.example.com",
+      }),
+    ).toBe("https://abc.preview.example.com/blog/my-post");
   });
 
   it("returns null when there is no blog app block", () => {

--- a/apps/web/src/components/sandbox/content/blog/blog-preview-url.ts
+++ b/apps/web/src/components/sandbox/content/blog/blog-preview-url.ts
@@ -1,4 +1,5 @@
 import { withDraftPointer } from "@/components/sections-editor/section-preview-url";
+import { extractPathParams } from "@/components/sections-editor/page-path-utils";
 
 const str = (value: unknown): string =>
   typeof value === "string" ? value : "";
@@ -30,16 +31,81 @@ function readBlogAppProp(
   return null;
 }
 
+/**
+ * The blog app's `pageSlug`/`categorySlug` props are optional and most sites
+ * (blog-manager-generated ones included) never set them — the actual post and
+ * category routes live in decofile Page blocks instead (a
+ * `website/pages/Page.tsx` / `$live/pages/LivePage.tsx` with a `path`). When
+ * the app block omits the prop we recover the template from that Page block so
+ * "See preview" still works. A Page is the blog post/category page when its
+ * section tree includes the well-known full-page section (`BlogPostPage` /
+ * `BlogCategoryPage`); we pick the fewest-param match so a paginated variant
+ * (`…/page/:page`) never shadows the canonical route.
+ */
+const PAGE_RESOLVE_TYPES = new Set([
+  "website/pages/Page.tsx",
+  "$live/pages/LivePage.tsx",
+]);
+
+/** The `path` of a decofile Page block, or `null` for any other block shape. */
+function pageBlockPath(block: unknown): string | null {
+  if (!block || typeof block !== "object" || Array.isArray(block)) return null;
+  const obj = block as Record<string, unknown>;
+  if (typeof obj.__resolveType !== "string") return null;
+  if (!PAGE_RESOLVE_TYPES.has(obj.__resolveType)) return null;
+  return typeof obj.path === "string" ? obj.path : null;
+}
+
+/** Count the dynamic params in a path template, ignoring the `*` catch-all. */
+function paramCount(path: string): number {
+  return extractPathParams(path).filter((name) => name !== "*").length;
+}
+
+/**
+ * Finds the path template of the Page block whose section tree references the
+ * given full-page section marker (e.g. `BlogPostPage`), preferring the
+ * fewest-param candidate. Returns `null` when no Page matches.
+ */
+function findBlogPageTemplateByMarker(
+  decofile: Record<string, unknown>,
+  marker: RegExp,
+): string | null {
+  let best: string | null = null;
+  let bestParams = Number.POSITIVE_INFINITY;
+  for (const block of Object.values(decofile)) {
+    const path = pageBlockPath(block);
+    if (!path) continue;
+    if (!marker.test(JSON.stringify(block))) continue;
+    const params = paramCount(path);
+    if (params < bestParams) {
+      best = path;
+      bestParams = params;
+    }
+  }
+  return best;
+}
+
+/** Full-page section markers — never the `BlogPost*`/`BlogCategory*` body
+ * sections — so the post and category pages can't cross-match. */
+const BLOG_POST_PAGE_MARKER = /blogpostpage/i;
+const BLOG_CATEGORY_PAGE_MARKER = /blogcategorypage/i;
+
 export function findBlogPageSlug(
   decofile: Record<string, unknown>,
 ): string | null {
-  return readBlogAppProp(decofile, "pageSlug");
+  return (
+    readBlogAppProp(decofile, "pageSlug") ??
+    findBlogPageTemplateByMarker(decofile, BLOG_POST_PAGE_MARKER)
+  );
 }
 
 export function findBlogCategorySlug(
   decofile: Record<string, unknown>,
 ): string | null {
-  return readBlogAppProp(decofile, "categorySlug");
+  return (
+    readBlogAppProp(decofile, "categorySlug") ??
+    findBlogPageTemplateByMarker(decofile, BLOG_CATEGORY_PAGE_MARKER)
+  );
 }
 
 export function firstCategorySlug(post: Record<string, unknown>): string {
@@ -70,10 +136,9 @@ export function applyBlogPageSlug(
   return path;
 }
 
-// The `categorySlug` template's dynamic segment for the category slug — deco
-// has used `:category`, `:slug` and `:categorySlug` across versions.
-const HAS_CATEGORY_PARAM = /:(?:categorySlug|category|slug)\??/;
-const ALL_CATEGORY_PARAMS = /:(?:categorySlug|category|slug)\??/g;
+// Category route param names deco has used (`categoria` before `category` so the longer pt-BR match wins).
+const HAS_CATEGORY_PARAM = /:(?:categorySlug|categoria|category|slug)\??/;
+const ALL_CATEGORY_PARAMS = /:(?:categorySlug|categoria|category|slug)\??/g;
 
 /**
  * Substitutes the category slug into the blog app's `categorySlug` route


### PR DESCRIPTION
## Summary

The **"See preview"** button in the blog post/category editor stayed permanently disabled for blogs generated via `blog-manager` (repro'd on the `bagaggio` org). Root cause: the button is gated on a computed `previewUrl`, which was always `null` because `findBlogPageSlug`/`findBlogCategorySlug` only read the blog app block's `pageSlug`/`categorySlug` props — and those props are **optional with no upstream default**, so real sites (bagaggio included) never set them. The blog app block is literally `{"__resolveType":"site/apps/deco/blog.ts"}`.

The actual post/category routes don't live on the app block — they're **decofile Page blocks** (`website/pages/Page.tsx` with a `path`, e.g. `/blog/:slug`, `/blog/categoria/:categoria`). The preview logic simply wasn't looking there.

## Fix

In `blog-preview-url.ts`, when the blog app omits `pageSlug`/`categorySlug`, fall back to the decofile Page blocks:

- Detect the blog **post** page by the `BlogPostPage` full-page section marker and the **category** page by `BlogCategoryPage` (markers chosen so they never cross-match the `BlogPostSeo`/`BlogCategoryHeader` body sections).
- Pick the **fewest-param** candidate, so a paginated variant (`.../page/:page`) never shadows the canonical route.
- Accept the pt-BR `:categoria` param used by real sites (bagaggio's category route is `/blog/categoria/:categoria`).
- The app prop, when present, **still wins** — no regression.

## Testing

- `bun test .../blog-preview-url.test.ts` → 34 pass. Added coverage for: Page-block fallback for post & category, app-prop precedence, paginated-variant disambiguation, negative cross-match (category page ≠ post page), pt-BR `:categoria` substitution, and an end-to-end `buildBlogPostPreviewUrl` from a Page block — all using the real bagaggio decofile shapes.
- Full blog folder suite → 209 pass. `tsc --noEmit`, `oxlint`, `biome` all clean.

## Notes / out of scope

- The preview origin is still `lifecycle.previewUrl` (the sandbox dev server). If the sandbox/preview is down, the button correctly stays disabled — that's a separate concern from route resolution.
- The disabled button communicates its reason only via a native `title` attribute, which barely surfaces. Converting it to the design-system `Tooltip` is a worthwhile follow-up but left out to keep this PR focused on the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the blog "See preview" button staying disabled when the blog app omits `pageSlug`/`categorySlug`. The preview route now falls back to the decofile Page block that contains the blog post or category page; the app prop still wins when present.

- Detects the post/category page by its full-page section marker and picks the fewest-param route so paginated variants don't shadow the canonical one.
- Accepts the pt-BR `:categoria` param used by real sites.
- The button still stays disabled when the preview sandbox is down; that's a separate concern.

<sup>Written for commit db77fc91bc42f3260f05f2181a94c5f16a44c21b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

