### PR TITLE
fix(search): ⌘K filters again, and finds your connections

### DIFF
--- a/.github/actions/start-minio/action.yml
+++ b/.github/actions/start-minio/action.yml
@@ -9,10 +9,12 @@ description: >-
 inputs:
   image:
     description: MinIO container image — single source of truth for the pinned version.
-    # Docker Hub, not quay.io: same official image/tags, but quay.io
-    # intermittently times out in CI, and GitHub-hosted runners are exempt
-    # from Docker Hub rate limits for public images.
-    default: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    # quay.io, not Docker Hub: `minio/minio` no longer EXISTS on Docker Hub
+    # (the pull fails "repository does not exist", not a rate limit), so the
+    # old preference for it — same tags, no runner rate limit — is moot. quay
+    # is MinIO's own registry and carries the identical tag;
+    # tests/multi-pod/docker-compose.yml has pulled from it since #4748.
+    default: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
   port:
     description: Host port to publish and probe for readiness.
     default: "9000"

--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -42,6 +42,7 @@ import {
   recordDecryptFailure,
   recordDecryptSuccess,
 } from "./decrypt-failure-tracker";
+import { escapeLikePattern } from "./threads";
 import type { ConnectionStoragePort } from "./ports";
 import type { Database } from "./types";
 
@@ -399,6 +400,47 @@ export class ConnectionStorage implements ConnectionStoragePort {
     );
 
     return { items, totalCount };
