### PR TITLE
fix(sections-editor): stop Add variant button overlapping field controls

### DIFF
--- a/apps/web/src/components/sections-editor/fields/multivariate-field-wrapper.tsx
+++ b/apps/web/src/components/sections-editor/fields/multivariate-field-wrapper.tsx
@@ -69,14 +69,15 @@ export function MultivariateFieldWrapper({
 
   if (!isMultivariateWrapper(value)) {
     return (
-      <div className="relative grid w-full min-w-0 grid-cols-[minmax(0,1fr)] gap-2">
+      <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2">
+        {renderInnerField(props)}
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
               type="button"
               variant="ghost"
               size="icon"
-              className="absolute right-0 top-0 size-6 text-muted-foreground hover:text-foreground"
+              className="size-6 shrink-0 text-muted-foreground hover:text-foreground"
               aria-label={t(
                 "sectionsEditor.multivariateFieldWrapper.addVariant",
               )}
@@ -92,7 +93,6 @@ export function MultivariateFieldWrapper({
             {t("sectionsEditor.multivariateFieldWrapper.addVariant")}
           </TooltipContent>
         </Tooltip>
-        {renderInnerField(props)}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

In the site editor's section properties panel, the multivariate **Add variant** flag button was absolutely positioned at `right-0 top-0` of the field it wraps (`multivariate-field-wrapper.tsx`).

That's empty space for the common stacked field (label above input), but `BooleanField` is the one field with an inline layout — `flex items-center justify-between` with the `Switch` pinned right — so the flag rendered directly on top of the toggle. It covered the switch, stole clicks aimed at its right half, and popped the "Add variant" tooltip over the control on hover.

**Fix:** give the button its own gutter column (`grid-cols-[minmax(0,1fr)_auto] items-start`) instead of overlaying the field. The button keeps its visual position (top-right, aligned with the label row thanks to `items-start`) and now also renders *after* the field in the DOM, so focus order is input → Add variant rather than the reverse.

Trade-off: fields that can be made multivariate lose ~32px of width to the gutter. That's the cost of not covering controls; the alternative — keeping the overlay and special-casing boolean via a layout hint threaded from `schema-form.tsx` — is more code and breaks again for the next inline-layout field.

## Testing

- `bun run fmt`, `bun run --cwd=apps/web check`, `bun run lint` (0 errors; the 14 warnings are pre-existing and none are in the touched file).
- Verified manually in the sections editor: the "Use Simple Search" toggle on Global Header is no longer covered, and the flag button still wraps the field into a variant.

No existing test asserted the overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the "Add variant" button in the sections editor's property panel from overlapping field controls, so boolean toggles are no longer covered or have their clicks stolen.

The button now sits in its own gutter column instead of overlaying the field and renders after the field, so focus order is input → Add variant. Fields that can be multivariate lose ~32px of width to the gutter.

<sup>Written for commit c093378fc511d8f5eecd80c9ab3ba7f860d0f153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

