### PR TITLE
feat(git-providers): add Bitbucket Cloud as a third git provider

### DIFF
--- a/apps/api/migrations/213-bitbucket-git-provider.ts
+++ b/apps/api/migrations/213-bitbucket-git-provider.ts
@@ -1,0 +1,49 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * A third git provider kind, Bitbucket Cloud. The three `type`/`provider`
+ * columns were created with inline CHECK constraints naming the two kinds of
+ * the day, so each is re-stated with the third. The auto-generated names are
+ * Postgres's `<table>_<column>_check`.
+ */
+
+const CONSTRAINTS = [
+  { table: "git_provider_accounts", column: "type" },
+  { table: "git_provider_oauth_states", column: "provider" },
+  { table: "repositories", column: "provider" },
+] as const;
+
+async function restate(
+  db: Kysely<unknown>,
+  kinds: readonly string[],
+): Promise<void> {
+  for (const { table, column } of CONSTRAINTS) {
+    const name = `${table}_${column}_check`;
+    const list = kinds.map((kind) => `'${kind}'`).join(", ");
+    await sql
+      .raw(`ALTER TABLE ${table} DROP CONSTRAINT IF EXISTS ${name}`)
+      .execute(db);
+    await sql
+      .raw(
+        `ALTER TABLE ${table} ADD CONSTRAINT ${name} CHECK (${column} IN (${list}))`,
+      )
+      .execute(db);
+  }
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await restate(db, ["github", "gitlab", "bitbucket"]);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Rows of the new kind would violate the narrower check; remove them first
+  // (repositories cascade from their account, oauth states are transient).
+  await sql`DELETE FROM repositories WHERE provider = 'bitbucket'`.execute(db);
+  await sql`DELETE FROM git_provider_oauth_states WHERE provider = 'bitbucket'`.execute(
+    db,
+  );
+  await sql`DELETE FROM git_provider_accounts WHERE type = 'bitbucket'`.execute(
+    db,
+  );
+  await restate(db, ["github", "gitlab"]);
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -1,6 +1,7 @@
 import * as migration211userfsorg from "./211-user-fs-org";
 import * as migration210githubrepositoryauthorization from "./210-github-repository-authorization";
 import * as migration212codingagentmcpexcluded from "./212-coding-agent-mcp-excluded";
+import * as migration213bitbucketgitprovider from "./213-bitbucket-git-provider";
 import * as migration209githubinstallationauthorization from "./209-github-installation-authorization";
 import * as migration208githubconnectflows from "./208-github-connect-flows";
 import * as migration207taskboardprsrepoidx from "./207-task-board-prs-repo-idx";
@@ -460,6 +461,7 @@ const migrations: Record<string, Migration> = {
     migration210githubrepositoryauthorization,
   "211-user-fs-org": migration211userfsorg,
   "212-coding-agent-mcp-excluded": migration212codingagentmcpexcluded,
+  "213-bitbucket-git-provider": migration213bitbucketgitprovider,
 };
 
 export default migrations;

--- a/apps/api/src/api/routes/git-providers.ts
+++ b/apps/api/src/api/routes/git-providers.ts
@@ -16,7 +16,8 @@
  * The encrypted ten-minute user grant is deleted after selection; saved
  * accounts mint repository-restricted tokens using the App private key.
  *
- * GitLab: standard OAuth with a refreshable grant stored on the account.
+ * GitLab and Bitbucket: standard OAuth with a refreshable grant stored on the
+ * account.
  *
  * Every starter answers 503 when the deployment has no credentials for that
  * provider — the feature is dormant until configured.
@@ -42,6 +43,12 @@ import {
   githubAuthorizeUrl,
 } from "@/git-providers/github/oauth";
 import { gitlabCurrentUser } from "@/git-providers/gitlab/client";
+import { readBitbucketOAuthConfig } from "@/git-providers/bitbucket/env";
+import { bitbucketPrincipalForToken } from "@/git-providers/bitbucket/client";
+import {
+  bitbucketAuthorizeUrl,
+  exchangeBitbucketCode,
+} from "@/git-providers/bitbucket/oauth";
 import {
   exchangeGitlabCode,
   gitlabAuthorizeUrl,
@@ -64,7 +71,7 @@ export function sanitizeReturnTo(raw: string | undefined | null): string {
   return raw;
 }
 
-function callbackUrl(provider: "github" | "gitlab"): string {
+function callbackUrl(provider: GitProviderKind): string {
   return `${getPublicUrl()}/api/_git/${provider}/callback`;
 }
 
@@ -384,6 +391,34 @@ export const createGitProviderRoutes = () => {
     );
   });
 
+  /** Bitbucket Cloud: one host, so the query carries no `host`. */
+  app.get("/git-providers/bitbucket/connect", async (c) => {
+    const ctx = c.get("studioContext");
+    if (!ctx.auth.user) return c.json({ error: "Unauthorized" }, 401);
+    const config = readBitbucketOAuthConfig();
+    if (!config) {
+      return c.json(
+        {
+          error:
+            "No Bitbucket OAuth consumer is configured. Connect with an access token instead.",
+        },
+        503,
+      );
+    }
+    const state = await mintState(ctx, {
+      provider: "bitbucket",
+      host: config.host,
+      returnTo: sanitizeReturnTo(c.req.query("returnTo")),
+    });
+    return c.redirect(
+      bitbucketAuthorizeUrl({
+        clientId: config.clientId,
+        redirectUri: callbackUrl("bitbucket"),
+        state,
+      }),
+    );
+  });
+
   return app;
 };
 