+  }
+
+  /**
+   * Title search for the command palette.
+   *
+   * Deliberately NOT `list()`: that one runs every row through
+   * `deserializeConnection`, which decrypts the connection token, the
+   * configuration state, the OAuth config and every STDIO env var. A palette
+   * fires this on each keystroke and renders nothing but a name and an icon,
+   * so pulling live credentials into memory to answer it is both waste and
+   * needless exposure. Selects the display columns only — no vault call.
+   *
+   * VIRTUAL connections are excluded because they are projects/agents, which
+   * the palette already lists from its own client-side scope.
+   */
+  async searchByTitle(
+    organizationId: string,
+    search: string,
+    limit: number,
+  ): Promise<Array<Pick<ConnectionEntity, "id" | "title" | "icon" | "slug">>> {
+    let query = this.db
+      .selectFrom("connections")
+      .select(["id", "title", "icon", "slug"])
+      .where("organization_id", "=", organizationId)
+      .where("connection_type", "!=", "VIRTUAL");
+
+    if (search) {
+      query = query.where("title", "ilike", `%${escapeLikePattern(search)}%`);
+    }
+
+    const rows = await query
+      .orderBy("updated_at", "desc")
+      .limit(limit)
+      .execute();
+
+    return rows.map((row) => ({
+      id: row.id,
+      title: row.title ?? "",
+      icon: row.icon ?? null,
+      slug: row.slug ?? null,
+    }));
   }
 
   async update(

--- a/apps/api/src/tools/search/global-search.integration.test.ts
+++ b/apps/api/src/tools/search/global-search.integration.test.ts
@@ -28,6 +28,22 @@ describe("GLOBAL_SEARCH", () => {
       title: "Gamma launch retro",
       created_by: env.userId,
     });
+    await env.ctx.storage.connections.create({
+      id: "conn_stripe",
+      organization_id: env.orgId,
+      title: "Stripe Payments",
+      connection_type: "HTTP",
+      connection_url: "https://mcp.stripe.example/mcp",
+      created_by: env.userId,
+    });
+    await env.ctx.storage.connections.create({
+      id: "conn_linear",
+      organization_id: env.orgId,
+      title: "Linear",
+      connection_type: "HTTP",
+      connection_url: "https://mcp.linear.example/mcp",
+      created_by: env.userId,
+    });
   });
   afterAll(async () => {
     await env.close();
@@ -89,9 +105,45 @@ describe("GLOBAL_SEARCH", () => {
     const unfiltered = GLOBAL_SEARCH.outputSchema.parse(
       await GLOBAL_SEARCH.handler({ query: "launch" }, env.ctx),
     );
-    expect(filtered.items.map((i) => i.id).sort()).toEqual(
-      unfiltered.items.map((i) => i.id).sort(),
+    /** Compare the THREAD rows of each call, not every row: the unfiltered
+     *  call also returns tasks and connections, so an equality over the whole
+     *  list only held while no other type happened to match. */
+    const threadIds = (items: typeof filtered.items) =>
+      items
+        .filter((item) => item.type === "thread")
+        .map((item) => item.id)
+        .sort();
+
+    expect(threadIds(filtered.items)).toEqual(threadIds(unfiltered.items));
+    expect(filtered.items.every((item) => item.type === "thread")).toBe(true);
+  });
+
+  it("finds a connection by a token in its title", async () => {
+    const parsed = GLOBAL_SEARCH.outputSchema.parse(
+      await GLOBAL_SEARCH.handler({ query: "stripe" }, env.ctx),
     );
+    const connections = parsed.items.filter(
+      (item) => item.type === "connection",
+    );
+
+    expect(connections.map((item) => item.id)).toEqual(["conn_stripe"]);
+    // The client routes on `slug`, so it has to survive the round trip.
+    expect(connections[0]?.slug).toBeTruthy();
+  });
+
+  it("narrows to connections when `types` asks for them", async () => {
+    const parsed = GLOBAL_SEARCH.outputSchema.parse(
+      await GLOBAL_SEARCH.handler(
+        { query: "", types: ["connection"] },
+        env.ctx,
+      ),
+    );
+
+    expect(parsed.items.every((item) => item.type === "connection")).toBe(true);
+    expect(parsed.items.map((item) => item.id).sort()).toEqual([
+      "conn_linear",
+      "conn_stripe",
+    ]);
   });
 
   it("returns no items when `types` is an empty array", async () => {

--- a/apps/api/src/tools/search/global-search.test.ts
+++ b/apps/api/src/tools/search/global-search.test.ts
@@ -21,6 +21,42 @@ describe("GLOBAL_SEARCH input schema", () => {
   });
 });
 
+describe("GLOBAL_SEARCH searchable types", () => {
+  it("accepts `connection` as a type filter", () => {
+    const result = GLOBAL_SEARCH.inputSchema.safeParse({
+      query: "stripe",
+      types: ["connection"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("parses a connection row, and one with no slug", () => {
+    // `slug` is what `/$org/settings/connections/$appSlug` routes on, so the
+    // nullable branch is the contract the client's list fallback depends on.
+    const rows = [
+      {
+        type: "connection",
+        id: "conn_1",
+        title: "Stripe",
+        icon: null,
+        slug: "stripe",
+      },
+      {
+        type: "connection",
+        id: "conn_2",
+        title: "Legacy",
+        icon: null,
+        slug: null,
+      },
+    ];
+    const result = GLOBAL_SEARCH.outputSchema.safeParse({
+      items: rows,
+      totalCount: rows.length,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("normalizeSearchQuery", () => {
   it("treats an empty string as no query", () => {
     expect(normalizeSearchQuery("")).toBeUndefined();

--- a/apps/api/src/tools/search/global-search.ts
+++ b/apps/api/src/tools/search/global-search.ts
@@ -5,7 +5,8 @@
  * matches so callers can render mixed result lists without knowing which
  * resource types are searchable today.
  *
- * Threads and task-board cards are searchable. To add a new resource type:
+ * Threads, task-board cards and MCP connections are searchable. To add a new
+ * resource type:
  *   1. Extend `SearchResultSchema` with a new discriminated branch.
  *   2. Add a corresponding case in the handler that queries that resource.
  *   3. Add the type name to `SEARCHABLE_TYPES`.
@@ -20,7 +21,7 @@ import { requireOrganization } from "../../core/studio-context";
 import { normalizeThreadForResponse } from "../thread/helpers";
 import { taskKey } from "@decocms/shared/task-key";
 
-const SEARCHABLE_TYPES = ["thread", "task"] as const;
+const SEARCHABLE_TYPES = ["thread", "task", "connection"] as const;
 
 const ThreadResultSchema = z.object({
   type: z.literal("thread"),
@@ -47,9 +48,21 @@ const TaskResultSchema = z.object({
   repo: z.string().nullable(),
 });
 
+/** An installed MCP server. Addressed by `slug`, which is what
+ *  `/$org/settings/connections/$appSlug` routes on — a row whose slug is null
+ *  has no detail page, so the client must not mint one. */
+const ConnectionResultSchema = z.object({
+  type: z.literal("connection"),
+  id: z.string(),
+  title: z.string(),
+  icon: z.string().nullable(),
+  slug: z.string().nullable(),
+});
+
 const SearchResultSchema = z.discriminatedUnion("type", [
   ThreadResultSchema,
   TaskResultSchema,
+  ConnectionResultSchema,
 ]);
 
 const InputSchema = z.object({
@@ -113,7 +126,7 @@ export function includesSearchType(
 export const GLOBAL_SEARCH = defineTool({
   name: "GLOBAL_SEARCH",
   description:
-    "Search across organization resources by free-text query. Returns a typed union of matches (currently: threads and task-board cards). New resource types may be added over time without changes to the call shape.",
+    "Search across organization resources by free-text query. Returns a typed union of matches (currently: threads, task-board cards and MCP connections). New resource types may be added over time without changes to the call shape.",
   annotations: {
     title: "Global Search",
     readOnlyHint: true,
@@ -130,6 +143,7 @@ export const GLOBAL_SEARCH = defineTool({
     const limit = input.limit ?? 20;
     const includeThreads = includesSearchType(input.types, "thread");
     const includeTasks = includesSearchType(input.types, "task");
+    const includeConnections = includesSearchType(input.types, "connection");
 
     const items: z.infer<typeof SearchResultSchema>[] = [];
     let totalCount = 0;
@@ -183,6 +197,26 @@ export const GLOBAL_SEARCH = defineTool({
             : null,
           status: task.status ?? null,
           repo: task.repo ?? null,
+        });
+      }
+    }
+
+    if (includeConnections) {
+      /** Same empty-query contract as tasks: no term means "most recently
+       *  updated", which the storage query already orders by. */
+      const connections = await ctx.storage.connections.searchByTitle(
+        organization.id,
+        normalizeSearchQuery(input.query) ?? "",
+        limit,
+      );
+      totalCount += connections.length;
+      for (const connection of connections) {
+        items.push({
+          type: "connection",
+          id: connection.id,
+          title: connection.title,
+          icon: connection.icon ?? null,
+          slug: connection.slug ?? null,
         });
       }
     }

--- a/apps/api/src/tools/thread/test-helpers.ts
+++ b/apps/api/src/tools/thread/test-helpers.ts
@@ -1,13 +1,15 @@
 /**
  * Test scaffolding for thread tool tests. Mirrors the manual context
  * construction in `connection/connection-tools.test.ts`, but only wires the
- * storage modules the thread tools touch (threads, virtualMcps, taskBoard).
+ * storage modules the thread tools touch (threads, virtualMcps, taskBoard,
+ * connections).
  *
- * `taskBoard` is REAL, not a `null as never` stub: GLOBAL_SEARCH searches
- * threads and task-board cards in one call, so a stub would only move the
- * failure from "undefined is not an object" to a null dereference one frame
- * later. A real storage over the same test database also lets a caller seed
- * cards and assert on the task half of the result.
+ * `taskBoard` and `connections` are REAL, not `null as never` stubs:
+ * GLOBAL_SEARCH searches threads, task-board cards and connections in one
+ * call, so a stub would only move the failure from "undefined is not an
+ * object" to a null dereference one frame later. A real storage over the same
+ * test database also lets a caller seed rows and assert on those halves of the
+ * result.
  */
 
 import { vi } from "bun:test";
@@ -25,6 +27,7 @@ import {
 } from "../../storage/threads";
 import { VirtualMCPStorage } from "../../storage/virtual";
 import { TaskBoardStorage } from "../../storage/task-board";
+import { ConnectionStorage } from "../../storage/connection";
 import type { BoundAuthClient, StudioContext } from "../../core/studio-context";
 
 const ORG_ID = "org_test";
@@ -70,6 +73,7 @@ export async function buildThreadTestContext(): Promise<ThreadTestEnv> {
   const threads = new OrgScopedThreadStorage(sqlThreads, ORG_ID);
   const virtualMcps = new VirtualMCPStorage(database.db);
   const taskBoard = new TaskBoardStorage(database.db);
+  const connections = new ConnectionStorage(database.db, vault);
 
   const ctx = {
     timings: {
@@ -88,8 +92,8 @@ export async function buildThreadTestContext(): Promise<ThreadTestEnv> {
       threads,
       virtualMcps,
       taskBoard,
+      connections,
       // Stub the rest — thread tools don't touch these.
-      connections: null as never,
       organizationSettings: null as never,
       monitoring: null as never,
       users: null as never,

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -14,9 +14,9 @@
  *             blocks on the network.
  *
  * cmdk does its own filtering over the rendered items, so the local groups are
- * rendered whole and it decides what matches. The remote group is fetched on
- * the deferred term and rendered with `value` set to the raw text so cmdk does
- * not filter server results a second time.
+ * rendered whole and it decides what matches. Remote rows carry the live term
+ * in `keywords` so that filter always scores them — the server already matched
+ * them, on text (a task key, a message body) that is not in their `value`.
  */
 
 import { useDeferredValue, useState } from "react";
@@ -41,6 +41,7 @@ import {
   CommandItem,
   CommandList,
 } from "@decocms/ui/components/command.tsx";
+import { IntegrationIcon } from "@/components/integration-icon";
 import { ProjectIcon } from "@/components/project-icon";
 import { DESTINATION_ROUTE } from "@/hooks/use-destination-route";
 import { useProjectScope } from "@/hooks/use-project-scope";
@@ -61,7 +62,14 @@ type SearchHit =
       title: string;
       virtual_mcp_id: string | null;
     }
-  | { type: "task"; id: string; title: string; key: string | null };
+  | { type: "task"; id: string; title: string; key: string | null }
+  | {
+      type: "connection";
+      id: string;
+      title: string;
+      icon: string | null;
+      slug: string | null;
+    };
 
 /**
  * GLOBAL_SEARCH, on the deferred term.
@@ -143,6 +151,25 @@ export function CommandPalette({
    * nothing.
    */
   const openHit = (hit: SearchHit) => {
+    if (hit.type === "connection") {
+      /** `slug` is what the detail route keys on. A row without one has no
+       *  detail page, so it falls back to the connections list rather than
+       *  minting a URL that resolves to nothing — same rule as a keyless
+       *  card below. */
+      if (!hit.slug) {
+        navigate({
+          to: "/$org/settings/connections",
+          params: { org: org.slug },
+          search: { tab: "all" as const },
+        });
+        return;
+      }
+      navigate({
+        to: "/$org/settings/connections/$appSlug",
+        params: { org: org.slug, appSlug: hit.slug },
+      });
+      return;
+    }
     if (hit.type === "task") {
       navigate({
         to: DESTINATION_ROUTE.tasks,
@@ -159,6 +186,17 @@ export function CommandPalette({
       },
     });
   };
+
+  /** The one thing that keeps a server-matched row on screen: cmdk scores an
+   *  item over `value` PLUS `keywords`, so handing it the live term is an
+   *  exact match and a guaranteed non-zero score. Without it a hit matched on
+   *  a task key or a message body — text that is not in `value` — scores 0 and
+   *  cmdk unmounts it, and the server's answer renders as "No results". `term`,
+   *  not `deferredTerm`: cmdk filters against what is in the input right now. */
+  const remoteKeywords = [term];
+
+  const connectionHits = hits.filter((hit) => hit.type === "connection");
+  const resultHits = hits.filter((hit) => hit.type !== "connection");
 
   const orgParams = { org: org.slug };
 
@@ -206,12 +244,6 @@ export function CommandPalette({
       onOpenChange={(next) => (next ? onOpenChange(true) : close())}
       title={t("commandPalette.title")}
       description={t("commandPalette.description")}
-      /** GLOBAL_SEARCH already matched these rows — server-side, against the
-       *  task key and the message body. cmdk's own filter only sees the item
-       *  `value` (title + id), scores a hit like "ENG-42" at 0 and unmounts
-       *  it, so the server's answer renders as "No results". Same reason
-       *  `global-search-dialog.tsx` turns it off. */
-      shouldFilter={false}
     >
       <CommandInput
         placeholder={t("commandPalette.placeholder")}
@@ -342,14 +374,30 @@ export function CommandPalette({
           </CommandItem>
         </CommandGroup>
 
-        {hits.length > 0 && (
+        {connectionHits.length > 0 && (
+          <CommandGroup heading={t("commandPalette.connections")}>
+            {connectionHits.map((hit) => (
+              <CommandItem
+                key={`connection:${hit.id}`}
+                value={`${hit.title} ${hit.id}`}
+                keywords={remoteKeywords}
+                onSelect={() => go(() => openHit(hit), "connection")}
+              >
+                {/* 2xs matches ProjectIcon: one 16px mark for every named thing in the list. */}
+                <IntegrationIcon icon={hit.icon} name={hit.title} size="2xs" />
+                <span className="truncate">{hit.title}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {resultHits.length > 0 && (
           <CommandGroup heading={t("commandPalette.results")}>
-            {hits.map((hit) => (
-              /** `value` is the raw title so cmdk does not re-filter what the
-               *  server already matched. */
+            {resultHits.map((hit) => (
               <CommandItem
                 key={`${hit.type}:${hit.id}`}
                 value={`${hit.title} ${hit.id}`}
+                keywords={remoteKeywords}
                 onSelect={() => go(() => openHit(hit), hit.type)}
               >
                 {hit.type === "thread" ? <MessageSquare01 /> : <Columns03 />}

--- a/apps/web/src/i18n/en/command-palette.ts
+++ b/apps/web/src/i18n/en/command-palette.ts
@@ -5,6 +5,7 @@ export const commandPalette = {
   "commandPalette.empty": "Nothing found.",
   "commandPalette.goTo": "Go to",
   "commandPalette.projects": "Projects",
+  "commandPalette.connections": "Connections",
   "commandPalette.actions": "Actions",
   "commandPalette.results": "Results",
   "commandPalette.newProject": "New project",

--- a/apps/web/src/i18n/pt-br/command-palette.ts
+++ b/apps/web/src/i18n/pt-br/command-palette.ts
@@ -8,6 +8,7 @@ export const commandPalette = {
   "commandPalette.empty": "Nada encontrado.",
   "commandPalette.goTo": "Ir para",
   "commandPalette.projects": "Projetos",
+  "commandPalette.connections": "Conex\u00f5es",
   "commandPalette.actions": "A\u00e7\u00f5es",
   "commandPalette.results": "Resultados",
   "commandPalette.newProject": "Novo projeto",

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -7895,7 +7895,7 @@ export interface StudioToolIO {
     input: {
       query: string;
       limit?: number | undefined;
-      types?: ("task" | "thread")[] | undefined;
+      types?: ("connection" | "task" | "thread")[] | undefined;
     };
     output: {
       items: (
@@ -7918,6 +7918,13 @@ export interface StudioToolIO {
             key: string | null;
             status: string | null;
             repo: string | null;
+          }
+        | {
+            type: "connection";
+            id: string;
+            title: string;
+            icon: string | null;
+            slug: string | null;
           }
       )[];
       totalCount: number;

--- a/packages/ui/src/components/command-filter.test.ts
+++ b/packages/ui/src/components/command-filter.test.ts
@@ -28,6 +28,22 @@ describe("cmdk default filter", () => {
     expect(score("Home", "", undefined)).toBeGreaterThan(0);
   });
 
+  test("narrows a project list to the ones that match", () => {
+    // The reported bug, in the shape the palette actually renders: project
+    // rows carry a `project ` prefix in their `value`, so the prefix must not
+    // swallow the match — and a project that does NOT match has to disappear
+    // alongside the destinations.
+    const row = (title: string) => `project ${title}`;
+
+    expect(
+      score(row("investor-relations"), "invest", undefined),
+    ).toBeGreaterThan(0);
+    expect(score(row("Acme Investors"), "invest", undefined)).toBeGreaterThan(
+      0,
+    );
+    expect(score(row("my-shop"), "invest", undefined)).toBe(0);
+  });
+
   test("drops a server-matched row whose value lacks the search text", () => {
     // The failure mode: GLOBAL_SEARCH matched this card on its key, which is
     // not in `value`, so cmdk scores it 0 and a found result renders as

--- a/packages/ui/src/components/command-filter.test.ts
+++ b/packages/ui/src/components/command-filter.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The scoring contract every palette built on `Command` depends on.
+ *
+ * A palette mixes two kinds of row: LOCAL ones cmdk can score from their
+ * `value`, and REMOTE ones a server already matched — on text (a task key, a
+ * message body) that is never in `value`. Turning `shouldFilter` off to keep
+ * the remote rows visible is the trap: it disables scoring for the WHOLE list,
+ * so the local rows stop filtering too and every destination and project stays
+ * on screen no matter what is typed. `keywords` is the way out — it lets a
+ * remote row opt out of scoring without the local rows losing it.
+ *
+ * These assertions pin that, so a cmdk bump that stops honoring `keywords`
+ * fails here instead of silently un-filtering a palette.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { defaultFilter } from "cmdk";
+
+const score = defaultFilter!;
+
+describe("cmdk default filter", () => {
+  test("scores a local row by its value, and drops one that does not match", () => {
+    expect(score("Investors", "invest", undefined)).toBeGreaterThan(0);
+    expect(score("Home", "invest", undefined)).toBe(0);
+  });
+
+  test("keeps every row when nothing is typed", () => {
+    expect(score("Home", "", undefined)).toBeGreaterThan(0);
+  });
+
+  test("drops a server-matched row whose value lacks the search text", () => {
+    // The failure mode: GLOBAL_SEARCH matched this card on its key, which is
+    // not in `value`, so cmdk scores it 0 and a found result renders as
+    // "No results".
+    expect(score("Fix the login bug task_abc", "ENG-42", undefined)).toBe(0);
+  });
+
+  test("keeps that same row once the live term is passed as a keyword", () => {
+    expect(
+      score("Fix the login bug task_abc", "ENG-42", ["ENG-42"]),
+    ).toBeGreaterThan(0);
+    expect(
+      score("Weekly sync notes thr_9", "invest", ["invest"]),
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -43,10 +43,17 @@ function CommandDialog({
   className?: string;
   /** Overrides cmdk's default fuzzy scorer (e.g. a stricter substring match). */
   filter?: React.ComponentProps<typeof CommandPrimitive>["filter"];
-  /** `false` when the LIST is already the answer — a server-side search whose
-   *  rows cmdk cannot score, because the text that matched (a task key, a
-   *  message body) is not in the item's `value`. Without it cmdk scores those
-   *  rows 0 and unmounts them, and a found result renders as "No results". */
+  /** `false` when EVERY row is already the answer — a dialog that renders a
+   *  server-side search and nothing else, whose rows cmdk cannot score because
+   *  the text that matched (a task key, a message body) is not in the item's
+   *  `value`.
+   *
+   *  Not for a dialog that MIXES server rows with local ones (destinations,
+   *  actions, a project list). This switch is list-wide, so turning it off to
+   *  save the server rows also stops the local ones from filtering, and every
+   *  one of them stays on screen no matter what is typed. Leave it on there
+   *  and give each server row `keywords={[searchTerm]}` instead — see
+   *  `command-filter.test.ts` and `command-palette.tsx`. */
   shouldFilter?: React.ComponentProps<typeof CommandPrimitive>["shouldFilter"];
 }) {
   return (


### PR DESCRIPTION
Reported in Slack with a screenshot: typing `invest` into ⌘K still showed Home, Reports, Tasks, Library, Discover and the whole Projects list.

## The palette never filtered anything

`shouldFilter={false}` on `CommandDialog`, there since the palette shipped in #6801. It was added for a real reason — GLOBAL_SEARCH matches a row server-side on text that is not in the item's `value` (a task key, a message body), so cmdk scores it 0 and unmounts it, and a found result renders as "No results".

But that switch is **list-wide**. Turning it off to save the remote rows turned scoring off for the local ones too, so no destination, project or action ever filtered.

cmdk scores an item over `value` **plus** `keywords`. Measured against the pinned cmdk 1.1.1:

| row | search | keywords | score |
|---|---|---|---|
| `Fix the login bug task_abc` | `ENG-42` | — | **0** — unmounted |
| `Fix the login bug task_abc` | `ENG-42` | `["ENG-42"]` | **0.9** — survives |
| `Home` | `invest` | — | **0** — correctly filtered |
| `Investors` | `invest` | — | 0.99 |

So a remote row can opt out of filtering on its own without the rest of the list losing it. The remote rows now carry the live term as a keyword and the switch is gone.

`packages/ui/src/components/command-filter.test.ts` pins both halves, so a cmdk bump that stops honoring `keywords` fails there instead of silently un-filtering a palette. The prop stays on `CommandDialog` for a dialog that really is all-remote (`global-search-dialog.tsx`) — its doc comment now says when *not* to reach for it.

## Connections weren't searchable at all

The other half of the report. Added as a third GLOBAL_SEARCH type, following the recipe in that tool's own header, so the LLM and every other caller get them too. Projects/agents were already rendered — they just never filtered, which the fix above covers.

The query is a new `ConnectionStorage.searchByTitle`, not `list()`. `list()` runs every row through `deserializeConnection`, which decrypts the connection token, the configuration state, the OAuth config and every STDIO env var — pulling live credentials into memory on each keystroke to render a name and an icon. The new one selects display columns only and never touches the vault. VIRTUAL rows are excluded; those are the projects the palette already lists.

A hit routes to `/$org/settings/connections/$appSlug`, falling back to the list when `slug` is null rather than minting a URL that resolves to nothing.

## Trap this surfaced

`buildThreadTestContext` held `connections: null as never`. Once GLOBAL_SEARCH touched it, every thread-tool integration test would have crashed — the exact trap that helper's own header already documents for `taskBoard`. Now wired real.

## Testing

- `bun run check` — clean, all workspaces
- `bun run lint` — 0 errors, nothing in the touched files
- `bun run knip` — clean
- New: 4 unit (`command-filter.test.ts`), 2 schema (`global-search.test.ts`), 2 real-Postgres (`global-search.integration.test.ts`)
- Integration suite verified against a real `postgres:16`: **8 pass**. Reverting the feature flips the 2 new ones to fail, so they bite.
- Full `bun run test` on this branch: 9015 pass / 344 fail. On `origin/main`: 9007 pass / 344 fail — **identical failure sets** (`diff` clean; pre-existing local-env failures). The +8 are these tests.

Not done: connection search matches `title` only, not `app_name`/`slug`. Worth adding if someone renames a connection away from its app name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J3dR1R2d7C2AFS5Ry36hR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ⌘K palette so typing narrows results again, makes MCP connections searchable from it, and fixes CI by pulling MinIO from quay.io since the Docker Hub repo was deleted.

**Bug Fixes**
- A list-wide `shouldFilter={false}` stopped every destination, project, and action from filtering; remote rows now carry the live search term in `keywords` instead, and `command-filter.test.ts` pins that cmdk contract so a bump that breaks it fails there.
- The `start-minio` CI action now pulls from `quay.io/minio/minio` — the Docker Hub `minio/minio` repo no longer exists, which was failing every container job.

**New Features**
- Connections are a third `GLOBAL_SEARCH` type, so the LLM and other tool callers get them too.
- The palette routes a connection hit to its settings page, falling back to the connections list when `slug` is null.
- A new `ConnectionStorage.searchByTitle` selects display columns only and never touches credentials — `list()` would pull live tokens and OAuth configs into memory on each keystroke.
- `buildThreadTestContext` now wires real connection storage instead of the `null as never` stub.

<sup>Written for commit 7e0ce9c52774143871c31ee21e8cd859bc16c4b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

