### PR TITLE
fix(cms): scroll draft list in the branch picker

### DIFF
--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -315,7 +315,8 @@ export function BranchPicker({
           />
         ) : (
           <>
-            <div className="flex flex-col">
+            {/* Scroll the list, not the popover: the rows below must stay reachable. */}
+            <div className="flex max-h-[min(50vh,20rem)] flex-col overflow-y-auto">
               {unlisted &&
                 value &&
                 (editing === value ? (


### PR DESCRIPTION
## What is this contribution about?
The draft (release) list in the CMS branch picker had no height cap or overflow, so with many drafts the popover grew past the viewport with no way to scroll — and the "New draft" / "Advanced" rows at the bottom became unreachable. The list is now capped at `min(50vh, 20rem)` and scrolls on its own, keeping those rows visible.

## How did you verify your code works?
`bun run fmt` (no changes), `tsc --noEmit` for `apps/web` (clean), and `bun run lint` (0 errors; 14 pre-existing warnings in unrelated files). No automated test added: this is a CSS-only change, which fits neither the unit tier (pure logic) nor warrants a new e2e spec.

## Screenshots/Demonstration
Before: the popover overflowed the window bottom (see the reported screenshot with ~25 "Rascunho N" entries running off-screen).

## How to Test
1. Open a CMS project with 15+ drafts.
2. Click the branch/version picker in the header.
3. The draft list scrolls within the popover, and "New draft" and "Advanced" stay visible at the bottom.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the draft list in the CMS branch picker at `min(50vh, 20rem)` and makes it scroll, so the popover no longer overflows the viewport and the "New draft" / "Advanced" rows stay reachable. Adds a Playwright component test that mounts the picker with 40 drafts and verifies the list scrolls within the popover while the actions below it remain visible.

<sup>Written for commit b9049e258aab88b6766eb51d485911973af6e320. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

