### PR TITLE
fix(content-editor): honor contentCollection/contentItem deep-link params

### DIFF
--- a/apps/web/src/components/sandbox/content/content-browser.tsx
+++ b/apps/web/src/components/sandbox/content/content-browser.tsx
@@ -2,6 +2,7 @@ import { useOptionalChatTask } from "@/components/chat/chat-context";
 import { Spinner } from "@decocms/ui/components/spinner.tsx";
 import { Suspense, lazy, useState } from "react";
 import { type Query } from "@tanstack/react-query";
+import { useSearch } from "@tanstack/react-router";
 import {
   AlertCircle,
   CornerUpRight,
@@ -356,9 +357,27 @@ function ContentBrowserReady({
     { fetchEnabled: devServerReady },
   );
 
-  const [activeCollection, setActiveCollection] =
-    useState<CollectionId>("pages");
-  const [selection, setSelection] = useState<Selection>(null);
+  // Blog Manager's "Editar no Studio" redirect: ?contentCollection=posts&
+  // contentItem=<blockKey> pre-selects a blog collection and opens a specific
+  // record. Read once via a lazy initializer (not an effect) — normal
+  // navigation takes over afterwards, same one-shot shape as the storefront
+  // "." deep-link below.
+  const contentDeepLink = useSearch({ strict: false }) as {
+    contentCollection?: string;
+    contentItem?: string;
+  };
+  const [activeCollection, setActiveCollection] = useState<CollectionId>(
+    () =>
+      (contentDeepLink.contentCollection &&
+        isBlogKind(contentDeepLink.contentCollection as CollectionId) &&
+        (contentDeepLink.contentCollection as CollectionId)) ||
+      "pages",
+  );
+  const [selection, setSelection] = useState<Selection>(() =>
+    contentDeepLink.contentItem && isBlogKind(activeCollection)
+      ? { collection: activeCollection, key: contentDeepLink.contentItem }
+      : null,
+  );
   // Page that should open with the inline SEO form in SectionsEditor.
   const [openPageSeoKey, setOpenPageSeoKey] = useState<string | null>(null);
   // Storefront "." deep-link: open the visited page once the decofile loads. One-shot, so a later manual selection is never clobbered.


### PR DESCRIPTION
## Problem

Clicking "Editar no Studio ↗" in the Blog Manager doesn't land on the
post being edited — it opens the generic Posts list instead.

## Root cause

The Blog Manager's redirect (`decocms/spire-agent` PR
[#11](https://github.com/decocms/spire-agent/pull/11), merged
2026-07-14) navigates to:

```
{studioBase}/{org}/{taskId}?virtualmcpid=...&main=content&contentCollection=posts&contentItem=collections/blog/posts/<file>.json
```

`ContentBrowser` never read `contentCollection`/`contentItem`. This
support was written once, in #4302 — but that PR is stale (based on a
pre-rename `apps/mesh/...` path that no longer exists after the
mesh→web rename) and bundles two unrelated features, so it never
merged.

## Fix

Extracted just the deep-link piece and reapplied it to the current
`apps/web/...` layout: seed `activeCollection`/`selection` from
`useSearch({ strict: false })` via lazy `useState` initializers,
mirroring the existing storefront "." deep-link pattern
(`deepLinkPage`) already in this file. Read once — normal navigation
takes over from there. Older Studio builds without this change simply
ignore the extra params (unaffected — same graceful-degradation the
spire-agent side already relies on).

## Test plan

- [x] `tsc --noEmit` (apps/web) clean
- [ ] Click "Editar no Studio" from a Blog Manager post → lands on that
      exact post in the content editor (needs a live deploy to verify)

## Related

- Does NOT touch #4302 — that PR's product-string-editor + post-status
  work is unrelated and still needs its own rebase/decision.
- Companion investigation also found a real Checklist-block data
  contract bug in spire-agent causing a `Minified React error #31`
  crash when opening posts with a checklist section — fixed separately
  in decocms/spire-agent.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the content editor so Blog Manager’s “Editar no Studio” link opens the exact post instead of landing on the generic Posts list.

`ContentBrowser` now reads the `contentCollection` and `contentItem` query params once on mount and uses them to seed the active collection and selection. Normal navigation takes over afterward, and older Studio builds ignore the extra params without any change in behavior.

<sup>Written for commit e661516c750069a18a78b196afc2ff1d0e4fac97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