@@ -539,6 +574,63 @@ gitProviderCallbackRoutes.get("/gitlab/callback", async (c) => {
     return c.redirect(finish(returnTo));
   } catch (error) {
     console.error("[git-providers] gitlab callback failed", {
+      host,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return c.redirect(finish(returnTo, "exchange_failed"));
+  }
+});
+
+gitProviderCallbackRoutes.get("/bitbucket/callback", async (c) => {
+  const ctx = await ContextFactory.create(c.req.raw);
+  const consumed = await consumeState(ctx, "bitbucket", c.req.query("state"));
+  if (!consumed.ok) {
+    return c.redirect(finish(consumed.returnTo, consumed.error));
+  }
+  const { returnTo, state } = consumed;
+  const { host } = state;
+  const config = readBitbucketOAuthConfig();
+  const code = c.req.query("code");
+  if (!config || config.host !== host) {
+    return c.redirect(finish(returnTo, "not_configured"));
+  }
+  if (!code) {
+    return c.redirect(finish(returnTo, c.req.query("error") ?? "denied"));
+  }
+  try {
+    const grant = await exchangeBitbucketCode({
+      clientId: config.clientId,
+      clientSecret: config.clientSecret,
+      code,
+      redirectUri: callbackUrl("bitbucket"),
+    });
+    const principal = await bitbucketPrincipalForToken(host, grant.accessToken);
+    const account = await ctx.storage.gitProviderAccounts.upsert({
+      organizationId: state.organizationId,
+      type: "bitbucket",
+      host,
+      authKind: "oauth",
+      externalAccountId: principal.externalAccountId,
+      login: principal.login,
+      avatarUrl: principal.avatarUrl,
+      createdBy: state.userId,
+    });
+    await ctx.storage.gitProviderAccountCredentials.upsert({
+      connectionId: account.id,
+      accessToken: grant.accessToken,
+      refreshToken: grant.refreshToken,
+      scope: grant.scope,
+      expiresAt:
+        grant.expiresIn !== null
+          ? new Date(Date.now() + grant.expiresIn * 1000)
+          : null,
+      clientId: config.clientId,
+      clientSecret: config.clientSecret,
+      tokenEndpoint: grant.tokenEndpoint,
+    });
+    return c.redirect(finish(returnTo));
+  } catch (error) {
+    console.error("[git-providers] bitbucket callback failed", {
       host,
       message: error instanceof Error ? error.message : String(error),
     });

--- a/apps/api/src/git-providers/bitbucket/change-requests.test.ts
+++ b/apps/api/src/git-providers/bitbucket/change-requests.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test";
+import {
+  conflictFromDiffstat,
+  countUnresolved,
+  isConflictRefusal,
+  isDuplicateRefusal,
+  mapComments,
+  mapCommitStatus,
+  mapState,
+  mapStatusState,
+  reviewBlockedFrom,
+} from "./change-requests";
+
+describe("mapState", () => {
+  test("maps Bitbucket's four lifecycle values", () => {
+    expect(mapState("OPEN")).toBe("open");
+    expect(mapState("MERGED")).toBe("merged");
+    expect(mapState("DECLINED")).toBe("closed");
+    expect(mapState("SUPERSEDED")).toBe("closed");
+  });
+  test("reads anything unexpected as open, never as finished", () => {
+    expect(mapState(undefined)).toBe("open");
+    expect(mapState("weird")).toBe("open");
+  });
+});
+
+describe("mapStatusState", () => {
+  test("splits a commit status into the state and conclusion pair", () => {
+    expect(mapStatusState("SUCCESSFUL")).toEqual({
+      state: "completed",
+      conclusion: "success",
+    });
+    expect(mapStatusState("FAILED")).toEqual({
+      state: "completed",
+      conclusion: "failure",
+    });
+    expect(mapStatusState("INPROGRESS")).toEqual({
+      state: "running",
+      conclusion: null,
+    });
+  });
+  test("reads a stopped build as red, not as nothing", () => {
+    expect(mapStatusState("STOPPED")).toEqual({
+      state: "completed",
+      conclusion: "cancelled",
+    });
+  });
+  test("anything unknown is still queued", () => {
+    expect(mapStatusState(null)).toEqual({ state: "queued", conclusion: null });
+  });
+});
+
+describe("mapCommitStatus", () => {
+  test("reads a status into a run, timing it from its own stamps", () => {
+    expect(
+      mapCommitStatus({
+        key: "ci/build",
+        name: "Build",
+        state: "SUCCESSFUL",
+        url: "https://ci.example/1",
+        description: "all green",
+        created_on: "2026-09-11T12:00:00Z",
+        updated_on: "2026-09-11T12:02:30Z",
+      }),
+    ).toEqual({
+      id: "ci/build",
+      name: "Build",
+      state: "completed",
+      conclusion: "success",
+      url: "https://ci.example/1",
+      durationMs: 150_000,
+      summary: "all green",
+    });
+  });
+  test("has no duration while running", () => {
+    expect(
+      mapCommitStatus({
+        key: "ci",
+        state: "INPROGRESS",
+        created_on: "2026-09-11T12:00:00Z",
+        updated_on: "2026-09-11T12:01:00Z",
+      }).durationMs,
+    ).toBeNull();
+  });
+});
+
+describe("mapComments / countUnresolved", () => {
+  const comments = [
+    {
+      id: 1,
+      content: { raw: "Looks good" },
+      user: { nickname: "ada" },
+      created_on: "2026-09-11T12:00:00Z",
+      updated_on: "2026-09-11T12:05:00Z",
+      links: {
+        html: { href: "https://bitbucket.org/a/s/pull-requests/1#comment-1" },
+      },
+    },
+    {
+      id: 2,
+      content: { raw: "Preview: https://preview.example" },
+      user: { nickname: "bot" },
+      created_on: "2026-09-11T11:00:00Z",
+    },
+    {
+      id: 3,
+      content: { raw: "rename this" },
+      user: { nickname: "ada" },
+      created_on: "2026-09-11T12:01:00Z",
+      inline: { path: "a.ts" },
+    },
+    {
+      id: 4,
+      content: { raw: "done" },
+      user: { nickname: "bob" },
+      created_on: "2026-09-11T12:02:00Z",
+      inline: { path: "a.ts" },
+      parent: { id: 3 },
+    },
+    {
+      id: 5,
+      content: { raw: "resolved thread" },
+      created_on: "2026-09-11T12:03:00Z",
+      inline: { path: "b.ts" },
+      resolution: { type: "resolution" },
+    },
+    {
+      id: 6,
+      content: { raw: "gone" },
+      deleted: true,
+      created_on: "2026-09-11T12:04:00Z",
+    },
+  ];
+
+  test("keeps only live comments on the pull request itself, oldest first", () => {
+    const mapped = mapComments(
+      comments,
+      "https://bitbucket.org/a/s/pull-requests/1",
+    );
+    expect(mapped.map((c) => c.id)).toEqual(["2", "1"]);
+    expect(mapped[1]).toEqual({
+      id: "1",
+      author: "ada",
+      body: "Looks good",
+      createdAt: "2026-09-11T12:00:00Z",
+      updatedAt: "2026-09-11T12:05:00Z",
+      url: "https://bitbucket.org/a/s/pull-requests/1#comment-1",
+    });
+    // No edit time: the creation time stands in.
+    expect(mapped[0]!.updatedAt).toBe("2026-09-11T11:00:00Z");
+  });
+
+  test("counts live, top-level inline threads with no resolution", () => {
+    expect(countUnresolved(comments)).toBe(1);
+  });
+});
+
+describe("conflictFromDiffstat", () => {
+  test("null when the diffstat could not be read", () => {
+    expect(conflictFromDiffstat(null)).toBeNull();
+  });
+  test("true only when an entry is a merge conflict", () => {
+    expect(conflictFromDiffstat([{ status: "modified" }])).toBe(false);
+    expect(
+      conflictFromDiffstat([
+        { status: "modified" },
+        { status: "merge conflict" },
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("reviewBlockedFrom", () => {
+  test("someone asked for changes", () => {
+    expect(
+      reviewBlockedFrom({
+        participants: [{ state: "approved" }, { state: "changes_requested" }],
+      }),
+    ).toBe(true);
+    expect(reviewBlockedFrom({ participants: [{ state: "approved" }] })).toBe(
+      false,
+    );
+    expect(reviewBlockedFrom({})).toBe(false);
+  });
+});
+
+describe("refusal prose", () => {
+  test("a conflict names itself", () => {
+    expect(isConflictRefusal("There are merge conflicts")).toBe(true);
+    expect(isConflictRefusal("You need two approvals")).toBe(false);
+  });
+  test("a duplicate pull request", () => {
+    expect(
+      isDuplicateRefusal("There is already an open pull request from x to y"),
+    ).toBe(true);
+    expect(isDuplicateRefusal("A pull request already exists")).toBe(true);
+    expect(isDuplicateRefusal("source branch not found")).toBe(false);
+  });
+});

--- a/apps/api/src/git-providers/bitbucket/change-requests.test.ts
+++ b/apps/api/src/git-providers/bitbucket/change-requests.test.ts
@@ -3,7 +3,6 @@ import {
   conflictFromDiffstat,
   countUnresolved,
   isConflictRefusal,
-  isDuplicateRefusal,
   mapComments,
   mapCommitStatus,
   mapState,
@@ -188,12 +187,5 @@ describe("refusal prose", () => {
   test("a conflict names itself", () => {
     expect(isConflictRefusal("There are merge conflicts")).toBe(true);
     expect(isConflictRefusal("You need two approvals")).toBe(false);
-  });
-  test("a duplicate pull request", () => {
-    expect(
-      isDuplicateRefusal("There is already an open pull request from x to y"),
-    ).toBe(true);
-    expect(isDuplicateRefusal("A pull request already exists")).toBe(true);
-    expect(isDuplicateRefusal("source branch not found")).toBe(false);
   });
 });

--- a/apps/api/src/git-providers/bitbucket/change-requests.ts
+++ b/apps/api/src/git-providers/bitbucket/change-requests.ts
@@ -223,11 +223,6 @@ export function isConflictRefusal(message: string): boolean {
   return /conflict/i.test(message);
 }
 
-/** A pull request opened on a source/destination pair that already has one. */
-export function isDuplicateRefusal(message: string): boolean {
-  return /already (?:an? )?open|already exists/i.test(message);
-}
-
 export class BitbucketChangeRequestClient implements ChangeRequestClient {
   readonly repo: RepoRef;
   private readonly tokenSource: TokenSource;
@@ -302,6 +297,7 @@ export class BitbucketChangeRequestClient implements ChangeRequestClient {
       updatedAt: pr.updated_on ?? null,
       base: pr.destination?.branch?.name ?? "main",
       head: pr.source?.branch?.name ?? "",
+      // 12-char short hash on this payload; every commit endpoint accepts it.
       headSha: pr.source?.commit?.hash ?? "",
       // The source repository is on the payload; absent means the fork is gone.
       headRepoPath: pr.source?.repository?.full_name ?? null,
@@ -403,7 +399,21 @@ export class BitbucketChangeRequestClient implements ChangeRequestClient {
     return best;
   }
 
+  /**
+   * Bitbucket does not refuse a second pull request for a source/destination
+   * pair that already has an open one: `POST /pullrequests` UPDATES it in
+   * place, title and description included (verified against bitbucket.org).
+   * So the duplicate is detected here, before anything is sent, and reported
+   * as {@link ChangeRequestExists} the way the other providers' refusals are.
+   */
   async open(params: OpenChangeRequestParams): Promise<ChangeRequest> {
+    const existing = await this.openFor(params.head, params.base);
+    if (existing) {
+      throw new ChangeRequestExists(
+        `Bitbucket already has an open pull request from ${params.head} to ${params.base}: #${existing.number}`,
+        existing,
+      );
+    }
     const res = await bitbucketFetch(
       `${this.repoBase}/pullrequests`,
       await this.token(),
@@ -418,14 +428,22 @@ export class BitbucketChangeRequestClient implements ChangeRequestClient {
       },
     );
     if (res.ok) return this.map((await res.json()) as RawPullRequest);
-    const failure = await bitbucketFailure(res);
-    if (isDuplicateRefusal(failure.message)) {
-      throw new ChangeRequestExists(
-        failure.message,
-        await this.readForBranch(params.head).catch(() => null),
-      );
-    }
-    throw failure;
+    throw await bitbucketFailure(res);
+  }
+
+  /** The open pull request proposing `head` onto `base`, if any. */
+  private async openFor(
+    head: string,
+    base: string,
+  ): Promise<ChangeRequest | null> {
+    const params = new URLSearchParams({
+      state: "OPEN",
+      q: `source.branch.name = ${bbqString(head)} AND destination.branch.name = ${bbqString(base)}`,
+      pagelen: "1",
+    });
+    const rows = await this.values<RawPullRequest>(`/pullrequests?${params}`);
+    const first = rows?.[0];
+    return first ? this.map(first) : null;
   }
 
   /** Bitbucket's update requires the title alongside, so the current one rides along. */

--- a/apps/api/src/git-providers/bitbucket/change-requests.ts
+++ b/apps/api/src/git-providers/bitbucket/change-requests.ts
@@ -1,0 +1,594 @@
+/**
+ * `ChangeRequestClient` over Bitbucket Cloud's REST 2.0 API.
+ *
+ * A Bitbucket pull request is the same object GitHub's is, so the read side
+ * maps almost field-for-field. Where Bitbucket carries less on the single
+ * read than the others, the neutral field answers "unknown" rather than a
+ * guess: the pull request payload has no mergeability, no CI rollup and no
+ * merge timestamp, so the cheap read reports `conflicting: null` and
+ * `checks: null`, and the detailed read pays for them — the pull request's
+ * diffstat names conflicting files, and the head commit's statuses are the CI
+ * signal. `mergedAt` is the last update of a merged pull request, which is
+ * the merge in the overwhelming case and never earlier than it.
+ *
+ * Bitbucket Cloud only — see `http.ts`.
+ */
+
+import { changeRequestUrl, type RepoRef } from "@decocms/shared/git-providers";
+import { retry, RetryError } from "@decocms/shared/std";
+import { GitProviderError, type TokenSource } from "../types";
+import {
+  type ChangeRequest,
+  type ChangeRequestClient,
+  type ChangeRequestComment,
+  type ChangeRequestDetail,
+  ChangeRequestExists,
+  type CheckConclusion,
+  type CheckRun,
+  type CheckState,
+  type MergeOutcome,
+  type MergeParams,
+  type MergeRefusal,
+  type OpenChangeRequestParams,
+  summarizeChecks,
+} from "../change-requests";
+import { repositoryApiPath } from "./client";
+import {
+  BITBUCKET_API_BASE,
+  bbqString,
+  bitbucketFailure,
+  bitbucketFetch,
+  type BitbucketPage,
+} from "./http";
+
+/** Bitbucket caps pull request listings at 50 per page; other listings at 100. */
+const PR_PAGE_SIZE = 50;
+const PAGE_SIZE = 100;
+/** Merged pull requests scanned when looking for the latest merge into a branch. */
+const MERGED_SCANNED = 20;
+
+export interface RawPullRequest {
+  id?: number | null;
+  title?: string | null;
+  description?: string | null;
+  state?: string | null;
+  draft?: boolean | null;
+  updated_on?: string | null;
+  destination?: { branch?: { name?: string | null } | null } | null;
+  source?: {
+    branch?: { name?: string | null } | null;
+    commit?: { hash?: string | null } | null;
+    repository?: { full_name?: string | null } | null;
+  } | null;
+  author?: { nickname?: string | null } | null;
+  merge_commit?: { hash?: string | null } | null;
+  links?: { html?: { href?: string | null } | null } | null;
+  participants?: Array<{ state?: string | null }> | null;
+}
+
+/** Bitbucket's four lifecycle values, in the neutral vocabulary. */
+export function mapState(state: unknown): ChangeRequest["state"] {
+  if (state === "MERGED") return "merged";
+  if (state === "DECLINED" || state === "SUPERSEDED") return "closed";
+  return "open";
+}
+
+/**
+ * A commit status, split into the state/conclusion pair a reader sees. Pure —
+ * unit-tested. `STOPPED` reads as cancelled, and therefore red, on purpose: a
+ * build that did not finish is not evidence the head is good.
+ */
+export function mapStatusState(state: unknown): {
+  state: CheckState;
+  conclusion: CheckConclusion | null;
+} {
+  switch (state) {
+    case "SUCCESSFUL":
+      return { state: "completed", conclusion: "success" };
+    case "FAILED":
+      return { state: "completed", conclusion: "failure" };
+    case "STOPPED":
+      return { state: "completed", conclusion: "cancelled" };
+    case "INPROGRESS":
+      return { state: "running", conclusion: null };
+    default:
+      return { state: "queued", conclusion: null };
+  }
+}
+
+export interface RawCommitStatus {
+  key?: string | null;
+  name?: string | null;
+  state?: string | null;
+  url?: string | null;
+  description?: string | null;
+  created_on?: string | null;
+  updated_on?: string | null;
+}
+
+/**
+ * A commit status as a run. Bitbucket has no run object: a status is a link
+ * plus a state, so `id` is its key (stable per build system), the duration is
+ * the gap between its creation and its last update once it has finished, and
+ * its description is the only report it carries.
+ */
+export function mapCommitStatus(status: RawCommitStatus): CheckRun {
+  const { state, conclusion } = mapStatusState(status.state);
+  const started = status.created_on ? Date.parse(status.created_on) : NaN;
+  const finished = status.updated_on ? Date.parse(status.updated_on) : NaN;
+  return {
+    id: status.key ?? null,
+    name: status.name ?? status.key ?? "",
+    state,
+    conclusion,
+    url: status.url ?? null,
+    durationMs:
+      state === "completed" &&
+      Number.isFinite(started) &&
+      Number.isFinite(finished)
+        ? Math.max(0, finished - started)
+        : null,
+    summary: status.description ?? null,
+  };
+}
+
+export interface RawComment {
+  id?: number | null;
+  content?: { raw?: string | null } | null;
+  user?: { nickname?: string | null } | null;
+  created_on?: string | null;
+  updated_on?: string | null;
+  deleted?: boolean | null;
+  inline?: { path?: string | null } | null;
+  parent?: { id?: number | null } | null;
+  resolution?: unknown;
+  links?: { html?: { href?: string | null } | null } | null;
+}
+
+/**
+ * The comments on the pull request itself. Inline comments are review
+ * threads on a file and line — a different thing, counted by
+ * {@link countUnresolved} — and a deleted comment is a tombstone.
+ */
+export function mapComments(
+  comments: RawComment[],
+  crUrl: string,
+): ChangeRequestComment[] {
+  return comments
+    .filter(
+      (comment) =>
+        comment.deleted !== true &&
+        !comment.inline &&
+        typeof comment.content?.raw === "string",
+    )
+    .map((comment) => ({
+      id: String(comment.id ?? 0),
+      author: comment.user?.nickname ?? "",
+      body: comment.content?.raw ?? "",
+      createdAt: comment.created_on ?? "",
+      updatedAt: comment.updated_on ?? comment.created_on ?? "",
+      url:
+        comment.links?.html?.href ??
+        (comment.id == null ? crUrl : `${crUrl}#comment-${comment.id}`),
+    }))
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+/**
+ * Review threads still open. Only an inline comment can be resolved on
+ * Bitbucket, a thread is its top-level comment (no `parent`), and resolution
+ * is recorded on that comment — so an unresolved thread is a live, top-level
+ * inline comment with no `resolution`.
+ */
+export function countUnresolved(comments: RawComment[]): number {
+  let count = 0;
+  for (const comment of comments) {
+    if (comment.deleted === true) continue;
+    if (!comment.inline || comment.parent) continue;
+    if (comment.resolution == null) count += 1;
+  }
+  return count;
+}
+
+export interface RawDiffstatEntry {
+  status?: string | null;
+}
+
+/**
+ * Whether the pull request's diffstat reports a conflict. Bitbucket computes
+ * mergeability lazily and reports it here — as an entry whose status is
+ * "merge conflict" — rather than on the pull request. Pure — unit-tested.
+ */
+export function conflictFromDiffstat(
+  entries: RawDiffstatEntry[] | null,
+): boolean | null {
+  if (entries === null) return null;
+  return entries.some((entry) => entry.status === "merge conflict");
+}
+
+/** Someone asked for changes — the only review decision Bitbucket reports as a state. */
+export function reviewBlockedFrom(pr: Pick<RawPullRequest, "participants">) {
+  return (pr.participants ?? []).some(
+    (participant) => participant.state === "changes_requested",
+  );
+}
+
+/**
+ * True when a merge refusal is Bitbucket saying the branch does not apply.
+ * Pure — unit-tested. Bitbucket's refusal prose names the conflict when that
+ * is the reason, which is why the refusal path can classify without a second
+ * read in the common case.
+ */
+export function isConflictRefusal(message: string): boolean {
+  return /conflict/i.test(message);
+}
+
+/** A pull request opened on a source/destination pair that already has one. */
+export function isDuplicateRefusal(message: string): boolean {
+  return /already (?:an? )?open|already exists/i.test(message);
+}
+
+export class BitbucketChangeRequestClient implements ChangeRequestClient {
+  readonly repo: RepoRef;
+  private readonly tokenSource: TokenSource;
+  private readonly repoBase: string;
+
+  constructor(params: { repo: RepoRef; tokenSource: TokenSource }) {
+    this.repo = params.repo;
+    this.tokenSource = params.tokenSource;
+    this.repoBase = `${BITBUCKET_API_BASE}${repositoryApiPath(params.repo)}`;
+  }
+
+  private async token(): Promise<string> {
+    const issued = await this.tokenSource.get();
+    if (issued) return issued.token;
+    throw new GitProviderError({
+      provider: "bitbucket",
+      status: 401,
+      message: `No usable Bitbucket token for ${this.repo.path}; reconnect the account`,
+    });
+  }
+
+  /** One REST call under the repository. 404 answers null; other non-2xx throws. */
+  private async call(
+    pathAndQuery: string,
+    init: {
+      method?: "GET" | "POST" | "PUT" | "DELETE";
+      body?: unknown;
+      accept?: string;
+    } = {},
+  ): Promise<Response | null> {
+    const res = await bitbucketFetch(
+      `${this.repoBase}${pathAndQuery}`,
+      await this.token(),
+      init,
+    );
+    if (res.status === 404) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
+    if (!res.ok) throw await bitbucketFailure(res);
+    return res;
+  }
+
+  private async json<T>(
+    pathAndQuery: string,
+    init?: { method?: "GET" | "POST" | "PUT" | "DELETE"; body?: unknown },
+  ): Promise<T | null> {
+    const res = await this.call(pathAndQuery, init);
+    return res === null ? null : ((await res.json()) as T);
+  }
+
+  private async values<T>(pathAndQuery: string): Promise<T[] | null> {
+    const page = await this.json<BitbucketPage<T>>(pathAndQuery);
+    return page === null ? null : (page.values ?? []);
+  }
+
+  private prPath(id: number): string {
+    return `/pullrequests/${id}`;
+  }
+
+  private map(pr: RawPullRequest): ChangeRequest {
+    const id = pr.id ?? 0;
+    const state = mapState(pr.state);
+    return {
+      number: id,
+      url: pr.links?.html?.href ?? changeRequestUrl(this.repo, id),
+      title: pr.title ?? "",
+      body: pr.description ?? "",
+      state,
+      draft: pr.draft === true,
+      mergedAt: state === "merged" ? (pr.updated_on ?? null) : null,
+      updatedAt: pr.updated_on ?? null,
+      base: pr.destination?.branch?.name ?? "main",
+      head: pr.source?.branch?.name ?? "",
+      headSha: pr.source?.commit?.hash ?? "",
+      // The source repository is on the payload; absent means the fork is gone.
+      headRepoPath: pr.source?.repository?.full_name ?? null,
+      author: pr.author?.nickname ?? "",
+      conflicting: null,
+      checks: null,
+      changedFiles: null,
+    };
+  }
+
+  async read(number: number): Promise<ChangeRequest | null> {
+    const pr = await this.json<RawPullRequest>(this.prPath(number));
+    return pr ? this.map(pr) : null;
+  }
+
+  /**
+   * Bitbucket lists only OPEN pull requests unless every state is asked for
+   * by name, and a merged one is exactly what a publish surface wants to see.
+   */
+  async readForBranch(branch: string): Promise<ChangeRequest | null> {
+    const params = new URLSearchParams({
+      q: `source.branch.name = ${bbqString(branch)}`,
+      sort: "-updated_on",
+      pagelen: "1",
+    });
+    for (const state of ["OPEN", "MERGED", "DECLINED", "SUPERSEDED"]) {
+      params.append("state", state);
+    }
+    const rows = await this.values<RawPullRequest>(`/pullrequests?${params}`);
+    const newest = rows?.[0];
+    return newest ? this.map(newest) : null;
+  }
+
+  async readDetailed(
+    target: { number: number } | { branch: string },
+  ): Promise<ChangeRequestDetail | null> {
+    const id =
+      "number" in target
+        ? target.number
+        : ((await this.readForBranch(target.branch))?.number ?? null);
+    if (id === null) return null;
+    const pr = await this.json<RawPullRequest>(this.prPath(id));
+    if (!pr) return null;
+    const base = this.map(pr);
+
+    const [statuses, comments, diffstat] = await Promise.all([
+      base.headSha
+        ? this.values<RawCommitStatus>(
+            `/commit/${encodeURIComponent(base.headSha)}/statuses?pagelen=${PAGE_SIZE}`,
+          )
+        : Promise.resolve(null),
+      this.values<RawComment>(
+        `${this.prPath(id)}/comments?pagelen=${PAGE_SIZE}`,
+      ),
+      this.json<BitbucketPage<RawDiffstatEntry>>(
+        `${this.prPath(id)}/diffstat?pagelen=${PAGE_SIZE}`,
+      ),
+    ]);
+
+    const checkRuns = (statuses ?? []).map(mapCommitStatus);
+    const diffEntries = diffstat?.values ?? null;
+    return {
+      ...base,
+      conflicting: conflictFromDiffstat(diffEntries),
+      checks: summarizeChecks(checkRuns),
+      changedFiles: diffstat?.size ?? diffEntries?.length ?? null,
+      checkRuns,
+      comments: mapComments(comments ?? [], base.url),
+      unresolvedConversations: countUnresolved(comments ?? []),
+      reviewBlocked: reviewBlockedFrom(pr),
+    };
+  }
+
+  async listOpen(limit: number): Promise<ChangeRequest[]> {
+    const rows = await this.values<RawPullRequest>(
+      `/pullrequests?state=OPEN&sort=-updated_on` +
+        `&pagelen=${Math.min(limit, PR_PAGE_SIZE)}`,
+    );
+    return (rows ?? []).map((pr) => this.map(pr));
+  }
+
+  async lastMergedInto(base: string): Promise<ChangeRequest | null> {
+    const params = new URLSearchParams({
+      state: "MERGED",
+      q: `destination.branch.name = ${bbqString(base)}`,
+      sort: "-updated_on",
+      pagelen: String(MERGED_SCANNED),
+    });
+    const rows = await this.values<RawPullRequest>(`/pullrequests?${params}`);
+    let best: ChangeRequest | null = null;
+    let bestAt = -Infinity;
+    for (const raw of rows ?? []) {
+      const pr = this.map(raw);
+      const at = pr.mergedAt ? Date.parse(pr.mergedAt) : NaN;
+      if (Number.isNaN(at) || at <= bestAt) continue;
+      best = pr;
+      bestAt = at;
+    }
+    return best;
+  }
+
+  async open(params: OpenChangeRequestParams): Promise<ChangeRequest> {
+    const res = await bitbucketFetch(
+      `${this.repoBase}/pullrequests`,
+      await this.token(),
+      {
+        method: "POST",
+        body: {
+          title: params.title,
+          description: params.body || undefined,
+          source: { branch: { name: params.head } },
+          destination: { branch: { name: params.base } },
+        },
+      },
+    );
+    if (res.ok) return this.map((await res.json()) as RawPullRequest);
+    const failure = await bitbucketFailure(res);
+    if (isDuplicateRefusal(failure.message)) {
+      throw new ChangeRequestExists(
+        failure.message,
+        await this.readForBranch(params.head).catch(() => null),
+      );
+    }
+    throw failure;
+  }
+
+  /** Bitbucket's update requires the title alongside, so the current one rides along. */
+  async describe(number: number, body: string): Promise<void> {
+    const current = await this.json<RawPullRequest>(this.prPath(number));
+    if (!current) {
+      throw new GitProviderError({
+        provider: "bitbucket",
+        status: 404,
+        message: `Bitbucket pull request #${number} not found in ${this.repo.path}`,
+      });
+    }
+    await this.call(this.prPath(number), {
+      method: "PUT",
+      body: { title: current.title ?? "", description: body },
+    });
+  }
+
+  /**
+   * Bitbucket merges asynchronously when the repository is large: a 202 with
+   * nothing merged yet. The pull request itself is then polled until it
+   * leaves OPEN, bounded, so the caller gets a settled answer either way.
+   */
+  async merge(number: number, params: MergeParams = {}): Promise<MergeOutcome> {
+    const message = [params.commitTitle, params.commitMessage]
+      .filter(Boolean)
+      .join("\n\n");
+    let res: Response;
+    try {
+      res = await bitbucketFetch(
+        `${this.repoBase}${this.prPath(number)}/merge`,
+        await this.token(),
+        {
+          method: "POST",
+          body: {
+            type: "pullrequest",
+            merge_strategy:
+              params.strategy === "squash" ? "squash" : "merge_commit",
+            close_source_branch: false,
+            ...(message ? { message } : {}),
+          },
+        },
+      );
+    } catch (cause) {
+      const detail = cause instanceof Error ? cause.message : String(cause);
+      const rateLimited =
+        cause instanceof GitProviderError && cause.isRateLimited;
+      return {
+        merged: false,
+        reason: rateLimited ? "rate_limited" : "error",
+        detail,
+      };
+    }
+    if (res.status === 202) {
+      await res.body?.cancel().catch(() => {});
+      return this.awaitAsyncMerge(number);
+    }
+    if (res.ok) {
+      await res.body?.cancel().catch(() => {});
+      return { merged: true };
+    }
+    const failure = await bitbucketFailure(res);
+    return {
+      merged: false,
+      reason: await this.classifyRefusal(number, res.status, failure.message),
+      detail: failure.message,
+    };
+  }
+
+  private async awaitAsyncMerge(number: number): Promise<MergeOutcome> {
+    try {
+      const state = await retry(
+        async () => {
+          const pr = await this.read(number);
+          if (!pr) {
+            throw new GitProviderError({
+              provider: "bitbucket",
+              status: 404,
+              message: `Bitbucket pull request #${number} vanished while merging`,
+            });
+          }
+          if (pr.state === "open") {
+            throw new GitProviderError({
+              provider: "bitbucket",
+              status: 202,
+              message: "merge still in progress",
+            });
+          }
+          return pr.state;
+        },
+        {
+          maxAttempts: 6,
+          minTimeout: 500,
+          maxTimeout: 4_000,
+          jitter: 0.5,
+          isRetriable: (err) =>
+            err instanceof GitProviderError && err.status === 202,
+        },
+      );
+      return state === "merged"
+        ? { merged: true }
+        : {
+            merged: false,
+            reason: "blocked",
+            detail: `Bitbucket left pull request #${number} ${state}`,
+          };
+    } catch (err) {
+      const cause = err instanceof RetryError ? err.cause : err;
+      if (cause instanceof GitProviderError && cause.status === 202) {
+        return {
+          merged: false,
+          reason: "error",
+          detail: `Bitbucket is still merging pull request #${number}; check again shortly`,
+        };
+      }
+      if (cause instanceof GitProviderError && cause.status === 404) {
+        return { merged: false, reason: "not_found", detail: cause.message };
+      }
+      return {
+        merged: false,
+        reason: "error",
+        detail: cause instanceof Error ? cause.message : String(cause),
+      };
+    }
+  }
+
+  /**
+   * When the status and prose alone are not conclusive the pull request's
+   * diffstat answers whether the branch applies — one extra call, only on the
+   * refusal path. Everything else a merge can be refused for (a required
+   * approval, an unresolved task, a failed build, a branch restriction) needs a
+   * person.
+   */
+  private async classifyRefusal(
+    number: number,
+    status: number,
+    message: string,
+  ): Promise<MergeRefusal> {
+    if (status === 404) return "not_found";
+    if (status === 429) return "rate_limited";
+    if (isConflictRefusal(message)) return "conflict";
+    const entries = await this.values<RawDiffstatEntry>(
+      `${this.prPath(number)}/diffstat?pagelen=${PAGE_SIZE}`,
+    ).catch(() => null);
+    return conflictFromDiffstat(entries) === true ? "conflict" : "blocked";
+  }
+
+  /**
+   * A commit status is a link and a state, never a log: Bitbucket publishes
+   * build output only through the system that ran it (its own Pipelines, or
+   * whatever posted the status). Nothing to read here.
+   */
+  async readCheckLog(_checkId: string): Promise<string | null> {
+    return null;
+  }
+
+  /**
+   * Bitbucket deployments and environments carry no published URL — an
+   * environment is a name and a type, not an address — so a deploy's URL only
+   * ever reaches the pull request as a commit status or a bot comment, both of
+   * which the detailed read already carries.
+   */
+  async readDeployedUrl(_sha: string): Promise<string | null> {
+    return null;
+  }
+}

--- a/apps/api/src/git-providers/bitbucket/client.test.ts
+++ b/apps/api/src/git-providers/bitbucket/client.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import {
+  bitbucketArchiveUrl,
+  encodeSrcPath,
+  mapBitbucketRepository,
+  repositoryApiPath,
+  splitBitbucketPath,
+} from "./client";
+
+describe("splitBitbucketPath", () => {
+  test("workspace and slug", () => {
+    expect(splitBitbucketPath("acme/site")).toEqual({
+      workspace: "acme",
+      slug: "site",
+    });
+  });
+  test("refuses anything but two segments", () => {
+    expect(() => splitBitbucketPath("site")).toThrow(/workspace\/repo_slug/);
+    expect(() => splitBitbucketPath("a/b/c")).toThrow(/workspace\/repo_slug/);
+  });
+});
+
+describe("repositoryApiPath", () => {
+  test("encodes each segment", () => {
+    expect(repositoryApiPath({ path: "acme/site" })).toBe(
+      "/repositories/acme/site",
+    );
+    expect(repositoryApiPath({ path: "acme/my site" })).toBe(
+      "/repositories/acme/my%20site",
+    );
+  });
+});
+
+describe("encodeSrcPath", () => {
+  test("encodes segments and keeps the slashes", () => {
+    expect(encodeSrcPath("src/app.ts")).toBe("src/app.ts");
+    expect(encodeSrcPath("/README.md")).toBe("README.md");
+    expect(encodeSrcPath("docs/a b#c.md")).toBe("docs/a%20b%23c.md");
+  });
+});
+
+describe("bitbucketArchiveUrl", () => {
+  test("is the web host's download, pinned to the ref", () => {
+    const repo = {
+      provider: "bitbucket" as const,
+      host: "bitbucket.org",
+      path: "acme/site",
+    };
+    expect(bitbucketArchiveUrl(repo, "main")).toBe(
+      "https://bitbucket.org/acme/site/get/main.tar.gz",
+    );
+    expect(bitbucketArchiveUrl(repo, "feat/x")).toBe(
+      "https://bitbucket.org/acme/site/get/feat%2Fx.tar.gz",
+    );
+  });
+});
+
+describe("mapBitbucketRepository", () => {
+  const payload = {
+    uuid: "{1111-2222}",
+    full_name: "Acme/Site",
+    is_private: true,
+    description: "Storefront",
+    mainbranch: { name: "main" },
+    links: { html: { href: "https://bitbucket.org/Acme/Site" } },
+    updated_on: "2026-09-01T00:00:00Z",
+  };
+
+  test("maps the repository payload to a RepoSummary", () => {
+    expect(mapBitbucketRepository(payload, "bitbucket.org")).toEqual({
+      ref: { provider: "bitbucket", host: "bitbucket.org", path: "Acme/Site" },
+      externalId: "{1111-2222}",
+      defaultBranch: "main",
+      webUrl: "https://bitbucket.org/Acme/Site",
+      visibility: "private",
+      description: "Storefront",
+      updatedAt: "2026-09-01T00:00:00Z",
+    });
+  });
+
+  test("a public repository, missing the optional fields", () => {
+    const summary = mapBitbucketRepository(
+      { uuid: "{x}", full_name: "acme/empty", is_private: false },
+      "bitbucket.org",
+    );
+    expect(summary.visibility).toBe("public");
+    expect(summary.defaultBranch).toBeNull();
+    expect(summary.description).toBeNull();
+    expect(summary.updatedAt).toBeNull();
+    expect(summary.webUrl).toBe("https://bitbucket.org/acme/empty");
+  });
+
+  test("rejects a payload missing the identity fields", () => {
+    expect(() =>
+      mapBitbucketRepository({ full_name: "acme/site" }, "bitbucket.org"),
+    ).toThrow();
+  });
+});

--- a/apps/api/src/git-providers/bitbucket/client.ts
+++ b/apps/api/src/git-providers/bitbucket/client.ts
@@ -1,0 +1,428 @@
+/**
+ * Bitbucket Cloud REST 2.0 client. One instance per account row; the
+ * `TokenSource` decides whether the bearer is an OAuth grant or a workspace /
+ * project / repository access token — Bitbucket accepts all of them as
+ * `Authorization: Bearer`.
+ *
+ * A repository is addressed as `workspace/repo_slug`, exactly two segments,
+ * so `RepoRef.path` splits without encoding tricks. Bitbucket Cloud only —
+ * see `http.ts`.
+ */
+
+import {
+  type RepoRef,
+  repoWebUrl,
+  splitOwnerName,
+} from "@decocms/shared/git-providers";
+import { z } from "zod";
+import {
+  type GitAccessToken,
+  type GitIdentity,
+  type GitProviderClient,
+  GitProviderError,
+  type ListReposOptions,
+  type ProviderPrincipal,
+  type RepoSummary,
+  type TokenOptions,
+  type TokenSource,
+} from "../types";
+import { BITBUCKET_HOST } from "./env";
+import {
+  assertBitbucketCloud,
+  BITBUCKET_API_BASE,
+  bbqString,
+  bitbucketFailure,
+  bitbucketFetch,
+  bitbucketJson,
+  type BitbucketPage,
+} from "./http";
+
+/** A whole-repo archive is a download, not a REST call — it needs room to stream. */
+const ARCHIVE_TIMEOUT_MS = 60_000;
+const DEFAULT_PER_PAGE = 30;
+const MAX_PER_PAGE = 100;
+
+/**
+ * `workspace` and `repo_slug` for a Bitbucket path. Throws for anything but
+ * two segments: a `RepoRef` built by `parseRepoUrl` never has more, so a bad
+ * one here is a caller passing another provider's ref.
+ */
+export function splitBitbucketPath(path: string): {
+  workspace: string;
+  slug: string;
+} {
+  const { owner: workspace, name: slug } = splitOwnerName({ path });
+  if (!workspace || !slug || workspace.includes("/")) {
+    throw new GitProviderError({
+      provider: "bitbucket",
+      status: 400,
+      message: `${path} is not a Bitbucket repository path (expected workspace/repo_slug)`,
+    });
+  }
+  return { workspace, slug };
+}
+
+/** `/repositories/{workspace}/{repo_slug}` — the prefix of every repository call. */
+export function repositoryApiPath(repo: Pick<RepoRef, "path">): string {
+  const { workspace, slug } = splitBitbucketPath(repo.path);
+  return `/repositories/${encodeURIComponent(workspace)}/${encodeURIComponent(slug)}`;
+}
+
+/**
+ * The web host's archive download. The REST API has no archive endpoint; this
+ * is the same URL the "Download repository" button uses, and it accepts the
+ * repository credential.
+ */
+export function bitbucketArchiveUrl(repo: RepoRef, ref: string): string {
+  return `${repoWebUrl(repo)}/get/${encodeURIComponent(ref)}.tar.gz`;
+}
+
+const BitbucketRepositorySchema = z.object({
+  uuid: z.string().min(1),
+  full_name: z.string().min(1),
+  is_private: z.boolean(),
+  description: z.string().nullish(),
+  mainbranch: z.object({ name: z.string().nullish() }).nullish(),
+  links: z.object({ html: z.object({ href: z.string() }).nullish() }).nullish(),
+  updated_on: z.string().nullish(),
+});
+export type BitbucketRepository = z.infer<typeof BitbucketRepositorySchema>;
+
+/**
+ * Map a `/repositories/{ws}/{slug}` payload to the provider-neutral summary.
+ * Bitbucket has no "internal" visibility — a repository is private or it is
+ * not.
+ */
+export function mapBitbucketRepository(
+  json: unknown,
+  host: string,
+): RepoSummary {
+  const repository = BitbucketRepositorySchema.parse(json);
+  const ref: RepoRef = {
+    provider: "bitbucket",
+    host,
+    path: repository.full_name,
+  };
+  return {
+    ref,
+    externalId: repository.uuid,
+    defaultBranch: repository.mainbranch?.name ?? null,
+    webUrl: repository.links?.html?.href ?? repoWebUrl(ref),
+    visibility: repository.is_private ? "private" : "public",
+    description: repository.description ?? null,
+    updatedAt: repository.updated_on ?? null,
+  };
+}
+
+const AvatarLinksSchema = z
+  .object({ avatar: z.object({ href: z.string().nullish() }).nullish() })
+  .nullish();
+
+const BitbucketUserSchema = z.object({
+  uuid: z.string().min(1),
+  nickname: z.string().min(1),
+  display_name: z.string().nullish(),
+  links: AvatarLinksSchema,
+});
+
+const BitbucketWorkspaceSchema = z.object({
+  uuid: z.string().min(1),
+  slug: z.string().min(1),
+  links: AvatarLinksSchema,
+});
+
+/**
+ * Who a token authenticates as. The routes call this to validate a pasted
+ * access token and to seed the account row (`externalAccountId`, `login`).
+ *
+ * Three answers are tried because Bitbucket's tokens are not all users: an
+ * OAuth grant or a user-level token answers `/user`; a workspace or project
+ * access token is refused there (it has no user) but can list its own
+ * workspace; a repository access token can do neither and is identified by
+ * the workspace of the repository it belongs to. The last refusal is the one
+ * surfaced when nothing works.
+ */
+export async function bitbucketPrincipalForToken(
+  host: string,
+  token: string,
+): Promise<ProviderPrincipal> {
+  assertBitbucketCloud(host);
+  const user = await tryJson(`${BITBUCKET_API_BASE}/user`, token);
+  if (user.ok) {
+    const parsed = BitbucketUserSchema.parse(user.json);
+    return {
+      externalAccountId: parsed.uuid,
+      login: parsed.nickname,
+      avatarUrl: parsed.links?.avatar?.href ?? null,
+    };
+  }
+  const workspaces = await tryJson(
+    `${BITBUCKET_API_BASE}/workspaces?pagelen=1`,
+    token,
+  );
+  if (workspaces.ok) {
+    const first = (workspaces.json as BitbucketPage<unknown>).values?.[0];
+    if (first !== undefined) return workspacePrincipal(first);
+  }
+  const repositories = await tryJson(
+    `${BITBUCKET_API_BASE}/repositories?role=member&pagelen=1`,
+    token,
+  );
+  if (repositories.ok) {
+    const first = (repositories.json as BitbucketPage<{ workspace?: unknown }>)
+      .values?.[0];
+    if (first?.workspace !== undefined) {
+      return workspacePrincipal(first.workspace);
+    }
+  }
+  throw repositories.ok
+    ? new GitProviderError({
+        provider: "bitbucket",
+        status: 401,
+        message:
+          "Bitbucket did not recognise the token as a user, a workspace or a repository member",
+      })
+    : repositories.failure;
+}
+
+function workspacePrincipal(json: unknown): ProviderPrincipal {
+  const workspace = BitbucketWorkspaceSchema.parse(json);
+  return {
+    externalAccountId: workspace.uuid,
+    login: workspace.slug,
+    avatarUrl: workspace.links?.avatar?.href ?? null,
+  };
+}
+
+async function tryJson(
+  url: string,
+  token: string,
+): Promise<
+  { ok: true; json: unknown } | { ok: false; failure: GitProviderError }
+> {
+  const res = await bitbucketFetch(url, token);
+  if (!res.ok) return { ok: false, failure: await bitbucketFailure(res) };
+  return { ok: true, json: await bitbucketJson(res, "principal") };
+}
+
+export class BitbucketProviderClient implements GitProviderClient {
+  readonly kind = "bitbucket" as const;
+  readonly host: string;
+  private readonly tokenSource: TokenSource;
+
+  constructor(params: { host: string; tokenSource: TokenSource }) {
+    assertBitbucketCloud(params.host);
+    this.host = BITBUCKET_HOST;
+    this.tokenSource = params.tokenSource;
+  }
+
+  async tokenForRepo(
+    _repo: RepoRef,
+    opts?: TokenOptions,
+  ): Promise<GitAccessToken> {
+    return this.accountToken(opts);
+  }
+
+  async accountToken(opts?: TokenOptions): Promise<GitAccessToken> {
+    const token = await this.tokenSource.get(opts);
+    if (!token) {
+      throw new GitProviderError({
+        provider: "bitbucket",
+        status: 401,
+        message: "Bitbucket account is not authenticated",
+      });
+    }
+    return token;
+  }
+
+  async getRepo(repo: RepoRef): Promise<RepoSummary | null> {
+    const res = await this.get(repositoryApiPath(repo));
+    if (!res) return null;
+    return mapBitbucketRepository(
+      await bitbucketJson(res, "get_repo"),
+      this.host,
+    );
+  }
+
+  /**
+   * Repositories the token can reach as a member, newest activity first.
+   * Bitbucket filters server-side with its query language; `name ~ "x"` is
+   * a case-insensitive substring match on the repository name.
+   */
+  async listRepos(
+    opts: ListReposOptions = {},
+  ): Promise<{ repositories: RepoSummary[]; hasMore: boolean }> {
+    const params = new URLSearchParams({
+      role: "member",
+      sort: "-updated_on",
+      pagelen: String(
+        Math.min(MAX_PER_PAGE, Math.max(1, opts.perPage ?? DEFAULT_PER_PAGE)),
+      ),
+      page: String(Math.max(1, opts.page ?? 1)),
+    });
+    const query = opts.query?.trim();
+    if (query) params.set("q", `name ~ ${bbqString(query)}`);
+    const res = await this.get(`/repositories?${params}`);
+    if (!res) return { repositories: [], hasMore: false };
+    const page = await bitbucketJson<BitbucketPage<unknown>>(res, "list_repos");
+    if (!Array.isArray(page.values)) {
+      throw new GitProviderError({
+        provider: "bitbucket",
+        status: 502,
+        message: "Bitbucket /repositories returned no values array",
+      });
+    }
+    return {
+      repositories: page.values.map((repository) =>
+        mapBitbucketRepository(repository, this.host),
+      ),
+      hasMore: !!page.next,
+    };
+  }
+
+  async readFile(
+    repo: RepoRef,
+    path: string,
+    ref?: string,
+  ): Promise<string | null> {
+    let branch = ref;
+    if (!branch) {
+      const summary = await this.getRepo(repo);
+      if (!summary?.defaultBranch) return null;
+      branch = summary.defaultBranch;
+    }
+    const res = await this.get(
+      `${repositoryApiPath(repo)}/src/${encodeURIComponent(branch)}/${encodeSrcPath(path)}`,
+      { accept: "text/plain, */*" },
+    );
+    if (!res) return null;
+    return res.text();
+  }
+
+  /**
+   * The web host's download, not an API call. It authenticates the way `git`
+   * does on that host (Basic with the `x-token-auth` user), so the bearer form
+   * is tried first and the Basic form on a 401. Omitting `ref` downloads the
+   * default branch, which costs one repository read to name.
+   */
+  async archiveTarball(
+    repo: RepoRef,
+    ref?: string,
+  ): Promise<ReadableStream<Uint8Array> | null> {
+    let at = ref;
+    if (!at) {
+      const summary = await this.getRepo(repo);
+      if (!summary?.defaultBranch) return null;
+      at = summary.defaultBranch;
+    }
+    const url = bitbucketArchiveUrl(repo, at);
+    const init = {
+      accept: "application/octet-stream, */*",
+      timeoutMs: ARCHIVE_TIMEOUT_MS,
+    };
+    let res = await this.authedFetch(url, init);
+    if (res.status === 401 || res.status === 403) {
+      await res.body?.cancel().catch(() => {});
+      const { token } = await this.accountToken();
+      res = await bitbucketFetch(url, token, { ...init, basicAuth: true });
+    }
+    if (res.status === 404) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
+    if (!res.ok) throw await bitbucketFailure(res);
+    return res.body;
+  }
+
+  /**
+   * The user behind the token, when there is one. A workspace, project or
+   * repository access token has no user and answers null, so callers fall
+   * back to the bot identity — the same shape as a GitHub installation token.
+   * The address needs the `email` scope; without it the noreply form stands in.
+   */
+  async identity(): Promise<GitIdentity | null> {
+    const res = await this.authedFetch(`${BITBUCKET_API_BASE}/user`);
+    if (res.status === 401 || res.status === 403) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
+    if (!res.ok) throw await bitbucketFailure(res);
+    const user = BitbucketUserSchema.parse(
+      await bitbucketJson(res, "identity"),
+    );
+    return {
+      name: user.display_name || user.nickname,
+      email:
+        (await this.primaryEmail()) ??
+        `${user.nickname}@users.noreply.${this.host}`,
+    };
+  }
+
+  private async primaryEmail(): Promise<string | null> {
+    const res = await this.authedFetch(
+      `${BITBUCKET_API_BASE}/user/emails?pagelen=${MAX_PER_PAGE}`,
+    );
+    if (!res.ok) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
+    const page = await bitbucketJson<
+      BitbucketPage<{
+        email?: string | null;
+        is_primary?: boolean | null;
+        is_confirmed?: boolean | null;
+      }>
+    >(res, "user_emails").catch(() => null);
+    const emails = page?.values ?? [];
+    const pick =
+      emails.find((e) => e.is_primary === true && e.is_confirmed !== false) ??
+      emails.find((e) => e.is_confirmed !== false);
+    return typeof pick?.email === "string" && pick.email ? pick.email : null;
+  }
+
+  private async get(
+    pathAndQuery: string,
+    init?: { accept?: string },
+  ): Promise<Response | null> {
+    const res = await this.authedFetch(
+      `${BITBUCKET_API_BASE}${pathAndQuery}`,
+      init,
+    );
+    if (res.status === 404) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
+    if (!res.ok) throw await bitbucketFailure(res);
+    return res;
+  }
+
+  /**
+   * One authenticated call. A 401 means the token died before `expiresAt`
+   * said so (revoked, rotated): re-mint/refresh once and retry, matching the
+   * other providers' behaviour for the same case.
+   */
+  private async authedFetch(
+    url: string,
+    init: { accept?: string; timeoutMs?: number } = {},
+  ): Promise<Response> {
+    const first = await this.accountToken();
+    const res = await bitbucketFetch(url, first.token, init);
+    if (res.status !== 401) return res;
+    await res.body?.cancel().catch(() => {});
+    const refreshed = await this.accountToken({ forceRefresh: true });
+    return bitbucketFetch(url, refreshed.token, init);
+  }
+}
+
+/**
+ * A repository file path inside a `/src/{commit}/{path}` URL: each segment
+ * encoded, the slashes kept, a leading slash dropped so `/README.md` and
+ * `README.md` address the same file.
+ */
+export function encodeSrcPath(path: string): string {
+  return path
+    .replace(/^\/+/, "")
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}

--- a/apps/api/src/git-providers/bitbucket/client.ts
+++ b/apps/api/src/git-providers/bitbucket/client.ts
@@ -135,12 +135,10 @@ const BitbucketWorkspaceSchema = z.object({
  * Who a token authenticates as. The routes call this to validate a pasted
  * access token and to seed the account row (`externalAccountId`, `login`).
  *
- * Three answers are tried because Bitbucket's tokens are not all users: an
+ * Two answers are tried because Bitbucket's tokens are not all users: an
  * OAuth grant or a user-level token answers `/user`; a workspace or project
  * access token is refused there (it has no user) but can list its own
- * workspace; a repository access token can do neither and is identified by
- * the workspace of the repository it belongs to. The last refusal is the one
- * surfaced when nothing works.
+ * workspace. A repository access token can do neither, so it is refused.
  */
 export async function bitbucketPrincipalForToken(
   host: string,
@@ -157,32 +155,24 @@ export async function bitbucketPrincipalForToken(
     };
   }
   const workspaces = await tryJson(
-    `${BITBUCKET_API_BASE}/workspaces?pagelen=1`,
+    `${BITBUCKET_API_BASE}/user/workspaces?pagelen=1`,
     token,
   );
   if (workspaces.ok) {
-    const first = (workspaces.json as BitbucketPage<unknown>).values?.[0];
-    if (first !== undefined) return workspacePrincipal(first);
-  }
-  const repositories = await tryJson(
-    `${BITBUCKET_API_BASE}/repositories?role=member&pagelen=1`,
-    token,
-  );
-  if (repositories.ok) {
-    const first = (repositories.json as BitbucketPage<{ workspace?: unknown }>)
+    const first = (workspaces.json as BitbucketPage<{ workspace?: unknown }>)
       .values?.[0];
     if (first?.workspace !== undefined) {
       return workspacePrincipal(first.workspace);
     }
   }
-  throw repositories.ok
+  throw workspaces.ok
     ? new GitProviderError({
         provider: "bitbucket",
         status: 401,
         message:
-          "Bitbucket did not recognise the token as a user, a workspace or a repository member",
+          "Bitbucket did not recognise the token as a user or a workspace member. Connect through OAuth, or use a workspace or project access token; a repository access token cannot be identified.",
       })
-    : repositories.failure;
+    : workspaces.failure;
 }
 
 function workspacePrincipal(json: unknown): ProviderPrincipal {
@@ -246,38 +236,78 @@ export class BitbucketProviderClient implements GitProviderClient {
 
   /**
    * Repositories the token can reach as a member, newest activity first.
-   * Bitbucket filters server-side with its query language; `name ~ "x"` is
-   * a case-insensitive substring match on the repository name.
+   *
+   * Bitbucket retired the workspace-less `/repositories` listing (changelog
+   * CHANGE-2770; it answers 410), so this lists the token's workspaces and
+   * reads one page per workspace, merged newest-first. With one workspace —
+   * the common case — that is exactly Bitbucket's own paging; with several, a
+   * page is the union of each workspace's page `n` trimmed to `perPage`,
+   * which over-delivers on later pages rather than skipping anything.
+   * `name ~ "x"` is a case-insensitive substring match on the name.
    */
   async listRepos(
     opts: ListReposOptions = {},
   ): Promise<{ repositories: RepoSummary[]; hasMore: boolean }> {
+    const perPage = Math.min(
+      MAX_PER_PAGE,
+      Math.max(1, opts.perPage ?? DEFAULT_PER_PAGE),
+    );
     const params = new URLSearchParams({
       role: "member",
       sort: "-updated_on",
-      pagelen: String(
-        Math.min(MAX_PER_PAGE, Math.max(1, opts.perPage ?? DEFAULT_PER_PAGE)),
-      ),
+      pagelen: String(perPage),
       page: String(Math.max(1, opts.page ?? 1)),
     });
     const query = opts.query?.trim();
     if (query) params.set("q", `name ~ ${bbqString(query)}`);
-    const res = await this.get(`/repositories?${params}`);
-    if (!res) return { repositories: [], hasMore: false };
-    const page = await bitbucketJson<BitbucketPage<unknown>>(res, "list_repos");
-    if (!Array.isArray(page.values)) {
-      throw new GitProviderError({
-        provider: "bitbucket",
-        status: 502,
-        message: "Bitbucket /repositories returned no values array",
-      });
-    }
+
+    const workspaces = await this.workspaceSlugs();
+    const pages = await Promise.all(
+      workspaces.map(async (slug): Promise<BitbucketPage<unknown>> => {
+        const res = await this.get(
+          `/repositories/${encodeURIComponent(slug)}?${params}`,
+        );
+        if (!res) return { values: [], next: null };
+        const page = await bitbucketJson<BitbucketPage<unknown>>(
+          res,
+          "list_repos",
+        );
+        if (!Array.isArray(page.values)) {
+          throw new GitProviderError({
+            provider: "bitbucket",
+            status: 502,
+            message: `Bitbucket /repositories/${slug} returned no values array`,
+          });
+        }
+        return page;
+      }),
+    );
+    const merged = pages
+      .flatMap((page) => page.values ?? [])
+      .map((repository) => mapBitbucketRepository(repository, this.host))
+      .sort((a, b) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""));
+    const single = workspaces.length <= 1;
     return {
-      repositories: page.values.map((repository) =>
-        mapBitbucketRepository(repository, this.host),
-      ),
-      hasMore: !!page.next,
+      repositories: single ? merged : merged.slice(0, perPage),
+      hasMore:
+        pages.some((page) => !!page.next) ||
+        (!single && merged.length > perPage),
     };
+  }
+
+  /**
+   * Slugs of the workspaces the token is a member of. `/user/workspaces` is
+   * the one listing Bitbucket still serves; `/workspaces` answers 404.
+   */
+  private async workspaceSlugs(): Promise<string[]> {
+    const res = await this.get(`/user/workspaces?pagelen=${MAX_PER_PAGE}`);
+    if (!res) return [];
+    const page = await bitbucketJson<
+      BitbucketPage<{ workspace?: { slug?: string | null } | null }>
+    >(res, "list_workspaces");
+    return (page.values ?? []).flatMap((access) =>
+      typeof access.workspace?.slug === "string" ? [access.workspace.slug] : [],
+    );
   }
 
   async readFile(

--- a/apps/api/src/git-providers/bitbucket/content.test.ts
+++ b/apps/api/src/git-providers/bitbucket/content.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "bun:test";
+import {
+  branchAuthor,
+  buildCommitForm,
+  isBranchExistsConflict,
+  isCommitConflict,
+  mapDiffstatEntry,
+  mapPullRequest,
+  mapPullRequestState,
+  mapSrcEntry,
+  parseTreeSha,
+  treeSha,
+} from "./content";
+
+describe("treeSha / parseTreeSha", () => {
+  test("round-trips, including a path with a colon in it", () => {
+    const sha = treeSha("abc123", ".deco/blocks/site:home.json");
+    expect(sha).toBe("abc123:.deco/blocks/site:home.json");
+    expect(parseTreeSha(sha)).toEqual({
+      commit: "abc123",
+      path: ".deco/blocks/site:home.json",
+    });
+  });
+  test("refuses a sha that is not of the synthetic form", () => {
+    expect(() => parseTreeSha("abc123")).toThrow(/<commit>:<path>/);
+    expect(() => parseTreeSha(":path")).toThrow(/<commit>:<path>/);
+    expect(() => parseTreeSha("abc:")).toThrow(/<commit>:<path>/);
+  });
+});
+
+describe("mapSrcEntry", () => {
+  test("a file carries its size and pins the listed commit", () => {
+    expect(
+      mapSrcEntry(
+        {
+          type: "commit_file",
+          path: ".deco/blocks/a.json",
+          size: 42,
+          commit: { hash: "c1" },
+        },
+        "main",
+      ),
+    ).toEqual({
+      path: ".deco/blocks/a.json",
+      sha: "c1:.deco/blocks/a.json",
+      type: "blob",
+      size: 42,
+    });
+  });
+  test("a directory is a tree without a size", () => {
+    expect(
+      mapSrcEntry({ type: "commit_directory", path: ".deco/blocks" }, "c1"),
+    ).toEqual({ path: ".deco/blocks", sha: "c1:.deco/blocks", type: "tree" });
+  });
+  test("anything else is dropped", () => {
+    expect(mapSrcEntry({ type: "submodule", path: "vendor" }, "c1")).toBeNull();
+    expect(mapSrcEntry({ type: "commit_file" }, "c1")).toBeNull();
+  });
+});
+
+describe("buildCommitForm", () => {
+  const exists = (present: string[]) => (path: string) =>
+    present.includes(path);
+
+  test("writes are fields named by path; deletes go under files", () => {
+    const form = buildCommitForm({
+      branch: "main",
+      parent: "p1",
+      message: "save",
+      changes: [
+        { path: "a.json", content: "A" },
+        { path: "b.json", deleted: true },
+      ],
+      existsAtParent: exists(["b.json"]),
+    });
+    expect(form).not.toBeNull();
+    expect(form!.get("a.json")).toBe("A");
+    expect(form!.getAll("files")).toEqual(["b.json"]);
+    expect(form!.get("message")).toBe("save");
+    expect(form!.get("branch")).toBe("main");
+    expect(form!.get("parents")).toBe("p1");
+  });
+
+  test("deleting a path that is not there is dropped, not sent", () => {
+    const form = buildCommitForm({
+      branch: "main",
+      parent: "p1",
+      message: "save",
+      changes: [
+        { path: "gone.json", deleted: true },
+        { path: "a.json", content: "A" },
+      ],
+      existsAtParent: exists([]),
+    });
+    expect(form!.getAll("files")).toEqual([]);
+    expect(form!.get("a.json")).toBe("A");
+  });
+
+  test("two changes to one path collapse to the last", () => {
+    const form = buildCommitForm({
+      branch: "main",
+      parent: "p1",
+      message: "save",
+      changes: [
+        { path: "a.json", content: "first" },
+        { path: "a.json", content: "second" },
+      ],
+      existsAtParent: exists([]),
+    });
+    expect(form!.getAll("a.json")).toEqual(["second"]);
+  });
+
+  test("nothing to commit yields no form", () => {
+    expect(
+      buildCommitForm({
+        branch: "main",
+        parent: "p1",
+        message: "save",
+        changes: [{ path: "gone.json", deleted: true }],
+        existsAtParent: exists([]),
+      }),
+    ).toBeNull();
+    expect(
+      buildCommitForm({
+        branch: "main",
+        parent: "p1",
+        message: "save",
+        changes: [],
+        existsAtParent: exists([]),
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("isCommitConflict", () => {
+  test("a parents guard that no longer names the tip", () => {
+    expect(isCommitConflict(400, "parents is not the tip of branch")).toBe(
+      true,
+    );
+    expect(isCommitConflict(409, "The branch has moved: conflict")).toBe(true);
+  });
+  test("other 400s are not conflicts", () => {
+    expect(isCommitConflict(400, "message is required")).toBe(false);
+  });
+  test("other statuses are never conflicts, whatever the message says", () => {
+    expect(isCommitConflict(403, "conflict")).toBe(false);
+    expect(isCommitConflict(500, "tip")).toBe(false);
+  });
+});
+
+describe("isBranchExistsConflict", () => {
+  test("400 with the branch-exists prose", () => {
+    expect(
+      isBranchExistsConflict(400, "A branch with the name 'x' already exists"),
+    ).toBe(true);
+    expect(isBranchExistsConflict(400, "BRANCH_ALREADY_EXISTS")).toBe(true);
+  });
+  test("a 400 for anything else is a plain failure", () => {
+    expect(isBranchExistsConflict(400, "target is required")).toBe(false);
+  });
+  test("a 403 on a protected branch is not a conflict", () => {
+    expect(isBranchExistsConflict(403, "already exists")).toBe(false);
+  });
+});
+
+describe("mapPullRequestState / mapPullRequest", () => {
+  test("OPEN and MERGED pass through; everything else is closed", () => {
+    expect(mapPullRequestState("OPEN")).toBe("open");
+    expect(mapPullRequestState("MERGED")).toBe("merged");
+    expect(mapPullRequestState("DECLINED")).toBe("closed");
+    expect(mapPullRequestState("SUPERSEDED")).toBe("closed");
+    expect(mapPullRequestState(undefined)).toBe("closed");
+  });
+  test("id is the number and the html link is the url", () => {
+    expect(
+      mapPullRequest({
+        id: 12,
+        title: "Ship",
+        state: "OPEN",
+        links: { html: { href: "https://bitbucket.org/a/s/pull-requests/12" } },
+      }),
+    ).toEqual({
+      number: 12,
+      url: "https://bitbucket.org/a/s/pull-requests/12",
+      title: "Ship",
+      state: "open",
+    });
+  });
+});
+
+describe("mapDiffstatEntry", () => {
+  test("a surviving file gets the synthetic sha at head", () => {
+    expect(
+      mapDiffstatEntry(
+        { status: "modified", old: { path: "a.ts" }, new: { path: "a.ts" } },
+        "h1",
+      ),
+    ).toEqual({ filename: "a.ts", status: "modified", sha: "h1:a.ts" });
+  });
+  test("a removed file keeps an empty sha", () => {
+    expect(
+      mapDiffstatEntry({ status: "removed", old: { path: "a.ts" } }, "h1"),
+    ).toEqual({ filename: "a.ts", status: "removed", sha: "" });
+  });
+  test("a rename carries the previous filename", () => {
+    expect(
+      mapDiffstatEntry(
+        { status: "renamed", old: { path: "old.ts" }, new: { path: "new.ts" } },
+        "h1",
+      ),
+    ).toEqual({
+      filename: "new.ts",
+      status: "renamed",
+      sha: "h1:new.ts",
+      previousFilename: "old.ts",
+    });
+  });
+  test("an entry with no path is dropped", () => {
+    expect(mapDiffstatEntry({ status: "modified" }, "h1")).toBeNull();
+  });
+});
+
+describe("branchAuthor", () => {
+  test("prefers the resolved account, then the raw name", () => {
+    expect(
+      branchAuthor({
+        target: { author: { user: { nickname: "viktor" }, raw: "V <v@x>" } },
+      }),
+    ).toBe("viktor");
+    expect(
+      branchAuthor({ target: { author: { raw: "Ada Lovelace <ada@x.io>" } } }),
+    ).toBe("Ada Lovelace");
+  });
+  test("null when nothing is known", () => {
+    expect(branchAuthor({})).toBeNull();
+    expect(branchAuthor({ target: { author: { raw: "  " } } })).toBeNull();
+  });
+});

--- a/apps/api/src/git-providers/bitbucket/content.ts
+++ b/apps/api/src/git-providers/bitbucket/content.ts
@@ -953,30 +953,15 @@ export class BitbucketContentClient implements RepoContentClient {
    * listing — callers treat "no `.deco/` yet" as normal.
    */
   private async listTree(treeish: string, path: string): Promise<TreeEntry[]> {
-    const out: TreeEntry[] = [];
     const dir = path ? `${encodeSrcPath(path)}/` : "";
-    let page = 1;
-    for (let visited = 0; visited < MAX_PAGES; visited++) {
-      const listing = await this.json<BitbucketPage<BitbucketSrcEntry>>(
-        `${this.repoBase}/src/${encodeRef(treeish)}/${dir}?pagelen=${PAGE_SIZE}&page=${page}`,
-      );
-      if (listing === null) return out;
-      if (!Array.isArray(listing.values)) {
-        throw new GitProviderError({
-          provider: "bitbucket",
-          status: 502,
-          message: "Bitbucket /src returned no values array",
-        });
-      }
-      for (const row of listing.values) {
-        const entry = mapSrcEntry(row, treeish);
-        if (entry) out.push(entry);
-      }
-      const next = nextPageNumber(listing);
-      if (next === null || next <= page) break;
-      page = next;
-    }
-    return out;
+    const rows = await this.pages<BitbucketSrcEntry>(
+      `${this.repoBase}/src/${encodeRef(treeish)}/${dir}?pagelen=${PAGE_SIZE}`,
+    );
+    if (rows === null) return [];
+    return rows.flatMap((row) => {
+      const entry = mapSrcEntry(row, treeish);
+      return entry ? [entry] : [];
+    });
   }
 
   /**
@@ -988,32 +973,25 @@ export class BitbucketContentClient implements RepoContentClient {
     from: string,
     exclude: string,
   ): Promise<Array<{ hash: string; message?: string | null }>> {
-    const out: Array<{ hash: string; message?: string | null }> = [];
-    let page = 1;
-    for (let visited = 0; visited < MAX_PAGES; visited++) {
-      const listing = await this.json<
-        BitbucketPage<{ hash?: string | null; message?: string | null }>
-      >(
-        `${this.repoBase}/commits/${encodeRef(from)}?exclude=${encodeRef(exclude)}` +
-          `&pagelen=${PAGE_SIZE}&page=${page}&fields=values.hash,values.message,next`,
-      );
-      if (listing === null) {
-        throw new GitProviderError({
-          provider: "bitbucket",
-          status: 404,
-          message: `Bitbucket cannot compare ${exclude}...${from} in ${this.repo.path}`,
-        });
-      }
-      for (const row of listing.values ?? []) {
-        if (typeof row.hash === "string") {
-          out.push({ hash: row.hash, message: row.message });
-        }
-      }
-      const next = nextPageNumber(listing);
-      if (next === null || next <= page) break;
-      page = next;
+    const rows = await this.pages<{
+      hash?: string | null;
+      message?: string | null;
+    }>(
+      `${this.repoBase}/commits/${encodeRef(from)}?exclude=${encodeRef(exclude)}` +
+        `&pagelen=${PAGE_SIZE}&fields=values.hash,values.message,next`,
+    );
+    if (rows === null) {
+      throw new GitProviderError({
+        provider: "bitbucket",
+        status: 404,
+        message: `Bitbucket cannot compare ${exclude}...${from} in ${this.repo.path}`,
+      });
     }
-    return out;
+    return rows.flatMap((row) =>
+      typeof row.hash === "string"
+        ? [{ hash: row.hash, message: row.message }]
+        : [],
+    );
   }
 
   /**
@@ -1025,18 +1003,39 @@ export class BitbucketContentClient implements RepoContentClient {
     source: string,
     destination: string,
   ): Promise<BitbucketDiffstatEntry[]> {
-    const out: BitbucketDiffstatEntry[] = [];
     const spec = `${encodeRef(source)}..${encodeRef(destination)}`;
-    let page = 1;
-    for (let visited = 0; visited < MAX_PAGES; visited++) {
-      const listing = await this.json<BitbucketPage<BitbucketDiffstatEntry>>(
-        `${this.repoBase}/diffstat/${spec}?topic=true&pagelen=${PAGE_SIZE}&page=${page}`,
-      );
-      if (listing === null) return out;
-      out.push(...(listing.values ?? []));
-      const next = nextPageNumber(listing);
-      if (next === null || next <= page) break;
-      page = next;
+    return (
+      (await this.pages<BitbucketDiffstatEntry>(
+        `${this.repoBase}/diffstat/${spec}?topic=true&pagelen=${PAGE_SIZE}`,
+      )) ?? []
+    );
+  }
+
+  /**
+   * Every row of a paginated listing, following the `next` URLs Bitbucket
+   * hands back. Those are the only way to page some listings — `src` pages by
+   * an opaque cursor and refuses `page=2` — so no page number is ever built
+   * here. Null when the first page is a 404; bounded by `MAX_PAGES`.
+   */
+  private async pages<T>(firstPathAndQuery: string): Promise<T[] | null> {
+    const out: T[] = [];
+    let url: string | null = `${BITBUCKET_API_BASE}${firstPathAndQuery}`;
+    for (let visited = 0; url !== null && visited < MAX_PAGES; visited++) {
+      const listing: BitbucketPage<T> | null = await this.jsonAt(url);
+      if (listing === null) return visited === 0 ? null : out;
+      if (!Array.isArray(listing.values)) {
+        throw new GitProviderError({
+          provider: "bitbucket",
+          status: 502,
+          message: `Bitbucket listing returned no values array: ${url}`,
+        });
+      }
+      out.push(...listing.values);
+      // Only Bitbucket's own API is followed, whatever a payload says.
+      url =
+        listing.next && listing.next.startsWith(BITBUCKET_API_BASE)
+          ? listing.next
+          : null;
     }
     return out;
   }
@@ -1053,13 +1052,21 @@ export class BitbucketContentClient implements RepoContentClient {
     return (await this.provider.tokenForRepo(this.repo)).token;
   }
 
-  private async json<T>(
-    pathAndQuery: string,
-    init?: CallInit,
-  ): Promise<T | null> {
-    const res = await this.call(pathAndQuery, init);
+  private json<T>(pathAndQuery: string, init?: CallInit): Promise<T | null> {
+    return this.jsonAt(`${BITBUCKET_API_BASE}${pathAndQuery}`, init);
+  }
+
+  private async jsonAt<T>(url: string, init?: CallInit): Promise<T | null> {
+    const res = await this.callAt(url, init);
     if (res === null) return null;
     return (await res.json()) as T;
+  }
+
+  private call(
+    pathAndQuery: string,
+    init: CallInit = {},
+  ): Promise<Response | null> {
+    return this.callAt(`${BITBUCKET_API_BASE}${pathAndQuery}`, init);
   }
 
   /**
@@ -1067,15 +1074,11 @@ export class BitbucketContentClient implements RepoContentClient {
    * try/catch; every other non-2xx becomes a `GitProviderError`, carrying a
    * wait hint when Bitbucket rate-limited us.
    */
-  private async call(
-    pathAndQuery: string,
+  private async callAt(
+    url: string,
     init: CallInit = {},
   ): Promise<Response | null> {
-    const res = await bitbucketFetch(
-      `${BITBUCKET_API_BASE}${pathAndQuery}`,
-      await this.token(),
-      init,
-    );
+    const res = await bitbucketFetch(url, await this.token(), init);
     if (res.status === 404) {
       await res.body?.cancel().catch(() => {});
       return null;

--- a/apps/api/src/git-providers/bitbucket/content.ts
+++ b/apps/api/src/git-providers/bitbucket/content.ts
@@ -1,0 +1,1091 @@
+/**
+ * `RepoContentClient` over Bitbucket Cloud's REST 2.0 API.
+ *
+ * Bitbucket exposes no Git Data plumbing and, unlike GitLab, no object shas
+ * either: a directory listing (`/src/{commit}/{dir}/`) names each entry's
+ * path, type and size, but not its blob. The interface's `TreeEntry.sha` is
+ * therefore SYNTHETIC here — `<commit>:<path>`, a commit in whose tree the
+ * path has this content — and `readBlob` reads it back as `/src/{commit}/
+ * {path}`. Two commits are used, for two costs:
+ *
+ * - a listing pins the LISTED commit: one call names every entry, which is
+ *   what the read path needs. Its shas change on every commit, so the blob
+ *   cache runs cold after a save and the read falls back to the tarball
+ *   path, which exists for exactly that;
+ * - a path-set lookup pins the LAST commit that touched each path: one
+ *   `filehistory` call per path, so the same content at two refs compares
+ *   equal — which is what the discard plan needs from `getEntriesAtPaths`.
+ *
+ * Writes are one `POST /src` per commit, carrying every file as a multipart
+ * field and `parents` as the guard. Where Bitbucket cannot express the
+ * interface's wording, the gap is documented on the method: file modes
+ * (`commitFiles`), moving a branch to an arbitrary sha (`forceBranchHead`),
+ * rewriting history (`rewriteBranch`), merging without a pull request
+ * (`mergeBranches`). Bitbucket Cloud only — see `http.ts`.
+ */
+
+import type { RepoRef } from "@decocms/shared/git-providers";
+import { mapBounded, retry, RetryError } from "@decocms/shared/std";
+import {
+  type BranchPage,
+  type ChangeRequestInfo,
+  type FileChange,
+  type FileMode,
+  type RepoContentClient,
+  RepoWriteConflict,
+  type TreeEntry,
+} from "../content";
+import { decoDirFor, groupPathsByDirectory } from "../paths";
+import { GitProviderError, type TokenSource } from "../types";
+import {
+  BitbucketProviderClient,
+  encodeSrcPath,
+  repositoryApiPath,
+} from "./client";
+import {
+  BITBUCKET_API_BASE,
+  bbqString,
+  bitbucketFailure,
+  bitbucketFetch,
+  type BitbucketPage,
+  nextPageNumber,
+} from "./http";
+
+const PAGE_SIZE = 100;
+/** 100 pages × 100 entries — a directory or a compare past that is a bug, not a repo. */
+const MAX_PAGES = 100;
+/** Bounds the per-path fan-out so a large discard does not trip Bitbucket's hourly limit. */
+const FANOUT_CONCURRENCY = 8;
+
+/** `<commit>:<path>` — see the module note. */
+export function treeSha(commit: string, path: string): string {
+  return `${commit}:${path}`;
+}
+
+/** The inverse of {@link treeSha}. A commit hash never contains a colon; a path may. */
+export function parseTreeSha(sha: string): { commit: string; path: string } {
+  const colon = sha.indexOf(":");
+  if (colon <= 0 || colon === sha.length - 1) {
+    throw new GitProviderError({
+      provider: "bitbucket",
+      status: 400,
+      message: `${sha} is not a Bitbucket tree sha (expected <commit>:<path>)`,
+    });
+  }
+  return { commit: sha.slice(0, colon), path: sha.slice(colon + 1) };
+}
+
+/** A `src` directory listing row. `commit.hash` is the commit that was listed. */
+interface BitbucketSrcEntry {
+  type?: string | null;
+  path?: string | null;
+  size?: number | null;
+  commit?: { hash?: string | null } | null;
+}
+
+/** A listing row as a tree entry, or null for anything that is not a file or directory. */
+export function mapSrcEntry(
+  row: BitbucketSrcEntry,
+  listedCommit: string,
+): TreeEntry | null {
+  if (typeof row.path !== "string" || row.path.length === 0) return null;
+  const type =
+    row.type === "commit_file"
+      ? "blob"
+      : row.type === "commit_directory"
+        ? "tree"
+        : null;
+  if (type === null) return null;
+  const commit = row.commit?.hash ?? listedCommit;
+  return {
+    path: row.path,
+    sha: treeSha(commit, row.path),
+    type,
+    ...(type === "blob" && typeof row.size === "number"
+      ? { size: row.size }
+      : {}),
+  };
+}
+
+/**
+ * A change with its bytes in hand. Bitbucket cannot point a commit at a blob
+ * that already exists, so a `copyFromRef` change is read into `content`
+ * before the form is built.
+ */
+export type ResolvedChange =
+  | { path: string; content: string; mode?: FileMode }
+  | { path: string; deleted: true };
+
+/**
+ * The multipart body of `POST /src`: `message`, `branch`, `parents`, one
+ * field per written file named by its path, and a `files` entry per deleted
+ * path. Two changes to one path collapse to the last one. Null when nothing
+ * remains to commit — Bitbucket refuses an empty form.
+ *
+ * `existsAtParent` decides whether a delete is sent at all: deleting what is
+ * not there is a no-op, and Bitbucket would fail the whole commit over it.
+ */
+export function buildCommitForm(params: {
+  branch: string;
+  parent: string;
+  message: string;
+  changes: readonly ResolvedChange[];
+  existsAtParent: (path: string) => boolean;
+}): FormData | null {
+  const collapsed = new Map<string, ResolvedChange>();
+  for (const change of params.changes) collapsed.set(change.path, change);
+
+  const form = new FormData();
+  let entries = 0;
+  for (const [path, change] of collapsed) {
+    if ("deleted" in change) {
+      if (!params.existsAtParent(path)) continue;
+      form.append("files", path);
+    } else {
+      form.append(path, change.content);
+    }
+    entries += 1;
+  }
+  if (entries === 0) return null;
+  form.append("message", params.message);
+  form.append("branch", params.branch);
+  form.append("parents", params.parent);
+  return form;
+}
+
+/**
+ * Whether a refused commit means "someone else wrote first" rather than "this
+ * request was wrong": the `parents` guard no longer names the branch tip.
+ */
+export function isCommitConflict(status: number, message: string): boolean {
+  if (status !== 400 && status !== 409) return false;
+  return /parent|tip|fast[- ]?forward|behind|conflict|out of date/i.test(
+    message,
+  );
+}
+
+/** `POST /refs/branches` on a name that is taken answers 400. */
+export function isBranchExistsConflict(
+  status: number,
+  message: string,
+): boolean {
+  return (
+    status === 400 && /already exists|BRANCH_ALREADY_EXISTS/i.test(message)
+  );
+}
+
+/**
+ * Bitbucket's pull-request states, in the interface's vocabulary. An
+ * unrecognised state is reported as closed rather than as actionable.
+ */
+export function mapPullRequestState(
+  state: string | null | undefined,
+): ChangeRequestInfo["state"] {
+  if (state === "OPEN") return "open";
+  if (state === "MERGED") return "merged";
+  return "closed";
+}
+
+interface BitbucketPullRequestRow {
+  id: number;
+  title?: string | null;
+  state?: string | null;
+  links?: { html?: { href?: string | null } | null } | null;
+  merge_commit?: { hash?: string | null } | null;
+}
+
+export function mapPullRequest(pr: BitbucketPullRequestRow): ChangeRequestInfo {
+  return {
+    number: pr.id,
+    url: pr.links?.html?.href ?? "",
+    title: pr.title ?? "",
+    state: mapPullRequestState(pr.state),
+  };
+}
+
+interface BitbucketDiffstatEntry {
+  status?: string | null;
+  old?: { path?: string | null } | null;
+  new?: { path?: string | null } | null;
+}
+
+/**
+ * One diffstat entry in the interface's file shape. Bitbucket's status words
+ * are already the interface's (`added`, `removed`, `modified`, `renamed`); a
+ * surviving file's sha is the synthetic one at `head`, and a removed path
+ * (absent there by definition) keeps `sha: ""`.
+ */
+export function mapDiffstatEntry(
+  entry: BitbucketDiffstatEntry,
+  headCommit: string,
+): {
+  filename: string;
+  status: string;
+  sha: string;
+  previousFilename?: string;
+} | null {
+  const filename = entry.new?.path ?? entry.old?.path;
+  if (!filename) return null;
+  const status = entry.status ?? "modified";
+  const renamed =
+    status === "renamed" && entry.old?.path && entry.old.path !== filename;
+  return {
+    filename,
+    status,
+    sha: status === "removed" ? "" : treeSha(headCommit, filename),
+    ...(renamed ? { previousFilename: entry.old!.path! } : {}),
+  };
+}
+
+/** Commit author for a branch row: the account when Bitbucket resolved one, else the raw name. */
+export function branchAuthor(row: {
+  target?: {
+    author?: {
+      user?: { nickname?: string | null } | null;
+      raw?: string | null;
+    } | null;
+  } | null;
+}): string | null {
+  const author = row.target?.author;
+  if (author?.user?.nickname) return author.user.nickname;
+  const raw = author?.raw?.trim();
+  if (!raw) return null;
+  const name = raw.replace(/\s*<[^>]*>\s*$/, "").trim();
+  return name || null;
+}
+
+interface CallInit {
+  method?: "GET" | "POST" | "PUT" | "DELETE";
+  body?: unknown;
+  accept?: string;
+}
+
+export class BitbucketContentClient implements RepoContentClient {
+  readonly repo: RepoRef;
+  private readonly repoBase: string;
+  /** Owns token minting and the archive download; both are already solved there. */
+  private readonly provider: BitbucketProviderClient;
+  private defaultBranch: string | null = null;
+
+  constructor(params: { repo: RepoRef; tokenSource: TokenSource }) {
+    this.repo = params.repo;
+    this.repoBase = repositoryApiPath(params.repo);
+    this.provider = new BitbucketProviderClient({
+      host: params.repo.host,
+      tokenSource: params.tokenSource,
+    });
+  }
+
+  async getDefaultBranch(): Promise<string> {
+    if (this.defaultBranch) return this.defaultBranch;
+    const repository = await this.json<{
+      mainbranch?: { name?: string | null } | null;
+    }>(this.repoBase);
+    if (repository === null) {
+      throw new GitProviderError({
+        provider: "bitbucket",
+        status: 404,
+        message: `Bitbucket repository ${this.repo.path} not found`,
+      });
+    }
+    if (!repository.mainbranch?.name) {
+      throw new GitProviderError({
+        provider: "bitbucket",
+        status: 409,
+        message: `Bitbucket repository ${this.repo.path} has no main branch (empty repository)`,
+      });
+    }
+    this.defaultBranch = repository.mainbranch.name;
+    return this.defaultBranch;
+  }
+
+  async getBranch(
+    branch: string,
+  ): Promise<{ sha: string; committedAt: string } | null> {
+    const json = await this.json<{
+      target?: { hash?: string | null; date?: string | null } | null;
+    }>(`${this.repoBase}/refs/branches/${encodeRef(branch)}`);
+    const target = json?.target;
+    if (!target?.hash) return null;
+    if (!target.date) {
+      throw new GitProviderError({
+        provider: "bitbucket",
+        status: 502,
+        message: `Bitbucket branch ${branch} came back without a commit date`,
+      });
+    }
+    return { sha: target.hash, committedAt: target.date };
+  }
+
+  /**
+   * Bitbucket filters branch names server-side with its query language, so
+   * this is one request. `size` is the true match count when Bitbucket
+   * bothers to count; when it omits it (a very large repository) the page's
+   * length is the honest lower bound.
+   */
+  async searchBranches(params: {
+    query: string;
+    limit: number;
+    cursor?: string | null;
+  }): Promise<BranchPage> {
+    // Bitbucket pages by number, so the opaque cursor IS the next page number.
+    const page = Number(params.cursor) || 1;
+    const query = new URLSearchParams({
+      sort: "name",
+      pagelen: String(Math.min(params.limit, PAGE_SIZE)),
+      page: String(page),
+    });
+    if (params.query) query.set("q", `name ~ ${bbqString(params.query)}`);
+    const listing = await this.json<
+      BitbucketPage<{
+        name?: string | null;
+        target?: {
+          author?: {
+            user?: { nickname?: string | null } | null;
+            raw?: string | null;
+          } | null;
+        } | null;
+      }>
+    >(`${this.repoBase}/refs/branches?${query}`);
+    if (listing === null) {
+      return { branches: [], totalCount: 0, nextCursor: null };
+    }
+    const branches = (listing.values ?? []).flatMap((row) =>
+      typeof row.name === "string"
+        ? [{ name: row.name, author: branchAuthor(row) }]
+        : [],
+    );
+    const next = nextPageNumber(listing);
+    return {
+      branches,
+      totalCount:
+        typeof listing.size === "number" ? listing.size : branches.length,
+      nextCursor: next === null ? null : String(next),
+    };
+  }
+
+  getArchive(ref: string): Promise<ReadableStream<Uint8Array> | null> {
+    return this.provider.archiveTarball(this.repo, ref);
+  }
+
+  /**
+   * At most two listings: the `.deco/` directory (which reveals whether the
+   * merged artifact is committed) and `.deco/blocks/`. Direct blob children
+   * are returned unfiltered, exactly as the other implementations do —
+   * `blockEntriesInTree` downstream applies the `*.json` rule.
+   */
+  async listDecofileEntries(
+    treeish: string,
+    packagePath: string | null,
+  ): Promise<TreeEntry[]> {
+    const decoDir = decoDirFor(packagePath);
+    const children = await this.listTree(treeish, decoDir);
+    const out: TreeEntry[] = [];
+    const gen = children.find(
+      (entry) =>
+        entry.type === "blob" && entry.path === `${decoDir}/blocks.gen.json`,
+    );
+    if (gen) out.push(gen);
+    const hasBlocksDir = children.some(
+      (entry) => entry.type === "tree" && entry.path === `${decoDir}/blocks`,
+    );
+    if (!hasBlocksDir) return out;
+    for (const child of await this.listTree(treeish, `${decoDir}/blocks`)) {
+      if (child.type === "blob") out.push(child);
+    }
+    return out;
+  }
+
+  /**
+   * One listing per distinct directory, then one `filehistory` read per file
+   * found, so the sha pins the last commit that touched the path — the form
+   * that compares equal across refs (see the module note).
+   */
+  async getEntriesAtPaths(
+    treeish: string,
+    paths: string[],
+  ): Promise<Map<string, TreeEntry>> {
+    const byDir = groupPathsByDirectory(paths);
+    const listings = await mapBounded(
+      [...byDir.keys()],
+      FANOUT_CONCURRENCY,
+      (dir) => this.listTree(treeish, dir),
+    );
+    const found: TreeEntry[] = [];
+    let index = 0;
+    for (const wanted of byDir.values()) {
+      const byPath = new Map(
+        (listings[index++] ?? []).map((entry) => [entry.path, entry]),
+      );
+      for (const path of wanted) {
+        const entry = byPath.get(path);
+        if (entry?.type === "blob") found.push(entry);
+      }
+    }
+    const pinned = await mapBounded(
+      found,
+      FANOUT_CONCURRENCY,
+      async (entry) => {
+        const { commit } = parseTreeSha(entry.sha);
+        const touched = await this.lastCommitTouching(commit, entry.path);
+        return touched
+          ? { ...entry, sha: treeSha(touched, entry.path) }
+          : entry;
+      },
+    );
+    return new Map(pinned.map((entry) => [entry.path, entry]));
+  }
+
+  async readBlob(sha: string): Promise<string> {
+    const { commit, path } = parseTreeSha(sha);
+    const content = await this.readFileAtRef(commit, path);
+    if (content === null) {
+      throw new GitProviderError({
+        provider: "bitbucket",
+        status: 404,
+        message: `Bitbucket has no ${path} at ${commit} in ${this.repo.path}`,
+      });
+    }
+    return content;
+  }
+
+  async readFileAtRef(ref: string, path: string): Promise<string | null> {
+    const res = await this.call(
+      `${this.repoBase}/src/${encodeRef(ref)}/${encodeSrcPath(path)}`,
+      { accept: "text/plain, */*" },
+    );
+    return res === null ? null : res.text();
+  }
+
+  /**
+   * One `POST /src`, guarded by `parents`. `branch` must already exist —
+   * creating one as a side effect of a write is `createBranch`'s job.
+   *
+   * The head is read first so the common lost race costs one request and no
+   * upload, then `parents` carries the approved sha into Bitbucket's own
+   * transaction, where a branch that moved meanwhile refuses the commit. Both
+   * refusals become `RepoWriteConflict` so the coalescer rebuilds and retries
+   * rather than clobbering the other writer.
+   *
+   * Bitbucket's form has no file mode: an executable written here keeps the
+   * mode the path already had and a NEW file is regular. `mode` is accepted
+   * for the interface and cannot be honoured — the one content bit this
+   * provider loses.
+   */
+  async commitFiles(params: {
+    branch: string;
+    message: string;
+    expectedHead: string | null;
+    rewriteFrom?: string;
+    changes: FileChange[];
+  }): Promise<{ sha: string }> {
+    const { branch, message, expectedHead, rewriteFrom } = params;
+    const head = await this.getBranch(branch);
+    if (expectedHead !== null && head?.sha !== expectedHead) {
+      throw new RepoWriteConflict(
+        `Bitbucket branch ${branch} is at ${head?.sha ?? "(absent)"}, expected ${expectedHead}`,
+      );
+    }
+    const changes = await this.resolveCopies(params.changes);
+    if (rewriteFrom !== undefined) {
+      return this.rewriteBranch({
+        branch,
+        message,
+        expectedHead,
+        rewriteFrom,
+        changes,
+      });
+    }
+    if (head === null) {
+      throw new GitProviderError({
+        provider: "bitbucket",
+        status: 404,
+        message: `Bitbucket branch ${branch} does not exist in ${this.repo.path}`,
+      });
+    }
+    const sha = await this.commitOnto({
+      branch,
+      parent: head.sha,
+      message,
+      changes,
+    });
+    return { sha: sha ?? head.sha };
+  }
+
+  /**
+   * A history rewrite. `POST /src` with `parents` set to an ancestor of the
+   * branch tip is attempted first — Bitbucket refuses it when the branch is
+   * protected against force pushes, or when it treats the move as a
+   * non-fast-forward at all. Only then does this fall back to replacing the
+   * branch: build the commit on a throwaway first so the content exists
+   * before the target is touched, then delete and recreate the target at it.
+   * The fallback is what costs a window — the branch briefly does not exist —
+   * and it fails too if the branch is protected against deletion.
+   */
+  private async rewriteBranch(params: {
+    branch: string;
+    message: string;
+    expectedHead: string | null;
+    rewriteFrom: string;
+    changes: readonly ResolvedChange[];
+  }): Promise<{ sha: string }> {
+    const { branch, message, expectedHead, rewriteFrom, changes } = params;
+
+    await this.assertHeadIs(branch, expectedHead);
+    const direct = await this.commitOnto({
+      branch,
+      parent: rewriteFrom,
+      message,
+      changes,
+    }).catch((cause: unknown) => {
+      if (
+        cause instanceof GitProviderError &&
+        cause.status >= 400 &&
+        cause.status < 500 &&
+        ![401, 403, 404, 429].includes(cause.status)
+      ) {
+        return undefined;
+      }
+      throw cause;
+    });
+    if (direct === null) {
+      // Nothing to commit: the rewrite is a plain move to `rewriteFrom`.
+      await this.forceBranchHead(branch, rewriteFrom);
+      return { sha: rewriteFrom };
+    }
+    if (direct !== undefined) return { sha: direct };
+
+    const staging = `studio-rewrite-${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`;
+    await this.createBranch(staging, rewriteFrom);
+    let sha: string;
+    try {
+      sha =
+        (await this.commitOnto({
+          branch: staging,
+          parent: rewriteFrom,
+          message,
+          changes,
+        })) ?? rewriteFrom;
+      /** Re-read as late as possible: the guard has to hold when the target is
+       * replaced, not when this call started. */
+      const current = await this.getBranch(branch);
+      if (expectedHead !== null && current?.sha !== expectedHead) {
+        throw new RepoWriteConflict(
+          `Bitbucket branch ${branch} moved to ${current?.sha ?? "(absent)"} while rewriting it`,
+        );
+      }
+    } catch (cause) {
+      await this.deleteBranch(staging).catch(() => {});
+      throw cause;
+    }
+    await this.deleteBranch(branch);
+    await this.createBranchAt(branch, sha);
+    await this.deleteBranch(staging).catch(() => {});
+    return { sha };
+  }
+
+  private async assertHeadIs(
+    branch: string,
+    expectedHead: string | null,
+  ): Promise<void> {
+    if (expectedHead === null) return;
+    const current = await this.getBranch(branch);
+    if (current?.sha !== expectedHead) {
+      throw new RepoWriteConflict(
+        `Bitbucket branch ${branch} is at ${current?.sha ?? "(absent)"}, not ${expectedHead}`,
+      );
+    }
+  }
+
+  /**
+   * One `POST /src` on `branch` parented on `parent`. Null when the changes
+   * reduce to nothing (deletes for paths that are already gone). Bitbucket
+   * answers 201 with an empty body, so the new sha is the branch head read
+   * straight after — a write landing in that gap would be reported as ours,
+   * which is the residual window of a provider with no commit-returning write.
+   */
+  private async commitOnto(params: {
+    branch: string;
+    parent: string;
+    message: string;
+    changes: readonly ResolvedChange[];
+  }): Promise<string | null> {
+    const { branch, parent, message, changes } = params;
+    const deletions = changes.flatMap((change) =>
+      "deleted" in change ? [change.path] : [],
+    );
+    const present = new Set(
+      (
+        await mapBounded(deletions, FANOUT_CONCURRENCY, async (path) =>
+          (await this.existsAt(parent, path)) ? [path] : [],
+        )
+      ).flat(),
+    );
+    const form = buildCommitForm({
+      branch,
+      parent,
+      message,
+      changes,
+      existsAtParent: (path) => present.has(path),
+    });
+    if (form === null) return null;
+
+    const res = await bitbucketFetch(
+      `${BITBUCKET_API_BASE}${this.repoBase}/src`,
+      await this.token(),
+      { method: "POST", body: form },
+    );
+    if (!res.ok) {
+      const failure = await bitbucketFailure(res);
+      if (isCommitConflict(failure.status, failure.message)) {
+        throw new RepoWriteConflict(
+          `Bitbucket refused the commit on ${branch}: ${failure.message}`,
+          { cause: failure },
+        );
+      }
+      throw failure;
+    }
+    await res.body?.cancel().catch(() => {});
+    const head = await this.getBranch(branch);
+    if (!head) {
+      throw new GitProviderError({
+        provider: "bitbucket",
+        status: 502,
+        message: `Bitbucket accepted the commit on ${branch} but the branch cannot be read back`,
+      });
+    }
+    return head.sha;
+  }
+
+  /** `copyFromRef` changes, read into content. */
+  private resolveCopies(
+    changes: readonly FileChange[],
+  ): Promise<ResolvedChange[]> {
+    return mapBounded(
+      [...changes],
+      FANOUT_CONCURRENCY,
+      async (change): Promise<ResolvedChange> => {
+        if (!("copyFromRef" in change)) return change;
+        const content = await this.readFileAtRef(
+          change.copyFromRef,
+          change.path,
+        );
+        if (content === null) {
+          throw new GitProviderError({
+            provider: "bitbucket",
+            status: 404,
+            message: `${change.path} does not exist at ${change.copyFromRef} in ${this.repo.path}`,
+          });
+        }
+        return { path: change.path, content, mode: change.mode };
+      },
+    );
+  }
+
+  async createBranch(branch: string, sha: string): Promise<void> {
+    try {
+      await this.createBranchAt(branch, sha);
+    } catch (cause) {
+      if (
+        cause instanceof GitProviderError &&
+        isBranchExistsConflict(cause.status, cause.message)
+      ) {
+        throw new RepoWriteConflict(
+          `Bitbucket branch ${branch} already exists in ${this.repo.path}`,
+          { cause },
+        );
+      }
+      throw cause;
+    }
+  }
+
+  /**
+   * Bitbucket has no ref-update endpoint: a branch can only be created or
+   * deleted, never repointed. So this deletes and recreates, which is NOT
+   * atomic — between the two calls the branch does not exist, and a failure
+   * after the delete leaves it missing rather than stale. The interface
+   * already declares this method unguarded, so the caller re-reads the head
+   * before calling either way.
+   */
+  async forceBranchHead(branch: string, sha: string): Promise<void> {
+    await this.deleteBranch(branch);
+    await this.createBranchAt(branch, sha);
+  }
+
+  /**
+   * Bitbucket has no merge endpoint on the repository — merging means opening
+   * a pull request and merging it, so this leaves one behind where GitHub
+   * leaves nothing. An open pull request for the same pair is reused.
+   */
+  async mergeBranches(
+    base: string,
+    head: string,
+    message: string,
+  ): Promise<string | null> {
+    const ahead = await this.commitsIn(head, base);
+    if (ahead.length === 0) return null;
+    const title = message.split("\n")[0] || message;
+    const pr =
+      (await this.findOpenChangeRequest(base, head)) ??
+      (await this.createChangeRequest({ base, head, title }));
+    return this.mergePullRequest(pr.number, base, message);
+  }
+
+  async createChangeRequest(params: {
+    base: string;
+    head: string;
+    title: string;
+  }): Promise<ChangeRequestInfo> {
+    const json = await this.json<BitbucketPullRequestRow>(
+      `${this.repoBase}/pullrequests`,
+      {
+        method: "POST",
+        body: {
+          title: params.title,
+          source: { branch: { name: params.head } },
+          destination: { branch: { name: params.base } },
+        },
+      },
+    );
+    if (!json) {
+      throw new GitProviderError({
+        provider: "bitbucket",
+        status: 404,
+        message: `Bitbucket repository ${this.repo.path} not found`,
+      });
+    }
+    return mapPullRequest(json);
+  }
+
+  async findOpenChangeRequest(
+    base: string,
+    head: string,
+  ): Promise<ChangeRequestInfo | null> {
+    const query = new URLSearchParams({
+      state: "OPEN",
+      q: `source.branch.name = ${bbqString(head)} AND destination.branch.name = ${bbqString(base)}`,
+      pagelen: "1",
+    });
+    const page = await this.json<BitbucketPage<BitbucketPullRequestRow>>(
+      `${this.repoBase}/pullrequests?${query}`,
+    );
+    const first = page?.values?.[0];
+    return first ? mapPullRequest(first) : null;
+  }
+
+  /** Two commit listings — `head` minus `base` for ahead, the reverse for behind. */
+  async compare(
+    base: string,
+    head: string,
+  ): Promise<{ aheadBy: number; behindBy: number }> {
+    const [ahead, behind] = await Promise.all([
+      this.commitsIn(head, base),
+      this.commitsIn(base, head),
+    ]);
+    return { aheadBy: ahead.length, behindBy: behind.length };
+  }
+
+  async compareDetailed(
+    base: string,
+    head: string,
+  ): Promise<{
+    aheadBy: number;
+    behindBy: number;
+    mergeBaseSha: string;
+    files: Array<{
+      filename: string;
+      status: string;
+      sha: string;
+      previousFilename?: string;
+    }>;
+    commitMessages: string[];
+  }> {
+    const [ahead, behind, mergeBaseSha] = await Promise.all([
+      this.commitsIn(head, base),
+      this.commitsIn(base, head),
+      this.mergeBaseSha(base, head),
+    ]);
+    if (ahead.length === 0) {
+      return {
+        aheadBy: 0,
+        behindBy: behind.length,
+        mergeBaseSha,
+        files: [],
+        commitMessages: [],
+      };
+    }
+    // The newest commit `head` has that `base` lacks IS head's tip.
+    const headCommit = ahead[0]!.hash;
+    const entries = await this.diffstat(head, base);
+    return {
+      aheadBy: ahead.length,
+      behindBy: behind.length,
+      mergeBaseSha,
+      files: entries.flatMap((entry) => {
+        const mapped = mapDiffstatEntry(entry, headCommit);
+        return mapped ? [mapped] : [];
+      }),
+      commitMessages: ahead
+        .map((commit) => (commit.message ?? "").split("\n")[0] ?? "")
+        .filter((title) => title.length > 0),
+    };
+  }
+
+  private async createBranchAt(branch: string, sha: string): Promise<void> {
+    const res = await this.call(`${this.repoBase}/refs/branches`, {
+      method: "POST",
+      body: { name: branch, target: { hash: sha } },
+    });
+    if (res === null) {
+      throw new GitProviderError({
+        provider: "bitbucket",
+        status: 404,
+        message: `Bitbucket could not branch ${branch} from ${sha}: repository or ref not found`,
+      });
+    }
+    await res.body?.cancel().catch(() => {});
+  }
+
+  private async deleteBranch(branch: string): Promise<void> {
+    const res = await this.call(
+      `${this.repoBase}/refs/branches/${encodeRef(branch)}`,
+      { method: "DELETE" },
+    );
+    await res?.body?.cancel().catch(() => {});
+  }
+
+  /**
+   * Bitbucket merges asynchronously on a large repository (202) and refuses
+   * with 400/409 while it is still computing mergeability right after the
+   * pull request was created, so this retries a bounded number of times; a
+   * genuine conflict exhausts the attempts and surfaces Bitbucket's message.
+   */
+  private async mergePullRequest(
+    id: number,
+    base: string,
+    message: string,
+  ): Promise<string> {
+    const attempt = async (): Promise<string> => {
+      const res = await bitbucketFetch(
+        `${BITBUCKET_API_BASE}${this.repoBase}/pullrequests/${id}/merge`,
+        await this.token(),
+        {
+          method: "POST",
+          body: {
+            type: "pullrequest",
+            message,
+            merge_strategy: "merge_commit",
+            close_source_branch: false,
+          },
+        },
+      );
+      if (res.status === 202) {
+        await res.body?.cancel().catch(() => {});
+        throw new GitProviderError({
+          provider: "bitbucket",
+          status: 202,
+          message: `Bitbucket is still merging pull request #${id}`,
+        });
+      }
+      if (!res.ok) throw await bitbucketFailure(res);
+      const json = (await res.json()) as BitbucketPullRequestRow;
+      if (json.state !== "MERGED") {
+        throw new GitProviderError({
+          provider: "bitbucket",
+          status: 409,
+          message: `Bitbucket left pull request #${id} in state ${json.state ?? "unknown"}`,
+        });
+      }
+      if (json.merge_commit?.hash) return json.merge_commit.hash;
+      const merged = await this.getBranch(base);
+      if (!merged) {
+        throw new GitProviderError({
+          provider: "bitbucket",
+          status: 502,
+          message: `Bitbucket merged #${id} without reporting a commit sha`,
+        });
+      }
+      return merged.sha;
+    };
+    try {
+      return await retry(attempt, {
+        maxAttempts: 4,
+        minTimeout: 500,
+        maxTimeout: 4_000,
+        jitter: 0.5,
+        isRetriable: (err) =>
+          err instanceof GitProviderError &&
+          (err.status === 202 || err.status === 409),
+      });
+    } catch (err) {
+      if (err instanceof RetryError && err.cause instanceof GitProviderError) {
+        throw err.cause;
+      }
+      throw err;
+    }
+  }
+
+  /** Whether `path` is a file at `ref` — one metadata read, no content. */
+  private async existsAt(ref: string, path: string): Promise<boolean> {
+    const json = await this.json<{ type?: string | null }>(
+      `${this.repoBase}/src/${encodeRef(ref)}/${encodeSrcPath(path)}?format=meta`,
+    );
+    return json?.type === "commit_file";
+  }
+
+  /** The last commit that touched `path`, as of `commit`; null when Bitbucket cannot say. */
+  private async lastCommitTouching(
+    commit: string,
+    path: string,
+  ): Promise<string | null> {
+    const page = await this.json<
+      BitbucketPage<{ commit?: { hash?: string | null } | null }>
+    >(
+      `${this.repoBase}/filehistory/${encodeRef(commit)}/${encodeSrcPath(path)}` +
+        "?pagelen=1&fields=values.commit.hash",
+    ).catch(() => null);
+    return page?.values?.[0]?.commit?.hash ?? null;
+  }
+
+  /**
+   * Direct children of `path` at `treeish`, following Bitbucket's pagination.
+   * A missing directory (or a missing ref) answers 404, which is the empty
+   * listing — callers treat "no `.deco/` yet" as normal.
+   */
+  private async listTree(treeish: string, path: string): Promise<TreeEntry[]> {
+    const out: TreeEntry[] = [];
+    const dir = path ? `${encodeSrcPath(path)}/` : "";
+    let page = 1;
+    for (let visited = 0; visited < MAX_PAGES; visited++) {
+      const listing = await this.json<BitbucketPage<BitbucketSrcEntry>>(
+        `${this.repoBase}/src/${encodeRef(treeish)}/${dir}?pagelen=${PAGE_SIZE}&page=${page}`,
+      );
+      if (listing === null) return out;
+      if (!Array.isArray(listing.values)) {
+        throw new GitProviderError({
+          provider: "bitbucket",
+          status: 502,
+          message: "Bitbucket /src returned no values array",
+        });
+      }
+      for (const row of listing.values) {
+        const entry = mapSrcEntry(row, treeish);
+        if (entry) out.push(entry);
+      }
+      const next = nextPageNumber(listing);
+      if (next === null || next <= page) break;
+      page = next;
+    }
+    return out;
+  }
+
+  /**
+   * Commits reachable from `from` but not from `exclude` — Bitbucket's answer
+   * to "how far ahead", newest first. Bounded: past `MAX_PAGES` the count is a
+   * lower bound, which is honest for a comparison nobody will read to the end.
+   */
+  private async commitsIn(
+    from: string,
+    exclude: string,
+  ): Promise<Array<{ hash: string; message?: string | null }>> {
+    const out: Array<{ hash: string; message?: string | null }> = [];
+    let page = 1;
+    for (let visited = 0; visited < MAX_PAGES; visited++) {
+      const listing = await this.json<
+        BitbucketPage<{ hash?: string | null; message?: string | null }>
+      >(
+        `${this.repoBase}/commits/${encodeRef(from)}?exclude=${encodeRef(exclude)}` +
+          `&pagelen=${PAGE_SIZE}&page=${page}&fields=values.hash,values.message,next`,
+      );
+      if (listing === null) {
+        throw new GitProviderError({
+          provider: "bitbucket",
+          status: 404,
+          message: `Bitbucket cannot compare ${exclude}...${from} in ${this.repo.path}`,
+        });
+      }
+      for (const row of listing.values ?? []) {
+        if (typeof row.hash === "string") {
+          out.push({ hash: row.hash, message: row.message });
+        }
+      }
+      const next = nextPageNumber(listing);
+      if (next === null || next <= page) break;
+      page = next;
+    }
+    return out;
+  }
+
+  /**
+   * Files `source` changed against the merge base with `destination`.
+   * Bitbucket's spec is `source..destination` — the pull-request order, the
+   * REVERSE of git's — and `topic=true` asks for the three-dot form.
+   */
+  private async diffstat(
+    source: string,
+    destination: string,
+  ): Promise<BitbucketDiffstatEntry[]> {
+    const out: BitbucketDiffstatEntry[] = [];
+    const spec = `${encodeRef(source)}..${encodeRef(destination)}`;
+    let page = 1;
+    for (let visited = 0; visited < MAX_PAGES; visited++) {
+      const listing = await this.json<BitbucketPage<BitbucketDiffstatEntry>>(
+        `${this.repoBase}/diffstat/${spec}?topic=true&pagelen=${PAGE_SIZE}&page=${page}`,
+      );
+      if (listing === null) return out;
+      out.push(...(listing.values ?? []));
+      const next = nextPageNumber(listing);
+      if (next === null || next <= page) break;
+      page = next;
+    }
+    return out;
+  }
+
+  /** Empty string when the refs share no history — Bitbucket answers 404 there. */
+  private async mergeBaseSha(base: string, head: string): Promise<string> {
+    const json = await this.json<{ hash?: string | null }>(
+      `${this.repoBase}/merge-base/${encodeRef(head)}..${encodeRef(base)}`,
+    );
+    return json?.hash ?? "";
+  }
+
+  private async token(): Promise<string> {
+    return (await this.provider.tokenForRepo(this.repo)).token;
+  }
+
+  private async json<T>(
+    pathAndQuery: string,
+    init?: CallInit,
+  ): Promise<T | null> {
+    const res = await this.call(pathAndQuery, init);
+    if (res === null) return null;
+    return (await res.json()) as T;
+  }
+
+  /**
+   * One authenticated REST call. 404 resolves to null so "absent" needs no
+   * try/catch; every other non-2xx becomes a `GitProviderError`, carrying a
+   * wait hint when Bitbucket rate-limited us.
+   */
+  private async call(
+    pathAndQuery: string,
+    init: CallInit = {},
+  ): Promise<Response | null> {
+    const res = await bitbucketFetch(
+      `${BITBUCKET_API_BASE}${pathAndQuery}`,
+      await this.token(),
+      init,
+    );
+    if (res.status === 404) {
+      await res.body?.cancel().catch(() => {});
+      return null;
+    }
+    if (!res.ok) throw await bitbucketFailure(res);
+    return res;
+  }
+}
+
+/** Branch names and revisions are one path segment: slashes encode too. */
+function encodeRef(ref: string): string {
+  return encodeURIComponent(ref);
+}

--- a/apps/api/src/git-providers/bitbucket/env.ts
+++ b/apps/api/src/git-providers/bitbucket/env.ts
@@ -1,0 +1,38 @@
+/**
+ * Deployment config for Studio's Bitbucket Cloud OAuth consumer.
+ *
+ * Optional, like its GitHub and GitLab counterparts: unset, the Bitbucket
+ * half of the git-providers routes answers 503 and an org connects with an
+ * access token instead. Read through this helper only; tools never touch
+ * `process.env`.
+ *
+ * Bitbucket Cloud has one host, so there is no `*_HOST` variable: the OAuth
+ * consumer is registered on bitbucket.org and nowhere else. Bitbucket Data
+ * Center is a different product with a different API and is not served here.
+ */
+
+import { DEFAULT_HOSTS } from "@decocms/shared/git-providers";
+import type { GitProviderCapability } from "../types";
+
+export const BITBUCKET_HOST = DEFAULT_HOSTS.bitbucket;
+
+export interface BitbucketOAuthConfig {
+  host: string;
+  /** Atlassian calls this the consumer "Key". */
+  clientId: string;
+  clientSecret: string;
+}
+
+export function readBitbucketOAuthConfig(
+  env: Record<string, string | undefined> = process.env,
+): BitbucketOAuthConfig | null {
+  const clientId = env.BITBUCKET_OAUTH_CLIENT_ID?.trim();
+  const clientSecret = env.BITBUCKET_OAUTH_CLIENT_SECRET?.trim();
+  if (!clientId || !clientSecret) return null;
+  return { host: BITBUCKET_HOST, clientId, clientSecret };
+}
+
+export function bitbucketCapability(): GitProviderCapability {
+  const config = readBitbucketOAuthConfig();
+  return { configured: config !== null, hosts: config ? [config.host] : [] };
+}

--- a/apps/api/src/git-providers/bitbucket/http.test.ts
+++ b/apps/api/src/git-providers/bitbucket/http.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import { GitProviderError } from "../types";
+import {
+  assertBitbucketCloud,
+  bbqString,
+  bitbucketErrorMessage,
+  bitbucketJson,
+  bitbucketRetryAfterMs,
+  nextPageNumber,
+} from "./http";
+
+describe("assertBitbucketCloud", () => {
+  test("accepts bitbucket.org in any case", () => {
+    expect(() => assertBitbucketCloud("bitbucket.org")).not.toThrow();
+    expect(() => assertBitbucketCloud("Bitbucket.ORG")).not.toThrow();
+  });
+  test("refuses a self-hosted host, naming Data Center", () => {
+    expect(() => assertBitbucketCloud("bitbucket.acme.com")).toThrow(
+      /Data Center/,
+    );
+  });
+});
+
+describe("bitbucketErrorMessage", () => {
+  test("flattens the REST error object", () => {
+    expect(
+      bitbucketErrorMessage(
+        JSON.stringify({
+          type: "error",
+          error: { message: "Bad request", detail: "parents is not the tip" },
+        }),
+      ),
+    ).toBe("Bad request; parents is not the tip");
+  });
+  test("flattens field errors too", () => {
+    expect(
+      bitbucketErrorMessage(
+        JSON.stringify({
+          error: {
+            message: "Invalid",
+            fields: { source: ["already an open pull request"] },
+          },
+        }),
+      ),
+    ).toContain("already an open pull request");
+  });
+  test("reads the OAuth shape", () => {
+    expect(
+      bitbucketErrorMessage(
+        JSON.stringify({
+          error: "invalid_grant",
+          error_description: "The code has expired",
+        }),
+      ),
+    ).toBe("invalid_grant; The code has expired");
+  });
+  test("falls back to the raw text for a non-JSON body", () => {
+    expect(bitbucketErrorMessage("<html>Gateway</html>")).toBe(
+      "<html>Gateway</html>",
+    );
+  });
+});
+
+describe("bitbucketRetryAfterMs", () => {
+  const now = Date.parse("2026-09-11T12:00:00Z");
+  test("Retry-After in seconds", () => {
+    expect(
+      bitbucketRetryAfterMs(new Headers({ "retry-after": "30" }), now),
+    ).toBe(30_000);
+  });
+  test("Retry-After as an HTTP date", () => {
+    expect(
+      bitbucketRetryAfterMs(
+        new Headers({ "retry-after": "Fri, 11 Sep 2026 12:00:10 GMT" }),
+        now,
+      ),
+    ).toBe(10_000);
+  });
+  test("null when Bitbucket gave no hint", () => {
+    expect(bitbucketRetryAfterMs(new Headers(), now)).toBeNull();
+  });
+});
+
+describe("bitbucketJson", () => {
+  test("parses a well-formed 2xx body", async () => {
+    const res = new Response(JSON.stringify({ id: 1 }), { status: 200 });
+    await expect(bitbucketJson(res, "get_repo")).resolves.toEqual({ id: 1 });
+  });
+  test("degrades a malformed 2xx body into a GitProviderError", async () => {
+    const res = new Response("<html>Not JSON</html>", { status: 200 });
+    await expect(bitbucketJson(res, "get_repo")).rejects.toBeInstanceOf(
+      GitProviderError,
+    );
+  });
+});
+
+describe("nextPageNumber", () => {
+  test("reads the page the next url points at", () => {
+    expect(
+      nextPageNumber({
+        next: "https://api.bitbucket.org/2.0/repositories?role=member&page=3",
+      }),
+    ).toBe(3);
+  });
+  test("null when the listing is exhausted or the url is odd", () => {
+    expect(nextPageNumber({})).toBeNull();
+    expect(nextPageNumber({ next: null })).toBeNull();
+    expect(nextPageNumber({ next: "not a url" })).toBeNull();
+    expect(nextPageNumber({ next: "https://x.y/z" })).toBeNull();
+  });
+});
+
+describe("bbqString", () => {
+  test("quotes and escapes for Bitbucket's query language", () => {
+    expect(bbqString("feat/x")).toBe('"feat/x"');
+    expect(bbqString('say "hi"')).toBe('"say \\"hi\\""');
+    expect(bbqString("a\\b")).toBe('"a\\\\b"');
+  });
+});

--- a/apps/api/src/git-providers/bitbucket/http.ts
+++ b/apps/api/src/git-providers/bitbucket/http.ts
@@ -1,0 +1,213 @@
+/**
+ * Bitbucket Cloud REST 2.0 plumbing shared by every Bitbucket caller: the API
+ * base, the headers and timeout one call sends, the conversion of a refusal
+ * into `GitProviderError`, and the paginated envelope every listing uses.
+ *
+ * Nothing here decides which token to send; callers pass one. Every token
+ * Studio stores for Bitbucket — an OAuth access token, a workspace, project
+ * or repository access token — is accepted as `Authorization: Bearer`.
+ *
+ * Bitbucket Cloud only. Bitbucket Data Center (self-hosted) speaks
+ * `/rest/api/1.0` with different shapes; `assertBitbucketCloud` refuses such a
+ * host up front so the failure is one clear message rather than a trail of
+ * confusing 404s.
+ */
+
+import { apiBaseUrlFor } from "@decocms/shared/git-providers";
+import { GitProviderError } from "../types";
+import { BITBUCKET_HOST } from "./env";
+
+/** Matches the other providers: one REST call, not a download. */
+const BITBUCKET_TIMEOUT_MS = 15_000;
+
+export const BITBUCKET_API_BASE = apiBaseUrlFor("bitbucket", BITBUCKET_HOST);
+
+/** Bitbucket Cloud is the one host this client speaks. */
+export function assertBitbucketCloud(host: string): void {
+  if (host.toLowerCase() === BITBUCKET_HOST) return;
+  throw new GitProviderError({
+    provider: "bitbucket",
+    status: 400,
+    message: `${host} is not Bitbucket Cloud. Only bitbucket.org is supported; Bitbucket Data Center has a different API.`,
+  });
+}
+
+/**
+ * How long Bitbucket asked us to wait, in ms, or null when it did not say.
+ * Bitbucket answers 429 with a `Retry-After` in seconds when it gives a hint
+ * at all; there is no reset header. `now` is injected so an HTTP-date form is
+ * testable.
+ */
+export function bitbucketRetryAfterMs(
+  headers: Headers,
+  now: number = Date.now(),
+): number | null {
+  const retryAfter = headers.get("retry-after");
+  if (retryAfter === null) return null;
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const at = Date.parse(retryAfter);
+  return Number.isFinite(at) ? Math.max(0, at - now) : null;
+}
+
+/**
+ * The human-readable half of a Bitbucket error body. Two shapes:
+ * `{"type": "error", "error": {"message": "...", "detail": "...", "fields":
+ * {...}}}` for the REST API, and `{"error": "...", "error_description": "..."}`
+ * for OAuth. The conflict classifiers match on this text, so flattening both
+ * is load-bearing, not cosmetic.
+ */
+export function bitbucketErrorMessage(bodyText: string): string {
+  const flatten = (value: unknown): string[] => {
+    if (typeof value === "string") return value.length > 0 ? [value] : [];
+    if (Array.isArray(value)) return value.flatMap(flatten);
+    if (value !== null && typeof value === "object") {
+      return Object.values(value).flatMap(flatten);
+    }
+    return [];
+  };
+  try {
+    const parsed: unknown = JSON.parse(bodyText);
+    if (parsed !== null && typeof parsed === "object") {
+      const record = parsed as Record<string, unknown>;
+      const parts = [
+        ...flatten(record.error),
+        ...flatten(record.error_description),
+      ];
+      if (parts.length > 0) return parts.join("; ");
+    }
+  } catch {
+    // Not JSON: an HTML error page or an empty body. Fall through to the text.
+  }
+  return bodyText.slice(0, 300);
+}
+
+/** A `GitProviderError` for a non-2xx response, reading its body for the message. */
+export async function bitbucketFailure(
+  res: Response,
+): Promise<GitProviderError> {
+  const text = await res.text().catch(() => "");
+  const detail = text ? bitbucketErrorMessage(text) : res.statusText;
+  return new GitProviderError({
+    provider: "bitbucket",
+    status: res.status,
+    message: `Bitbucket API ${res.status}: ${detail}`,
+    retryAfterMs:
+      res.status === 429 ? bitbucketRetryAfterMs(res.headers) : null,
+  });
+}
+
+/**
+ * Parse a response body as JSON, degrading a malformed 2xx body into a
+ * `GitProviderError` instead of letting a raw `SyntaxError` escape — mirrors
+ * `gitlab/http.ts`'s `gitlabJson`.
+ */
+export async function bitbucketJson<T>(
+  res: Response,
+  operation: string,
+): Promise<T> {
+  const text = await res.text();
+  try {
+    return JSON.parse(text) as T;
+  } catch (cause) {
+    throw new GitProviderError({
+      provider: "bitbucket",
+      status: res.status,
+      message: `Bitbucket ${operation} returned invalid JSON: ${text.slice(0, 300)}`,
+      cause,
+    });
+  }
+}
+
+export interface BitbucketFetchInit {
+  method?: "GET" | "POST" | "PUT" | "DELETE";
+  /** A `FormData` is sent as multipart (the `src` commit endpoint); anything else as JSON. */
+  body?: unknown;
+  accept?: string;
+  timeoutMs?: number;
+  /**
+   * `Basic x-token-auth:<token>` instead of `Bearer` — the web host's
+   * archive download authenticates the way `git` does, not the way the API does.
+   */
+  basicAuth?: boolean;
+}
+
+/**
+ * One authenticated call. A network or timeout failure becomes a
+ * `GitProviderError` with `status: 0`; every response — including 4xx — is
+ * returned, so a caller can give 404 and 409 their endpoint-specific meaning.
+ */
+export async function bitbucketFetch(
+  url: string,
+  token: string,
+  init: BitbucketFetchInit = {},
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    Authorization: init.basicAuth
+      ? `Basic ${Buffer.from(`x-token-auth:${token}`).toString("base64")}`
+      : `Bearer ${token}`,
+    Accept: init.accept ?? "application/json",
+  };
+  const multipart = init.body instanceof FormData;
+  if (init.body !== undefined && !multipart) {
+    headers["Content-Type"] = "application/json";
+  }
+  try {
+    return await fetch(url, {
+      method: init.method ?? "GET",
+      headers,
+      body:
+        init.body === undefined
+          ? undefined
+          : multipart
+            ? (init.body as FormData)
+            : JSON.stringify(init.body),
+      signal: AbortSignal.timeout(init.timeoutMs ?? BITBUCKET_TIMEOUT_MS),
+    });
+  } catch (cause) {
+    throw new GitProviderError({
+      provider: "bitbucket",
+      status: 0,
+      message: `Bitbucket request failed: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+      cause,
+    });
+  }
+}
+
+/**
+ * Bitbucket's paginated envelope. `next` is a full URL for the following
+ * page; `size` is the total and is "optional, not provided in all responses"
+ * — refs and commits omit it once counting would cost too much.
+ */
+export interface BitbucketPage<T> {
+  values?: T[] | null;
+  next?: string | null;
+  size?: number | null;
+  page?: number | null;
+}
+
+/**
+ * The page number `next` points at, or null when the listing is exhausted.
+ * Pure — the `next` URL is opaque to callers, but a page NUMBER is what the
+ * interface's cursor carries, and what a caller can pass back as `page=`.
+ */
+export function nextPageNumber(page: BitbucketPage<unknown>): number | null {
+  if (!page.next) return null;
+  try {
+    const raw = new URL(page.next).searchParams.get("page");
+    const n = Number(raw);
+    return raw !== null && Number.isInteger(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A string literal in Bitbucket's query language (`q=name ~ "foo"`): double
+ * quotes and backslashes are the only escapes it understands.
+ */
+export function bbqString(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}

--- a/apps/api/src/git-providers/bitbucket/oauth.test.ts
+++ b/apps/api/src/git-providers/bitbucket/oauth.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { bitbucketAuthorizeUrl, bitbucketTokenEndpoint } from "./oauth";
+
+describe("bitbucketAuthorizeUrl", () => {
+  const base = {
+    clientId: "consumer-key",
+    redirectUri: "https://studio.example.com/api/_git/bitbucket/callback",
+    state: "opaque-state",
+  };
+
+  test("targets bitbucket.org's authorize page with the code flow params", () => {
+    const url = new URL(bitbucketAuthorizeUrl(base));
+    expect(url.origin).toBe("https://bitbucket.org");
+    expect(url.pathname).toBe("/site/oauth2/authorize");
+    expect(url.searchParams.get("client_id")).toBe("consumer-key");
+    expect(url.searchParams.get("redirect_uri")).toBe(base.redirectUri);
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("state")).toBe("opaque-state");
+  });
+
+  test("carries no scope — scopes live on the consumer", () => {
+    const url = new URL(bitbucketAuthorizeUrl(base));
+    expect(url.searchParams.has("scope")).toBe(false);
+  });
+
+  test("encodes the redirect URI so its own query string survives", () => {
+    const redirectUri = "https://studio.example.com/cb?next=/repos&x=1";
+    const url = new URL(bitbucketAuthorizeUrl({ ...base, redirectUri }));
+    expect(url.searchParams.get("redirect_uri")).toBe(redirectUri);
+  });
+});
+
+describe("bitbucketTokenEndpoint", () => {
+  test("is the site's access_token endpoint", () => {
+    expect(bitbucketTokenEndpoint()).toBe(
+      "https://bitbucket.org/site/oauth2/access_token",
+    );
+  });
+});

--- a/apps/api/src/git-providers/bitbucket/oauth.ts
+++ b/apps/api/src/git-providers/bitbucket/oauth.ts
@@ -1,0 +1,144 @@
+/**
+ * Bitbucket Cloud OAuth 2.0 authorization-code flow.
+ *
+ * URL building is pure so the routes can unit-test the redirect they send the
+ * browser to. `exchangeBitbucketCode` is the one network call; Bitbucket
+ * issues a short-lived access token (2h) plus a refresh token, so callers
+ * persist the grant and the shared refresh helper renews it.
+ *
+ * Two things differ from GitLab's flow. Scopes are fixed on the OAuth consumer
+ * when it is registered, so the authorize URL carries none — the consumer
+ * needs `account`, `repository:write` and `pullrequest:write` (and `email` for
+ * commit identity). And Bitbucket's token endpoint answers `scopes`, plural.
+ * It accepts the client credentials in the POST body as well as as HTTP
+ * Basic; the body is used here because that is the only form the shared
+ * refresh helper (`oauth/refresh-access-token.ts`) sends, and an exchange
+ * that works must not be followed by a refresh that cannot.
+ */
+
+import { GitProviderError } from "../types";
+import { BITBUCKET_HOST } from "./env";
+
+export interface BitbucketAuthorizeUrlParams {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+}
+
+export function bitbucketAuthorizeUrl(
+  params: BitbucketAuthorizeUrlParams,
+): string {
+  const url = new URL(`https://${BITBUCKET_HOST}/site/oauth2/authorize`);
+  url.searchParams.set("client_id", params.clientId);
+  url.searchParams.set("redirect_uri", params.redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("state", params.state);
+  return url.toString();
+}
+
+export function bitbucketTokenEndpoint(): string {
+  return `https://${BITBUCKET_HOST}/site/oauth2/access_token`;
+}
+
+export interface ExchangeBitbucketCodeParams {
+  clientId: string;
+  clientSecret: string;
+  code: string;
+  redirectUri: string;
+}
+
+export interface BitbucketTokenGrant {
+  accessToken: string;
+  refreshToken: string | null;
+  /** Seconds until `accessToken` expires, as Bitbucket reported it. */
+  expiresIn: number | null;
+  /** Space-separated, as the shared grant store expects. */
+  scope: string | null;
+  tokenEndpoint: string;
+}
+
+interface BitbucketTokenResponse {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  expires_in?: unknown;
+  scopes?: unknown;
+  error?: unknown;
+  error_description?: unknown;
+}
+
+const TOKEN_TIMEOUT_MS = 15_000;
+
+export async function exchangeBitbucketCode(
+  params: ExchangeBitbucketCodeParams,
+): Promise<BitbucketTokenGrant> {
+  const tokenEndpoint = bitbucketTokenEndpoint();
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    client_id: params.clientId,
+    client_secret: params.clientSecret,
+    code: params.code,
+    redirect_uri: params.redirectUri,
+  });
+
+  let res: Response;
+  try {
+    res = await fetch(tokenEndpoint, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body,
+      signal: AbortSignal.timeout(TOKEN_TIMEOUT_MS),
+    });
+  } catch (cause) {
+    throw new GitProviderError({
+      provider: "bitbucket",
+      status: 0,
+      message: `Bitbucket token exchange failed: ${describeCause(cause)}`,
+      cause,
+    });
+  }
+
+  const json = (await res
+    .json()
+    .catch(() => null)) as BitbucketTokenResponse | null;
+  if (!res.ok || !json || typeof json.error === "string") {
+    const detail =
+      json && typeof json.error_description === "string"
+        ? json.error_description
+        : json && typeof json.error === "string"
+          ? json.error
+          : res.statusText;
+    throw new GitProviderError({
+      provider: "bitbucket",
+      status: res.status,
+      message: `Bitbucket token exchange failed (${res.status}): ${detail}`,
+    });
+  }
+  if (typeof json.access_token !== "string" || !json.access_token) {
+    throw new GitProviderError({
+      provider: "bitbucket",
+      status: res.status,
+      message: "Bitbucket token exchange returned no access_token",
+    });
+  }
+
+  return {
+    accessToken: json.access_token,
+    refreshToken:
+      typeof json.refresh_token === "string" && json.refresh_token
+        ? json.refresh_token
+        : null,
+    expiresIn:
+      typeof json.expires_in === "number" && Number.isFinite(json.expires_in)
+        ? json.expires_in
+        : null,
+    scope: typeof json.scopes === "string" ? json.scopes : null,
+    tokenEndpoint,
+  };
+}
+
+function describeCause(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}

--- a/apps/api/src/git-providers/capabilities.ts
+++ b/apps/api/src/git-providers/capabilities.ts
@@ -3,7 +3,7 @@
  * credentials, without the caller reading an environment variable.
  *
  * The connect flows themselves are provider-specific by construction (a GitHub
- * App installation and a GitLab OAuth grant are different dances, and
+ * App installation and a GitLab or Bitbucket OAuth grant are different dances, and
  * `api/routes/git-providers.ts` implements both), but "can we offer this at
  * all" is one question with one shape per provider. Each provider answers for
  * itself; this is only the assembly, so no host or env var is named here.
@@ -12,11 +12,16 @@
 import type { GitProviderKind } from "@decocms/shared/git-providers";
 import { githubCapability } from "./github/app-auth";
 import { gitlabCapability } from "./gitlab/env";
+import { bitbucketCapability } from "./bitbucket/env";
 import type { GitProviderCapability } from "./types";
 
 export function providerCapabilities(): Record<
   GitProviderKind,
   GitProviderCapability
 > {
-  return { github: githubCapability(), gitlab: gitlabCapability() };
+  return {
+    github: githubCapability(),
+    gitlab: gitlabCapability(),
+    bitbucket: bitbucketCapability(),
+  };
 }

--- a/apps/api/src/git-providers/clients.ts
+++ b/apps/api/src/git-providers/clients.ts
@@ -1,9 +1,9 @@
 /**
  * The composition root: from a repository to a client that can act on it.
  *
- * This is the ONE module that knows both providers exist. Everything above it
+ * This is the ONE module that knows every provider exists. Everything above it
  * speaks `RepoRef` and gets back an interface; everything below it is one
- * provider's own vocabulary, sealed in `github/` or `gitlab/`. The `switch`
+ * provider's own vocabulary, sealed in `github/`, `gitlab/` or `bitbucket/`. The `switch`
  * here is a registry, not knowledge — adding a provider is a case and a
  * directory.
  *
@@ -13,7 +13,7 @@
  * - the row matching the repository's identity, for records written before the
  *   id was captured;
  * - the legacy `mcp-github` connection, for orgs not migrated yet. GitHub
- *   only — GitLab never had one.
+ *   only — GitLab and Bitbucket never had one.
  *
  * The two capability factories differ deliberately in what they do when no
  * path works. A content client THROWS: every caller is about to read or write
@@ -52,6 +52,9 @@ import { resolveLegacyGithubConnection } from "./github/legacy-connection";
 import { GitlabChangeRequestClient } from "./gitlab/change-requests";
 import { gitlabCurrentUser } from "./gitlab/client";
 import { GitlabContentClient } from "./gitlab/content";
+import { BitbucketChangeRequestClient } from "./bitbucket/change-requests";
+import { bitbucketPrincipalForToken } from "./bitbucket/client";
+import { BitbucketContentClient } from "./bitbucket/content";
 import {
   GitProviderError,
   type GitTokenKind,
@@ -67,6 +70,8 @@ function contentClientFor({
       return new GithubContentClient({ repo: ref, tokenSource });
     case "gitlab":
       return new GitlabContentClient({ repo: ref, tokenSource });
+    case "bitbucket":
+      return new BitbucketContentClient({ repo: ref, tokenSource });
   }
 }
 
@@ -79,6 +84,8 @@ function changeRequestClientFor({
       return new GithubChangeRequestClient({ repo: ref, tokenSource });
     case "gitlab":
       return new GitlabChangeRequestClient({ repo: ref, tokenSource });
+    case "bitbucket":
+      return new BitbucketChangeRequestClient({ repo: ref, tokenSource });
   }
 }
 
@@ -276,12 +283,14 @@ export function principalForToken(
   switch (provider) {
     case "gitlab":
       return gitlabCurrentUser(host, token);
+    case "bitbucket":
+      return bitbucketPrincipalForToken(host, token);
     case "github":
       throw new GitProviderError({
         provider,
         status: 400,
         message:
-          "GitHub accounts connect through the GitHub App; tokens are accepted for GitLab only",
+          "GitHub accounts connect through the GitHub App; tokens are accepted for GitLab and Bitbucket only",
       });
   }
 }

--- a/apps/api/src/git-providers/credentials.ts
+++ b/apps/api/src/git-providers/credentials.ts
@@ -33,6 +33,7 @@ import type { Database } from "@/storage/types";
 import { getGithubAppAuth } from "./github/app-auth";
 import { GithubProviderClient } from "./github/client";
 import { GitlabProviderClient } from "./gitlab/client";
+import { BitbucketProviderClient } from "./bitbucket/client";
 import {
   type GitProviderClient,
   GitProviderError,
@@ -162,6 +163,15 @@ export function clientForAccount(
     }
     case "gitlab":
       return new GitlabProviderClient({
+        host: account.host,
+        tokenSource: grantTokenSource(
+          credentials,
+          account.id,
+          grantKind(account.authKind),
+        ),
+      });
+    case "bitbucket":
+      return new BitbucketProviderClient({
         host: account.host,
         tokenSource: grantTokenSource(
           credentials,

--- a/apps/api/src/git-providers/gitlab/content.test.ts
+++ b/apps/api/src/git-providers/gitlab/content.test.ts
@@ -2,9 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   isProtectedBranch,
   buildCommitActions,
-  decoDirFor,
-  directoryOf,
-  groupPathsByDirectory,
   isBranchExistsConflict,
   isCommitConflict,
   mapCompareDiff,
@@ -253,64 +250,6 @@ describe("mapMergeRequest", () => {
       title: "",
       state: "closed",
     });
-  });
-});
-
-describe("directoryOf", () => {
-  test("a nested path", () => {
-    expect(directoryOf(".deco/blocks/page.json")).toBe(".deco/blocks");
-  });
-  test("a root file has the empty directory", () => {
-    expect(directoryOf("README.md")).toBe("");
-  });
-  test("a leading slash addresses the same file", () => {
-    expect(directoryOf("/src/app.ts")).toBe("src");
-  });
-});
-
-describe("groupPathsByDirectory", () => {
-  test("siblings share one bucket", () => {
-    expect(
-      groupPathsByDirectory([
-        ".deco/blocks/a.json",
-        ".deco/blocks/b.json",
-        "apps/site/.deco/blocks/c.json",
-      ]),
-    ).toEqual(
-      new Map([
-        [".deco/blocks", [".deco/blocks/a.json", ".deco/blocks/b.json"]],
-        ["apps/site/.deco/blocks", ["apps/site/.deco/blocks/c.json"]],
-      ]),
-    );
-  });
-
-  test("duplicates are listed once", () => {
-    expect(groupPathsByDirectory(["a/b.json", "a/b.json"])).toEqual(
-      new Map([["a", ["a/b.json"]]]),
-    );
-  });
-
-  test("root files bucket under the empty directory", () => {
-    expect(groupPathsByDirectory(["deno.json", "a/b.json"])).toEqual(
-      new Map([
-        ["", ["deno.json"]],
-        ["a", ["a/b.json"]],
-      ]),
-    );
-  });
-
-  test("empty and slash-only input yields no buckets", () => {
-    expect(groupPathsByDirectory([])).toEqual(new Map());
-    expect(groupPathsByDirectory(["", "/"])).toEqual(new Map());
-  });
-});
-
-describe("decoDirFor", () => {
-  test("a repo-root project", () => {
-    expect(decoDirFor(null)).toBe(".deco");
-  });
-  test("a nested project", () => {
-    expect(decoDirFor("apps/site")).toBe("apps/site/.deco");
   });
 });
 

--- a/apps/api/src/git-providers/gitlab/content.ts
+++ b/apps/api/src/git-providers/gitlab/content.ts
@@ -29,6 +29,7 @@ import {
   GitlabProviderClient,
 } from "./client";
 import { gitlabApiBaseUrl, gitlabFailure } from "./http";
+import { decoDirFor, groupPathsByDirectory } from "../paths";
 import { GitProviderError, type TokenSource } from "../types";
 import {
   type BranchPage,
@@ -207,40 +208,6 @@ export function mapMergeRequest(mr: GitlabMergeRequestRow): ChangeRequestInfo {
     title: mr.title ?? "",
     state: mapMergeRequestState(mr.state),
   };
-}
-
-/** Repo-relative directory of `path`; `""` for a file at the repo root. */
-export function directoryOf(path: string): string {
-  const normalized = path.replace(/^\/+/, "");
-  const slash = normalized.lastIndexOf("/");
-  return slash === -1 ? "" : normalized.slice(0, slash);
-}
-
-/**
- * Paths bucketed by the directory they live in, deduplicated, insertion
- * ordered. One bucket is one tree listing, which is what keeps
- * `getEntriesAtPaths` scaling with the path set instead of with repo size.
- */
-export function groupPathsByDirectory(
-  paths: readonly string[],
-): Map<string, string[]> {
-  const byDir = new Map<string, string[]>();
-  const seen = new Set<string>();
-  for (const raw of paths) {
-    const path = raw.replace(/^\/+/, "");
-    if (path === "" || seen.has(path)) continue;
-    seen.add(path);
-    const dir = directoryOf(path);
-    const bucket = byDir.get(dir);
-    if (bucket) bucket.push(path);
-    else byDir.set(dir, [path]);
-  }
-  return byDir;
-}
-
-/** `<packagePath>/.deco`, or `.deco` for a single-project repo. */
-export function decoDirFor(packagePath: string | null): string {
-  return packagePath ? `${packagePath}/.deco` : ".deco";
 }
 
 interface GitlabCompareDiff {

--- a/apps/api/src/git-providers/index.ts
+++ b/apps/api/src/git-providers/index.ts
@@ -11,17 +11,17 @@
  * - `credentials.ts` — which credential reaches which repository. Neutral.
  * - `clients.ts` — the composition root, and the one module that knows both
  *   providers exist.
- * - `github/`, `gitlab/` — one provider's own vocabulary, and the only place
+ * - `github/`, `gitlab/`, `bitbucket/` — one provider's own vocabulary, and the only place
  *   its name, hosts, endpoints and error prose appear.
  *
  * Two rules keep that honest, and both are about imports:
  *
- * 1. Nothing OUTSIDE this directory imports `github/` or `gitlab/`. If a
+ * 1. Nothing OUTSIDE this directory imports `github/`, `gitlab/` or `bitbucket/`. If a
  *    caller needs one provider specifically, it wants a capability this
  *    interface does not express yet — add it here rather than reaching past
  *    it. Two standing exceptions, both provider-specific *by construction*:
- *    `api/routes/git-providers.ts` (a GitHub App installation and a GitLab
- *    OAuth grant are different redirect dances, so there is no one flow to
+ *    `api/routes/git-providers.ts` (a GitHub App installation and a GitLab or
+ *    Bitbucket OAuth grant are different redirect dances, so there is no one flow to
  *    implement) and `tools/github/list-user-orgs.ts` (listing App
  *    installations has no counterpart to abstract over).
  * 2. Nothing INSIDE this directory imports this barrel. Implementations

--- a/apps/api/src/git-providers/paths.test.ts
+++ b/apps/api/src/git-providers/paths.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { decoDirFor, directoryOf, groupPathsByDirectory } from "./paths";
+
+describe("directoryOf", () => {
+  test("a nested path", () => {
+    expect(directoryOf(".deco/blocks/page.json")).toBe(".deco/blocks");
+  });
+  test("a root file has the empty directory", () => {
+    expect(directoryOf("README.md")).toBe("");
+  });
+  test("a leading slash addresses the same file", () => {
+    expect(directoryOf("/src/app.ts")).toBe("src");
+  });
+});
+
+describe("groupPathsByDirectory", () => {
+  test("siblings share one bucket", () => {
+    expect(
+      groupPathsByDirectory([
+        ".deco/blocks/a.json",
+        ".deco/blocks/b.json",
+        ".deco/blocks.gen.json",
+      ]),
+    ).toEqual(
+      new Map([
+        [".deco/blocks", [".deco/blocks/a.json", ".deco/blocks/b.json"]],
+        [".deco", [".deco/blocks.gen.json"]],
+      ]),
+    );
+  });
+  test("duplicates are listed once", () => {
+    expect(groupPathsByDirectory(["a/x", "a/x", "/a/x"])).toEqual(
+      new Map([["a", ["a/x"]]]),
+    );
+  });
+  test("root files bucket under the empty directory", () => {
+    expect(groupPathsByDirectory(["README.md"])).toEqual(
+      new Map([["", ["README.md"]]]),
+    );
+  });
+  test("empty and slash-only input yields no buckets", () => {
+    expect(groupPathsByDirectory(["", "/", "//"])).toEqual(new Map());
+  });
+});
+
+describe("decoDirFor", () => {
+  test("a repo-root project", () => {
+    expect(decoDirFor(null)).toBe(".deco");
+  });
+  test("a nested project", () => {
+    expect(decoDirFor("apps/site")).toBe("apps/site/.deco");
+  });
+});

--- a/apps/api/src/git-providers/paths.ts
+++ b/apps/api/src/git-providers/paths.ts
@@ -1,0 +1,39 @@
+/**
+ * Repository-path arithmetic shared by the providers that address trees by
+ * directory (GitLab, Bitbucket) rather than by object sha (GitHub). Pure —
+ * no provider vocabulary, no I/O.
+ */
+
+/** Repo-relative directory of `path`; `""` for a file at the repo root. */
+export function directoryOf(path: string): string {
+  const normalized = path.replace(/^\/+/, "");
+  const slash = normalized.lastIndexOf("/");
+  return slash === -1 ? "" : normalized.slice(0, slash);
+}
+
+/**
+ * Paths bucketed by the directory they live in, deduplicated, insertion
+ * ordered. One bucket is one tree listing, which is what keeps a lookup of a
+ * caller-known path set scaling with the set instead of with repo size.
+ */
+export function groupPathsByDirectory(
+  paths: readonly string[],
+): Map<string, string[]> {
+  const byDir = new Map<string, string[]>();
+  const seen = new Set<string>();
+  for (const raw of paths) {
+    const path = raw.replace(/^\/+/, "");
+    if (path === "" || seen.has(path)) continue;
+    seen.add(path);
+    const dir = directoryOf(path);
+    const bucket = byDir.get(dir);
+    if (bucket) bucket.push(path);
+    else byDir.set(dir, [path]);
+  }
+  return byDir;
+}
+
+/** `<packagePath>/.deco`, or `.deco` for a single-project repo. */
+export function decoDirFor(packagePath: string | null): string {
+  return packagePath ? `${packagePath}/.deco` : ".deco";
+}

--- a/apps/api/src/git-providers/types.ts
+++ b/apps/api/src/git-providers/types.ts
@@ -1,7 +1,7 @@
 /**
  * Git provider client contract.
  *
- * One implementation per `GitProviderKind` (github, gitlab). The account row's
+ * One implementation per `GitProviderKind` (github, gitlab, bitbucket). The account row's
  * `type` picks the implementation (`registry.ts`); its `auth_kind` picks how
  * tokens are produced (`credentials.ts`). Nothing outside `git-providers/`
  * builds a provider URL, header or token — callers speak `RepoRef` and get

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -2252,7 +2252,7 @@ export interface NotificationTable {
 
 // ============================== Git providers ===============================
 
-export type GitProviderKindColumn = "github" | "gitlab";
+export type GitProviderKindColumn = "github" | "gitlab" | "bitbucket";
 export type GitAuthKindColumn = "github_app" | "oauth" | "token";
 export type GitAccountStatusColumn = "active" | "revoked";
 

--- a/apps/api/src/tools/change-requests/index.ts
+++ b/apps/api/src/tools/change-requests/index.ts
@@ -183,7 +183,7 @@ export const CHANGE_REQUEST_LIST_OPEN = defineTool({
 export const CHANGE_REQUEST_CHECK_LOG = defineTool({
   name: "CHANGE_REQUEST_CHECK_LOG",
   description:
-    "Read one CI run's report — a GitHub check run's output markdown, or the tail of a GitLab job's trace.",
+    "Read one CI run's report — a GitHub check run's output markdown, or the tail of a GitLab job's trace. Bitbucket commit statuses carry no report, so this answers nothing there.",
   annotations: {
     title: "Read CI Run Report",
     readOnlyHint: true,

--- a/apps/api/src/tools/git/index.ts
+++ b/apps/api/src/tools/git/index.ts
@@ -108,6 +108,11 @@ export const GIT_PROVIDER_CAPABILITIES = defineTool({
       oauthHosts: z.array(z.string()),
       connectPath: z.string().nullable(),
     }),
+    bitbucket: z.object({
+      /** `["bitbucket.org"]` when an OAuth consumer is configured; tokens work either way. */
+      oauthHosts: z.array(z.string()),
+      connectPath: z.string().nullable(),
+    }),
   }),
   handler: async (_input, ctx) => {
     requireAuth(ctx);
@@ -125,6 +130,12 @@ export const GIT_PROVIDER_CAPABILITIES = defineTool({
         oauthHosts: capabilities.gitlab.hosts,
         connectPath: capabilities.gitlab.configured
           ? `${base}/gitlab/connect`
+          : null,
+      },
+      bitbucket: {
+        oauthHosts: capabilities.bitbucket.hosts,
+        connectPath: capabilities.bitbucket.configured
+          ? `${base}/bitbucket/connect`
           : null,
       },
     };
@@ -158,7 +169,7 @@ export const GIT_ACCOUNT_LIST = defineTool({
 export const GIT_ACCOUNT_CONNECT_TOKEN = defineTool({
   name: "GIT_ACCOUNT_CONNECT_TOKEN",
   description:
-    "Connect a git provider account with a personal, project or group access token. Validates the token against the provider before storing it encrypted. Use this for self-managed GitLab instances (no OAuth application) or when OAuth is not wanted.",
+    "Connect a git provider account with an access token: a GitLab personal, project or group token, or a Bitbucket Cloud workspace, project or repository access token. Validates the token against the provider before storing it encrypted. Use this for self-managed GitLab instances (no OAuth application) or when OAuth is not wanted.",
   annotations: {
     title: "Connect git account with a token",
     readOnlyHint: false,
@@ -169,12 +180,14 @@ export const GIT_ACCOUNT_CONNECT_TOKEN = defineTool({
   _meta: { ui: { visibility: "app" } },
   inputSchema: z.object({
     type: GitProviderKindSchema.describe(
-      "Provider; only gitlab accepts tokens today",
+      "Provider; gitlab and bitbucket accept tokens (GitHub connects through the App)",
     ),
     host: z
       .string()
       .min(1)
-      .describe("Provider host, e.g. gitlab.com or gitlab.acme.com"),
+      .describe(
+        "Provider host, e.g. gitlab.com, gitlab.acme.com or bitbucket.org",
+      ),
     token: z.string().min(1).describe("Access token with api scope"),
   }),
   outputSchema: z.object({ account: AccountOutputSchema }),
@@ -350,7 +363,7 @@ export const REPOSITORY_LINK = defineTool({
       const ref = parseRepoUrl(input.url);
       if (!ref) {
         throw new Error(
-          "Could not recognise the repository URL. Use a full https URL from GitHub or GitLab.",
+          "Could not recognise the repository URL. Use a full https URL from GitHub, GitLab or Bitbucket.",
         );
       }
       const repository = await ctx.storage.repositories.upsert({

--- a/apps/api/src/tools/org-repo-sync/index.ts
+++ b/apps/api/src/tools/org-repo-sync/index.ts
@@ -162,7 +162,7 @@ export const ORG_REPO_SYNC_CREATE = defineTool({
   name: "ORG_REPO_SYNC_CREATE",
   description:
     "Keep a git repository mirrored into a new org-fs volume. Takes exactly " +
-    "one of repositoryId (a connected GitHub/GitLab repository) or " +
+    "one of repositoryId (a connected GitHub/GitLab/Bitbucket repository) or " +
     "connectionId (a legacy repo-scoped mcp-github connection), plus an " +
     "EMPTY volume name; the repo is synced every ~10 minutes (and on " +
     "ORG_REPO_SYNC_RUN). The volume is a mirror — files not in the repo are " +

--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -239,8 +239,10 @@ export function parseRepoProbe(stdout: string): {
  * ends up with both authenticated; a second host of the SAME provider replaces
  * the first, which is why one account per host is the supported shape.
  *
- * The userinfo username tells the two apart, exactly as the daemon does:
- * `x-access-token` is GitHub, `oauth2` is GitLab. `glab` needs `is_oauth2` so
+ * The userinfo username tells the providers apart, exactly as the daemon does:
+ * `x-access-token` is GitHub, `oauth2` is GitLab, `x-token-auth` is Bitbucket —
+ * which has no CLI to configure, so it falls through; the daemon exports the
+ * primary checkout's token as `BITBUCKET_TOKEN` for `curl` instead. `glab` needs `is_oauth2` so
  * it sends a bearer token (the only form GitLab accepts for an OAuth token, and
  * one it also accepts for an access token), and refuses a config that is not
  * 0600.
@@ -372,8 +374,9 @@ export const TASK_ADD_REPO = defineTool({
     "files, and do not run git, before it returns. Call it once, with the " +
     "repository the task is about; it waits for the checkout and returns the " +
     "repository root listing, so you can start reading files immediately after. " +
-    "`git` and the repository's CLI (`gh` for GitHub, `glab` for GitLab) are " +
-    "authenticated once it returns. Call TASK_ADD_REPO with " +
+    "`git` and the repository's CLI (`gh` for GitHub, `glab` for GitLab; Bitbucket has " +
+    "no CLI — its token is the password in `git remote get-url origin`, for `curl` " +
+    "against api.bitbucket.org) are authenticated once it returns. Call TASK_ADD_REPO with " +
     "no arguments to list the repositories available.",
   annotations: {
     title: "Add Repository",

--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -408,6 +408,17 @@ describe("the prompt speaks each checkout's own provider", () => {
     expect(openLine(prompt)).not.toContain("pull request");
   });
 
+  test("a Bitbucket run is told there is no CLI, and called a pull request", () => {
+    const prompt = buildClaudeCodeTaskPrompt(task, {
+      ...repo,
+      provider: "bitbucket",
+      url: "https://bitbucket.org/acme/site",
+    });
+    expect(prompt).toContain("hosted on Bitbucket, so `git` is authenticated");
+    expect(prompt).toContain("BITBUCKET_TOKEN");
+    expect(openLine(prompt)).toContain("pull request");
+  });
+
   test("a GitHub run keeps gh and pull-request wording", () => {
     const prompt = buildClaudeCodeTaskPrompt(task, repo);
     expect(prompt).toContain("hosted on GitHub, so `git` and `gh`");

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -24,6 +24,7 @@ import {
   type RepoChoice,
 } from "@/git-providers/repo-choices";
 import {
+  checkoutCommandFor,
   type GitProviderKind,
   providerCli,
 } from "@decocms/shared/git-providers";
@@ -179,9 +180,12 @@ export async function resolveTaskRepoChoice(
 const MIXED_PROVIDER_NOTE =
   "Each checkout is authenticated for ITS OWN host: use `gh` inside a GitHub " +
   "repository and `glab` inside a GitLab one (`glab mr create` is the " +
-  "counterpart of `gh pr create`). A run can hold both at once, so pick the " +
-  "one that matches the repository you are standing in — check its remote " +
-  "with `git remote get-url origin` if you are unsure.";
+  "counterpart of `gh pr create`). Bitbucket has no CLI: inside a Bitbucket " +
+  "repository open pull requests through the Studio tools or the REST API with " +
+  '`curl -H "Authorization: Bearer $BITBUCKET_TOKEN"` against api.bitbucket.org. ' +
+  "A run can hold several at once, so pick the one that matches the repository " +
+  "you are standing in — check its remote with `git remote get-url origin` if " +
+  "you are unsure.";
 
 export function buildClaudeCodeTaskPrompt(
   task: { id: string; title: string; description: string | null },
@@ -223,7 +227,7 @@ export function buildClaudeCodeTaskPrompt(
   lines.push(
     "",
     repo
-      ? `The repository ${repo.owner}/${repo.name} is already cloned at your working directory, on its own branch. It is hosted on ${repo.provider === "gitlab" ? "GitLab" : "GitHub"}, so \`git\` and \`${cli.cli}\` are authenticated there. ${SHALLOW_CHECKOUT_NOTE}`
+      ? `The repository ${repo.owner}/${repo.name} is already cloned at your working directory, on its own branch. It is hosted on ${cli.name}, so ${cli.cli ? `\`git\` and \`${cli.cli}\` are` : "`git` is"} authenticated there${cli.cli ? "" : " (Bitbucket has no CLI; `$BITBUCKET_TOKEN` is the bearer for its REST API)"}. ${SHALLOW_CHECKOUT_NOTE}`
       : [
           "Your working directory is EMPTY: this organization has several repositories, so " +
             "nothing has been cloned yet. FIRST call `mcp__studio__TASK_ADD_REPO` with the " +
@@ -254,7 +258,7 @@ export function buildClaudeCodeTaskPrompt(
   if (opts?.resolveConflict && opts.pr) {
     lines.push(
       `Pull request #${opts.pr.number} (${opts.pr.url}) is approved but has a MERGE CONFLICT with its base branch.`,
-      `Check that branch out (\`${cli.checkoutCommand} ${opts.pr.number}\`), merge or rebase the base branch into it, resolve the conflicts, and push to update the SAME ${cli.changeRequest} — do NOT open a new one. Resolve by preserving BOTH sides' intent; never blindly discard either side, and change only what the conflict requires.`,
+      `Check that branch out (\`${checkoutCommandFor(repo?.provider ?? "github", opts.pr.number)}\`), merge or rebase the base branch into it, resolve the conflicts, and push to update the SAME ${cli.changeRequest} — do NOT open a new one. Resolve by preserving BOTH sides' intent; never blindly discard either side, and change only what the conflict requires.`,
       "",
     );
   } else if (opts?.feedback) {
@@ -268,7 +272,7 @@ export function buildClaudeCodeTaskPrompt(
         : "A reviewer requested changes on your previous work:",
       opts.feedback,
       opts.pr
-        ? `Check that branch out (\`${cli.checkoutCommand} ${opts.pr.number}\`) before editing, address the feedback, then push to update the SAME ${cli.changeRequest} — do NOT open a new one.`
+        ? `Check that branch out (\`${checkoutCommandFor(repo?.provider ?? "github", opts.pr.number)}\`) before editing, address the feedback, then push to update the SAME ${cli.changeRequest} — do NOT open a new one.`
         : "Address this feedback.",
       "",
     );

--- a/apps/api/src/tools/task-board/create.ts
+++ b/apps/api/src/tools/task-board/create.ts
@@ -73,8 +73,9 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
     if (input.prUrl && !pr) {
       throw new Error(
         `Not a change request URL: ${input.prUrl} (expected ` +
-          "https://github.com/<owner>/<repo>/pull/<number> or " +
-          "https://gitlab.com/<namespace>/<project>/-/merge_requests/<iid>)",
+          "https://github.com/<owner>/<repo>/pull/<number>, " +
+          "https://gitlab.com/<namespace>/<project>/-/merge_requests/<iid> or " +
+          "https://bitbucket.org/<workspace>/<repo>/pull-requests/<id>)",
       );
     }
 

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -779,7 +779,7 @@ async function enqueueReviewerForTask(
     "How to work:",
     `- Call \`${prsGetTool}\` with the task id below to find the pull request under review.`,
     repo
-      ? `- The repository ${repo.owner}/${repo.name} is already cloned at your working directory and \`git\` and its CLI (\`gh\` for GitHub, \`glab\` for GitLab) are authenticated — check the PR's branch out there to inspect / exercise the change. ${SHALLOW_CHECKOUT_NOTE}`
+      ? `- The repository ${repo.owner}/${repo.name} is already cloned at your working directory and \`git\` and its CLI (\`gh\` for GitHub, \`glab\` for GitLab; Bitbucket has no CLI — use the REST API with \`curl\` and \`$BITBUCKET_TOKEN\`) are authenticated — check the PR's branch out there to inspect / exercise the change. ${SHALLOW_CHECKOUT_NOTE}`
       : sandboxed
         ? `- Your working directory is EMPTY. Call \`mcp__studio__TASK_ADD_REPO\` ${
             pinnedRepo

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -775,7 +775,7 @@ export async function refreshItemPrCards(
 export const TASK_BOARD_ITEM_PRS_GET = defineTool({
   name: "TASK_BOARD_ITEM_PRS_GET",
   description:
-    "Get the change requests (GitHub pull requests, GitLab merge requests) " +
+    "Get the change requests (GitHub and Bitbucket pull requests, GitLab merge requests) " +
     "linked to a task board item, each enriched with live state (title, " +
     "open/closed, draft, merged) fetched from its provider.",
   annotations: {

--- a/apps/api/src/tools/task-board/run-reactions.test.ts
+++ b/apps/api/src/tools/task-board/run-reactions.test.ts
@@ -226,6 +226,17 @@ describe("isPrCreateBashCommand", () => {
         "curl -X POST https://gitlab.com/api/v4/projects/group%2Fstore/merge_requests -d '{}'",
       ),
     ).toBe(true);
+    // Bitbucket has no CLI, so the REST POST is the only bash shape there.
+    expect(
+      isPrCreateBashCommand(
+        "curl -X POST -H \"Authorization: Bearer $BITBUCKET_TOKEN\" https://api.bitbucket.org/2.0/repositories/acme/site/pullrequests -d '{}'",
+      ),
+    ).toBe(true);
+    expect(
+      isPrCreateBashCommand(
+        "curl https://api.bitbucket.org/2.0/repositories/acme/site/pullrequests",
+      ),
+    ).toBe(false);
   });
 
   it("does not match unrelated gh / git / curl commands", () => {

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -732,11 +732,12 @@ export function isPrCreateMcpTool(toolName: string): boolean {
  * aliases and script wrappers. The reliable path is the tool above.
  *
  * Both CLIs are in the sandbox image and the checkout's own credential decides
- * which one is authenticated, so a run can genuinely use either.
+ * which one is authenticated, so a run can genuinely use either. Bitbucket has
+ * no CLI, so there the REST POST is the only bash shape.
  */
 const CLI_CREATE = /\b(?:gh\s+pr|glab\s+mr)\s+create\b/;
 const REST_CHANGE_REQUESTS =
-  /\/(?:repos\/[^\s"']+\/pulls|projects\/[^\s"']+\/merge_requests)\b/;
+  /\/(?:repos\/[^\s"']+\/pulls|projects\/[^\s"']+\/merge_requests|repositories\/[^\s"']+\/pullrequests)\b/;
 const HTTP_POST = /(?:-X|--request)\s+POST/;
 
 /** True when a bash command opens a change request (either CLI, or a REST POST). */

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -261,8 +261,9 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     if (input.prUrl && !pr) {
       throw new Error(
         `Not a change request URL: ${input.prUrl} (expected ` +
-          "https://github.com/<owner>/<repo>/pull/<number> or " +
-          "https://gitlab.com/<namespace>/<project>/-/merge_requests/<iid>)",
+          "https://github.com/<owner>/<repo>/pull/<number>, " +
+          "https://gitlab.com/<namespace>/<project>/-/merge_requests/<iid> or " +
+          "https://bitbucket.org/<workspace>/<repo>/pull-requests/<id>)",
       );
     }
 

--- a/apps/web/src/components/git-account-connect.tsx
+++ b/apps/web/src/components/git-account-connect.tsx
@@ -19,14 +19,53 @@ import {
 import { Input } from "@decocms/ui/components/input.tsx";
 import { Label } from "@decocms/ui/components/label.tsx";
 import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
-import { GitHubIcon } from "@/components/icons/github-icon";
-import { GitLabIcon } from "@/components/icons/gitlab-icon";
+import { DEFAULT_HOSTS } from "@decocms/shared/git-providers";
+import { GitProviderIcon } from "@/components/icons/git-provider-icon";
 import {
   useGitProviderCapabilities,
   useConnectGitAccountToken,
 } from "@/hooks/use-git-providers";
 import { useProjectContext } from "@/sdk";
 import { useT } from "@/i18n/use-t.ts";
+
+/** The providers that accept a pasted access token (GitHub connects through its App). */
+type TokenProvider = "gitlab" | "bitbucket";
+
+type Key = Parameters<ReturnType<typeof useT>>[0];
+
+/**
+ * Per-provider copy for the token dialog. GitLab has self-managed hosts, so
+ * its dialog asks for one; Bitbucket is Cloud only, so the host is fixed.
+ */
+const TOKEN_COPY: Record<
+  TokenProvider,
+  {
+    action: Key;
+    hint: Key;
+    title: Key;
+    description: Key;
+    placeholder: Key;
+    askHost: boolean;
+  }
+> = {
+  gitlab: {
+    action: "settings.repositories.connectGitlabToken",
+    hint: "settings.repositories.gitlabTokenHint",
+    title: "settings.repositories.tokenDialogTitle",
+    description: "settings.repositories.tokenDialogDescription",
+    placeholder: "settings.repositories.tokenPlaceholder",
+    askHost: true,
+  },
+  bitbucket: {
+    action: "settings.repositories.connectBitbucketToken",
+    hint: "settings.repositories.bitbucketTokenHint",
+    title: "settings.repositories.tokenDialogTitleBitbucket",
+    description: "settings.repositories.tokenDialogDescriptionBitbucket",
+    placeholder: "settings.repositories.tokenPlaceholderBitbucket",
+    askHost: false,
+  },
+};
+
 function errorMessage(error: unknown, fallback: string) {
   return error instanceof Error ? error.message : fallback;
 }
@@ -37,34 +76,44 @@ export function GitAccountConnect({
   layout?: "buttons" | "picker";
   disabled?: boolean;
 }) {
-  const [open, setOpen] = useState(false);
+  const [tokenProvider, setTokenProvider] = useState<TokenProvider | null>(
+    null,
+  );
   return (
     <>
       <ConnectActions
         layout={layout}
         disabled={disabled}
-        onTokenDialog={() => setOpen(true)}
+        onTokenDialog={setTokenProvider}
       />
-      {open && <TokenConnectDialog open onOpenChange={setOpen} />}
+      {tokenProvider && (
+        <TokenConnectDialog
+          provider={tokenProvider}
+          onOpenChange={(open) => {
+            if (!open) setTokenProvider(null);
+          }}
+        />
+      )}
     </>
   );
 }
 function TokenConnectDialog({
-  open,
+  provider,
   onOpenChange,
 }: {
-  open: boolean;
+  provider: TokenProvider;
   onOpenChange: (open: boolean) => void;
 }) {
   const t = useT();
+  const copy = TOKEN_COPY[provider];
   const connect = useConnectGitAccountToken();
-  const [host, setHost] = useState("gitlab.com");
+  const [host, setHost] = useState(DEFAULT_HOSTS[provider]);
   const [token, setToken] = useState("");
 
   function handleConnect() {
     if (!host.trim() || !token.trim()) return;
     connect.mutate(
-      { type: "gitlab", host: host.trim(), token: token.trim() },
+      { type: provider, host: host.trim(), token: token.trim() },
       {
         onSuccess: (account) => {
           toast.success(
@@ -80,38 +129,36 @@ function TokenConnectDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>
-            {t("settings.repositories.tokenDialogTitle")}
-          </DialogTitle>
-          <DialogDescription>
-            {t("settings.repositories.tokenDialogDescription")}
-          </DialogDescription>
+          <DialogTitle>{t(copy.title)}</DialogTitle>
+          <DialogDescription>{t(copy.description)}</DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-3">
+          {copy.askHost && (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor={`${provider}-host`}>
+                {t("settings.repositories.tokenHostLabel")}
+              </Label>
+              <Input
+                id={`${provider}-host`}
+                value={host}
+                onChange={(e) => setHost(e.target.value)}
+                placeholder={t("settings.repositories.tokenHostPlaceholder")}
+              />
+            </div>
+          )}
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="gitlab-host">
-              {t("settings.repositories.tokenHostLabel")}
-            </Label>
-            <Input
-              id="gitlab-host"
-              value={host}
-              onChange={(e) => setHost(e.target.value)}
-              placeholder={t("settings.repositories.tokenHostPlaceholder")}
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="gitlab-token">
+            <Label htmlFor={`${provider}-token`}>
               {t("settings.repositories.tokenLabel")}
             </Label>
             <Input
-              id="gitlab-token"
+              id={`${provider}-token`}
               type="password"
               value={token}
               onChange={(e) => setToken(e.target.value)}
-              placeholder={t("settings.repositories.tokenPlaceholder")}
+              placeholder={t(copy.placeholder)}
               autoComplete="off"
             />
           </div>
@@ -214,7 +261,7 @@ function ConnectActions({
 }: {
   layout: "buttons" | "picker";
   disabled: boolean;
-  onTokenDialog: () => void;
+  onTokenDialog: (provider: TokenProvider) => void;
 }) {
   const t = useT();
   const capabilities = useGitProviderCapabilities();
@@ -230,9 +277,11 @@ function ConnectActions({
     );
   const github = capabilities.data?.github;
   const gitlab = capabilities.data?.gitlab;
+  const bitbucket = capabilities.data?.bitbucket;
 
   const githubConfigured = github?.configured === true;
   const gitlabConfigured = (gitlab?.oauthHosts.length ?? 0) > 0;
+  const bitbucketConfigured = (bitbucket?.oauthHosts.length ?? 0) > 0;
 
   if (capabilities.isPending) {
     return <Skeleton className="h-9 w-40" />;
@@ -253,7 +302,7 @@ function ConnectActions({
             ? "settings.repositories.browseAccount"
             : "settings.repositories.githubUnavailable",
         )}
-        icon={<GitHubIcon size={16} />}
+        icon={<GitProviderIcon provider="github" size={16} />}
         href={github?.connectPath ? connectUrl(github.connectPath) : undefined}
         disabled={disabled || !githubConfigured || !github?.connectPath}
       />
@@ -262,19 +311,32 @@ function ConnectActions({
           layout={layout}
           label={t("settings.repositories.connectGitlab")}
           description={t("settings.repositories.browseAccount")}
-          icon={<GitLabIcon size={16} />}
+          icon={<GitProviderIcon provider="gitlab" size={16} />}
           href={connectUrl(gitlab.connectPath)}
           disabled={disabled}
         />
       )}
-      <ConnectAction
-        layout={layout}
-        label={t("settings.repositories.connectGitlabToken")}
-        description={t("settings.repositories.gitlabTokenHint")}
-        icon={<GitLabIcon size={16} />}
-        onClick={onTokenDialog}
-        disabled={disabled}
-      />
+      {bitbucketConfigured && bitbucket?.connectPath && (
+        <ConnectAction
+          layout={layout}
+          label={t("settings.repositories.connectBitbucket")}
+          description={t("settings.repositories.browseAccount")}
+          icon={<GitProviderIcon provider="bitbucket" size={16} />}
+          href={connectUrl(bitbucket.connectPath)}
+          disabled={disabled}
+        />
+      )}
+      {(["gitlab", "bitbucket"] as const).map((provider) => (
+        <ConnectAction
+          key={provider}
+          layout={layout}
+          label={t(TOKEN_COPY[provider].action)}
+          description={t(TOKEN_COPY[provider].hint)}
+          icon={<GitProviderIcon provider={provider} size={16} />}
+          onClick={() => onTokenDialog(provider)}
+          disabled={disabled}
+        />
+      ))}
     </div>
   );
 }

--- a/apps/web/src/components/icons/bitbucket-icon.tsx
+++ b/apps/web/src/components/icons/bitbucket-icon.tsx
@@ -1,0 +1,20 @@
+export function BitbucketIcon({
+  size,
+  className,
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className={className}
+    >
+      <path d="M.778 1.213a.768.768 0 00-.768.892l3.263 19.81c.084.5.515.868 1.022.873H19.95a.772.772 0 00.77-.646l3.27-20.03a.768.768 0 00-.768-.891zM14.52 15.53H9.522L8.17 8.466h7.561z" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/icons/git-provider-icon.tsx
+++ b/apps/web/src/components/icons/git-provider-icon.tsx
@@ -1,0 +1,27 @@
+import type { GitProviderKind } from "@decocms/shared/git-providers";
+import { BitbucketIcon } from "./bitbucket-icon";
+import { GitHubIcon } from "./github-icon";
+import { GitLabIcon } from "./gitlab-icon";
+
+const ICONS: Record<
+  GitProviderKind,
+  (props: { size?: number; className?: string }) => React.ReactNode
+> = {
+  github: GitHubIcon,
+  gitlab: GitLabIcon,
+  bitbucket: BitbucketIcon,
+};
+
+/** The one place a provider kind becomes a logo, so no surface can fall back to the wrong one. */
+export function GitProviderIcon({
+  provider,
+  size = 16,
+  className,
+}: {
+  provider: GitProviderKind;
+  size?: number;
+  className?: string;
+}) {
+  const Icon = ICONS[provider];
+  return <Icon size={size} className={className} />;
+}

--- a/apps/web/src/components/repository-picker.tsx
+++ b/apps/web/src/components/repository-picker.tsx
@@ -1,3 +1,4 @@
+import type { GitProviderKind } from "@decocms/shared/git-providers";
 import { GitAccountConnect } from "@/components/git-account-connect";
 import { useDeferredValue, useState } from "react";
 import { ArrowLeft, ChevronRight, GitBranch01 } from "@untitledui/icons";
@@ -14,8 +15,7 @@ import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
 import { Spinner } from "@decocms/ui/components/spinner.tsx";
 import { cn } from "@decocms/ui/lib/utils.ts";
 import { CollectionSearch } from "@/components/collections/collection-search";
-import { GitHubIcon } from "@/components/icons/github-icon";
-import { GitLabIcon } from "@/components/icons/gitlab-icon";
+import { GitProviderIcon } from "@/components/icons/git-provider-icon";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import {
   type GitAccount,
@@ -36,13 +36,11 @@ function ProviderIcon({
   provider,
   className,
 }: {
-  provider: "github" | "gitlab";
+  provider: GitProviderKind;
   className?: string;
 }) {
-  return provider === "gitlab" ? (
-    <GitLabIcon size={16} className={className} />
-  ) : (
-    <GitHubIcon size={16} className={className} />
+  return (
+    <GitProviderIcon provider={provider} size={16} className={className} />
   );
 }
 
@@ -60,7 +58,7 @@ function RepoRow({
   busy,
   onSelect,
 }: {
-  provider: "github" | "gitlab";
+  provider: GitProviderKind;
   path: string;
   host: string;
   hint?: string | null;

--- a/apps/web/src/hooks/use-git-providers.ts
+++ b/apps/web/src/hooks/use-git-providers.ts
@@ -7,6 +7,7 @@
  * is also what a repository falls back to when its account is deleted.
  */
 
+import type { GitProviderKind } from "@decocms/shared/git-providers";
 import {
   useInfiniteQuery,
   type InfiniteData,
@@ -108,7 +109,7 @@ export function useConnectGitAccountToken() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (input: {
-      type: "github" | "gitlab";
+      type: GitProviderKind;
       host: string;
       token: string;
     }) => (await studio.call("GIT_ACCOUNT_CONNECT_TOKEN", input)).account,

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -121,15 +121,17 @@ export const settings = {
     "Accounts Studio uses to read your repositories and push changes on your behalf.",
   "settings.repositories.accountsEmptyTitle": "No accounts connected",
   "settings.repositories.accountsEmptyDescription":
-    "Connect a GitHub or GitLab account to browse your repositories and link private ones.",
+    "Connect a GitHub, GitLab or Bitbucket account to browse your repositories and link private ones.",
   "settings.repositories.noProvidersTitle": "No git provider configured",
   "settings.repositories.noProvidersDescription":
-    "Signing in with GitHub or GitLab needs provider credentials an administrator configures for this deployment. You can still connect a GitLab account with an access token.",
+    "Signing in with GitHub, GitLab or Bitbucket needs provider credentials an administrator configures for this deployment. You can still connect a GitLab or Bitbucket account with an access token.",
   "settings.repositories.githubUnavailable":
     "Ask an administrator to enable GitHub.",
   "settings.repositories.browseAccount": "Browse repositories in your account.",
   "settings.repositories.gitlabTokenHint":
     "Use a personal, project or group access token.",
+  "settings.repositories.bitbucketTokenHint":
+    "Use a workspace, project or repository access token.",
   "settings.repositories.addGithubAccount":
     "Add GitHub account or organization",
   "settings.repositories.githubSelectTitle": "Select repositories",
@@ -186,6 +188,9 @@ export const settings = {
     "Could not connect your git account. Try again. If it keeps failing, contact an administrator.",
   "settings.repositories.connectGitlab": "Connect GitLab",
   "settings.repositories.connectGitlabToken": "Connect GitLab with a token",
+  "settings.repositories.connectBitbucket": "Connect Bitbucket",
+  "settings.repositories.connectBitbucketToken":
+    "Connect Bitbucket with a token",
   "settings.repositories.authKindGithubApp": "GitHub App",
   "settings.repositories.authKindOauth": "OAuth",
   "settings.repositories.authKindToken": "Personal token",
@@ -200,10 +205,15 @@ export const settings = {
   "settings.repositories.tokenDialogTitle": "Connect GitLab with a token",
   "settings.repositories.tokenDialogDescription":
     "Use a personal, project or group access token with the api scope — agents push branches and open merge requests with it. Stored encrypted and never shown again.",
+  "settings.repositories.tokenDialogTitleBitbucket":
+    "Connect Bitbucket with a token",
+  "settings.repositories.tokenDialogDescriptionBitbucket":
+    "Use a workspace, project or repository access token that can write repositories and pull requests — agents push branches and open pull requests with it. Bitbucket Cloud only. Stored encrypted and never shown again.",
   "settings.repositories.tokenHostLabel": "Host",
   "settings.repositories.tokenHostPlaceholder": "gitlab.com",
   "settings.repositories.tokenLabel": "Access token",
   "settings.repositories.tokenPlaceholder": "glpat-…",
+  "settings.repositories.tokenPlaceholderBitbucket": "ATCTT…",
   "settings.repositories.connect": "Connect",
   "settings.repositories.connecting": "Connecting…",
   "settings.repositories.connected": 'Connected as "{login}"',
@@ -212,7 +222,7 @@ export const settings = {
     "Repositories available to this organization's agents and workflows.",
   "settings.repositories.reposEmptyTitle": "No repositories yet",
   "settings.repositories.reposEmptyDescription":
-    "Choose a repository from a connected GitHub or GitLab account.",
+    "Choose a repository from a connected GitHub, GitLab or Bitbucket account.",
   "settings.repositories.addRepository": "Add repository",
   "settings.repositories.unlink": "Unlink",
   "settings.repositories.unlinkTitle": 'Unlink "{path}"?',

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -126,15 +126,17 @@ export const settings = {
     "Contas que o Studio usa para ler seus repositórios e enviar alterações em seu nome.",
   "settings.repositories.accountsEmptyTitle": "Nenhuma conta conectada",
   "settings.repositories.accountsEmptyDescription":
-    "Conecte uma conta do GitHub ou GitLab para navegar pelos seus repositórios e vincular os privados.",
+    "Conecte uma conta do GitHub, GitLab ou Bitbucket para navegar pelos seus repositórios e vincular os privados.",
   "settings.repositories.noProvidersTitle": "Nenhum provedor git configurado",
   "settings.repositories.noProvidersDescription":
-    "Entrar com GitHub ou GitLab depende de credenciais do provedor que um administrador configura nesta instalação. Você ainda pode conectar uma conta do GitLab com um token de acesso.",
+    "Entrar com GitHub, GitLab ou Bitbucket depende de credenciais do provedor que um administrador configura nesta instalação. Você ainda pode conectar uma conta do GitLab ou do Bitbucket com um token de acesso.",
   "settings.repositories.githubUnavailable":
     "Peça a um administrador para habilitar o GitHub.",
   "settings.repositories.browseAccount": "Busque repositórios da sua conta.",
   "settings.repositories.gitlabTokenHint":
     "Use um token de acesso pessoal, de projeto ou de grupo.",
+  "settings.repositories.bitbucketTokenHint":
+    "Use um token de acesso de workspace, de projeto ou de repositório.",
   "settings.repositories.addGithubAccount":
     "Adicionar conta ou organização do GitHub",
   "settings.repositories.githubSelectTitle": "Selecionar repositórios",
@@ -194,6 +196,9 @@ export const settings = {
     "Não foi possível conectar sua conta git. Tente novamente. Se o erro persistir, entre em contato com um administrador.",
   "settings.repositories.connectGitlab": "Conectar GitLab",
   "settings.repositories.connectGitlabToken": "Conectar GitLab com um token",
+  "settings.repositories.connectBitbucket": "Conectar Bitbucket",
+  "settings.repositories.connectBitbucketToken":
+    "Conectar Bitbucket com um token",
   "settings.repositories.authKindGithubApp": "GitHub App",
   "settings.repositories.authKindOauth": "OAuth",
   "settings.repositories.authKindToken": "Token pessoal",
@@ -208,10 +213,15 @@ export const settings = {
   "settings.repositories.tokenDialogTitle": "Conectar o GitLab com um token",
   "settings.repositories.tokenDialogDescription":
     "Use um token de acesso pessoal, de projeto ou de grupo com o escopo api — os agentes usam ele para dar push e abrir merge requests. É guardado criptografado e não é exibido novamente.",
+  "settings.repositories.tokenDialogTitleBitbucket":
+    "Conectar o Bitbucket com um token",
+  "settings.repositories.tokenDialogDescriptionBitbucket":
+    "Use um token de acesso de workspace, de projeto ou de repositório com permissão de escrita em repositórios e pull requests — os agentes usam ele para dar push e abrir pull requests. Somente Bitbucket Cloud. É guardado criptografado e não é exibido novamente.",
   "settings.repositories.tokenHostLabel": "Host",
   "settings.repositories.tokenHostPlaceholder": "gitlab.com",
   "settings.repositories.tokenLabel": "Token de acesso",
   "settings.repositories.tokenPlaceholder": "glpat-…",
+  "settings.repositories.tokenPlaceholderBitbucket": "ATCTT…",
   "settings.repositories.connect": "Conectar",
   "settings.repositories.connecting": "Conectando…",
   "settings.repositories.connected": 'Conectado como "{login}"',
@@ -220,7 +230,7 @@ export const settings = {
     "Repositórios disponíveis para os agentes e automações desta organização.",
   "settings.repositories.reposEmptyTitle": "Nenhum repositório ainda",
   "settings.repositories.reposEmptyDescription":
-    "Escolha um repositório de uma conta conectada do GitHub ou GitLab.",
+    "Escolha um repositório de uma conta conectada do GitHub, GitLab ou Bitbucket.",
   "settings.repositories.addRepository": "Adicionar repositório",
   "settings.repositories.unlink": "Desvincular",
   "settings.repositories.unlinkTitle": 'Desvincular "{path}"?',

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -130,8 +130,7 @@ import {
   reviewsSatisfiedForPromotion,
 } from "./review-status";
 import { formatTimeAgo } from "@/lib/format-time";
-import { GitHubIcon } from "@/components/icons/github-icon";
-import { GitLabIcon } from "@/components/icons/gitlab-icon";
+import { GitProviderIcon } from "@/components/icons/git-provider-icon";
 import { parseChangeRequestUrl } from "@decocms/shared/git-providers";
 import { useConnections, useProjectContext } from "@/sdk";
 import { NO_TASKS, useProjectIndex } from "@/hooks/use-project-index";
@@ -1909,11 +1908,10 @@ function PrCard({
       )}
     >
       <div className="flex items-center gap-3">
-        {parseChangeRequestUrl(pr.url)?.repo.provider === "gitlab" ? (
-          <GitLabIcon className="size-4 shrink-0 text-foreground" />
-        ) : (
-          <GitHubIcon className="size-4 shrink-0 text-foreground" />
-        )}
+        <GitProviderIcon
+          provider={parseChangeRequestUrl(pr.url)?.repo.provider ?? "github"}
+          className="size-4 shrink-0 text-foreground"
+        />
         <span className="min-w-0 flex-1 truncate text-sm text-foreground">
           {pr.title ?? `${pr.repoOwner}/${pr.repoName}`}
         </span>

--- a/apps/web/src/views/settings/repositories.tsx
+++ b/apps/web/src/views/settings/repositories.tsx
@@ -8,6 +8,7 @@
  * disconnected.
  */
 
+import type { GitProviderKind } from "@decocms/shared/git-providers";
 import { GitAccountConnect } from "@/components/git-account-connect";
 import { GithubConnectDialog } from "@/components/github-connect-dialog";
 import { useProjectContext } from "@/sdk";
@@ -36,8 +37,7 @@ import { Alert, AlertDescription } from "@decocms/ui/components/alert.tsx";
 
 import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
 
-import { GitHubIcon } from "@/components/icons/github-icon";
-import { GitLabIcon } from "@/components/icons/gitlab-icon";
+import { GitProviderIcon } from "@/components/icons/git-provider-icon";
 import { SettingsGroupPage } from "@/components/settings/settings-group-page";
 import { SettingsSection } from "@/components/settings/settings-section";
 import {
@@ -55,13 +55,15 @@ function ProviderIcon({
   provider,
   size = 16,
 }: {
-  provider: "github" | "gitlab";
+  provider: GitProviderKind;
   size?: number;
 }) {
-  return provider === "gitlab" ? (
-    <GitLabIcon size={size} className="text-muted-foreground" />
-  ) : (
-    <GitHubIcon size={size} className="text-muted-foreground" />
+  return (
+    <GitProviderIcon
+      provider={provider}
+      size={size}
+      className="text-muted-foreground"
+    />
   );
 }
 
@@ -265,7 +267,10 @@ function AccountsSection({
   const githubConfigured = capabilities.data?.github.configured === true;
   const gitlabConfigured =
     (capabilities.data?.gitlab.oauthHosts.length ?? 0) > 0;
-  const anyProviderConfigured = githubConfigured || gitlabConfigured;
+  const bitbucketConfigured =
+    (capabilities.data?.bitbucket.oauthHosts.length ?? 0) > 0;
+  const anyProviderConfigured =
+    githubConfigured || gitlabConfigured || bitbucketConfigured;
   if (accounts.isError) throw accounts.error;
   const rows = accounts.data ?? [];
 

--- a/apps/web/src/views/settings/synced-repos.tsx
+++ b/apps/web/src/views/settings/synced-repos.tsx
@@ -26,7 +26,7 @@ import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
 import { GitBranch01 } from "@untitledui/icons";
 import { RepositoryPicker } from "@/components/repository-picker";
 import { useRepositories, type Repository } from "@/hooks/use-git-providers";
-import { GitLabIcon } from "@/components/icons/gitlab-icon";
+import { GitProviderIcon } from "@/components/icons/git-provider-icon";
 
 import { useT } from "@/i18n/use-t.ts";
 import {
@@ -82,8 +82,12 @@ function SyncRow({
     <div className="flex items-center justify-between gap-4 py-3 border-b border-border/60 last:border-b-0">
       <div className="flex items-start gap-3 min-w-0">
         <div className="size-9 rounded-md bg-muted flex items-center justify-center shrink-0">
-          {repository?.provider === "gitlab" ? (
-            <GitLabIcon size={16} className="text-muted-foreground" />
+          {repository ? (
+            <GitProviderIcon
+              provider={repository.provider}
+              size={16}
+              className="text-muted-foreground"
+            />
           ) : (
             <GitBranch01 size={16} className="text-muted-foreground" />
           )}

--- a/deploy/helm/studio/templates/secret.yaml
+++ b/deploy/helm/studio/templates/secret.yaml
@@ -61,6 +61,12 @@ stringData:
   {{- with .Values.secret.GITLAB_OAUTH_CLIENT_SECRET }}
   GITLAB_OAUTH_CLIENT_SECRET: {{ . | quote }}
   {{- end }}
+  {{- with .Values.secret.BITBUCKET_OAUTH_CLIENT_ID }}
+  BITBUCKET_OAUTH_CLIENT_ID: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secret.BITBUCKET_OAUTH_CLIENT_SECRET }}
+  BITBUCKET_OAUTH_CLIENT_SECRET: {{ . | quote }}
+  {{- end }}
   {{- with .Values.secret.AUTH_RESEND_API_KEY }}
   AUTH_RESEND_API_KEY: {{ . | quote }}
   {{- end }}

--- a/packages/e2e/tests/git-providers.spec.ts
+++ b/packages/e2e/tests/git-providers.spec.ts
@@ -28,7 +28,7 @@ interface Repository {
   id: string;
   organizationId: string;
   accountId: string | null;
-  provider: "github" | "gitlab";
+  provider: "github" | "gitlab" | "bitbucket";
   host: string;
   path: string;
   externalId: string | null;
@@ -247,6 +247,7 @@ test.describe("Git providers: repositories as an org entity", () => {
         installPath: string | null;
       };
       gitlab: { oauthHosts: string[]; connectPath: string | null };
+      bitbucket: { oauthHosts: string[]; connectPath: string | null };
     }>(ctx, orgSlug, "GIT_PROVIDER_CAPABILITIES", {});
 
     if (caps.github.configured) {
@@ -265,6 +266,14 @@ test.describe("Git providers: repositories as an org entity", () => {
     } else {
       expect(caps.gitlab.connectPath).toBe(
         `/api/${orgSlug}/git-providers/gitlab/connect`,
+      );
+    }
+    if (caps.bitbucket.oauthHosts.length === 0) {
+      expect(caps.bitbucket.connectPath).toBeNull();
+    } else {
+      expect(caps.bitbucket.oauthHosts).toEqual(["bitbucket.org"]);
+      expect(caps.bitbucket.connectPath).toBe(
+        `/api/${orgSlug}/git-providers/bitbucket/connect`,
       );
     }
   });

--- a/packages/sandbox/daemon-go/internal/config/classify.go
+++ b/packages/sandbox/daemon-go/internal/config/classify.go
@@ -221,7 +221,9 @@ func TokenFromCloneUrl(rawUrl string) string {
 // the credential baked into a clone URL, keyed off the userinfo username Studio
 // chose for the provider: `x-access-token` is GitHub (`gh` reads GH_TOKEN, plus
 // GH_HOST off github.com), `oauth2` is GitLab (`glab` reads GITLAB_TOKEN and
-// GITLAB_HOST). Empty for an SSH, anonymous or unrecognised URL.
+// GITLAB_HOST), `x-token-auth` is Bitbucket, which has no CLI — BITBUCKET_TOKEN
+// is what an agent's `curl` against api.bitbucket.org sends as its bearer.
+// Empty for an SSH, anonymous or unrecognised URL.
 //
 // The GitLab entries are NOT sufficient on their own: glab sends an env token
 // as `PRIVATE-TOKEN`, which GitLab rejects for an OAuth access token (verified
@@ -254,6 +256,8 @@ func CliEnvFromCloneUrl(rawUrl string) map[string]string {
 			env["GITLAB_HOST"] = "https://" + host
 		}
 		return env
+	case "x-token-auth":
+		return map[string]string{"BITBUCKET_TOKEN": token}
 	}
 	return nil
 }

--- a/packages/sandbox/daemon-go/internal/config/classify_test.go
+++ b/packages/sandbox/daemon-go/internal/config/classify_test.go
@@ -328,6 +328,7 @@ func TestCliEnvFromCloneUrl(t *testing.T) {
 		{"github enterprise", "https://x-access-token:tok@ghe.acme.com/acme/site.git", map[string]string{"GH_TOKEN": "tok", "GH_HOST": "ghe.acme.com"}},
 		{"gitlab", "https://oauth2:tok-gl@gitlab.com/group/sub/project.git", map[string]string{"GITLAB_TOKEN": "tok-gl", "GITLAB_HOST": "https://gitlab.com"}},
 		{"self-hosted gitlab with port", "https://oauth2:t@gitlab.acme.com:8443/g/p.git", map[string]string{"GITLAB_TOKEN": "t", "GITLAB_HOST": "https://gitlab.acme.com:8443"}},
+		{"bitbucket", "https://x-token-auth:tok-bb@bitbucket.org/acme/site.git", map[string]string{"BITBUCKET_TOKEN": "tok-bb"}},
 		{"anonymous", "https://github.com/acme/site.git", nil},
 		{"ssh", "git@github.com:acme/site.git", nil},
 		{"unknown username", "https://user:pw@example.com/a/b.git", nil},

--- a/packages/shared/src/git-providers/change-request-ref.test.ts
+++ b/packages/shared/src/git-providers/change-request-ref.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { RepoRef } from "./types";
 import {
   changeRequestUrl,
   findChangeRequestUrl,
@@ -19,6 +20,12 @@ describe("changeRequestUrl", () => {
         7,
       ),
     ).toBe("https://gitlab.com/group/sub/site/-/merge_requests/7");
+    expect(
+      changeRequestUrl(
+        { provider: "bitbucket", host: "bitbucket.org", path: "acme/site" },
+        7,
+      ),
+    ).toBe("https://bitbucket.org/acme/site/pull-requests/7");
   });
 });
 
@@ -195,5 +202,42 @@ describe("findChangeRequestUrl", () => {
   test("nothing to find", () => {
     expect(findChangeRequestUrl("nothing here")).toBeNull();
     expect(findChangeRequestUrl("https://github.com/acme/site")).toBeNull();
+  });
+});
+
+describe("bitbucket pull requests", () => {
+  const repo: RepoRef = {
+    provider: "bitbucket",
+    host: "bitbucket.org",
+    path: "acme/site",
+  };
+  test("a browser url, with or without a trailing tab", () => {
+    expect(
+      parseChangeRequestUrl("https://bitbucket.org/acme/site/pull-requests/12"),
+    ).toEqual({
+      repo,
+      number: 12,
+      url: "https://bitbucket.org/acme/site/pull-requests/12",
+    });
+    expect(
+      parseChangeRequestUrl(
+        "https://bitbucket.org/acme/site/pull-requests/12/overview",
+      )?.number,
+    ).toBe(12);
+  });
+  test("the API url maps back to the browser host", () => {
+    expect(
+      parseChangeRequestUrl(
+        "https://api.bitbucket.org/2.0/repositories/acme/site/pullrequests/12",
+      ),
+    ).toEqual({
+      repo,
+      number: 12,
+      url: "https://bitbucket.org/acme/site/pull-requests/12",
+    });
+  });
+  test("found inside a curl response body", () => {
+    const body = `{"id": 12, "links": {"html": {"href": "https://bitbucket.org/acme/site/pull-requests/12"}}}`;
+    expect(findChangeRequestUrl(body)?.number).toBe(12);
   });
 });

--- a/packages/shared/src/git-providers/change-request-ref.ts
+++ b/packages/shared/src/git-providers/change-request-ref.ts
@@ -1,10 +1,10 @@
 /**
  * Pure helpers over a change request's identity — the provider-neutral name for
- * what GitHub calls a pull request and GitLab a merge request.
+ * what GitHub and Bitbucket call a pull request and GitLab a merge request.
  *
  * A change request is addressed by its repository plus a per-repository number
- * (GitHub's `number`, GitLab's `iid` — both 1-based and both scoped to the
- * project, which is why one field carries them). Every URL convention lives
+ * (GitHub's `number`, GitLab's `iid`, Bitbucket's `id` — all 1-based and all scoped to
+ * the repository, which is why one field carries them). Every URL convention lives
  * here so nothing outside this module hand-builds `github.com/.../pull/1`.
  */
 
@@ -13,7 +13,7 @@ import type { GitProviderKind, RepoRef } from "./types";
 
 export interface ChangeRequestRef {
   repo: RepoRef;
-  /** Per-repository number: GitHub's `number`, GitLab's `iid`. */
+  /** Per-repository number: GitHub's `number`, GitLab's `iid`, Bitbucket's `id`. */
   number: number;
   /** Canonical browser URL — the display and dedup key. */
   url: string;
@@ -23,6 +23,7 @@ export interface ChangeRequestRef {
 const WEB_SUFFIX: Record<GitProviderKind, string> = {
   github: "pull",
   gitlab: "-/merge_requests",
+  bitbucket: "pull-requests",
 };
 
 /** Canonical browser URL for a change request. */
@@ -46,6 +47,10 @@ const URL_PATTERNS: { re: RegExp; api?: boolean }[] = [
   { re: /https?:\/\/([^/\s"']+)\/([^\s"']+?)\/-\/merge_requests\/(\d+)/ },
   // https://<host>/<owner>/<repo>/pull/<number>
   { re: /https?:\/\/([^/\s"']+)\/([^/\s"']+\/[^/\s"']+)\/pull\/(\d+)/ },
+  // https://bitbucket.org/<workspace>/<repo>/pull-requests/<id>
+  {
+    re: /https?:\/\/([^/\s"']+)\/([^/\s"']+\/[^/\s"']+)\/pull-requests\/(\d+)/,
+  },
   // https://api.github.com/repos/<owner>/<repo>/pulls/<number>
   {
     re: /https?:\/\/([^/\s"']+)\/repos\/([^/\s"']+\/[^/\s"']+)\/pulls\/(\d+)/,
@@ -56,16 +61,27 @@ const URL_PATTERNS: { re: RegExp; api?: boolean }[] = [
     re: /https?:\/\/([^/\s"']+)\/api\/v4\/projects\/([^/\s"']+)\/merge_requests\/(\d+)/,
     api: true,
   },
+  // https://api.bitbucket.org/2.0/repositories/<workspace>/<repo>/pullrequests/<id>
+  {
+    re: /https?:\/\/([^/\s"']+)\/2\.0\/repositories\/([^/\s"']+\/[^/\s"']+)\/pullrequests\/(\d+)/,
+    api: true,
+  },
 ];
 
 /**
- * `api.github.com` addresses `github.com`'s repositories, and
- * `<host>/api/v4/...` addresses `<host>`'s — so an API match has to be mapped
- * back to the browser host before the repository can be identified.
+ * `api.github.com` addresses `github.com`'s repositories, `api.bitbucket.org`
+ * addresses `bitbucket.org`'s, and `<host>/api/v4/...` addresses `<host>`'s — so
+ * an API match has to be mapped back to the browser host before the
+ * repository can be identified.
  */
+const WEB_HOST_OF_API_HOST: Record<string, string> = {
+  "api.github.com": "github.com",
+  "api.bitbucket.org": "bitbucket.org",
+};
+
 function webHostOf(host: string): string {
   const h = host.toLowerCase();
-  return h === "api.github.com" ? "github.com" : h;
+  return WEB_HOST_OF_API_HOST[h] ?? h;
 }
 
 function refFrom(

--- a/packages/shared/src/git-providers/cli.test.ts
+++ b/packages/shared/src/git-providers/cli.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { changeRequestLabel, checkoutCommandFor, providerCli } from "./cli";
+
+describe("providerCli", () => {
+  test("each provider names its own CLI, or none", () => {
+    expect(providerCli("github").cli).toBe("gh");
+    expect(providerCli("gitlab").cli).toBe("glab");
+    // Bitbucket ships no CLI; the create command is the REST API over curl.
+    expect(providerCli("bitbucket").cli).toBeNull();
+    expect(providerCli("bitbucket").createCommand).toContain(
+      "api.bitbucket.org/2.0/repositories",
+    );
+    expect(providerCli("bitbucket").createCommand).toContain("BITBUCKET_TOKEN");
+  });
+});
+
+describe("checkoutCommandFor", () => {
+  test("fills the number in where the CLI takes one", () => {
+    expect(checkoutCommandFor("github", 7)).toBe("gh pr checkout 7");
+    expect(checkoutCommandFor("gitlab", 7)).toBe("glab mr checkout 7");
+  });
+  test("names the source branch where no CLI can address a number", () => {
+    const command = checkoutCommandFor("bitbucket", 7);
+    expect(command).toContain("git checkout <source branch>");
+    expect(command).not.toContain("7");
+  });
+});
+
+describe("changeRequestLabel", () => {
+  test("writes the number the way each provider does", () => {
+    expect(changeRequestLabel("github", 7)).toBe("PR #7");
+    expect(changeRequestLabel("gitlab", 7)).toBe("MR !7");
+    expect(changeRequestLabel("bitbucket", 7)).toBe("PR #7");
+  });
+});

--- a/packages/shared/src/git-providers/cli.ts
+++ b/packages/shared/src/git-providers/cli.ts
@@ -3,20 +3,34 @@
  *
  * An agent's prompt has to name a concrete command — "open a pull request" is
  * not runnable — so the vocabulary has to vary with the provider rather than
- * hardcode GitHub's. Pure data; the sandbox image ships both CLIs and the
- * checkout's own credential decides which one is authenticated.
+ * hardcode GitHub's. Pure data; the sandbox image ships the CLIs that exist
+ * and the checkout's own credential decides which one is authenticated.
+ *
+ * Bitbucket has no official CLI, so its "command" is the REST API over
+ * `curl`. The sandbox exports the checkout's token as `BITBUCKET_TOKEN` for
+ * exactly that (see the daemon's `CliEnvFromCloneUrl`).
  */
 
 import type { GitProviderKind } from "./types";
 
 export interface ProviderCli {
-  /** The binary the sandbox has authenticated for this provider. */
-  cli: string;
+  /** The provider's name as people write it. */
+  name: string;
+  /**
+   * The binary the sandbox has authenticated for this provider, or null when
+   * the provider ships none and the agent speaks REST instead.
+   */
+  cli: string | null;
   /** What the provider calls a proposed change, lower case, singular. */
   changeRequest: string;
+  /** Its abbreviation, the way a reader of that provider expects it. */
+  abbreviation: string;
   /** Opens one from the current checkout. */
   createCommand: string;
-  /** Checks an existing one out by its number, which the caller appends. */
+  /**
+   * Checks an existing one out. `{number}` stands for its number; a provider
+   * whose command cannot address it by number names the source branch instead.
+   */
   checkoutCommand: string;
   /** How the provider writes a change request's number in prose. */
   numberSigil: string;
@@ -24,23 +38,50 @@ export interface ProviderCli {
 
 const CLIS: Record<GitProviderKind, ProviderCli> = {
   github: {
+    name: "GitHub",
     cli: "gh",
     changeRequest: "pull request",
+    abbreviation: "PR",
     createCommand: "gh pr create",
-    checkoutCommand: "gh pr checkout",
+    checkoutCommand: "gh pr checkout {number}",
     numberSigil: "#",
   },
   gitlab: {
+    name: "GitLab",
     cli: "glab",
     changeRequest: "merge request",
+    abbreviation: "MR",
     createCommand: "glab mr create",
-    checkoutCommand: "glab mr checkout",
+    checkoutCommand: "glab mr checkout {number}",
     numberSigil: "!",
+  },
+  bitbucket: {
+    name: "Bitbucket",
+    cli: null,
+    changeRequest: "pull request",
+    abbreviation: "PR",
+    createCommand:
+      'curl -fsS -X POST -H "Authorization: Bearer $BITBUCKET_TOKEN" -H "Content-Type: application/json" ' +
+      "https://api.bitbucket.org/2.0/repositories/<workspace>/<repo>/pullrequests " +
+      `-d '{"title":"<title>","source":{"branch":{"name":"<branch>"}},"destination":{"branch":{"name":"<base>"}}}'`,
+    // Bitbucket Cloud publishes no per-pull-request ref, so the source branch
+    // (on the pull request itself) is the only handle.
+    checkoutCommand:
+      "git fetch origin <source branch> && git checkout <source branch>",
+    numberSigil: "#",
   },
 };
 
 export function providerCli(provider: GitProviderKind): ProviderCli {
   return CLIS[provider];
+}
+
+/** The checkout command for one change request, its number filled in. */
+export function checkoutCommandFor(
+  provider: GitProviderKind,
+  number: number,
+): string {
+  return CLIS[provider].checkoutCommand.replace("{number}", String(number));
 }
 
 /**
@@ -52,7 +93,6 @@ export function changeRequestLabel(
   provider: GitProviderKind,
   number: number,
 ): string {
-  const { cli, numberSigil } = CLIS[provider];
-  const abbreviation = cli === "gh" ? "PR" : "MR";
+  const { abbreviation, numberSigil } = CLIS[provider];
   return `${abbreviation} ${numberSigil}${number}`;
 }

--- a/packages/shared/src/git-providers/repo-ref.test.ts
+++ b/packages/shared/src/git-providers/repo-ref.test.ts
@@ -18,6 +18,8 @@ describe("providerForHost", () => {
     expect(providerForHost("github.com")).toBe("github");
     expect(providerForHost("GitHub.com")).toBe("github");
     expect(providerForHost("gitlab.com")).toBe("gitlab");
+    expect(providerForHost("bitbucket.org")).toBe("bitbucket");
+    expect(providerForHost("www.bitbucket.org")).toBe("bitbucket");
   });
   test("recognises self-hosted gitlab by convention", () => {
     expect(providerForHost("gitlab.acme.com")).toBe("gitlab");
@@ -26,7 +28,8 @@ describe("providerForHost", () => {
   });
   test("is unknown for an arbitrary host", () => {
     expect(providerForHost("git.acme.com")).toBeNull();
-    expect(providerForHost("bitbucket.org")).toBeNull();
+    // Self-hosted Bitbucket is Data Center, a different API — not recognised.
+    expect(providerForHost("bitbucket.acme.com")).toBeNull();
   });
   test("does not match gitlab as a mid-label substring", () => {
     expect(providerForHost("notgitlab.com")).toBeNull();
@@ -157,5 +160,51 @@ describe("identity + derived urls", () => {
     expect(cloneUrlFor(gl, "a/b")).toBe(
       "https://oauth2:a%2Fb@gitlab.acme.com/group/sub/project.git",
     );
+  });
+});
+
+describe("bitbucket", () => {
+  const expected: RepoRef = {
+    provider: "bitbucket",
+    host: "bitbucket.org",
+    path: "acme/site",
+  };
+  test("https, clone and browser urls collapse to workspace/slug", () => {
+    expect(parseRepoUrl("https://bitbucket.org/acme/site")).toEqual(expected);
+    expect(parseRepoUrl("https://bitbucket.org/acme/site.git")).toEqual(
+      expected,
+    );
+    // Bitbucket's own HTTPS clone URL carries the user in the userinfo.
+    expect(parseRepoUrl("https://viktor@bitbucket.org/acme/site.git")).toEqual(
+      expected,
+    );
+    expect(parseRepoUrl("git@bitbucket.org:acme/site.git")).toEqual(expected);
+    expect(
+      parseRepoUrl("https://bitbucket.org/acme/site/pull-requests/12/overview"),
+    ).toEqual(expected);
+    expect(
+      parseRepoUrl("https://bitbucket.org/acme/site/src/main/README.md"),
+    ).toEqual(expected);
+    expect(parseRepoUrl("https://bitbucket.org/acme/site/branch/feat")).toEqual(
+      expected,
+    );
+  });
+  test("a bare workspace/slug with the provider given", () => {
+    expect(parseRepoUrl("acme/site", { provider: "bitbucket" })).toEqual(
+      expected,
+    );
+  });
+  test("a workspace alone is not a repository", () => {
+    expect(parseRepoUrl("https://bitbucket.org/acme")).toBeNull();
+  });
+  test("clone url uses the x-token-auth user and the api base is api.bitbucket.org", () => {
+    expect(cloneUrlFor(expected, "tok")).toBe(
+      "https://x-token-auth:tok@bitbucket.org/acme/site.git",
+    );
+    expect(cloneUrlFor(expected)).toBe("https://bitbucket.org/acme/site.git");
+    expect(apiBaseUrlFor("bitbucket", "bitbucket.org")).toBe(
+      "https://api.bitbucket.org/2.0",
+    );
+    expect(repoWebUrl(expected)).toBe("https://bitbucket.org/acme/site");
   });
 });

--- a/packages/shared/src/git-providers/repo-ref.ts
+++ b/packages/shared/src/git-providers/repo-ref.ts
@@ -10,24 +10,39 @@ import type { GitProviderKind, RepoRef } from "./types";
 export const DEFAULT_HOSTS: Record<GitProviderKind, string> = {
   github: "github.com",
   gitlab: "gitlab.com",
-};
-
-/** Username git expects in the userinfo of an HTTPS clone URL, per provider. */
-const CLONE_USERNAMES: Record<GitProviderKind, string> = {
-  github: "x-access-token",
-  gitlab: "oauth2",
+  bitbucket: "bitbucket.org",
 };
 
 /**
- * Best-effort provider for a host. `github.com` and `gitlab.com` are certain;
- * a self-hosted GitLab is recognised by convention (`gitlab.` prefix / a
- * `gitlab` label). Anything else is unknown and callers must pass the provider
- * explicitly (an account row always knows its `type`).
+ * Username git expects in the userinfo of an HTTPS clone URL, per provider.
+ * The sandbox daemon and `TASK_ADD_REPO` switch on this value to tell the
+ * providers apart from a clone URL alone, so each must stay distinct.
+ */
+const CLONE_USERNAMES: Record<GitProviderKind, string> = {
+  github: "x-access-token",
+  gitlab: "oauth2",
+  bitbucket: "x-token-auth",
+};
+
+/**
+ * Providers whose repository path is exactly `owner/name` (`workspace/slug`
+ * on Bitbucket). Only GitLab nests namespaces to arbitrary depth.
+ */
+const TWO_SEGMENT_PROVIDERS = new Set<GitProviderKind>(["github", "bitbucket"]);
+
+/**
+ * Best-effort provider for a host. `github.com`, `gitlab.com` and
+ * `bitbucket.org` are certain; a self-hosted GitLab is recognised by
+ * convention (`gitlab.` prefix / a `gitlab` label). Anything else is unknown
+ * and callers must pass the provider explicitly (an account row always knows
+ * its `type`). A self-hosted Bitbucket is deliberately NOT recognised: that is
+ * Bitbucket Data Center, whose API and URL shapes this module does not speak.
  */
 export function providerForHost(host: string): GitProviderKind | null {
   const h = host.toLowerCase();
   if (h === "github.com" || h === "www.github.com") return "github";
   if (h === "gitlab.com" || h === "www.gitlab.com") return "gitlab";
+  if (h === "bitbucket.org" || h === "www.bitbucket.org") return "bitbucket";
   if (/(^|[.-])gitlab([.-]|$)/.test(h)) return "gitlab";
   return null;
 }
@@ -38,34 +53,18 @@ function normalizeHost(rawHost: string): string {
 }
 
 /**
- * Path segments GitHub appends after `owner/name` in browser URLs. Anything
- * after these is dropped so a PR/tree/blob link still parses to its repo.
- */
-const GITHUB_SUBPATH_MARKERS = new Set([
-  "tree",
-  "blob",
-  "pull",
-  "pulls",
-  "issues",
-  "commit",
-  "commits",
-  "compare",
-  "actions",
-  "releases",
-  "settings",
-  "wiki",
-]);
-
-/**
  * Parse a repository URL into a `RepoRef`. Accepts:
  * - `https://host/path[.git]` and browser URLs with a trailing sub-path
- *   (`/pull/1`, `/tree/main`, GitLab's `/-/merge_requests/1`)
- * - `git@host:path.git` and `ssh://git@host/path.git`
+ *   (`/pull/1`, `/tree/main`, GitLab's `/-/merge_requests/1`, Bitbucket's
+ *   `/pull-requests/1` and `/src/main/...`)
+ * - `git@host:path.git`, `ssh://git@host/path.git` and Bitbucket's
+ *   `https://user@bitbucket.org/path.git`
  * - a bare `owner/name` when `provider` is given (host defaults per provider)
  *
  * Returns null when the provider cannot be determined or the path has fewer
- * than two segments. GitHub paths are exactly two segments; GitLab paths keep
- * every namespace level.
+ * than two segments. GitHub and Bitbucket paths are exactly two segments, so
+ * anything after them is a sub-resource and dropped; GitLab paths keep every
+ * namespace level.
  */
 export function parseRepoUrl(
   input: string,
@@ -109,13 +108,7 @@ export function parseRepoUrl(
   // GitLab browser URLs: everything from `/-/` on is a sub-resource.
   const dash = segments.indexOf("-");
   if (dash >= 0) segments = segments.slice(0, dash);
-  if (provider === "github") {
-    const marker = segments.findIndex(
-      (s, i) => i >= 2 && GITHUB_SUBPATH_MARKERS.has(s),
-    );
-    if (marker >= 0) segments = segments.slice(0, marker);
-    segments = segments.slice(0, 2);
-  }
+  if (TWO_SEGMENT_PROVIDERS.has(provider)) segments = segments.slice(0, 2);
   if (segments.length < 2) return null;
   const last = segments[segments.length - 1]!;
   segments[segments.length - 1] = last.replace(/\.git$/i, "");
@@ -126,7 +119,7 @@ export function parseRepoUrl(
 }
 
 /**
- * Case-insensitive identity: both providers forbid two repositories whose
+ * Case-insensitive identity: every provider forbids two repositories whose
  * paths differ only by case inside one namespace, and GitHub resolves
  * `Owner/Name` and `owner/name` to the same repository.
  */
@@ -147,7 +140,7 @@ export function repoName(ref: Pick<RepoRef, "path">): string {
   return segments[segments.length - 1] ?? ref.path;
 }
 
-/** Everything before the last segment — owner (GitHub) or namespace (GitLab). */
+/** Everything before the last segment — owner (GitHub), workspace (Bitbucket) or namespace (GitLab). */
 export function repoNamespace(ref: Pick<RepoRef, "path">): string {
   const i = ref.path.lastIndexOf("/");
   return i < 0 ? "" : ref.path.slice(0, i);
@@ -177,15 +170,24 @@ export function cloneUrlFor(ref: RepoRef, token?: string | null): string {
   return `https://${user}:${encodeURIComponent(token)}@${base}`;
 }
 
-/** REST API base for a provider host (GitHub Enterprise and self-hosted GitLab included). */
+/**
+ * REST API base for a provider host (GitHub Enterprise and self-hosted GitLab
+ * included). Bitbucket is Bitbucket Cloud only: its API lives on a separate
+ * host, and a self-hosted Data Center instance speaks a different API that no
+ * client here implements, so the host is not consulted.
+ */
 export function apiBaseUrlFor(provider: GitProviderKind, host: string): string {
   const h = normalizeHost(host);
-  if (provider === "github") {
-    return h === "github.com"
-      ? "https://api.github.com"
-      : `https://${h}/api/v3`;
+  switch (provider) {
+    case "github":
+      return h === "github.com"
+        ? "https://api.github.com"
+        : `https://${h}/api/v3`;
+    case "gitlab":
+      return `https://${h}/api/v4`;
+    case "bitbucket":
+      return "https://api.bitbucket.org/2.0";
   }
-  return `https://${h}/api/v4`;
 }
 
 /** Build a `RepoRef` from GitHub's legacy `owner`/`name` pair. */

--- a/packages/shared/src/git-providers/types.ts
+++ b/packages/shared/src/git-providers/types.ts
@@ -5,14 +5,16 @@
  * row (the credential holder) whose `type` selects the provider client. Both
  * schemas here are the wire shape the API tools return and the web reads;
  * nothing in them names a GitHub-only concept except the optional
- * `installationId`, which is null for every other provider.
+ * `installationId`, which is null for every other provider. Bitbucket means
+ * Bitbucket Cloud (bitbucket.org); Bitbucket Data Center has a different API
+ * and is not a kind here.
  *
  * Pure module (no DB / network / node deps) so api and web share it.
  */
 
 import { z } from "zod";
 
-export const GIT_PROVIDER_KINDS = ["github", "gitlab"] as const;
+export const GIT_PROVIDER_KINDS = ["github", "gitlab", "bitbucket"] as const;
 export const GitProviderKindSchema = z.enum(GIT_PROVIDER_KINDS);
 export type GitProviderKind = z.infer<typeof GitProviderKindSchema>;
 
@@ -56,7 +58,7 @@ export const GitProviderAccountSchema = z.object({
   externalAccountId: z
     .string()
     .describe(
-      "Provider-side account identity: installation id (GitHub App) or user/group id.",
+      "Provider-side account identity: installation id (GitHub App), user/group id (GitLab) or user/workspace uuid (Bitbucket).",
     ),
   login: z.string().describe("Display login of the account/namespace"),
   avatarUrl: z.string().nullable(),

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -7592,6 +7592,7 @@ export interface StudioToolIO {
         installPath: string | null;
       };
       gitlab: { oauthHosts: string[]; connectPath: string | null };
+      bitbucket: { oauthHosts: string[]; connectPath: string | null };
     };
   };
   GIT_ACCOUNT_LIST: {
@@ -7600,7 +7601,7 @@ export interface StudioToolIO {
       accounts: {
         id: string;
         organizationId: string;
-        type: "github" | "gitlab";
+        type: "github" | "gitlab" | "bitbucket";
         host: string;
         authKind: "token" | "oauth" | "github_app";
         externalAccountId: string;
@@ -7616,12 +7617,16 @@ export interface StudioToolIO {
     };
   };
   GIT_ACCOUNT_CONNECT_TOKEN: {
-    input: { type: "github" | "gitlab"; host: string; token: string };
+    input: {
+      type: "github" | "gitlab" | "bitbucket";
+      host: string;
+      token: string;
+    };
     output: {
       account: {
         id: string;
         organizationId: string;
-        type: "github" | "gitlab";
+        type: "github" | "gitlab" | "bitbucket";
         host: string;
         authKind: "token" | "oauth" | "github_app";
         externalAccountId: string;
@@ -7644,7 +7649,7 @@ export interface StudioToolIO {
         id: string;
         organizationId: string;
         accountId: string | null;
-        provider: "github" | "gitlab";
+        provider: "github" | "gitlab" | "bitbucket";
         host: string;
         path: string;
         externalId: string | null;
@@ -7666,7 +7671,11 @@ export interface StudioToolIO {
     };
     output: {
       repositories: {
-        ref: { provider: "github" | "gitlab"; host: string; path: string };
+        ref: {
+          provider: "github" | "gitlab" | "bitbucket";
+          host: string;
+          path: string;
+        };
         externalId: string;
         defaultBranch: string | null;
         webUrl: string;
@@ -7684,7 +7693,7 @@ export interface StudioToolIO {
         id: string;
         organizationId: string;
         accountId: string | null;
-        provider: "github" | "gitlab";
+        provider: "github" | "gitlab" | "bitbucket";
         host: string;
         path: string;
         externalId: string | null;

--- a/plugins/ban-git-provider-reachthrough.js
+++ b/plugins/ban-git-provider-reachthrough.js
@@ -33,7 +33,7 @@
  */
 
 const LAYER = "git-providers";
-const PROVIDERS = ["github", "gitlab"];
+const PROVIDERS = ["github", "gitlab", "bitbucket"];
 
 /** Files permitted to reach a provider directory. Suffix-matched. */
 const ALLOWLIST = [

--- a/selfhost/examples/docker-compose/.env.example
+++ b/selfhost/examples/docker-compose/.env.example
@@ -54,3 +54,12 @@ S3_SECRET_ACCESS_KEY=minioadmin
 # GITLAB_OAUTH_HOST=gitlab.com
 # GITLAB_OAUTH_CLIENT_ID=
 # GITLAB_OAUTH_CLIENT_SECRET=
+#
+# Bitbucket Cloud: register an OAuth consumer on the workspace (permissions:
+# Account read, Email read, Repositories write, Pull requests write) with
+# callback <PUBLIC_URL>/api/_git/bitbucket/callback. Its Key is the client id.
+# Bitbucket Data Center is not supported; without a consumer, bitbucket.org
+# accounts connect with a workspace, project or repository access token
+# instead (GIT_ACCOUNT_CONNECT_TOKEN).
+# BITBUCKET_OAUTH_CLIENT_ID=
+# BITBUCKET_OAUTH_CLIENT_SECRET=


### PR DESCRIPTION
## Summary

Adds **Bitbucket Cloud** next to GitHub and GitLab. It is one more folder under `apps/api/src/git-providers/` implementing the same three contracts (`GitProviderClient`, `RepoContentClient`, `ChangeRequestClient`), plus the wiring a third `GitProviderKind` needs everywhere the kind is enumerated.

### Provider folder (`git-providers/bitbucket/`)
- `env.ts` — `BITBUCKET_OAUTH_CLIENT_ID` / `BITBUCKET_OAUTH_CLIENT_SECRET`; unset means the connect route answers 503 and orgs connect with an access token.
- `http.ts` — REST 2.0 transport, error-body flattening, `Retry-After`, paginated envelope helpers. Refuses any host other than `bitbucket.org` (Data Center has a different API).
- `oauth.ts` — authorize URL + code exchange. Client credentials go in the POST body, the one form the shared refresh helper sends.
- `client.ts` — repo/user/workspace reads, listing, raw file, archive (web host download), identity. `bitbucketPrincipalForToken` tries `/user`, then `/workspaces`, then `/repositories` so workspace/project/repository access tokens (which have no user) can be connected.
- `content.ts` — tree listing, path lookups, `POST /src` commits guarded by `parents`, branch create/delete, rewrite with a staging-branch fallback, PR-based merge, compare via `/commits?exclude=`, `/diffstat`, `/merge-base`.
- `change-requests.ts` — pull request read/list/open/describe/merge (incl. the async 202 path), statuses as check runs, comments, unresolved inline threads, diffstat-based conflict detection.

### Wiring
- Shared: `GIT_PROVIDER_KINDS`, default host, `x-token-auth` clone user, `pull-requests` URL shapes, and a CLI entry. Bitbucket ships no CLI, so the vocabulary points agents at the REST API over `curl` and `checkoutCommandFor()` names the source branch instead of a number.
- API: registry switches, credential factory, capabilities, `principalForToken`, connect + callback routes, `GIT_PROVIDER_CAPABILITIES` output, tool descriptions, task prompt builder, PR-create bash heuristic.
- DB: migration `213-bitbucket-git-provider` re-states the three `CHECK (... IN ('github','gitlab'))` constraints with the new kind.
- Sandbox daemon (Go): `x-token-auth` clone URLs export `BITBUCKET_TOKEN`.
- Web: Bitbucket icon, one `GitProviderIcon` map replacing four github/gitlab ternaries, OAuth + token connect actions, per-provider token dialog, en + pt-br copy.
- Lint: `ban-git-provider-reachthrough` protects the new directory.
- Deploy: Helm secret + docker-compose `.env.example`.
- GitLab: its pure path helpers move to a neutral `git-providers/paths.ts` shared with Bitbucket.

## Screenshots

Settings → Repositories with a GitLab and a Bitbucket OAuth consumer configured (placeholder credentials on a local dev server). Without a consumer only the token buttons show.

![Settings → Repositories connect surface](https://raw.githubusercontent.com/decocms/studio/assets/bitbucket-git-provider/screenshots/bitbucket-git-provider/1-settings-repositories.png)

The Bitbucket token dialog. Bitbucket is Cloud only, so unlike GitLab's dialog it asks for no host.

![Connect Bitbucket with a token dialog](https://raw.githubusercontent.com/decocms/studio/assets/bitbucket-git-provider/screenshots/bitbucket-git-provider/2-bitbucket-token-dialog.png)

## Design notes
- **Synthetic tree shas.** Bitbucket listings carry no blob shas, so `TreeEntry.sha` is `<commit>:<path>`. Listings pin the listed commit (one call); path-set lookups pin the last commit touching each path via `filehistory`, so equal content compares equal across refs (what the discard plan needs). `readBlob` reads it back as `/src/{commit}/{path}`. See the module note in `content.ts`.
- **Cheap read is honest about gaps.** The PR payload has no mergeability or CI rollup, so `read()` answers `conflicting: null` / `checks: null`; `readDetailed()` pays for both. `readCheckLog` and `readDeployedUrl` return null — Bitbucket publishes neither.
- **File modes** cannot be set through `POST /src`; the exec bit is the one content property this provider loses (documented on `commitFiles`).

## Testing
- `bun run check`, `bun run lint` (0 errors, no warnings in touched files), `bun run fmt:check`, `knip` — clean.
- `bun test` over `git-providers`, `shared/git-providers`, `tools/task-board`, `tools/git`, `migrations`, `plugins`: 939 pass. New unit tests cover every pure helper in the Bitbucket folder, the shared URL/CLI helpers, the PR-create heuristic, and the prompt builder.
- `go build ./... && go test ./internal/config/...` in `packages/sandbox/daemon-go` — pass.
- e2e `git-providers.spec.ts` asserts the new capability shape and connect path.
- Booted the full dev stack locally with migration 213 applied and drove the settings page above.

### Verified against a live workspace

Connected a real bitbucket.org workspace through the OAuth flow (code exchange with body credentials, `/user` identity, stored refresh token) and drove the clients against a private test repository. Read side: repository facts, default branch, branch head, raw file, branch search, path-set lookup with synthetic shas, archive download over Bearer. Write side: branch create and duplicate refusal, guarded commit, stale-`parents` refusal surfacing as `RepoWriteConflict`, edit + delete commit, `compare` and `compareDetailed` (diffstat direction and merge base confirmed), `readBlob` through a synthetic sha, pull request open / read / readForBranch / readDetailed / describe / squash merge / lastMergedInto, and a cleanup commit on `main`.

Three things differed from the documentation and are fixed in the second commit:
1. The workspace-less `GET /2.0/repositories` listing answers **410** (CHANGE-2770) and `GET /2.0/workspaces` answers **404**. `listRepos` now discovers workspaces via `GET /2.0/user/workspaces` and reads one page per workspace; the token-principal fallback uses the same listing.
2. `src` directory listings paginate by an **opaque cursor** and refuse `page=2`. Every paginated read in the content client now follows Bitbucket's `next` URL instead of building page numbers.
3. `POST /pullrequests` on a pair that already has an open pull request **updates it in place** (title and description included) rather than refusing. `open()` now looks the pair up first and raises `ChangeRequestExists`.

Still worth a look in production: the pull request payload abbreviates the head hash to 12 characters (accepted by every commit endpoint and by `asHeadSha`), and a repository access token cannot be connected by paste because Bitbucket no longer offers a listing that would identify its workspace; workspace and project tokens and OAuth all work.

