### PR TITLE
fix(blog): stop gating "See preview" on unrelated content fields

### DIFF
--- a/apps/web/src/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/web/src/components/sandbox/content/blog/post-editor.tsx
@@ -158,16 +158,14 @@ export function PostEditor({
             type="button"
             variant="outline"
             size="sm"
-            disabled={!previewUrl || hasErrors}
+            disabled={!previewUrl}
             title={
-              hasErrors
-                ? missingLabel
-                : previewUrl
-                  ? t("sandbox.postEditor.previewTooltip")
-                  : t("sandbox.postEditor.previewRequiresSlugAndCategory")
+              previewUrl
+                ? t("sandbox.postEditor.previewTooltip")
+                : t("sandbox.postEditor.previewRequiresSlugAndCategory")
             }
             onClick={() => {
-              if (previewUrl && !hasErrors) {
+              if (previewUrl) {
                 window.open(previewUrl, "_blank", "noopener,noreferrer");
               }
             }}


### PR DESCRIPTION
## Problem

After #7150 (previewUrl route-resolution fix), "Ver visualização" still
shows disabled for some posts — e.g. Bagaggio's "Mochila Escolar..." draft,
which shows a red "1 problema" badge.

## Root cause

`#7150` fixed the right thing (previewUrl couldn't be built at all before),
but the button's disabled condition was never just about the URL:

```tsx
disabled={!previewUrl || hasErrors}
```

`hasErrors` comes from `missingPostFields()` — Title, Slug, Category,
Excerpt, **Cover image**. Slug/Category are already covered: when either is
missing, `buildBlogPostPreviewUrl` → `applyBlogPageSlug` already returns
`null`, so `previewUrl` itself is falsy. But Title/Excerpt/Cover image have
zero bearing on whether the URL resolves — a draft missing its excerpt still
renders fine at its route. Gating preview on them conflates "is this
publish-ready" (correct place: the Published toggle, via
`blocksPostStatus`) with "can we open a preview link" (only needs
slug+category, i.e. `previewUrl`).

So once #7150 made `previewUrl` resolve correctly, the button *still*
stayed disabled for any post missing excerpt/cover image/title — same
symptom, different, independent gate.

## Fix

`disabled={!previewUrl}`. The "N problema(s)" badge next to Saved is
untouched (still `hasErrors`-gated) — it keeps nudging toward
publish-readiness. This only stops it from also blocking the unrelated
preview button.

## Test plan

- [x] `tsc --noEmit` (apps/web) clean
- [x] `bun test blog-preview-url.test.ts` — 34 pass (unchanged, this PR
      doesn't touch URL-building, only the button's gate)
- [ ] Live: open a post missing excerpt/cover image (like the Bagaggio one
      in the report) and confirm "Ver visualização" is now clickable

## Related

Follow-up to #7150 (Daniel Furtado) — same investigation thread as #7151
and spire-agent#12.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the blog post preview button so it's no longer disabled by content fields that don't affect the preview URL. Previously, drafts missing Title, Excerpt, or Cover image kept the button disabled even though only Slug and Category determine whether the URL resolves.

**Bug Fixes**
- The disabled condition now only checks `previewUrl`; the "N problema(s)" badge still uses `hasErrors` and is unchanged.

<sup>Written for commit de0e1034154cfb1f781aa79c3239cfcbe7c27ae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

