### PR TITLE
refactor(email): give the transactional sender resolver one home

### DIFF
--- a/apps/api/src/auth/email-providers.ts
+++ b/apps/api/src/auth/email-providers.ts
@@ -7,6 +7,7 @@
  * - Other email-based features
  */
 
+import { getConfig } from "@/core/config";
 import { Resend, SendGrid } from "./known-email-providers";
 
 // Provider-specific config types
@@ -77,4 +78,20 @@ export function findEmailProvider(
   id: string,
 ): EmailProviderConfig | undefined {
   return providers.find((p) => p.id === id);
+}
+
+/**
+ * The deployment's configured transactional sender, or null when it has none
+ * — then nothing is sent, and nothing is stamped as sent.
+ *
+ * Every non-auth mail reuses the invitation provider: one configured sender,
+ * no second provider abstraction and no new env var.
+ */
+export function resolveTransactionalSender() {
+  const auth = getConfig().auth;
+  const providers = auth.emailProviders ?? [];
+  const provider = auth.inviteEmailProviderId
+    ? findEmailProvider(providers, auth.inviteEmailProviderId)
+    : providers[0];
+  return provider ? createEmailSender(provider) : null;
 }

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -8,7 +8,7 @@
   "harnesses/decopilot/background-tool-workflow.ts": "1ae73b5a614ae6439942c1e52de52deeb3e18d1bb7e528be820720b592cfe833",
   "jira/dbos-jira-trigger-sweep.ts": "07108e0a60f298d206c7f11bf36500bde8e61701b42bdab6b5ba9d7e99997eca",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
-  "notifications/dbos-digest.ts": "673bc164593266704d2918a0bcaaf838a2480dfb46d1d19c02bdb38c73ecc370",
+  "notifications/dbos-digest.ts": "b950c3f567626ae9e4fbde71817a60900510fb90d8311ca2345472df56581f53",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",
   "tools/task-board/dbos-github-read.ts": "02f8d9e13cdca01a7e7a6ad00767229b7bf83443a4d773e836fad6aca95020f5",
   "tools/task-board/dbos-tag-merged-sweep.ts": "afc48f5309fd1da3196167855b52ec0074a5f24b8a96b8ef9be2e07a8abb7a0a"

--- a/apps/api/src/notifications/dbos-digest.ts
+++ b/apps/api/src/notifications/dbos-digest.ts
@@ -26,9 +26,8 @@
 
 import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
 import type { Kysely } from "kysely";
-import { getConfig } from "@/core/config";
 import { getBaseUrl } from "@/core/server-constants";
-import { createEmailSender, findEmailProvider } from "@/auth/email-providers";
+import { resolveTransactionalSender } from "@/auth/email-providers";
 import type { Database } from "@/storage/types";
 import { buildDigestEmail, type DigestRow } from "./digest-email";
 import { NotificationDataSchema } from "./schema";
@@ -165,22 +164,8 @@ function groupByRecipient(rows: PendingRow[]): PendingRow[][] {
   return [...byUser.values()];
 }
 
