### PR TITLE
fix(content): move Advanced group below Calendar in content sidebar

### DIFF
--- a/apps/web/src/components/sandbox/content/collections-sidebar.tsx
+++ b/apps/web/src/components/sandbox/content/collections-sidebar.tsx
@@ -64,7 +64,6 @@ export function CollectionsSidebar({
           active={active === "redirects"}
           onSelect={onSelect}
         />
-        <AdvancedGroup active={active} counts={counts} onSelect={onSelect} />
         <CollectionRow
           id="site"
           icon={Settings01}
@@ -86,6 +85,7 @@ export function CollectionsSidebar({
           active={active === "calendar"}
           onSelect={onSelect}
         />
+        <AdvancedGroup active={active} counts={counts} onSelect={onSelect} />
         {showBlog && (
           <>
             <div className="mt-3 flex items-center gap-1.5 px-2.5 pb-1 pt-1 text-xs font-medium text-muted-foreground/70">


### PR DESCRIPTION
## Summary

Moves the collapsible **Advanced** group in the Content sidebar so it renders below **Calendar** instead of between Redirects and Site.

New top-level order: Pages → Redirects → Site → SEO → Calendar → **Advanced** (Blog section still follows when enabled).

## Testing

- `bun run fmt` passes
- Visual-only reordering in `apps/web/src/components/sandbox/content/collections-sidebar.tsx`; no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the collapsible Advanced group in the content sidebar to render below Calendar instead of between Redirects and Site. The new top-level order is Pages → Redirects → Site → SEO → Calendar → Advanced, with the Blog section still following when enabled. This is a visual-only reordering with no logic changes.

<sup>Written for commit ff1b8ae22909870395699ab7268b8e4f29e5a5e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

