### PR TITLE
fix(sections-editor): stop Add variant button overlapping field controls

### DIFF
--- a/apps/web/src/components/sections-editor/fields/multivariate-field-wrapper.tsx
+++ b/apps/web/src/components/sections-editor/fields/multivariate-field-wrapper.tsx
@@ -69,14 +69,15 @@ export function MultivariateFieldWrapper({
 
   if (!isMultivariateWrapper(value)) {
     return (
-      <div className="relative grid w-full min-w-0 grid-cols-[minmax(0,1fr)] gap-2">
+      <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2">
+        {renderInnerField(props)}
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
               type="button"
               variant="ghost"
               size="icon"
-              className="absolute right-0 top-0 size-6 text-muted-foreground hover:text-foreground"
+              className="size-6 shrink-0 text-muted-foreground hover:text-foreground"
               aria-label={t(
                 "sectionsEditor.multivariateFieldWrapper.addVariant",
               )}
@@ -92,7 +93,6 @@ export function MultivariateFieldWrapper({
             {t("sectionsEditor.multivariateFieldWrapper.addVariant")}
           </TooltipContent>
         </Tooltip>
-        {renderInnerField(props)}
       </div>
     );
   }


### PR DESCRIPTION
Same change as #7156, pushed to an in-repo branch so CI secrets (GITLEAKS_LICENSE, Docker Hub creds for the e2e MinIO pull) are available — fork PRs don't get repo secrets, which is why the checks failed there.

Original author: @vitoUwu
Supersedes #7156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the sections editor's "Add variant" button from overlapping field controls. The button was absolutely positioned on top of the field, which worked for stacked layouts but covered BooleanField's inline switch and blocked its clicks; it now sits in its own grid column and renders after the field so tab order goes input → Add variant.

<sup>Written for commit c093378fc511d8f5eecd80c9ab3ba7f860d0f153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/7254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

