### PR TITLE
fix(task-board): a stale card repo must not veto binding the sole repo

### DIFF
--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -281,6 +281,16 @@ describe("pickSoleTaskRepo", () => {
       ),
     ).toBeNull();
   });
+  /** The card's `repo` is free text, so it goes stale: a renamed repository, a
+   *  value from the github-connection era, a typo. It must narrow the choice,
+   *  never veto it — an org with exactly one repo bound that repo before this
+   *  parameter existed, and still has to. */
+  test("a preference that matches nothing falls back to the sole repo", () => {
+    const sole = [choice("one", "acme", "web")];
+    expect(pickSoleTaskRepo(sole, "acme/renamed-away")?.id).toBe("one");
+    expect(pickSoleTaskRepo(sole)?.id).toBe("one");
+  });
+
   test("no clonable repo is not eligible", () => {
     expect(pickSoleTaskRepo([])).toBeNull();
   });

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -75,16 +75,23 @@ export interface TaskRepo {
 export function pickSoleTaskRepo(
   choices: RepoChoice[],
   /** The card's own `repo`, when it has one: narrow to it first, so a
-   *  multi-repo org still binds a checkout before dispatch. An unknown or
-   *  ambiguous name narrows to nothing and falls back to the mid-run pick. */
+   *  multi-repo org still binds a checkout before dispatch.
+   *
+   *  A HINT, never a veto. `repo` is free text that goes stale — a renamed
+   *  repository, a value from the github-connection era, a typo — and letting
+   *  a stale one empty the set would stop binding the sole repo of a
+   *  single-repo org, which this bound before the parameter existed. So a
+   *  preference that matches nothing is discarded, not honored. */
   preferredRepo?: string,
 ): TaskRepo | null {
-  if (preferredRepo)
-    choices = choices.filter(
+  if (preferredRepo) {
+    const narrowed = choices.filter(
       (choice) =>
         `${choice.owner}/${choice.name}`.toLowerCase() ===
         preferredRepo.toLowerCase(),
     );
+    if (narrowed.length > 0) choices = narrowed;
+  }
   if (choices.length !== 1) return null;
   const chosen = choices[0]!;
   return {


### PR DESCRIPTION
Regression from #7159, on the Super Agent dispatch path and not behind a flag — so it's live for every org.

`pickSoleTaskRepo` gained a `preferredRepo` parameter that filtered the choices, and an empty filter result meant "don't bind". But `task.repo` is free text (`z.string()`) that goes stale — a renamed repository, a value from the github-connection era, a typo. So an org with **exactly one** repo stopped binding it whenever a card named something else, falling through to the mid-run `TASK_ADD_REPO` pick and costing a turn. That org bound its sole repo before the parameter existed.

The preference is now a **hint**: it narrows when it matches, and is discarded when it doesn't.

Multi-repo behavior is unchanged — a preference that matches nothing, or matches ambiguously, still declines to bind and defers to the mid-run pick. The existing test asserting that (`pickSoleTaskRepo(twoChoices, "other/repo") === null`) still passes, and still for the right reason: the filter empties, the original two choices stand, and `length !== 1` declines.

| choices | `task.repo` | before #7159 | after #7159 | this PR |
|---|---|---|---|---|
| 1 | unset | bind | bind | bind |
| 1 | matches | bind | bind | bind |
| 1 | **stale** | bind | **mid-run pick** | bind |
| N | matches | mid-run pick | bind | bind |
| N | stale/ambiguous | mid-run pick | mid-run pick | mid-run pick |

Deliberately unflagged, like the regression it repairs: flagging it off would leave the broken case live.

**Validation:** the new unit test fails on `main` (`expect(pickSoleTaskRepo(sole, "acme/renamed-away")?.id).toBe("one")` → received `undefined`) and passes here. Workspace type checks, lint (14 pre-existing warnings, 0 errors), knip, formatting, and 8,717 unit tests all pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where a card's stale `repo` value prevented binding an org's sole repository, forcing a mid-run pick that costs a turn. The card's `repo` is now a hint: it narrows the choices when it matches and is discarded when it doesn't.

- Multi-repo behavior is unchanged — a preference that matches nothing or matches ambiguously still defers to the mid-run pick.
- The fix is intentionally unflagged because the regression is live on the Super Agent dispatch path for every org.
- Adds a unit test that fails on `main` and passes here.

<sup>Written for commit 1c6767ef1369350806215ac4a133c41f9d0abc1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