-/** Null when the deployment has no email provider — nothing is loaded, nothing
- *  is stamped, so the rows go out whenever one is configured.
- *
- *  The digest reuses the invitation provider — one configured sender, no new
- *  provider abstraction and no new env var. */
-function resolveSender() {
-  const auth = getConfig().auth;
-  const providers = auth.emailProviders ?? [];
-  const provider = auth.inviteEmailProviderId
-    ? findEmailProvider(providers, auth.inviteEmailProviderId)
-    : providers[0];
-  return provider ? createEmailSender(provider) : null;
-}
-
 async function sendOne(rows: PendingRow[]): Promise<void> {
-  const sender = resolveSender();
+  const sender = resolveTransactionalSender();
   if (!sender) throw new Error("no email provider configured");
   const { subject, html } = buildDigestEmail(rows, getBaseUrl());
   await sender({ to: rows[0]!.email, subject, html });
@@ -220,7 +205,7 @@ async function userDigestWorkflowFn(
 ): Promise<void> {
   const wait = dueAtMs - Date.now();
   if (wait > 0) await DBOS.sleep(wait);
-  if (!resolveSender()) return;
+  if (!resolveTransactionalSender()) return;
   const rows = await DBOS.runStep(() => loadPendingForUser(userId), {
     name: "loadPendingForUser",
   });
@@ -245,7 +230,7 @@ async function digestSweepWorkflowFn(
   const orphanedBefore = new Date(
     scheduledTime.getTime() - DEBOUNCE_MS - SWEEP_GRACE_MS,
   );
-  const pending = resolveSender()
+  const pending = resolveTransactionalSender()
     ? await DBOS.runStep(() => loadOrphaned(orphanedBefore), {
         name: "loadOrphanedNotifications",
       })

--- a/apps/api/src/tools/task-board/pr-ready-email.ts
+++ b/apps/api/src/tools/task-board/pr-ready-email.ts
@@ -16,8 +16,7 @@
 import { taskKey } from "@decocms/shared/task-key";
 import { orgFlagEnabled } from "@decocms/shared/organization/schema";
 import { emailTemplate } from "@/auth/email-template";
-import { createEmailSender, findEmailProvider } from "@/auth/email-providers";
-import { getConfig } from "@/core/config";
+import { resolveTransactionalSender } from "@/auth/email-providers";
 import { getBaseUrl } from "@/core/server-constants";
 import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItem } from "@/storage/types";
@@ -69,17 +68,6 @@ export function buildPrReadyEmail(params: {
   };
 }
 
-/** The digest reuses the invitation provider; so does this. Null when the
- *  deployment has no email provider configured — then nothing is sent. */
-function resolveSender() {
-  const auth = getConfig().auth;
-  const providers = auth.emailProviders ?? [];
-  const provider = auth.inviteEmailProviderId
-    ? findEmailProvider(providers, auth.inviteEmailProviderId)
-    : providers[0];
-  return provider ? createEmailSender(provider) : null;
-}
-
 export async function emailReporterPrReady(
   ctx: StudioContext,
   item: TaskBoardItem,
@@ -114,7 +102,7 @@ export async function emailReporterPrReady(
       .executeTakeFirst();
     if (!org?.slug) return;
 
-    const sender = resolveSender();
+    const sender = resolveTransactionalSender();
     if (!sender) return;
 
     const { subject, html } = buildPrReadyEmail({


### PR DESCRIPTION
Follow-up cleanup on #7159. `pr-ready-email.ts` shipped a byte-for-byte copy of `dbos-digest.ts`'s `resolveSender` — same body, same comment about reusing the invitation provider. My duplication; extracting it now, before a third caller copies it again.

The resolver moves next to `createEmailSender`, which is what it builds.

**No behavior change.** Both call sites resolve the same provider in the same order (explicit `inviteEmailProviderId`, else the first configured one), so a deployment with no provider still sends nothing and stamps nothing.

The workflow-source snapshot moves because `dbos-digest.ts` changed. Recovery-compatible — one call swapped for an identical one, no step added, removed or reordered — so `DBOS_WORKFLOW_VERSION` stays at 11.

**Validation:** workspace type checks, lint (14 pre-existing warnings, 0 errors), knip, formatting, and 8,709 unit tests all pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the duplicated transactional sender resolution from `dbos-digest.ts` and `pr-ready-email.ts` into one `resolveTransactionalSender` in `email-providers.ts`. No behavior change — deployments without a provider still send nothing and stamp nothing.

**Refactors**
- Moves the resolver next to `createEmailSender`, which it builds.
- Both call sites resolve the same provider in the same order.
- The workflow-source snapshot updates because `dbos-digest.ts` changed; recovery-compatible, so `DBOS_WORKFLOW_VERSION` stays at 11.

<sup>Written for commit cfa01e6c2d0586f9bb05d07d7675f174a23f5e11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

