### PR TITLE
fix(content-editor): declare contentCollection/contentItem in route search schemas

### DIFF
--- a/apps/web/src/components/sandbox/content/content-browser.tsx
+++ b/apps/web/src/components/sandbox/content/content-browser.tsx
@@ -110,6 +110,7 @@ import {
   scanBlogEntries,
   stampPostModified,
 } from "./blog/blog-data";
+import type { ContentSearchParams } from "./content-search-params";
 import {
   rescheduleToDay,
   scheduledPostPayload,
@@ -362,10 +363,7 @@ function ContentBrowserReady({
   // record. Read once via a lazy initializer (not an effect) — normal
   // navigation takes over afterwards, same one-shot shape as the storefront
   // "." deep-link below.
-  const contentDeepLink = useSearch({ strict: false }) as {
-    contentCollection?: string;
-    contentItem?: string;
-  };
+  const contentDeepLink = useSearch({ strict: false }) as ContentSearchParams;
   const [activeCollection, setActiveCollection] = useState<CollectionId>(
     () =>
       (contentDeepLink.contentCollection &&

--- a/apps/web/src/components/sandbox/content/content-search-params.ts
+++ b/apps/web/src/components/sandbox/content/content-search-params.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+/**
+ * Search params the content editor reads, declared ONCE.
+ *
+ * `ContentBrowser` reads these with `useSearch({ strict: false })`, which
+ * returns the route's VALIDATED search — a param a route's `validateSearch`
+ * doesn't declare is stripped by zod before the component ever sees it. Every
+ * route that can host the content editor spreads this into its own schema, so
+ * a param the browser consumes cannot silently be dropped by the router
+ * (which is exactly how the Blog Manager's "Editar no Studio" deep-link
+ * landed on the generic Pages list instead of the post).
+ *
+ * `contentPageId`/`contentPath`/`contentPathTemplate`: storefront "." deep-link
+ * (set by `/choose-editor`) — the CMS page id, the concrete URL and its route
+ * template. `contentCollection`/`contentItem`: Blog Manager "Editar no Studio"
+ * — a blog collection plus the decofile block key of the record to open.
+ */
+export const contentSearchParams = {
+  contentPageId: z.string().optional(),
+  contentPath: z.string().optional(),
+  contentPathTemplate: z.string().optional(),
+  contentCollection: z.string().optional(),
+  contentItem: z.string().optional(),
+} as const;
+
+export type ContentSearchParams = z.infer<
+  z.ZodObject<typeof contentSearchParams>
+>;

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -22,6 +22,7 @@ import { LOCALSTORAGE_KEYS } from "@/lib/localstorage-keys";
 import { readLastLocation, saveLastLocation } from "@/lib/last-location";
 import { promoteLegacyTaskParam } from "@/lib/legacy-route-translation";
 import { isKnownPanelSegment } from "@/layouts/main-panel-tabs/panel-route";
+import { contentSearchParams } from "@/components/sandbox/content/content-search-params";
 
 const rootRoute = createRootRoute({
   /** No `<Providers>` here: each entry (`index.web.tsx`, `index.native.tsx`)
@@ -415,13 +416,8 @@ const unifiedChatSearchSchema = z.object({
    *  carried in the URL (same context as `/commerce-onboarding?siteUrl=…`) so the
    *  modal is self-describing. Falls back to the connection's stored metadata. */
   siteUrl: z.string().optional(),
-  /** Storefront "." deep-link: preselect a page in the content editor. Set by
-   *  `/choose-editor`; consumed by ContentBrowser. `contentPageId` is the CMS
-   *  page id; `contentPath`/`contentPathTemplate` are the concrete URL and its
-   *  route template (page.path in the decofile stores the template). */
-  contentPageId: z.string().optional(),
-  contentPath: z.string().optional(),
-  contentPathTemplate: z.string().optional(),
+  /** Content editor deep-links — declared in `content-search-params.ts`. */
+  ...contentSearchParams,
   /** Task board view state (`main=board`) — persisted in the URL so a refresh
    *  or a shared link keeps the layout and filters. See `filters-search.ts`. */
   view: z.string().optional(),
@@ -565,10 +561,8 @@ const agentsRoute = createRoute({
     /** Commerce onboarding hand-off (see `/$org/reports`). */
     connect: z.coerce.string().optional(),
     siteUrl: z.string().optional(),
-    /** Storefront "." deep-link: preselect a page in the content editor. */
-    contentPageId: z.string().optional(),
-    contentPath: z.string().optional(),
-    contentPathTemplate: z.string().optional(),
+    /** Content editor deep-links — declared in `content-search-params.ts`. */
+    ...contentSearchParams,
   }),
   component: () => null,
 });


### PR DESCRIPTION
## Bug

The Blog Manager's "Editar no Studio ↗" button redirects to
`?virtualmcpid=…&main=content&contentCollection=posts&contentItem=<blockKey>`
expecting the content editor to open on that exact post — instead it lands on
an empty/generic content editor (attachments 2 vs 3 in the report).

## Root cause

`#7151` added the `contentCollection`/`contentItem` read + selection logic
inside `ContentBrowser` (`useSearch({ strict: false })`), but neither route
that can host it — the unified-chat route (`/$org/$taskId`) nor the agents
route (`/$org/agents/{-$panel}`) — declared those two keys in their
`validateSearch` schema.

TanStack Router validates search params per-route and **strips any key the
matched route's schema doesn't declare** before the component ever reads it.
So the params were dropped in-flight and `ContentBrowser` always saw
`contentCollection: undefined`, falling back to the generic Pages view —
reproducing exactly the bug `#7151` was meant to fix.

## Fix

Factored the content-editor search params (storefront "." deep-link +
`contentCollection`/`contentItem`) into one `content-search-params.ts` module,
spread into both route schemas that can render `ContentBrowser`. A future
param the browser reads now can't silently be dropped by one route and not
the other.

## Note on the second reported issue

The "Ver visualização" (post preview) button was also reported as
not-clickable. That's already fixed on `main` by `#7150` (derive preview
route from decofile Page blocks) and `#7152` (stop gating the button on
unrelated publish-readiness fields) — both merged today, just not yet
deployed to `studio.decocms.com`. Not reproducible against current `main`;
no additional change needed.

## Testing

- `bun test apps/web/src` — 3357 pass / 110 fail, identical to `main`
  baseline (the 110 are pre-existing pt-BR locale-formatting failures,
  unrelated to this change).
- `bun run check` (apps/web) — same error count as `main` baseline (1983,
  all pre-existing `@decocms/ui` unbuilt-package resolution errors).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Blog Manager's "Editar no Studio" deep-link so the content editor opens on the selected post instead of a generic empty editor.

- The `contentCollection`/`contentItem` search params were stripped by TanStack Router because the hosting routes didn't declare them in their `validateSearch` schemas.
- Declares all content-editor search params once in `content-search-params.ts` and spreads them into both route schemas that render `ContentBrowser`.
- The reported preview button issue is already fixed on `main` and not reproducible here.

<sup>Written for commit 95a30d028ed9895373e8d0245657e530af521255. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

